### PR TITLE
Added EmbedMongo support

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -26,6 +26,11 @@
 		</dependency>
 		<!-- Optional -->
 		<dependency>
+			<groupId>de.flapdoodle.embed</groupId>
+			<artifactId>de.flapdoodle.embed.mongo</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>com.atomikos</groupId>
 			<artifactId>transactions-jdbc</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/EmbedMongoAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/EmbedMongoAutoConfiguration.java
@@ -1,0 +1,35 @@
+package org.springframework.boot.autoconfigure.mongo;
+
+import com.mongodb.Mongo;
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.IMongodConfig;
+import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.Net;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+
+import static de.flapdoodle.embed.mongo.distribution.Version.V2_6_1;
+import static de.flapdoodle.embed.process.runtime.Network.localhostIsIPv6;
+
+@Configuration
+@ConditionalOnClass({ Mongo.class, MongodStarter.class})
+public class EmbedMongoAutoConfiguration {
+
+	@Autowired
+	private MongoProperties properties;
+
+	@Bean(initMethod = "start", destroyMethod = "stop")
+	public MongodExecutable embedMongoServer() throws IOException {
+		IMongodConfig mongodConfig = new MongodConfigBuilder()
+				.version(V2_6_1)
+				.net(new Net(properties.getPort(), localhostIsIPv6()))
+				.build();
+		return MongodStarter.getDefaultInstance().prepare(mongodConfig);
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/EmbedMongoAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/EmbedMongoAutoConfiguration.java
@@ -6,6 +6,7 @@ import de.flapdoodle.embed.mongo.MongodStarter;
 import de.flapdoodle.embed.mongo.config.IMongodConfig;
 import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
 import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
@@ -13,7 +14,6 @@ import org.springframework.context.annotation.Configuration;
 
 import java.io.IOException;
 
-import static de.flapdoodle.embed.mongo.distribution.Version.V2_6_1;
 import static de.flapdoodle.embed.process.runtime.Network.localhostIsIPv6;
 
 @Configuration
@@ -26,7 +26,7 @@ public class EmbedMongoAutoConfiguration {
 	@Bean(initMethod = "start", destroyMethod = "stop")
 	public MongodExecutable embedMongoServer() throws IOException {
 		IMongodConfig mongodConfig = new MongodConfigBuilder()
-				.version(V2_6_1)
+				.version(Version.Main.PRODUCTION)
 				.net(new Net(properties.getPort(), localhostIsIPv6()))
 				.build();
 		return MongodStarter.getDefaultInstance().prepare(mongodConfig);

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -42,6 +42,7 @@ org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration,\
 org.springframework.boot.autoconfigure.mobile.DeviceResolverAutoConfiguration,\
 org.springframework.boot.autoconfigure.mobile.DeviceDelegatingViewResolverAutoConfiguration,\
 org.springframework.boot.autoconfigure.mobile.SitePreferenceAutoConfiguration,\
+org.springframework.boot.autoconfigure.mongo.EmbedMongoAutoConfiguration,\
 org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,\
 org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration,\
 org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/EmbedMongoAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/EmbedMongoAutoConfigurationTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.mongo;
+
+import com.mongodb.CommandResult;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.boot.test.EnvironmentTestUtils.addEnvironment;
+import static org.springframework.util.SocketUtils.findAvailableTcpPort;
+
+public class EmbedMongoAutoConfigurationTests {
+
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void close() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void shouldReturnVersionOfEmbeddedMongoServer() {
+		this.context = new AnnotationConfigApplicationContext(
+				MongoAutoConfiguration.class, MongoDataAutoConfiguration.class, EmbedMongoAutoConfiguration.class);
+		int mongoPort = findAvailableTcpPort();
+		addEnvironment(context, "spring.data.mongodb.host=localhost", "spring.data.mongodb.port=" + mongoPort);
+		MongoTemplate mongo = context.getBean(MongoTemplate.class);
+		CommandResult buildInfo = mongo.executeCommand("{ buildInfo: 1 }");
+		assertEquals("2.6.1", buildInfo.getString("version"));
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/EmbedMongoAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/EmbedMongoAutoConfigurationTests.java
@@ -39,10 +39,11 @@ public class EmbedMongoAutoConfigurationTests {
 
 	@Test
 	public void shouldReturnVersionOfEmbeddedMongoServer() {
-		this.context = new AnnotationConfigApplicationContext(
-				MongoAutoConfiguration.class, MongoDataAutoConfiguration.class, EmbedMongoAutoConfiguration.class);
+		this.context = new AnnotationConfigApplicationContext();
 		int mongoPort = findAvailableTcpPort();
 		addEnvironment(context, "spring.data.mongodb.host=localhost", "spring.data.mongodb.port=" + mongoPort);
+		context.register(MongoAutoConfiguration.class, MongoDataAutoConfiguration.class, EmbedMongoAutoConfiguration.class);
+		context.refresh();
 		MongoTemplate mongo = context.getBean(MongoTemplate.class);
 		CommandResult buildInfo = mongo.executeCommand("{ buildInfo: 1 }");
 		assertEquals("2.6.1", buildInfo.getString("version"));

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -59,6 +59,7 @@
 		<commons-pool2.version>2.2</commons-pool2.version>
 		<crashub.version>1.3.0</crashub.version>
 		<dropwizard-metrics.version>3.1.0</dropwizard-metrics.version>
+		<embedmongo.version>1.46.4</embedmongo.version>
 		<flyway.version>3.0</flyway.version>
 		<freemarker.version>2.3.21</freemarker.version>
 		<gemfire.version>7.0.2</gemfire.version>
@@ -403,6 +404,11 @@
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
 				<version>${logback.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.flapdoodle.embed</groupId>
+				<artifactId>de.flapdoodle.embed.mongo</artifactId>
+				<version>${embedmongo.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.atomikos</groupId>


### PR DESCRIPTION
Hi,

I've added autoconfiguration for the EmbedMongo library. EmbedMongo [1] is something like H2 or HSQL, but for MongoDB, so basically you can run your tests against Mongo server instead of mocks. EmbedMongo is even better then H2/HSQL, because it starts *real* MongoDB server, not emulator of your RDBMS.

EmbedMongo is Apache 2 licenses, available in the Maven Central and actively developed/maintained for a long time. I can't imagine working with Mongo without it anymore :) .

What this autoconfig does is detecting if EmbedMongo + JavaDriver are present in the classpath. If so, then new embedded MongoDB process is started on port specified in `spring.data.mongodb.port` property.

Cheers.

[1] https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo