### PR TITLE
Bad Tomcat 8 section reference to websockets pom

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -570,8 +570,7 @@ Tomcat 8 for it to work. For example, using the starter poms in Maven:
 ----
 
 change the classpath to use Tomcat 8
-for it to work. The {github-code}/spring-boot-samples/spring-boot-sample-websocket/pom.xml[websocket sample]
-shows you how to do that in Maven.
+for it to work. 
 
 
 


### PR DESCRIPTION
Removed this link "The websocket sample shows you how to do that in Maven." since the example no longer has properties that show how this is done. Dave Syer edited the section in a previous issue by adding the example to the POM ( https://github.com/spring-projects/spring-boot/issues/430 ) but it appears that the bad link was not removed.
