### PR TITLE
Updated liquibase dependency to 3.2. Fixes issue #1382

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -91,7 +91,7 @@
 		<json-path.version>0.9.1</json-path.version>
 		<jstl.version>1.2</jstl.version>
 		<junit.version>4.11</junit.version>
-		<liquibase.version>3.0.8</liquibase.version>
+		<liquibase.version>3.2.2</liquibase.version>
 		<log4j.version>1.2.17</log4j.version>
 		<log4j2.version>2.0.2</log4j2.version>
 		<logback.version>1.1.2</logback.version>

--- a/spring-boot/src/main/java/org/springframework/boot/liquibase/SpringPackageScanClassResolver.java
+++ b/spring-boot/src/main/java/org/springframework/boot/liquibase/SpringPackageScanClassResolver.java
@@ -47,25 +47,20 @@ public class SpringPackageScanClassResolver extends DefaultPackageScanClassResol
 		this.logger = logger;
 	}
 
-	@Override
-	protected void find(PackageScanFilter test, String packageName, ClassLoader loader,
-			Set<Class<?>> classes) {
-		MetadataReaderFactory metadataReaderFactory = new CachingMetadataReaderFactory(
-				loader);
-		try {
-			Resource[] resources = scan(loader, packageName);
-			for (Resource resource : resources) {
-				Class<?> candidate = loadClass(loader, metadataReaderFactory, resource);
-				if (candidate != null && test.matches(candidate)) {
-					classes.add(candidate);
-				}
-			}
-		}
-		catch (IOException ex) {
-			throw new IllegalStateException(ex);
-		}
-	}
-
+    @Override
+    protected void findAllClasses(String packageName, ClassLoader loader) {
+        MetadataReaderFactory metadataReaderFactory = new CachingMetadataReaderFactory(
+                loader);
+        try {
+            Resource[] resources = scan(loader, packageName);
+            for (Resource resource : resources) {
+                addFoundClass(loadClass(loader, metadataReaderFactory, resource));
+            }
+        }
+        catch (IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
 	private Resource[] scan(ClassLoader loader, String packageName) throws IOException {
 		ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(loader);
 		String pattern = ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX


### PR DESCRIPTION
Support for Liquibase 3.2.x + 

Updated dependency in pom.xml and changed the API used by SpringPackageScanClassResolver to match what is available in 3.2+
