### PR TITLE
Enhance production-ready features docs with git info configuration for WAR-packaged apps.

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -289,7 +289,7 @@ If your app is packaged as a WAR file, you will have to specify the location of 
 
 [source,properties,indent=0]
 ----
-	git.properties: /WEB-INF/classes/git.properties
+	git.properties=/WEB-INF/classes/git.properties
 ----
 
 For Maven users the `spring-boot-starter-parent` POM includes a pre-configured plugin to


### PR DESCRIPTION
Everything works out of the box for JAR-packaged apps.  This will hopefully save a few people a few hours of debugging wondering why it won't work when the app is WAR-packaged.
