### PR TITLE
Maven plugin groupId filtering should be exact (#649)

### DIFF
--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractDependencyFilterMojo.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractDependencyFilterMojo.java
@@ -28,7 +28,6 @@ import org.apache.maven.shared.artifact.filter.collection.ArtifactFilterExceptio
 import org.apache.maven.shared.artifact.filter.collection.ArtifactIdFilter;
 import org.apache.maven.shared.artifact.filter.collection.ArtifactsFilter;
 import org.apache.maven.shared.artifact.filter.collection.FilterArtifacts;
-import org.apache.maven.shared.artifact.filter.collection.GroupIdFilter;
 
 /**
  * A base mojo filtering the dependencies of the project.
@@ -96,7 +95,7 @@ public abstract class AbstractDependencyFilterMojo extends AbstractMojo {
 		}
 		filters.addFilter(new ArtifactIdFilter("",
 				cleanFilterConfig(this.excludeArtifactIds)));
-		filters.addFilter(new GroupIdFilter("", cleanFilterConfig(this.excludeGroupIds)));
+		filters.addFilter(new MatchingGroupIdFilter(cleanFilterConfig(this.excludeGroupIds)));
 		if (this.excludes != null) {
 			filters.addFilter(new ExcludeFilter(this.excludes));
 		}

--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/MatchingGroupIdFilter.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/MatchingGroupIdFilter.java
@@ -1,0 +1,28 @@
+package org.springframework.boot.maven;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.shared.artifact.filter.collection.AbstractArtifactFeatureFilter;
+
+/**
+ * An {@link org.apache.maven.shared.artifact.filter.collection.ArtifactsFilter
+ * ArtifactsFilter} that filters by matching groupId.
+ *
+ * Preferred over the {@link org.apache.maven.shared.artifact.filter.collection.GroupIdFilter} due
+ * to that classes use of {@link String#startsWith} to match on prefix.
+ *
+ * @author Mark Ingram
+ * @since 1.1
+ */
+public class MatchingGroupIdFilter extends AbstractArtifactFeatureFilter {
+
+	/**
+	 * Create a new instance with the CSV groupId values that should be excluded.
+	 */
+	public MatchingGroupIdFilter(String exclude) {
+		super("", exclude);
+	}
+
+	protected String getArtifactFeature(Artifact artifact) {
+		return artifact.getGroupId();
+	}
+}

--- a/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/DependencyFilterMojoTests.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/DependencyFilterMojoTests.java
@@ -51,6 +51,19 @@ public class DependencyFilterMojoTests {
 		assertSame("Wrong filtered artifact", artifact, artifacts.iterator().next());
 	}
 
+	@Test
+	public void groupIdFilterShouldOnlyFilterExactMatches() throws MojoExecutionException {
+		TestableDependencyFilterMojo mojo = new TestableDependencyFilterMojo(
+				Collections.<Exclude>emptyList(), "com.foo", "");
+
+		Artifact artifact = createArtifact("com.foo.bar", "one");
+		Set<Artifact> artifacts = mojo.filterDependencies(
+				createArtifact("com.foo", "one"), createArtifact("com.foo", "two"),
+				artifact);
+		assertEquals("wrong filtering of artifacts", 1, artifacts.size());
+		assertSame("Wrong filtered artifact", artifact, artifacts.iterator().next());
+	}
+
 	private Artifact createArtifact(String groupId, String artifactId) {
 		Artifact a = mock(Artifact.class);
 		given(a.getGroupId()).willReturn(groupId);


### PR DESCRIPTION
Following from the work in #649, I used the plugin to filter "org.springframework" groupId artifacts. Noted that (for me anyway) an unexpected side effect was the removal of "org.springframework.boot" artifacts. Would it be less surprising to require an exact match on groupId?

This is also mentioned in a long standing JIRA on the Maven Dependency Plugin project: http://jira.codehaus.org/browse/MDEP-237
