### PR TITLE
RabbitMQ virtual hosts can now start with a slash

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -21,7 +21,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Configuration properties for Rabbit.
- * 
+ *
  * @author Greg Turnquist
  * @author Dave Syer
  */
@@ -110,10 +110,15 @@ public class RabbitProperties {
 	}
 
 	public void setVirtualHost(String virtualHost) {
-		while (virtualHost.startsWith("/") && virtualHost.length() > 0) {
-			virtualHost = virtualHost.substring(1);
-		}
-		this.virtualHost = "/" + virtualHost;
+        if ("".equals(virtualHost) || virtualHost.equals("/")) {
+            this.virtualHost = "/";
+        } else {
+//            remove all trailing /
+            while (virtualHost.startsWith("/") && virtualHost.length() > 0) {
+                virtualHost = virtualHost.substring(1);
+            }
+            this.virtualHost = virtualHost;
+        }
 	}
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoconfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoconfigurationTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.autoconfigure.amqp;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -30,12 +33,9 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 /**
  * Tests for {@link RabbitAutoConfiguration}.
- * 
+ *
  * @author Greg Turnquist
  */
 public class RabbitAutoconfigurationTests {
@@ -74,7 +74,7 @@ public class RabbitAutoconfigurationTests {
 				.getBean(CachingConnectionFactory.class);
 		assertEquals("remote-server", connectionFactory.getHost());
 		assertEquals(9000, connectionFactory.getPort());
-		assertEquals("/vhost", connectionFactory.getVirtualHost());
+        assertEquals("vhost", connectionFactory.getVirtualHost());
 	}
 
 	@Test
@@ -87,18 +87,6 @@ public class RabbitAutoconfigurationTests {
 		CachingConnectionFactory connectionFactory = this.context
 				.getBean(CachingConnectionFactory.class);
 		assertEquals("/", connectionFactory.getVirtualHost());
-	}
-
-	@Test
-	public void testRabbitTemplateVirtualHostMissingSlash() {
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(TestConfiguration.class, RabbitAutoConfiguration.class);
-		EnvironmentTestUtils.addEnvironment(this.context,
-				"spring.rabbitmq.virtual_host:foo");
-		this.context.refresh();
-		CachingConnectionFactory connectionFactory = this.context
-				.getBean(CachingConnectionFactory.class);
-		assertEquals("/foo", connectionFactory.getVirtualHost());
 	}
 
 	@Test

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
@@ -16,19 +16,19 @@
 
 package org.springframework.boot.autoconfigure.amqp;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import org.junit.Test;
+
 /**
  * Tests for {@link RabbitProperties}.
- * 
+ *
  * @author Dave Syer
  */
 public class RabbitPropertiesTests {
 
-	private RabbitProperties properties = new RabbitProperties();
+	private final RabbitProperties properties = new RabbitProperties();
 
 	@Test
 	public void addressesNotSet() {
@@ -49,5 +49,29 @@ public class RabbitPropertiesTests {
 		assertNull(this.properties.getHost());
 		assertEquals(9999, this.properties.getPort());
 	}
+
+    @Test
+    public void testDefaultVirtualHost() {
+        this.properties.setVirtualHost("/");
+        assertEquals("/", this.properties.getVirtualHost());
+    }
+
+    @Test
+    public void testemptyVirtualHost() {
+        this.properties.setVirtualHost("");
+        assertEquals("/", this.properties.getVirtualHost());
+    }
+
+    @Test
+    public void testCustomVirtualHost() {
+        this.properties.setVirtualHost("myvHost");
+        assertEquals("myvHost", this.properties.getVirtualHost());
+    }
+
+    @Test
+    public void testCustomFalsyVirtualHost() {
+        this.properties.setVirtualHost("/myvHost");
+        assertEquals("myvHost", this.properties.getVirtualHost());
+    }
 
 }


### PR DESCRIPTION
Virtual Hosts do not need a leading slash.
