### PR TITLE
Fixed typo

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -201,7 +201,7 @@ content into your application; rather pick only the properties that you need.
 
 	# ELASTICSEARCH ({sc-spring-boot-autoconfigure}/elasticsearch/ElasticsearchProperties.{sc-ext}[ElasticsearchProperties}])
 	spring.data.elasticsearch.cluster-name= # The cluster name (defaults to elasticsearch)
-	spring.data.elasticsearch.cluster-node= # The address(es) of the server node (comma-separated; if not specified starts a client node)
+	spring.data.elasticsearch.cluster-nodes= # The address(es) of the server node (comma-separated; if not specified starts a client node)
 	spring.data.elasticsearch.local=true # if local mode should be used with client nodes
 	spring.data.elasticsearch.repositories.enabled=true # if spring data repository support is enabled
 


### PR DESCRIPTION
Just fixing a typo in appendix-application-properties.adoc.
