### PR TITLE
AMQ connection URL autodetection.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQConnectionFactoryConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQConnectionFactoryConfiguration.java
@@ -20,6 +20,10 @@ import javax.jms.ConnectionFactory;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.pool.PooledConnectionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -34,10 +38,33 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 class ActiveMQConnectionFactoryConfiguration {
 
+    private static final String DEFAULT_EMBEDDED_BROKER_URL = "vm://localhost?broker.persistent=false";
+
+    private static final String DEFAULT_MQTT_BROKER_URL = "mqtt://localhost:1883";
+
+	@Bean
+	@Qualifier("autodetectedAmqConnectionUrl")
+	@ConditionalOnClass(name = "org.junit.runner.Runner")
+	public String testingAmqConnectionUrl() {
+		return DEFAULT_EMBEDDED_BROKER_URL;
+	}
+
+	@Bean
+	@Qualifier("autodetectedAmqConnectionUrl")
+	@ConditionalOnClass(name = "org.apache.activemq.transport.mqtt.MQTTTransport")
+	@ConditionalOnMissingClass(name = "org.junit.runner.Runner")
+	public String mqttAmqConnectionUrl() {
+		return DEFAULT_MQTT_BROKER_URL;
+	}
+
+	@Autowired(required = false)
+	@Qualifier("autodetectedAmqConnectionUrl")
+	private String autodetectedAmqConnectionUrl;
+
 	@Bean
 	public ConnectionFactory jmsConnectionFactory(ActiveMQProperties properties) {
 		ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactoryFactory(
-				properties).createConnectionFactory(ActiveMQConnectionFactory.class);
+				properties, autodetectedAmqConnectionUrl).createConnectionFactory(ActiveMQConnectionFactory.class);
 		if (properties.isPooled()) {
 			PooledConnectionFactory pool = new PooledConnectionFactory();
 			pool.setConnectionFactory(connectionFactory);

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQConnectionFactoryFactory.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQConnectionFactoryFactory.java
@@ -35,10 +35,17 @@ class ActiveMQConnectionFactoryFactory {
 
 	private final ActiveMQProperties properties;
 
-	public ActiveMQConnectionFactoryFactory(ActiveMQProperties properties) {
+	private final String autodetectedAmqConnectionUrl;
+
+	public ActiveMQConnectionFactoryFactory(ActiveMQProperties properties, String autodetectedAmqConnectionUrl) {
 		Assert.notNull(properties, "Properties must not be null");
 		this.properties = properties;
+		this.autodetectedAmqConnectionUrl = autodetectedAmqConnectionUrl;
 	}
+
+    public ActiveMQConnectionFactoryFactory(ActiveMQProperties properties) {
+		this(properties, null);
+    }
 
 	public <T extends ActiveMQConnectionFactory> T createConnectionFactory(
 			Class<T> factoryClass) {
@@ -69,6 +76,9 @@ class ActiveMQConnectionFactoryFactory {
 		}
 		if (this.properties.isInMemory()) {
 			return DEFAULT_EMBEDDED_BROKER_URL;
+		}
+		if(properties.isAutodetectConnection() && this.autodetectedAmqConnectionUrl != null) {
+    		return autodetectedAmqConnectionUrl;
 		}
 		return DEFAULT_NETWORK_BROKER_URL;
 	}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQProperties.java
@@ -29,7 +29,9 @@ public class ActiveMQProperties {
 
 	private String brokerUrl;
 
-	private boolean inMemory = true;
+	private boolean autodetectConnection = true;
+
+	private boolean inMemory;
 
 	private boolean pooled;
 
@@ -43,6 +45,14 @@ public class ActiveMQProperties {
 
 	public void setBrokerUrl(String brokerUrl) {
 		this.brokerUrl = brokerUrl;
+	}
+
+	public boolean isAutodetectConnection() {
+	return autodetectConnection;
+	}
+
+	public void setAutodetectConnection(boolean autodetectConnection) {
+	this.autodetectConnection = autodetectConnection;
 	}
 
 	/**

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
@@ -153,15 +153,15 @@ public class JmsAutoConfigurationTests {
 	}
 
 	@Test
-	public void testActiveMQOverriddenStandalone() {
-		load(TestConfiguration.class, "spring.activemq.inMemory:false");
+	public void testActiveMQOverriddenEmbedded() {
+		load(TestConfiguration.class, "spring.activemq.autodetectConnection:false", "spring.activemq.inMemory:true");
 		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
 		ActiveMQConnectionFactory connectionFactory = this.context
 				.getBean(ActiveMQConnectionFactory.class);
 		assertNotNull(jmsTemplate);
 		assertNotNull(connectionFactory);
 		assertEquals(jmsTemplate.getConnectionFactory(), connectionFactory);
-		assertEquals(ACTIVEMQ_NETWORK_URL,
+		assertEquals(ACTIVEMQ_EMBEDDED_URL,
 				((ActiveMQConnectionFactory) jmsTemplate.getConnectionFactory())
 						.getBrokerURL());
 	}
@@ -195,9 +195,9 @@ public class JmsAutoConfigurationTests {
 	}
 
 	@Test
-	public void testActiveMQOverriddenPoolAndStandalone() {
-		load(TestConfiguration.class, "spring.activemq.pooled:true",
-				"spring.activemq.inMemory:false");
+	public void testActiveMQOverriddenPoolAndEmbedded() {
+		load(TestConfiguration.class, "spring.activemq.autodetectConnection:false", "spring.activemq.pooled:true",
+				"spring.activemq.inMemory:true");
 		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
 		PooledConnectionFactory pool = this.context
 				.getBean(PooledConnectionFactory.class);
@@ -206,7 +206,7 @@ public class JmsAutoConfigurationTests {
 		assertEquals(jmsTemplate.getConnectionFactory(), pool);
 		ActiveMQConnectionFactory factory = (ActiveMQConnectionFactory) pool
 				.getConnectionFactory();
-		assertEquals(ACTIVEMQ_NETWORK_URL, factory.getBrokerURL());
+		assertEquals(ACTIVEMQ_EMBEDDED_URL, factory.getBrokerURL());
 	}
 
 	@Test

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQPropertiesTests.java
@@ -34,8 +34,8 @@ public class ActiveMQPropertiesTests {
 	private final ActiveMQProperties properties = new ActiveMQProperties();
 
 	@Test
-	public void getBrokerUrlIsInMemoryByDefault() {
-		assertEquals(DEFAULT_EMBEDDED_BROKER_URL, new ActiveMQConnectionFactoryFactory(
+	public void getBrokerUrlIsNetworkByDefault() {
+		assertEquals(DEFAULT_NETWORK_BROKER_URL, new ActiveMQConnectionFactoryFactory(
 				this.properties).determineBrokerUrl());
 	}
 
@@ -48,9 +48,9 @@ public class ActiveMQPropertiesTests {
 	}
 
 	@Test
-	public void getBrokerUrlWithInMemorySetToFalse() {
-		this.properties.setInMemory(false);
-		assertEquals(DEFAULT_NETWORK_BROKER_URL, new ActiveMQConnectionFactoryFactory(
+	public void getBrokerUrlWithInMemorySetToTrue() {
+		this.properties.setInMemory(true);
+		assertEquals(DEFAULT_EMBEDDED_BROKER_URL, new ActiveMQConnectionFactoryFactory(
 				this.properties).determineBrokerUrl());
 	}
 


### PR DESCRIPTION
Hi,

I'm working with the ActiveMQ projects and customers on the daily basis, so I'd like to propose some enhancement to the AMQ autoconfiguration.

From my experience ActiveMQ users tend to follow this usage pattern of the client connection URL:
- for tests they use `vm` transport, no matter what transport is used in the production
- for non-test environments, if there is some additional transport jar available in the classpath, then it is very likely that the user would use that transport for the AMQ client connection. For example presence of the `activemq-mqtt.jar` in the classpath indicates that MQTT connection will be used.
- for non-test environments, if there is no additional AMQ transport jar available, then use plain old TCP connection

Currently Spring Boot defaults to VM transport. Actually I don't think that this is the best default, as from my experience there are not so many non-test situations where AMQ users would like to connect to the embedded broker instead of the external one. This is especially true for Spring Boot apps, which usually aren't deployed into servers shipped with the broker, but are rather executed as fat jars.

I propose the following defaults:
a) connect to `tcp://localhost:61616` for non-tests environments
b) connect to `vm` for the test environment
c) for non-tests environments, try to detect if some other common AMQ transports are available in the classpath. If so, then Spring Boot should try to use them. For example presence of the `activemq-mqtt` jar in the classpath should result in connection URL defaulting to `mqtt://localhost:1883`

I've created a proof of concept demonstrating the approach I'm thinking about. Any thoughts? :)

Cheers.
