### PR TITLE
Add spring-boot-autoconfigure to the starter parent POM

### DIFF
--- a/spring-boot-starters/spring-boot-starter-parent/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-parent/pom.xml
@@ -20,7 +20,7 @@
 		<java.version>1.6</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<spring-boot.version>1.0.2.BUILD-SNAPSHOT</spring-boot.version>
+		<spring-boot.version>1.1.0.BUILD-SNAPSHOT</spring-boot.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -49,6 +49,11 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-actuator</artifactId>
+				<version>${spring-boot.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-autoconfigure</artifactId>
 				<version>${spring-boot.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
This commit fixes the spring boot version and add the `autoconfigure` module in the dependency management so that it can be referred to for a project not using the starter at all.

Maybe there should be some sort of integration test because it can be hard to track such issue.
