### PR TITLE
Adding MySQL health check, adding accessor to Indicator to allow user to...

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/HealthEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/HealthEndpoint.java
@@ -46,4 +46,8 @@ public class HealthEndpoint<T> extends AbstractEndpoint<T> {
 		return this.indicator.health();
 	}
 
+	public HealthIndicator<? extends T> getIndicator() {
+		return indicator;
+	}
+
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/SimpleHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/SimpleHealthIndicator.java
@@ -48,6 +48,7 @@ public class SimpleHealthIndicator implements HealthIndicator<Map<String, Object
 				"SELECT COUNT(*) FROM INFORMATION_SCHEMA.SYSTEM_USERS");
 		queries.put("Oracle", "SELECT 'Hello' from DUAL");
 		queries.put("Apache Derby", "SELECT 1 FROM SYSIBM.SYSDUMMY1");
+		queries.put("MySQL", "SELECT 1");
 	}
 
 	private static String DEFAULT_QUERY = "SELECT 'Hello'";


### PR DESCRIPTION
... customize query.  This will enable other custom queries to be configured using the pre-wired `SimpleHealthIndicator` @Bean.  An alternative approach could be to have the user provide a query via their own @Bean definition or better yet via configuration (subsection of `ManagementServerProperties` ?).
