### PR TITLE
Autoconfigure spring-cloud

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -276,6 +276,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-spring-service-connector</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.thymeleaf</groupId>
 			<artifactId>thymeleaf</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cloud/CloudAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cloud/CloudAutoConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cloud;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.Cloud;
+import org.springframework.cloud.app.ApplicationInstanceInfo;
+import org.springframework.cloud.config.java.CloudScan;
+import org.springframework.cloud.config.java.CloudScanConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Spring Cloud.
+ * <p>
+ * Activates when there is no bean of type {@link Cloud} is configured in the context,
+ * the {@link Cloud} type (this spring-cloud) is on the classpath, and the "cloud" profile
+ * is active.
+ * <p>
+ * Once in effect, the auto-configuration is the equivalent of adding the {@link CloudScan}
+ * annotation in one of the configuration file. Specifically, it adds a bean for each service
+ * bound to the app and one for {@link ApplicationInstanceInfo}
+ * 
+ * @author Ramnivas Laddad
+ *
+ */
+@Configuration
+@Profile("cloud")
+@Order(Ordered.HIGHEST_PRECEDENCE + 20) // make this happen before other autoconfig (data, mongo etc.)
+@ConditionalOnClass(Cloud.class)
+@ConditionalOnMissingBean(Cloud.class)
+@ConditionalOnProperty(prefix = "spring.cloud", name = "enabled", havingValue = "true", matchIfMissing = true)
+@Import(CloudScanConfiguration.class)
+public class CloudAutoConfiguration {
+
+}

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -52,7 +52,8 @@ org.springframework.boot.autoconfigure.web.MultipartAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.HttpMessageConvertersAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.ErrorMvcAutoConfiguration,\
-org.springframework.boot.autoconfigure.websocket.WebSocketAutoConfiguration
+org.springframework.boot.autoconfigure.websocket.WebSocketAutoConfiguration,\
+org.springframework.boot.autoconfigure.cloud.CloudAutoConfiguration
 
 # Template availability providers
 org.springframework.boot.autoconfigure.template.TemplateAvailabilityProvider=\

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -112,6 +112,7 @@
 		<spring-security.version>3.2.4.RELEASE</spring-security.version>
 		<spring-security-jwt.version>1.0.2.RELEASE</spring-security-jwt.version>
 		<spring-ws.version>2.2.0.RELEASE</spring-ws.version>
+		<spring-cloud.version>1.1.0.BUILD-SNAPSHOT</spring-cloud.version>
 		<thymeleaf.version>2.1.3.RELEASE</thymeleaf.version>
 		<thymeleaf-extras-springsecurity3.version>2.1.1.RELEASE</thymeleaf-extras-springsecurity3.version>
 		<thymeleaf-layout-dialect.version>1.2.5</thymeleaf-layout-dialect.version>
@@ -1146,6 +1147,11 @@
 						<artifactId>commons-logging</artifactId>
 					</exclusion>
 				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-spring-service-connector</artifactId>
+				<version>${spring-cloud.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.thymeleaf</groupId>


### PR DESCRIPTION
Enable if all of the following is true:
- spring-cloud is on the classpath
- There is no Cloud bean present (usually done by extending AbstractCloudConfig)
- The "cloud" profile is active
