### PR TITLE
Update JacksonAutoConfiguration.java

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
@@ -112,6 +112,9 @@ public class JacksonAutoConfiguration {
 			if (this.httpMapperProperties.isJsonSortKeys()) {
 				builder.featuresToEnable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
 			}
+			if (this.httpMapperProperties.isJsonPrettyPrint()) {
+				builder.featuresToEnable(SerializationFeature.INDENT_OUTPUT);
+			}
 			configureFeatures(builder, this.jacksonProperties.getDeserialization());
 			configureFeatures(builder, this.jacksonProperties.getSerialization());
 			configureFeatures(builder, this.jacksonProperties.getMapper());


### PR DESCRIPTION
This will allow compatibility with all HttpMapperProperties.isJsonPrettyPrint properties. Now, we just can do it setting the property spring.jackson.serialization.INDENT_OUTPUT=true
