### PR TITLE
spring-boot-actuator/readme.MD explains deprecated way of instantiating AuthenticationManagerBuilder

### DIFF
--- a/spring-boot-actuator/README.md
+++ b/spring-boot-actuator/README.md
@@ -297,11 +297,11 @@ point to a database or directory server, you only need to provide a
 
 
 
-    @Bean
-    public AuthenticationManager authenticationManager() throws Exception {
-        return new AuthenticationManagerBuilder(
-                ObjectPostProcessor.QUIESCENT_POSTPROCESSOR).inMemoryAuthentication().withUser("client")
-                .password("secret").roles("USER").and().and().build();
+    @Autowired
+    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
+        auth
+                .inMemoryAuthentication()
+                    .withUser("client").password("secret").roles("USER");
     }
 
 Try it out:


### PR DESCRIPTION
In the tutorial on [`spring-boot-actuator/README.md`](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-actuator/README.md) (search for substring "QUIESCENT" on the page) in the part which describes how to instantiate custom `AuthenticationManager` an instance of `AuthenticationManagerBuilder` is used.

The `README.md` suggests this code

``` java
@Bean
public AuthenticationManager authenticationManager() throws Exception {
    return new AuthenticationManagerBuilder(
            ObjectPostProcessor.QUIESCENT_POSTPROCESSOR).inMemoryAuthentication().withUser("client")
            .password("secret").roles("USER").and().and().build();
}
```

Which uses field `ObjectPostProcessor.QUIESCENT_POSTPROCESSOR`  and pass it into the constructor of the builder.

However, this field  `ObjectPostProcessor.QUIESCENT_POSTPROCESSOR` seems to be deprecated as it is  present in _3.2.RC1_ but not in _3.2.0.RELEASE_, thus it is not clear of how to instantiate `AuthenticationManagerBuilder`?

It seems that this was a planned deprecation (judging by the 'closed' issue https://jira.springsource.org/browse/SEC-2191)
, however my attempts to find any instructions on how to wire this  builder into my sprint-boot-actuator project were fruitless. 

Hope someone can help.
