### PR TITLE
Remove empty pluginManagement entry for maven-antrun-plugin in spring-boot-starter-parent pom

### DIFF
--- a/spring-boot-starters/spring-boot-starter-parent/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-parent/pom.xml
@@ -97,10 +97,6 @@
 					</configuration>
 				</plugin>
 				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-antrun-plugin</artifactId>
-				</plugin>
-				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>exec-maven-plugin</artifactId>
 					<configuration>


### PR DESCRIPTION
I think this entry is superfluous as the version comes from spring-boot-dependencies and an empty pluginManagement entry (only containing groupId and artifactId) does nothing.

Thanks for your great work.
