### PR TITLE
Make Spring Boot work in Java 1.6 on Mac OS X (fixes #496)

### DIFF
--- a/spring-boot-parent/pom.xml
+++ b/spring-boot-parent/pom.xml
@@ -330,7 +330,7 @@
 						<configuration>
 							<rules>
 								<requireJavaVersion>
-									<version>(1.6,1.8)</version>
+									<version>(1.7,1.8)</version>
 								</requireJavaVersion>
 							</rules>
 						</configuration>

--- a/spring-boot-tools/spring-boot-maven-plugin/pom.xml
+++ b/spring-boot-tools/spring-boot-maven-plugin/pom.xml
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>com.sun</groupId>
 			<artifactId>tools</artifactId>
-			<version>1.6</version>
+			<version>${java.version}</version>
 			<scope>system</scope>
 			<systemPath>${tools-jar}</systemPath>
 		</dependency>
@@ -143,7 +143,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.1</version>
 				<configuration>
 					<goalPrefix>spring-boot</goalPrefix>
 				</configuration>


### PR DESCRIPTION
Currently Spring Boot fails in Java 1.6 on Mac OS X due to the
"tools.jar" being integrated into classes.jar in the Apple version of
Java 6.

Apple fixed this with Java 7, but we should still support Java 6. We had
to roll back to maven-plugin-plugin 3.1 to make this work with Java 6
and 7.

All tests pass with Java 6 and Java 7.

This fixes https://github.com/spring-projects/spring-boot/issues/496 and restores Java 6 support on Mac OS X.
