### PR TITLE
Fix a small typo in howto.adoc

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -2246,7 +2246,7 @@ but the rest of it is normal for a Spring application in Servlet 2.5. Example:
 		<filter>
 			<filter-name>metricFilter</filter-name>
 			<filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
-		</filte>r
+		</filter>
 
 		<filter-mapping>
 			<filter-name>metricFilter</filter-name>


### PR DESCRIPTION
Hello, I spotted a little typo when reading the `current-SNAPSHOT` version of the guide, I have signed the CLA under the name Paul d'Hubert before making this pull request. 
