### PR TITLE
Ignore IntelliJ build stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ manifest.yml
 MANIFEST.MF
 settings.xml
 activemq-data
+*.iml
+.idea


### PR DESCRIPTION
Simple update to the root .gitignore file to avoid adding gobs of IntelliJ stuff to the project.
