### PR TITLE
Remove formatting of boot and app versions

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/ResourceBanner.java
+++ b/spring-boot/src/main/java/org/springframework/boot/ResourceBanner.java
@@ -98,7 +98,7 @@ public class ResourceBanner implements Banner {
 	}
 
 	private String getVersionString(String version) {
-		return (version == null ? "" : " (v" + version + ")");
+		return (version == null ? "" : version);
 	}
 
 }


### PR DESCRIPTION
Formatting of the ${application.version} and ${spring-boot.version} variables along with added parenthesis should not be explicitly defined in the code. Instead it should be defined as needed within the banner.txt
