### PR TITLE
RelaxedDataBinder handling for untyped map

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/bind/RelaxedDataBinder.java
+++ b/spring-boot/src/main/java/org/springframework/boot/bind/RelaxedDataBinder.java
@@ -229,6 +229,9 @@ public class RelaxedDataBinder extends DataBinder {
 			return;
 		}
 		TypeDescriptor descriptor = parent.getMapValueTypeDescriptor();
+		if (descriptor == null) {
+			descriptor = TypeDescriptor.valueOf(Object.class);
+		}
 		if (!descriptor.isMap() && !descriptor.isCollection()
 				&& !descriptor.getType().equals(Object.class)) {
 			return;

--- a/spring-boot/src/test/java/org/springframework/boot/bind/RelaxedDataBinderTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/bind/RelaxedDataBinderTests.java
@@ -259,6 +259,13 @@ public class RelaxedDataBinderTests {
 	}
 
 	@Test
+	public void testBindNestedUntypedMap() throws Exception {
+		TargetWithNestedUntypedMap target = new TargetWithNestedUntypedMap();
+		bind(target, "nested.foo: bar\n" + "nested.value: 123");
+		assertEquals("123", target.getNested().get("value"));
+	}
+	
+	@Test
 	public void testBindNestedMapOfString() throws Exception {
 		TargetWithNestedMapOfString target = new TargetWithNestedMapOfString();
 		bind(target, "nested.foo: bar\n" + "nested.value.foo: 123");
@@ -503,6 +510,22 @@ public class RelaxedDataBinderTests {
 		}
 
 	}
+	
+	@SuppressWarnings("rawtypes")
+	public static class TargetWithNestedUntypedMap {
+
+		private Map nested;
+
+		public Map getNested() {
+			return this.nested;
+		}
+
+		public void setNested(Map nested) {
+			this.nested = nested;
+		}
+
+	}
+
 
 	public static class TargetWithNestedMapOfString {
 


### PR DESCRIPTION
`parent.getMapValueTypeDescriptor()` return null when binding to an untyped map.
This causes a NPE exception.

This patch treats an untyped map as having a value type of Object.class.

I have signed the agreement (76520140326040007)
