### PR TITLE
Make HypermediaAutoConfiguration more lenient.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hateoas/HypermediaAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hateoas/HypermediaAutoConfiguration.java
@@ -19,9 +19,11 @@ package org.springframework.boot.autoconfigure.hateoas;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.hateoas.LinkDiscoverers;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
@@ -31,10 +33,12 @@ import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType
  * {@link EnableHypermediaSupport}.
  * 
  * @author Roy Clarkson
+ * @author Oliver Gierke
  * @since 1.1.0
  */
 @Configuration
 @ConditionalOnClass(Resource.class)
+@ConditionalOnMissingBean(LinkDiscoverers.class)
 @AutoConfigureAfter(WebMvcAutoConfiguration.class)
 public class HypermediaAutoConfiguration {
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hateoas/HypermediaAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hateoas/HypermediaAutoConfigurationTests.java
@@ -18,9 +18,12 @@ package org.springframework.boot.autoconfigure.hateoas;
 
 import org.junit.After;
 import org.junit.Test;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.hateoas.LinkDiscoverer;
 import org.springframework.hateoas.LinkDiscoverers;
 import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
 import org.springframework.hateoas.hal.HalLinkDiscoverer;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
@@ -31,6 +34,7 @@ import static org.junit.Assert.assertTrue;
  * Tests for {@link HypermediaAutoConfiguration}.
  * 
  * @author Roy Clarkson
+ * @author Oliver Gierke
  */
 public class HypermediaAutoConfigurationTests {
 
@@ -52,6 +56,22 @@ public class HypermediaAutoConfigurationTests {
 		assertNotNull(discoverers);
 		LinkDiscoverer discoverer = discoverers.getLinkDiscovererFor(MediaTypes.HAL_JSON);
 		assertTrue(HalLinkDiscoverer.class.isInstance(discoverer));
+	}
+	
+	@Test
+	public void doesBackOffIfEnableHypermediaSupportIsDeclaredManually() {
+		
+		this.context = new AnnotationConfigWebApplicationContext();
+		this.context.register(SampleConfig.class, HypermediaAutoConfiguration.class);
+		this.context.refresh();
+		
+		this.context.getBean(LinkDiscoverers.class);
+	}
+	
+	@Configuration
+	@EnableHypermediaSupport(type = HypermediaType.HAL)
+	static class SampleConfig {
+		
 	}
 
 }


### PR DESCRIPTION
HypermediaAutoConfiguration didn't consider an @EnableHypermediaSupport 
annotation being present in the user configuration which could've caused 
it to be evaluated twice.

This is especially the case if both the auto-configuration for Spring 
HATEOAS and Spring Data REST kick in as Spring Data REST actively declares
@EnableHypermediaSupport. The double evaluation then causes injection
ambiguities as we now get multiple beans of e.g. LinkDiscoverers deployed.
