### PR TITLE
Now custom SpringApplication class can be used when extending SpringApplicationContextLoader

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/test/SpringApplicationContextLoader.java
+++ b/spring-boot/src/main/java/org/springframework/boot/test/SpringApplicationContextLoader.java
@@ -58,7 +58,7 @@ public class SpringApplicationContextLoader extends AbstractContextLoader {
 	public ApplicationContext loadContext(MergedContextConfiguration mergedConfig)
 			throws Exception {
 
-		SpringApplication application = new SpringApplication();
+		SpringApplication application = getSpringApplication();
 		application.setSources(getSources(mergedConfig));
 		if (!ObjectUtils.isEmpty(mergedConfig.getActiveProfiles())) {
 			application.setAdditionalProfiles(mergedConfig.getActiveProfiles());
@@ -75,6 +75,15 @@ public class SpringApplicationContextLoader extends AbstractContextLoader {
 		application.setInitializers(initializers);
 
 		return application.run();
+	}
+
+	/**
+	 * Builds new {@link org.springframework.boot.SpringApplication} instance. You can override
+	 * this method to add custom behaviour
+	 * @return {@link org.springframework.boot.SpringApplication} instance
+	 */
+	protected SpringApplication getSpringApplication() {
+		return new SpringApplication();
 	}
 
 	private Set<Object> getSources(MergedContextConfiguration mergedConfig) {


### PR DESCRIPTION
Currently it's not possible to reasonably extend SpringApplicationContextLoader for example to add external libraries support. Because SpringApplication class can be easily extended then allowing users to provide theirs own implementation will makes hooking easy.
