### PR TITLE
fixed ExplodedArchive which fail on windows when run exploded jar file

### DIFF
--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/archive/ExplodedArchive.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/archive/ExplodedArchive.java
@@ -39,7 +39,7 @@ import org.springframework.boot.loader.AsciiBytes;
 
 /**
  * {@link Archive} implementation backed by an exploded archive directory.
- * 
+ *
  * @author Phillip Webb
  */
 public class ExplodedArchive extends Archive {
@@ -72,11 +72,7 @@ public class ExplodedArchive extends Archive {
 
 	private void buildEntries(File file) {
 		if (!file.equals(this.root)) {
-			String name = file.getAbsolutePath().substring(
-					this.root.getAbsolutePath().length() + 1);
-			if (file.isDirectory()) {
-				name += "/";
-			}
+            String name = file.toURI().getPath().substring(root.toURI().getPath().length());
 			FileEntry entry = new FileEntry(new AsciiBytes(name), file);
 			this.entries.put(entry.getName(), entry);
 		}
@@ -92,7 +88,7 @@ public class ExplodedArchive extends Archive {
 	@Override
 	public URL getUrl() throws MalformedURLException {
 		FilteredURLStreamHandler handler = new FilteredURLStreamHandler();
-		return new URL("file", "", -1, this.root.getAbsolutePath() + "/", handler);
+        return new URL("file", "", -1, this.root.toURI().getPath(), handler);
 	}
 
 	@Override
@@ -181,7 +177,7 @@ public class ExplodedArchive extends Archive {
 		@Override
 		protected URLConnection openConnection(URL url) throws IOException {
 			String name = url.getPath().substring(
-					ExplodedArchive.this.root.getAbsolutePath().length() + 1);
+					ExplodedArchive.this.root.toURI().getPath().length());
 			if (ExplodedArchive.this.entries.containsKey(new AsciiBytes(name))) {
 				return new URL(url.toString()).openConnection();
 			}

--- a/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/archive/ExplodedArchiveTests.java
+++ b/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/archive/ExplodedArchiveTests.java
@@ -122,7 +122,7 @@ public class ExplodedArchiveTests {
 		Map<String, Entry> nestedEntries = getEntriesMap(nested);
 		assertThat(nestedEntries.size(), equalTo(1));
 		assertThat(nested.getUrl().toString(),
-				equalTo("file:" + this.rootFolder.getPath() + File.separator + "d/"));
+				equalTo("file:" + this.rootFolder.toURI().getPath() + "d/"));
 	}
 
 	@Test


### PR DESCRIPTION
When run exploded jar on windows `java org.springframework.boot.loader.JarLauncher`

You will get

```
java.lang.IllegalStateException: No 'Start-Class' manifest entry specified in file:C:\foo\bar/
        at org.springframework.boot.loader.archive.Archive.getMainClass(Archive.java:56)
        at org.springframework.boot.loader.ExecutableArchiveLauncher.getMainClass(ExecutableArchiveLauncher.java:73)
        at org.springframework.boot.loader.Launcher.launch(Launcher.java:53)
        at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:42)
```

The fix will use platform independent path from `file.toURI().getPath()` instead `file.getAbsolutePath()`.

After the fix, `mvn clean install` on spring-boot project root pass. And it pass on windows as well for command `mvn clean install -f spring-boot-tools/spring-boot-loader/pom.xml`
