### PR TITLE
Allow external instantiation of the ErrorPageFilter class.

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/web/ErrorPageFilter.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/web/ErrorPageFilter.java
@@ -56,7 +56,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  */
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
-class ErrorPageFilter extends AbstractConfigurableEmbeddedServletContainer implements
+public class ErrorPageFilter extends AbstractConfigurableEmbeddedServletContainer implements
 		Filter, NonEmbeddedServletContainerFactory {
 
 	private static Log logger = LogFactory.getLog(ErrorPageFilter.class);


### PR DESCRIPTION
In some edge cases, the ErrorPageFilter may be instantiated by a container
or configured in a web.xml.  A package private class causes
java.lang.IllegalAccessException to be thrown in these cases.  See the
following:

  #2026
  #993

Fixes #2026.
