### PR TITLE
Starters based on spring-cloud

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -342,6 +342,11 @@
 				<artifactId>spring-boot-starter-ws</artifactId>
 				<version>1.2.0.BUILD-SNAPSHOT</version>
 			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-cloud</artifactId>
+				<version>1.2.0.BUILD-SNAPSHOT</version>
+			</dependency>
 
 			<!-- Third Party -->
 			<dependency>
@@ -1022,6 +1027,21 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-spring-service-connector</artifactId>
+				<version>${spring-cloud.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-cloudfoundry-connector</artifactId>
+				<version>${spring-cloud.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-heroku-connector</artifactId>
+				<version>${spring-cloud.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-localconfig-connector</artifactId>
 				<version>${spring-cloud.version}</version>
 			</dependency>
 			<dependency>

--- a/spring-boot-starters/pom.xml
+++ b/spring-boot-starters/pom.xml
@@ -54,6 +54,7 @@
 		<module>spring-boot-starter-web</module>
 		<module>spring-boot-starter-websocket</module>
 		<module>spring-boot-starter-ws</module>
+		<module>spring-boot-starter-cloud</module>
 	</modules>
 	<build>
 		<plugins>

--- a/spring-boot-starters/spring-boot-starter-cloud/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-cloud/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starters</artifactId>
+		<version>1.2.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-starter-cloud</artifactId>
+	<name>Spring Boot Cloud Multiplatform Starter</name>
+	<description>Spring Boot Starter for Spring Cloud</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-spring-service-connector</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-cloudfoundry-connector</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-heroku-connector</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-localconfig-connector</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-boot-starters/spring-boot-starter-cloud/src/main/resources/META-INF/spring.provides
+++ b/spring-boot-starters/spring-boot-starter-cloud/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: spring-cloud-spring-service-connector,spring-cloud-cloudfoundry-connector,spring-cloud-heroku-connector,spring-cloud-localconfig-connector


### PR DESCRIPTION
- spring-boot-starter-cloud-cloudfoundry is a starter for CloudFounry
- spring-boot-starter-cloud-heroku is a starter for Heroku
- spring-boot-starter-cloud-localconfig is a starer for local config (test platform)
- spring-boot-starter-cloud-multiplatform includes all of the above
- spring-boot-starter-cloud is a starter without a platform (user must add a platform-specific
    dependency)

Fixes #1325
