### PR TITLE
Fix spring.factories so MultipartAutoConfigure loads properly  [BS-157]

### DIFF
--- a/spring-bootstrap/src/main/java/org/springframework/bootstrap/autoconfigure/web/MultipartAutoConfiguration.java
+++ b/spring-bootstrap/src/main/java/org/springframework/bootstrap/autoconfigure/web/MultipartAutoConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.web.multipart.support.StandardServletMultipartResolve
  * @author Greg Turnquist
  */
 @Configuration
+@ConditionalOnBean(MultipartConfigElement.class)
 public class MultipartAutoConfiguration {
 
 	@Bean

--- a/spring-bootstrap/src/main/resources/META-INF/spring.factories
+++ b/spring-bootstrap/src/main/resources/META-INF/spring.factories
@@ -10,6 +10,7 @@ org.springframework.bootstrap.autoconfigure.orm.jpa.HibernateJpaAutoConfiguratio
 org.springframework.bootstrap.autoconfigure.thymeleaf.ThymeleafAutoConfiguration,\
 org.springframework.bootstrap.autoconfigure.web.EmbeddedServletContainerAutoConfiguration,\
 org.springframework.bootstrap.autoconfigure.web.ServerPropertiesAutoConfiguration,\
+org.springframework.bootstrap.autoconfigure.web.MultipartAutoConfiguration,\
 org.springframework.bootstrap.autoconfigure.web.WebMvcAutoConfiguration
 
 # Application Context Initializers


### PR DESCRIPTION
After discovering that MultipartAutoConfigure wasn't loading when used, realized I needed to register it with spring.factories. Added it there, but it broke some tests. So tweaked it so that it only loads if the specified bean is detected. I verified that this patch passes all the unit tests AND works with my sample application as expected.
