### PR TITLE
Allow ANSI output to be configured manually

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -711,7 +711,10 @@ messages to the console you can start your application with a `--debug` flag.
 	$ java -jar myapp.jar --debug
 ----
 
-If your terminal supports ANSI, color output will be used to aid readability.
+If your terminal supports ANSI, color output will be used to aid readability. You can set
+`spring.output.ansi.enabled` to a
+{dc-spring-boot}/ansi/AnsiOutput.Enabled.{dc-ext}[supported value] to override the auto
+detection.
 
 
 

--- a/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiOutput.java
+++ b/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiOutput.java
@@ -121,8 +121,26 @@ public abstract class AnsiOutput {
 		}
 	}
 
+	/**
+	 * Possible values to pass to {@link AnsiOutput#setEnabled}. Determines when to output
+	 * ANSI escape sequences for coloring application output.
+	 */
 	public static enum Enabled {
-		DETECT, ALWAYS, NEVER
+		/**
+		 * Try to detect whether ANSI coloring capabilities are available. The default
+		 * value for {@link AnsiOutput}.
+		 */
+		DETECT,
+
+		/**
+		 * Enable ANSI-colored output
+		 */
+		ALWAYS,
+
+		/**
+		 * Disable ANSI-colored output
+		 */
+		NEVER
 	};
 
 }

--- a/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiOutputApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiOutputApplicationListener.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.ansi;
+
+import org.springframework.boot.ansi.AnsiOutput.Enabled;
+import org.springframework.boot.context.config.ConfigFileApplicationListener;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+/**
+ * An {@link ApplicationListener} that configures {@link AnsiOutput} depending on the the
+ * value of the property <code>spring.output.ansi.enabled</code>. See {@link Enabled} for
+ * valid values.
+ *
+ * @author Raphael von der Grün
+ */
+public class AnsiOutputApplicationListener implements
+		ApplicationListener<ApplicationEnvironmentPreparedEvent>, Ordered {
+
+	private static final String ANSIOUTPUT_ENABLED_PROPERTY = "spring.output.ansi.enabled";
+
+	@Override
+	public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
+		ConfigurableEnvironment env = event.getEnvironment();
+		Enabled enabled = env.getProperty(ANSIOUTPUT_ENABLED_PROPERTY, Enabled.class,
+				Enabled.DETECT);
+		AnsiOutput.setEnabled(enabled);
+	}
+
+	@Override
+	public int getOrder() {
+		return ConfigFileApplicationListener.DEFAULT_ORDER + 1;
+	}
+
+}

--- a/spring-boot/src/main/resources/META-INF/spring.factories
+++ b/spring-boot/src/main/resources/META-INF/spring.factories
@@ -14,6 +14,7 @@ org.springframework.boot.context.config.DelegatingApplicationContextInitializer
 
 # Application Listeners
 org.springframework.context.ApplicationListener=\
+org.springframework.boot.ansi.AnsiOutputApplicationListener,\
 org.springframework.boot.builder.ParentContextCloserApplicationListener,\
 org.springframework.boot.cloudfoundry.VcapApplicationListener,\
 org.springframework.boot.context.FileEncodingApplicationListener,\
@@ -22,4 +23,3 @@ org.springframework.boot.context.config.DelegatingApplicationListener,\
 org.springframework.boot.liquibase.LiquibaseServiceLocatorApplicationListener,\
 org.springframework.boot.logging.ClasspathLoggingApplicationListener,\
 org.springframework.boot.logging.LoggingApplicationListener
-


### PR DESCRIPTION
Fixes #1243

I think the new property should also be added to `appendix-application-properties.adoc` but it didn't fit anywhere. Maybe under #LOGGING. But then the name should probably be different...

Looking forward to your feedback.
