### PR TITLE
#58 - Upgraded Spring Data JPA dependencies to Babbage release train.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/AbstractRepositoryConfigurationSourceSupport.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/AbstractRepositoryConfigurationSourceSupport.java
@@ -29,7 +29,9 @@ import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.boot.autoconfigure.AutoConfigurationUtils;
+import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.type.AnnotationMetadata;
@@ -46,9 +48,10 @@ import org.springframework.data.repository.config.RepositoryConfigurationExtensi
  * 
  * @author Phillip Webb
  * @author Dave Syer
+ * @author Oliver Gierke
  */
 public abstract class AbstractRepositoryConfigurationSourceSupport implements
-		BeanFactoryAware, ImportBeanDefinitionRegistrar, BeanClassLoaderAware {
+		BeanFactoryAware, ImportBeanDefinitionRegistrar, BeanClassLoaderAware, EnvironmentAware {
 
 	private static Log logger = LogFactory
 			.getLog(AbstractRepositoryConfigurationSourceSupport.class);
@@ -56,6 +59,8 @@ public abstract class AbstractRepositoryConfigurationSourceSupport implements
 	private ClassLoader beanClassLoader;
 
 	private BeanFactory beanFactory;
+	
+	private Environment environment;
 
 	@Override
 	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata,
@@ -90,7 +95,7 @@ public abstract class AbstractRepositoryConfigurationSourceSupport implements
 		StandardAnnotationMetadata metadata = new StandardAnnotationMetadata(
 				getConfiguration(), true);
 		AnnotationRepositoryConfigurationSource configurationSource = new AnnotationRepositoryConfigurationSource(
-				metadata, getAnnotation()) {
+				metadata, getAnnotation(), environment) {
 
 			@Override
 			public java.lang.Iterable<String> getBasePackages() {
@@ -136,4 +141,8 @@ public abstract class AbstractRepositoryConfigurationSourceSupport implements
 		this.beanFactory = beanFactory;
 	}
 
+	@Override
+	public void setEnvironment(Environment environment) {
+		this.environment = environment;
+	}
 }

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -37,8 +37,8 @@
 		<spring-integration.version>2.2.4.RELEASE</spring-integration.version>
 		<spring-integration-groovydsl.version>1.0.0.M1</spring-integration-groovydsl.version>
 		<spring-batch.version>2.2.0.RELEASE</spring-batch.version>
-		<spring-data-jpa.version>1.3.2.RELEASE</spring-data-jpa.version>
-		<spring-data-mongo.version>1.2.3.RELEASE</spring-data-mongo.version>
+		<spring-data-jpa.version>1.4.1.RELEASE</spring-data-jpa.version>
+		<spring-data-mongo.version>1.3.1.RELEASE</spring-data-mongo.version>
 		<thymeleaf.version>2.0.16</thymeleaf.version>
 		<thymeleaf-extras-springsecurity3.version>2.0.0</thymeleaf-extras-springsecurity3.version>
 		<thymeleaf-layout-dialect.version>1.1.1</thymeleaf-layout-dialect.version>


### PR DESCRIPTION
Adapted to changes in the API in Spring Data Commons which requires to pass in the current Environment into the AnnotationRepositoryConfigurationSource.
