### PR TITLE
Fix for wildcard recursive classpath handling

### DIFF
--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/archive/ExplodedArchive.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/archive/ExplodedArchive.java
@@ -56,11 +56,18 @@ public class ExplodedArchive extends Archive {
 
 	private Manifest manifest;
 
+	private boolean recursive = true;
+
 	public ExplodedArchive(File root) {
+		this(root, true);
+	}
+
+	public ExplodedArchive(File root, boolean recursive) {
 		if (!root.exists() || !root.isDirectory()) {
 			throw new IllegalArgumentException("Invalid source folder " + root);
 		}
 		this.root = root;
+		this.recursive = recursive;
 		buildEntries(root);
 		this.entries = Collections.unmodifiableMap(this.entries);
 	}
@@ -73,14 +80,16 @@ public class ExplodedArchive extends Archive {
 	private void buildEntries(File file) {
 		if (!file.equals(this.root)) {
 			String name = file.toURI().getPath()
-					.substring(root.toURI().getPath().length());
+					.substring(this.root.toURI().getPath().length());
 			FileEntry entry = new FileEntry(new AsciiBytes(name), file);
 			this.entries.put(entry.getName(), entry);
 		}
 		if (file.isDirectory()) {
-			for (File child : file.listFiles()) {
-				if (!SKIPPED_NAMES.contains(child.getName())) {
-					buildEntries(child);
+			if (this.recursive) {
+				for (File child : file.listFiles()) {
+					if (!SKIPPED_NAMES.contains(child.getName())) {
+						buildEntries(child);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Previous fix for handling wildcard entries in a classpath
imposed a new problem in a case where entry is a directory
with a jar files but also contains a lot of nested directories.

For example entry "./*" resulted for scanning whole disk starting
from "/". In case of default hadoop classpath, it scanned everything
under hadoop's installation. On some cases this deep scan was hidden
and was revealed by NPE's for file access exceptions.

When we want to support wildcard entries we only want to get
jar files from that directory, while boot itself have a need
to travel recursively to find classfiles from an expoded archive.

We handle this case by using recursive(true by default) flag in
ExplodedArchive and this flag is set to false in PropertiesLauncher
if we match wildcard.
