### PR TITLE
Ensure registration of Jackson modules in the environment of an embedded Tomcat

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
@@ -55,25 +55,10 @@ import com.fasterxml.jackson.datatype.jsr310.JSR310Module;
  */
 @Configuration
 @ConditionalOnClass(ObjectMapper.class)
-@EnableConfigurationProperties(HttpMapperProperties.class)
 public class JacksonAutoConfiguration {
 
 	@Autowired
-	private HttpMapperProperties properties = new HttpMapperProperties();
-
-	@Autowired
 	private ListableBeanFactory beanFactory;
-
-	@Bean
-	@Primary
-	@ConditionalOnMissingBean
-	public ObjectMapper jacksonObjectMapper() {
-		ObjectMapper objectMapper = new ObjectMapper();
-		if (this.properties.isJsonSortKeys()) {
-			objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
-		}
-		return objectMapper;
-	}
 
 	@PostConstruct
 	private void registerModulesWithObjectMappers() {
@@ -87,6 +72,27 @@ public class JacksonAutoConfiguration {
 		return BeanFactoryUtils.beansOfTypeIncludingAncestors(this.beanFactory, type)
 				.values();
 	}
+
+    @Configuration
+    @ConditionalOnClass(ObjectMapper.class)
+    @EnableConfigurationProperties(HttpMapperProperties.class)
+    static class JacksonObjectMapperAutoConfiguration {
+
+        @Autowired
+       	private HttpMapperProperties properties = new HttpMapperProperties();
+
+        @Bean
+       	@Primary
+       	@ConditionalOnMissingBean
+       	public ObjectMapper jacksonObjectMapper() {
+       		ObjectMapper objectMapper = new ObjectMapper();
+       		if (this.properties.isJsonSortKeys()) {
+       			objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+       		}
+       		return objectMapper;
+       	}
+
+    }
 
 	@Configuration
 	@ConditionalOnClass(JodaModule.class)


### PR DESCRIPTION
Separate the configuration/creation of the default ObjectMapper bean from the registration of Jackson modules. 
This is to avoid circular creations of the default ObjectMapper bean (and thus failing to obtain the ObjectMapper and registering the module(s)).

Sorry for not writing any tests to verify this, but I'm still new to Spring Boot and don't know yet how to write such a test with the embedded Tomcat.  
