### PR TITLE
Fix typo: spring.data.mongodb.uri instead of spring.data.mongodb.url

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -1296,7 +1296,7 @@ the URL `mongodb://localhost/test`:
 	}
 ----
 
-You can set `spring.data.mongodb.url` property to change the `url`, or alternatively
+You can set `spring.data.mongodb.uri` property to change the `url`, or alternatively
 specify a `host`/`port`. For example, you might declare the following in your
 `application.properties`:
 


### PR DESCRIPTION
It took a while to figure out what's wrong, but otherwise it's a pleasure to work with Spring Boot :wink:
