### PR TITLE
Fix JmsTemplate default pubSubDomain setting

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsTemplateProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsTemplateProperties.java
@@ -21,7 +21,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "spring.jms")
 public class JmsTemplateProperties {
 
-	private boolean pubSubDomain = true;
+	private boolean pubSubDomain = false;
 
 	public boolean isPubSubDomain() {
 		return this.pubSubDomain;

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsTemplateAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsTemplateAutoConfigurationTests.java
@@ -94,23 +94,23 @@ public class JmsTemplateAutoConfigurationTests {
 	}
 
 	@Test
-	public void testPubSubEnabledByDefault() {
+	public void testPubSubDisabledByDefault() {
 		this.context = new AnnotationConfigApplicationContext();
 		this.context
 				.register(TestConfiguration.class, JmsTemplateAutoConfiguration.class);
 		this.context.refresh();
 		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
-		assertTrue(jmsTemplate.isPubSubDomain());
+		assertFalse(jmsTemplate.isPubSubDomain());
 	}
 
 	@Test
-	public void testJmsTemplatePostProcessedSoThatPubSubIsFalse() {
+	public void testJmsTemplatePostProcessedSoThatPubSubIsTrue() {
 		this.context = new AnnotationConfigApplicationContext();
 		this.context.register(TestConfiguration4.class,
 				JmsTemplateAutoConfiguration.class);
 		this.context.refresh();
 		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
-		assertFalse(jmsTemplate.isPubSubDomain());
+		assertTrue(jmsTemplate.isPubSubDomain());
 	}
 
 	@Test
@@ -262,7 +262,7 @@ public class JmsTemplateAutoConfigurationTests {
 				throws BeansException {
 			if (bean.getClass().isAssignableFrom(JmsTemplate.class)) {
 				JmsTemplate jmsTemplate = (JmsTemplate) bean;
-				jmsTemplate.setPubSubDomain(false);
+				jmsTemplate.setPubSubDomain(true);
 			}
 			return bean;
 		}

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -171,7 +171,7 @@ content into your application; rather pick only the properties that you need.
 	spring.activemq.pooled=false
 
 	# JMS ({sc-spring-boot-autoconfigure}/jms/JmsTemplateProperties.{sc-ext}[JmsTemplateProperties])
-	spring.jms.pub-sub-domain=
+	spring.jms.pub-sub-domain= # false for queue (default), true for topic
 
 	# SPRING BATCH ({sc-spring-boot-autoconfigure}/batch/BatchDatabaseInitializer.{sc-ext}[BatchDatabaseInitializer])
 	spring.batch.job.names=job1,job2


### PR DESCRIPTION
Prior to this commit, a JmsTemplate bean created automatically by Boot
had its "pubSubDomain" flag enabled. It's far more usual to fallback on
queue rather than topic.

This commit flips the default value of the configuration property.
