### PR TITLE
A few improvements for the MongoDB auto-configuration.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/MongoRepositoriesAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/MongoRepositoriesAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import com.mongodb.MongoClientURI;
  * Repositories.
  * 
  * @author Dave Syer
+ * @author Oliver Gierke
  * @see EnableMongoRepositories
  */
 @Configuration
@@ -80,7 +81,7 @@ public class MongoRepositoriesAutoConfiguration {
 
 	}
 
-	@ConfigurationProperties(name = "spring.data.mongo")
+	@ConfigurationProperties(name = "spring.data.mongodb")
 	public static class MongoProperties {
 
 		private String host;

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/MongoRepositoriesAutoConfigureRegistrar.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/MongoRepositoriesAutoConfigureRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,11 @@ package org.springframework.boot.autoconfigure.data;
 
 import java.lang.annotation.Annotation;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.data.mongodb.repository.config.MongoRepositoryConfigurationExtension;
+import org.springframework.data.mongodb.repository.support.MongoRepositoryFactoryBean;
 import org.springframework.data.repository.config.RepositoryConfigurationExtension;
 
 /**
@@ -28,7 +30,9 @@ import org.springframework.data.repository.config.RepositoryConfigurationExtensi
  * Repositories.
  * 
  * @author Dave Syer
+ * @author Oliver Gierke
  */
+@ConditionalOnMissingBean(MongoRepositoryFactoryBean.class)
 class MongoRepositoriesAutoConfigureRegistrar extends
 		AbstractRepositoryConfigurationSourceSupport {
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/JpaRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/JpaRepositoriesAutoConfigurationTests.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertNotNull;
  * Tests for {@link JpaRepositoriesAutoConfiguration}.
  * 
  * @author Dave Syer
+ * @author Oliver Gierke
  */
 public class JpaRepositoriesAutoConfigurationTests {
 
@@ -65,7 +66,7 @@ public class JpaRepositoriesAutoConfigurationTests {
 				PropertyPlaceholderAutoConfiguration.class);
 		this.context.refresh();
 		assertNotNull(this.context
-				.getBean(org.springframework.boot.autoconfigure.data.alt.CityRepository.class));
+				.getBean(org.springframework.boot.autoconfigure.data.alt.JpaCityRepository.class));
 		assertNotNull(this.context.getBean(PlatformTransactionManager.class));
 		assertNotNull(this.context.getBean(EntityManagerFactory.class));
 	}
@@ -77,7 +78,7 @@ public class JpaRepositoriesAutoConfigurationTests {
 	}
 
 	@Configuration
-	@EnableJpaRepositories(basePackageClasses = org.springframework.boot.autoconfigure.data.alt.CityRepository.class)
+	@EnableJpaRepositories(basePackageClasses = org.springframework.boot.autoconfigure.data.alt.JpaCityRepository.class)
 	@TestAutoConfigurationPackage(City.class)
 	protected static class CustomConfiguration {
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/MongoRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/MongoRepositoriesAutoConfigurationTests.java
@@ -19,19 +19,25 @@ package org.springframework.boot.autoconfigure.data;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.autoconfigure.TestAutoConfigurationPackage;
+import org.springframework.boot.autoconfigure.data.alt.MongoDbCityRepository;
 import org.springframework.boot.autoconfigure.data.mongo.City;
 import org.springframework.boot.autoconfigure.data.mongo.CityRepository;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests for {@link MongoRepositoriesAutoConfiguration}.
  * 
  * @author Dave Syer
+ * @author Oliver Gierke
  */
 public class MongoRepositoriesAutoConfigurationTests {
 
@@ -45,7 +51,9 @@ public class MongoRepositoriesAutoConfigurationTests {
 				PropertyPlaceholderAutoConfiguration.class);
 		this.context.refresh();
 		assertNotNull(this.context.getBean(CityRepository.class));
-		assertNotNull(this.context.getBean(Mongo.class));
+		
+		Mongo mongo = this.context.getBean(Mongo.class);
+		assertThat(mongo, is(instanceOf(MongoClient.class)));
 	}
 
 	@Test
@@ -55,7 +63,20 @@ public class MongoRepositoriesAutoConfigurationTests {
 				MongoRepositoriesAutoConfiguration.class,
 				PropertyPlaceholderAutoConfiguration.class);
 		this.context.refresh();
-		assertNotNull(this.context.getBean(Mongo.class));
+		
+		Mongo mongo = this.context.getBean(Mongo.class);
+		assertThat(mongo, is(instanceOf(MongoClient.class)));
+	}
+	
+	@Test
+	public void doesNotTriggerDefaultRepositoryDetectionIfCustomized() {
+		
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(CustomizedConfiguration.class,
+				MongoRepositoriesAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		assertNotNull(this.context.getBean(MongoDbCityRepository.class));
 	}
 
 	@Configuration
@@ -70,4 +91,10 @@ public class MongoRepositoriesAutoConfigurationTests {
 
 	}
 
+	@Configuration
+	@TestAutoConfigurationPackage(MongoRepositoriesAutoConfigurationTests.class)
+	@EnableMongoRepositories(basePackageClasses = MongoDbCityRepository.class)
+	protected static class CustomizedConfiguration {
+		
+	}
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/alt/JpaCityRepository.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/alt/JpaCityRepository.java
@@ -19,6 +19,6 @@ package org.springframework.boot.autoconfigure.data.alt;
 import org.springframework.boot.autoconfigure.data.jpa.City;
 import org.springframework.data.repository.Repository;
 
-public interface CityRepository extends Repository<City, Long> {
+public interface JpaCityRepository extends Repository<City, Long> {
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/alt/MongoDbCityRepository.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/alt/MongoDbCityRepository.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure.data.alt;
+
+import org.springframework.boot.autoconfigure.data.mongo.City;
+import org.springframework.data.repository.Repository;
+
+public interface MongoDbCityRepository extends Repository<City, Long> {
+
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -46,7 +46,7 @@
 		<spring-integration.version>3.0.0.RELEASE</spring-integration.version>
 		<spring-batch.version>2.2.4.RELEASE</spring-batch.version>
 		<spring-data-jpa.version>1.4.3.RELEASE</spring-data-jpa.version>
-		<spring-data-mongo.version>1.3.3.RELEASE</spring-data-mongo.version>
+		<spring-data-mongodb.version>1.3.3.RELEASE</spring-data-mongodb.version>
 		<spring-data-redis.version>1.1.1.RELEASE</spring-data-redis.version>
 		<spring-rabbit.version>1.2.1.RELEASE</spring-rabbit.version>
 		<spring-mobile.version>1.1.0.RELEASE</spring-mobile.version>


### PR DESCRIPTION
Allow to deactivate MongoDB repository auto-detection by using
@EnableMongoRepositories. Adapted the test helper classes accordingly.

Updated MongoDB test to check that the configuration returns a new MongoClient.

Changed the property prefix and dependency management version property
from …mongo to …mongodb to be consistent with the Spring Data module
name.
