### PR TITLE
Add fixed date format

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
@@ -142,10 +142,10 @@ public class WebMvcAutoConfiguration {
 		@Value("${spring.mvc.message-codes-resolver.format:}")
 		private DefaultMessageCodesResolver.Format messageCodesResolverFormat = null;
 
-		@Value("${spring.mvc.fixed.locale:}")
+		@Value("${spring.mvc.locale:}")
 		private String locale = "";
 
-		@Value("${spring.mvc.fixed.date-format:}")
+		@Value("${spring.mvc.date-format:}")
 		private String dateFormat = "";
 
 		@Autowired
@@ -200,13 +200,13 @@ public class WebMvcAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(LocaleResolver.class)
-		@ConditionalOnExpression("'${spring.mvc.fixed.locale:}' != ''")
+		@ConditionalOnExpression("'${spring.mvc.locale:}' != ''")
 		public LocaleResolver localeResolver() {
 			return new FixedLocaleResolver(StringUtils.parseLocaleString(this.locale));
 		}
 
 		@Bean
-		@ConditionalOnExpression("'${spring.mvc.fixed.date-format:}' != ''")
+		@ConditionalOnExpression("'${spring.mvc.date-format:}' != ''")
 		public Formatter<Date> dateFormatter() {
 			return new DateFormatter(this.dateFormat);
 		}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfigurationTests.java
@@ -169,7 +169,7 @@ public class WebMvcAutoConfigurationTests {
 	public void overrideFixedLocale() throws Exception {
 		this.context = new AnnotationConfigEmbeddedWebApplicationContext();
 		// set fixed locale
-		EnvironmentTestUtils.addEnvironment(this.context, "spring.mvc.fixed.locale:en_UK");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.mvc.locale:en_UK");
 		this.context.register(AllResources.class, Config.class,
 				WebMvcAutoConfiguration.class,
 				HttpMessageConvertersAutoConfiguration.class,
@@ -203,7 +203,7 @@ public class WebMvcAutoConfigurationTests {
 	public void overrideFixedDateFormat() throws Exception {
 		this.context = new AnnotationConfigEmbeddedWebApplicationContext();
 		// set fixed date format
-		EnvironmentTestUtils.addEnvironment(this.context, "spring.mvc.fixed.date-format:dd*MM*yyyy");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.mvc.date-format:dd*MM*yyyy");
 		this.context.register(AllResources.class, Config.class,
 				WebMvcAutoConfiguration.class,
 				HttpMessageConvertersAutoConfiguration.class,

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -67,8 +67,8 @@ content into your application; rather pick only the properties that you need.
 	# SPRING MVC ({sc-spring-boot-autoconfigure}/web/HttpMapperProperties.{sc-ext}[HttpMapperProperties])
 	http.mappers.json-pretty-print=false # pretty print JSON
 	http.mappers.json-sort-keys=false # sort keys
-	spring.mvc.fixed.locale= # set fixed locale, e.g. en_UK
-	spring.mvc.fixed.date-format= # set fixed date format, e.g. dd/MM/yyyy
+	spring.mvc.locale= # set fixed locale, e.g. en_UK
+	spring.mvc.date-format= # set fixed date format, e.g. dd/MM/yyyy
 	spring.mvc.message-codes-resolver.format= # PREFIX_ERROR_CODE / POSTFIX_ERROR_CODE
 	spring.view.prefix= # MVC view prefix
 	spring.view.suffix= # ... and suffix


### PR DESCRIPTION
To accompany the earlier added fixed locale I've added this PR to add a fixed date format option.

This change also includes change to fixed locale property name. I changed `spring.mvc.locale` to `spring.mvc.fixed.locale` to group the fixed locale and date format.

Note that `noLocaleResolver()` in `WebMvcAutoConfigurationTests` was missing the `@Test` annotation so I added that one as well.

M
