### PR TITLE
Maven polishing

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -12,7 +12,7 @@
 		<spring.integration.version>2.2.4.RELEASE</spring.integration.version>
 		<spring.batch.version>2.2.0.RELEASE</spring.batch.version>
 		<spring-data-jpa.version>1.3.4.RELEASE</spring-data-jpa.version>
-		
+		<spring-data-mongodb.version>1.2.3.RELEASE</spring-data-mongodb.version>
 		<groovy.version>2.1.6</groovy.version>
 		<gradle.version>1.6</gradle.version>
 		<tomcat.version>7.0.42</tomcat.version>
@@ -355,7 +355,11 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
-			
+			<dependency>
+				<groupId>org.springframework.data</groupId>
+				<artifactId>spring-data-mongodb</artifactId>
+				<version>${spring-data-mongodb.version}</version>
+			</dependency>
 			<dependency>
 				<groupId>org.springframework.integration</groupId>
 				<artifactId>spring-integration-core</artifactId>


### PR DESCRIPTION
The version information of the managed dependencies as well as maven plugins 
are now defined via maven properties and can be overriden in sub-projects.
Updated version of spring-data-jpa dependency to the latest version 1.3.4.RELEASE. Added the latest version of spring-data-mongodb as managed dependency.
