### PR TITLE
update maven-javadoc-plugin from 2.9.1 to 2.10.1

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -1417,7 +1417,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.9.1</version>
+					<version>2.10.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
this is needed to be compatible with jdk8, else every javadoc link is pointing to jdk7 javadoc

http://jira.codehaus.org/browse/MJAVADOC-395
