### PR TITLE
fixed jetty9 MalformedURLException for Jar files

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactory.java
@@ -40,6 +40,7 @@ import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlet.ServletMapping;
+import org.eclipse.jetty.util.resource.JarResource;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.webapp.AbstractConfiguration;
@@ -259,7 +260,7 @@ public class JettyEmbeddedServletContainerFactory extends
 		if (root != null) {
 			try {
 				if (!root.isDirectory()) {
-					Resource resource = Resource.newResource("jar:" + root.toURI() + "!");
+					Resource resource = JarResource.newJarResource(Resource.newResource(root));
 					handler.setBaseResource(resource);
 				}
 				else {


### PR DESCRIPTION
My Jetty 9 application throws `java.net.MalformedURLException: no !/ in spec`. It seems that `/` required at the end of url. 

I have signed CLA.