### PR TITLE
TomcatEmbeddedServletContainer should fails fast

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainer.java
@@ -108,7 +108,7 @@ public class TomcatEmbeddedServletContainer implements EmbeddedServletContainer 
 			catch (Exception e) {
 				this.logger.error("Cannot start connector: ", e);
         throw new EmbeddedServletContainerException(
-                "Unable to start embdedded Tomcat connectors", ex);
+                "Unable to start embdedded Tomcat connectors", e);
 			}
 		}
 	}


### PR DESCRIPTION
Hi,

when Spring Boot application uses Tomcat embedded servlet container and started twice,
there will be a BindException (adress already in use), which is obviously correct.
But, the application starts and only the exception is logged.

I would expect, that the application will automatically shut down, when there are exceptions during startup phase.
Because, this is the behavior like using Jetty embedded container.

This patch simple re-throws the Excpetion, so that the application will do System.exit() and shuts down.

Regards
Martin
