### PR TITLE
Make Thymeleaf TemplateResolver's characterEncoding can be configured.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
@@ -102,7 +102,8 @@ public class ThymeleafAutoConfiguration {
 			resolver.setTemplateMode(this.environment.getProperty("mode", "HTML5"));
 			resolver.setCacheable(this.environment.getProperty("cache", Boolean.class,
 					true));
-			resolver.setCharacterEncoding(this.environment.getProperty("encoding",null));
+			resolver.setCharacterEncoding(this.environment.getProperty("encoding", String.class,
+			                null));
 			return resolver;
 		}
 


### PR DESCRIPTION
Make Thymeleaf TemplateResolver's characterEncoding can be configured.
1. In TemplateResolver you set the character encoding in which your files ARE in disk, this is, the one that should be used for reading them and converting their bytes into chars (characters are encoding-independent). 
2. In ThymeleafViewResolver you set the character encoding in which your processed pages should be written into the HTTP response's output stream, this is, the one that should be used for converting your characters back into bytes for transferring them over the network. 

In ThymeleafAutoConfiguration.java, ThymeleafViewResolver's encoding is set to UTF-8, but TemplateResolver's encoding is not be set.Your template file's(*.html) encoding must is same to system's .Add a line code to make it can be configured:
···
resolver.setCharacterEncoding(this.environment.getProperty("encoding", null,true));
···

Now ,you can add code in appplication.properties:

···
spring.thymeleaf.encoding=UTF-8
···
