### PR TITLE
Include spring-aspects in Spring Data JPA starter.

### DIFF
--- a/spring-boot-starters/spring-boot-starter-data-jpa/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-data-jpa/pom.xml
@@ -35,5 +35,9 @@
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-jpa</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-aspects</artifactId>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Declared spring-aspects as additional dependency in Spring Data JPA
starter pom. This is necessary to let the auditing feature work
correctly.
