### PR TITLE
Avoid double logging config init + support for slf4j-log4j.

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/logging/AbstractLoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/AbstractLoggingSystem.java
@@ -42,7 +42,6 @@ public abstract class AbstractLoggingSystem extends LoggingSystem {
 
 	@Override
 	public void beforeInitialize() {
-		initializeWithSensibleDefaults();
 	}
 
 	@Override

--- a/spring-boot/src/main/java/org/springframework/boot/logging/log4j/Log4JLoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/log4j/Log4JLoggingSystem.java
@@ -23,10 +23,12 @@ import java.util.Map;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 import org.springframework.boot.logging.AbstractLoggingSystem;
 import org.springframework.boot.logging.LogLevel;
 import org.springframework.boot.logging.LoggingSystem;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.Log4jConfigurer;
 import org.springframework.util.StringUtils;
 
@@ -52,6 +54,15 @@ public class Log4JLoggingSystem extends AbstractLoggingSystem {
 
 	public Log4JLoggingSystem(ClassLoader classLoader) {
 		super(classLoader, "log4j.xml", "log4j.properties");
+	}
+
+	@Override
+	public void beforeInitialize() {
+		super.beforeInitialize();
+		if (ClassUtils.isPresent("org.slf4j.bridge.SLF4JBridgeHandler", getClassLoader())) {
+			SLF4JBridgeHandler.removeHandlersForRootLogger();
+			SLF4JBridgeHandler.install();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
As stated in the LoggingApplicationContextInitializer javadoc, sensible defaults should only be loaded if default configs cannot be found. When logging.config is defined org.springframework.boot.logging.log4j.Log4JLoggingSystem#initialize is invoked twice. Also added support for slf4j-log4j. 
