### PR TITLE
Add support for spring-data-couchbase to autoconfigure

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -111,7 +111,12 @@
 			<artifactId>spring-data-mongodb</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-couchbase</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-redis</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/CouchbaseRepositoriesAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/CouchbaseRepositoriesAutoConfiguration.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data;
+
+import com.couchbase.client.CouchbaseClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.couchbase.core.CouchbaseTemplate;
+import org.springframework.data.couchbase.repository.CouchbaseRepository;
+import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories;
+
+import javax.annotation.PreDestroy;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Spring Data's Couchbase
+ * Repositories.
+ *
+ * @author Michael Nitschinger
+ * @see EnableCouchbaseRepositories
+ */
+@Configuration
+@ConditionalOnClass ({CouchbaseClient.class, CouchbaseRepository.class})
+public class CouchbaseRepositoriesAutoConfiguration {
+
+	@Import (CouchbaseRepositoriesAutoConfigureRegistrar.class)
+	@Configuration
+	@EnableConfigurationProperties (CouchbaseProperties.class)
+	protected static class CouchbaseRepositoriesConfiguration {
+
+		@Autowired
+		private CouchbaseProperties config;
+
+		@PreDestroy
+		public void close() throws URISyntaxException, IOException {
+			couchbaseClient().shutdown();
+		}
+
+		@Bean
+		@ConditionalOnMissingBean (CouchbaseClient.class)
+		CouchbaseClient couchbaseClient() throws URISyntaxException, IOException {
+			return this.config.couchbaseClient();
+		}
+
+		@Bean
+		@ConditionalOnMissingBean (CouchbaseTemplate.class)
+		CouchbaseTemplate couchbaseTemplate(CouchbaseClient couchbaseClient) {
+			return new CouchbaseTemplate(couchbaseClient);
+		}
+	}
+
+	@ConfigurationProperties (name = "spring.data.couchbase")
+	public static class CouchbaseProperties {
+
+		private String host = "127.0.0.1";
+		private String bucket = "default";
+		private String password = "";
+
+		public CouchbaseClient couchbaseClient() throws URISyntaxException, IOException {
+			return new CouchbaseClient(
+					Arrays.asList(new URI("http://" + getHost() + ":8091/pools")),
+					getBucket(),
+					getPassword()
+			);
+		}
+
+		public String getHost() {
+			return host;
+		}
+
+		public void setHost(String host) {
+			this.host = host;
+		}
+
+		public String getBucket() {
+			return bucket;
+		}
+
+		public void setBucket(String bucket) {
+			this.bucket = bucket;
+		}
+
+		public String getPassword() {
+			return password;
+		}
+
+		public void setPassword(String password) {
+			this.password = password;
+		}
+	}
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/CouchbaseRepositoriesAutoConfigureRegistrar.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/CouchbaseRepositoriesAutoConfigureRegistrar.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data;
+
+import org.springframework.data.couchbase.repository.config.CouchbaseRepositoryConfigurationExtension;
+import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories;
+import org.springframework.data.repository.config.RepositoryConfigurationExtension;
+
+import java.lang.annotation.Annotation;
+
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+
+/**
+ * {@link ImportBeanDefinitionRegistrar} used to auto-configure Spring Data Couchbase
+ * Repositories.
+ *
+ * @author Michael Nitschinger
+ */
+class CouchbaseRepositoriesAutoConfigureRegistrar extends
+	AbstractRepositoryConfigurationSourceSupport {
+
+	@Override
+	protected Class<? extends Annotation> getAnnotation() {
+		return EnableCouchbaseRepositories.class;
+	}
+
+	@Override
+	protected Class<?> getConfiguration() {
+		return EnableCouchbaseRepositoriesConfiguration.class;
+	}
+
+	@Override
+	protected RepositoryConfigurationExtension getRepositoryConfigurationExtension() {
+		return new CouchbaseRepositoryConfigurationExtension();
+	}
+
+	@EnableCouchbaseRepositories
+	private static class EnableCouchbaseRepositoriesConfiguration {
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -7,6 +7,7 @@ org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration,\
 org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.JpaRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.MongoRepositoriesAutoConfiguration,\
+org.springframework.boot.autoconfigure.data.CouchbaseRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration,\
 org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,\
 org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/CouchbaseRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/CouchbaseRepositoriesAutoConfigurationTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data;
+
+import com.couchbase.client.CouchbaseClient;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.ComponentScanDetectorConfiguration;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.couchbase.City;
+import org.springframework.boot.autoconfigure.data.couchbase.CityRepository;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link CouchbaseRepositoriesAutoConfiguration}.
+ *
+ * @author Michael Nitschinger
+ */
+public class CouchbaseRepositoriesAutoConfigurationTests {
+
+	private AnnotationConfigApplicationContext context;
+
+	@Test
+	public void testDefaultRepositoryConfiguration() throws Exception {
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(TestConfiguration.class,
+			ComponentScanDetectorConfiguration.class,
+			CouchbaseRepositoriesAutoConfiguration.class,
+			PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		assertNotNull(this.context.getBean(CityRepository.class));
+		assertNotNull(this.context.getBean(CouchbaseClient.class));
+	}
+
+	@Test
+	public void testNoRepositoryConfiguration() throws Exception {
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(EmptyConfiguration.class,
+			ComponentScanDetectorConfiguration.class,
+			CouchbaseRepositoriesAutoConfiguration.class,
+			PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		assertNotNull(this.context.getBean(CouchbaseClient.class));
+	}
+
+	@Configuration
+	@ComponentScan (basePackageClasses = City.class)
+	protected static class TestConfiguration {
+		@Bean
+		public CouchbaseClient clientMock() {
+			return mock(CouchbaseClient.class);
+		}
+	}
+
+	@Configuration
+	protected static class EmptyConfiguration {
+		@Bean
+		public CouchbaseClient clientMock() {
+			return mock(CouchbaseClient.class);
+		}
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/couchbase/City.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/couchbase/City.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.couchbase;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.couchbase.core.mapping.Document;
+
+import java.io.Serializable;
+
+/**
+ * @author Michael Nitschinger
+ */
+@Document
+public class City implements Serializable {
+
+	@Id
+	private String id;
+
+	private String name;
+	private String state;
+	private String country;
+	private String map;
+
+	public City(String id, String name, String country) {
+		this.id = id;
+		this.name = name;
+		this.country = country;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getState() {
+		return state;
+	}
+
+	public void setState(String state) {
+		this.state = state;
+	}
+
+	public String getCountry() {
+		return country;
+	}
+
+	public void setCountry(String country) {
+		this.country = country;
+	}
+
+	public String getMap() {
+		return map;
+	}
+
+	public void setMap(String map) {
+		this.map = map;
+	}
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/couchbase/CityRepository.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/couchbase/CityRepository.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.couchbase;
+
+import org.springframework.data.couchbase.repository.CouchbaseRepository;
+
+/**
+ * @author Michael Nitschinger
+ */
+public interface CityRepository extends CouchbaseRepository<City, String> {
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -40,7 +40,8 @@
 		<spring-integration-groovydsl.version>1.0.0.M1</spring-integration-groovydsl.version>
 		<spring-batch.version>2.2.2.RELEASE</spring-batch.version>
 		<spring-data-jpa.version>1.4.2.RELEASE</spring-data-jpa.version>
-		<spring-data-mongo.version>1.3.2.RELEASE</spring-data-mongo.version>
+        <spring-data-mongo.version>1.3.2.RELEASE</spring-data-mongo.version>
+        <spring-data-couchbase.version>1.0.0.M1</spring-data-couchbase.version>
 		<spring-data-redis.version>1.1.0.RELEASE</spring-data-redis.version>
 		<spring-rabbit.version>1.2.0.RELEASE</spring-rabbit.version>
 		<spring-mobile.version>1.1.0.RELEASE</spring-mobile.version>
@@ -404,6 +405,11 @@
 				<artifactId>spring-data-mongodb</artifactId>
 				<version>${spring-data-mongo.version}</version>
 			</dependency>
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-couchbase</artifactId>
+                <version>${spring-data-couchbase.version}</version>
+            </dependency>
 			<dependency>
 				<groupId>org.springframework.data</groupId>
 				<artifactId>spring-data-redis</artifactId>

--- a/spring-boot-starters/pom.xml
+++ b/spring-boot-starters/pom.xml
@@ -19,6 +19,7 @@
 		<module>spring-boot-starter-aop</module>
 		<module>spring-boot-starter-batch</module>
 		<module>spring-boot-starter-data-jpa</module>
+		<module>spring-boot-starter-data-couchbase</module>
 		<module>spring-boot-starter-integration</module>
 		<module>spring-boot-starter-jdbc</module>
 		<module>spring-boot-starter-jetty</module>


### PR DESCRIPTION
This changeset adds support and tests for spring-data-couchbase autoconfigure.

It currently works against M1 because M2 is not in the right milestone repository and needs to be moved (will do a separate PR to update to the latest milestone).
