### PR TITLE
Unify console and file logback patterns

### DIFF
--- a/spring-boot/src/main/resources/org/springframework/boot/logging/logback/defaults.xml
+++ b/spring-boot/src/main/resources/org/springframework/boot/logging/logback/defaults.xml
@@ -10,7 +10,7 @@ initialization performed by Boot
 	<conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
 	<property name="CONSOLE_LOG_PATTERN" value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t{14}]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex"/>
-	<property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %5p ${PID:- } [%t] --- %-40.40logger{39} : %m%n%wex"/>
+	<property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %5p ${PID:- } --- [%t] %-40.40logger{39} : %m%n%wex"/>
 
 	<appender name="DEBUG_LEVEL_REMAPPER" class="org.springframework.boot.logging.logback.LevelRemappingAppender">
 		<destinationLogger>org.springframework.boot</destinationLogger>


### PR DESCRIPTION
It now matches exactly the layout of the CONSOLE_LOG_PATTERN. Actually we are redirecting the console output to a file and we are parsing the logfiles with Logstash. To make this migration a bit easier we need an identical pattern.
