### PR TITLE
Support for sorting json keys

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/HttpMapperProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/HttpMapperProperties.java
@@ -27,6 +27,8 @@ public class HttpMapperProperties {
 
 	private boolean jsonPrettyPrint = false;
 
+	private boolean jsonSortKeys = false;
+
 	public void setJsonPrettyPrint(boolean jsonPrettyPrint) {
 		this.jsonPrettyPrint = jsonPrettyPrint;
 	}
@@ -35,4 +37,12 @@ public class HttpMapperProperties {
 		return this.jsonPrettyPrint;
 	}
 
+
+	public boolean isJsonSortKeys() {
+		return this.jsonSortKeys;
+	}
+
+	public void setJsonSortKeys(boolean jsonSortKeys) {
+		this.jsonSortKeys = jsonSortKeys;
+	}
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/HttpMessageConvertersAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/HttpMessageConvertersAutoConfiguration.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import javax.annotation.PostConstruct;
 
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -87,7 +88,9 @@ public class HttpMessageConvertersAutoConfiguration {
 		@ConditionalOnMissingBean
 		@Primary
 		public ObjectMapper jacksonObjectMapper() {
-			return new ObjectMapper();
+			ObjectMapper objectMapper = new ObjectMapper();
+			configureObjectMapper(objectMapper);
+			return objectMapper;
 		}
 
 		@Bean
@@ -100,6 +103,11 @@ public class HttpMessageConvertersAutoConfiguration {
 			return converter;
 		}
 
+		private void configureObjectMapper(ObjectMapper objectMapper) {
+			if (this.properties.isJsonSortKeys()) {
+				objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
This PR makes it possible to turn on SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS feature of json ObjectMapper via configuration property `http.mappers.jsonSortKeys`. It's quite convenient for debugging purposes.
