### PR TITLE
this thymleaf dialect allows parsing of conditional comments, e.g. IE

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -381,6 +381,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.thymeleaf.extras</groupId>
+			<artifactId>thymeleaf-extras-conditionalcomments</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.projectreactor.spring</groupId>
 			<artifactId>reactor-spring-context</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
@@ -41,6 +41,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.util.Assert;
 import org.thymeleaf.dialect.IDialect;
+import org.thymeleaf.extras.conditionalcomments.dialect.ConditionalCommentsDialect;
 import org.thymeleaf.extras.springsecurity3.dialect.SpringSecurityDialect;
 import org.thymeleaf.spring4.SpringTemplateEngine;
 import org.thymeleaf.spring4.resourceresolver.SpringResourceResourceResolver;
@@ -162,6 +163,19 @@ public class ThymeleafAutoConfiguration {
 		}
 
 	}
+
+	@Configuration
+	@ConditionalOnClass(ConditionalCommentsDialect.class)
+	protected static class ThymeleafConditionalCommentsDialectConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean
+		public ConditionalCommentsDialect conditionalCommentsDialect() {
+			return new ConditionalCommentsDialect();
+		}
+
+	}
+
 
 	@Configuration
 	@ConditionalOnClass({ Servlet.class })

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -126,6 +126,7 @@
 		<sun-mail.version>${javax-mail.version}</sun-mail.version>
 		<thymeleaf.version>2.1.3.RELEASE</thymeleaf.version>
 		<thymeleaf-extras-springsecurity3.version>2.1.1.RELEASE</thymeleaf-extras-springsecurity3.version>
+		<thymeleaf-extras-conditionalcomments.version>2.1.1.RELEASE</thymeleaf-extras-conditionalcomments.version>
 		<thymeleaf-layout-dialect.version>1.2.7</thymeleaf-layout-dialect.version>
 		<thymeleaf-extras-data-attribute.version>1.3</thymeleaf-extras-data-attribute.version>
 		<tomcat.version>8.0.15</tomcat.version>
@@ -1396,6 +1397,11 @@
 				<groupId>org.thymeleaf.extras</groupId>
 				<artifactId>thymeleaf-extras-springsecurity3</artifactId>
 				<version>${thymeleaf-extras-springsecurity3.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.thymeleaf.extras</groupId>
+				<artifactId>thymeleaf-extras-conditionalcomments</artifactId>
+				<version>${thymeleaf-extras-conditionalcomments.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.yaml</groupId>


### PR DESCRIPTION
Example:

<!--[if lt IE 8]>
  <link rel="stylesheet" th:href="@{/styleIE.css}" type="text/css"/>
<![endif]-->

without this dialect all thymleaf attributes are ignored inside the condition
