### PR TITLE
Addresses GH-1508, allows spring boot to load from nested urls

### DIFF
--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/Handler.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/Handler.java
@@ -43,6 +43,8 @@ public class Handler extends URLStreamHandler {
 
 	private static final String FILE_PROTOCOL = "file:";
 
+	private static final String JAR_PROTOCOL = "jar:";
+
 	private static final String SEPARATOR = "!/";
 
 	private static final String[] FALLBACK_HANDLERS = { "sun.net.www.protocol.jar.Handler" };
@@ -142,7 +144,16 @@ public class Handler extends URLStreamHandler {
 		if (separatorIndex == -1) {
 			throw new MalformedURLException("Jar URL does not contain !/ separator");
 		}
-		String name = spec.substring(0, separatorIndex);
+
+		int startIndex = 0;
+
+		// strip any jar: protocols from the spec
+	    int jarIndex;
+		while((jarIndex = spec.indexOf(JAR_PROTOCOL, startIndex)) > -1) {
+			startIndex = jarIndex + JAR_PROTOCOL.length();
+		}
+
+		String name = spec.substring(startIndex, separatorIndex);
 		return getRootJarFile(name);
 	}
 

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
@@ -73,11 +73,17 @@ class JarURLConnection extends java.net.JarURLConnection {
 		// What we pass to super is ultimately ignored
 		super(EMPTY_JAR_URL);
 		this.url = url;
-		String spec = url.getFile().substring(jarFile.getUrl().getFile().length());
+
+		String spec = url.getFile().substring(jarFile.getUrl().getFile().length()
+			+ (url.getFile().indexOf(jarFile.getUrl().getFile())));
+
 		int separator;
+
 		while ((separator = spec.indexOf(SEPARATOR)) > 0) {
 			jarFile = getNestedJarFile(jarFile, spec.substring(0, separator));
+
 			spec = spec.substring(separator + SEPARATOR.length());
+
 		}
 		this.jarFile = jarFile;
 		this.jarEntryName = getJarEntryName(spec);

--- a/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
+++ b/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
@@ -418,4 +418,18 @@ public class JarFileTests {
 		url.openConnection().getInputStream();
 	}
 
+	@Test
+	public void loadFileFromNestedURL() throws Exception {
+		// gh-1508
+		JarFile.registerUrlProtocolHandler();
+		String spec =
+			"jar:jar:" + this.rootJarFile.toURI() + "!/nested.jar!/3.dat";
+		URL url = new URL(spec);
+		assertThat(url.toString(), equalTo(spec));
+		InputStream inputStream = url.openStream();
+		assertThat(inputStream, notNullValue());
+		assertThat(inputStream.read(), equalTo(3));
+
+	}
+
 }


### PR DESCRIPTION
Eclipselink kept building orm.xml urls with a nested url (two jar: prefixes) which was causing some issues with the resource loader in spring-boot.
