### PR TITLE
Improved detection of manual Spring Data JPA configuration.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jpa/JpaRepositoriesAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jpa/JpaRepositoriesAutoConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.data.jpa.repository.support.EntityManagerBeanDefinitionRegistrarPostProcessor;
+import org.springframework.data.jpa.repository.config.JpaRepositoryConfigExtension;
 import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
@@ -57,7 +57,7 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport;
 @Configuration
 @ConditionalOnBean(DataSource.class)
 @ConditionalOnClass(JpaRepository.class)
-@ConditionalOnMissingBean({RepositoryFactoryBeanSupport.class, EntityManagerBeanDefinitionRegistrarPostProcessor.class})
+@ConditionalOnMissingBean({RepositoryFactoryBeanSupport.class, JpaRepositoryConfigExtension.class})
 @ConditionalOnProperty(value = "spring.data.jpa.repositories.enabled", match = "true", defaultMatch = true)
 @Import(JpaRepositoriesAutoConfigureRegistrar.class)
 @AutoConfigureAfter(HibernateJpaAutoConfiguration.class)

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoRepositoriesAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoRepositoriesAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.data.mongodb.repository.config.MongoRepositoryConfigurationExtension;
 import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
 
 import com.mongodb.Mongo;
@@ -53,7 +54,7 @@ import com.mongodb.Mongo;
  */
 @Configuration
 @ConditionalOnClass({ Mongo.class, MongoRepository.class })
-@ConditionalOnMissingBean(RepositoryFactoryBeanSupport.class)
+@ConditionalOnMissingBean({RepositoryFactoryBeanSupport.class, MongoRepositoryConfigurationExtension.class})
 @ConditionalOnProperty(value = "spring.data.mongo.repositories.enabled", match="true", defaultMatch = true)
 @Import(MongoRepositoriesAutoConfigureRegistrar.class)
 @AutoConfigureAfter(MongoAutoConfiguration.class)

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/solr/SolrRepositoriesAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/solr/SolrRepositoriesAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
 import org.springframework.data.solr.repository.SolrRepository;
+import org.springframework.data.solr.repository.config.SolrRepositoryConfigExtension;
 
 /**
  * Enables auto configuration for Spring Data Solr repositories.
@@ -39,11 +40,12 @@ import org.springframework.data.solr.repository.SolrRepository;
  * do.
  *
  * @author Christoph Strobl
+ * @author Oliver Gierke
  * @since 1.1.0
  */
 @Configuration
 @ConditionalOnClass({ SolrServer.class, SolrRepository.class })
-@ConditionalOnMissingBean(RepositoryFactoryBeanSupport.class)
+@ConditionalOnMissingBean({RepositoryFactoryBeanSupport.class, SolrRepositoryConfigExtension.class})
 @ConditionalOnProperty(value= "spring.data.solr.repositories.enabled", match="true", defaultMatch = true)
 @Import(SolrRepositoriesAutoConfigureRegistrar.class)
 public class SolrRepositoriesAutoConfiguration {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/jpa/JpaRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/jpa/JpaRepositoriesAutoConfigurationTests.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.autoconfigure.TestAutoConfigurationPackage;
-import org.springframework.boot.autoconfigure.data.alt.jpa.CityJpaRepository;
 import org.springframework.boot.autoconfigure.data.alt.mongo.CityMongoDbRepository;
 import org.springframework.boot.autoconfigure.data.alt.solr.CitySolrRepository;
 import org.springframework.boot.autoconfigure.data.jpa.city.City;

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/solr/SolrRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/solr/SolrRepositoriesAutoConfigurationTests.java
@@ -20,6 +20,7 @@ import org.apache.solr.client.solrj.SolrServer;
 import org.apache.solr.client.solrj.impl.HttpSolrServer;
 import org.junit.After;
 import org.junit.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.autoconfigure.TestAutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.data.alt.solr.CitySolrRepository;
@@ -36,9 +37,10 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 
 /**
- * Tests for {@link SolrRepositoriesAutoConfiguration}
+ * Tests for {@link SolrRepositoriesAutoConfiguration}.
  *
  * @author Christoph Strobl
+ * @author Oliver Gierke
  */
 public class SolrRepositoriesAutoConfigurationTests {
 
@@ -70,6 +72,13 @@ public class SolrRepositoriesAutoConfigurationTests {
 		initContext(CustomizedConfiguration.class);
 		assertThat(this.context.getBean(CitySolrRepository.class), notNullValue());
 	}
+	
+	@Test(expected = NoSuchBeanDefinitionException.class)
+	public void autoConfigurationShouldNotKickInEvenIfManualConfigDidNotCreateAnyRepositories() {
+		
+		initContext(SortOfInvalidCustomConfiguration.class);
+		this.context.getBean(CityRepository.class);
+	}
 
 	private void initContext(Class<?> configClass) {
 
@@ -99,4 +108,8 @@ public class SolrRepositoriesAutoConfigurationTests {
 
 	}
 
+	@Configuration
+	@TestAutoConfigurationPackage(SolrRepositoriesAutoConfigurationTests.class)
+	@EnableSolrRepositories("foo.bar")// to not find any repositories
+	protected static class SortOfInvalidCustomConfiguration {}
 }

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -100,7 +100,7 @@
 		<spring.version>4.0.6.RELEASE</spring.version>
 		<spring-amqp.version>1.3.5.RELEASE</spring-amqp.version>
 		<spring-batch.version>3.0.1.RELEASE</spring-batch.version>
-		<spring-data-releasetrain.version>Dijkstra-SR1</spring-data-releasetrain.version>
+		<spring-data-releasetrain.version>Dijkstra-BUILD-SNAPSHOT</spring-data-releasetrain.version>
 		<spring-hateoas.version>0.14.0.RELEASE</spring-hateoas.version>
 		<spring-integration.version>4.0.2.RELEASE</spring-integration.version>
 		<spring-loaded.version>1.2.0.RELEASE</spring-loaded.version>


### PR DESCRIPTION
The Spring Data JPA repository auto configuration now considers the
presence of a bean of type EntityManagerBeanDefinitionRegistrarPostProcessor
as indicator for manual configuration. This bean is added by using
@EnableJpaRepositories to the configuration manually.
