### PR TITLE
CodahaleMetricWriter fails under load test due to parallel access to writer and gauges

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/writer/CodahaleMetricWriter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/writer/CodahaleMetricWriter.java
@@ -86,8 +86,16 @@ public class CodahaleMetricWriter implements MetricWriter {
 		}
 		else {
 			final double gauge = value.getValue().doubleValue();
-			this.registry.remove(name);
-			this.registry.register(name, new SimpleGauge(gauge));
+
+			// ensure we synchronize on the registry to avoid another thread
+			// pre-empting this thread after remove causing register to be
+			// called twice causing an error in CodaHale metrics
+			// NOTE: this probably should not be synchronized, but CodaHale
+			// provides no other methods to get or add a particular gauge
+			synchronized (this.registry) {
+				this.registry.remove(name);
+				this.registry.register(name, new SimpleGauge(gauge));
+			}
 		}
 	}
 


### PR DESCRIPTION
The MetricFilter that delegates to the CodahaleMetricWriter fails when taking several parallel requests to the same URL as it tries to update a gauge which causes a `registry.remove` followed by `registry.register`.  The latter fails if two threads call `register` back to back as the first will register and the second will fail as having already been registered.

This pull request adds a test case showcasing the error and offers a fix by synchronizing on the registry.  Synchronizing is not the best choice due to blocking in the parallism, but I do not see a better way to avoid the error scenario with the API that Codahale exposes.
