### PR TITLE
Add a note on maven filtering

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -172,6 +172,12 @@ placeholders in `application.properties`, e.g.
 	server.port=${port:8080}
 ----
 
+TIP: If you have enabled maven filtering for the `application.properties` you may want
+to avoid using `${*}` for the tokens to filter as it conflicts with those placeholders.
+You can either use `@*@` (i.e. `@maven.token@` instead of `${maven.token}`) or you can
+configure the `maven-resources-plugin` to use
+http://maven.apache.org/plugins/maven-resources-plugin/resources-mojo.html#delimiters[other delimiters].
+
 NOTE: In this specific case the port binding will work in a PaaS environment like Heroku
 and Cloud Foundry, since in those two platforms the `PORT` environment variable is set
 automatically and Spring can bind to capitalized synonyms for `Environment` properties.


### PR DESCRIPTION
This commit adds a documentation note explaining how to change the delimiters used to filter maven tokens as these conflict with the delimiters used by Spring (i.e. ${foo:default}).

This is a follow-up of #521 
