### PR TITLE
Fix LoggingApplicationListener

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/logging/LoggingApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/LoggingApplicationListener.java
@@ -183,13 +183,11 @@ public class LoggingApplicationListener implements SmartApplicationListener {
 			try {
 				ResourceUtils.getURL(value).openStream().close();
 				system.initialize(value);
-				return;
 			}
 			catch (Exception ex) {
-				// Swallow exception and continue
+				this.logger.warn("Logging environment value '" + value
+						+ "' cannot be opened and will be ignored");
 			}
-			this.logger.warn("Logging environment value '" + value
-					+ "' cannot be opened and will be ignored");
 		}
 		else {
 


### PR DESCRIPTION
- If `logging.config` is set and could open/read the resource
  then, return.
  - Currently, it logs warning though the resource is successfully
    read.
