### PR TITLE
Update README link text to be M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ before you begin:
 ### Manual installation
 You can download the Spring CLI distribution from the Spring software repository:
 
-* [spring-boot-cli-0.5.0.BUILD-SNAPSHOT-bin.zip](http://repo.springsource.org/milestone/org/springframework/boot/spring-boot-cli/0.5.0.M1/spring-boot-cli-0.5.0.M1-bin.zip)
-* [spring-boot-cli-0.5.0.BUILD-SNAPSHOT-bin.tar.gz](http://repo.springsource.org/milestone/org/springframework/boot/spring-boot-cli/0.5.0.M1/spring-boot-cli-0.5.0.M1-bin.tar.gz)
+* [spring-boot-cli-0.5.0.M1-bin.zip](http://repo.springsource.org/milestone/org/springframework/boot/spring-boot-cli/0.5.0.M1/spring-boot-cli-0.5.0.M1-bin.zip)
+* [spring-boot-cli-0.5.0.M1-bin.tar.gz](http://repo.springsource.org/milestone/org/springframework/boot/spring-boot-cli/0.5.0.M1/spring-boot-cli-0.5.0.M1-bin.tar.gz)
 
 Cutting edge [snapshot distributions](http://repo.springsource.org/snapshot/org/springframework/boot/spring-boot-cli/)
 are also available.


### PR DESCRIPTION
Previously the link text for the download of 0.5.0.M1 was labeled as a
SNAPSHOT.

This commit updates the link text to be the correct version.
