### PR TITLE
Omit any file that is not a zip when repackaging

### DIFF
--- a/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/task/ProjectLibraries.java
+++ b/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/task/ProjectLibraries.java
@@ -17,9 +17,7 @@
 package org.springframework.boot.gradle.task;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.gradle.api.Project;
@@ -36,10 +34,6 @@ import org.springframework.boot.loader.tools.LibraryScope;
  * @author Andy Wilkinson
  */
 class ProjectLibraries implements Libraries {
-
-	private static final Set<String> SUPPORTED_TYPES = Collections
-			.unmodifiableSet(new HashSet<String>(Arrays.asList("jar", "ejb",
-					"ejb-client", "test-jar", "bundle")));
 
 	private final Project project;
 
@@ -109,9 +103,7 @@ class ProjectLibraries implements Libraries {
 	private void libraries(LibraryScope scope, Set<ResolvedArtifact> artifacts,
 			LibraryCallback callback) throws IOException {
 		for (ResolvedArtifact artifact : artifacts) {
-			if (SUPPORTED_TYPES.contains(artifact.getType())) {
-				callback.library(artifact.getFile(), scope);
-			}
+			callback.library(artifact.getFile(), scope);
 		}
 	}
 }

--- a/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/RepackagerTests.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/RepackagerTests.java
@@ -30,6 +30,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.springframework.boot.loader.tools.sample.ClassWithMainMethod;
 import org.springframework.boot.loader.tools.sample.ClassWithoutMainMethod;
+import org.springframework.util.FileCopyUtils;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -256,6 +257,8 @@ public class RepackagerTests {
 		TestJarFile libJar = new TestJarFile(this.temporaryFolder);
 		libJar.addClass("a/b/C.class", ClassWithoutMainMethod.class);
 		final File libJarFile = libJar.getFile();
+		final File libNonJarFile = this.temporaryFolder.newFile();
+		FileCopyUtils.copy(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 }, libNonJarFile);
 		this.testJarFile.addClass("a/b/C.class", ClassWithMainMethod.class);
 		File file = this.testJarFile.getFile();
 		Repackager repackager = new Repackager(file);
@@ -263,9 +266,11 @@ public class RepackagerTests {
 			@Override
 			public void doWithLibraries(LibraryCallback callback) throws IOException {
 				callback.library(libJarFile, LibraryScope.COMPILE);
+				callback.library(libNonJarFile, LibraryScope.COMPILE);
 			}
 		});
 		assertThat(hasEntry(file, "lib/" + libJarFile.getName()), equalTo(true));
+		assertThat(hasEntry(file, "lib/" + libNonJarFile.getName()), equalTo(false));
 	}
 
 	@Test

--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/ArtifactsLibraries.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/ArtifactsLibraries.java
@@ -17,10 +17,8 @@
 package org.springframework.boot.maven;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -33,12 +31,9 @@ import org.springframework.boot.loader.tools.LibraryScope;
  * {@link Libraries} backed by Maven {@link Artifact}s
  * 
  * @author Phillip Webb
+ * @author Andy Wilkinson
  */
 public class ArtifactsLibraries implements Libraries {
-
-	private static final Set<String> SUPPORTED_TYPES = Collections
-			.unmodifiableSet(new HashSet<String>(Arrays.asList("jar", "ejb",
-					"ejb-client", "test-jar", "bundle")));
 
 	private static final Map<String, LibraryScope> SCOPES;
 	static {
@@ -58,11 +53,9 @@ public class ArtifactsLibraries implements Libraries {
 	@Override
 	public void doWithLibraries(LibraryCallback callback) throws IOException {
 		for (Artifact artifact : this.artifacts) {
-			if (SUPPORTED_TYPES.contains(artifact.getType())) {
-				LibraryScope scope = SCOPES.get(artifact.getScope());
-				if (scope != null && artifact.getFile() != null) {
-					callback.library(artifact.getFile(), scope);
-				}
+			LibraryScope scope = SCOPES.get(artifact.getScope());
+			if (scope != null && artifact.getFile() != null) {
+				callback.library(artifact.getFile(), scope);
 			}
 		}
 	}

--- a/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ArtifactsLibrariesTest.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ArtifactsLibrariesTest.java
@@ -30,7 +30,6 @@ import org.springframework.boot.loader.tools.LibraryScope;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**
  * Tests for {@link ArtifactsLibraries}.
@@ -66,13 +65,4 @@ public class ArtifactsLibrariesTest {
 		this.libs.doWithLibraries(this.callback);
 		verify(this.callback).library(this.file, LibraryScope.COMPILE);
 	}
-
-	@Test
-	public void doesNotIncludePoms() throws Exception {
-		given(this.artifact.getType()).willReturn("pom");
-		given(this.artifact.getScope()).willReturn("compile");
-		this.libs.doWithLibraries(this.callback);
-		verifyZeroInteractions(this.callback);
-	}
-
 }


### PR DESCRIPTION
Rather than using an artifact's type to determine whether or not it should be included, we now look at the file's header to determine if it's a zip file. A pleasant side-effect of this change is that the logic for deciding what should be included is now in a single location, `Repackager`, rather than being split across the two `Libraries` implementations in the Maven and Gradle plugins.
