### PR TITLE
Reading data-${platform}.sql in addition to schema-${platform}.sql, schema.sql, data.sql

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
@@ -96,8 +96,8 @@ public class DataSourceAutoConfiguration implements EnvironmentAware {
 
 		String schema = this.datasourceProperties.getProperty("schema");
 		if (schema == null) {
-			schema = "classpath*:schema-"
-					+ this.datasourceProperties.getProperty("platform", "all")
+			String platform = this.datasourceProperties.getProperty("platform", "all");
+			schema = "classpath*:schema-" + platform + ".sql,classpath*:data-" + platform
 					+ ".sql,classpath*:schema.sql,classpath*:data.sql";
 		}
 

--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -1062,7 +1062,8 @@ not something you want to be on the classpath in production. It is a Hibernate f
 === Initialize a database using Spring JDBC
 Spring JDBC has a `DataSource` initializer feature. Spring Boot enables it by default and
 loads SQL from the standard locations `schema.sql` and `data.sql` (in the root of the
-classpath). In addition Spring Boot will load a file `schema-${platform}.sql` where
+classpath). In addition Spring Boot will load the `schema-${platform}.sql` 
+and `data-${platform}.sql` files (if present), where
 `platform` is the value of `spring.datasource.platform`, e.g. you might choose to set
 it to the vendor name of the database (`hsqldb`, `h2`, `oracle`, `mysql`,
 `postgresql` etc.). Spring Boot enables the failfast feature of the Spring JDBC


### PR DESCRIPTION
It took me some time to realise why only `schema-{platform}.sql` file is loaded on startup, `data-{platform}.sql` is not. To be fair, [documentation](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-intialize-a-database-using-spring-jdbc) mentions this but I didn't focus on that part too much since I thought it was something obvious. Only after analysing the code I saw that it was not included in the scanned list.
I'm assuming there _was_ a reason to leave it out but it feels like data script would be more likely to be platform-specific than schema. In my case `data-h2.sql` would only be loaded to seed the in-memory database for tests and development mode. Production database has real data and I don't want to touch it during application's startup so using `data.sql` is out of the question.

This PR adds `data-{platform}.sql` to the list of parsed SQL scripts, also updated the relevant part of documentation. I don't think it could do any harm, hope there won't be any reasons to reject this proposal. If there's a legitimate reason for not allowing this, I feel documentation should offer alternative way of doing this (looking at [the code](https://github.com/spring-projects/spring-boot/blob/50190a4de7dec55df462fb06c2d888176403d654/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java#L97), it would most likely be specifying value of `spring.datasource.schema` by hand?)

---

I have signed the CLA.
