### PR TITLE
CLI autoconfiguration should support org.springframework.ui.Model

### DIFF
--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/autoconfigure/SpringMvcCompilerAutoConfiguration.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/autoconfigure/SpringMvcCompilerAutoConfiguration.java
@@ -50,7 +50,8 @@ public class SpringMvcCompilerAutoConfiguration extends CompilerAutoConfiguratio
 		imports.addStarImports("org.springframework.web.bind.annotation",
 				"org.springframework.web.servlet.config.annotation",
 				"org.springframework.web.servlet",
-				"org.springframework.web.servlet.handler", "org.springframework.http");
+				"org.springframework.web.servlet.handler", "org.springframework.http",
+				"org.springframework.ui");
 		imports.addStaticImport(GroovyTemplate.class.getName(), "template");
 	}
 


### PR DESCRIPTION
Creating a Spring MVC app using the CLI requires an extra import statement if you use Model.
