### PR TITLE
Jackson JSON support for spring-boot-starter-jersey

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -994,6 +994,11 @@
 				<version>${jersey.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.glassfish.jersey.media</groupId>
+				<artifactId>jersey-media-json-jackson</artifactId>
+				<version>${jersey.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.hamcrest</groupId>
 				<artifactId>hamcrest-core</artifactId>
 				<version>${hamcrest.version}</version>

--- a/spring-boot-starters/spring-boot-starter-jersey/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-jersey/pom.xml
@@ -65,5 +65,9 @@
 			<groupId>org.glassfish.jersey.ext</groupId>
 			<artifactId>jersey-spring3</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.media</groupId>
+			<artifactId>jersey-media-json-jackson</artifactId>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
`spring-boot-starter-jersey` does not support JSON out of the box as does spring web. 

I've created a tiny demo here: https://github.com/tadaskay/spring-jersey-demo
Spring controller will return JSON, while Jersey controller will give `500`:
`o.g.j.m.i.WriterInterceptorExecutor      : MessageBodyWriter not found for media type=application/json, type=class demo.beans.HelloBean, genericType=class demo.beans.HelloBean`

Luckily, all that's needed to support jackson is `jersey-media-json-jackson` [module](https://jersey.java.net/documentation/latest/media.html#json.jackson).
