### PR TITLE
minor fix for javadoc

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactory.java
@@ -162,7 +162,7 @@ public abstract class AbstractEmbeddedServletContainerFactory implements
 	}
 
 	/**
-	 * @return the session timeout in minutes
+	 * @return the session timeout in seconds
 	 */
 	public int getSessionTimeout() {
 		return this.sessionTimeout;


### PR DESCRIPTION
IN all other places (javadoc and code) this field referred as being "seconds".
