### PR TITLE
Adds auto configuration for the scalate template engine

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -195,6 +195,11 @@
 			<artifactId>aspectjweaver</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>org.fusesource.scalate</groupId>
+			<artifactId>scalate-spring-mvc_2.10</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<!-- Test -->
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/scalate/ScalateAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/scalate/ScalateAutoConfiguration.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.scalate;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletContext;
+
+import org.fusesource.scalate.layout.DefaultLayoutStrategy;
+import org.fusesource.scalate.servlet.Config;
+import org.fusesource.scalate.servlet.ServletTemplateEngine;
+import org.fusesource.scalate.spring.view.ScalateViewResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+import org.springframework.boot.bind.RelaxedPropertyResolver;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.Environment;
+import org.springframework.web.context.ServletContextAware;
+
+import scala.collection.JavaConversions;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Scalate. Possible options by
+ * application properties:
+ * <ul>
+ * <li>spring.scalate.prefix: The path of the templates (default: templates/)</li>
+ * <li>spring.scalate.suffix: The extension of the template files. If empty, needs to be
+ * specified in the controller (default: .scaml)</li>
+ * <li>spring.scalate.layout: The path for the default layout (default: templates/layout.scaml)</li>
+ * </ul>
+ * 
+ * @author Christoph Nagel
+ */
+@Configuration
+@ConditionalOnClass(ServletTemplateEngine.class)
+@AutoConfigureAfter(WebMvcAutoConfiguration.class)
+public class ScalateAutoConfiguration {
+
+	public static final String DEFAULT_PREFIX = "templates/";
+
+	public static final String DEFAULT_SUFFIX = ".scaml";
+
+	public static final String DEFAULT_LAYOUT = "templates/layout.scaml";
+
+	@Configuration
+	@ConditionalOnMissingBean(ServletTemplateEngine.class)
+	protected static class ScalateDefaultConfiguration implements EnvironmentAware,
+			ServletContextAware {
+
+		private RelaxedPropertyResolver env;
+
+		private ServletContext servletContext;
+
+		@Override
+		public void setEnvironment(Environment environment) {
+			this.env = new RelaxedPropertyResolver(environment, "spring.scalate.");
+		}
+
+		@Override
+		public void setServletContext(ServletContext servletContext) {
+			this.servletContext = servletContext;
+		}
+
+		@Bean
+		public Config config() {
+			return new Config() {
+
+				@Override
+				public ServletContext getServletContext() {
+					return servletContext;
+				}
+
+				@Override
+				public String getName() {
+					return env.getProperty("servlet_name", "unknown");
+				}
+
+				@Override
+				public Enumeration<?> getInitParameterNames() {
+					return null;
+				}
+
+				@Override
+				public String getInitParameter(String name) {
+					return null;
+				}
+			};
+		}
+
+		@Bean
+		public ServletTemplateEngine servletTemplateEngine() {
+			// initialize the template engine
+			ServletTemplateEngine engine = new ServletTemplateEngine(config());
+			// set layout strategy
+			List<String> layouts = new ArrayList<String>(1);
+			layouts.add(env.getProperty("layout", DEFAULT_LAYOUT));
+			engine.layoutStrategy_$eq(new DefaultLayoutStrategy(engine,
+					JavaConversions.asScalaBuffer(layouts)));
+			return engine;
+		}
+	}
+
+	@Configuration
+	@ConditionalOnClass({ Servlet.class })
+	protected static class ScalateViewResolverConfiguration implements EnvironmentAware {
+
+		@Autowired
+		private ServletTemplateEngine servletTemplateEngine;
+
+		private RelaxedPropertyResolver env;
+
+		@Override
+		public void setEnvironment(Environment environment) {
+			this.env = new RelaxedPropertyResolver(environment, "spring.scalate.");
+		}
+
+		@Bean
+		@ConditionalOnMissingBean(name = "scalateViewResolver")
+		public ScalateViewResolver scalateViewResolver() {
+			ScalateViewResolver resolver = new ScalateViewResolver();
+			resolver.templateEngine_$eq(servletTemplateEngine);
+			resolver.setOrder(Ordered.LOWEST_PRECEDENCE - 20);
+			resolver.setPrefix(env.getProperty("prefix", DEFAULT_PREFIX));
+			resolver.setSuffix(env.getProperty("suffix", DEFAULT_SUFFIX));
+			return resolver;
+		}
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -21,6 +21,7 @@ org.springframework.boot.autoconfigure.mobile.DeviceResolverAutoConfiguration,\
 org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,\
 org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,\
 org.springframework.boot.autoconfigure.reactor.ReactorAutoConfiguration,\
+org.springframework.boot.autoconfigure.scalate.ScalateAutoConfiguration,\
 org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration,\
 org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/scalate/ScalateAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/scalate/ScalateAutoConfigurationTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.scalate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletContext;
+
+import org.fusesource.scalate.servlet.ServletTemplateEngine;
+import org.fusesource.scalate.spring.view.ScalateViewResolver;
+import org.fusesource.scalate.support.UriTemplateSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.view.AbstractUrlBasedView;
+
+/**
+ * Tests for {@link ScalateAutoConfiguration}.
+ * 
+ * @author Christoph Nagel
+ */
+public class ScalateAutoConfigurationTests {
+
+	AnnotationConfigWebApplicationContext context;
+
+	/**
+	 * Initializes the application and servlet context.
+	 */
+	@Before
+	public void initContext() {
+		context = new AnnotationConfigWebApplicationContext();
+		ServletContext servletContext = new MockServletContext("");
+		servletContext.setAttribute(
+				WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, context);
+		context.setServletContext(servletContext);
+		context.register(ScalateAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		context.refresh();
+	}
+
+	@After
+	public void closeContext() {
+		context.close();
+	}
+
+	/**
+	 * Checks if the template engine is able to find requested files.
+	 */
+	@Test
+	public void test_ServletTemplateEngine() {
+		ServletTemplateEngine engine = context.getBean(ServletTemplateEngine.class);
+		UriTemplateSource source = engine.uriToSource("templates/scalate_view.scaml");
+		assertTrue(source.delegate().toFile().get().exists());
+	}
+
+	/**
+	 * Renders the scalate_view.scaml template without layout.
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void test_ScalateViewResolver_default() throws Exception {
+		Map<String, Object> model = new HashMap<String, Object>();
+		model.put("name", "Foo");
+		// render
+		String output = render("scalate_view", model);
+		// check output
+		assertEquals("<p>Hello Foo</p>", output);
+	}
+
+	/**
+	 * Renders the scalate_view.scaml template with layout.scaml
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void test_ScalateViewResolver_layout() throws Exception {
+		// render
+		String output = render("layout:scalate_view", new HashMap<String, Object>());
+		// check output
+		assertTrue(output.contains("<p>Hello Unknown</p>"));
+		assertTrue(output.startsWith("<!DOCTYPE html>"));
+	}
+
+	/**
+	 * Renders the scalate_view.scaml template with layout.jade
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void test_ScalateViewResolver_customized() throws Exception {
+		// set specific parameters
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("spring.scalate.suffix", "");
+		map.put("spring.scalate.layout", "templates/layout.jade");
+		context.getEnvironment().getPropertySources().addFirst(
+				new MapPropertySource("test", map));
+		context.refresh();
+		// render
+		String output = render("layout:scalate_view.scaml", new HashMap<String, Object>());
+		// check output
+		assertTrue(output.contains("<p>Hello Unknown</p>"));
+		assertTrue(output.startsWith("<!DOCTYPE html>"));
+	}
+
+	/**
+	 * Helper to render a view
+	 * 
+	 * @param viewUrl The view name
+	 * @param model The model accessible in the view by attributes
+	 * @return The rendered view output
+	 * @throws Exception
+	 */
+	protected String render(String viewUrl, Map<String, Object> model) throws Exception {
+		// get resolver
+		ScalateViewResolver resolver = context.getBean(ScalateViewResolver.class);
+		// get view
+		AbstractUrlBasedView view = resolver.buildView(viewUrl);
+		// initialize view
+		view.setApplicationContext(context);
+		MockHttpServletRequest request = new MockHttpServletRequest(
+				context.getServletContext());
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		// render view
+		view.render(model, request, response);
+		return response.getContentAsString().trim();
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/resources/templates/layout.jade
+++ b/spring-boot-autoconfigure/src/test/resources/templates/layout.jade
@@ -1,0 +1,9 @@
+-@ var body: String
+-@ var title: String = "Default title"
+
+!!! 5
+html
+	head
+		title= title
+	body
+		= unescape(body)

--- a/spring-boot-autoconfigure/src/test/resources/templates/layout.scaml
+++ b/spring-boot-autoconfigure/src/test/resources/templates/layout.scaml
@@ -1,0 +1,9 @@
+-@ var body: String
+-@ var title: String = "Default title"
+
+!!! 5
+%html
+	%head
+		%title= title
+	%body
+		= unescape(body)

--- a/spring-boot-autoconfigure/src/test/resources/templates/scalate_view.scaml
+++ b/spring-boot-autoconfigure/src/test/resources/templates/scalate_view.scaml
@@ -1,0 +1,4 @@
+- attributes("title") = "Home"
+-@ var name: String = "Unknown"
+
+%p Hello #{name}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -55,6 +55,7 @@
 		<thymeleaf-extras-springsecurity3.version>2.1.1.RELEASE</thymeleaf-extras-springsecurity3.version>
 		<thymeleaf-layout-dialect.version>1.2.1</thymeleaf-layout-dialect.version>
 		<tomcat.version>7.0.47</tomcat.version>
+		<scalate.version>1.6.1</scalate.version>
 	</properties>
 	<prerequisites>
 		<maven>3.0.0</maven>
@@ -246,6 +247,11 @@
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-annotations</artifactId>
 				<version>${jetty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.fusesource.scalate</groupId>
+				<artifactId>scalate-spring-mvc_2.10</artifactId>
+				<version>${scalate.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Hello Spring boot team,

I implemented an auto configuration for the scalate template engine to support more view formats making web development much easier.
Therefore I used the *scalate-spring-mvc_2.10* maven module.
The commit contains the auto configuration class and some tests with resource files.

Regards,
Christoph.