### PR TITLE
Support new property endpoints.(configprops|env).pattern-to-sanitize

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -330,12 +330,15 @@ content into your application; rather pick only the properties that you need.
 	endpoints.configprops.sensitive=true
 	endpoints.configprops.enabled=true
 	endpoints.configprops.keys-to-sanitize=password,secret
+	endpoints.configprops.pattern-to-sanitize:.*(password|secret).* # alternative to keys-to-sanitize
 	endpoints.dump.id=dump
 	endpoints.dump.sensitive=true
 	endpoints.dump.enabled=true
 	endpoints.env.id=env
 	endpoints.env.sensitive=true
 	endpoints.env.enabled=true
+	endpoints.env.keys-to-sanitize=password,secret
+	endpoints.env.pattern-to-sanitize:.*(password|secret).* # alternative to keys-to-sanitize
 	endpoints.health.id=health
 	endpoints.health.sensitive=false
 	endpoints.health.enabled=true


### PR DESCRIPTION
Currently, `endpoionts.(configprops|env).keys-to-sanitize` are supported to mask secret property values.
However, this sanitize only when suffix of property name matches the specified key.

I'd like to sanitize more flexible. So I've introduced `endpoionts.(configprops|env).pattern-to-sanitize`. 
These new properties enable to configure regex pattern to mask.

This commit still keeps backward compatibility with `endpoionts.(configprops|env).keys-to-sanitize`. 
Please review.
