### PR TITLE
Added missing dependency management declaration for spring-aspects.

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -301,6 +301,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>
+				<artifactId>spring-aspects</artifactId>
+				<version>${spring.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework</groupId>
 				<artifactId>spring-beans</artifactId>
 				<version>${spring.version}</version>
 			</dependency>


### PR DESCRIPTION
`spring-aspects` was missing from the version-fixing dependency declarations in `spring-boot-dependencies/pom.xml`. This caused the version for the library having to be set manually in Boot projects.
