### PR TITLE
Add application version info to JAR manifest.

### DIFF
--- a/spring-boot-starters/spring-boot-starter-parent/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-parent/pom.xml
@@ -68,6 +68,7 @@
 						<archive>
 							<manifest>
 								<mainClass>${start-class}</mainClass>
+								<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
 							</manifest>
 						</archive>
 					</configuration>
@@ -93,6 +94,7 @@
 						<archive>
 							<manifest>
 								<mainClass>${start-class}</mainClass>
+								<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
 							</manifest>
 						</archive>
 					</configuration>


### PR DESCRIPTION
According to [Spring Boot's reference guide](http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-banner), a custom `banner.txt` should support the `${application.version}` and `${application.formatted-version}` placeholders. However, these only work if the application's manifest contains an `Implementation-Version` field. This patch configures the `maven-jar-plugin` in the `spring-boot-starter-parent` POM to provide the necessary field.