### PR TITLE
Provide dependency management for json-path

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -82,6 +82,7 @@
 		<jdom2.version>2.0.5</jdom2.version>
 		<joda-time.version>2.3</joda-time.version>
 		<jolokia.version>1.2.2</jolokia.version>
+		<json-path.version>0.9.1</json-path.version>
 		<jstl.version>1.2</jstl.version>
 		<junit.version>4.11</junit.version>
 		<liquibase.version>3.0.8</liquibase.version>
@@ -404,6 +405,11 @@
 				<groupId>com.h2database</groupId>
 				<artifactId>h2</artifactId>
 				<version>${h2.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.jayway.jsonpath</groupId>
+				<artifactId>json-path</artifactId>
+				<version>${json-path.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.zaxxer</groupId>

--- a/spring-boot-starters/spring-boot-starter-test/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-test/pom.xml
@@ -35,6 +35,10 @@
 			<artifactId>hamcrest-library</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.jayway.jsonpath</groupId>
+			<artifactId>json-path</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
 			<exclusions>


### PR DESCRIPTION
Added `com.jayway.jsonpath` to `spring-boot-starter-test`.

JsonPath is mentioned in the documentation (http://docs.spring.io/spring/docs/current/spring-framework-reference/html/testing.html#spring-mvc-test-server) so I was surprised that using it causes:

```
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.164 sec <<< FAILURE! - in demo.FooBarTest
testFooBar(demo.FooBarTest)  Time elapsed: 0.163 sec  <<< ERROR!
java.lang.NoClassDefFoundError: com/jayway/jsonpath/InvalidPathException
        at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
        at org.springframework.test.web.servlet.result.JsonPathResultMatchers.<init>(JsonPathResultMatchers.java:43)
        at org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath(MockMvcResultMatchers.java:183)
```

Added it to the starter so it's available out of the box

---

I've signed the CLA already.
