### PR TITLE
Corrected a typo

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
+++ b/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
@@ -66,7 +66,7 @@ If you import additional starters, you can safely omit the version number.
 
 [[using-boot-maven-without-a-parent]]
 ==== Using Spring Boot without the parent POM
-No everyone likes inheriting from the `spring-boot-starter-parent` POM. You may have your
+Not everyone likes inheriting from the `spring-boot-starter-parent` POM. You may have your
 own corporate standard parent that you need to use, or you may just prefer to explicitly
 declare all your Maven configuration.
 


### PR DESCRIPTION
Corrected a trivial typo in the 12.1.2 Using Spring Boot without the parent POM section
