### PR TITLE
added failing test for nested url - gh-1508

### DIFF
--- a/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
+++ b/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
@@ -418,4 +418,18 @@ public class JarFileTests {
 		url.openConnection().getInputStream();
 	}
 
+	@Test
+	public void loadFileFromNestedURL() throws Exception {
+		// gh-1508
+		JarFile.registerUrlProtocolHandler();
+		String spec =
+			"jar:jar:" + this.rootJarFile.toURI() + "!/nested.jar!/3.dat";
+		URL url = new URL(spec);
+		assertThat(url.toString(), equalTo(spec));
+		InputStream inputStream = url.openStream();
+		assertThat(inputStream, notNullValue());
+		assertThat(inputStream.read(), equalTo(3));
+
+	}
+
 }


### PR DESCRIPTION
This issue appeared when using eclipselink (without spring data) it kept generating urls with nested protocols 
e.g
jar:jar:<main jar>!/<nested jar>!/META-INF/orm.xml

which fail to load.
