### PR TITLE
Add systemLoadAverage to SystemPublicMetrics

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/SystemPublicMetrics.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/SystemPublicMetrics.java
@@ -74,6 +74,8 @@ public class SystemPublicMetrics implements PublicMetrics, Ordered {
 				.getUptime()));
 		result.add(new Metric<Long>("instance.uptime", System.currentTimeMillis()
 				- this.timestamp));
+		result.add(new Metric<Double>("systemLoadAverage", ManagementFactory
+				.getOperatingSystemMXBean().getSystemLoadAverage()));
 	}
 
 	/**

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/SystemPublicMetricsTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/SystemPublicMetricsTests.java
@@ -42,6 +42,7 @@ public class SystemPublicMetricsTests {
 		assertTrue(results.containsKey("mem.free"));
 		assertTrue(results.containsKey("processors"));
 		assertTrue(results.containsKey("uptime"));
+		assertTrue(results.containsKey("systemLoadAverage"));
 
 		assertTrue(results.containsKey("heap.committed"));
 		assertTrue(results.containsKey("heap.init"));


### PR DESCRIPTION
Adds OperatingSystemMXBean.getSystemLoadAverage() to the metrics-Endpoint. Returns the system load average for the last minute. But it is not supported on all OSes (some return -1).
