### PR TITLE
adding test-sources jar to the build

### DIFF
--- a/spring-boot-parent/pom.xml
+++ b/spring-boot-parent/pom.xml
@@ -450,6 +450,7 @@
 								<id>attach-sources</id>
 								<goals>
 									<goal>jar-no-fork</goal>
+									<goal>test-jar-no-fork</goal>
 								</goals>
 							</execution>
 						</executions>


### PR DESCRIPTION
tests.jar is already deployed into maven central. But test-sources.jar is not. I'm writing my one starter and reuse your tests, extending them with my own - seeing the sources is very helpful. Now I'm installing test-sources.jar into my local maven repo for every spring-boot version.
