### PR TITLE
Added Janino to BOM

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -75,7 +75,7 @@
 		<hsqldb.version>2.3.2</hsqldb.version>
 		<jackson.version>2.3.3</jackson.version>
 		<janino.version>2.6.1</janino.version>
-        <javassist.version>3.18.1-GA</javassist.version> <!-- Same as Hibernate -->
+		<javassist.version>3.18.1-GA</javassist.version> <!-- Same as Hibernate -->
 		<jedis.version>2.4.1</jedis.version>
 		<jetty.version>8.1.14.v20131031</jetty.version>
 		<jetty-jsp.version>2.2.0.v201112011158</jetty-jsp.version>


### PR DESCRIPTION
Hi,

In order to evaluate conditional expressions in configuration files Logback requires [1] Janino to be in the classpath. Since Spring BOM provides preferred version of the Logback...

```
<dependency>
  <groupId>ch.qos.logback</groupId>
  <artifactId>logback-classic</artifactId>
</dependency>
```

... it will be nice to have the proper version of Janino for that Logback out of the box as well:

```
<dependency>
  <groupId>ch.qos.logback</groupId>
  <artifactId>logback-classic</artifactId>
</dependency>
<dependency>
  <groupId>org.codehaus.janino</groupId>
  <artifactId>janino</artifactId>
</dependency>
```

Cheers.

[1] http://logback.qos.ch/codes.html#ifJanino
