### PR TITLE
Introduced awaitility for verifying delayed assestions

### DIFF
--- a/spring-boot-actuator/pom.xml
+++ b/spring-boot-actuator/pom.xml
@@ -136,5 +136,10 @@
 			<artifactId>tomcat-embed-logging-juli</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.jayway.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/ShutdownEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/ShutdownEndpointTests.java
@@ -21,8 +21,12 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.concurrent.TimeUnit;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static com.jayway.awaitility.Awaitility.to;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -31,6 +35,7 @@ import static org.junit.Assert.assertTrue;
  * 
  * @author Phillip Webb
  * @author Dave Syer
+ * @author Jakub Kubrynski
  */
 public class ShutdownEndpointTests extends AbstractEndpointTests<ShutdownEndpoint> {
 
@@ -44,8 +49,9 @@ public class ShutdownEndpointTests extends AbstractEndpointTests<ShutdownEndpoin
 		assertThat((String) getEndpointBean().invoke().get("message"),
 				startsWith("Shutting down"));
 		assertTrue(this.context.isActive());
-		Thread.sleep(600);
-		assertFalse(this.context.isActive());
+
+		await().atMost(2, TimeUnit.SECONDS)
+				.untilCall(to(this.context).isActive(), equalTo(false));
 	}
 
 	@Configuration

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/ShutdownParentEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/ShutdownParentEndpointTests.java
@@ -24,6 +24,14 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static com.jayway.awaitility.Awaitility.reset;
+import static com.jayway.awaitility.Awaitility.to;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -33,6 +41,7 @@ import static org.junit.Assert.assertTrue;
  * Tests for {@link ShutdownEndpoint}.
  * 
  * @author Dave Syer
+ * @author Jakub Kubrynski
  */
 public class ShutdownParentEndpointTests {
 
@@ -52,8 +61,8 @@ public class ShutdownParentEndpointTests {
 		assertThat((String) getEndpointBean().invoke().get("message"),
 				startsWith("Shutting down"));
 		assertTrue(this.context.isActive());
-		Thread.sleep(600);
-		assertFalse(this.context.isActive());
+		await().atMost(2, TimeUnit.SECONDS)
+				.untilCall(to(this.context).isActive(), equalTo(false));
 	}
 
 	@Test
@@ -63,8 +72,8 @@ public class ShutdownParentEndpointTests {
 		assertThat((String) getEndpointBean().invoke().get("message"),
 				startsWith("Shutting down"));
 		assertTrue(this.context.isActive());
-		Thread.sleep(600);
-		assertFalse(this.context.isActive());
+		await().atMost(2, TimeUnit.SECONDS)
+				.untilCall(to(this.context).isActive(), equalTo(false));
 	}
 
 	private ShutdownEndpoint getEndpointBean() {

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -68,6 +68,7 @@
 		<jolokia.version>1.2.0</jolokia.version>
 		<jstl.version>1.2</jstl.version>
 		<junit.version>4.11</junit.version>
+		<awaitility.version>1.5.0</awaitility.version>
 		<lettuce.version>2.3.3</lettuce.version>
 		<liquibase.version>3.1.1</liquibase.version>
 		<log4j.version>1.2.17</log4j.version>
@@ -175,6 +176,11 @@
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
 				<version>${junit.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.jayway.awaitility</groupId>
+				<artifactId>awaitility</artifactId>
+				<version>${awaitility.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>log4j</groupId>


### PR DESCRIPTION
When build environment is heavily used it could fail tests using Thread.sleep(). Awaitility is better option, because:
1. It checks for result every 100 ms, and don't have to wait max time
2. According to the former, we can specify higher max time, which solves basic problem
