### PR TITLE
Better configuration of JDBC connection pools

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/CommonsDataSourceConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/CommonsDataSourceConfiguration.java
@@ -16,18 +16,16 @@
 
 package org.springframework.boot.autoconfigure.jdbc;
 
-import java.sql.SQLException;
-
-import javax.annotation.PreDestroy;
-import javax.sql.DataSource;
-
 import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.commons.pool.impl.GenericObjectPool;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.dao.DataAccessResourceFailureException;
+
+import javax.annotation.PreDestroy;
+import javax.sql.DataSource;
+import java.sql.SQLException;
 
 /**
  * Configuration for a Commons DBCP database pool. The DBCP pool is popular but not
@@ -44,34 +42,21 @@ public class CommonsDataSourceConfiguration extends AbstractDataSourceConfigurat
 	private BasicDataSource pool;
 
 	public CommonsDataSourceConfiguration() {
-		// Ensure to set the correct default value for Commons DBCP
-		setInitialSize(0);
 	}
 
 	@Bean(destroyMethod = "close")
-	public DataSource dataSource() {
+	public DataSource dataSource() throws Exception {
 		logger.info("Hint: using Commons DBCP BasicDataSource. It's going to work, "
 				+ "but the Tomcat DataSource is more reliable.");
 		this.pool = new BasicDataSource();
 		this.pool.setDriverClassName(getDriverClassName());
-		this.pool.setUrl(getUrl());
 		if (getUsername() != null) {
 			this.pool.setUsername(getUsername());
 		}
 		if (getPassword() != null) {
 			this.pool.setPassword(getPassword());
 		}
-		this.pool.setInitialSize(getInitialSize());
-		this.pool.setMaxActive(getMaxActive());
-		this.pool.setMaxIdle(getMaxIdle());
-		this.pool.setMinIdle(getMinIdle());
-		this.pool.setTestOnBorrow(isTestOnBorrow());
-		this.pool.setTestOnReturn(isTestOnReturn());
-		this.pool.setTestWhileIdle(isTestWhileIdle());
-		this.pool.setTimeBetweenEvictionRunsMillis(getTimeBetweenEvictionRunsMillis());
-		this.pool.setMinEvictableIdleTimeMillis(getMinEvictableIdleTimeMillis());
-		this.pool.setValidationQuery(getValidationQuery());
-		this.pool.setMaxWait(getMaxWaitMillis());
+		configurePoolUsingJavaBeanProperties(pool);
 		return this.pool;
 	}
 
@@ -81,24 +66,8 @@ public class CommonsDataSourceConfiguration extends AbstractDataSourceConfigurat
 			try {
 				this.pool.close();
 			} catch (SQLException ex) {
-				throw new DataAccessResourceFailureException(
-						"Could not close data source", ex);
+				throw new DataAccessResourceFailureException("Could not close data source", ex);
 			}
 		}
-	}
-
-	@Override
-	protected int getDefaultTimeBetweenEvictionRunsMillis() {
-		return (int) GenericObjectPool.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS;
-	}
-
-	@Override
-	protected int getDefaultMinEvictableIdleTimeMillis() {
-		return (int) GenericObjectPool.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS;
-	}
-
-	@Override
-	protected int getDefaultMaxWaitMillis() {
-		return (int) GenericObjectPool.DEFAULT_MAX_WAIT;
 	}
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/TomcatDataSourceConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/TomcatDataSourceConfiguration.java
@@ -16,11 +16,11 @@
 
 package org.springframework.boot.autoconfigure.jdbc;
 
-import javax.annotation.PreDestroy;
-import javax.sql.DataSource;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PreDestroy;
+import javax.sql.DataSource;
 
 /**
  * Configuration for a Tomcat database pool. The Tomcat pool provides superior performance
@@ -32,36 +32,19 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class TomcatDataSourceConfiguration extends AbstractDataSourceConfiguration {
 
-	private String jdbcInterceptors;
-	private long validationInterval = 30000;
 	private org.apache.tomcat.jdbc.pool.DataSource pool;
 
 	@Bean(destroyMethod = "close")
-	public DataSource dataSource() {
+	public DataSource dataSource() throws Exception {
 		this.pool = new org.apache.tomcat.jdbc.pool.DataSource();
 		this.pool.setDriverClassName(getDriverClassName());
-		this.pool.setUrl(getUrl());
 		if (getUsername() != null) {
 			this.pool.setUsername(getUsername());
 		}
 		if (getPassword() != null) {
 			this.pool.setPassword(getPassword());
 		}
-		this.pool.setInitialSize(getInitialSize());
-		this.pool.setMaxActive(getMaxActive());
-		this.pool.setMaxIdle(getMaxIdle());
-		this.pool.setMinIdle(getMinIdle());
-		this.pool.setTestOnBorrow(isTestOnBorrow());
-		this.pool.setTestOnReturn(isTestOnReturn());
-		this.pool.setTestWhileIdle(isTestWhileIdle());
-		this.pool.setTimeBetweenEvictionRunsMillis(getTimeBetweenEvictionRunsMillis());
-		this.pool.setMinEvictableIdleTimeMillis(getMinEvictableIdleTimeMillis());
-		this.pool.setValidationQuery(getValidationQuery());
-		this.pool.setValidationInterval(this.validationInterval);
-		this.pool.setMaxWait(getMaxWaitMillis());
-		if (jdbcInterceptors != null) {
-			this.pool.setJdbcInterceptors(this.jdbcInterceptors);
-		}
+		configurePoolUsingJavaBeanProperties(pool);
 		return this.pool;
 	}
 
@@ -71,23 +54,4 @@ public class TomcatDataSourceConfiguration extends AbstractDataSourceConfigurati
 			this.pool.close();
 		}
 	}
-
-	@Override
-	protected int getDefaultTimeBetweenEvictionRunsMillis() {
-		return 5000;
-	}
-
-	@Override
-	protected int getDefaultMinEvictableIdleTimeMillis() {
-		return 60000;
-	}
-
-	@Override
-	protected int getDefaultMaxWaitMillis() {
-		return 30000;
-	}
-
-	public void setJdbcInterceptors(String jdbcInterceptors) { this.jdbcInterceptors = jdbcInterceptors; }
-
-	public void setValidationInterval(long validationInterval) { this.validationInterval = validationInterval; }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/CommonsDataSourceConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/CommonsDataSourceConfigurationTests.java
@@ -16,16 +16,18 @@
 
 package org.springframework.boot.autoconfigure.jdbc;
 
-import javax.sql.DataSource;
-
 import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.pool.impl.GenericObjectPool;
 import org.junit.Test;
 import org.springframework.boot.test.EnvironmentTestUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
+import javax.sql.DataSource;
+import java.sql.Connection;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link CommonsDataSourceConfiguration}.
@@ -54,8 +56,20 @@ public class CommonsDataSourceConfigurationTests {
 		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.timeBetweenEvictionRunsMillis:10000");
 		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.minEvictableIdleTimeMillis:12345");
 		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.maxWait:1234");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.defaultAutoCommit:true");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.defaultReadOnly:true");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.defaultTransactionIsolation:SERIALIZABLE");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.defaultCatalog:blah");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.validationQueryTimeout:5544");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.removeAbandoned:true");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.removeAbandonedTimeout:6666");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.logAbandoned:true");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.maxActive:1000");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.minIdle:100");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.maxIdle:1000");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.datasource.initialSize:100");
 		this.context.refresh();
-		BasicDataSource ds = this.context.getBean(BasicDataSource.class);
+		BasicDataSource ds = (BasicDataSource) this.context.getBean(DataSource.class);
 		assertEquals("jdbc:foo//bar/spam", ds.getUrl());
 		assertEquals(true, ds.getTestWhileIdle());
 		assertEquals(true, ds.getTestOnBorrow());
@@ -63,6 +77,20 @@ public class CommonsDataSourceConfigurationTests {
 		assertEquals(10000, ds.getTimeBetweenEvictionRunsMillis());
 		assertEquals(12345, ds.getMinEvictableIdleTimeMillis());
 		assertEquals(1234, ds.getMaxWait());
+		assertTrue(ds.getDefaultAutoCommit());
+		assertTrue(ds.getDefaultReadOnly());
+		assertEquals(Connection.TRANSACTION_SERIALIZABLE, ds.getDefaultTransactionIsolation());
+		assertEquals("blah", ds.getDefaultCatalog());
+		assertEquals(5544, ds.getValidationQueryTimeout());
+		assertTrue(ds.getRemoveAbandoned());
+		assertEquals(6666, ds.getRemoveAbandonedTimeout());
+		assertTrue(ds.getLogAbandoned());
+		assertEquals(1000, ds.getMaxActive());
+		assertEquals(100, ds.getMinIdle());
+		assertEquals(1000, ds.getMaxIdle());
+		assertEquals(100, ds.getInitialSize());
+
+
 	}
 
 	@Test
@@ -73,6 +101,7 @@ public class CommonsDataSourceConfigurationTests {
 		assertEquals(GenericObjectPool.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS, ds.getTimeBetweenEvictionRunsMillis());
 		assertEquals(GenericObjectPool.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS, ds.getMinEvictableIdleTimeMillis());
 		assertEquals(GenericObjectPool.DEFAULT_MAX_WAIT, ds.getMaxWait());
+		assertEquals(300, ds.getRemoveAbandonedTimeout());
 	}
 
 }


### PR DESCRIPTION
This PR is changing a way in which JDBC connection pool is configured. It exploits the fact that dataSources are JavaBeans-compatible so it's easy to set them up using property editors using available properties values. This approach is better from previous because:
- there is no need to take care of each setting individually (less boring coding),
- default values are correctly preserved for each implementation of connection pool (nothing gets set if no property is present)
- new settings of future versions of Tomcat connection pool / Commons DBCP, once available, will be automatically handled (true, they will be not tested, but it's still better)
- it's easy to add other implementation of connection pools in the future as long as they conform to JavaBeans spec.

Let me know what do you think.
