### PR TITLE
Propagate exception for test failures 

### DIFF
--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/CommandRunner.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/CommandRunner.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.boot.cli.command.status.ExitStatus;
+import org.springframework.boot.cli.command.test.TestFailedException;
 import org.springframework.boot.cli.util.Log;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -176,6 +177,9 @@ public class CommandRunner implements Iterable<Command> {
 		}
 		catch (NoArgumentsException ex) {
 			showUsage();
+			return 1;
+		}
+		catch(TestFailedException e) {
 			return 1;
 		}
 		catch (Exception ex) {

--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/test/TestFailedException.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/test/TestFailedException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.cli.command.test;
+
+/**
+ * Thrown when tests fail to execute
+ *
+ * @author Graeme Rocher
+ * @since 1.2
+ */
+public class TestFailedException extends RuntimeException {
+    public TestFailedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/spring-boot-cli/src/main/java/org/springframework/boot/groovy/DelegateTestRunner.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/groovy/DelegateTestRunner.java
@@ -18,6 +18,7 @@ package org.springframework.boot.groovy;
 
 import org.junit.internal.TextListener;
 import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
 import org.springframework.boot.cli.command.test.TestRunner;
 
 /**
@@ -28,9 +29,10 @@ import org.springframework.boot.cli.command.test.TestRunner;
  */
 public class DelegateTestRunner {
 
-	public static void run(Class<?>[] testClasses) {
+	public static void run(Class<?>[] testClasses, Result result) {
 		JUnitCore jUnitCore = new JUnitCore();
 		jUnitCore.addListener(new TextListener(System.out));
+		jUnitCore.addListener(result.createListener());
 		jUnitCore.run(testClasses);
 	}
 

--- a/spring-boot-cli/src/test/java/org/springframework/boot/cli/CliTester.java
+++ b/spring-boot-cli/src/test/java/org/springframework/boot/cli/CliTester.java
@@ -78,8 +78,12 @@ public class CliTester implements TestRule {
 
 	public String test(String... args) throws Exception {
 		Future<TestCommand> future = submitCommand(new TestCommand(), args);
-		this.commands.add(future.get(this.timeout, TimeUnit.MILLISECONDS));
-		return getOutput();
+		try {
+			this.commands.add(future.get(this.timeout, TimeUnit.MILLISECONDS));
+			return getOutput();
+		} catch (Exception e) {
+			return getOutput();
+		}
 	}
 
 	public String grab(String... args) throws Exception {


### PR DESCRIPTION
This ensures the correct status code is returned for failing tests. Fix for https://github.com/spring-projects/spring-boot/issues/2048
