### PR TITLE
Tweaks for boot gradle plugin to ease excluding dependencies

### DIFF
--- a/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/SpringBootPlugin.java
+++ b/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/SpringBootPlugin.java
@@ -31,7 +31,7 @@ import org.springframework.boot.gradle.task.RunJar;
  */
 public class SpringBootPlugin implements Plugin<Project> {
 
-	private static final String REPACKAGE_TASK_NAME = "repackage";
+	private static final String REPACKAGE_TASK_NAME = "bootRepackage";
 
 	private static final String RUN_JAR_TASK_NAME = "runJar";
 
@@ -40,6 +40,11 @@ public class SpringBootPlugin implements Plugin<Project> {
 		project.getPlugins().apply(BasePlugin.class);
 		project.getPlugins().apply(JavaPlugin.class);
 		project.getExtensions().create("springBoot", SpringBootPluginExtension.class);
+
+		// register BootRepackage so that we can use
+		// task foo(type: BootRepackage) {}
+		project.getExtensions().getExtraProperties()
+				.set("BootRepackage", Repackage.class);
 		Repackage packageTask = addRepackageTask(project);
 		ensureTaskRunsOnAssembly(project, packageTask);
 		addRunJarTask(project);

--- a/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/SpringBootPluginExtension.groovy
+++ b/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/SpringBootPluginExtension.groovy
@@ -60,6 +60,11 @@ public class SpringBootPluginExtension {
 	String providedConfiguration
 
 	/**
+	 * The name of the custom configuration to use.
+	 */
+	String customConfiguration
+
+	/**
 	 * If the original source archive should be backed-up before being repackaged.
 	 */
 	boolean backupSource = true;

--- a/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/task/Repackage.java
+++ b/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/task/Repackage.java
@@ -34,6 +34,18 @@ import org.springframework.boot.loader.tools.Repackager;
  */
 public class Repackage extends DefaultTask {
 
+	private String customConfiguration;
+
+	private Object withJarTask;
+
+	public void setCustomConfiguration(String customConfiguration) {
+		this.customConfiguration = customConfiguration;
+	}
+
+	public void setWithJarTask(Object withJarTask) {
+		this.withJarTask = withJarTask;
+	}
+
 	@TaskAction
 	public void repackage() {
 		Project project = getProject();
@@ -43,10 +55,23 @@ public class Repackage extends DefaultTask {
 		if (extension.getProvidedConfiguration() != null) {
 			libraries.setProvidedConfigurationName(extension.getProvidedConfiguration());
 		}
+		if (this.customConfiguration != null) {
+			libraries.setCustomConfigurationName(this.customConfiguration);
+		}
+		else if (extension.getCustomConfiguration() != null) {
+			libraries.setCustomConfigurationName(extension.getCustomConfiguration());
+		}
 		project.getTasks().withType(Jar.class, new Action<Jar>() {
 
 			@Override
 			public void execute(Jar archive) {
+				// if withJarTask is set, compare tasks
+				// and bail out if we didn't match
+				if (Repackage.this.withJarTask != null
+						&& !archive.equals(Repackage.this.withJarTask)) {
+					return;
+				}
+
 				if ("".equals(archive.getClassifier())) {
 					File file = archive.getArchivePath();
 					if (file.exists()) {

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/LibraryScope.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/LibraryScope.java
@@ -55,4 +55,14 @@ public interface LibraryScope {
 		};
 	};
 
+	/**
+	 * Marker for custom scope when custom configuration is used.
+	 */
+	public static final LibraryScope CUSTOM = new LibraryScope() {
+		@Override
+		public String toString() {
+			return "custom";
+		};
+	};
+
 }


### PR DESCRIPTION
- Repackage changed to bootRepackage (I'm a bit nervous to have a generic task name repackage created automatically)
- Register BootRepackage order to use task foo(type: BootRepackage){}
- Allow user to use customConfiguration

// I can start by creating a new configuration which is
// excluding some dependencies
configurations {
  hadoopruntime.exclude group: 'log4j'
  hadoopruntime.exclude group: 'org.slf4j'
  hadoopruntime.exclude group: 'org.apache.hadoop'
  hadoopruntime.exclude group: 'org.apache.hive'
  hadoopruntime.exclude group: 'commons-logging'
  hadoopruntime.exclude group: 'org.codehaus.jettison'
  hadoopruntime.exclude group: 'com.thoughtworks.xstream'
}
dependencies {
  compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
  compile "org.springframework.batch:spring-batch-infrastructure:$springBatchVersion"
  compile "org.springframework.data:spring-yarn-batch:$springDataVersion"
  compile "org.springframework.data:spring-yarn-boot:$springDataVersion"
  runtime "org.springframework.data:spring-data-hadoop:$springDataVersion"
  runtime "org.springframework.data:spring-data-hadoop-core:$springDataVersion"
  runtime "log4j:log4j:$log4jVersion"
  runtime "org.slf4j:slf4j-log4j12:$slf4jVersion"
  testCompile "org.springframework.data:spring-yarn-test:$springDataVersion"
  testCompile "org.hamcrest:hamcrest-core:$hamcrestVersion"
  testCompile "org.hamcrest:hamcrest-library:$hamcrestVersion"
  hadoopruntime configurations.runtime
}

// I can set this custom configuration globally
// or omit it if handled with custom tasks
springBoot {
  backupSource = true
  customConfiguration = 'hadoopruntime'
}

// within my project I'd create custom jars
task appmasterJar(type: Jar) {
  appendix = 'appmaster'
  from sourceSets.main.output
  exclude('**/_Container_')
  exclude('**/_Client_')
}

task clientJar(type: Jar) {
  appendix = 'client'
  from sourceSets.main.output
  exclude('**/_Appmaster_')
  exclude('**/_Container_')
}

// I can create a custom tasks for boot repackage
// and set it to run only with spesific jar task
task clientBoot(type: BootRepackage, dependsOn: clientJar) {
  withJarTask = clientJar
}

task appmasterBoot(type: BootRepackage, dependsOn: appmasterJar) {
  customConfiguration = "hadoopruntime"
  withJarTask = appmasterJar
}

// I could disable jar/bootRepackage tasks if not needed
// this may be needed if custom jars are repackaged
// Main bootRepackage may re-repackage custom jars if
// its task is executed later than custom jar tasks
//jar.enabled = false
//bootRepackage.enabled = false

// This trick may help to execute tasks on
// a spesific order, doesn't matter
// if main bootRepackage disabled
task bootJars
bootJars.dependsOn = [clientBoot,containerBoot,appmasterBoot]

build.dependsOn(clientBoot)
build.dependsOn(containerBoot)
build.dependsOn(appmasterBoot)
//build.dependsOn(bootJars)
