### PR TITLE
Fix typos in documentation, as well as "thread.deamon" typo in code

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/CrshAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/CrshAutoConfiguration.java
@@ -79,7 +79,7 @@ import org.springframework.util.StringUtils;
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for embedding an extensible shell
  * into a Spring Boot enabled application. By default a SSH daemon is started on port
- * 2000. If the CRaSH Telnet plugin is available on the classpath, Telnet deamon will be
+ * 2000. If the CRaSH Telnet plugin is available on the classpath, Telnet daemon will be
  * launched on port 5000.
  * 
  * <p>

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/VanillaPublicMetrics.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/VanillaPublicMetrics.java
@@ -96,7 +96,7 @@ public class VanillaPublicMetrics implements PublicMetrics {
 		ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
 		result.add(new Metric<Long>("threads.peak", new Long(threadMxBean
 				.getPeakThreadCount())));
-		result.add(new Metric<Long>("threads.deamon", new Long(threadMxBean
+		result.add(new Metric<Long>("threads.daemon", new Long(threadMxBean
 				.getDaemonThreadCount())));
 		result.add(new Metric<Long>("threads", new Long(threadMxBean.getThreadCount())));
 	}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/VanillaPublicMetricsTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/VanillaPublicMetricsTests.java
@@ -70,7 +70,7 @@ public class VanillaPublicMetricsTests {
 		assertTrue(results.containsKey("heap"));
 
 		assertTrue(results.containsKey("threads.peak"));
-		assertTrue(results.containsKey("threads.deamon"));
+		assertTrue(results.containsKey("threads.daemon"));
 		assertTrue(results.containsKey("threads"));
 
 		assertTrue(results.containsKey("classes.loaded"));

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -155,7 +155,7 @@ content into your application; rather pick only the properties that you need.
 
 	# DATASOURCE ({sc-spring-boot-autoconfigure}/jdbc/DataSourceAutoConfiguration.{sc-ext}[DataSourceAutoConfiguration] & {sc-spring-boot-autoconfigure}//jdbc/AbstractDataSourceConfiguration.{sc-ext}[AbstractDataSourceConfiguration])
 	spring.datasource.name= # name of the data source
-	spring.datasource.intialize=true # populate using data.sql
+	spring.datasource.initialize=true # populate using data.sql
 	spring.datasource.schema= # a schema resource reference
 	spring.datasource.platform= # the platform to use in the schema resource (schema-${platform}.sql)
 	spring.datasource.continueOnError=false # continue even if can't be initialized

--- a/spring-boot-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-boot-docs/src/main/asciidoc/getting-started.adoc
@@ -120,7 +120,7 @@ Here is a typical `pom.xml` file:
 		</build>
 
 ifeval::["{spring-boot-repo}" != "release"]
-		<!-- Add Spring repoistories -->
+		<!-- Add Spring repositories -->
 		<!-- (you don't need this if you are using a .RELEASE version) -->
 		<repositories>
 			<repository>
@@ -487,7 +487,7 @@ currently have.
 
 The `mvn dependency:tree` command prints tree representation of your project dependencies.
 You can see that `spring-boot-starter-parent` provides no
-dependenciesby itself. Let's edit our `pom.xml` and add the `spring-boot-starter-web` dependency
+dependencies by itself. Let's edit our `pom.xml` and add the `spring-boot-starter-web` dependency
 just below the `parent` section:
 
 [source,xml,indent=0,subs="verbatim,quotes,attributes"]

--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -1283,7 +1283,7 @@ you encounter a server error (machine clients consuming JSON and other media typ
 see a sensible response with the right error code). To switch it off you can set
 `error.whitelabel.enabled=false`, but normally in addition or alternatively to that you
 will want to add your own error page replacing the whitelabel one. Exactly how you do this
-dependns on the templating technology that you are using. For example, if you are using
+depends on the templating technology that you are using. For example, if you are using
 Thymeleaf you would add an `error.html` template and if you are using FreeMarker you would
 add an `error.ftl` template. In general what you need is a `View` that resolves with a name
 of `error`, and/or a `@Controller` that handles the `/error` path. Unless you replaced some
@@ -1453,7 +1453,7 @@ you would add the following:
 ----
 
 WARNING: Each Spring Boot release is designed and tested against a specific set of
-third-party dependencies. Overriding versions may cause compatibilty issues.
+third-party dependencies. Overriding versions may cause compatibility issues.
 
 
 

--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -178,7 +178,7 @@ interface needs to be provided or the default implementation has to be configure
 
 Assuming a new `Status` with code `FATAL` is being used in one of your `HealthIndicator` 
 implementations. To configure the severity or order add the following to your application properties:
-`healt.status.order: FATAL, DOWN, UNKOWN, UP`.
+`health.status.order: FATAL, DOWN, UNKNOWN, UP`.
 
 
 
@@ -289,7 +289,7 @@ in your `application.properties`:
 === Customizing the management server context path
 Sometimes it is useful to group all management endpoints under a single path. For example,
 your application might already use `/info` for another purpose. You can use the
-`management.contextPath` property to set a prefix for your manangement endpoint:
+`management.contextPath` property to set a prefix for your management endpoint:
 
 [source,properties,indent=0]
 ----
@@ -605,7 +605,7 @@ decrement). Metrics for all HTTP requests are automatically recorded, so if you 
 		"mem.free": 933858,
 		"processors": 8,
 		"threads": 15,
-		"threads.deamon": 11,
+		"threads.daemon": 11,
 		"threads.peak": 15,
 		"uptime": 494836
 	}
@@ -668,15 +668,15 @@ http://matt.aimonetti.net/posts/2013/06/26/practical-guide-to-graphite-monitorin
 Metric service implementations are usually bound to a
 {sc-spring-boot-actuator}/metrics/repository/MetricRepository.{sc-ext}[`MetricRepository`].
 A `MetricRepository` is responsible for storing and retrieving metric information. Spring
-Boot provides an `InMemoryMetricRespository` and a `RedisMetricRepository` out of the
+Boot provides an `InMemoryMetricRepository` and a `RedisMetricRepository` out of the
 box (the in-memory repository is the default) but you can also write your own. The
 `MetricRepository` interface is actually composed of higher level `MetricReader` and
 `MetricWriter` interfaces. For full details refer to the
 {dc-spring-boot-actuator}/metrics/repository/MetricRepository.{dc-ext}[Javadoc].
 
 There's nothing to stop you hooking a `MetricRepository` with back-end storage directly
-into your app, but we recommend using the default `InMemoryMetricRespository` 
-(possibly with a custom `Map` instance if you are worried about heap usage) and 
+into your app, but we recommend using the default `InMemoryMetricRepository`
+(possibly with a custom `Map` instance if you are worried about heap usage) and
 populating a back-end repository through a scheduled export job. In that way you get
 some buffering in memory of the metric values and you can reduce the network
 chatter by exporting less frequently or in batches. Spring Boot provides

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-cli.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-cli.adoc
@@ -193,7 +193,7 @@ your application to see what fails before adding imports.
 
 [[cli-automatic-main-method]]
 ==== Automatic main method
-Unlike the equilvement Java application, you do not need to include a
+Unlike the equivalent Java application, you do not need to include a
 `public static void main(String[] args)` method with your `Groovy` scripts. A
 `SpringApplication` is automatically created, with your compiled code acting as the
 `source`.


### PR DESCRIPTION
Most are simple typos from the docs, but one item of note is that the new actuator metric for displaying the number of daemon threads was "thread.deamon" rather than "thread.daemon"

I've signed the CLA
