### PR TITLE
Support setting the MessageCodeResolver format

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
@@ -31,7 +31,6 @@ import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -51,6 +50,8 @@ import org.springframework.format.Formatter;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.util.StringUtils;
+import org.springframework.validation.DefaultMessageCodesResolver;
+import org.springframework.validation.MessageCodesResolver;
 import org.springframework.web.accept.ContentNegotiationManager;
 import org.springframework.web.context.request.RequestContextListener;
 import org.springframework.web.filter.HiddenHttpMethodFilter;
@@ -144,6 +145,9 @@ public class WebMvcAutoConfiguration {
 		@Value("${spring.resources.cachePeriod:}")
 		private Integer cachePeriod;
 
+		@Value("${spring.mvc.message-codes-resolver.format:}")
+		private String messageCodesResolverFormat = "";
+
 		@Value("${spring.mvc.locale:}")
 		private String locale = "";
 
@@ -204,6 +208,15 @@ public class WebMvcAutoConfiguration {
 			return new FixedLocaleResolver(StringUtils.parseLocaleString(this.locale));
 		}
 
+		@Bean
+		@ConditionalOnMissingBean(MessageCodesResolver.class)
+		@ConditionalOnExpression("'${spring.mvc.message-codes-resolver.format:}' != ''")
+		public MessageCodesResolver messageCodesResolver() {
+			DefaultMessageCodesResolver resolver = new DefaultMessageCodesResolver();
+			resolver.setMessageCodeFormatter(DefaultMessageCodesResolver.Format.valueOf(messageCodesResolverFormat));
+			return resolver;
+		}
+		
 		@Override
 		public void addFormatters(FormatterRegistry registry) {
 			for (Converter<?, ?> converter : getBeansOfType(Converter.class)) {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfigurationTests.java
@@ -16,6 +16,12 @@
 
 package org.springframework.boot.autoconfigure.web;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
 import java.lang.reflect.Field;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -43,6 +49,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.validation.MessageCodesResolver;
 import org.springframework.web.servlet.HandlerAdapter;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.LocaleResolver;
@@ -54,12 +61,6 @@ import org.springframework.web.servlet.i18n.FixedLocaleResolver;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.springframework.web.servlet.resource.ResourceHttpRequestHandler;
 import org.springframework.web.servlet.view.AbstractView;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 
 /**
  * Tests for {@link WebMvcAutoConfiguration}.
@@ -178,6 +179,30 @@ public class WebMvcAutoConfigurationTests {
 		assertThat(localeResolver, instanceOf(FixedLocaleResolver.class));
 		// test locale resolver uses fixed locale and not user preferred locale
 		assertThat(locale.toString(), equalTo("en_UK"));
+	}
+
+	@Test(expected = NoSuchBeanDefinitionException.class)
+	public void noMessageCodeResolver() throws Exception {
+		this.context = new AnnotationConfigEmbeddedWebApplicationContext();
+		this.context.register(AllResources.class, Config.class,
+				WebMvcAutoConfiguration.class,
+				HttpMessageConvertersAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		this.context.getBean(MessageCodesResolver.class);
+	}
+
+	@Test
+	public void overrideMessageCodesFormat() throws Exception {
+		this.context = new AnnotationConfigEmbeddedWebApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.mvc.message-codes-resolver.format:POSTFIX_ERROR_CODE");
+		this.context.register(AllResources.class, Config.class,
+				WebMvcAutoConfiguration.class,
+				HttpMessageConvertersAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		this.context.getBean(MessageCodesResolver.class);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -68,6 +68,7 @@ content into your application; rather pick only the properties that you need.
 	http.mappers.json-pretty-print=false # pretty print JSON
 	http.mappers.json-sort-keys=false # sort keys
 	spring.mvc.locale= # set fixed locale, e.g. en_UK
+	spring.mvc.message-codes-resolver.format= # PREFIX_ERROR_CODE / POSTFIX_ERROR_CODE
 	spring.view.prefix= # MVC view prefix
 	spring.view.suffix= # ... and suffix
 	spring.resources.cache-period= # cache timeouts in headers sent to browser


### PR DESCRIPTION
In traditional non-Spring Boot app I would set MessageCodeResolver format like:

```
@Configuration
@EnableWebMvc
public class WebConfig extends WebMvcConfigurerAdapter {

    @Override
    public MessageCodesResolver getMessageCodesResolver() {
        DefaultMessageCodesResolver messageCodesResolver = new DefaultMessageCodesResolver();
        messageCodesResolver.setMessageCodeFormatter(DefaultMessageCodesResolver.Format.POSTFIX_ERROR_CODE);
        return messageCodesResolver;
    }
```

Would be nice if Spring Boot could support this automatically by setting the format via an application property like:

```
spring.messages.resolver.format: prefix # prefix or postfix
```

See http://docs.spring.io/spring/docs/4.0.3.RELEASE/javadoc-api/org/springframework/validation/DefaultMessageCodesResolver.Format.html
