### PR TITLE
Add Velocity property to reflect the preferFilesystemAccess attribute from factory

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/velocity/VelocityAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/velocity/VelocityAutoConfiguration.java
@@ -81,6 +81,7 @@ public class VelocityAutoConfiguration {
 
 		protected void applyProperties(VelocityEngineFactory factory) {
 			factory.setResourceLoaderPath(this.properties.getResourceLoaderPath());
+			factory.setPreferFileSystemAccess(this.properties.isPreferFileSystemAccess());
 			Properties velocityProperties = new Properties();
 			velocityProperties.putAll(this.properties.getProperties());
 			factory.setVelocityProperties(velocityProperties);

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/velocity/VelocityProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/velocity/VelocityProperties.java
@@ -48,6 +48,8 @@ public class VelocityProperties extends AbstractTemplateViewResolverProperties {
 
 	private String toolboxConfigLocation;
 
+	private boolean preferFileSystemAccess = true;
+
 	public VelocityProperties() {
 		super(DEFAULT_PREFIX, DEFAULT_SUFFIX);
 	}
@@ -90,6 +92,14 @@ public class VelocityProperties extends AbstractTemplateViewResolverProperties {
 
 	public void setToolboxConfigLocation(String toolboxConfigLocation) {
 		this.toolboxConfigLocation = toolboxConfigLocation;
+	}
+
+	public boolean isPreferFileSystemAccess() {
+		return preferFileSystemAccess;
+	}
+
+	public void setPreferFileSystemAccess(boolean preferFileSystemAccess) {
+		this.preferFileSystemAccess = preferFileSystemAccess;
 	}
 
 	@Override


### PR DESCRIPTION
This pull request just adds an new property "spring.velocity.preferFileSystemAccess" for the VelocityAutoConfiguration which reflects the   correspondenting attribute from VelocityEngineFactory.
