### PR TITLE
minor doc changes based on RC5 migration experience

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -422,7 +422,7 @@ that sets up the connector to be secure:
 	private static class MyCustomizer implements EmbeddedServletContainerCustomizer {
 
 		@Override
-		public void customize(ConfigurableEmbeddedServletContainerFactory factory) {
+		public void customize(ConfigurableEmbeddedServletContainer factory) {
 			if(factory instanceof TomcatEmbeddedServletContainerFactory) {
 				customizeTomcat((TomcatEmbeddedServletContainerFactory) factory));
 			}

--- a/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
+++ b/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
@@ -82,6 +82,7 @@ keep the benefit of the dependency management (but not the plugin management) us
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
 				<version>{spring-boot-version}</version>
+				<type>pom</type>
 		        <scope>import</scope>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
`ConfigurableEmbeddedServletContainerFactory` does not exist, and pulling in the dependencies of the starter parent should be of type pom.
