### PR TITLE
Migrate ActiveMQ to new artifacts and latest version

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -43,7 +43,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.activemq</groupId>
-			<artifactId>activemq-core</artifactId>
+			<artifactId>activemq-client</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -44,7 +44,7 @@
 		</developer>
 	</developers>
 	<properties>
-		<activemq.version>5.7.0</activemq.version>
+		<activemq.version>5.9.0</activemq.version>
 		<aspectj.version>1.7.4</aspectj.version>
 		<codahale-metrics.version>3.0.2</codahale-metrics.version>
 		<commons-dbcp.version>1.4</commons-dbcp.version>
@@ -193,7 +193,12 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.activemq</groupId>
-				<artifactId>activemq-core</artifactId>
+				<artifactId>activemq-broker</artifactId>
+				<version>${activemq.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.activemq</groupId>
+				<artifactId>activemq-client</artifactId>
 				<version>${activemq.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
This changes the ActiveMQ artifacts based on https://activemq.apache.org/activemq-580-release.html, and moves up to latest 5.9.0 release.

When this is merged and release, https://github.com/spring-guides/gs-messaging-jms needs to be updated.
