### PR TITLE
Upgraded to improved Spring Data repository configuration API.

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -45,8 +45,8 @@
 		<spring.version>4.0.1.RELEASE</spring.version>
 		<spring-integration.version>3.0.0.RELEASE</spring-integration.version>
 		<spring-batch.version>2.2.4.RELEASE</spring-batch.version>
-		<spring-data-jpa.version>1.4.3.RELEASE</spring-data-jpa.version>
-		<spring-data-mongodb.version>1.3.3.RELEASE</spring-data-mongodb.version>
+		<spring-data-jpa.version>1.5.0.RC1</spring-data-jpa.version>
+		<spring-data-mongodb.version>1.4.0.RC1</spring-data-mongodb.version>
 		<spring-data-redis.version>1.1.1.RELEASE</spring-data-redis.version>
 		<spring-rabbit.version>1.2.1.RELEASE</spring-rabbit.version>
 		<spring-mobile.version>1.1.0.RELEASE</spring-mobile.version>
@@ -696,4 +696,15 @@
 			</plugins>
 		</pluginManagement>
 	</build>
+	
+	<repositories>
+		<repository>
+			<id>spring-libs-milestone</id>
+			<url>http://repo.spring.io/libs-milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+	
 </project>


### PR DESCRIPTION
NOTE: This PR contains a pending upgrade to the Spring Data Codd release
train which has not gone GA yet. Thus the request is pending until the GA
release and will get the custom dependency upgrade in pom.xml removed.
I just wanted to get the implementation update done to verify the fix for
DATACMNS-420 is actually sufficient to improve the Boot autoconfg code.
I'll update the PR once the Codd GA release is done.

AbstractRepositoryConfigurationSourceSupport now uses the newly
introduced RepositoryConfigurationDelegate instead of effectively
reimplementing Spring Data Commons functionality which was prone to
changes in the API (code that wasn't considered to be API in the first
place).

Switched from implementing BeanClassLoaderAware to ResourceLoaderAware
to avoid having to set up a DefaultResourceLoader which should also
improve the IDE integration.
