### PR TITLE
Added Joda-time dependency in spring-boot-dependencies pom

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -389,6 +389,11 @@
 				<artifactId>snakeyaml</artifactId>
 				<version>1.12</version>
 			</dependency>
+			<dependency>
+				<groupId>joda-time</groupId>
+				<artifactId>joda-time</artifactId>
+				<version>2.3</version>
+			</dependency>						
 		</dependencies>
 	</dependencyManagement>
 	<build>


### PR DESCRIPTION
This may not be required - because JSR 310 is part of JDK 1.8. This will help until JDK 1.8 is released though.
