### PR TITLE
Activate WebSecurityEnabler only for web applications

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ManagementSecurityAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ManagementSecurityAutoConfiguration.java
@@ -165,6 +165,7 @@ public class ManagementSecurityAutoConfiguration {
 	@Configuration
 	@ConditionalOnExpression("${management.security.enabled:true} && !${security.basic.enabled:true}")
 	@ConditionalOnMissingBean(WebSecurityConfiguration.class)
+	@ConditionalOnWebApplication
 	@EnableWebSecurity
 	protected static class WebSecurityEnabler extends AuthenticationManagerConfiguration {
 	}


### PR DESCRIPTION
Done in order to align with the rest of the configuration. Absent this check,
the bean will be installed in non-web applications without the corresponding
dependencies, causing the bootstrap to fail.
