### PR TITLE
[BS-162] Tune expected exceptions to support more platforms

### DIFF
--- a/spring-bootstrap-actuator/src/test/java/org/springframework/bootstrap/actuate/autoconfigure/EndpointWebMvcAutoConfigurationTests.java
+++ b/spring-bootstrap-actuator/src/test/java/org/springframework/bootstrap/actuate/autoconfigure/EndpointWebMvcAutoConfigurationTests.java
@@ -15,8 +15,11 @@
  */
 package org.springframework.bootstrap.actuate.autoconfigure;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.io.FileNotFoundException;
-import java.net.ConnectException;
+import java.net.SocketException;
 import java.net.URI;
 import java.nio.charset.Charset;
 
@@ -42,13 +45,11 @@ import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-
 /**
  * Tests for {@link EndpointWebMvcAutoConfiguration}.
  * 
  * @author Phillip Webb
+ * @author Greg Turnquist
  */
 public class EndpointWebMvcAutoConfigurationTests {
 
@@ -170,7 +171,7 @@ public class EndpointWebMvcAutoConfigurationTests {
 			}
 		} catch (Exception ex) {
 			if (expected == null) {
-				if (ConnectException.class.isInstance(ex)
+				if (SocketException.class.isInstance(ex)
 						|| FileNotFoundException.class.isInstance(ex)) {
 					return;
 				}

--- a/spring-bootstrap/src/test/java/org/springframework/bootstrap/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
+++ b/spring-bootstrap/src/test/java/org/springframework/bootstrap/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
@@ -16,9 +16,16 @@
 
 package org.springframework.bootstrap.context.embedded;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
 import java.io.FileWriter;
 import java.io.IOException;
-import java.net.ConnectException;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -45,17 +52,11 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.StreamUtils;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-
 /**
  * Base for testing classes that extends {@link AbstractEmbeddedServletContainerFactory}.
  * 
  * @author Phillip Webb
+ * @author Greg Turnquist
  */
 public abstract class AbstractEmbeddedServletContainerFactoryTests {
 
@@ -91,8 +92,7 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		factory.setPort(0);
 		this.container = factory
 				.getEmbeddedServletContainer(exampleServletRegistration());
-		this.thrown.expect(ConnectException.class);
-		this.thrown.expectMessage("Connection refused");
+		this.thrown.expect(SocketException.class);
 		getResponse("http://localhost:8080/hello");
 	}
 
@@ -102,7 +102,7 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		this.container = factory
 				.getEmbeddedServletContainer(exampleServletRegistration());
 		this.container.stop();
-		this.thrown.expect(ConnectException.class);
+		this.thrown.expect(SocketException.class);
 		getResponse("http://localhost:8080/hello");
 	}
 


### PR DESCRIPTION
It appears that some machines break when looking for ConnectionException,
but not SocketException, both of which are IOExceptions. This seems to make
tests pass on more machines without compromising the intentions of the API.
