### PR TITLE
Use random port in spring-boot tests

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/test/WebTestUtils.java
+++ b/spring-boot/src/main/java/org/springframework/boot/test/WebTestUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test;
+
+import org.springframework.boot.context.embedded.EmbeddedServletContainer;
+import org.springframework.util.Assert;
+
+/**
+ * Web related test utilities.
+ *
+ * @author Stephane Nicoll
+ */
+public class WebTestUtils {
+
+	/**
+	 * Returns a local URL suitable for the specified {@link EmbeddedServletContainer}.
+	 * @param container the server to contact
+	 * @param resourcePath the full path to the resource
+	 * @return a suitable url for the specified resource
+	 */
+	public static String getLocalUrl(EmbeddedServletContainer container, String resourcePath) {
+		Assert.notNull(resourcePath, "ResourcePath must not be null");
+		String suffix = resourcePath;
+		if (!suffix.startsWith("/")) {
+			suffix = "/" + suffix;
+		}
+		return "http://localhost:" + container.getPort() + suffix;
+	}
+}

--- a/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
@@ -541,7 +541,7 @@ public class SpringApplicationTests {
 
 		@Bean
 		public JettyEmbeddedServletContainerFactory container() {
-			return new JettyEmbeddedServletContainerFactory();
+			return new JettyEmbeddedServletContainerFactory(0);
 		}
 
 	}

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
@@ -37,6 +37,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.InOrder;
+
+import org.springframework.boot.test.WebTestUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpRequest;
@@ -44,11 +46,11 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.HttpComponentsAsyncClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.util.FileCopyUtils;
+import org.springframework.util.SocketUtils;
 import org.springframework.util.StreamUtils;
 import org.springframework.util.concurrent.ListenableFuture;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyObject;
@@ -88,18 +90,17 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		this.container = factory
 				.getEmbeddedServletContainer(exampleServletRegistration());
 		this.container.start();
-		assertThat(getResponse("http://localhost:8080/hello"), equalTo("Hello World"));
+		assertThat(getResponse(getLocalUrl("/hello")), equalTo("Hello World"));
 	}
 
 	@Test
-	public void emptyServerWhenPortIsZero() throws Exception {
+	public void emptyServerWhenPortIsMinusOne() throws Exception {
 		AbstractEmbeddedServletContainerFactory factory = getFactory();
-		factory.setPort(0);
+		factory.setPort(-1);
 		this.container = factory
 				.getEmbeddedServletContainer(exampleServletRegistration());
 		this.container.start();
-		this.thrown.expect(IOException.class);
-		getResponse("http://localhost:8080/hello");
+		assertThat(container.getPort(), lessThan(0)); // Jetty is -2
 	}
 
 	@Test
@@ -110,7 +111,7 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		this.container.start();
 		this.container.stop();
 		this.thrown.expect(IOException.class);
-		getResponse("http://localhost:8080/hello");
+		getResponse(getLocalUrl("/hello"));
 	}
 
 	@Test
@@ -121,7 +122,7 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		this.container.start();
 		HttpComponentsAsyncClientHttpRequestFactory clientHttpRequestFactory = new HttpComponentsAsyncClientHttpRequestFactory();
 		ListenableFuture<ClientHttpResponse> response1 = clientHttpRequestFactory
-				.createAsyncRequest(new URI("http://localhost:8080/hello"),
+				.createAsyncRequest(new URI(getLocalUrl("/hello")),
 						HttpMethod.GET).executeAsync();
 		assertThat(response1.get(10, TimeUnit.SECONDS).getRawStatusCode(), equalTo(200));
 
@@ -131,7 +132,7 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		this.container.start();
 
 		ListenableFuture<ClientHttpResponse> response2 = clientHttpRequestFactory
-				.createAsyncRequest(new URI("http://localhost:8080/hello"),
+				.createAsyncRequest(new URI(getLocalUrl("/hello")),
 						HttpMethod.GET).executeAsync();
 		assertThat(response2.get(10, TimeUnit.SECONDS).getRawStatusCode(), equalTo(200));
 	}
@@ -143,7 +144,7 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 				exampleServletRegistration(), new FilterRegistrationBean(
 						new ExampleFilter()));
 		this.container.start();
-		assertThat(getResponse("http://localhost:8080/hello"), equalTo("[Hello World]"));
+		assertThat(getResponse(getLocalUrl("/hello")), equalTo("[Hello World]"));
 	}
 
 	@Test
@@ -188,12 +189,13 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 	@Test
 	public void specificPort() throws Exception {
 		AbstractEmbeddedServletContainerFactory factory = getFactory();
-		factory.setPort(8081);
+		int specificPort = SocketUtils.findAvailableTcpPort(40000);
+		factory.setPort(specificPort);
 		this.container = factory
 				.getEmbeddedServletContainer(exampleServletRegistration());
 		this.container.start();
-		assertThat(getResponse("http://localhost:8081/hello"), equalTo("Hello World"));
-		assertEquals(8081, this.container.getPort());
+		assertThat(getResponse("http://localhost:" + specificPort + "/hello"), equalTo("Hello World"));
+		assertEquals(specificPort, this.container.getPort());
 	}
 
 	@Test
@@ -203,7 +205,7 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		this.container = factory
 				.getEmbeddedServletContainer(exampleServletRegistration());
 		this.container.start();
-		assertThat(getResponse("http://localhost:8080/say/hello"), equalTo("Hello World"));
+		assertThat(getResponse(getLocalUrl("/say/hello")), equalTo("Hello World"));
 	}
 
 	@Test
@@ -264,7 +266,7 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		factory.setDocumentRoot(this.temporaryFolder.getRoot());
 		this.container = factory.getEmbeddedServletContainer();
 		this.container.start();
-		assertThat(getResponse("http://localhost:8080/test.txt"), equalTo("test"));
+		assertThat(getResponse(getLocalUrl("/test.txt")), equalTo("test"));
 	}
 
 	@Test
@@ -278,7 +280,7 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		factory.setMimeMappings(mimeMappings);
 		this.container = factory.getEmbeddedServletContainer();
 		this.container.start();
-		ClientHttpResponse response = getClientResponse("http://localhost:8080/test.xxcss");
+		ClientHttpResponse response = getClientResponse(getLocalUrl("/test.xxcss"));
 		assertThat(response.getHeaders().getContentType().toString(), equalTo("text/css"));
 		response.close();
 	}
@@ -290,8 +292,12 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		this.container = factory.getEmbeddedServletContainer(
 				exampleServletRegistration(), errorServletRegistration());
 		this.container.start();
-		assertThat(getResponse("http://localhost:8080/hello"), equalTo("Hello World"));
-		assertThat(getResponse("http://localhost:8080/bang"), equalTo("Hello World"));
+		assertThat(getResponse(getLocalUrl("/hello")), equalTo("Hello World"));
+		assertThat(getResponse(getLocalUrl("/bang")), equalTo("Hello World"));
+	}
+
+	protected String getLocalUrl(String resourcePath) {
+		return WebTestUtils.getLocalUrl(container, resourcePath);
 	}
 
 	protected String getResponse(String url) throws IOException, URISyntaxException {

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/EmbeddedServletContainerMvcIntegrationTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/EmbeddedServletContainerMvcIntegrationTests.java
@@ -16,16 +16,22 @@
 
 package org.springframework.boot.context.embedded;
 
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
 import java.net.URI;
 import java.nio.charset.Charset;
 
 import org.junit.After;
 import org.junit.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainerFactory;
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.boot.test.WebTestUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpMethod;
@@ -39,13 +45,10 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-
 /**
  * Integration tests for {@link EmbeddedWebApplicationContext} and
  * {@link EmbeddedServletContainer}s running Spring MVC.
- * 
+ *
  * @author Phillip Webb
  */
 public class EmbeddedServletContainerMvcIntegrationTests {
@@ -62,27 +65,26 @@ public class EmbeddedServletContainerMvcIntegrationTests {
 
 	@Test
 	public void tomcat() throws Exception {
-		this.context = new AnnotationConfigEmbeddedWebApplicationContext(
-				TomcatEmbeddedServletContainerFactory.class, Config.class);
-		doTest(this.context, "http://localhost:8080/hello");
+		this.context = new AnnotationConfigEmbeddedWebApplicationContext(TomcatConfig.class);
+		doTest(this.context, "/hello");
 	}
 
 	@Test
 	public void jetty() throws Exception {
-		this.context = new AnnotationConfigEmbeddedWebApplicationContext(
-				JettyEmbeddedServletContainerFactory.class, Config.class);
-		doTest(this.context, "http://localhost:8080/hello");
+		this.context = new AnnotationConfigEmbeddedWebApplicationContext(JettyConfig.class);
+		doTest(this.context, "/hello");
 	}
 
 	@Test
 	public void advancedConfig() throws Exception {
 		this.context = new AnnotationConfigEmbeddedWebApplicationContext(
 				AdvancedConfig.class);
-		doTest(this.context, "http://localhost:8081/example/spring/hello");
+		doTest(this.context, "/example/spring/hello");
 	}
 
-	private void doTest(AnnotationConfigEmbeddedWebApplicationContext context, String url)
+	private void doTest(AnnotationConfigEmbeddedWebApplicationContext context, String resourcePath)
 			throws Exception {
+		String url = WebTestUtils.getLocalUrl(context.getEmbeddedServletContainer(), resourcePath);
 		SimpleClientHttpRequestFactory clientHttpRequestFactory = new SimpleClientHttpRequestFactory();
 		ClientHttpRequest request = clientHttpRequestFactory.createRequest(new URI(url),
 				HttpMethod.GET);
@@ -94,6 +96,24 @@ public class EmbeddedServletContainerMvcIntegrationTests {
 		}
 		finally {
 			response.close();
+		}
+	}
+
+	@Configuration
+	@Import(Config.class)
+	public static class TomcatConfig {
+		@Bean
+		public EmbeddedServletContainerFactory containerFactory() {
+			return new TomcatEmbeddedServletContainerFactory(0);
+		}
+	}
+
+	@Configuration
+	@Import(Config.class)
+	public static class JettyConfig {
+		@Bean
+		public EmbeddedServletContainerFactory containerFactory() {
+			return new JettyEmbeddedServletContainerFactory(0);
 		}
 	}
 
@@ -125,9 +145,8 @@ public class EmbeddedServletContainerMvcIntegrationTests {
 
 		@Bean
 		public EmbeddedServletContainerFactory containerFactory() {
-			JettyEmbeddedServletContainerFactory factory = new JettyEmbeddedServletContainerFactory();
-			factory.setPort(this.env.getProperty("port", Integer.class));
-			factory.setContextPath("/example");
+			JettyEmbeddedServletContainerFactory factory = new JettyEmbeddedServletContainerFactory(0);
+			factory.setContextPath(this.env.getProperty("context"));
 			return factory;
 		}
 

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactoryTests.java
@@ -45,7 +45,7 @@ public class JettyEmbeddedServletContainerFactoryTests extends
 
 	@Override
 	protected JettyEmbeddedServletContainerFactory getFactory() {
-		return new JettyEmbeddedServletContainerFactory();
+		return new JettyEmbeddedServletContainerFactory(0);
 	}
 
 	@Test

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactoryTests.java
@@ -28,10 +28,10 @@ import org.apache.catalina.startup.Tomcat;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.springframework.boot.context.embedded.AbstractEmbeddedServletContainerFactoryTests;
+import org.springframework.util.SocketUtils;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.inOrder;
@@ -51,7 +51,7 @@ public class TomcatEmbeddedServletContainerFactoryTests extends
 
 	@Override
 	protected TomcatEmbeddedServletContainerFactory getFactory() {
-		return new TomcatEmbeddedServletContainerFactory();
+		return new TomcatEmbeddedServletContainerFactory(0);
 	}
 
 	// JMX MBean names clash if you get more than one Engine with the same name...
@@ -59,12 +59,16 @@ public class TomcatEmbeddedServletContainerFactoryTests extends
 	public void tomcatEngineNames() throws Exception {
 		TomcatEmbeddedServletContainerFactory factory = getFactory();
 		this.container = factory.getEmbeddedServletContainer();
-		factory.setPort(8081);
+		factory.setPort(SocketUtils.findAvailableTcpPort(40000));
 		TomcatEmbeddedServletContainer container2 = (TomcatEmbeddedServletContainer) factory
 				.getEmbeddedServletContainer();
-		assertEquals("Tomcat", ((TomcatEmbeddedServletContainer) this.container)
-				.getTomcat().getEngine().getName());
-		assertEquals("Tomcat-1", container2.getTomcat().getEngine().getName());
+
+		// Make sure that the names are different
+		String firstContainerName = ((TomcatEmbeddedServletContainer) this.container)
+				.getTomcat().getEngine().getName();
+		String secondContainerName = container2.getTomcat().getEngine().getName();
+		assertFalse("Tomcat engines must have different names",
+				firstContainerName.equals(secondContainerName));
 		container2.stop();
 	}
 

--- a/spring-boot/src/test/java/org/springframework/boot/test/SpringApplicationIntegrationTestTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/test/SpringApplicationIntegrationTestTests.java
@@ -18,7 +18,10 @@ package org.springframework.boot.test;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory;
+import org.springframework.boot.context.embedded.EmbeddedWebApplicationContext;
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
 import org.springframework.boot.test.SpringApplicationIntegrationTestTests.Config;
 import org.springframework.context.annotation.Bean;
@@ -44,10 +47,13 @@ import static org.junit.Assert.assertEquals;
 @IntegrationTest
 public class SpringApplicationIntegrationTestTests {
 
+	@Autowired
+	private EmbeddedWebApplicationContext applicationContext;
+
 	@Test
 	public void runAndTestHttpEndpoint() {
-		String body = new RestTemplate().getForObject("http://localhost:8080/",
-				String.class);
+		String home = WebTestUtils.getLocalUrl(applicationContext.getEmbeddedServletContainer(), "/");
+		String body = new RestTemplate().getForObject(home, String.class);
 		assertEquals("Hello World", body);
 	}
 
@@ -63,7 +69,7 @@ public class SpringApplicationIntegrationTestTests {
 
 		@Bean
 		public EmbeddedServletContainerFactory embeddedServletContainer() {
-			return new TomcatEmbeddedServletContainerFactory();
+			return new TomcatEmbeddedServletContainerFactory(0);
 		}
 
 		@RequestMapping("/")

--- a/spring-boot/src/test/resources/org/springframework/boot/context/embedded/conf.properties
+++ b/spring-boot/src/test/resources/org/springframework/boot/context/embedded/conf.properties
@@ -1,1 +1,1 @@
-port=8081
+context=/example


### PR DESCRIPTION
This commit updates the test suite of the spring-boot module to use random ports instead of hard coding `8080` or `8081`. When this is not possible and a different value is required, `SocketUtils` is used to find
a random ports in the range above 40000.

A new utility class has been created. `WebTestUtils` has only one method for now and creates a local url for a given embedded container.

Partly fixes gh-337
