### PR TITLE
Update flyway from 3.0 to 3.1

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -59,7 +59,7 @@
 		<commons-pool2.version>2.2</commons-pool2.version>
 		<crashub.version>1.3.0</crashub.version>
 		<dropwizard-metrics.version>3.1.0</dropwizard-metrics.version>
-		<flyway.version>3.0</flyway.version>
+		<flyway.version>3.1</flyway.version>
 		<freemarker.version>2.3.21</freemarker.version>
 		<gemfire.version>7.0.2</gemfire.version>
 		<glassfish-el.version>3.0.0</glassfish-el.version>


### PR DESCRIPTION
Includes an important fix to restore JDK 6 compatibility with the Gradle plugin, see [here](https://github.com/flyway/flyway/issues/779).
[Release notes](http://flywaydb.org/documentation/releaseNotes.html)