### PR TITLE
MongoDataAutoConfiguration now sets up packages for @Document scanning.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoDataAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoDataAutoConfiguration.java
@@ -133,7 +133,7 @@ public class MongoDataAutoConfiguration {
 	@ConditionalOnMissingBean
 	public MongoMappingContext mongoMappingContext(BeanFactory beanFactory) throws ClassNotFoundException {
 
-		Collection<String> basePackages = getMappingBasePackages(this.properties, beanFactory);
+		Collection<String> basePackages = getMappingBasePackages(beanFactory);
 		
 		MongoMappingContext context = new MongoMappingContext();
 		context.setInitialEntitySet(getInitialEntitySet(basePackages));
@@ -152,17 +152,10 @@ public class MongoDataAutoConfiguration {
 	/**
 	 * Returns the base packages to be used for domain type scanning.
 	 * 
-	 * @param properties the {@link MongoProperties} to inspect for manually configured packages.
-	 * @param beanFactory the {@link BeanFactory} to lookup auto-configuration packages from as fallback.
+	 * @param beanFactory the {@link BeanFactory} to lookup auto-configuration packages from.
 	 * @return
 	 */
-	private static Collection<String> getMappingBasePackages(MongoProperties properties, BeanFactory beanFactory) {
-
-		List<String> explicitPackages = properties.getMappingBasePackages();
-
-		if (!explicitPackages.isEmpty()) {
-			return explicitPackages;
-		}
+	private static Collection<String> getMappingBasePackages(BeanFactory beanFactory) {
 
 		try {
 			return AutoConfigurationPackages.get(beanFactory);

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
@@ -18,7 +18,6 @@ package org.springframework.boot.autoconfigure.mongo;
 
 import java.net.UnknownHostException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -82,11 +81,6 @@ public class MongoProperties {
 	 * Login password of the mongo server.
 	 */
 	private char[] password;
-	
-	/**
-	 * The packages to scan for {@code @Document} and {@code Persistent} annotated types.
-	 */
-	private List<String> mappingBasePackages = Collections.emptyList();
 
 	public String getHost() {
 		return this.host;
@@ -159,14 +153,6 @@ public class MongoProperties {
 
 	public void setGridFsDatabase(String gridFsDatabase) {
 		this.gridFsDatabase = gridFsDatabase;
-	}
-	
-	public List<String> getMappingBasePackages() {
-		return mappingBasePackages;
-	}
-	
-	public void setMappingBasePackages(List<String> mappingBasePackages) {
-		this.mappingBasePackages = mappingBasePackages;
 	}
 
 	public String getMongoClientDatabase() {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoDataAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoDataAutoConfigurationTests.java
@@ -101,17 +101,6 @@ public class MongoDataAutoConfigurationTests {
 		assertDomainTypesDiscovered(this.context.getBean(MongoMappingContext.class), City.class);
 	}
 	
-	@Test
-	public void prefersMappingBasePackageConfiguredInEnvironment() {
-		
-		this.context = new AnnotationConfigApplicationContext();
-		EnvironmentTestUtils.addEnvironment(this.context, "spring.data.mongodb.mappingBasePackages = " + Country.class.getPackage().getName());
-		this.context.register(MongoAutoConfiguration.class, MongoDataAutoConfiguration.class);
-		this.context.refresh();
-		
-		assertDomainTypesDiscovered(this.context.getBean(MongoMappingContext.class), Country.class);
-	}
-	
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	private static void assertDomainTypesDiscovered(MongoMappingContext mappingContext, Class<?>... types) {
 		


### PR DESCRIPTION
MongoDataAutoConfiguration now sets up the domain type scanning for all 
auto-configuration packages.

This currently implemented by effectively copying AbstractMongoConfiguration's
getInitialEntitySet() but we can remove that as soon as we've exposed that
functionality in Spring Data MongoDB's config class.

Issue: #2107.
