### PR TITLE
support for maxWait, jdbcInterceptors and validationInterval

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/AbstractDataSourceConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/AbstractDataSourceConfiguration.java
@@ -61,6 +61,8 @@ public abstract class AbstractDataSourceConfiguration implements BeanClassLoader
 
 	private int minEvictableIdleTimeMillis = getDefaultMinEvictableIdleTimeMillis();
 
+	private int maxWaitMillis = getDefaultMaxWaitMillis();
+
 	private ClassLoader classLoader;
 
 	private EmbeddedDatabaseConnection embeddedDatabaseConnection = EmbeddedDatabaseConnection.NONE;
@@ -182,6 +184,8 @@ public abstract class AbstractDataSourceConfiguration implements BeanClassLoader
 		this.minEvictableIdleTimeMillis = minEvictableIdleTimeMillis;
 	}
 
+	public void setMaxWait(int maxWaitMillis) { this.maxWaitMillis = maxWaitMillis; }
+
 	public int getInitialSize() {
 		return this.initialSize;
 	}
@@ -218,8 +222,11 @@ public abstract class AbstractDataSourceConfiguration implements BeanClassLoader
 
 	protected int getMinEvictableIdleTimeMillis() { return this.minEvictableIdleTimeMillis; }
 
+	protected int getMaxWaitMillis() { return this.maxWaitMillis; }
+
 	protected abstract int getDefaultTimeBetweenEvictionRunsMillis();
 
 	protected abstract int getDefaultMinEvictableIdleTimeMillis();
 
+	protected abstract int getDefaultMaxWaitMillis();
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/CommonsDataSourceConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/CommonsDataSourceConfiguration.java
@@ -71,7 +71,7 @@ public class CommonsDataSourceConfiguration extends AbstractDataSourceConfigurat
 		this.pool.setTimeBetweenEvictionRunsMillis(getTimeBetweenEvictionRunsMillis());
 		this.pool.setMinEvictableIdleTimeMillis(getMinEvictableIdleTimeMillis());
 		this.pool.setValidationQuery(getValidationQuery());
-
+		this.pool.setMaxWait(getMaxWaitMillis());
 		return this.pool;
 	}
 
@@ -95,5 +95,10 @@ public class CommonsDataSourceConfiguration extends AbstractDataSourceConfigurat
 	@Override
 	protected int getDefaultMinEvictableIdleTimeMillis() {
 		return (int) GenericObjectPool.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS;
+	}
+
+	@Override
+	protected int getDefaultMaxWaitMillis() {
+		return (int) GenericObjectPool.DEFAULT_MAX_WAIT;
 	}
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/TomcatDataSourceConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/TomcatDataSourceConfiguration.java
@@ -32,6 +32,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class TomcatDataSourceConfiguration extends AbstractDataSourceConfiguration {
 
+	private String jdbcInterceptors;
+	private long validationInterval = 30000;
 	private org.apache.tomcat.jdbc.pool.DataSource pool;
 
 	@Bean(destroyMethod = "close")
@@ -55,6 +57,11 @@ public class TomcatDataSourceConfiguration extends AbstractDataSourceConfigurati
 		this.pool.setTimeBetweenEvictionRunsMillis(getTimeBetweenEvictionRunsMillis());
 		this.pool.setMinEvictableIdleTimeMillis(getMinEvictableIdleTimeMillis());
 		this.pool.setValidationQuery(getValidationQuery());
+		this.pool.setValidationInterval(this.validationInterval);
+		this.pool.setMaxWait(getMaxWaitMillis());
+		if (jdbcInterceptors != null) {
+			this.pool.setJdbcInterceptors(this.jdbcInterceptors);
+		}
 		return this.pool;
 	}
 
@@ -74,4 +81,13 @@ public class TomcatDataSourceConfiguration extends AbstractDataSourceConfigurati
 	protected int getDefaultMinEvictableIdleTimeMillis() {
 		return 60000;
 	}
+
+	@Override
+	protected int getDefaultMaxWaitMillis() {
+		return 30000;
+	}
+
+	public void setJdbcInterceptors(String jdbcInterceptors) { this.jdbcInterceptors = jdbcInterceptors; }
+
+	public void setValidationInterval(long validationInterval) { this.validationInterval = validationInterval; }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/CommonsDataSourceConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/CommonsDataSourceConfigurationTests.java
@@ -53,6 +53,7 @@ public class CommonsDataSourceConfigurationTests {
 		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.testOnReturn:true");
 		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.timeBetweenEvictionRunsMillis:10000");
 		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.minEvictableIdleTimeMillis:12345");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.maxWait:1234");
 		this.context.refresh();
 		BasicDataSource ds = this.context.getBean(BasicDataSource.class);
 		assertEquals("jdbc:foo//bar/spam", ds.getUrl());
@@ -61,6 +62,7 @@ public class CommonsDataSourceConfigurationTests {
 		assertEquals(true, ds.getTestOnReturn());
 		assertEquals(10000, ds.getTimeBetweenEvictionRunsMillis());
 		assertEquals(12345, ds.getMinEvictableIdleTimeMillis());
+		assertEquals(1234, ds.getMaxWait());
 	}
 
 	@Test
@@ -70,6 +72,7 @@ public class CommonsDataSourceConfigurationTests {
 		BasicDataSource ds = this.context.getBean(BasicDataSource.class);
 		assertEquals(GenericObjectPool.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS, ds.getTimeBetweenEvictionRunsMillis());
 		assertEquals(GenericObjectPool.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS, ds.getMinEvictableIdleTimeMillis());
+		assertEquals(GenericObjectPool.DEFAULT_MAX_WAIT, ds.getMaxWait());
 	}
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/TomcatDataSourceConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/TomcatDataSourceConfigurationTests.java
@@ -20,6 +20,9 @@ import java.lang.reflect.Field;
 
 import javax.sql.DataSource;
 
+import org.apache.tomcat.jdbc.pool.DataSourceProxy;
+import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.apache.tomcat.jdbc.pool.interceptor.SlowQueryReport;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.BeanCreationException;
@@ -30,6 +33,7 @@ import org.springframework.util.ReflectionUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link TomcatDataSourceConfiguration}.
@@ -62,6 +66,9 @@ public class TomcatDataSourceConfigurationTests {
 		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.testOnReturn:true");
 		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.timeBetweenEvictionRunsMillis:10000");
 		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.minEvictableIdleTimeMillis:12345");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.maxWait:1234");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.jdbcInterceptors:SlowQueryReport");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.validationInterval:9999");
 		this.context.refresh();
 		org.apache.tomcat.jdbc.pool.DataSource ds = this.context.getBean(org.apache.tomcat.jdbc.pool.DataSource.class);
 		assertEquals("jdbc:foo//bar/spam", ds.getUrl());
@@ -70,6 +77,19 @@ public class TomcatDataSourceConfigurationTests {
 		assertEquals(true, ds.isTestOnReturn());
 		assertEquals(10000, ds.getTimeBetweenEvictionRunsMillis());
 		assertEquals(12345, ds.getMinEvictableIdleTimeMillis());
+		assertEquals(1234, ds.getMaxWait());
+		assertEquals(9999L, ds.getValidationInterval());
+		assertDataSourceHasInterceptors(ds);
+	}
+
+	private void assertDataSourceHasInterceptors(DataSourceProxy ds) throws ClassNotFoundException {
+		PoolProperties.InterceptorDefinition[] interceptors = ds.getJdbcInterceptorsAsArray();
+		for (PoolProperties.InterceptorDefinition interceptor : interceptors) {
+			if (SlowQueryReport.class == interceptor.getInterceptorClass()) {
+				return;
+			}
+		}
+		fail("SlowQueryReport interceptor should have been set.");
 	}
 
 	@Test
@@ -79,6 +99,8 @@ public class TomcatDataSourceConfigurationTests {
 		org.apache.tomcat.jdbc.pool.DataSource ds = this.context.getBean(org.apache.tomcat.jdbc.pool.DataSource.class);
 		assertEquals(5000, ds.getTimeBetweenEvictionRunsMillis());
 		assertEquals(60000, ds.getMinEvictableIdleTimeMillis());
+		assertEquals(30000, ds.getMaxWait());
+		assertEquals(30000L, ds.getValidationInterval());
 	}
 
 	@Test(expected = BeanCreationException.class)


### PR DESCRIPTION
This PR add support for some additional jdbc connection pool settings useful in highly concurrent environments: maxWait, jdbcInterceptors and validationInterval.
