### PR TITLE
Added support to allow manually declaring a EntityManagerFactoryBean.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/JpaBaseConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/JpaBaseConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.orm.jpa.EntityManagerFactoryInfo;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.JpaVendorAdapter;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -51,6 +52,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
  * 
  * @author Phillip Webb
  * @author Dave Syer
+ * @author Oliver Gierke
  */
 public abstract class JpaBaseConfiguration implements BeanFactoryAware, EnvironmentAware {
 
@@ -64,14 +66,16 @@ public abstract class JpaBaseConfiguration implements BeanFactoryAware, Environm
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(PlatformTransactionManager.class)
 	public PlatformTransactionManager transactionManager() {
-		return new JpaTransactionManager(entityManagerFactory().getObject());
+		return new JpaTransactionManager();
 	}
 
 	@Bean
-	public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
+	@ConditionalOnMissingBean(EntityManagerFactoryInfo.class)
+	public LocalContainerEntityManagerFactoryBean entityManagerFactory(JpaVendorAdapter jpaVendorAdapter) {
 		LocalContainerEntityManagerFactoryBean entityManagerFactoryBean = new LocalContainerEntityManagerFactoryBean();
-		entityManagerFactoryBean.setJpaVendorAdapter(jpaVendorAdapter());
+		entityManagerFactoryBean.setJpaVendorAdapter(jpaVendorAdapter);
 		entityManagerFactoryBean.setDataSource(getDataSource());
 		entityManagerFactoryBean.setPackagesToScan(getPackagesToScan());
 		entityManagerFactoryBean.getJpaPropertyMap().putAll(
@@ -81,6 +85,7 @@ public abstract class JpaBaseConfiguration implements BeanFactoryAware, Environm
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(JpaVendorAdapter.class)
 	public JpaVendorAdapter jpaVendorAdapter() {
 		AbstractJpaVendorAdapter adapter = createJpaVendorAdapter();
 		adapter.setShowSql(this.environment.getProperty("show-sql", Boolean.class, true));

--- a/spring-boot-autoconfigure/src/test/resources/META-INF/persistence.xml
+++ b/spring-boot-autoconfigure/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+	<persistence-unit name="manually-configured">
+		<class>org.springframework.boot.autoconfigure.orm.jpa.test.City</class>
+		<exclude-unlisted-classes>true</exclude-unlisted-classes>
+	</persistence-unit>
+</persistence>


### PR DESCRIPTION
Added the necessary @ConditionalOnMissingBean annotations to allow selectively declaring an EntityManagerFactoryBean, a JpaVendorAdapter or a PlatformTransactionManager. Especially the first one might be necessary to make sure the persistence provider evaluates an orm.xml. This unfortunately rules out using the packages to scan feature of Spring's LCEMFB.

I've filed https://jira.springsource.org/browse/SPR-11260 to potentially remove the need for this workaround in Spring itself.
