### PR TITLE
gh-1206 AMQP Restore vHost Leading /

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -110,11 +110,7 @@ public class RabbitProperties {
 	}
 
 	public void setVirtualHost(String virtualHost) {
-		while (virtualHost.startsWith("/") && virtualHost.length() > 0) {
-			virtualHost = virtualHost.substring(1);
-		}
 		this.virtualHost = ("".equals(virtualHost) ? "/" : virtualHost);
-
 	}
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoconfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoconfigurationTests.java
@@ -16,9 +16,13 @@
 
 package org.springframework.boot.autoconfigure.amqp;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
 import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -29,9 +33,6 @@ import org.springframework.boot.test.EnvironmentTestUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests for {@link RabbitAutoConfiguration}.
@@ -74,7 +75,7 @@ public class RabbitAutoconfigurationTests {
 				.getBean(CachingConnectionFactory.class);
 		assertEquals("remote-server", connectionFactory.getHost());
 		assertEquals(9000, connectionFactory.getPort());
-		assertEquals("vhost", connectionFactory.getVirtualHost());
+		assertEquals("/vhost", connectionFactory.getVirtualHost());
 	}
 
 	@Test
@@ -87,6 +88,30 @@ public class RabbitAutoconfigurationTests {
 		CachingConnectionFactory connectionFactory = this.context
 				.getBean(CachingConnectionFactory.class);
 		assertEquals("/", connectionFactory.getVirtualHost());
+	}
+
+	@Test
+	public void testRabbitTemplateVirtualHostNoLeadingSlash() {
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(TestConfiguration.class, RabbitAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.rabbitmq.virtual_host:foo");
+		this.context.refresh();
+		CachingConnectionFactory connectionFactory = this.context
+				.getBean(CachingConnectionFactory.class);
+		assertEquals("foo", connectionFactory.getVirtualHost());
+	}
+
+	@Test
+	public void testRabbitTemplateVirtualHostMultiLeadingSlashes() {
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(TestConfiguration.class, RabbitAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.rabbitmq.virtual_host:///foo");
+		this.context.refresh();
+		CachingConnectionFactory connectionFactory = this.context
+				.getBean(CachingConnectionFactory.class);
+		assertEquals("///foo", connectionFactory.getVirtualHost());
 	}
 
 	@Test

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
@@ -16,10 +16,10 @@
 
 package org.springframework.boot.autoconfigure.amqp;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
 
 /**
  * Tests for {@link RabbitProperties}.
@@ -71,7 +71,7 @@ public class RabbitPropertiesTests {
 	@Test
 	public void testCustomFalsyVirtualHost() {
 		this.properties.setVirtualHost("/myvHost");
-		assertEquals("myvHost", this.properties.getVirtualHost());
+		assertEquals("/myvHost", this.properties.getVirtualHost());
 	}
 
 }


### PR DESCRIPTION
vHosts have no restrictions requiring a leading slash and
can have any number of leading slashes.

https://github.com/spring-projects/spring-boot/commit/ad1636fd349b2e6636837d98af1ba1d07500ec9f

broke vHosts with a leading / by removing it.

See gh-1206
