### PR TITLE
update javadoc and test to reflect current VanillaHealthCheckIndicator implementation

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/VanillaHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/VanillaHealthIndicator.java
@@ -17,10 +17,11 @@
 package org.springframework.boot.actuate.health;
 
 /**
- * Default implementation of {@link HealthIndicator} that simply returns {@literal "ok"}.
- * 
+ * Default implementation of {@link HealthIndicator} that simply returns {@literal "UP"}.
+ *
  * @author Dave Syer
  * @author Christian Dupuis
+ * @see Status#UP
  */
 public class VanillaHealthIndicator extends AbstractHealthIndicator {
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/VanillaHealthIndicatorTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/VanillaHealthIndicatorTests.java
@@ -22,13 +22,13 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for {@link VanillaHealthIndicator}.
- * 
+ *
  * @author Phillip Webb
  */
 public class VanillaHealthIndicatorTests {
 
 	@Test
-	public void ok() throws Exception {
+	public void indicatesUp() throws Exception {
 		VanillaHealthIndicator healthIndicator = new VanillaHealthIndicator();
 		assertEquals(Status.UP, healthIndicator.health().getStatus());
 	}


### PR DESCRIPTION
as of spring-boot 1.1.0, the VanillaHealthCheckIndicator returns Status.UP instead of "ok".
