### PR TITLE
Added Guava 18.0 as a dependency in spring-boot-dependencies

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -63,6 +63,7 @@
 		<freemarker.version>2.3.20</freemarker.version>
 		<gemfire.version>7.0.2</gemfire.version>
 		<gradle.version>1.6</gradle.version>
+		<guava.version>18.0</guava.version>
 		<groovy.version>2.3.6</groovy.version>
 		<h2.version>1.3.176</h2.version>
 		<hamcrest.version>1.3</hamcrest.version>
@@ -1321,6 +1322,11 @@
 				<artifactId>wsdl4j</artifactId>
 				<version>${wsdl4j.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>${guava.version}</version>
+			</dependency>			
 		</dependencies>
 	</dependencyManagement>
 	<build>


### PR DESCRIPTION
Added in guava 18.0 as a dependency. One of the reasons to add guava is because Spring 4.x now supports guava cache as a cache abstraction option, apart from the other useful utilities that guava provides for a spring-boot user. Please review and merge if appropriate
