### PR TITLE
Added liquibase autoconfiguration for executing database migrations on startup

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -142,6 +142,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-acl</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.liquibase;
+
+import javax.annotation.PostConstruct;
+import javax.sql.DataSource;
+
+import liquibase.integration.spring.SpringLiquibase;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.util.Assert;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Liquibase.
+ * 
+ * @author Marcel Overdijk
+ */
+@Configuration
+@ConditionalOnClass(SpringLiquibase.class)
+@AutoConfigureAfter(DataSourceAutoConfiguration.class)
+public class LiquibaseAutoConfiguration {
+
+	@Configuration
+	@ConditionalOnMissingBean(SpringLiquibase.class)
+	@EnableConfigurationProperties(LiquibaseProperties.class)
+	public static class LiquibaseConfiguration {
+
+		@Autowired
+		private LiquibaseProperties properties = new LiquibaseProperties();
+
+		@Autowired
+		private ResourceLoader resourceLoader = new DefaultResourceLoader();
+
+		@Autowired
+		private DataSource dataSource;
+
+		@PostConstruct
+		public void checkChangelogExists() {
+			if (this.properties.isCheckChangeLogLocation()) {
+				Resource resource = this.resourceLoader.getResource(this.properties.getChangeLog());
+				Assert.state(resource.exists(), "Cannot find changelog location: "
+						+ resource + " (please add changelog or check your Liquibase configuration)");
+			}
+		}
+
+		@Bean
+		public SpringLiquibase liquibase() {
+			SpringLiquibase liquibase = new SpringLiquibase();
+			liquibase.setChangeLog(this.properties.getChangeLog());
+			liquibase.setContexts(this.properties.getContexts());
+	        liquibase.setDataSource(dataSource);
+	        liquibase.setDefaultSchema(this.properties.getDefaultSchema());
+	        liquibase.setDropFirst(this.properties.isDropFirst());
+	        liquibase.setShouldRun(this.properties.isShouldRun());
+			return liquibase;
+		}
+	}
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.liquibase;
+
+import javax.validation.constraints.NotNull;
+
+import liquibase.integration.spring.SpringLiquibase;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties to configure {@link SpringLiquibase}.
+ * 
+ * @author Marcel Overdijk
+ */
+@ConfigurationProperties(prefix = "spring.liquibase", ignoreUnknownFields = false)
+public class LiquibaseProperties {
+
+	@NotNull
+	private String changeLog = "classpath:/db/changelog/db.changelog-master.yaml";
+
+	private boolean checkChangeLogLocation = true;
+	
+	private String contexts;
+
+	private String defaultSchema;
+
+	private boolean dropFirst = false;
+
+	private boolean shouldRun = true;
+
+	public String getChangeLog() {
+		return changeLog;
+	}
+
+	public void setChangeLog(String changeLog) {
+		this.changeLog = changeLog;
+	}
+
+	public boolean isCheckChangeLogLocation() {
+		return checkChangeLogLocation;
+	}
+
+	public void setCheckChangeLogLocation(boolean checkChangeLogLocation) {
+		this.checkChangeLogLocation = checkChangeLogLocation;
+	}
+
+	public String getContexts() {
+		return contexts;
+	}
+
+	public void setContexts(String contexts) {
+		this.contexts = contexts;
+	}
+
+	public String getDefaultSchema() {
+		return defaultSchema;
+	}
+
+	public void setDefaultSchema(String defaultSchema) {
+		this.defaultSchema = defaultSchema;
+	}
+
+	public boolean isDropFirst() {
+		return dropFirst;
+	}
+
+	public void setDropFirst(boolean dropFirst) {
+		this.dropFirst = dropFirst;
+	}
+
+	public boolean isShouldRun() {
+		return shouldRun;
+	}
+
+	public void setShouldRun(boolean shouldRun) {
+		this.shouldRun = shouldRun;
+	}
+}

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -16,6 +16,7 @@ org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,\
 org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration,\
 org.springframework.boot.autoconfigure.jms.JmsTemplateAutoConfiguration,\
 org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration,\
+org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration,\
 org.springframework.boot.autoconfigure.mobile.DeviceResolverAutoConfiguration,\
 org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,\
 org.springframework.boot.autoconfigure.mongo.MongoTemplateAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.liquibase;
+
+import liquibase.integration.spring.SpringLiquibase;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link LiquibaseAutoConfiguration}.
+ * 
+ * @author Marcel Overdijk
+ */
+public class LiquibaseAutoConfigurationTests {
+
+	@Rule
+	public ExpectedException expected = ExpectedException.none();
+
+	private AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();;
+
+	@After
+	public void close() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void testNoDataSource() throws Exception {
+		this.context.register(LiquibaseAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.expected.expect(BeanCreationException.class);
+		this.expected.expectMessage("No qualifying bean");
+		this.expected.expectMessage("DataSource");
+		this.context.refresh();
+	}
+
+	@Test
+	public void testDefaultSpringLiquibase() throws Exception {
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				LiquibaseAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		SpringLiquibase liquibase = this.context.getBean(SpringLiquibase.class);
+		assertEquals("classpath:/db/changelog/db.changelog-master.yaml", liquibase.getChangeLog());
+		assertNull(liquibase.getContexts());
+		assertNull(liquibase.getDefaultSchema());
+		assertFalse(liquibase.isDropFirst());
+	}
+
+	@Test
+	public void testOverrideChangeLog() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.liquibase.change-log:classpath:/db/changelog/db.changelog-override.xml");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				LiquibaseAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		SpringLiquibase liquibase = this.context.getBean(SpringLiquibase.class);
+		assertEquals("classpath:/db/changelog/db.changelog-override.xml", liquibase.getChangeLog());
+	}
+
+	@Test
+	public void testOverrideContexts() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.liquibase.contexts:test, production");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				LiquibaseAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		SpringLiquibase liquibase = this.context.getBean(SpringLiquibase.class);
+		assertEquals("test, production", liquibase.getContexts());
+	}
+	
+	@Test
+	public void testOverrideDefaultSchema() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.liquibase.default-schema:public");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				LiquibaseAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		SpringLiquibase liquibase = this.context.getBean(SpringLiquibase.class);
+		assertEquals("public", liquibase.getDefaultSchema());
+	}
+	
+	@Test
+	public void testOverrideDropFirst() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.liquibase.drop-first:true");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				LiquibaseAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		SpringLiquibase liquibase = this.context.getBean(SpringLiquibase.class);
+		assertTrue(liquibase.isDropFirst());
+	}
+	
+	@Test(expected = BeanCreationException.class)
+	public void testChangeLogDoesNotExist() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.liquibase.change-log:classpath:/no-such-changelog.yaml");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				LiquibaseAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+	}
+}

--- a/spring-boot-autoconfigure/src/test/resources/db/changelog/db.changelog-master.yaml
+++ b/spring-boot-autoconfigure/src/test/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1
+      author: marceloverdijk
+      changes:
+        - createTable:
+            tableName: customer
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: varchar(50)
+                  constraints:
+                    nullable: false

--- a/spring-boot-autoconfigure/src/test/resources/db/changelog/db.changelog-override.xml
+++ b/spring-boot-autoconfigure/src/test/resources/db/changelog/db.changelog-override.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="1" author="marceloverdijk">
+        <createTable tableName="customer">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="varchar(50)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -137,6 +137,13 @@ content into your application; rather pick only the properties that you need.
 	spring.jpa.hibernate.naming-strategy= # naming classname
 	spring.jpa.hibernate.ddl-auto= # defaults to create-drop for embedded dbs
 
+	# LIQUIBASE ({sc-spring-boot-autoconfigure}/liquibase/LiquibaseProperties.{sc-ext}[LiquibaseProperties])
+	spring.liquibase.change-log=classpath:/db/changelog/db.changelog-master.yaml
+	spring.liquibase.contexts= # runtime contexts to use
+	spring.liquibase.default-schema= # default database schema to use
+	spring.liquibase.drop-first=false
+	spring.liquibase.should-run=true
+
 	# JMX
 	spring.jmx.enabled=true # Expose MBeans from Spring
 
@@ -148,7 +155,6 @@ content into your application; rather pick only the properties that you need.
 	spring.rabbitmq.password= # login password
 	spring.rabbitmq.virtualhost=
 	spring.rabbitmq.dynamic=
-
 
 	# REDIS ({sc-spring-boot-autoconfigure}/redis/RedisProperties.{sc-ext}[RedisProperties])
 	spring.redis.host=localhost # server host

--- a/spring-boot-docs/src/main/asciidoc/appendix-auto-configuration-classes.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-auto-configuration-classes.adoc
@@ -53,6 +53,9 @@ The following auto-configuration classes are from the `spring-boot-autoconfigure
 |{sc-spring-boot-autoconfigure}/data/JpaRepositoriesAutoConfiguration.{sc-ext}[JpaRepositoriesAutoConfiguration]
 |{dc-spring-boot-autoconfigure}/data/JpaRepositoriesAutoConfiguration.{dc-ext}[javadoc]
 
+|{sc-spring-boot-autoconfigure}/liquibase/LiquibaseAutoConfiguration.{sc-ext}[LiquibaseAutoConfiguration]
+|{dc-spring-boot-autoconfigure}/liquibase/LiquibaseAutoConfiguration.{dc-ext}[javadoc]
+
 |{sc-spring-boot-autoconfigure}/MessageSourceAutoConfiguration.{sc-ext}[MessageSourceAutoConfiguration]
 |{dc-spring-boot-autoconfigure}/MessageSourceAutoConfiguration.{dc-ext}[javadoc]
 

--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -1049,6 +1049,21 @@ independence: usually only one or at most couple of platforms is needed.
 
 
 
+[[howto-execute-liquibase-database-migrations-on-startup]]
+==== Execute Liquibase database migrations on startup
+To automatically run Liquibase database migrations on startup, add the
+`spring-boot-starter-liquibase` to your classpath.
+
+The master change log is by default read from `db/changelog/db.changelog-master.yaml` but
+can be set using `spring.liquibase.change-log`. See
+{sc-spring-boot-autoconfigure}/liquibase/LiquibaseProperties.{sc-ext}[`LiquibaseProperties`]
+for details of available settings like contexts, default schema etc.
+
+There is a {github-code}/spring-boot-samples/spring-boot-sample-liquibase[Liquibase sample] so
+you can see how to set things up.
+
+
+
 [[howto-batch-applications]]
 == Batch applications
 

--- a/spring-boot-docs/src/main/asciidoc/index.adoc
+++ b/spring-boot-docs/src/main/asciidoc/index.adoc
@@ -1,5 +1,5 @@
 = Spring Boot Reference Guide
-Phillip Webb; Dave Syer; Josh Long; Stéphane Nicoll; Rob Winch;
+Phillip Webb; Dave Syer; Josh Long; Stéphane Nicoll; Rob Winch; Marcel Overdijk;
 :doctype: book
 :toc:
 :toclevels: 4

--- a/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
+++ b/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
@@ -237,6 +237,9 @@ and Hibernate.
 |`spring-boot-starter-jdbc`
 |JDBC Database support.
 
+|`spring-boot-starter-liquibase`
+|Support for Liquibase database migrations.
+
 |`spring-boot-starter-mobile`
 |Support for `spring-mobile`
 

--- a/spring-boot-samples/pom.xml
+++ b/spring-boot-samples/pom.xml
@@ -33,6 +33,7 @@
 		<module>spring-boot-sample-data-rest</module>
 		<module>spring-boot-sample-integration</module>
 		<module>spring-boot-sample-jetty</module>
+		<module>spring-boot-sample-liquibase</module>
 		<module>spring-boot-sample-profile</module>
 		<module>spring-boot-sample-secure</module>
 		<module>spring-boot-sample-servlet</module>

--- a/spring-boot-samples/spring-boot-sample-liquibase/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-liquibase/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<!-- Your own application should inherit from spring-boot-starter-parent -->
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-samples</artifactId>
+		<version>1.0.2.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-sample-liquibase</artifactId>
+	<name>Spring Boot Liquibase Sample</name>
+	<description>Spring Boot Liquibase Sample</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-liquibase</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hsqldb</groupId>
+			<artifactId>hsqldb</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-samples/spring-boot-sample-liquibase/src/main/java/sample/liquibase/SampleLiquibaseApplication.java
+++ b/spring-boot-samples/spring-boot-sample-liquibase/src/main/java/sample/liquibase/SampleLiquibaseApplication.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.liquibase;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan
+@EnableAutoConfiguration
+public class SampleLiquibaseApplication {
+
+	public static void main(String[] args) throws Exception {
+		SpringApplication.run(SampleLiquibaseApplication.class, args);
+	}
+}

--- a/spring-boot-samples/spring-boot-sample-liquibase/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-liquibase/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.jpa.hibernate.ddl-auto: none

--- a/spring-boot-samples/spring-boot-sample-liquibase/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/spring-boot-samples/spring-boot-sample-liquibase/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,38 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1
+      author: marceloverdijk
+      changes:
+        - createTable:
+            tableName: person
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: first_name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+  - changeSet:
+      id: 2
+      author: marceloverdijk
+      changes:
+        - insert:
+            tableName: person
+            columns:
+              - column:
+                  name: first_name
+                  value: Marcel
+              - column:
+                  name: last_name
+                  value: Overdijk

--- a/spring-boot-samples/spring-boot-sample-liquibase/src/test/java/sample/liquibase/SampleLiquibaseApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-liquibase/src/test/java/sample/liquibase/SampleLiquibaseApplicationTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.liquibase;
+
+import java.net.ConnectException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.boot.test.OutputCapture;
+import org.springframework.core.NestedCheckedException;
+
+import static org.junit.Assert.assertTrue;
+
+public class SampleLiquibaseApplicationTests {
+
+	@Rule
+	public OutputCapture outputCapture = new OutputCapture();
+
+	@Test
+	public void testDefaultSettings() throws Exception {
+		try {
+			SampleLiquibaseApplication.main(new String[0]);
+		}
+		catch (IllegalStateException ex) {
+			if (serverNotRunning(ex)) {
+				return;
+			}
+		}
+		String output = this.outputCapture.toString();
+		assertTrue("Wrong output: " + output,
+				output.contains("Successfully acquired change log lock") &&
+				output.contains("Creating database history table with name: PUBLIC.DATABASECHANGELOG") &&
+				output.contains("Table person created") &&
+				output.contains("ChangeSet classpath:/db/changelog/db.changelog-master.yaml::1::marceloverdijk ran successfully") &&
+				output.contains("New row inserted into person") &&
+				output.contains("ChangeSet classpath:/db/changelog/db.changelog-master.yaml::2::marceloverdijk ran successfully") &&
+				output.contains("Successfully released change log lock"));
+	}
+
+	private boolean serverNotRunning(IllegalStateException ex) {
+		@SuppressWarnings("serial")
+		NestedCheckedException nested = new NestedCheckedException("failed", ex) {
+		};
+		if (nested.contains(ConnectException.class)) {
+			Throwable root = nested.getRootCause();
+			if (root.getMessage().contains("Connection refused")) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/spring-boot-starters/pom.xml
+++ b/spring-boot-starters/pom.xml
@@ -29,6 +29,7 @@
 		<module>spring-boot-starter-integration</module>
 		<module>spring-boot-starter-jdbc</module>
 		<module>spring-boot-starter-jetty</module>
+		<module>spring-boot-starter-liquibase</module>
 		<module>spring-boot-starter-logging</module>
 		<module>spring-boot-starter-log4j</module>
 		<module>spring-boot-starter-mobile</module>

--- a/spring-boot-starters/spring-boot-starter-liquibase/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-liquibase/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starters</artifactId>
+		<version>1.0.2.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-starter-liquibase</artifactId>
+	<name>Spring Boot Liquibase Starter</name>
+	<description>Spring Boot Liquibase Starter</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-boot-starters/spring-boot-starter-liquibase/src/main/resources/META-INF/spring.provides
+++ b/spring-boot-starters/spring-boot-starter-liquibase/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: liquibase-core

--- a/spring-boot-starters/spring-boot-starter-parent/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-parent/pom.xml
@@ -103,6 +103,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-liquibase</artifactId>
+				<version>${spring-boot.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-logging</artifactId>
 				<version>${spring-boot.version}</version>
 			</dependency>


### PR DESCRIPTION
This pull request is for https://github.com/spring-projects/spring-boot/issues/662.
It contains a liquibase starter module, auto configuration to create SpringLiquibase bean to execute migrations on startup, tests, a liquibase sample application and updated documentation.
