### PR TITLE
Replace confusing '+' profile syntax.

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -556,7 +556,8 @@ active profiles in `application.properties` then *replace* them using the comman
 switch.
 
 Sometimes it is useful to have profile specific properties that *add* to the active
-profiles rather than replace them. The `+` prefix can be used to add active profiles.
+profiles rather than replace them. The `spring.profiles.include` property can be used
+to add active profiles.
 
 For example, when an application with following properties is run using the switch
 `--spring.profiles.active=prod` the `proddb` and `prodmq` profiles will also be activated:
@@ -567,7 +568,7 @@ For example, when an application with following properties is run using the swit
 	my.property: fromyamlfile
 	---
 	spring.profiles: prod
-	spring.profiles.active: +proddb,+prodmq
+	spring.profiles.include: proddb,prodmq
 ----
 
 

--- a/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
@@ -92,6 +92,8 @@ public class ConfigFileApplicationListener implements
 
 	private static final String ACTIVE_PROFILES_PROPERTY = "spring.profiles.active";
 
+	private static final String INCLUDE_PROFILES_PROPERTY = "spring.profiles.include";
+
 	private static final String CONFIG_NAME_PROPERTY = "spring.config.name";
 
 	private static final String CONFIG_LOCATION_PROPERTY = "spring.config.location";
@@ -274,9 +276,9 @@ public class ConfigFileApplicationListener implements
 
 			if (this.environment.containsProperty(ACTIVE_PROFILES_PROPERTY)) {
 				// Any pre-existing active profiles set via property sources (e.g. System
-				// properties) take precedence over those added in config files (unless
-				// latter are prefixed with "+").
-				addActiveProfiles(this.environment.getProperty(ACTIVE_PROFILES_PROPERTY));
+				// properties) take precedence over those added in config files.
+				tryToSetActiveProfiles(this.environment
+						.getProperty(ACTIVE_PROFILES_PROPERTY));
 			}
 			else {
 				// Pre-existing active profiles set via Environment.setActiveProfiles()
@@ -330,32 +332,42 @@ public class ConfigFileApplicationListener implements
 				PropertySource<?> propertySource = this.propertiesLoader.load(resource,
 						name, profile);
 				if (propertySource != null) {
-					addActiveProfiles(propertySource
+					tryToSetActiveProfiles(propertySource
 							.getProperty(ACTIVE_PROFILES_PROPERTY));
+					addIncludeProfiles(propertySource
+							.getProperty(INCLUDE_PROFILES_PROPERTY));
 				}
 				return propertySource;
 			}
 			return null;
 		}
 
-		private void addActiveProfiles(Object property) {
-			String profiles = (property == null ? null : property.toString());
-			boolean profilesNotActivatedWhenCalled = !this.activatedProfiles;
-			for (String profile : asResolvedSet(profiles, null)) {
-				// A profile name prefixed with "+" is always added even if it is
-				// activated in a config file (without the "+" it can be disabled
-				// by an explicit Environment property set before the file was
-				// processed).
-				boolean addition = profile.startsWith("+");
-				profile = (addition ? profile.substring(1) : profile);
-				if (profilesNotActivatedWhenCalled || addition) {
-					this.profiles.add(profile);
-					if (!this.environment.acceptsProfiles(profile)) {
-						// If it's already accepted we assume the order was set
-						// intentionally
-						prependProfile(this.environment, profile);
-					}
+		private void tryToSetActiveProfiles(Object property) {
+			if (!this.activatedProfiles == true) {
+				Set<String> profiles = getProfilesForProperty(property);
+				activeProfiles(profiles);
+				if (profiles.size() > 0) {
 					this.activatedProfiles = true;
+				}
+			}
+		}
+
+		private void addIncludeProfiles(Object property) {
+			Set<String> profiles = getProfilesForProperty(property);
+			activeProfiles(profiles);
+		}
+
+		private Set<String> getProfilesForProperty(Object property) {
+			return asResolvedSet((property == null ? null : property.toString()), null);
+		}
+
+		private void activeProfiles(Set<String> profiles) {
+			for (String profile : profiles) {
+				this.profiles.add(profile);
+				if (!this.environment.acceptsProfiles(profile)) {
+					// If it's already accepted we assume the order was set
+					// intentionally
+					prependProfile(this.environment, profile);
 				}
 			}
 		}

--- a/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileApplicationListenerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileApplicationListenerTests.java
@@ -433,8 +433,8 @@ public class ConfigFileApplicationListenerTests {
 		SpringApplication application = new SpringApplication(Config.class);
 		application.setWebEnvironment(false);
 		ConfigurableApplicationContext context = application
-				.run("--spring.profiles.active=activateprofile");
-		assertThat(context.getEnvironment(), acceptsProfiles("activateprofile"));
+				.run("--spring.profiles.active=includeprofile");
+		assertThat(context.getEnvironment(), acceptsProfiles("includeprofile"));
 		assertThat(context.getEnvironment(), acceptsProfiles("specific"));
 		assertThat(context.getEnvironment(), acceptsProfiles("morespecific"));
 		assertThat(context.getEnvironment(), acceptsProfiles("yetmorespecific"));

--- a/spring-boot/src/test/resources/application-activateprofile.properties
+++ b/spring-boot/src/test/resources/application-activateprofile.properties
@@ -1,1 +1,0 @@
-spring.profiles.active=+specific

--- a/spring-boot/src/test/resources/application-includeprofile.properties
+++ b/spring-boot/src/test/resources/application-includeprofile.properties
@@ -1,0 +1,1 @@
+spring.profiles.include=specific

--- a/spring-boot/src/test/resources/application-morespecific.properties
+++ b/spring-boot/src/test/resources/application-morespecific.properties
@@ -1,1 +1,2 @@
-spring.profiles.active=+yetmorespecific,missing
+spring.profiles.include=yetmorespecific
+spring.profiles.active=missing

--- a/spring-boot/src/test/resources/application-specific.properties
+++ b/spring-boot/src/test/resources/application-specific.properties
@@ -1,1 +1,1 @@
-spring.profiles.active=+morespecific
+spring.profiles.include=morespecific

--- a/spring-boot/src/test/resources/enableprofileviaapplicationproperties.yml
+++ b/spring-boot/src/test/resources/enableprofileviaapplicationproperties.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: +a
+    include: a


### PR DESCRIPTION
Replace the confusing `spring.profiles.active` `+` syntax with a new
`spring.profiles.include` property.

Fixes gh-483
