### PR TITLE
When multiple Tomcat containers are started in the same JVM there is a c...

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
@@ -127,10 +127,12 @@ public class TomcatEmbeddedServletContainerFactory extends
 				: createTempDir("tomcat"));
 		tomcat.setBaseDir(baseDir.getAbsolutePath());
 		connector = new Connector(this.protocol);
+		long id = System.identityHashCode(tomcat);
 		tomcat.getService().addConnector(connector);
 		customizeConnector(connector);
 		tomcat.setConnector(connector);
 		tomcat.getHost().setAutoDeploy(false);
+		tomcat.getEngine().setName(tomcat.getEngine().getName()+"-"+id);
 		tomcat.getEngine().setBackgroundProcessorDelay(-1);
 
 		prepareContext(tomcat.getHost(), initializers);


### PR DESCRIPTION
When multiple Tomcat containers are started in the same JVM there is a conflict on the JMX beans they create. Components get prefixed with the name of the Engine they run in, and if the different StandardEngine objects have the same name, there will be one JMX bean yet two actual underlying components. During a shutdown, Tomcat will attempt to unregister the same JMX bean multiple times. Simple workaround is to give the Engine a unique name in the JVM

This commit avoids errors like
06-Dec-2013 15:51:27 org.apache.catalina.util.LifecycleMBeanBase unregister
WARNING: Failed to unregister MBean with name [Tomcat:type=Valve,host=localhost,name=ErrorReportValve] during component destruction
javax.management.InstanceNotFoundException: Tomcat:type=Valve,host=localhost,name=ErrorReportValve
    at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.getMBean(DefaultMBeanServerInterceptor.java:1094)
    at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.exclusiveUnregisterMBean(DefaultMBeanServerInterceptor.java:415)
    at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.unregisterMBean(DefaultMBeanServerInterceptor.java:403)
    at com.sun.jmx.mbeanserver.JmxMBeanServer.unregisterMBean(JmxMBeanServer.java:506)
    at org.apache.catalina.util.LifecycleMBeanBase.unregister(LifecycleMBeanBase.java:194)
    at org.apache.catalina.util.LifecycleMBeanBase.destroyInternal(LifecycleMBeanBase.java:73)
    at org.apache.catalina.util.LifecycleBase.destroy(LifecycleBase.java:305)
    at org.apache.catalina.core.StandardPipeline.removeValve(StandardPipeline.java:460)
    at org.apache.catalina.core.StandardPipeline.destroyInternal(StandardPipeline.java:222)
    at org.apache.catalina.util.LifecycleBase.destroy(LifecycleBase.java:305)
    at org.apache.catalina.core.ContainerBase.destroyInternal(ContainerBase.java:1229)
    at org.apache.catalina.util.LifecycleBase.destroy(LifecycleBase.java:305)
    at org.apache.catalina.core.ContainerBase.removeChild(ContainerBase.java:1041)
    at org.apache.catalina.core.ContainerBase.destroyInternal(ContainerBase.java:1234)
    at org.apache.catalina.util.LifecycleBase.destroy(LifecycleBase.java:305)
    at org.apache.catalina.core.StandardService.destroyInternal(StandardService.java:593)
    at org.apache.catalina.util.LifecycleBase.destroy(LifecycleBase.java:305)
    at org.apache.catalina.core.StandardServer.destroyInternal(StandardServer.java:822)
    at org.apache.catalina.util.LifecycleBase.destroy(LifecycleBase.java:305)
    at org.apache.catalina.startup.Tomcat.destroy(Tomcat.java:361)
    at org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer.stop(TomcatEmbeddedServletContainer.java:126)
