### PR TITLE
Document how to remote debug gradle started app

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -1589,6 +1589,33 @@ Check {spring-boot-maven-plugin-site}/examples/run-debug.html[this example] for 
 
 
 
+[[howto-remote-debug-gradle-run]]
+=== Remote debug a Spring Boot application started with Gradle
+To attach a remote debugger to a Spring Boot application started with Gradle you can use
+the `applicationDefaultJvmArgs` in `build.gradle` or `--debug-jvm` command line option.
+
+`build.gradle`:
+
+[source,groovy,indent=0,subs="verbatim,attributes"]
+----
+	applicationDefaultJvmArgs = [
+	    "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
+	]
+----
+
+
+Command line:
+
+[indent=0]
+----
+	$ gradle run --debug-jvm
+----
+
+
+Check http://www.gradle.org/docs/current/userguide/application_plugin.html[Gradle Application Plugin] for more details.
+
+
+
 [[howto-build-an-executable-archive-with-ant]]
 === Build an executable archive with Ant
 To build with Ant you need to grab dependencies, compile and then create a jar or war


### PR DESCRIPTION
It took me a while to figure out how to remote debug spring sagan app while I'm exploring it.
I created an [issue](https://github.com/spring-io/sagan/issues/422) in sagan project, but it may also be helpful if it is documented in spring-boot too.

Thanks,
