### PR TITLE
HornetQ starter

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -112,6 +112,16 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.hornetq</groupId>
+			<artifactId>hornetq-jms-client</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.hornetq</groupId>
+			<artifactId>hornetq-jms-server</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/HornetQAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/HornetQAutoConfiguration.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jms.ConnectionFactory;
+
+import org.hornetq.api.core.TransportConfiguration;
+import org.hornetq.api.core.client.HornetQClient;
+import org.hornetq.api.core.client.ServerLocator;
+import org.hornetq.api.jms.HornetQJMSClient;
+import org.hornetq.api.jms.JMSFactoryType;
+import org.hornetq.core.config.impl.ConfigurationImpl;
+import org.hornetq.core.remoting.impl.invm.InVMAcceptorFactory;
+import org.hornetq.core.remoting.impl.invm.InVMConnectorFactory;
+import org.hornetq.core.remoting.impl.netty.NettyConnectorFactory;
+import org.hornetq.core.remoting.impl.netty.TransportConstants;
+import org.hornetq.jms.client.HornetQConnectionFactory;
+import org.hornetq.jms.server.config.JMSConfiguration;
+import org.hornetq.jms.server.config.JMSQueueConfiguration;
+import org.hornetq.jms.server.config.TopicConfiguration;
+import org.hornetq.jms.server.config.impl.JMSConfigurationImpl;
+import org.hornetq.jms.server.config.impl.JMSQueueConfigurationImpl;
+import org.hornetq.jms.server.config.impl.TopicConfigurationImpl;
+import org.hornetq.jms.server.embedded.EmbeddedJMS;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration Auto-configuration}
+ * to integrate with an HornetQ broker. Connect by default to a broker available on the
+ * local machine with the default settings. If the necessary classes are present, the broker
+ * can also be embedded in the application itself.
+ *
+ * @author Stephane Nicoll
+ * @since 1.1
+ */
+@Configuration
+@AutoConfigureBefore(JmsTemplateAutoConfiguration.class)
+@ConditionalOnClass(ConnectionFactory.class)
+@ConditionalOnMissingBean(ConnectionFactory.class)
+public class HornetQAutoConfiguration {
+
+	@Configuration
+	@ConditionalOnClass({NettyConnectorFactory.class, HornetQJMSClient.class})
+	@ConditionalOnExpression("'${spring.hornetq.mode:netty}' == 'netty'")
+	protected static class NettyConnection {
+
+		@Configuration
+		@EnableConfigurationProperties(HornetQProperties.class)
+		static class HornetQNettyConfiguration {
+
+			@Autowired
+			private HornetQProperties properties;
+
+			@Bean
+			public ConnectionFactory jmsConnectionFactory() {
+				Map<String, Object> connectionParams = new HashMap<String, Object>();
+				connectionParams.put(TransportConstants.HOST_PROP_NAME, properties.getHost());
+				connectionParams.put(TransportConstants.PORT_PROP_NAME, properties.getPort());
+				TransportConfiguration transportConfiguration =
+						new TransportConfiguration(NettyConnectorFactory.class.getName(), connectionParams);
+				return HornetQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, transportConfiguration);
+			}
+
+		}
+	}
+
+	@Configuration
+	@ConditionalOnClass({InVMConnectorFactory.class, EmbeddedJMS.class})
+	@ConditionalOnExpression("'${spring.hornetq.mode:netty}' == 'embedded'")
+	protected static class EmbeddedConnection {
+
+		@Configuration
+		@EnableConfigurationProperties(HornetQProperties.class)
+		static class HornetQEmbeddedConfiguration {
+
+			@Autowired
+			private HornetQProperties properties;
+
+			@Autowired(required = false)
+			private Collection<JMSQueueConfiguration> queuesConfiguration;
+
+			@Autowired(required = false)
+			private Collection<TopicConfiguration> topicsConfiguration;
+
+			@Bean
+			public ConnectionFactory jmsConnectionFactory() {
+				ServerLocator serverLocator = HornetQClient.createServerLocatorWithoutHA(
+						new TransportConfiguration(InVMConnectorFactory.class.getName()));
+				return new HornetQConnectionFactory(serverLocator);
+			}
+
+			@Bean(initMethod = "start", destroyMethod = "stop")
+			@ConditionalOnMissingBean(EmbeddedJMS.class)
+			public SpringEmbeddedHornetQ hornetQServer(org.hornetq.core.config.Configuration hornetQConfiguration,
+					JMSConfiguration hornetQJmsConfiguration) {
+				SpringEmbeddedHornetQ bootstrap = new SpringEmbeddedHornetQ();
+				bootstrap.setConfiguration(hornetQConfiguration);
+				bootstrap.setJmsConfiguration(hornetQJmsConfiguration);
+				return bootstrap;
+			}
+
+			@Bean
+			@ConditionalOnMissingBean(org.hornetq.core.config.Configuration.class)
+			public org.hornetq.core.config.Configuration hornetQConfiguration() {
+				ConfigurationImpl configuration = new ConfigurationImpl();
+
+				configuration.setSecurityEnabled(false);
+
+				properties.getEmbedded().configure(configuration);
+
+				configuration.getAcceptorConfigurations().add(
+						new TransportConfiguration(InVMAcceptorFactory.class.getName()));
+
+				// https://issues.jboss.org/browse/HORNETQ-1143
+				configuration.setClusterPassword("SpringBootRules");
+				return configuration;
+			}
+
+			@Bean
+			@ConditionalOnMissingBean(JMSConfiguration.class)
+			public JMSConfiguration hornetQJmsConfiguration() {
+				JMSConfiguration jmsConfig = new JMSConfigurationImpl();
+
+				if (this.queuesConfiguration != null) {
+					jmsConfig.getQueueConfigurations().addAll(queuesConfiguration);
+				}
+				if (this.topicsConfiguration != null) {
+					jmsConfig.getTopicConfigurations().addAll(this.topicsConfiguration);
+				}
+
+				for (String queue : properties.getEmbedded().getQueues()) {
+					JMSQueueConfiguration queueConfig = createSimpleQueueConfiguration(queue);
+					jmsConfig.getQueueConfigurations().add(queueConfig);
+				}
+				for (String topic : properties.getEmbedded().getTopics()) {
+					TopicConfiguration topicConfig = createSimpleTopicConfiguration(topic);
+					jmsConfig.getTopicConfigurations().add(topicConfig);
+				}
+
+				return jmsConfig;
+			}
+
+
+			private JMSQueueConfiguration createSimpleQueueConfiguration(String name) {
+				return new JMSQueueConfigurationImpl(name, null,
+						this.properties.getEmbedded().isPersistent(), "/queue/" + name);
+			}
+
+			private TopicConfiguration createSimpleTopicConfiguration(String name) {
+				return new TopicConfigurationImpl(name, "/topic/" + name);
+			}
+
+		}
+
+	}
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/HornetQMode.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/HornetQMode.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms;
+
+/**
+ * Define the mode in which HornetQ can operate.
+ *
+ * @author Stephane Nicoll
+ * @since 1.1
+ */
+public enum HornetQMode {
+
+	/**
+	 * Connect to a broker using the native HornetQ protocol (i.e. netty).
+	 */
+	netty,
+
+	/**
+	 * Embed (i.e. start) the broker in the application.
+	 */
+	embedded
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/HornetQProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/HornetQProperties.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms;
+
+import java.io.File;
+
+import org.hornetq.core.config.Configuration;
+import org.hornetq.core.server.JournalType;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for HornetQ
+ *
+ * @author Stephane Nicoll
+ * @since 1.1
+ */
+@ConfigurationProperties(prefix = "spring.hornetq")
+public class HornetQProperties {
+
+	private HornetQMode mode = HornetQMode.netty;
+
+	private String host = "localhost";
+
+	private int port = 5445;
+
+	private final Embedded embedded = new Embedded();
+
+	public HornetQMode getMode() {
+		return mode;
+	}
+
+	public void setMode(HornetQMode mode) {
+		this.mode = mode;
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	public Embedded getEmbedded() {
+		return embedded;
+	}
+
+	public static class Embedded {
+
+		private boolean persistent;
+
+		private String dataDirectory;
+
+		private String[] queues = new String[0];
+
+		private String[] topics = new String[0];
+
+		/**
+		 * Applies the configuration defined in this instance to
+		 * the specified HornetQ {@link org.hornetq.core.config.Configuration}
+		 */
+		public void configure(Configuration configuration) {
+			configuration.setPersistenceEnabled(persistent);
+
+			// https://issues.jboss.org/browse/HORNETQ-1302
+			String rootDataDir = (this.dataDirectory != null ? this.dataDirectory : createDataDir());
+			configuration.setJournalDirectory(rootDataDir + "/journal");
+
+			if (this.persistent) {
+				// Force fallback to NIO
+				configuration.setJournalType(JournalType.NIO);
+
+				// Those directories should be configured separately.
+				configuration.setLargeMessagesDirectory(rootDataDir + "/largemessages");
+				configuration.setBindingsDirectory(rootDataDir + "/bindings");
+				configuration.setPagingDirectory(rootDataDir + "/paging");
+			}
+		}
+
+		public boolean isPersistent() {
+			return persistent;
+		}
+
+		public void setPersistent(boolean persistent) {
+			this.persistent = persistent;
+		}
+
+		public String getDataDirectory() {
+			return dataDirectory;
+		}
+
+		public void setDataDirectory(String dataDirectory) {
+			this.dataDirectory = dataDirectory;
+		}
+
+		public String[] getQueues() {
+			return queues;
+		}
+
+		public void setQueues(String[] queues) {
+			this.queues = queues;
+		}
+
+		public String[] getTopics() {
+			return topics;
+		}
+
+		public void setTopics(String[] topics) {
+			this.topics = topics;
+		}
+
+		/**
+		 * Creates a root data directory for HornetQ if none is provided.
+		 */
+		static String createDataDir() {
+			String tmpDir = System.getProperty("java.io.tmpdir");
+			return new File(tmpDir, "hornetq-data").getAbsolutePath();
+		}
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/NoOpBindingRegistry.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/NoOpBindingRegistry.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms;
+
+import org.hornetq.spi.core.naming.BindingRegistry;
+
+/**
+ * A no-op implementation of the {@link org.hornetq.spi.core.naming.BindingRegistry}.
+ *
+ * @author Stephane Nicoll
+ * @since 1.1
+ */
+class NoOpBindingRegistry implements BindingRegistry {
+
+	public Object lookup(String name) {
+		// This callback is used to check if an entry is present in the context before
+		// creating a queue on the fly. This is actually never used to try to fetch a
+		// destination that is unknown.
+		return null;
+	}
+
+	public boolean bind(String name, Object obj) {
+		// This callback is used bind a Destination created on the fly by the embedded
+		// broker using the JNDI name that was specified in the configuration. This does
+		// not look very useful since it's used nowhere. It could be interesting to
+		// autowire a destination to use it but the wiring is a bit "asynchronous" so
+		// better not provide that feature at all.
+		return false;
+	}
+
+	public void unbind(String name) {
+	}
+
+	public void close() {
+	}
+
+	@Override
+	public Object getContext() {
+		return this;
+	}
+
+	@Override
+	public void setContext(Object ctx) {
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/SpringEmbeddedHornetQ.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/SpringEmbeddedHornetQ.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms;
+
+import org.hornetq.jms.server.embedded.EmbeddedJMS;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+
+/**
+ * An embedded HornetQ broker that uses a {@link NoOpBindingRegistry}
+ * to avoid dependency on other registries such as JNDI.
+ *
+ * @author Stephane Nicoll
+ * @since 1.1
+ */
+public class SpringEmbeddedHornetQ extends EmbeddedJMS implements BeanFactoryAware {
+
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.setRegistry(new NoOpBindingRegistry());
+	}
+}

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -19,6 +19,7 @@ org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration,
 org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,\
 org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration,\
 org.springframework.boot.autoconfigure.jms.ActiveMQAutoConfiguration,\
+org.springframework.boot.autoconfigure.jms.HornetQAutoConfiguration,\
 org.springframework.boot.autoconfigure.jms.JmsTemplateAutoConfiguration,\
 org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration,\
 org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/HornetQAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/HornetQAutoConfigurationTests.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.hornetq.api.core.TransportConfiguration;
+import org.hornetq.core.config.impl.ConfigurationImpl;
+import org.hornetq.core.remoting.impl.invm.InVMConnectorFactory;
+import org.hornetq.core.remoting.impl.netty.NettyConnectorFactory;
+import org.hornetq.jms.client.HornetQConnectionFactory;
+import org.hornetq.jms.server.config.JMSConfiguration;
+import org.hornetq.jms.server.config.JMSQueueConfiguration;
+import org.hornetq.jms.server.config.TopicConfiguration;
+import org.hornetq.jms.server.config.impl.JMSConfigurationImpl;
+import org.hornetq.jms.server.config.impl.JMSQueueConfigurationImpl;
+import org.hornetq.jms.server.config.impl.TopicConfigurationImpl;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+import org.springframework.jms.core.SessionCallback;
+import org.springframework.jms.support.destination.DestinationResolver;
+import org.springframework.jms.support.destination.DynamicDestinationResolver;
+
+/**
+ * @author Stephane Nicoll
+ */
+public class HornetQAutoConfigurationTests {
+
+	@Rule
+	public final TemporaryFolder folder = new TemporaryFolder();
+
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void tearDown() {
+		if (context != null) {
+			context.close();
+		}
+	}
+
+	@Test
+	public void nettyConnectionFactory() {
+		this.context = createContext(EmptyConfiguration.class);
+		this.context.refresh();
+
+		HornetQProperties hornetQProperties = context.getBean(HornetQProperties.class);
+		assertEquals(HornetQMode.netty, hornetQProperties.getMode());
+
+		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
+		HornetQConnectionFactory connectionFactory = this.context
+				.getBean(HornetQConnectionFactory.class);
+		assertEquals(jmsTemplate.getConnectionFactory(), connectionFactory);
+		assertNettyConnectionFactory(connectionFactory, "localhost", 5445);
+	}
+
+	@Test
+	public void nettyConnectionFactoryCustomHost() {
+		this.context = createContext(EmptyConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.hornetq.host:192.168.1.144", "spring.hornetq.port:9876");
+		this.context.refresh();
+
+		HornetQConnectionFactory connectionFactory = this.context
+				.getBean(HornetQConnectionFactory.class);
+		assertNettyConnectionFactory(connectionFactory, "192.168.1.144", 9876);
+	}
+
+	@Test
+	public void embeddedConnectionFactory() {
+		this.context = createContext(EmptyConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.hornetq.mode:embedded");
+		this.context.refresh();
+
+		HornetQProperties hornetQProperties = context.getBean(HornetQProperties.class);
+		assertEquals(HornetQMode.embedded, hornetQProperties.getMode());
+
+
+		assertEquals(1, context.getBeansOfType(SpringEmbeddedHornetQ.class).size());
+		org.hornetq.core.config.Configuration configuration =
+				context.getBean(org.hornetq.core.config.Configuration.class);
+		assertFalse("Persistence disabled by default", configuration.isPersistenceEnabled());
+		assertFalse("Security disabled by default", configuration.isSecurityEnabled());
+
+		HornetQConnectionFactory connectionFactory = this.context
+				.getBean(HornetQConnectionFactory.class);
+		assertInVmConnectionFactory(connectionFactory);
+	}
+
+	@Test
+	public void embeddedServerWithDestinations() {
+		this.context = createContext(EmptyConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.hornetq.mode:embedded",
+				"spring.hornetq.embedded.queues=Queue1,Queue2",
+				"spring.hornetq.embedded.topics=Topic1");
+		this.context.refresh();
+
+		DestinationChecker checker = new DestinationChecker(this.context);
+		checker.checkQueue("Queue1", true);
+		checker.checkQueue("Queue2", true);
+		checker.checkQueue("QueueDoesNotExist", false);
+
+		checker.checkTopic("Topic1", true);
+		checker.checkTopic("TopicDoesNotExist", false);
+	}
+
+	@Test
+	public void embeddedServerWithDestinationConfig() {
+		this.context = createContext(DestinationConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.hornetq.mode:embedded");
+		this.context.refresh();
+
+		DestinationChecker checker = new DestinationChecker(this.context);
+		checker.checkQueue("sampleQueue", true);
+		checker.checkTopic("sampleTopic", true);
+	}
+
+	@Test
+	public void embeddedServiceWithCustomJmsConfiguration() {
+		this.context = createContext(CustomJmsConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.hornetq.mode:embedded",
+				"spring.hornetq.embedded.queues=Queue1,Queue2"); // Ignored with custom config
+		this.context.refresh();
+		DestinationChecker checker = new DestinationChecker(this.context);
+		checker.checkQueue("custom", true); // See CustomJmsConfiguration
+
+		checker.checkQueue("Queue1", false);
+		checker.checkQueue("Queue2", false);
+	}
+
+	@Test
+	public void embeddedServiceWithCustomHornetQConfiguration() {
+		this.context = createContext(CustomHornetQConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.hornetq.mode:embedded");
+		this.context.refresh();
+		org.hornetq.core.config.Configuration configuration =
+				context.getBean(org.hornetq.core.config.Configuration.class);
+		assertEquals("customFooBar", configuration.getName());
+	}
+
+	@Test
+	public void embeddedWithPersistentMode() throws IOException, JMSException {
+		File dataFolder = folder.newFolder();
+
+		// Start the server and post a message to some queue
+		this.context = createContext(EmptyConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.hornetq.mode:embedded",
+				"spring.hornetq.embedded.queues=TestQueue",
+				"spring.hornetq.embedded.persistent:true",
+				"spring.hornetq.embedded.dataDirectory:" + dataFolder.getAbsolutePath());
+		this.context.refresh();
+
+		final String msgId = UUID.randomUUID().toString();
+		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
+		jmsTemplate.send("TestQueue", new MessageCreator() {
+			@Override
+			public Message createMessage(Session session) throws JMSException {
+				return session.createTextMessage(msgId);
+			}
+		});
+		this.context.close(); // Shutdown the broker
+
+		// Start the server again and check if our message is still here
+		this.context = createContext(EmptyConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.hornetq.mode:embedded",
+				"spring.hornetq.embedded.queues=TestQueue",
+				"spring.hornetq.embedded.persistent:true",
+				"spring.hornetq.embedded.dataDirectory:" + dataFolder.getAbsolutePath());
+		this.context.refresh();
+
+		JmsTemplate jmsTemplate2 = this.context.getBean(JmsTemplate.class);
+		jmsTemplate2.setReceiveTimeout(1000L);
+		Message message = jmsTemplate2.receive("TestQueue");
+		assertNotNull("No message on persistent queue", message);
+		assertEquals("Invalid message received on queue", msgId, ((TextMessage) message).getText());
+	}
+
+
+	private TransportConfiguration assertInVmConnectionFactory(HornetQConnectionFactory connectionFactory) {
+		TransportConfiguration transportConfig = getSingleTransportConfiguration(connectionFactory);
+		assertEquals(InVMConnectorFactory.class.getName(), transportConfig.getFactoryClassName());
+		return transportConfig;
+	}
+
+	private TransportConfiguration assertNettyConnectionFactory(HornetQConnectionFactory connectionFactory,
+			String host, int port) {
+		TransportConfiguration transportConfig = getSingleTransportConfiguration(connectionFactory);
+		assertEquals(NettyConnectorFactory.class.getName(), transportConfig.getFactoryClassName());
+		assertEquals(host, transportConfig.getParams().get("host"));
+		assertEquals(port, transportConfig.getParams().get("port"));
+		return transportConfig;
+	}
+
+	private TransportConfiguration getSingleTransportConfiguration(HornetQConnectionFactory connectionFactory) {
+		TransportConfiguration[] transportConfigurations =
+				connectionFactory.getServerLocator().getStaticTransportConfigurations();
+		assertEquals(1, transportConfigurations.length);
+		return transportConfigurations[0];
+	}
+
+
+	private AnnotationConfigApplicationContext createContext(
+			Class<?>... additionalClasses) {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		context.register(additionalClasses);
+		context.register(HornetQAutoConfiguration.class,
+				JmsTemplateAutoConfiguration.class);
+		return context;
+	}
+
+	private static class DestinationChecker {
+
+		private final JmsTemplate jmsTemplate;
+
+		private final DestinationResolver destinationResolver;
+
+		private DestinationChecker(ApplicationContext applicationContext) {
+			this.jmsTemplate = applicationContext.getBean(JmsTemplate.class);
+			this.destinationResolver = new DynamicDestinationResolver();
+		}
+
+		public void checkQueue(String name, boolean shouldExist) {
+			checkDestination(name, false, shouldExist);
+		}
+
+		public void checkTopic(String name, boolean shouldExist) {
+			checkDestination(name, true, shouldExist);
+		}
+
+		public void checkDestination(final String name, final boolean pubSub, final boolean shouldExist) {
+			jmsTemplate.execute(new SessionCallback<Void>() {
+				@Override
+				public Void doInJms(Session session) throws JMSException {
+					try {
+						Destination destination = destinationResolver.resolveDestinationName(session, name, pubSub);
+						if (!shouldExist) {
+							throw new IllegalStateException("Destination '" + name
+									+ "' was not expected but got " + destination);
+						}
+					}
+					catch (JMSException e) {
+						if (shouldExist) {
+							throw new IllegalStateException("Destination '" + name
+									+ "' was expected but got " + e.getMessage());
+						}
+					}
+					return null;
+				}
+			});
+		}
+	}
+
+	@Configuration
+	protected static class EmptyConfiguration {
+	}
+
+	@Configuration
+	protected static class DestinationConfiguration {
+
+		@Bean
+		JMSQueueConfiguration sampleQueueConfiguration() {
+			return new JMSQueueConfigurationImpl("sampleQueue", "foo=bar", false, "/queue/1");
+		}
+
+		@Bean
+		TopicConfiguration sampleTopicConfiguration() {
+			return new TopicConfigurationImpl("sampleTopic", "/topic/1");
+		}
+	}
+
+	@Configuration
+	protected static class CustomJmsConfiguration {
+
+		@Bean
+		public JMSConfiguration myJmsConfiguration() {
+			JMSConfiguration config = new JMSConfigurationImpl();
+			config.getQueueConfigurations().add(new JMSQueueConfigurationImpl("custom", null, false));
+			return config;
+		}
+	}
+
+	@Configuration
+	protected static class CustomHornetQConfiguration {
+
+		@Autowired
+		private HornetQProperties properties;
+
+		@Bean
+		public org.hornetq.core.config.Configuration myHornetQConfiguration() {
+			ConfigurationImpl config = new ConfigurationImpl();
+			properties.getEmbedded().configure(config);
+
+			// This is the real customization
+			config.setClusterPassword("Foobar");
+			config.setName("customFooBar");
+
+			return config;
+		}
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/HornetQPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/HornetQPropertiesTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.hornetq.core.config.Configuration;
+import org.hornetq.core.config.impl.ConfigurationImpl;
+import org.hornetq.core.server.JournalType;
+import org.junit.Test;
+
+/**
+ *
+ * @author Stephane Nicoll
+ */
+public class HornetQPropertiesTests {
+
+	@Test
+	public void defaultDataDir() {
+		HornetQProperties properties = new HornetQProperties();
+		properties.getEmbedded().setPersistent(true);
+
+		Configuration configuration = new ConfigurationImpl();
+		properties.getEmbedded().configure(configuration);
+
+		String expectedRoot = HornetQProperties.Embedded.createDataDir();
+		assertEquals("Wrong journal dir", new File(expectedRoot, "journal"),
+				new File(configuration.getJournalDirectory()));
+	}
+
+	@Test
+	public void persistenceSetup() {
+		HornetQProperties properties = new HornetQProperties();
+		properties.getEmbedded().setPersistent(true);
+
+		Configuration configuration = new ConfigurationImpl();
+		properties.getEmbedded().configure(configuration);
+
+		assertTrue(configuration.isPersistenceEnabled());
+		assertEquals(JournalType.NIO, configuration.getJournalType());
+	}
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -68,6 +68,7 @@
 		<hikaricp.version>1.3.8</hikaricp.version>
 		<httpclient.version>4.3.3</httpclient.version>
 		<httpasyncclient.version>4.0.1</httpasyncclient.version>
+		<hornetq.version>2.4.1.Final</hornetq.version>
 		<hsqldb.version>2.3.2</hsqldb.version>
 		<jackson.version>2.3.3</jackson.version>
 		<javassist.version>3.18.1-GA</javassist.version> <!-- Same as Hibernate -->
@@ -671,6 +672,16 @@
 				<groupId>org.hibernate.javax.persistence</groupId>
 				<artifactId>hibernate-jpa-2.0-api</artifactId>
 				<version>${hibernate-jpa-api.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.hornetq</groupId>
+				<artifactId>hornetq-jms-server</artifactId>
+				<version>${hornetq.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.hornetq</groupId>
+				<artifactId>hornetq-jms-client</artifactId>
+				<version>${hornetq.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hsqldb</groupId>

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -242,6 +242,16 @@ content into your application; rather pick only the properties that you need.
 	spring.activemq.in-memory=true # broker kind to create if no broker-url is specified
 	spring.activemq.pooled=false
 
+    # HornetQ ({sc-spring-boot-autoconfigure}/jms/HornetQProperties.{sc-ext}[HornetQProperties])
+	spring.hornetq.mode=netty # connection mode (netty, embedded)
+	spring.hornetq.host=localhost # hornetQ host (netty mode)
+	spring.hornetq.port=5445 # hornetQ port (netty mode)
+	spring.hornetq.embedded.persistent=false # message persistence
+	spring.hornetq.embedded.data-directory= # location of data content (when persistence is enabled)
+	spring.hornetq.embedded.queues= # comma separate queues to create on startup
+	spring.hornetq.embedded.topics= # comma separate topics to create on startup
+
+
 	# JMS ({sc-spring-boot-autoconfigure}/jms/JmsTemplateProperties.{sc-ext}[JmsTemplateProperties])
 	spring.jms.pub-sub-domain= # false for queue (default), true for topic
 

--- a/spring-boot-docs/src/main/asciidoc/appendix-auto-configuration-classes.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-auto-configuration-classes.adoc
@@ -50,6 +50,12 @@ The following auto-configuration classes are from the `spring-boot-autoconfigure
 |{sc-spring-boot-autoconfigure}/web/HttpMessageConvertersAutoConfiguration.{sc-ext}[HttpMessageConvertersAutoConfiguration]
 |{dc-spring-boot-autoconfigure}/web/HttpMessageConvertersAutoConfiguration.{dc-ext}[javadoc]
 
+|{sc-spring-boot-autoconfigure}/jms/ActiveMQAutoConfiguration.{sc-ext}[ActiveMQAutoConfiguration]
+|{dc-spring-boot-autoconfigure}/jms/ActiveMQAutoConfiguration.{dc-ext}[javadoc]
+
+|{sc-spring-boot-autoconfigure}/jms/HornetQAutoConfiguration.{sc-ext}[HornetQAutoConfiguration]
+|{dc-spring-boot-autoconfigure}/jms/HornetQAutoConfiguration.{dc-ext}[javadoc]
+
 |{sc-spring-boot-autoconfigure}/jms/JmsTemplateAutoConfiguration.{sc-ext}[JmsTemplateAutoConfiguration]
 |{dc-spring-boot-autoconfigure}/jms/JmsTemplateAutoConfiguration.{dc-ext}[javadoc]
 

--- a/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
+++ b/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
@@ -242,6 +242,9 @@ and Hibernate.
 |`spring-boot-starter-freemarker`
 |Support for the FreeMarker templating engine
 
+|`spring-boot-starter-hornetq`
+|Support for ``Java Message Service API'' via HornetQ.
+
 |`spring-boot-starter-integration`
 |Support for common `spring-integration` modules.
 

--- a/spring-boot-starters/pom.xml
+++ b/spring-boot-starters/pom.xml
@@ -30,6 +30,7 @@
 		<module>spring-boot-starter-data-rest</module>
 		<module>spring-boot-starter-data-solr</module>
 		<module>spring-boot-starter-freemarker</module>
+		<module>spring-boot-starter-hornetq</module>
 		<module>spring-boot-starter-integration</module>
 		<module>spring-boot-starter-jdbc</module>
 		<module>spring-boot-starter-jetty</module>

--- a/spring-boot-starters/spring-boot-starter-hornetq/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-hornetq/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starters</artifactId>
+		<version>1.1.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-starter-hornetq</artifactId>
+	<name>Spring Boot HornetQ Starter</name>
+	<description>Spring Boot HornetQ Starter</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-jms</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hornetq</groupId>
+			<artifactId>hornetq-jms-client</artifactId>
+		</dependency>
+	</dependencies>
+</project>


### PR DESCRIPTION
This commit provides a spring boot starter for the HornetQ JMS broker.
`HornetQAutoConfiguration` provides a `javax.jms.ConnectionFactory` that
integrates with HornetQ if none is present and if the necessary HornetQ
classes are present in the classpath.

The connection factory connects to a broker available on the local
machine by default. A configuration switch allows to enable an embedded
mode that starts HornetQ as part of the application.

In such a mode, the `spring.hornetq.embedded.*` properties provide
additional options to configure the embedded broker. In particular,
message persistence and data directory locations can be specified. It is
also possible to define the queue(s) and topic(s) to create on startup.

Relates to gh-765
