### PR TITLE
Add database property to RedisProperties

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/redis/RedisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/redis/RedisAutoConfiguration.java
@@ -65,6 +65,7 @@ public class RedisAutoConfiguration {
 			if (this.properties.getPassword() != null) {
 				factory.setPassword(this.properties.getPassword());
 			}
+			factory.setDatabase(this.properties.getDatabase());
 			return factory;
 		}
 
@@ -86,6 +87,7 @@ public class RedisAutoConfiguration {
 			if (this.properties.getPassword() != null) {
 				factory.setPassword(this.properties.getPassword());
 			}
+			factory.setDatabase(this.properties.getDatabase());
 			return factory;
 		}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/redis/RedisProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/redis/RedisProperties.java
@@ -26,6 +26,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "spring.redis")
 public class RedisProperties {
 
+	private int database = 0;
+
 	private String host = "localhost";
 
 	private String password;
@@ -64,6 +66,14 @@ public class RedisProperties {
 
 	public void setPool(RedisProperties.Pool pool) {
 		this.pool = pool;
+	}
+
+	public int getDatabase() {
+		return database;
+	}
+
+	public void setDatabase(int database) {
+		this.database = database;
 	}
 
 	/**

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/redis/RedisAutoConfigurationTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.autoconfigure.redis;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.test.EnvironmentTestUtils;
@@ -23,9 +26,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests for {@link RedisAutoConfiguration}.
@@ -51,11 +51,15 @@ public class RedisAutoConfigurationTests {
 	public void testOverrideRedisConfiguration() throws Exception {
 		this.context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils.addEnvironment(this.context, "spring.redis.host:foo");
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.redis.database:1");
 		this.context.register(RedisAutoConfiguration.class,
 				PropertyPlaceholderAutoConfiguration.class);
 		this.context.refresh();
 		assertEquals("foo", this.context.getBean(JedisConnectionFactory.class)
 				.getHostName());
+		assertEquals(1, this.context.getBean(JedisConnectionFactory.class)
+				.getDatabase());
 	}
 
 	@Test


### PR DESCRIPTION
This commit adds a database property to RedisAutoConfiguration RedisProperties, default is 0
Fixes https://github.com/spring-projects/spring-boot/issues/1379
