### PR TITLE
update flyway.locations property doc to set correct default path

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -257,7 +257,7 @@ content into your application; rather pick only the properties that you need.
 	spring.data.rest.base-uri= # base URI against which the exporter should calculate its links
 
 	# FLYWAY ({sc-spring-boot-autoconfigure}/flyway/FlywayProperties.{sc-ext}[FlywayProperties])
-	flyway.locations=classpath:db/migrations # locations of migrations scripts
+	flyway.locations=classpath:db/migration # locations of migrations scripts
 	flyway.schemas= # schemas to update
 	flyway.init-version= 1 # version to start migration
 	flyway.sql-migration-prefix=V


### PR DESCRIPTION
Tiny pull request to correct http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html

``` properties
flyway.locations=classpath:db/migrations # locations of migrations scripts
```

Whereas https://github.com/spring-projects/spring-boot/blob/master/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java#L41 is defined to `db/migration` without `s`
