### PR TITLE
Added Docker client autoConfiguration

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -56,6 +56,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.github.docker-java</groupId>
+			<artifactId>docker-java</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<optional>true</optional>
@@ -416,6 +421,11 @@
 		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mock-server</groupId>
+			<artifactId>mockserver-netty</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/docker/DockerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/docker/DockerAutoConfiguration.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.core.DockerClientBuilder;
+import com.github.dockerjava.core.DockerClientConfig;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static com.github.dockerjava.core.DockerClientConfig.createDefaultConfigBuilder;
+
+@Configuration
+@ConditionalOnClass(DockerClient.class)
+@EnableConfigurationProperties(DockerProperties.class)
+public class DockerAutoConfiguration {
+
+    @Bean
+    public DockerClient docker(DockerProperties dockerProperties) {
+	 DockerClientConfig.DockerClientConfigBuilder config = createDefaultConfigBuilder();
+	 if (dockerProperties.getVersion() != null) {
+	     config.withVersion(dockerProperties.getVersion());
+	 }
+	 if (dockerProperties.getUri() != null) {
+	     config.withUri(dockerProperties.getUri());
+	 }
+	 if (dockerProperties.getUsername() != null) {
+	     config.withUsername(dockerProperties.getUsername());
+	 }
+	 if (dockerProperties.getPassword() != null) {
+	     config.withPassword(dockerProperties.getPassword());
+	 }
+	 if (dockerProperties.getEmail() != null) {
+	     config.withEmail(dockerProperties.getEmail());
+	 }
+	 if (dockerProperties.getDockerCertPath() != null) {
+	     config.withDockerCertPath(dockerProperties.getDockerCertPath());
+	 }
+	 if (dockerProperties.getLoggingFilter() != null) {
+	     config.withLoggingFilter(dockerProperties.getLoggingFilter());
+	 }
+	 if (dockerProperties.getReadTimeout() != null) {
+	     config.withReadTimeout(dockerProperties.getReadTimeout());
+	 }
+	 return DockerClientBuilder.getInstance(config).build();
+    }
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/docker/DockerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/docker/DockerProperties.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure.docker;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.docker")
+public class DockerProperties {
+
+	private String version;
+
+	private String uri;
+
+	private String username;
+
+	private String password;
+
+	private String email;
+
+	private String dockerCertPath;
+
+	private Boolean loggingFilter;
+
+	private Integer readTimeout;
+
+	public String getVersion() {
+		return version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	public String getUri() {
+		return uri;
+	}
+
+	public void setUri(String uri) {
+		this.uri = uri;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	public String getDockerCertPath() {
+		return dockerCertPath;
+	}
+
+	public void setDockerCertPath(String dockerCertPath) {
+		this.dockerCertPath = dockerCertPath;
+	}
+
+	public Boolean getLoggingFilter() {
+		return loggingFilter;
+	}
+
+	public void setLoggingFilter(Boolean loggingFilter) {
+		this.loggingFilter = loggingFilter;
+	}
+
+	public Integer getReadTimeout() {
+		return readTimeout;
+	}
+
+	public void setReadTimeout(Integer readTimeout) {
+		this.readTimeout = readTimeout;
+	}
+}

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -17,6 +17,7 @@ org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfigura
 org.springframework.boot.autoconfigure.data.solr.SolrRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration,\
+org.springframework.boot.autoconfigure.docker.DockerAutoConfiguration,\
 org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration,\
 org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration,\
 org.springframework.boot.autoconfigure.hateoas.HypermediaAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/docker/DockerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/docker/DockerAutoConfigurationTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.core.DockerClientImpl;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockserver.integration.ClientAndServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import javax.ws.rs.ProcessingException;
+
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.springframework.boot.autoconfigure.docker.DockerUtils.isConnected;
+import static org.springframework.boot.test.EnvironmentTestUtils.addEnvironment;
+import static org.springframework.util.SocketUtils.findAvailableTcpPort;
+
+public class DockerAutoConfigurationTest extends Assert {
+
+	AnnotationConfigApplicationContext context;
+
+	ClientAndServer dockerServer;
+
+	@Before
+	public void setUp() {
+		context = new AnnotationConfigApplicationContext();
+		context.register(DockerAutoConfiguration.class);
+
+		int dockerPort = findAvailableTcpPort();
+		dockerServer = new ClientAndServer(dockerPort);
+
+		addEnvironment(context, "spring.docker.uri:http://localhost:" + dockerPort);
+	}
+
+	@After
+	public void tearDown() {
+		if (this.context != null) {
+			this.context.close();
+		}
+
+		dockerServer.stop();
+	}
+
+	@Test
+	public void shouldBeConnected() {
+		context.refresh();
+
+		dockerServer.when(request().withPath("/v1.15/_ping")).respond(response().withBody("OK"));
+
+		DockerClient docker = context.getBean(DockerClient.class);
+		assertTrue(isConnected(docker));
+	}
+
+	@Test
+	public void shouldNotBeConnected() {
+		context.refresh();
+
+		dockerServer.when(request().withPath("/v1.15/_ping")).respond(response().withStatusCode(404));
+
+		DockerClient docker = context.getBean(DockerClient.class);
+		assertFalse(isConnected(docker));
+	}
+
+	@Test
+	public void shouldUseGivenApiVersion() {
+		addEnvironment(context, "spring.docker.version:1.14");
+		context.refresh();
+
+		dockerServer.when(request().withPath("/v1.14/_ping")).respond(response().withBody("OK"));
+
+		DockerClient docker = context.getBean(DockerClient.class);
+		assertTrue(isConnected(docker));
+	}
+
+	@Test
+	public void shouldUseCredentials() {
+		String username = "henry";
+		String password = "secretPass";
+		String email = "docker@gmail.com";
+		addEnvironment(context,
+				"spring.docker.username:" + username,
+				"spring.docker.password:" + password,
+				"spring.docker.email:" + email);
+		context.refresh();
+
+		DockerClientImpl docker = (DockerClientImpl) context.getBean(DockerClient.class);
+		assertEquals(username, docker.authConfig().getUsername());
+		assertEquals(password, docker.authConfig().getPassword());
+		assertEquals(email, docker.authConfig().getEmail());
+	}
+
+}
+
+final class DockerUtils {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DockerUtils.class);
+
+	private DockerUtils() {
+	}
+
+	public static boolean isConnected(DockerClient docker) {
+		try {
+			docker.pingCmd().exec();
+			return true;
+		} catch (ProcessingException e) {
+			LOG.debug("Can't connect to the Docker server.", e);
+			return false;
+		} catch (DockerException e) {
+			LOG.debug("Can't connect to the Docker server.", e);
+			return false;
+		}
+	}
+
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -58,6 +58,7 @@
 		<commons-pool.version>1.6</commons-pool.version>
 		<commons-pool2.version>2.2</commons-pool2.version>
 		<crashub.version>1.3.0</crashub.version>
+		<docker-java.version>0.10.3</docker-java.version>
 		<dropwizard-metrics.version>3.1.0</dropwizard-metrics.version>
 		<flyway.version>3.0</flyway.version>
 		<freemarker.version>2.3.21</freemarker.version>
@@ -96,6 +97,7 @@
 		<log4j.version>1.2.17</log4j.version>
 		<log4j2.version>2.1</log4j2.version>
 		<logback.version>1.1.2</logback.version>
+		<mock-server.version>3.8.2</mock-server.version>
 		<mockito.version>1.10.8</mockito.version>
 		<mongodb.version>2.12.4</mongodb.version>
 		<mysql.version>5.1.34</mysql.version>
@@ -454,6 +456,11 @@
 				<groupId>com.gemstone.gemfire</groupId>
 				<artifactId>gemfire</artifactId>
 				<version>${gemfire.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.github.docker-java</groupId>
+				<artifactId>docker-java</artifactId>
+				<version>${docker-java.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.mxab.thymeleaf.extras</groupId>
@@ -1052,6 +1059,11 @@
 				<groupId>org.liquibase</groupId>
 				<artifactId>liquibase-core</artifactId>
 				<version>${liquibase.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.mock-server</groupId>
+				<artifactId>mockserver-netty</artifactId>
+				<version>${mock-server.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mockito</groupId>


### PR DESCRIPTION
Hi,

I created autoConfiguration for the docker-java [1] Docker client. In the most common scenario, adding docker-java to the classpath will provide `DockerClient` instance connected to the `$DOCKER_HOST` environment variable:

```
@Autowired
DockerClient docker;
...
docker.pullImageCmd("ubuntu").exec();
```

Cheers.

[1] https://github.com/docker-java/docker-java
