### PR TITLE
Security Documentation Cleanup

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -80,6 +80,7 @@ spring.thymeleaf.cache=true # set to false for hot refresh
 spring.messages.basename=messages
 spring.messages.encoding=UTF-8
 
+[[common-application-properties-security]]
 # SECURITY ({sc-spring-boot-autoconfigure}/security/SecurityProperties.{sc-ext}[SecurityProperties])
 security.user.name=user # login username
 security.user.password= # login password

--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -1100,12 +1100,13 @@ Look at {sc-spring-boot-actuator}/autoconfigure/ErrorMvcAutoConfiguration.{sc-ex
 === Secure an application
 If Spring Security is on the classpath then web applications will be secure by default
 (``basic'' authentication on all endpoints) . To add method-level security to a web
-application you can simply `@EnableGlobalMethodSecurity` with your desired settings.
+application you can simply `@EnableGlobalMethodSecurity` with your desired settings. Additional information can be found in the
+http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#jc-method[Spring Security Reference].
 
 The default `AuthenticationManager` has a single user (username ``user'' and password
 random, printed at INFO level when the application starts up). You can change the
 password by providing a `security.user.password`. This and other useful properties
-are externalized via {sc-spring-boot-autoconfigure}/security/SecurityProperties{sc-ext}[`SecurityProperties`.
+are externalized via {sc-spring-boot-autoconfigure}/security/SecurityProperties.{sc-ext}[`SecurityProperties`].
 
 
 [[howto-switch-off-spring-boot-security-configuration]]
@@ -1114,7 +1115,8 @@ If you define a `@Configuration` with `@EnableWebSecurity` anywhere in your appl
 it will switch off the default webapp security settings in Spring Boot. To tweak the
 defaults try setting properties in `security.*` (see
 {sc-spring-boot-autoconfigure}/security/SecurityProperties.{sc-ext}[`SecurityProperties`]
-for details of available settings).
+for details of available settings) and SECURITY section of
+<<common-application-properties-security,Common application properties>>.
 
 
 
@@ -1132,21 +1134,18 @@ use this in a webapp is to inject it into a void method in a
 [source,java,indent=0,subs="verbatim,quotes,attributes"]
 ----
 	@Configuration
-	@Order(0)
 	public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 		@Autowired
-		protected void init(AuthenticationManagerBuilder builder) {
-				builder.inMemoryAuthentication().withUser("barry"); // ...  etc.
+		public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
+				auth.inMemoryAuthentication()
+					.withUser("barry").password("password").roles("USER"); // ...  etc.
 		}
 
 		// ... other stuff for application security
 
 	}
 ----
-
-The configuration class that does this should declare an `@Order` so that it is used
-before the default one in Spring Boot (which has very low precedence).
 
 
 

--- a/spring-boot-docs/src/main/asciidoc/index.adoc
+++ b/spring-boot-docs/src/main/asciidoc/index.adoc
@@ -1,5 +1,5 @@
 = Spring Boot Reference Guide
-Phillip Webb; Dave Syer; Josh Long; Stéphane Nicoll;
+Phillip Webb; Dave Syer; Josh Long; Stéphane Nicoll; Rob Winch
 :doctype: book
 :toc:
 :toclevels: 4


### PR DESCRIPTION
- Add link to Spring Security's Global Method Security Java Configuration
- Fix link to SecurityProperties
- Add link to SECURITY Common application properties
- Remove unnecessary @Order from SecurityConfiguration
- Change method signature for @Autowired AuthenticationManagerBuilder to
  compile / match Spring docs
