### PR TITLE
Fix typo in ConfigFileAppListener#addProper(=>t)ySources

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
@@ -132,7 +132,7 @@ public class ConfigFileApplicationListener implements
 
 	private void onApplicationEnvironmentPreparedEvent(
 			ConfigurableEnvironment environment, SpringApplication application) {
-		addProperySources(environment);
+		addPropertySources(environment);
 		bindToSpringApplication(environment, application);
 	}
 
@@ -145,7 +145,7 @@ public class ConfigFileApplicationListener implements
 	 * @param environment the environment to add source to
 	 * @see #addPostProcessors(ConfigurableApplicationContext)
 	 */
-	protected void addProperySources(ConfigurableEnvironment environment) {
+	protected void addPropertySources(ConfigurableEnvironment environment) {
 		RandomValuePropertySource.addToEnvironment(environment);
 		try {
 			PropertySource<?> defaultProperties = environment.getPropertySources()

--- a/spring-boot/src/main/java/org/springframework/boot/test/ConfigFileApplicationContextInitializer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/test/ConfigFileApplicationContextInitializer.java
@@ -36,7 +36,7 @@ public class ConfigFileApplicationContextInitializer implements
 	public void initialize(final ConfigurableApplicationContext applicationContext) {
 		new ConfigFileApplicationListener() {
 			public void apply() {
-				addProperySources(applicationContext.getEnvironment());
+				addPropertySources(applicationContext.getEnvironment());
 				addPostProcessors(applicationContext);
 			}
 		}.apply();


### PR DESCRIPTION
Note that LoggingApplicationListenerTests#overrideConfigLocation fails
for me against these changes, but it also fails against master, so
appears unrelated.
