### PR TITLE
Update Cloud Foundry deployment docs.

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/cloud-deployment.adoc
+++ b/spring-boot-docs/src/main/asciidoc/cloud-deployment.adoc
@@ -30,62 +30,28 @@ developed>> in the ``Getting Started'' section up and running in the Cloud.
 [[cloud-deployment-cloud-foundry]]
 == Cloud Foundry
 Cloud Foundry provides default buildpacks that come into play if no other buildpack is
-specified. The Cloud Foundry Java buildpack has excellent support for Spring applications,
-including Spring Boot.  You can deploy stand-alone executable jar applications, as well as
-traditional `.war` packaged applications.
+specified. The Cloud Foundry https://github.com/cloudfoundry/java-buildpack[Java buildpack] has excellent 
+support for Spring applications, including Spring Boot.  You can deploy stand-alone executable jar 
+applications, as well as traditional `.war` packaged applications.
 
 Once you've built your application (using, for example, `mvn clean package`) and
-http://docs.run.pivotal.io/devguide/installcf/install-go-cli.html/[installed the `cf`
-command line tool], simply answer the `cf push` command  prompts as follows, substituting
-the path to  your compiled `.jar` for mine. Be sure to have
-http://docs.run.pivotal.io/devguide/installcf/whats-new-v6.html#login[logged in with your
-`cf` command line client] before attempting to use it.
+http://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html[installed the `cf`
+command line tool], simply deploy your applicationg using the `cf push` command as follows, substituting
+the path to your compiled `.jar`. Be sure to have
+http://docs.cloudfoundry.org/devguide/installcf/whats-new-v6.html#login[logged in with your
+`cf` command line client] before pushing an application.
 
 [indent=0,subs="verbatim,quotes,attributes"]
 ----
-	$ cf push --path target/demo-0.0.1-SNAPSHOT.jar
+	$ cf push acloudyspringtime -p target/demo-0.0.1-SNAPSHOT.jar
 ----
 
-If there is a Cloud Foundry `manifest.yml` file present in the same directory, it will be
-consulted. If not, the client will prompt you with questions it has about how it should
-deploy and manage your application, starting with its name:
+See the http://docs.cloudfoundry.org/devguide/installcf/whats-new-v6.html#push[`cf push` documentation] for 
+more options. If there is a Cloud Foundry http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html[`manifest.yml`] 
+file present in the same directory, it will be consulted. 
 
-[indent=0,subs="verbatim,quotes,attributes"]
-----
-	Name> *acloudyspringtime*
-
-	Instances> *1*
-
-	1: 128M
-	2: 256M
-	3: 512M
-	4: 1G
-	Memory Limit> *256M*
-
-	Creating acloudyspringtime... *OK*
-
-	1: acloudyspringtime
-	2: none
-	Subdomain> *acloudyspringtime*
-
-	1: cfapps.io
-	2: none
-	Domain> *cfapps.io*
-
-	Creating route acloudyspringtime.cfapps.io... *OK*
-	Binding acloudyspringtime.cfapps.io to acloudyspringtime... *OK*
-
-	Create services for application?> *n*
-
-	Bind other services to application?> *n*
-
-	Save configuration?> *y*
-
-	Saving to manifest.yml... *OK*
-----
-
-NOTE: Here we are substituting `acloudyspringtime` for whatever value you give `cf` when
-it asks for the `name` of your application.
+NOTE: Here we are substituting `acloudyspringtime` for whatever value you give `cf` 
+as the name of your application.
 
 At this point `cf` will start uploading your application:
 
@@ -107,7 +73,8 @@ At this point `cf` will start uploading your application:
 	  0 of 1 instances running (1 starting)
 	  ...
 	  1 of 1 instances running (1 running)
-	Push successful! App \'acloudyspringtime' available at acloudyspringtime.cfapps.io
+
+  App started
 ----
 
 Congratulations! The application is now live!
@@ -117,11 +84,12 @@ It's easy to then verify the status of the deployed application:
 [indent=0,subs="verbatim,quotes,attributes"]
 ----
 	$ cf apps
-	Getting applications in ... OK
+	Getting applications in ... 
+  OK
 
-	name                             status    usage      url
+  name                 requested state   instances   memory   disk   urls
 	...
-	acloudyspringtime                running   1 x 256M   acloudyspringtime.cfapps.io
+	acloudyspringtime    started           1/1         512M     1G     acloudyspringtime.cfapps.io
 	...
 ----
 


### PR DESCRIPTION
- Updates the CF deployment docs to reflect the fact that the Cloud Foundry v6 CLI no longer has an interactive mode for application push. 
- Updates some of the CLI output.
- Changes links to point to open-source CF docs instead of Pivotal commercial docs.
- Adds a few links. 

cc: @joshlong
