### PR TITLE
Add auto configuration support for Spring Data Solr.

### DIFF
--- a/spring-boot-actuator/pom.xml
+++ b/spring-boot-actuator/pom.xml
@@ -84,6 +84,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-solr</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-web</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -147,6 +147,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-solr</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.hateoas</groupId>
 			<artifactId>spring-hateoas</artifactId>
 			<optional>true</optional>
@@ -154,6 +159,11 @@
 		<dependency>
 			<groupId>com.lambdaworks</groupId>
 			<artifactId>lettuce</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.solr</groupId>
+			<artifactId>solr-solrj</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/SolrRepositoriesAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/SolrRepositoriesAutoConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data;
+
+import org.apache.solr.client.solrj.SolrServer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.solr.repository.SolrRepository;
+import org.springframework.data.solr.repository.support.SolrRepositoryFactoryBean;
+
+/**
+ * Enables auto configuration for Spring Data Solr repositories.
+ * <p>
+ * Activates when there is no bean of type
+ * {@link org.springframework.data.solr.repository.support.SolrRepositoryFactoryBean}
+ * found in context, and both
+ * {@link org.springframework.data.solr.repository.SolrRepository} and
+ * {@link org.apache.solr.client.solrj.SolrServer} can be found on classpath.
+ * </p>
+ * If active auto configuration does the same as
+ * {@link org.springframework.data.solr.repository.config.EnableSolrRepositories} would
+ * do.
+ * 
+ * @author Christoph Strobl
+ */
+@Configuration
+@ConditionalOnClass({ SolrServer.class, SolrRepository.class })
+@ConditionalOnMissingBean(SolrRepositoryFactoryBean.class)
+@Import(SolrRepositoriesAutoConfigureRegstrar.class)
+public class SolrRepositoriesAutoConfiguration {
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/SolrRepositoriesAutoConfigureRegstrar.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/SolrRepositoriesAutoConfigureRegstrar.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data;
+
+import java.lang.annotation.Annotation;
+
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.data.repository.config.RepositoryConfigurationExtension;
+import org.springframework.data.solr.repository.config.EnableSolrRepositories;
+import org.springframework.data.solr.repository.config.SolrRepositoryConfigExtension;
+
+/**
+ * {@link ImportBeanDefinitionRegistrar} used to auto-configure Spring Data Solr
+ * repositories.
+ * 
+ * @author Christoph Strobl
+ */
+public class SolrRepositoriesAutoConfigureRegstrar extends
+		AbstractRepositoryConfigurationSourceSupport {
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.springframework.boot.autoconfigure.data.
+	 * AbstractRepositoryConfigurationSourceSupport#getAnnotation()
+	 */
+	@Override
+	protected Class<? extends Annotation> getAnnotation() {
+		return EnableSolrRepositories.class;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.springframework.boot.autoconfigure.data.
+	 * AbstractRepositoryConfigurationSourceSupport#getConfiguration()
+	 */
+	@Override
+	protected Class<?> getConfiguration() {
+		return EnableSolrRepositoriesConfiguration.class;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.springframework.boot.autoconfigure.data.
+	 * AbstractRepositoryConfigurationSourceSupport#getRepositoryConfigurationExtension()
+	 */
+	@Override
+	protected RepositoryConfigurationExtension getRepositoryConfigurationExtension() {
+		return new SolrRepositoryConfigExtension();
+	}
+
+	@EnableSolrRepositories(multicoreSupport = true)
+	private static class EnableSolrRepositoriesConfiguration {
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/solr/SolrAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/solr/SolrAutoConfiguration.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.solr;
+
+import javax.annotation.PreDestroy;
+
+import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.impl.CloudSolrServer;
+import org.apache.solr.client.solrj.impl.HttpSolrServer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+/**
+ * Enables auto configuration for Solr.
+ * 
+ * @author Christoph Strobl
+ */
+@Configuration
+@ConditionalOnClass(SolrServer.class)
+@EnableConfigurationProperties(SolrProperties.class)
+public class SolrAutoConfiguration {
+
+	private @Autowired SolrProperties properties;
+
+	private SolrServer solrServer;
+
+	@PreDestroy
+	public void close() {
+		if (this.solrServer != null) {
+			this.solrServer.shutdown();
+		}
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public SolrServer solrServer() {
+
+		this.solrServer = createSolrServer();
+		return this.solrServer;
+	}
+
+	private SolrServer createSolrServer() {
+
+		if (StringUtils.hasText(this.properties.getZkHost())) {
+			return new CloudSolrServer(this.properties.getZkHost());
+		}
+		return new HttpSolrServer(this.properties.getHost());
+	}
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/solr/SolrProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/solr/SolrProperties.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.solr;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Solr.
+ * 
+ * @author Christoph Strobl
+ */
+@ConfigurationProperties(prefix = "spring.data.solr")
+public class SolrProperties {
+
+	private String host = "http://127.0.0.1:8983/solr";
+
+	private String zkHost;
+
+	public String getHost() {
+		return host;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public String getZkHost() {
+		return zkHost;
+	}
+
+	public void setZkHost(String zkHost) {
+		this.zkHost = zkHost;
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -13,8 +13,10 @@ org.springframework.boot.autoconfigure.data.JpaRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.MongoRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.hateoas.HypermediaAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoConfiguration,\
+org.springframework.boot.autoconfigure.data.SolrRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.CouchbaseRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration,\
+org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration,\
 org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,\
 org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration,\
 org.springframework.boot.autoconfigure.jms.JmsTemplateAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/JpaRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/JpaRepositoriesAutoConfigurationTests.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.autoconfigure.TestAutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.data.alt.CityMongoDbRepository;
+import org.springframework.boot.autoconfigure.data.alt.CitySolrRepository;
 import org.springframework.boot.autoconfigure.data.jpa.City;
 import org.springframework.boot.autoconfigure.data.jpa.CityRepository;
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
@@ -81,8 +82,10 @@ public class JpaRepositoriesAutoConfigurationTests {
 	}
 
 	@Configuration
-	@EnableJpaRepositories(basePackageClasses = org.springframework.boot.autoconfigure.data.alt.CityJpaRepository.class, excludeFilters = { @Filter(type = FilterType.ASSIGNABLE_TYPE, value = CityMongoDbRepository.class) })
-	@TestAutoConfigurationPackage(City.class)
+	@EnableJpaRepositories(basePackageClasses = org.springframework.boot.autoconfigure.data.alt.CityJpaRepository.class, excludeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, value = CityMongoDbRepository.class),
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, value = CitySolrRepository.class) })
+    @TestAutoConfigurationPackage(City.class)
 	protected static class CustomConfiguration {
 
 	}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/SolrRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/SolrRepositoriesAutoConfigurationTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure.data;
+
+import static org.hamcrest.core.IsInstanceOf.*;
+import static org.hamcrest.core.IsNull.*;
+import static org.junit.Assert.*;
+
+import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.impl.HttpSolrServer;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.TestAutoConfigurationPackage;
+import org.springframework.boot.autoconfigure.data.alt.CitySolrRepository;
+import org.springframework.boot.autoconfigure.data.solr.City;
+import org.springframework.boot.autoconfigure.data.solr.CityRepository;
+import org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.solr.repository.config.EnableSolrRepositories;
+
+/**
+ * @author Christoph Strobl
+ */
+public class SolrRepositoriesAutoConfigurationTests {
+
+	private AnnotationConfigApplicationContext context;
+
+	@Test
+	public void testDefaultRepositoryConfiguration() {
+
+		initContext(TestConfiguration.class);
+
+		assertThat(this.context.getBean(CityRepository.class), notNullValue());
+		assertThat(this.context.getBean(SolrServer.class), instanceOf(HttpSolrServer.class));
+	}
+
+	@Test
+	public void testNoRepositoryConfiguration() {
+
+		initContext(EmptyConfiguration.class);
+		assertThat(this.context.getBean(SolrServer.class), instanceOf(HttpSolrServer.class));
+	}
+
+	@Test
+	public void doesNotTriggerDefaultRepositoryDetectionIfCustomized() {
+
+		initContext(CustomizedConfiguration.class);
+		assertThat(this.context.getBean(CitySolrRepository.class), notNullValue());
+	}
+
+	private void initContext(Class<?> configClass) {
+
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(configClass, SolrAutoConfiguration.class, SolrRepositoriesAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+	}
+
+	@Configuration
+	@TestAutoConfigurationPackage(City.class)
+	static class TestConfiguration {
+
+	}
+
+	@Configuration
+	@TestAutoConfigurationPackage(SolrRepositoriesAutoConfigurationTests.class)
+	static class EmptyConfiguration {
+
+	}
+
+	@Configuration
+	@TestAutoConfigurationPackage(SolrRepositoriesAutoConfigurationTests.class)
+	@EnableSolrRepositories(basePackageClasses = CitySolrRepository.class, multicoreSupport = true)
+	protected static class CustomizedConfiguration {
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/alt/CitySolrRepository.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/alt/CitySolrRepository.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure.data.alt;
+
+import org.springframework.boot.autoconfigure.data.solr.City;
+import org.springframework.data.repository.Repository;
+
+/**
+ * @author Christoph Strobl
+ */
+public interface CitySolrRepository extends Repository<City, String> {
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/solr/City.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/solr/City.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure.data.solr;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.solr.core.mapping.Indexed;
+import org.springframework.data.solr.core.mapping.SolrDocument;
+
+/**
+ * @author Christoph Strobl
+ */
+@SolrDocument(solrCoreName = "collection1")
+public class City {
+
+	private @Id String id;
+	private @Indexed String name;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/solr/CityRepository.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/solr/CityRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure.data.solr;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+/**
+ * @author Christoph Strobl
+ */
+public interface CityRepository extends Repository<City, String> {
+
+	Page<City> findByNameStartingWith(String name, Pageable page);
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -81,12 +81,14 @@
 		<servlet-api.version>3.0.1</servlet-api.version>
 		<slf4j.version>1.7.7</slf4j.version>
 		<snakeyaml.version>1.13</snakeyaml.version>
+		<solr.version>4.7.2</solr.version>
 		<spock.version>0.7-groovy-2.0</spock.version>
 		<spring.version>4.0.3.RELEASE</spring.version>
 		<spring-integration.version>3.0.2.RELEASE</spring-integration.version>
 		<spring-batch.version>2.2.6.RELEASE</spring-batch.version>
 		<spring-data-couchbase.version>1.0.0.RELEASE</spring-data-couchbase.version>
 		<spring-data-redis.version>1.1.1.RELEASE</spring-data-redis.version>
+		<spring-data-solr.version>1.1.1.RELEASE</spring-data-solr.version>
 		<spring-data-releasetrain.version>Codd-SR2</spring-data-releasetrain.version>
 		<spring-hateoas.version>0.9.0.RELEASE</spring-hateoas.version>
 		<spring-plugin.version>1.0.0.RELEASE</spring-plugin.version>
@@ -401,6 +403,11 @@
 				<version>${slf4j.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.apache.solr</groupId>
+				<artifactId>solr-solrj</artifactId>
+				<version>${solr.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.spockframework</groupId>
 				<artifactId>spock-core</artifactId>
 				<version>${spock.version}</version>
@@ -535,6 +542,11 @@
 				<groupId>org.springframework.data</groupId>
 				<artifactId>spring-data-redis</artifactId>
 				<version>${spring-data-redis.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.data</groupId>
+				<artifactId>spring-data-solr</artifactId>
+				<version>${spring-data-solr.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.hateoas</groupId>

--- a/spring-boot-samples/pom.xml
+++ b/spring-boot-samples/pom.xml
@@ -31,6 +31,7 @@
 		<module>spring-boot-sample-data-mongodb</module>
 		<module>spring-boot-sample-data-redis</module>
 		<module>spring-boot-sample-data-rest</module>
+        <module>spring-boot-sample-data-solr</module>
 		<module>spring-boot-sample-integration</module>
 		<module>spring-boot-sample-jetty</module>
 		<module>spring-boot-sample-profile</module>

--- a/spring-boot-samples/spring-boot-sample-data-solr/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-data-solr/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-samples</artifactId>
+    <version>1.1.0.BUILD-SNAPSHOT</version>
+  </parent>
+  <artifactId>spring-boot-sample-data-solr</artifactId>
+  <name>Spring Boot Data Solr Sample</name>
+	<description>Spring Boot Data Solr Sample</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-solr</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-samples/spring-boot-sample-data-solr/src/main/java/sample/data/solr/Product.java
+++ b/spring-boot-samples/spring-boot-sample-data-solr/src/main/java/sample/data/solr/Product.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.data.solr;
+
+import java.util.List;
+
+import org.apache.solr.client.solrj.beans.Field;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.solr.core.geo.Point;
+import org.springframework.data.solr.core.mapping.SolrDocument;
+
+/**
+ * @author Christoph Strobl
+ */
+@SolrDocument(solrCoreName = "collection1")
+public class Product {
+
+	@Id
+	@Field
+	private String id;
+
+	@Field
+	private String name;
+
+	@Field
+	private Double price;
+
+	@Field("cat")
+	private List<String> category;
+
+	@Field("store")
+	private Point location;
+
+	public Product() {
+	}
+
+	public Product(String id, String name) {
+		super();
+		this.id = id;
+		this.name = name;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Double getPrice() {
+		return price;
+	}
+
+	public void setPrice(Double price) {
+		this.price = price;
+	}
+
+	public List<String> getCategory() {
+		return category;
+	}
+
+	public void setCategory(List<String> category) {
+		this.category = category;
+	}
+
+	public Point getLocation() {
+		return location;
+	}
+
+	public void setLocation(Point location) {
+		this.location = location;
+	}
+
+	@Override
+	public String toString() {
+		return "Product [id=" + id + ", name=" + name + ", price=" + price
+				+ ", category=" + category + ", location=" + location + "]";
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-data-solr/src/main/java/sample/data/solr/ProductRepository.java
+++ b/spring-boot-samples/spring-boot-sample-data-solr/src/main/java/sample/data/solr/ProductRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.data.solr;
+
+import java.util.List;
+
+import org.springframework.data.solr.repository.SolrCrudRepository;
+
+/**
+ * @author Christoph Strobl
+ */
+public interface ProductRepository extends SolrCrudRepository<Product, String> {
+
+	List<Product> findByNameStartingWith(String name);
+
+}

--- a/spring-boot-samples/spring-boot-sample-data-solr/src/main/java/sample/data/solr/SampleSolrApplication.java
+++ b/spring-boot-samples/spring-boot-sample-data-solr/src/main/java/sample/data/solr/SampleSolrApplication.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.data.solr;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Christoph Strobl
+ */
+@Configuration
+@EnableAutoConfiguration
+@ComponentScan
+public class SampleSolrApplication implements CommandLineRunner {
+
+	@Autowired
+	private ProductRepository repository;
+
+	@Override
+	public void run(String... args) throws Exception {
+
+		repository.deleteAll();
+
+		// insert some products
+		repository.save(new Product("1", "Nintendo Entertainment System"));
+		repository.save(new Product("2", "Sega Megadrive"));
+		repository.save(new Product("3", "Sony Playstation"));
+
+		// fetch all
+		System.out.println("Products found by findAll():");
+		System.out.println("----------------------------");
+		for (Product product : repository.findAll()) {
+			System.out.println(product);
+		}
+		System.out.println();
+
+		// fetch a single product
+		System.out.println("Products founds with findByNameStartingWith('So'):");
+		System.out.println("--------------------------------");
+		for (Product product : repository.findByNameStartingWith("So")) {
+			System.out.println(product);
+		}
+		System.out.println();
+	}
+
+	public static void main(String[] args) throws Exception {
+		SpringApplication.run(SampleSolrApplication.class, args);
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-data-solr/src/test/java/sample/data/solr/SampleSolrApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-data-solr/src/test/java/sample/data/solr/SampleSolrApplicationTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.data.solr;
+
+import static org.junit.Assert.*;
+
+import org.apache.solr.client.solrj.SolrServerException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.boot.test.OutputCapture;
+import org.springframework.core.NestedCheckedException;
+
+/**
+ * @author Christoph Strobl
+ */
+public class SampleSolrApplicationTests {
+
+	@Rule
+	public OutputCapture outputCapture = new OutputCapture();
+
+	@Test
+	public void testDefaultSettings() throws Exception {
+
+		try {
+			SampleSolrApplication.main(new String[0]);
+		} catch (IllegalStateException ex) {
+			if (serverNotRunning(ex)) {
+				return;
+			}
+		}
+		String output = this.outputCapture.toString();
+		assertTrue("Wrong output: " + output, output.contains("name=Sony Playstation"));
+	}
+
+	private boolean serverNotRunning(IllegalStateException ex) {
+
+		@SuppressWarnings("serial")
+		NestedCheckedException nested = new NestedCheckedException("failed", ex) {
+		};
+		if (nested.contains(SolrServerException.class)) {
+			Throwable root = nested.getRootCause();
+			if (root.getMessage().contains("Connection refused")) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/spring-boot-starters/pom.xml
+++ b/spring-boot-starters/pom.xml
@@ -44,5 +44,6 @@
 		<module>spring-boot-starter-web</module>
 		<module>spring-boot-starter-websocket</module>
 		<module>spring-boot-starter-data-rest</module>
+		<module>spring-boot-starter-data-solr</module>
 	</modules>
 </project>

--- a/spring-boot-starters/spring-boot-starter-data-solr/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-data-solr/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starters</artifactId>
+		<version>1.1.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-starter-data-solr</artifactId>
+	<name>Spring Boot Data Solr Starter</name>
+	<description>Spring Boot Data Solr Starter</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.solr</groupId>
+			<artifactId>solr-solrj</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-solr</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-boot-starters/spring-boot-starter-data-solr/src/main/resources/META-INF/spring.provides
+++ b/spring-boot-starters/spring-boot-starter-data-solr/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: spring-data-solr, solr-solrj

--- a/spring-boot-starters/spring-boot-starter-parent/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-parent/pom.xml
@@ -88,6 +88,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-data-solr</artifactId>
+				<version>${spring-boot.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-data-couchbase</artifactId>
 				<version>0.5.0.BUILD-SNAPSHOT</version>
 			</dependency>


### PR DESCRIPTION
Registers required components in application context if not available to set up environment for usage with [Spring Data Solr](https://github.com/spring-projects/spring-data-solr). Will listen on `SolrServer` and `SolrRepositories` for configuration. 

By default an `HttpSolrServer` is registered unless a `zkHost` (zookeeper host) is defined. In that case an instance of `CloudSolrServer` will be created. 

By default `multicoreSupport` is enabled, creating instances of `SolrServer` for each core defined via `@SolrDocument`.

The current implementation uses `spring-data-solr-1.1.1.RELEASE`. The next version `1.2.0.RELEASE` is part of release train [Dijkstra](https://github.com/spring-projects/spring-data-commons/wiki/Release-Train-Dijkstra).

---

Integration tests can be run against the default example configuration of Solr. 
1. Download und unpack Solr: http://www.apache.org/dyn/closer.cgi/lucene/solr/4.7.2
2. `$solr > cd example`
3. `$solr/example > java -jar start.jar`
