### PR TITLE
Updated Tomcat version updated to 8.0.0-RC3

### DIFF
--- a/spring-boot-samples/spring-boot-sample-websocket/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-websocket/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<properties>
 		<java.version>1.7</java.version>
-		<tomcat.version>8.0.0-RC1</tomcat.version>
+		<tomcat.version>8.0.0-RC3</tomcat.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
The RC1 version had some websocket issues, that prevented propper websocket communication.
In some cases the SocketJS communication was downgraded to 'xhr_streaming'.
