### PR TITLE
Fix quotes in a Gradle example

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -525,7 +525,7 @@ Example in Gradle:
 [source,groovy,indent=0,subs="verbatim,quotes,attributes"]
 ----
 	configurations {
-		compile.exclude module: 'spring-boot-starter-tomcat'
+		compile.exclude module: "spring-boot-starter-tomcat"
 	}
 
 	dependencies {


### PR DESCRIPTION
Fix quotes in order to make copy and past of the code work (single quotes are not displayed in the generated documentation)
