### PR TITLE
Relaxed <requireJavaVersion> configuration of the maven-enforcer-plugin

### DIFF
--- a/spring-boot-parent/pom.xml
+++ b/spring-boot-parent/pom.xml
@@ -342,7 +342,7 @@
 						<configuration>
 							<rules>
 								<requireJavaVersion>
-									<version>(1.7,1.8)</version>
+									<version>1.7</version>
 								</requireJavaVersion>
 							</rules>
 						</configuration>


### PR DESCRIPTION
This commit resolves #695 by changing the configuration so that all Java versions from 1.7 and above are allowed.
