### PR TITLE
Support for testWhileIdle, timeBetweenEvictionRunsMillis and minEvictableIdleTimeMillis parameters

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/AbstractDataSourceConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/AbstractDataSourceConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Base class for configuration of a database pool.
- * 
+ *
  * @author Dave Syer
  */
 @ConfigurationProperties(name = DataSourceAutoConfiguration.CONFIGURATION_PREFIX)
@@ -55,13 +55,13 @@ public abstract class AbstractDataSourceConfiguration implements BeanClassLoader
 
 	private boolean testOnReturn = false;
 
-    private boolean testWhileIdle = false;
+	private boolean testWhileIdle = false;
 
-    private int timeBetweenEvictionRunsMillis = getDefaultTimeBetweenEvictionRunsMillis();
+	private int timeBetweenEvictionRunsMillis = getDefaultTimeBetweenEvictionRunsMillis();
 
-    private int minEvictableIdleTimeMillis = getDefaultMinEvictableIdleTimeMillis();
+	private int minEvictableIdleTimeMillis = getDefaultMinEvictableIdleTimeMillis();
 
-    private ClassLoader classLoader;
+	private ClassLoader classLoader;
 
 	private EmbeddedDatabaseConnection embeddedDatabaseConnection = EmbeddedDatabaseConnection.NONE;
 
@@ -170,17 +170,19 @@ public abstract class AbstractDataSourceConfiguration implements BeanClassLoader
 		this.testOnReturn = testOnReturn;
 	}
 
-    public void setTestWhileIdle(boolean testWhileIdle) { this.testWhileIdle = testWhileIdle; }
+	public void setTestWhileIdle(boolean testWhileIdle) {
+		this.testWhileIdle = testWhileIdle;
+	}
 
-    public void setTimeBetweenEvictionRunsMillis(int timeBetweenEvictionRunsMillis) {
-        this.timeBetweenEvictionRunsMillis = timeBetweenEvictionRunsMillis;
-    }
+	public void setTimeBetweenEvictionRunsMillis(int timeBetweenEvictionRunsMillis) {
+		this.timeBetweenEvictionRunsMillis = timeBetweenEvictionRunsMillis;
+	}
 
-    public void setMinEvictableIdleTimeMillis(int minEvictableIdleTimeMillis) {
-        this.minEvictableIdleTimeMillis = minEvictableIdleTimeMillis;
-    }
+	public void setMinEvictableIdleTimeMillis(int minEvictableIdleTimeMillis) {
+		this.minEvictableIdleTimeMillis = minEvictableIdleTimeMillis;
+	}
 
-    public int getInitialSize() {
+	public int getInitialSize() {
 		return this.initialSize;
 	}
 
@@ -208,14 +210,16 @@ public abstract class AbstractDataSourceConfiguration implements BeanClassLoader
 		return this.testOnReturn;
 	}
 
-    protected boolean isTestWhileIdle() { return this.testWhileIdle; }
+	protected boolean isTestWhileIdle() {
+		return this.testWhileIdle;
+	}
 
-    protected int getTimeBetweenEvictionRunsMillis() { return this.timeBetweenEvictionRunsMillis; }
+	protected int getTimeBetweenEvictionRunsMillis() { return this.timeBetweenEvictionRunsMillis; }
 
-    protected int getMinEvictableIdleTimeMillis() { return this.minEvictableIdleTimeMillis; }
+	protected int getMinEvictableIdleTimeMillis() { return this.minEvictableIdleTimeMillis; }
 
-    protected abstract int getDefaultTimeBetweenEvictionRunsMillis();
+	protected abstract int getDefaultTimeBetweenEvictionRunsMillis();
 
-    protected abstract int getDefaultMinEvictableIdleTimeMillis();
+	protected abstract int getDefaultMinEvictableIdleTimeMillis();
 
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/CommonsDataSourceConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/CommonsDataSourceConfiguration.java
@@ -32,7 +32,7 @@ import org.springframework.dao.DataAccessResourceFailureException;
 /**
  * Configuration for a Commons DBCP database pool. The DBCP pool is popular but not
  * recommended in high volume environments (the Tomcat DataSource is more reliable).
- * 
+ *
  * @author Dave Syer
  * @see DataSourceAutoConfiguration
  */
@@ -67,9 +67,9 @@ public class CommonsDataSourceConfiguration extends AbstractDataSourceConfigurat
 		this.pool.setMinIdle(getMinIdle());
 		this.pool.setTestOnBorrow(isTestOnBorrow());
 		this.pool.setTestOnReturn(isTestOnReturn());
-        this.pool.setTestWhileIdle(isTestWhileIdle());
-        this.pool.setTimeBetweenEvictionRunsMillis(getTimeBetweenEvictionRunsMillis());
-        this.pool.setMinEvictableIdleTimeMillis(getMinEvictableIdleTimeMillis());
+		this.pool.setTestWhileIdle(isTestWhileIdle());
+		this.pool.setTimeBetweenEvictionRunsMillis(getTimeBetweenEvictionRunsMillis());
+		this.pool.setMinEvictableIdleTimeMillis(getMinEvictableIdleTimeMillis());
 		this.pool.setValidationQuery(getValidationQuery());
 
 		return this.pool;
@@ -80,21 +80,20 @@ public class CommonsDataSourceConfiguration extends AbstractDataSourceConfigurat
 		if (this.pool != null) {
 			try {
 				this.pool.close();
-			}
-			catch (SQLException ex) {
+			} catch (SQLException ex) {
 				throw new DataAccessResourceFailureException(
 						"Could not close data source", ex);
 			}
 		}
 	}
 
-    @Override
-    protected int getDefaultTimeBetweenEvictionRunsMillis() {
-        return (int) GenericObjectPool.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS;
-    }
+	@Override
+	protected int getDefaultTimeBetweenEvictionRunsMillis() {
+		return (int) GenericObjectPool.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS;
+	}
 
-    @Override
-    protected int getDefaultMinEvictableIdleTimeMillis() {
-        return (int) GenericObjectPool.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS;
-    }
+	@Override
+	protected int getDefaultMinEvictableIdleTimeMillis() {
+		return (int) GenericObjectPool.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS;
+	}
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/TomcatDataSourceConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/TomcatDataSourceConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Configuration;
 /**
  * Configuration for a Tomcat database pool. The Tomcat pool provides superior performance
  * and tends not to deadlock in high volume environments.
- * 
+ *
  * @author Dave Syer
  * @see DataSourceAutoConfiguration
  */
@@ -51,9 +51,9 @@ public class TomcatDataSourceConfiguration extends AbstractDataSourceConfigurati
 		this.pool.setMinIdle(getMinIdle());
 		this.pool.setTestOnBorrow(isTestOnBorrow());
 		this.pool.setTestOnReturn(isTestOnReturn());
-        this.pool.setTestWhileIdle(isTestWhileIdle());
-        this.pool.setTimeBetweenEvictionRunsMillis(getTimeBetweenEvictionRunsMillis());
-        this.pool.setMinEvictableIdleTimeMillis(getMinEvictableIdleTimeMillis());
+		this.pool.setTestWhileIdle(isTestWhileIdle());
+		this.pool.setTimeBetweenEvictionRunsMillis(getTimeBetweenEvictionRunsMillis());
+		this.pool.setMinEvictableIdleTimeMillis(getMinEvictableIdleTimeMillis());
 		this.pool.setValidationQuery(getValidationQuery());
 		return this.pool;
 	}
@@ -65,13 +65,13 @@ public class TomcatDataSourceConfiguration extends AbstractDataSourceConfigurati
 		}
 	}
 
-    @Override
-    protected int getDefaultTimeBetweenEvictionRunsMillis() {
-        return 5000;
-    }
+	@Override
+	protected int getDefaultTimeBetweenEvictionRunsMillis() {
+		return 5000;
+	}
 
-    @Override
-    protected int getDefaultMinEvictableIdleTimeMillis() {
-        return 60000;
-    }
+	@Override
+	protected int getDefaultMinEvictableIdleTimeMillis() {
+		return 60000;
+	}
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/CommonsDataSourceConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/CommonsDataSourceConfigurationTests.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests for {@link CommonsDataSourceConfiguration}.
- * 
+ *
  * @author Dave Syer
  */
 public class CommonsDataSourceConfigurationTests {
@@ -44,32 +44,32 @@ public class CommonsDataSourceConfigurationTests {
 		this.context.close();
 	}
 
-    @Test
-    public void testDataSourcePropertiesOverridden() throws Exception {
-        this.context.register(CommonsDataSourceConfiguration.class);
-        EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.url:jdbc:foo//bar/spam");
-        EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.testWhileIdle:true");
-        EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.testOnBorrow:true");
-        EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.testOnReturn:true");
-        EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.timeBetweenEvictionRunsMillis:10000");
-        EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.minEvictableIdleTimeMillis:12345");
-        this.context.refresh();
-        BasicDataSource ds = this.context.getBean(BasicDataSource.class);
-        assertEquals("jdbc:foo//bar/spam", ds.getUrl());
-        assertEquals(true, ds.getTestWhileIdle());
-        assertEquals(true, ds.getTestOnBorrow());
-        assertEquals(true, ds.getTestOnReturn());
-        assertEquals(10000, ds.getTimeBetweenEvictionRunsMillis());
-        assertEquals(12345, ds.getMinEvictableIdleTimeMillis());
-    }
+	@Test
+	public void testDataSourcePropertiesOverridden() throws Exception {
+		this.context.register(CommonsDataSourceConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.url:jdbc:foo//bar/spam");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.testWhileIdle:true");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.testOnBorrow:true");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.testOnReturn:true");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.timeBetweenEvictionRunsMillis:10000");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.minEvictableIdleTimeMillis:12345");
+		this.context.refresh();
+		BasicDataSource ds = this.context.getBean(BasicDataSource.class);
+		assertEquals("jdbc:foo//bar/spam", ds.getUrl());
+		assertEquals(true, ds.getTestWhileIdle());
+		assertEquals(true, ds.getTestOnBorrow());
+		assertEquals(true, ds.getTestOnReturn());
+		assertEquals(10000, ds.getTimeBetweenEvictionRunsMillis());
+		assertEquals(12345, ds.getMinEvictableIdleTimeMillis());
+	}
 
-    @Test
-    public void testDataSourceDefaultsPreserved() throws Exception {
-        this.context.register(CommonsDataSourceConfiguration.class);
-        this.context.refresh();
-        BasicDataSource ds = this.context.getBean(BasicDataSource.class);
-        assertEquals(GenericObjectPool.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS, ds.getTimeBetweenEvictionRunsMillis());
-        assertEquals(GenericObjectPool.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS, ds.getMinEvictableIdleTimeMillis());
-    }
+	@Test
+	public void testDataSourceDefaultsPreserved() throws Exception {
+		this.context.register(CommonsDataSourceConfiguration.class);
+		this.context.refresh();
+		BasicDataSource ds = this.context.getBean(BasicDataSource.class);
+		assertEquals(GenericObjectPool.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS, ds.getTimeBetweenEvictionRunsMillis());
+		assertEquals(GenericObjectPool.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS, ds.getMinEvictableIdleTimeMillis());
+	}
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/TomcatDataSourceConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/TomcatDataSourceConfigurationTests.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests for {@link TomcatDataSourceConfiguration}.
- * 
+ *
  * @author Dave Syer
  */
 public class TomcatDataSourceConfigurationTests {
@@ -57,29 +57,29 @@ public class TomcatDataSourceConfigurationTests {
 	public void testDataSourcePropertiesOverridden() throws Exception {
 		this.context.register(TomcatDataSourceConfiguration.class);
 		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.url:jdbc:foo//bar/spam");
-        EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.testWhileIdle:true");
-        EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.testOnBorrow:true");
-        EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.testOnReturn:true");
-        EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.timeBetweenEvictionRunsMillis:10000");
-        EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.minEvictableIdleTimeMillis:12345");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.testWhileIdle:true");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.testOnBorrow:true");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.testOnReturn:true");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.timeBetweenEvictionRunsMillis:10000");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.minEvictableIdleTimeMillis:12345");
 		this.context.refresh();
-        org.apache.tomcat.jdbc.pool.DataSource ds = this.context.getBean(org.apache.tomcat.jdbc.pool.DataSource.class);
-        assertEquals("jdbc:foo//bar/spam", ds.getUrl());
-        assertEquals(true, ds.isTestWhileIdle());
-        assertEquals(true, ds.isTestOnBorrow());
-        assertEquals(true, ds.isTestOnReturn());
-        assertEquals(10000, ds.getTimeBetweenEvictionRunsMillis());
-        assertEquals(12345, ds.getMinEvictableIdleTimeMillis());
+		org.apache.tomcat.jdbc.pool.DataSource ds = this.context.getBean(org.apache.tomcat.jdbc.pool.DataSource.class);
+		assertEquals("jdbc:foo//bar/spam", ds.getUrl());
+		assertEquals(true, ds.isTestWhileIdle());
+		assertEquals(true, ds.isTestOnBorrow());
+		assertEquals(true, ds.isTestOnReturn());
+		assertEquals(10000, ds.getTimeBetweenEvictionRunsMillis());
+		assertEquals(12345, ds.getMinEvictableIdleTimeMillis());
 	}
 
-    @Test
-    public void testDataSourceDefaultsPreserved() throws Exception {
-        this.context.register(TomcatDataSourceConfiguration.class);
-        this.context.refresh();
-        org.apache.tomcat.jdbc.pool.DataSource ds = this.context.getBean(org.apache.tomcat.jdbc.pool.DataSource.class);
-        assertEquals(5000, ds.getTimeBetweenEvictionRunsMillis());
-        assertEquals(60000, ds.getMinEvictableIdleTimeMillis());
-    }
+	@Test
+	public void testDataSourceDefaultsPreserved() throws Exception {
+		this.context.register(TomcatDataSourceConfiguration.class);
+		this.context.refresh();
+		org.apache.tomcat.jdbc.pool.DataSource ds = this.context.getBean(org.apache.tomcat.jdbc.pool.DataSource.class);
+		assertEquals(5000, ds.getTimeBetweenEvictionRunsMillis());
+		assertEquals(60000, ds.getMinEvictableIdleTimeMillis());
+	}
 
 	@Test(expected = BeanCreationException.class)
 	public void testBadUrl() throws Exception {


### PR DESCRIPTION
Tomcat connection pool (and dbcp) has possibility to test connections while idle, instead of onBorrow/onReturn but parameters needed to fine tune this feature were not read from application.properties.
This pull request adds support for testWhileIdle, timeBetweenEvictionRunsMillis and minEvictableTimeMillis respecting the differences in default values between DBCP and Tomcat Connection Pool.
