### PR TITLE
#1460 HibernateJpaAutoConfiguration only when Hibernate 4.3 is on the classpath

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfiguration.java
@@ -94,18 +94,12 @@ public class HibernateJpaAutoConfiguration extends JpaBaseConfiguration {
 
 	static class HibernateEntityManagerCondition extends SpringBootCondition {
 
-		private static String[] CLASS_NAMES = {
-				"org.hibernate.ejb.HibernateEntityManager",
-				"org.hibernate.jpa.HibernateEntityManager" };
-
 		@Override
 		public ConditionOutcome getMatchOutcome(ConditionContext context,
 				AnnotatedTypeMetadata metadata) {
-			for (String className : CLASS_NAMES) {
-				if (ClassUtils.isPresent(className, context.getClassLoader())) {
-					return ConditionOutcome.match("found HibernateEntityManager class");
-				}
-			}
+            if (ClassUtils.isPresent("org.hibernate.jpa.HibernateEntityManager", context.getClassLoader())) {
+                return ConditionOutcome.match("found HibernateEntityManager class");
+            }
 			return ConditionOutcome.noMatch("did not find HibernateEntityManager class");
 		}
 	}


### PR DESCRIPTION
The package structure of some internal classes were changed in Hibernate 4.3, which causes NoClassDefFoundErrors when using the current Boot Snapshot with Hibernate 4.2
