### PR TITLE
Additional Spring mobile improvements

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mobile/DeviceDelegatingViewResolverAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mobile/DeviceDelegatingViewResolverAutoConfiguration.java
@@ -36,7 +36,6 @@ import org.springframework.core.Ordered;
 import org.springframework.core.env.Environment;
 import org.springframework.mobile.device.view.LiteDeviceDelegatingViewResolver;
 import org.springframework.web.servlet.ViewResolver;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.thymeleaf.spring4.view.ThymeleafViewResolver;
 
@@ -52,10 +51,10 @@ import org.thymeleaf.spring4.view.ThymeleafViewResolver;
 @Configuration
 @ConditionalOnWebApplication
 @ConditionalOnClass(LiteDeviceDelegatingViewResolver.class)
-@AutoConfigureAfter(WebMvcAutoConfiguration.class)
+@AutoConfigureAfter({ WebMvcAutoConfiguration.class, ThymeleafAutoConfiguration.class })
 public class DeviceDelegatingViewResolverAutoConfiguration {
 
-	private static Log logger = LogFactory.getLog(WebMvcConfigurerAdapter.class);
+	private static Log logger = LogFactory.getLog(DeviceDelegatingViewResolverAutoConfiguration.class);
 
 	private static abstract class AbstractDelegateConfiguration implements
 			EnvironmentAware {
@@ -103,8 +102,7 @@ public class DeviceDelegatingViewResolverAutoConfiguration {
 	protected static class DeviceDelegatingViewResolverConfiguration {
 
 		@Configuration
-		@ConditionalOnBean(ThymeleafViewResolver.class)
-		@AutoConfigureAfter(ThymeleafAutoConfiguration.class)
+		@ConditionalOnBean(name = "thymeleafViewResolver")
 		protected static class ThymeleafViewResolverViewResolverDelegateConfiguration
 				extends AbstractDelegateConfiguration {
 
@@ -124,7 +122,7 @@ public class DeviceDelegatingViewResolverAutoConfiguration {
 		}
 
 		@Configuration
-		@ConditionalOnMissingBean(ThymeleafViewResolver.class)
+		@ConditionalOnMissingBean(name = "thymeleafViewResolver")
 		@ConditionalOnBean(InternalResourceViewResolver.class)
 		protected static class InternalResourceViewResolverDelegateConfiguration extends
 				AbstractDelegateConfiguration {

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -292,7 +292,7 @@ content into your application; rather pick only the properties that you need.
 	# SPRING MOBILE SITE PREFERENCE ({sc-spring-boot-autoconfigure}/mobile/SitePreferenceAutoConfiguration.{sc-ext}[SitePreferenceAutoConfiguration])
 	spring.mobile.sitepreference.enabled=true # enabled by default
 
-	# SPRING MOBILE DEVICE VIEWS ({sc-spring-boot-autoconfigure}/mobile/DevceDelegatingViewResolverAutoConfiguration.{sc-ext}[DevceDelegatingViewResolverAutoConfiguration])
+	# SPRING MOBILE DEVICE VIEWS ({sc-spring-boot-autoconfigure}/mobile/DeviceDelegatingViewResolverAutoConfiguration.{sc-ext}[DeviceDelegatingViewResolverAutoConfiguration])
 	spring.mobile.devicedelegatingviewresolver.enabled=true # disabled by default
 	spring.mobile.devicedelegatingviewresolver.normalPrefix=
 	spring.mobile.devicedelegatingviewresolver.normalSuffix=


### PR DESCRIPTION
Fix issues with DeviceDelegatingViewResolverAutoConfiguration
- Log to the correct class
- Set Auto-configure after Thymeleaf hint on main class instead of internal static class
- Use 'thymeleafViewResolver' bean name instead of class for conditional bean checks
- Fix class name in properties documentation
