### PR TITLE
Adding auto-configuration and starter pom for spring data neo4j

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -217,6 +217,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-neo4j</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-neo4j-rest</artifactId>
+        </dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-redis</artifactId>
 			<optional>true</optional>
 		</dependency>
@@ -373,4 +382,16 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+    <repositories>
+        <repository>
+            <id>repo.spring.io</id>
+            <url>http://repo.spring.io/libs-release</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jRepositoriesAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jRepositoriesAutoConfiguration.java
@@ -1,0 +1,42 @@
+package org.springframework.boot.autoconfigure.data.neo4j;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.neo4j.Neo4jAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.neo4j.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.core.GraphDatabase;
+import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.GraphRepositoryFactoryBean;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Spring Data's Neo4j
+ * Repositories.
+ * <p>
+ * Activates when there is no bean of type
+ * {@link org.springframework.data.neo4j.repository.GraphRepositoryFactoryBean}
+ * configured in the context, the Spring Data Graph
+ * {@link org.springframework.data.neo4j.repository.GraphRepository} type is on the
+ * classpath, the GraphDatabase is on the classpath, and there is no other
+ * configured {@link org.springframework.data.neo4j.repository.GraphRepository}.
+ * <p>
+ * Once in effect, the auto-configuration is the equivalent of enabling Mongo repositories
+ * using the
+ * {@link org.springframework.data.neo4j.config.EnableNeo4jRepositories}
+ * annotation.
+ *
+ * @author Amer Aljovic
+ * @see EnableNeo4jRepositories
+ */
+@Configuration
+@ConditionalOnClass({GraphDatabase.class, GraphRepository.class})
+@ConditionalOnMissingBean (GraphRepositoryFactoryBean.class)
+@ConditionalOnExpression ("${spring.data.neo4j.repositories.enabled:true}")
+@Import (Neo4jRepositoriesAutoConfigureRegistrar.class)
+@AutoConfigureAfter (Neo4jAutoConfiguration.class)
+public class Neo4jRepositoriesAutoConfiguration {
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jRepositoriesAutoConfigureRegistrar.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jRepositoriesAutoConfigureRegistrar.java
@@ -1,0 +1,37 @@
+package org.springframework.boot.autoconfigure.data.neo4j;
+
+import org.springframework.boot.autoconfigure.data.AbstractRepositoryConfigurationSourceSupport;
+import org.springframework.data.neo4j.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.config.Neo4jRepositoryConfigurationExtension;
+import org.springframework.data.repository.config.RepositoryConfigurationExtension;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * {@link org.springframework.context.annotation.ImportBeanDefinitionRegistrar} used to auto-configure Spring Data Neo4j
+ * Repositories.
+ *
+ * @author Amer Aljovic
+ */
+public class Neo4jRepositoriesAutoConfigureRegistrar
+    extends AbstractRepositoryConfigurationSourceSupport
+{
+    @Override
+    protected Class<? extends Annotation> getAnnotation() {
+        return EnableNeo4jRepositories.class;
+    }
+
+    @Override
+    protected Class<?> getConfiguration() {
+        return EnableNeo4jRepositoriesConfiguration.class;
+    }
+
+    @Override
+    protected RepositoryConfigurationExtension getRepositoryConfigurationExtension() {
+        return new Neo4jRepositoryConfigurationExtension();
+    }
+
+    @EnableNeo4jRepositories(basePackages = "")
+    private static class EnableNeo4jRepositoriesConfiguration {
+    }
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jAutoConfiguration.java
@@ -1,0 +1,41 @@
+package org.springframework.boot.autoconfigure.neo4j;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.core.GraphDatabase;
+import org.springframework.data.neo4j.rest.SpringRestGraphDatabase;
+
+/**
+ * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration Auto-configuration} for Neo4j.
+ *
+ * @author Amer Aljovic
+ */
+@Configuration
+@ConditionalOnClass(GraphDatabase.class)
+@EnableConfigurationProperties(Neo4jProperties.class)
+public class Neo4jAutoConfiguration
+{
+    @Autowired
+    private Neo4jProperties props;
+
+    @Bean
+    GraphDatabaseService graphDatabaseService() {
+        if (isNotEmpty(props.getUri())) {
+            if (isNotEmpty(props.getUsername()) && isNotEmpty(props.getPassword())) {
+                return new SpringRestGraphDatabase(
+                        props.getUri(), props.getUsername(), props.getPassword());
+            }
+            return new SpringRestGraphDatabase(props.getUri(), props.getUsername(), props.getPassword());
+        }
+        return new GraphDatabaseFactory().newEmbeddedDatabase(props.getLocalPath());
+    }
+
+    private boolean isNotEmpty(String value) {
+        return value != null && !value.isEmpty();
+    }
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDataAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDataAutoConfiguration.java
@@ -1,0 +1,27 @@
+package org.springframework.boot.autoconfigure.neo4j;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.config.Neo4jConfiguration;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Spring Data's Neo4j support.
+ * <p>
+ * Extends Neo4jConfiguration which already auto-configures Spring Data Neo4j.
+ * The base package is set to root by default.
+ *
+ * @author Amer Aljovic
+ */
+@Configuration
+@ConditionalOnClass(GraphDatabaseService.class)
+@AutoConfigureAfter(Neo4jAutoConfiguration.class)
+public class Neo4jDataAutoConfiguration extends Neo4jConfiguration
+{
+    public Neo4jDataAutoConfiguration()
+    {
+        setBasePackage("");
+    }
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jProperties.java
@@ -1,0 +1,52 @@
+package org.springframework.boot.autoconfigure.neo4j;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Neo4j.
+ *
+ * @author Amer Aljovic
+ */
+@ConfigurationProperties(prefix = "spring.data.neo4j")
+public class Neo4jProperties
+{
+    private String localPath = "testing.db";
+
+    private String uri;
+
+    private String username;
+
+    private String password;
+
+    public String getUri() {
+        return uri;
+    }
+
+    public String getLocalPath() {
+        return localPath;
+    }
+
+    public void setLocalPath(String localPath) {
+        this.localPath = localPath;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -13,6 +13,7 @@ org.springframework.boot.autoconfigure.cloud.CloudAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfiguration,\
+org.springframework.boot.autoconfigure.data.neo4j.Neo4jRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.solr.SolrRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoConfiguration,\
 org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration,\
@@ -38,6 +39,8 @@ org.springframework.boot.autoconfigure.mobile.DeviceDelegatingViewResolverAutoCo
 org.springframework.boot.autoconfigure.mobile.SitePreferenceAutoConfiguration,\
 org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,\
 org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration,\
+org.springframework.boot.autoconfigure.neo4j.Neo4jAutoConfiguration,\
+org.springframework.boot.autoconfigure.neo4j.Neo4jDataAutoConfiguration,\
 org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,\
 org.springframework.boot.autoconfigure.reactor.ReactorAutoConfiguration,\
 org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jAutoConfigurationTests.java
@@ -1,0 +1,50 @@
+package org.springframework.boot.autoconfigure.neo4j;
+
+import org.junit.After;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.kernel.EmbeddedGraphDatabase;
+import org.neo4j.rest.graphdb.RestGraphDatabase;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link org.springframework.boot.autoconfigure.neo4j.Neo4jAutoConfiguration}.
+ *
+ * @author Amer Aljovic
+ */
+public class Neo4jAutoConfigurationTests {
+    private AnnotationConfigApplicationContext context;
+
+    @After
+    public void close() {
+        if (context != null)
+            context.close();
+    }
+
+    @Test
+    public void testEmbeddedDatabaseConfiguration() {
+        context = new AnnotationConfigApplicationContext(
+                PropertyPlaceholderAutoConfiguration.class, Neo4jAutoConfiguration.class);
+
+        assertNotNull("GraphDatabaseService created", context.getBean(GraphDatabaseService.class));
+        assertTrue("Instance of EmbeddedGraphDatabase",
+                context.getBean(GraphDatabaseService.class) instanceof EmbeddedGraphDatabase);
+    }
+
+    @Test
+    public void testServerDatabaseConfiguration() {
+        context = new AnnotationConfigApplicationContext();
+        EnvironmentTestUtils.addEnvironment(context, "spring.data.neo4j.uri:http://localhost:7474/db/data");
+        context.register(PropertyPlaceholderAutoConfiguration.class, Neo4jAutoConfiguration.class);
+        context.refresh();
+
+        assertNotNull("GraphDatabaseService created", context.getBean(GraphDatabaseService.class));
+        assertTrue("Instance of RestGraphDatabase",
+                context.getBean(GraphDatabaseService.class) instanceof RestGraphDatabase);
+    }
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -108,7 +108,8 @@
 		<spring-cloud.version>1.1.0.RELEASE</spring-cloud.version>
 		<spring-batch.version>3.0.1.RELEASE</spring-batch.version>
 		<spring-data-releasetrain.version>Evans-RELEASE</spring-data-releasetrain.version>
-		<spring-hateoas.version>0.16.0.RELEASE</spring-hateoas.version>
+		<spring-data-neo4j-rest.version>3.2.0.RELEASE</spring-data-neo4j-rest.version>
+        <spring-hateoas.version>0.16.0.RELEASE</spring-hateoas.version>
 		<spring-integration.version>4.1.0.M1</spring-integration.version>
 		<spring-loaded.version>1.2.0.RELEASE</spring-loaded.version>
 		<spring-mobile.version>1.1.2.RELEASE</spring-mobile.version>
@@ -1106,6 +1107,11 @@
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-neo4j-rest</artifactId>
+                <version>${spring-data-neo4j-rest.version}</version>
+            </dependency>
 			<dependency>
 				<groupId>org.springframework.hateoas</groupId>
 				<artifactId>spring-hateoas</artifactId>

--- a/spring-boot-starters/pom.xml
+++ b/spring-boot-starters/pom.xml
@@ -28,6 +28,7 @@
 		<module>spring-boot-starter-data-gemfire</module>
 		<module>spring-boot-starter-data-jpa</module>
 		<module>spring-boot-starter-data-mongodb</module>
+        <module>spring-boot-starter-data-neo4j</module>
 		<module>spring-boot-starter-data-rest</module>
 		<module>spring-boot-starter-data-solr</module>
 		<module>spring-boot-starter-freemarker</module>

--- a/spring-boot-starters/spring-boot-starter-data-neo4j/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-data-neo4j/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starters</artifactId>
+		<version>1.2.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-starter-data-neo4j</artifactId>
+	<name>Spring Boot Data Neo4j Starter</name>
+	<description>Spring Boot Data Neo4j Starter</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+    <repositories>
+        <repository>
+            <id>repo.spring.io</id>
+            <url>http://repo.spring.io/libs-release</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-neo4j</artifactId>
+            <!--<exclusions>
+                ≈<exclusion>
+                    <groupId>org.neo4j</groupId>
+                    <artifactId>neo4j-cypher-compiler-1.9</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.neo4j</groupId>
+                    <artifactId>neo4j-cypher-compiler-2.0</artifactId>
+                </exclusion>
+            </exclusions>-->
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-neo4j-rest</artifactId>
+            <version>3.2.0.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+        </dependency>
+	</dependencies>
+</project>

--- a/spring-boot-starters/spring-boot-starter-data-neo4j/src/main/resources/META-INF/spring.provides
+++ b/spring-boot-starters/spring-boot-starter-data-neo4j/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: spring-data-neo4j


### PR DESCRIPTION
I'm open for improvement suggestions.

There are also some unresolved issues.
1. When compiling spring-boot-starter-data-neo4j module, it fails because
maven-enforcer-plugin:1.3.1 does not allow 'Dependency convergence errors'.
The error is inside <artifactId>spring-data-neo4j</artifactId> with
neo4j-cypher-compiler-1.9 and neo4j-cypher-compiler-2.0 which are the cause
of the dependency mismatch. The two dependencies are commented out (for now)
to not brake the build.

2. There is a problem with the unit test testEmbeddedDatabaseConfiguration so the
tests are not yet ready. The problem is that SpringRestGraphDatabase is correctly instantiated,
but not EmbeddedGraphDatabase. My guess is the version mismatch in the neo4j library
(see point 1 above). Note that this error is only present in the Unit tests.