### PR TITLE
Re-enable @ConfigurationProperties to bind uppercase OS environment variable

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/bind/PropertiesConfigurationFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/bind/PropertiesConfigurationFactory.java
@@ -253,17 +253,16 @@ public class PropertiesConfigurationFactory<T> implements FactoryBean<T>,
 		if (this.target != null) {
 			PropertyDescriptor[] descriptors = BeanUtils
 					.getPropertyDescriptors(this.target.getClass());
-			String[] prefixes = this.targetName != null ? new String[] {
-					this.targetName + ".", this.targetName + "_" } : new String[] { "" };
+			String prefix = this.targetName != null ? this.targetName + "." : "";
 			String[] suffixes = new String[] { ".*", "_*" };
 			for (PropertyDescriptor descriptor : descriptors) {
 				String name = descriptor.getName();
 				if (!name.equals("class")) {
-					for (String prefix : prefixes) {
-						names.add(prefix + name);
-						patterns.add(prefix + name);
+					for(String relaxedName : new RelaxedNames(prefix + name)) {
+						names.add(relaxedName);
+						patterns.add(relaxedName);
 						for (String suffix : suffixes) {
-							patterns.add(prefix + name + suffix);
+							patterns.add(relaxedName + suffix);
 						}
 					}
 				}


### PR DESCRIPTION
This was working before in 0.5.0.M6.
I've changed `PropertiesConfigurationFactory` to use `RelaxedNames`, like in `RelaxedDataBinder`, to test for values to bind from Java system properties or OS environment variables. This allows for instance `SERVER_PORT` to be bound to `ServerProperties#port`.

Fixes #387
