### PR TITLE
Make Spring Boot tests locale independent

### DIFF
--- a/spring-boot-cli/src/test/java/org/springframework/boot/cli/compiler/grape/DetailedProgressReporterTests.java
+++ b/spring-boot-cli/src/test/java/org/springframework/boot/cli/compiler/grape/DetailedProgressReporterTests.java
@@ -69,7 +69,7 @@ public final class DetailedProgressReporterTests {
 		this.session.getTransferListener().transferSucceeded(completedEvent);
 
 		assertTrue(new String(this.baos.toByteArray()).matches(String.format(
-				"Downloaded: %s%s \\(4KB at [0-9]+\\.[0-9]KB/sec\\)\\n", REPOSITORY,
+				"Downloaded: %s%s \\(4KB at [0-9]+(\\.|,)[0-9]KB/sec\\)\\n", REPOSITORY,
 				ARTIFACT)));
 	}
 }

--- a/spring-boot/src/test/java/org/springframework/boot/logging/java/JavaLoggerSystemTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/logging/java/JavaLoggerSystemTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.logging.java;
 
 import java.io.IOException;
+import java.util.Locale;
 
 import org.apache.commons.logging.impl.Jdk14Logger;
 import org.junit.After;
@@ -47,8 +48,12 @@ public class JavaLoggerSystemTests {
 
 	private Jdk14Logger logger;
 
+	private Locale defaultLocale;
+
 	@Before
 	public void init() throws SecurityException, IOException {
+		defaultLocale = Locale.getDefault();
+		Locale.setDefault(Locale.ENGLISH);
 		this.logger = new Jdk14Logger(getClass().getName());
 	}
 
@@ -57,6 +62,7 @@ public class JavaLoggerSystemTests {
 		System.clearProperty("LOG_FILE");
 		System.clearProperty("LOG_PATH");
 		System.clearProperty("PID");
+		Locale.setDefault(defaultLocale);
 	}
 
 	@Test


### PR DESCRIPTION
Before these changes, Spring Boot build failed on my computer configured with french default locale.
With these changes, they succeed in both french and english locales, and tests are more locale independent.

I did not find other way to change Java logger locale than changing the default one in JavaLoggerSystemTests. I hope this is fine for you.
