### PR TITLE
Fix for wildcard entries.

### DIFF
--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/PropertiesLauncher.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/PropertiesLauncher.java
@@ -406,6 +406,12 @@ public class PropertiesLauncher extends Launcher {
 				if (url.toString().endsWith(".jar") || url.toString().endsWith(".zip")) {
 					lib.add(0, new JarFileArchive(new File(url.toURI())));
 				}
+				else if (url.toString().endsWith("/*")) {
+					String name = url.getFile();
+					lib.add(0,
+							new ExplodedArchive(new File(name.substring(0,
+									name.length() - 1))));
+				}
 				else {
 					lib.add(0, new ExplodedArchive(new File(url.getFile())));
 				}


### PR DESCRIPTION
This small change now plays nice with wildcard classpath
entries coming from a parent classloader as its urls.

However care must be taken with url.toString() and url.getFile() in case those doesn't always return same ending if we're about to remove wildcard from it. I'm not 100% sure due to lack of knowledge of classloaders and url entries from it.
