### PR TITLE
Set version for Spring Data Commons

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -505,7 +505,6 @@
 				<groupId>org.springframework.data</groupId>
 				<artifactId>spring-data-commons</artifactId>
 				<version>${spring-data-commons.version}</version>
-				<optional>true</optional>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.hateoas</groupId>


### PR DESCRIPTION
spring-data-commons needs to have a fixed version to provide more consistency.
