### PR TITLE
fix for gh-732 - removing test-jar from build and publishing to repositories

### DIFF
--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -156,25 +156,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-jar-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>test-jar</goal>
-						</goals>
-						<configuration>
-							<excludes>
-								<exclude>*.properties</exclude>
-								<exclude>logback*.xml</exclude>
-								<exclude>*.yml</exclude>
-							</excludes>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>


### PR DESCRIPTION
No artifact in spring-boot repository currently declares dependency to any test-jar type artifact. So this configs seems to be outdated.
