### PR TITLE
Add java options for Heroku Procfile

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/cloud-deployment.adoc
+++ b/spring-boot-docs/src/main/asciidoc/cloud-deployment.adoc
@@ -153,7 +153,7 @@ for our starter REST application:
 
 [indent=0]
 ----
-	web: java -Dserver.port=$PORT -jar target/demo-0.0.1-SNAPSHOT.jar
+	web: java -Dserver.port=$PORT $JAVA_OPTS -jar target/demo-0.0.1-SNAPSHOT.jar
 ----
 
 Spring Boot makes `-D` arguments available as properties accessible from a Spring


### PR DESCRIPTION
Added $JAVA_OPTS variable to the sample Heroku Procfile. 
If this is left out it can cause memory issues when the app starts.
