### PR TITLE
Bugfix: DatabaseHealthEndpoint - ValidationQuery (1.1.x Branch)

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DataSourceHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DataSourceHealthIndicator.java
@@ -48,7 +48,7 @@ public class DataSourceHealthIndicator extends AbstractHealthIndicator {
 		queries.put("HSQL Database Engine",
 				"SELECT COUNT(*) FROM INFORMATION_SCHEMA.SYSTEM_USERS");
 		queries.put("Oracle", "SELECT 'Hello' from DUAL");
-		queries.put("Apache Derby", "SELECT 1 FROM SYSIBM.SYSDUMMY1");
+		queries.put("DB2", "SELECT 1 FROM SYSIBM.SYSDUMMY1");
 	}
 
 	private static String DEFAULT_QUERY = "SELECT 1";


### PR DESCRIPTION
Bugfix for validation query of DB2 datasources. Apache Derby has another validation query. Just the schema name in the query "SYSIBM" indeicates that this can only be a DB2 database query...
