### PR TITLE
Encoding issue fix

### DIFF
--- a/spring-boot/src/main/resources/org/springframework/boot/logging/logback/basic.xml
+++ b/spring-boot/src/main/resources/org/springframework/boot/logging/logback/basic.xml
@@ -8,6 +8,7 @@
 	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
 			<pattern>${CONSOLE_LOG_PATTERN}</pattern>
+			<charset>utf-8</charset>
 		</encoder>
 	</appender>
 


### PR DESCRIPTION
When I use this configuration to log messages in Russian I have encoding issues. This fix will help to improve logging module with multilanguage support.
