### PR TITLE
Added ComponentScanningApplicationContextInitializer.

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/builder/ComponentScanningApplicationContextInitializer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/builder/ComponentScanningApplicationContextInitializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.builder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ClassPathBeanDefinitionScanner;
+
+/**
+ * Spring project-level components scanner. Resolves base package from the system property, so end-user doesn't have to
+ * create custom wiring code.
+ */
+public class ComponentScanningApplicationContextInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    public static final String BASE_PACKAGE_PROPERTY_KEY = "spring.boot.basepackage";
+
+    private static final Logger LOG = LoggerFactory.getLogger(ComponentScanningApplicationContextInitializer.class);
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        LOG.debug("Initializing Spring Boot component scanner...");
+        String basePackage = System.getProperty(BASE_PACKAGE_PROPERTY_KEY);
+        if (basePackage != null) {
+            LOG.debug("Found base package definition: {}={}", BASE_PACKAGE_PROPERTY_KEY, basePackage);
+            ClassPathBeanDefinitionScanner scanner = new ClassPathBeanDefinitionScanner((BeanDefinitionRegistry) applicationContext, true);
+            scanner.setResourceLoader(applicationContext);
+            scanner.scan(basePackage);
+        } else {
+            LOG.debug("No base package definition ({}) found.", BASE_PACKAGE_PROPERTY_KEY);
+        }
+    }
+
+}

--- a/spring-boot/src/test/java/org/springframework/boot/builder/SpringApplicationBuilderTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/builder/SpringApplicationBuilderTests.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 
 import org.junit.After;
 import org.junit.Test;
+import org.springframework.boot.builder.scanner.ScannedComponent;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -36,6 +37,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.spy;
@@ -219,6 +221,18 @@ public class SpringApplicationBuilderTests {
 		this.context = application.run();
 		assertEquals(3, application.application().getInitializers().size());
 	}
+
+    @Test
+    public void componentScanningInitializer() throws Exception {
+        System.setProperty(
+                ComponentScanningApplicationContextInitializer.BASE_PACKAGE_PROPERTY_KEY,
+                "org.springframework.boot.builder.scanner"
+        );
+        SpringApplicationBuilder application = new SpringApplicationBuilder(
+                ExampleConfig.class).web(false).initializers(new ComponentScanningApplicationContextInitializer());
+        this.context = application.run();
+        assertNotNull(context.getBean(ScannedComponent.class));
+    }
 
 	@Configuration
 	static class ExampleConfig {

--- a/spring-boot/src/test/java/org/springframework/boot/builder/scanner/ScannedComponent.java
+++ b/spring-boot/src/test/java/org/springframework/boot/builder/scanner/ScannedComponent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.builder.scanner;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ScannedComponent {
+}


### PR DESCRIPTION
Hi,

In the environment where I deploy my microservices I often need to specify base package (containing application-level `@Components` and `@Configurations`) on the deployment level, via system properties. For example:

```
java -jar myapp.jar -Dspring.boot.basepackage=com.myapp
```

What about having `ComponentScanningApplicationContextInitializer` dedicated for this purpose?

Cheers.
