### PR TITLE
Use HttpMapper properties only if defined

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
@@ -109,7 +109,8 @@ public class JacksonAutoConfiguration {
 		@ConditionalOnMissingBean(Jackson2ObjectMapperBuilder.class)
 		public Jackson2ObjectMapperBuilder jacksonObjectMapperBuilder() {
 			Jackson2ObjectMapperBuilder builder = new Jackson2ObjectMapperBuilder();
-			if (this.httpMapperProperties.isJsonSortKeys()) {
+			Boolean isJsonSortKeys = this.httpMapperProperties.isJsonSortKeys();
+			if (isJsonSortKeys != null && isJsonSortKeys) {
 				builder.featuresToEnable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
 			}
 			configureFeatures(builder, this.jacksonProperties.getDeserialization());

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/HttpMapperProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/HttpMapperProperties.java
@@ -24,27 +24,28 @@ import org.springframework.http.converter.HttpMessageConverter;
  *
  * @author Dave Syer
  * @author Piotr Maj
+ * @author Sebastien Deleuze
  */
 @ConfigurationProperties(prefix = "http.mappers", ignoreUnknownFields = false)
 public class HttpMapperProperties {
 
-	private boolean jsonPrettyPrint;
+	private Boolean jsonPrettyPrint;
 
-	private boolean jsonSortKeys;
+	private Boolean jsonSortKeys;
 
-	public void setJsonPrettyPrint(boolean jsonPrettyPrint) {
+	public void setJsonPrettyPrint(Boolean jsonPrettyPrint) {
 		this.jsonPrettyPrint = jsonPrettyPrint;
 	}
 
-	public boolean isJsonPrettyPrint() {
+	public Boolean isJsonPrettyPrint() {
 		return this.jsonPrettyPrint;
 	}
 
-	public void setJsonSortKeys(boolean jsonSortKeys) {
+	public void setJsonSortKeys(Boolean jsonSortKeys) {
 		this.jsonSortKeys = jsonSortKeys;
 	}
 
-	public boolean isJsonSortKeys() {
+	public Boolean isJsonSortKeys() {
 		return this.jsonSortKeys;
 	}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/HttpMessageConvertersAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/HttpMessageConvertersAutoConfiguration.java
@@ -78,7 +78,9 @@ public class HttpMessageConvertersAutoConfiguration {
 				ObjectMapper objectMapper) {
 			MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
 			converter.setObjectMapper(objectMapper);
-			converter.setPrettyPrint(this.properties.isJsonPrettyPrint());
+			if (this.properties.isJsonPrettyPrint() != null) {
+				converter.setPrettyPrint(this.properties.isJsonPrettyPrint());
+			}
 			return converter;
 		}
 
@@ -99,7 +101,9 @@ public class HttpMessageConvertersAutoConfiguration {
 				Jackson2ObjectMapperBuilder builder) {
 			MappingJackson2XmlHttpMessageConverter converter = new MappingJackson2XmlHttpMessageConverter();
 			converter.setObjectMapper(builder.createXmlMapper(true).build());
-			converter.setPrettyPrint(this.properties.isJsonPrettyPrint());
+			if (this.properties.isJsonPrettyPrint() != null) {
+				converter.setPrettyPrint(this.properties.isJsonPrettyPrint());
+			}
 			return converter;
 		}
 


### PR DESCRIPTION
Without this fix, the following configuration is never taken in account:

``` java
@Bean
public Jackson2ObjectMapperBuilder jacksonBuilder() {
    return new Jackson2ObjectMapperBuilder().indentOutput(true);
}
```
