### PR TITLE
Set uri encoding to UTF-8 by default for Tomcat

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -43,6 +43,7 @@ import org.springframework.util.StringUtils;
  * {@link EmbeddedServletContainerCustomizerBeanPostProcessor} is active.
  * 
  * @author Dave Syer
+ * @author Stephane Nicoll
  */
 @ConfigurationProperties(name = "server", ignoreUnknownFields = false)
 public class ServerProperties implements EmbeddedServletContainerCustomizer {
@@ -144,6 +145,8 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer {
 
 		private int maxThreads = 0; // Number of threads in protocol handler
 
+		private String uriEncoding;
+
 		public int getMaxThreads() {
 			return this.maxThreads;
 		}
@@ -200,6 +203,14 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer {
 			this.remoteIpHeader = remoteIpHeader;
 		}
 
+		public String getUriEncoding() {
+			return uriEncoding;
+		}
+
+		public void setUriEncoding(String uriEncoding) {
+			this.uriEncoding = uriEncoding;
+		}
+
 		void customizeTomcat(TomcatEmbeddedServletContainerFactory factory) {
 			if (getBasedir() != null) {
 				factory.setBaseDirectory(getBasedir());
@@ -246,6 +257,9 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer {
 				}
 				valve.setSuffix(".log");
 				factory.addContextValves(valve);
+			}
+			if (getUriEncoding() != null) {
+				factory.setUriEncoding(getUriEncoding());
 			}
 		}
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.verify;
  * Tests for {@link ServerProperties}.
  * 
  * @author Dave Syer
+ * @author Stephane Nicoll
  */
 public class ServerPropertiesTests {
 
@@ -85,6 +86,15 @@ public class ServerPropertiesTests {
 		this.properties.setPort(8080);
 		this.properties.customize(factory);
 		verify(factory).setPort(8080);
+	}
+
+	@Test
+	public void testCustomizeUriEncoding() throws Exception {
+		Map<String, String> map = new HashMap<String, String>();
+		map.put("server.tomcat.uriEncoding", "US-ASCII");
+		new RelaxedDataBinder(this.properties, "server").bind(new MutablePropertyValues(
+				map));
+		assertEquals("US-ASCII", this.properties.getTomcat().getUriEncoding());
 	}
 
 }

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -61,6 +61,7 @@ server.tomcat.remote-ip-header=x-forwarded-for
 server.tomcat.basedir=/tmp # base dir (usually not needed, defaults to tmp)
 server.tomcat.background-processor-delay=30; # in seconds
 server.tomcat.max-threads = 0 # number of threads in protocol handler
+server.tomcat.uri-encoding = UTF-8 # character encoding to use for URL decoding
 
 # SPRING MVC ({sc-spring-boot-autoconfigure}/web/HttpMapperProperties.{sc-ext}[HttpMapperProperties])
 http.mappers.json-pretty-print=false # pretty print JSON

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
@@ -66,6 +66,7 @@ import org.springframework.util.StreamUtils;
  * @author Phillip Webb
  * @author Dave Syer
  * @author Brock Mills
+ * @author Stephane Nicoll
  * @see #setPort(int)
  * @see #setContextLifecycleListeners(Collection)
  * @see TomcatEmbeddedServletContainer
@@ -92,6 +93,8 @@ public class TomcatEmbeddedServletContainerFactory extends
 	private String protocol = DEFAULT_PROTOCOL;
 
 	private String tldSkip;
+
+	private String uriEncoding = "UTF-8";
 
 	/**
 	 * Create a new {@link TomcatEmbeddedServletContainerFactory} instance.
@@ -206,6 +209,10 @@ public class TomcatEmbeddedServletContainerFactory extends
 						.setAddress(getAddress());
 			}
 		}
+		if (getUriEncoding() != null) {
+			connector.setURIEncoding(getUriEncoding());
+		}
+
 		// If ApplicationContext is slow to start we want Tomcat not to bind to the socket
 		// prematurely...
 		connector.setProperty("bindOnInit", "false");
@@ -453,6 +460,22 @@ public class TomcatEmbeddedServletContainerFactory extends
 	 */
 	public List<Connector> getAdditionalTomcatConnectors() {
 		return this.additionalTomcatConnectors;
+	}
+
+	/**
+	 * Set the character encoding to use for URL decoding. If not
+	 * specified 'UTF-8' will be used.
+	 * @param uriEncoding the uri encoding to set
+	 */
+	public void setUriEncoding(String uriEncoding) {
+		this.uriEncoding = uriEncoding;
+	}
+
+	/**
+	 * Returns the character encoding to use for URL decoding.
+	 */
+	public String getUriEncoding() {
+		return uriEncoding;
 	}
 
 	private static class TomcatErrorPage {

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactoryTests.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.verify;
  * 
  * @author Phillip Webb
  * @author Dave Syer
+ * @author Stephane Nicoll
  */
 public class TomcatEmbeddedServletContainerFactoryTests extends
 		AbstractEmbeddedServletContainerFactoryTests {
@@ -190,11 +191,30 @@ public class TomcatEmbeddedServletContainerFactoryTests extends
 		factory.addConnectorCustomizers((TomcatConnectorCustomizer[]) null);
 	}
 
+	@Test
+	public void uriEncoding() throws Exception {
+		TomcatEmbeddedServletContainerFactory factory = getFactory();
+		factory.setUriEncoding("US-ASCII");
+		Tomcat tomcat = getTomcat(factory);
+		assertEquals("US-ASCII", tomcat.getConnector().getURIEncoding());
+	}
+
+	@Test
+	public void defaultUriEncoding() throws Exception {
+		TomcatEmbeddedServletContainerFactory factory = getFactory();
+		Tomcat tomcat = getTomcat(factory);
+		assertEquals("UTF-8", tomcat.getConnector().getURIEncoding());
+	}
+
 	private void assertTimeout(TomcatEmbeddedServletContainerFactory factory, int expected) {
-		this.container = factory.getEmbeddedServletContainer();
-		Tomcat tomcat = ((TomcatEmbeddedServletContainer) this.container).getTomcat();
+		Tomcat tomcat = getTomcat(factory);
 		Context context = (Context) tomcat.getHost().findChildren()[0];
 		assertThat(context.getSessionTimeout(), equalTo(expected));
+	}
+
+	private Tomcat getTomcat(TomcatEmbeddedServletContainerFactory factory) {
+		this.container = factory.getEmbeddedServletContainer();
+		return ((TomcatEmbeddedServletContainer) this.container).getTomcat();
 	}
 
 }


### PR DESCRIPTION
This commit introduces an extra `server.tomcat.uri-encoding` property used to configure the URI encoding for the embedded tomcat container.

This defaults to `UTF-8` instead of what tomcat uses by default (i.e. `ISO-8859-1`). Note that Jetty uses 'UTF-8' by default but can only be customized through the use of a system property so this new setting only applies for Tomcat.

Fixes gh-540
