### PR TITLE
Spring boot spring main sources constant

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -146,7 +146,7 @@ import org.springframework.web.context.support.StandardServletEnvironment;
  */
 public class SpringApplication {
 
-    public static final String MAIN_SOURCES = "spring.main.sources";
+	public static final String MAIN_SOURCES = "spring.main.sources";
 
 	private static final String DEFAULT_CONTEXT_CLASS = "org.springframework.context."
 			+ "annotation.AnnotationConfigApplicationContext";


### PR DESCRIPTION
Hi,

What about adding `spring.main.sources` constant in order to avoid hardcoding that property while using `SpringApplicationBuilder` or `SpringApplication#main(String[])`?

Cheers.
