### PR TITLE
Add JCache API dependency management

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -460,6 +460,11 @@
 				<version>${commons-pool.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>javax.cache</groupId>
+				<artifactId>cache-api</artifactId>
+				<version>1.0.0</version>
+			</dependency>
+			<dependency>
 				<groupId>javax.jms</groupId>
 				<artifactId>jms-api</artifactId>
 				<version>1.1-rev-1</version>


### PR DESCRIPTION
This commit adds an entry for JCache. Adding this dependency manually is necessary for Spring 4.1-based apps willing to use the JSR-107 annotations. 
