### PR TITLE
change credentials order in authentication manager example

### DIFF
--- a/spring-boot-actuator/README.md
+++ b/spring-boot-actuator/README.md
@@ -304,9 +304,9 @@ an `AuthenticationManager`, e.g. in your `SampleController`:
 
 Try it out:
 
-    $ curl user:password@localhost:8080/
-    {"status": 403, "error": "Forbidden", "message": "Access Denied"}
     $ curl client:secret@localhost:8080/
+    {"status": 403, "error": "Forbidden", "message": "Access Denied"}
+    $ curl user:password@localhost:8080/
     {"message": "Hello World"}
 
 ## Adding a database


### PR DESCRIPTION
username/password pairs were incorrect. The authentication manager has "user" and "password", so those credentials should be allowed to get the actual message.
