### PR TITLE
Fixed pubSubDomain support for autoconfigured JMS listeners

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsAnnotationDrivenConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsAnnotationDrivenConfiguration.java
@@ -48,12 +48,16 @@ class JmsAnnotationDrivenConfiguration {
 	@Autowired(required = false)
 	private PlatformTransactionManager transactionManager;
 
+	@Autowired
+	private JmsProperties properties;
+
 	@Bean
 	@ConditionalOnMissingBean(name = "jmsListenerContainerFactory")
 	public DefaultJmsListenerContainerFactory jmsListenerContainerFactory(
 			ConnectionFactory connectionFactory) {
 		DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
 		factory.setConnectionFactory(connectionFactory);
+		factory.setPubSubDomain(properties.isPubSubDomain());
 		if (this.transactionManager != null) {
 			factory.setTransactionManager(this.transactionManager);
 		}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
@@ -34,13 +34,16 @@ import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
 import org.springframework.jms.config.JmsListenerConfigUtils;
 import org.springframework.jms.config.JmsListenerContainerFactory;
 import org.springframework.jms.config.SimpleJmsListenerContainerFactory;
+import org.springframework.jms.config.JmsListenerEndpoint;
 import org.springframework.jms.core.JmsMessagingTemplate;
 import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.listener.DefaultMessageListenerContainer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link JmsAutoConfiguration}.
@@ -146,6 +149,17 @@ public class JmsAutoConfigurationTests {
 		load(TestConfiguration4.class);
 		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
 		assertTrue(jmsTemplate.isPubSubDomain());
+	}
+
+	@Test
+	public void testPubSubDomainActive() {
+		load(TestConfiguration.class, "spring.jms.pubSubDomain:true");
+		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
+		DefaultMessageListenerContainer defaultMessageListenerContainer = this.context
+				.getBean(DefaultJmsListenerContainerFactory.class)
+				.createListenerContainer(mock(JmsListenerEndpoint.class));
+		assertTrue(jmsTemplate.isPubSubDomain());
+		assertTrue(defaultMessageListenerContainer.isPubSubDomain());
 	}
 
 	@Test


### PR DESCRIPTION
**Issue**: `spring.jms.pubSubDomain` currently does not affect autoconfigured message listeners, so no matter if we set this flag to `true` or `false`, `@JmsListener` annotated listeners will not receive topic messages - which I believe is not the expected behaviour. 

This pull request fixes it by setting `pubSubDomain` property obtained from `JmsProperties` to autoconfigured `DefaultJmsListenerContainerFactory`.
