### PR TITLE
Grep metrics by Regexp

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/KeyUtils.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/KeyUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.endpoint;
+
+import java.util.regex.Pattern;
+
+/**
+ * Convenience class for working with keys.
+ *
+ * @author Sergei Egorov
+ */
+public class KeyUtils {
+    
+    private static final String[] REGEX_PARTS = { "*", "$", "^", "+" };
+
+    public static Pattern getPattern(String value) {
+        return getPattern(value, "^");
+    }
+
+    public static Pattern getPattern(String value, String prefix) {
+        if (isRegex(value)) {
+            return Pattern.compile(value, Pattern.CASE_INSENSITIVE);
+        }
+        return Pattern.compile(prefix + Pattern.quote(value) + "$", Pattern.CASE_INSENSITIVE);
+    }
+
+    public static boolean isRegex(String value) {
+        for (String part : REGEX_PARTS) {
+            if (value.contains(part)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
@@ -29,8 +29,6 @@ import org.springframework.util.Assert;
  */
 class Sanitizer {
 
-	private static final String[] REGEX_PARTS = { "*", "$", "^", "+" };
-
 	private Pattern[] keysToSanitize;
 
 	public Sanitizer() {
@@ -46,24 +44,8 @@ class Sanitizer {
 		Assert.notNull(keysToSanitize, "KeysToSanitize must not be null");
 		this.keysToSanitize = new Pattern[keysToSanitize.length];
 		for (int i = 0; i < keysToSanitize.length; i++) {
-			this.keysToSanitize[i] = getPattern(keysToSanitize[i]);
+			this.keysToSanitize[i] = KeyUtils.getPattern(keysToSanitize[i], ".*");
 		}
-	}
-
-	private Pattern getPattern(String value) {
-		if (isRegex(value)) {
-			return Pattern.compile(value, Pattern.CASE_INSENSITIVE);
-		}
-		return Pattern.compile(".*" + value + "$", Pattern.CASE_INSENSITIVE);
-	}
-
-	private boolean isRegex(String value) {
-		for (String part : REGEX_PARTS) {
-			if (value.contains(part)) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 	/**

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/KeyUtilsTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/KeyUtilsTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.endpoint;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link org.springframework.boot.actuate.endpoint.KeyUtils}.
+ *
+ * @author Sergei Egorov
+ */
+public class KeyUtilsTests {
+
+	@Test
+	public void defaults() throws Exception {
+		assertFalse(KeyUtils.isRegex("foo"));
+		assertFalse(KeyUtils.isRegex("foo.bar"));
+		
+		assertTrue(KeyUtils.isRegex("foo.*"));
+		assertTrue(KeyUtils.isRegex("foo.+"));
+		assertTrue(KeyUtils.isRegex("foo\\.*"));
+	}
+
+}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/MetricsMvcEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/MetricsMvcEndpointTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.endpoint.mvc;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.actuate.endpoint.MetricsEndpoint;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link MetricsMvcEndpoint}.
+ *
+ * @author Sergei Egorov
+ */
+public class MetricsMvcEndpointTests {
+    
+    private MetricsEndpoint endpoint = null;
+
+    private MetricsMvcEndpoint mvc = null;
+
+    @Before
+    public void init() {
+        this.endpoint = mock(MetricsEndpoint.class);
+        given(this.endpoint.isEnabled()).willReturn(true);
+        this.mvc = new MetricsMvcEndpoint(this.endpoint);
+    }
+    
+    @Test
+    public void all() {
+        Map<String, Object> metrics = new HashMap<String, Object>();
+        metrics.put("a", 1);
+        given(this.endpoint.invoke()).willReturn(metrics);
+        Object result = this.mvc.invoke();
+        assertTrue(result instanceof Map);
+        assertTrue(metrics.get("a") == ((Map<String, Object>) result).get("a"));
+    }
+
+    @Test
+    public void value() {
+        Map<String, Object> metrics = new HashMap<String, Object>();
+        metrics.put("group1.a", 1);
+        metrics.put("group1.b", 2);
+        metrics.put("group2.a", 3);
+        metrics.put("group2_a", 4);
+        metrics.put("foo", "bar");
+        given(this.endpoint.invoke()).willReturn(metrics);
+        Object result = this.mvc.value(".*");
+        assertTrue(result instanceof Map);
+        assertTrue(metrics.size() == ((Map<String, Object>) result).size());
+        assertTrue(metrics.get("group1.a") == ((Map<String, Object>) result).get("group1.a"));
+        assertTrue(metrics.get("group1.b") == ((Map<String, Object>) result).get("group1.b"));
+        assertTrue(metrics.get("group2.a") == ((Map<String, Object>) result).get("group2.a"));
+        assertTrue(metrics.get("group2_a") == ((Map<String, Object>) result).get("group2_a"));
+        assertTrue(metrics.get("foo") == ((Map<String, Object>) result).get("foo"));
+
+        result = this.mvc.value("group[0-9]+\\..*");
+        assertTrue(result instanceof Map);
+        assertTrue(3 == ((Map<String, Object>) result).size());
+        assertTrue(metrics.get("group1.a") == ((Map<String, Object>) result).get("group1.a"));
+        assertTrue(metrics.get("group1.b") == ((Map<String, Object>) result).get("group1.b"));
+        assertTrue(metrics.get("group2.a") == ((Map<String, Object>) result).get("group2.a"));
+
+        result = this.mvc.value("group1\\..*");
+        assertTrue(result instanceof Map);
+        assertTrue(2 == ((Map<String, Object>) result).size());
+        assertTrue(metrics.get("group1.a") == ((Map<String, Object>) result).get("group1.a"));
+        assertTrue(metrics.get("group1.b") == ((Map<String, Object>) result).get("group1.b"));
+
+        result = this.mvc.value("group2.a");
+        assertTrue(result instanceof Map);
+        assertTrue(1 == ((Map<String, Object>) result).size());
+        assertTrue(metrics.get("group2.a") == ((Map<String, Object>) result).get("group2.a"));
+    }
+
+    @Test
+    public void unknownValue() {
+        given(this.endpoint.invoke()).willReturn(Collections.<String, Object>emptyMap());
+
+        Object result = this.mvc.value("unknownKey");
+        assertTrue(result instanceof Map);
+        assertTrue(((Map) result).isEmpty());
+    }
+}


### PR DESCRIPTION
Hi!

I want to contribute this very useful feature to the MetricsMvcEndpoint. It allows you to grep metrics by key, so you can query like "/metrics/gauge\\.response\\.*" to get a list of all response times. 

I should note that this is a breaking change, so please review it and if we need to keep backward compatibility I will revert old implementation and just add another request mapping for it.


Thanks!