### PR TITLE
Fix issue #2264: endpoints.enabled property does not work

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/AbstractEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/AbstractEndpoint.java
@@ -104,7 +104,7 @@ public abstract class AbstractEndpoint<T> implements Endpoint<T>, EnvironmentAwa
 			return this.enabled;
 		}
 		if (this.environment != null) {
-			this.environment.getProperty(ENDPOINTS_ENABLED_PROPERTY, Boolean.class, true);
+			return this.environment.getProperty(ENDPOINTS_ENABLED_PROPERTY, Boolean.class, true);
 		}
 		return true;
 	}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/EnvironmentEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/EnvironmentEndpoint.java
@@ -110,6 +110,7 @@ public class EnvironmentEndpoint extends AbstractEndpoint<Map<String, Object>> i
 
 	@Override
 	public void setEnvironment(Environment environment) {
+		super.setEnvironment(environment);
 		this.environment = environment;
 	}
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/AbstractEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/AbstractEndpointTests.java
@@ -17,6 +17,8 @@
 package org.springframework.boot.actuate.endpoint;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
@@ -130,6 +132,31 @@ public abstract class AbstractEndpointTests<T extends Endpoint<?>> {
 		this.context.register(this.configClass);
 		this.context.refresh();
 		((AbstractEndpoint) getEndpointBean()).setEnabled(true);
+		assertThat(getEndpointBean().isEnabled(), equalTo(true));
+	}
+	
+
+	@Test
+	public void isAllEndpointsDisabled() throws Exception {
+		this.context = new AnnotationConfigApplicationContext();
+		PropertySource<?> propertySource = new MapPropertySource("test",
+				Collections.<String, Object> singletonMap("endpoints.enabled", false));
+		this.context.getEnvironment().getPropertySources().addFirst(propertySource);
+		this.context.register(this.configClass);
+		this.context.refresh();
+		assertThat(getEndpointBean().isEnabled(), equalTo(false));
+	}
+	
+	@Test
+	public void isOptIn() throws Exception {
+		this.context = new AnnotationConfigApplicationContext();
+		Map<String, Object> source = new HashMap<String, Object>();
+		source.put("endpoints.enabled", false);
+		source.put(this.property + ".enabled", true);
+		PropertySource<?> propertySource = new MapPropertySource("test", source);
+		this.context.getEnvironment().getPropertySources().addFirst(propertySource);
+		this.context.register(this.configClass);
+		this.context.refresh();
 		assertThat(getEndpointBean().isEnabled(), equalTo(true));
 	}
 


### PR DESCRIPTION
Fix issue #2264: endpoints.enabled property does not work due to missing return statement.
Also add modification to the EnvironmentEndpoint class that not properly
initializes the 'environment' property used by the 'isEnabled' method of
the super class.