### PR TITLE
Update JacksonAutoConfiguration with nicer defaults

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -94,7 +95,7 @@ public class JacksonAutoConfiguration {
 		@Primary
 		@ConditionalOnMissingBean
 		public ObjectMapper jacksonObjectMapper() {
-			ObjectMapper objectMapper = new ObjectMapper();
+			ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
 
 			if (this.httpMapperProperties.isJsonSortKeys()) {
 				objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS,

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfigurationTests.java
@@ -78,6 +78,16 @@ public class JacksonAutoConfigurationTests {
 	}
 
 	@Test
+	public void defaultFeatures() throws Exception {
+		this.context.register(JacksonAutoConfiguration.class);
+		this.context.refresh();
+		ObjectMapper mapper = this.context.getBean(ObjectMapper.class);
+		assertFalse(mapper.getSerializationConfig().isEnabled(MapperFeature.DEFAULT_VIEW_INCLUSION));
+		assertFalse(mapper.getDeserializationConfig().isEnabled(MapperFeature.DEFAULT_VIEW_INCLUSION));
+		assertFalse(mapper.getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES));
+	}
+
+	@Test
 	public void registersJodaModuleAutomatically() {
 		this.context.register(JacksonAutoConfiguration.class);
 		this.context.refresh();


### PR DESCRIPTION
The ObjectMapper instance is now created thanks to Jackson2ObjectMapperBuilder
in order to use the same nice default configuration than Spring Framework
4.1.1.

Customized properties are:
- MapperFeature.DEFAULT_VIEW_INCLUSION set to false
- DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES set to false

Fixes gh-1237
