### PR TITLE
Add docs for Spring Boot CLI via MacPorts

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-boot-docs/src/main/asciidoc/getting-started.adoc
@@ -353,6 +353,18 @@ Just execute `brew update` and try again.
 
 
 
+[[getting-started-macports-cli-installation]]
+==== MacPorts installation
+If you are on a Mac and using http://www.macports.org/[MacPorts], all you need to do to
+install the Spring Boot CLI is:
+
+[indent=0]
+----
+	$ sudo port install spring-boot-cli
+----
+
+
+
 [[getting-started-cli-command-line-completion]]
 ==== Command-line completion
 Spring Boot CLI ships with scripts that provide command completion for
@@ -370,8 +382,8 @@ manually, e.g. if you have installed using `GVM`
 	  grab  help  jar  run  test  version
 ----
 
-NOTE: If you install Spring Boot CLI using Homebrew, the command-line completion scripts
-are automatically registered with your shell.
+NOTE: If you install Spring Boot CLI using Homebrew or MacPorts, the command-line
+completion scripts are automatically registered with your shell.
 
 
 

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-cli.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-cli.adoc
@@ -14,7 +14,7 @@ a new project or write your own command for it.
 [[cli-installation]]
 == Installing the CLI
 The Spring Boot CLI can be installed manually; using GVM (the Groovy Environment
-Manually) or using Homebrew if you are an OSX user. See
+Manually) or using Homebrew or MacPorts if you are an OSX user. See
 _<<getting-started.adoc#getting-started-installing-the-cli>>_
 in the "`Getting started`" section for comprehensive installation instructions.
 


### PR DESCRIPTION
Spring Boot CLI is now also maintained in MacPorts. This is a small patch to the docs which tells users what port to install.
