### PR TITLE
Deleted version numbers of Maven plugins.

### DIFF
--- a/spring-boot-starters/spring-boot-starter-parent/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-parent/pom.xml
@@ -61,7 +61,6 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.1</version>
 					<configuration>
 						<source>${java.version}</source>
 						<target>${java.version}</target>
@@ -81,7 +80,6 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.15</version>
 					<configuration>
 						<includes>
 							<include>**/*Tests.java</include>
@@ -118,7 +116,6 @@
 				<plugin>
 					<groupId>pl.project13.maven</groupId>
 					<artifactId>git-commit-id-plugin</artifactId>
-					<version>2.1.10</version>
 					<executions>
 						<execution>
 							<goals>
@@ -153,7 +150,6 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>2.1</version>
 					<dependencies>
 						<dependency>
 							<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
The Maven plugin version numbers are defined in the pluginManagement of the spring-boot-dependencies pom.xml. Consequently, they can be deleted in the spring-boot-starter-parent pom.xml to avoid version conflicts and duplicated version management.
