### PR TITLE
Refactor SpringApplication#setupProfiles and #addPropertySources methods

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -269,8 +269,7 @@ public class SpringApplication {
 		try {
 			// Create and configure the environment
 			ConfigurableEnvironment environment = getOrCreateEnvironment();
-			addPropertySources(environment, args);
-			setupProfiles(environment);
+			configureEnvironment(environment, args);
 			for (SpringApplicationRunListener runListener : runListeners) {
 				runListener.environmentPrepared(environment);
 			}
@@ -382,11 +381,28 @@ public class SpringApplication {
 	}
 
 	/**
-	 * Add any {@link PropertySource}s to the environment.
-	 * @param environment the environment
-	 * @param args run arguments
+	 * Template method delegating to
+	 * {@link #configurePropertySources(ConfigurableEnvironment, String[])} and
+	 * {@link #configureProfiles(ConfigurableEnvironment, String[])} in that order. Override
+	 * this method for complete control over Environment customization, or one of the above
+	 * for fine-grained control over property sources or profiles, respectively.
+	 * @param environment this application's environment
+	 * @param args arguments passed to the {@code run} method
+	 * @see #configurePropertySources(ConfigurableEnvironment, String[])
+	 * @see #configureProfiles(ConfigurableEnvironment, String[])
 	 */
-	protected void addPropertySources(ConfigurableEnvironment environment, String[] args) {
+	protected void configureEnvironment(ConfigurableEnvironment environment, String[] args) {
+		configurePropertySources(environment, args);
+		configureProfiles(environment, args);
+	}
+
+	/**
+	 * Add, remove or re-order any {@link PropertySource}s in this application's environment.
+	 * @param environment this application's environment
+	 * @param args arguments passed to the {@code run} method
+	 * @see #configureEnvironment(ConfigurableEnvironment, String[])
+	 */
+	protected void configurePropertySources(ConfigurableEnvironment environment, String[] args) {
 		MutablePropertySources sources = environment.getPropertySources();
 		if (this.defaultProperties != null && !this.defaultProperties.isEmpty()) {
 			sources.addLast(new MapPropertySource("defaultProperties",
@@ -409,10 +425,14 @@ public class SpringApplication {
 	}
 
 	/**
-	 * Setup any active profiles on the environment.
-	 * @param environment the environment to configure
+	 * Configure which profiles are active (or active by default) for this application environment.
+	 * Consider overriding this method to programmatically enforce profile rules and semantics,
+	 * such as ensuring mutual exclusivity of profiles (e.g. 'dev' OR 'prod', but never both).
+	 * @param environment this application's environment
+	 * @param args arguments passed to the {@code run} method
+	 * @see #configureEnvironment(ConfigurableEnvironment, String[])
 	 */
-	protected void setupProfiles(ConfigurableEnvironment environment) {
+	protected void configureProfiles(ConfigurableEnvironment environment, String[] args) {
 		Set<String> profiles = new LinkedHashSet<String>();
 		environment.getActiveProfiles(); // ensure they are initialized
 		// But these ones should go first (last wins in a property key clash)


### PR DESCRIPTION
Here's one to consider prior to GA, especially given that it would be a breaking API change.

Regarding [SpringApplication#setupProfiles](https://github.com/spring-projects/spring-boot/blob/cd3d4b485d0c7cd6dbaaec7c17b4cbf90863762e/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java#L412):
- `configureX` vs. `setupX` is more aligned with existing naming conventions throughout the core framework.
- "setup" is not a verb.
- Configuring profiles is just one of the things a user could do with the `Environment` they're being handed (manipulating property sources would be another). Thus, `configureEnvironment` is a more accurate name.

As I was writing the above, I just noticed that there is also an [#addPropertySources](https://github.com/spring-projects/spring-boot/blob/cd3d4b485d0c7cd6dbaaec7c17b4cbf90863762e/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java#L385) method that accepts the `Environment` as well as the String[] of args passed to the `#run` method.

How about refactoring this arrangement as follows?
- Rename `#addPropertySources(Environment, String[])` to `#configurePropertySources(Environment, String[])` ("configure" is better here as well, given that property sources could be removed or reordered, not just "added").
- Rename `#setupProfiles(Environment)` to `#configureProfiles(Environment, String[])` (accept the String[] of args here too)
- Add `#configureEnvironment(Environment, String[])` as a template method that delegates to the above two methods in that order.
- Update [SpringApplication#run](https://github.com/spring-projects/spring-boot/blob/cd3d4b485d0c7cd6dbaaec7c17b4cbf90863762e/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java#L272) to call the new `#configureEnvironment` method instead of calling the former methods individually.
- Add JavaDoc `@see` references to each method to inform folks of the relationship between them.

I bring all of this up because we're now hooking into `#setupProfiles` in the Sagan application to codify and enforce our profile semantics, and we will be pointing users to it in blog posts and documentation. I was really glad to find this method—it suits our needs perfectly, and I could see using it becoming a best practice for apps that have anything beyond the most trivial profile arrangements.
