### PR TITLE
Removed possibility to get ClassCastException on Error occurence

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/DefaultErrorAttributes.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/DefaultErrorAttributes.java
@@ -163,7 +163,7 @@ public class DefaultErrorAttributes implements ErrorAttributes, HandlerException
 
 	@Override
 	public Throwable getError(RequestAttributes requestAttributes) {
-		Exception exception = getAttribute(requestAttributes, ERROR_ATTRIBUTE);
+		Throwable exception = getAttribute(requestAttributes, ERROR_ATTRIBUTE);
 		if (exception == null) {
 			exception = getAttribute(requestAttributes, "javax.servlet.error.exception");
 		}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/DefaultErrorAttributesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/DefaultErrorAttributesTests.java
@@ -143,6 +143,19 @@ public class DefaultErrorAttributesTests {
 				equalTo((Object) RuntimeException.class.getName()));
 		assertThat(attributes.get("message"), equalTo((Object) "Test"));
 	}
+	
+	@Test
+	public void getError() throws Exception {
+		Error error = new OutOfMemoryError("Test error");
+		this.request.setAttribute("javax.servlet.error.exception", error);
+		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(
+				this.requestAttributes, false);
+		assertThat(this.errorAttributes.getError(this.requestAttributes),
+				sameInstance((Object) error));
+		assertThat(attributes.get("exception"),
+				equalTo((Object) OutOfMemoryError.class.getName()));
+		assertThat(attributes.get("message"), equalTo((Object) "Test error"));
+	}
 
 	@Test
 	public void extractBindingResultErrors() throws Exception {


### PR DESCRIPTION
We encountered an issue in our production service when an OutOfMemoryError was thrown from a rest controller and caused a ClassCastException in Boot thus masking a real cause of the malfunction. The fix is a simple one-liner that changes a reference type to remove the casting issue.
