### PR TITLE
minor test fixes

### DIFF
--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/CrshAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/CrshAutoConfigurationTests.java
@@ -58,7 +58,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link CrshAutoConfiguration}.
- * 
+ *
  * @author Christian Dupuis
  */
 @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -117,7 +117,7 @@ public class CrshAutoConfigurationTests {
 
 		PluginLifeCycle lifeCycle = this.context.getBean(PluginLifeCycle.class);
 
-		assertEquals(lifeCycle.getConfig().getProperty("crash.ssh.port"), "3333");
+		assertEquals("3333", lifeCycle.getConfig().getProperty("crash.ssh.port"));
 	}
 
 	@Test
@@ -132,8 +132,7 @@ public class CrshAutoConfigurationTests {
 
 		PluginLifeCycle lifeCycle = this.context.getBean(PluginLifeCycle.class);
 
-		assertEquals(lifeCycle.getConfig().getProperty("crash.ssh.keypath"),
-				"~/.ssh/id.pem");
+		assertEquals("~/.ssh/id.pem", lifeCycle.getConfig().getProperty("crash.ssh.keypath"));
 	}
 
 	@Test
@@ -194,7 +193,7 @@ public class CrshAutoConfigurationTests {
 		this.context.refresh();
 
 		PluginLifeCycle lifeCycle = this.context.getBean(PluginLifeCycle.class);
-		assertEquals(lifeCycle.getConfig().get("crash.auth"), "simple");
+		assertEquals("simple", lifeCycle.getConfig().get("crash.auth"));
 	}
 
 	@Test
@@ -210,9 +209,8 @@ public class CrshAutoConfigurationTests {
 		this.context.refresh();
 
 		PluginLifeCycle lifeCycle = this.context.getBean(PluginLifeCycle.class);
-		assertEquals(lifeCycle.getConfig().get("crash.auth"), "jaas");
-		assertEquals(lifeCycle.getConfig().get("crash.auth.jaas.domain"),
-				"my-test-domain");
+		assertEquals("jaas", lifeCycle.getConfig().get("crash.auth"));
+		assertEquals("my-test-domain", lifeCycle.getConfig().get("crash.auth.jaas.domain"));
 	}
 
 	@Test
@@ -228,8 +226,8 @@ public class CrshAutoConfigurationTests {
 		this.context.refresh();
 
 		PluginLifeCycle lifeCycle = this.context.getBean(PluginLifeCycle.class);
-		assertEquals(lifeCycle.getConfig().get("crash.auth"), "key");
-		assertEquals(lifeCycle.getConfig().get("crash.auth.key.path"), "~/test.pem");
+		assertEquals("key", lifeCycle.getConfig().get("crash.auth"));
+		assertEquals("~/test.pem", lifeCycle.getConfig().get("crash.auth.key.path"));
 	}
 
 	@Test
@@ -246,7 +244,7 @@ public class CrshAutoConfigurationTests {
 		this.context.refresh();
 
 		PluginLifeCycle lifeCycle = this.context.getBean(PluginLifeCycle.class);
-		assertEquals(lifeCycle.getConfig().get("crash.auth"), "simple");
+		assertEquals("simple", lifeCycle.getConfig().get("crash.auth"));
 
 		AuthenticationPlugin<String> authenticationPlugin = null;
 		String authentication = lifeCycle.getConfig().getProperty("crash.auth");
@@ -260,8 +258,7 @@ public class CrshAutoConfigurationTests {
 		}
 		assertNotNull(authenticationPlugin);
 		assertTrue(authenticationPlugin.authenticate("user", "password"));
-		assertFalse(authenticationPlugin.authenticate(UUID.randomUUID().toString(),
-				"password"));
+		assertFalse(authenticationPlugin.authenticate(UUID.randomUUID().toString(), "password"));
 	}
 
 	@Test
@@ -287,11 +284,9 @@ public class CrshAutoConfigurationTests {
 				break;
 			}
 		}
-		assertTrue(authenticationPlugin.authenticate(SecurityConfiguration.USERNAME,
-				SecurityConfiguration.PASSWORD));
+		assertTrue(authenticationPlugin.authenticate(SecurityConfiguration.USERNAME, SecurityConfiguration.PASSWORD));
 
-		assertFalse(authenticationPlugin.authenticate(UUID.randomUUID().toString(),
-				SecurityConfiguration.PASSWORD));
+		assertFalse(authenticationPlugin.authenticate(UUID.randomUUID().toString(), SecurityConfiguration.PASSWORD));
 	}
 
 	@Test
@@ -316,11 +311,9 @@ public class CrshAutoConfigurationTests {
 				break;
 			}
 		}
-		assertTrue(authenticationPlugin.authenticate(SecurityConfiguration.USERNAME,
-				SecurityConfiguration.PASSWORD));
+		assertTrue(authenticationPlugin.authenticate(SecurityConfiguration.USERNAME, SecurityConfiguration.PASSWORD));
 
-		assertFalse(authenticationPlugin.authenticate(UUID.randomUUID().toString(),
-				SecurityConfiguration.PASSWORD));
+		assertFalse(authenticationPlugin.authenticate(UUID.randomUUID().toString(), SecurityConfiguration.PASSWORD));
 	}
 
 	@Configuration

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoconfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoconfigurationTests.java
@@ -58,7 +58,7 @@ public class RabbitAutoconfigurationTests {
 		assertNotNull(connectionFactory);
 		assertNotNull(amqpAdmin);
 		assertEquals(rabbitTemplate.getConnectionFactory(), connectionFactory);
-		assertEquals(connectionFactory.getHost(), "localhost");
+		assertEquals("localhost", connectionFactory.getHost());
 	}
 
 	@Test
@@ -72,9 +72,9 @@ public class RabbitAutoconfigurationTests {
 		this.context.refresh();
 		CachingConnectionFactory connectionFactory = this.context
 				.getBean(CachingConnectionFactory.class);
-		assertEquals(connectionFactory.getHost(), "remote-server");
-		assertEquals(connectionFactory.getPort(), 9000);
-		assertEquals(connectionFactory.getVirtualHost(), "/vhost");
+		assertEquals("remote-server", connectionFactory.getHost());
+		assertEquals(9000, connectionFactory.getPort());
+		assertEquals("/vhost", connectionFactory.getVirtualHost());
 	}
 
 	@Test
@@ -86,7 +86,7 @@ public class RabbitAutoconfigurationTests {
 		this.context.refresh();
 		CachingConnectionFactory connectionFactory = this.context
 				.getBean(CachingConnectionFactory.class);
-		assertEquals(connectionFactory.getVirtualHost(), "/");
+		assertEquals("/", connectionFactory.getVirtualHost());
 	}
 
 	@Test
@@ -98,7 +98,7 @@ public class RabbitAutoconfigurationTests {
 		this.context.refresh();
 		CachingConnectionFactory connectionFactory = this.context
 				.getBean(CachingConnectionFactory.class);
-		assertEquals(connectionFactory.getVirtualHost(), "/foo");
+		assertEquals("/foo", connectionFactory.getVirtualHost());
 	}
 
 	@Test
@@ -110,7 +110,7 @@ public class RabbitAutoconfigurationTests {
 		this.context.refresh();
 		CachingConnectionFactory connectionFactory = this.context
 				.getBean(CachingConnectionFactory.class);
-		assertEquals(connectionFactory.getVirtualHost(), "/");
+		assertEquals("/", connectionFactory.getVirtualHost());
 	}
 
 	@Test
@@ -122,8 +122,8 @@ public class RabbitAutoconfigurationTests {
 		CachingConnectionFactory connectionFactory = this.context
 				.getBean(CachingConnectionFactory.class);
 		assertEquals(rabbitTemplate.getConnectionFactory(), connectionFactory);
-		assertEquals(connectionFactory.getHost(), "otherserver");
-		assertEquals(connectionFactory.getPort(), 8001);
+		assertEquals("otherserver", connectionFactory.getHost());
+		assertEquals(8001, connectionFactory.getPort());
 	}
 
 	@Test

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.amqp;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for {@link RabbitProperties}.
@@ -45,7 +46,7 @@ public class RabbitPropertiesTests {
 	@Test
 	public void addressesDoubleValued() {
 		this.properties.setAddresses("myhost:9999,otherhost:1111");
-		assertEquals(null, this.properties.getHost());
+		assertNull(this.properties.getHost());
 		assertEquals(9999, this.properties.getPort());
 	}
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/CommonsDataSourceConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/CommonsDataSourceConfigurationTests.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link CommonsDataSourceConfiguration}.
@@ -62,9 +63,9 @@ public class CommonsDataSourceConfigurationTests {
 		this.context.refresh();
 		BasicDataSource ds = this.context.getBean(BasicDataSource.class);
 		assertEquals("jdbc:foo//bar/spam", ds.getUrl());
-		assertEquals(true, ds.getTestWhileIdle());
-		assertEquals(true, ds.getTestOnBorrow());
-		assertEquals(true, ds.getTestOnReturn());
+		assertTrue(ds.getTestWhileIdle());
+		assertTrue(ds.getTestOnBorrow());
+		assertTrue(ds.getTestOnReturn());
 		assertEquals(10000, ds.getTimeBetweenEvictionRunsMillis());
 		assertEquals(12345, ds.getMinEvictableIdleTimeMillis());
 		assertEquals(1234, ds.getMaxWait());

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/TomcatDataSourceConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/TomcatDataSourceConfigurationTests.java
@@ -33,6 +33,7 @@ import org.springframework.util.ReflectionUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -80,9 +81,9 @@ public class TomcatDataSourceConfigurationTests {
 		org.apache.tomcat.jdbc.pool.DataSource ds = this.context
 				.getBean(org.apache.tomcat.jdbc.pool.DataSource.class);
 		assertEquals("jdbc:foo//bar/spam", ds.getUrl());
-		assertEquals(true, ds.isTestWhileIdle());
-		assertEquals(true, ds.isTestOnBorrow());
-		assertEquals(true, ds.isTestOnReturn());
+		assertTrue(ds.isTestWhileIdle());
+		assertTrue(ds.isTestOnBorrow());
+		assertTrue(ds.isTestOnReturn());
 		assertEquals(10000, ds.getTimeBetweenEvictionRunsMillis());
 		assertEquals(12345, ds.getMinEvictableIdleTimeMillis());
 		assertEquals(1234, ds.getMaxWait());

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsTemplateAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsTemplateAutoConfigurationTests.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link JmsTemplateAutoConfiguration}.
- * 
+ *
  * @author Greg Turnquist
  */
 public class JmsTemplateAutoConfigurationTests {
@@ -55,10 +55,7 @@ public class JmsTemplateAutoConfigurationTests {
 		assertNotNull(jmsTemplate);
 		assertNotNull(connectionFactory);
 		assertEquals(jmsTemplate.getConnectionFactory(), connectionFactory);
-		assertEquals(
-				((ActiveMQConnectionFactory) jmsTemplate.getConnectionFactory())
-						.getBrokerURL(),
-				"vm://localhost");
+		assertEquals("vm://localhost", ((ActiveMQConnectionFactory) jmsTemplate.getConnectionFactory()).getBrokerURL());
 	}
 
 	@Test
@@ -144,10 +141,8 @@ public class JmsTemplateAutoConfigurationTests {
 		assertNotNull(jmsTemplate);
 		assertNotNull(connectionFactory);
 		assertEquals(jmsTemplate.getConnectionFactory(), connectionFactory);
-		assertEquals(
-				((ActiveMQConnectionFactory) jmsTemplate.getConnectionFactory())
-						.getBrokerURL(),
-				"tcp://localhost:61616");
+		assertEquals("tcp://localhost:61616",
+					 ((ActiveMQConnectionFactory) jmsTemplate.getConnectionFactory()).getBrokerURL());
 	}
 
 	@Test
@@ -165,10 +160,8 @@ public class JmsTemplateAutoConfigurationTests {
 		assertNotNull(jmsTemplate);
 		assertNotNull(connectionFactory);
 		assertEquals(jmsTemplate.getConnectionFactory(), connectionFactory);
-		assertEquals(
-				((ActiveMQConnectionFactory) jmsTemplate.getConnectionFactory())
-						.getBrokerURL(),
-				"tcp://remote-host:10000");
+		assertEquals("tcp://remote-host:10000",
+					 ((ActiveMQConnectionFactory) jmsTemplate.getConnectionFactory()).getBrokerURL());
 	}
 
 	@Test

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/MultipartAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/MultipartAutoConfigurationTests.java
@@ -157,13 +157,12 @@ public class MultipartAutoConfigurationTests {
 		this.context.register(ContainerWithNoMultipartTomcat.class,
 				BaseConfiguration.class);
 		this.context.refresh();
-		assertEquals(this.context.getBeansOfType(MultipartConfigElement.class).size(), 0);
+		assertEquals(0, this.context.getBeansOfType(MultipartConfigElement.class).size());
 	}
 
 	private void verifyServletWorks() {
 		RestTemplate restTemplate = new RestTemplate();
-		assertEquals(restTemplate.getForObject("http://localhost:8080/", String.class),
-				"Hello");
+		assertEquals("Hello", restTemplate.getForObject("http://localhost:8080/", String.class));
 	}
 
 	@Configuration

--- a/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/CommandRunnerTests.java
+++ b/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/CommandRunnerTests.java
@@ -31,6 +31,7 @@ import org.springframework.boot.cli.command.core.HintCommand;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
@@ -124,7 +125,7 @@ public class CommandRunnerTests {
 		verify(this.regularCommand).run("--", "--debug", "bar");
 		// When handled by the command itself it shouldn't cause the system property to be
 		// set
-		assertEquals(null, System.getProperty("debug"));
+		assertNull(System.getProperty("debug"));
 	}
 
 	@Test

--- a/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/PropertiesLauncherTests.java
+++ b/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/PropertiesLauncherTests.java
@@ -32,6 +32,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -71,7 +72,7 @@ public class PropertiesLauncherTests {
 	public void testUserSpecifiedMain() throws Exception {
 		PropertiesLauncher launcher = new PropertiesLauncher();
 		assertEquals("demo.Application", launcher.getMainClass());
-		assertEquals(null, System.getProperty("loader.main"));
+		assertNull(System.getProperty("loader.main"));
 	}
 
 	@Test

--- a/spring-boot/src/test/java/org/springframework/boot/bind/RelaxedDataBinderTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/bind/RelaxedDataBinderTests.java
@@ -54,6 +54,7 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for {@link RelaxedDataBinder}.
@@ -178,7 +179,7 @@ public class RelaxedDataBinderTests {
 		BindingResult result = bind(binder, target, "foo: bar\n" + "value: 123\n"
 				+ "bar: spam");
 		assertEquals(123, target.getValue());
-		assertEquals(null, target.getFoo());
+		assertNull(target.getFoo());
 		assertEquals(0, result.getErrorCount());
 	}
 

--- a/spring-boot/src/test/java/org/springframework/boot/cloudfoundry/VcapApplicationListenerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/cloudfoundry/VcapApplicationListenerTests.java
@@ -24,6 +24,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for {@link VcapApplicationListener}.
@@ -52,7 +53,7 @@ public class VcapApplicationListenerTests {
 	public void testUnparseableApplicationProperties() {
 		EnvironmentTestUtils.addEnvironment(this.context, "VCAP_APPLICATION:");
 		this.initializer.onApplicationEvent(this.event);
-		assertEquals(null, this.context.getEnvironment().getProperty("vcap"));
+		assertNull(this.context.getEnvironment().getProperty("vcap"));
 	}
 
 	@Test
@@ -62,7 +63,7 @@ public class VcapApplicationListenerTests {
 						this.context,
 						"VCAP_APPLICATION:{\"application_users\":null,\"instance_id\":\"bb7935245adf3e650dfb7c58a06e9ece\",\"instance_index\":0,\"version\":\"3464e092-1c13-462e-a47c-807c30318a50\",\"name\":\"foo\",\"uris\":[\"foo.cfapps.io\"],\"started_at\":\"2013-05-29 02:37:59 +0000\",\"started_at_timestamp\":1369795079,\"host\":\"0.0.0.0\",\"port\":61034,\"limits\":{\"mem\":128,\"disk\":1024,\"fds\":16384},\"version\":\"3464e092-1c13-462e-a47c-807c30318a50\",\"name\":\"dsyerenv\",\"uris\":[\"dsyerenv.cfapps.io\"],\"users\":[],\"start\":\"2013-05-29 02:37:59 +0000\",\"state_timestamp\":1369795079}");
 		this.initializer.onApplicationEvent(this.event);
-		assertEquals(null, this.context.getEnvironment().getProperty("vcap"));
+		assertNull(this.context.getEnvironment().getProperty("vcap"));
 	}
 
 	@Test

--- a/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesBindingPostProcessorTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesBindingPostProcessorTests.java
@@ -32,6 +32,7 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -64,7 +65,7 @@ public class ConfigurationPropertiesBindingPostProcessorTests {
 		}
 		catch (BeanCreationException ex) {
 			BindException bex = (BindException) ex.getRootCause();
-			assertTrue(1 == bex.getErrorCount());
+			assertEquals(1, bex.getErrorCount());
 		}
 	}
 
@@ -78,7 +79,7 @@ public class ConfigurationPropertiesBindingPostProcessorTests {
 		}
 		catch (BeanCreationException ex) {
 			BindException bex = (BindException) ex.getRootCause();
-			assertTrue(1 == bex.getErrorCount());
+			assertEquals(1, bex.getErrorCount());
 		}
 	}
 
@@ -92,7 +93,7 @@ public class ConfigurationPropertiesBindingPostProcessorTests {
 		}
 		catch (BeanCreationException ex) {
 			BindException bex = (BindException) ex.getRootCause();
-			assertTrue(2 == bex.getErrorCount());
+			assertEquals(2, bex.getErrorCount());
 		}
 	}
 

--- a/spring-boot/src/test/java/org/springframework/boot/yaml/YamlMapFactoryBeanTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/yaml/YamlMapFactoryBeanTests.java
@@ -103,7 +103,7 @@ public class YamlMapFactoryBeanTests {
 		@SuppressWarnings("unchecked")
 		Map<String, Object> sub = (Map<String, Object>) object;
 		assertTrue(sub.containsKey("key1.key2"));
-		assertTrue(sub.get("key1.key2").equals("value"));
+		assertEquals("value", sub.get("key1.key2"));
 	}
 
 }


### PR DESCRIPTION
Reverting arguments in assertEquals where constant was placed on
the "actual" place. Replacing assertEquals with assertFalse, assertTrue
and assertNull where applicable.
