### PR TITLE
Import Spring Data release train BOM instead of individual modules.

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -83,10 +83,8 @@
 		<spring.version>4.0.3.RELEASE</spring.version>
 		<spring-integration.version>3.0.1.RELEASE</spring-integration.version>
 		<spring-batch.version>2.2.5.RELEASE</spring-batch.version>
-		<spring-data-jpa.version>1.5.1.RELEASE</spring-data-jpa.version>
-		<spring-data-mongodb.version>1.4.1.RELEASE</spring-data-mongodb.version>
 		<spring-data-redis.version>1.1.1.RELEASE</spring-data-redis.version>
-		<spring-data-rest.version>2.0.1.RELEASE</spring-data-rest.version>
+		<spring-data-releasetrain.version>Codd-SR2</spring-data-releasetrain.version>
 		<spring-hateoas.version>0.9.0.RELEASE</spring-hateoas.version>
 		<spring-rabbit.version>1.2.1.RELEASE</spring-rabbit.version>
 		<spring-mobile.version>1.1.1.RELEASE</spring-mobile.version>
@@ -514,38 +512,15 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.data</groupId>
-				<artifactId>spring-data-jpa</artifactId>
-				<version>${spring-data-jpa.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>org.springframework</groupId>
-						<artifactId>spring-jdbc</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>org.springframework</groupId>
-						<artifactId>spring-orm</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.data</groupId>
-				<artifactId>spring-data-mongodb</artifactId>
-				<version>${spring-data-mongodb.version}</version>
+				<artifactId>spring-data-releasetrain</artifactId>
+				<version>${spring-data-releasetrain.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.data</groupId>
 				<artifactId>spring-data-redis</artifactId>
 				<version>${spring-data-redis.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.hateoas</groupId>
-				<artifactId>spring-hateoas</artifactId>
-				<version>${spring-hateoas.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.data</groupId>
-				<artifactId>spring-data-rest-webmvc</artifactId>
-				<version>${spring-data-rest.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.integration</groupId>

--- a/spring-boot-starters/spring-boot-starter-data-rest/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-data-rest/pom.xml
@@ -24,10 +24,6 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.hateoas</groupId>
-			<artifactId>spring-hateoas</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-webmvc</artifactId>
 		</dependency>


### PR DESCRIPTION
The dependencies pom.xml now declares an import to the spring-data-releasetrain BOM pom.xml which in turn constraints version numbers for a dedicated release train release. This has the effect of users being able to upgrade to a certain release train by redeclaring the spring-data-releasetrain.version property to e.g. Dijkstra-M1. Individual modules can be upgraded by simply declaring the dependency in the desired version manually in a <dependencies /> or <dependencyManagement /> block.

We'll have to wait for the application of this change until Codd SR2 is released as previously released versions unfortunately declare an invalid Spring Data REST artifact identifier (which would leave boot bit a broken starter pom for the data REST module).

Removed the explicit declaration for Spring HATEOAS as it is pulled in transitively by Spring Data REST anyway and thus makes sure it's in a compatible version.

TODOs:
- wait for Codd SR2 to be released before applying the patch (ETA April, 15th)
- move to Codd-SR2 as version number for the release train property
- drop snapshot repository declaration

/cc @wilkinsona
