### PR TITLE
Update appendix-application-properties.adoc

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -126,7 +126,7 @@ content into your application; rather pick only the properties that you need.
 	spring.velocity.properties.*=
 	spring.velocity.requestContextAttribute=
 	spring.velocity.resourceLoaderPath=classpath:/templates/
-	spring.velocity.suffix=.ftl
+	spring.velocity.suffix=.vm
 	spring.velocity.templateEncoding=UTF-8
 	spring.velocity.viewNames= # whitelist of view names that can be resolved
 


### PR DESCRIPTION
As mentionned [http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#howto-customize-view-resolvers]: ".vm" is the default suffix of Velocity view name
