### PR TITLE
Allow specifying agent class in repackager configuration

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/build-tool-plugins.adoc
+++ b/spring-boot-docs/src/main/asciidoc/build-tool-plugins.adoc
@@ -429,6 +429,11 @@ want the other Boot features but not this one)
  class name via the "run" task (`main` property) and/or the "startScripts"
  (`mainClassName` property) as an alternative to using the "springBoot" configuration.
 
+|`agentClass`
+|The agent class that should be included into manifest file (as a `Premain-Class` attribute).
+ It will also trigger adding retransform and redefine capabilities which allows you to use
+ built uber-jar file as `-javaagent` value.
+
 |`classifier`
 |A file name segment (before the extension) to add to the archive, so that the original is
  preserved in its original location. Defaults to null in which case the archive is

--- a/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/repackage/RepackageTask.java
+++ b/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/repackage/RepackageTask.java
@@ -48,6 +48,8 @@ public class RepackageTask extends DefaultTask {
 
 	private String mainClass;
 
+	private String agentClass;
+
 	private String classifier;
 
 	private File outputFile;
@@ -66,6 +68,14 @@ public class RepackageTask extends DefaultTask {
 
 	public void setMainClass(String mainClass) {
 		this.mainClass = mainClass;
+	}
+
+	public void setAgentClass(String agentClass) {
+		this.agentClass = agentClass;
+	}
+
+	public String getAgentClass() {
+		return agentClass;
 	}
 
 	public String getMainClass() {
@@ -165,6 +175,7 @@ public class RepackageTask extends DefaultTask {
 			}
 			Repackager repackager = new LoggingRepackager(file);
 			setMainClass(repackager);
+			setAgentClass(repackager);
 			if (this.extension.convertLayout() != null) {
 				repackager.setLayout(this.extension.convertLayout());
 			}
@@ -200,6 +211,13 @@ public class RepackageTask extends DefaultTask {
 			}
 			getLogger().info("Setting mainClass: " + mainClass);
 			repackager.setMainClass(mainClass);
+		}
+
+		private void setAgentClass(Repackager repackager) {
+			if (RepackageTask.this.agentClass != null) {
+				getLogger().info("Setting agentClass: " + RepackageTask.this.agentClass);
+				repackager.setAgentClass(RepackageTask.this.agentClass);
+			}
 		}
 	}
 

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Repackager.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Repackager.java
@@ -41,7 +41,17 @@ public class Repackager {
 
 	private static final byte[] ZIP_FILE_HEADER = new byte[] { 'P', 'K', 3, 4 };
 
+	private static final String AGENT_CLASS_ATTRIBUTE = "Premain-Class";
+
+	private static final String REDEFINE_ATTRIBUTE = "Can-Redefine-Classes";
+
+	private static final String RETRANSFORM_ATTRIBUTE = "Can-Retransform-Classes";
+
+	private static final String VALUE_TRUE = "true";
+
 	private String mainClass;
+
+	private String agentClass;
 
 	private boolean backupSource = true;
 
@@ -65,6 +75,14 @@ public class Repackager {
 	 */
 	public void setMainClass(String mainClass) {
 		this.mainClass = mainClass;
+	}
+
+	/**
+	 * Sets the premain class that should be added to manifest.
+	 * @param agentClass the premain class name
+	 */
+	public void setAgentClass(String agentClass) {
+		this.agentClass = agentClass;
 	}
 
 	/**
@@ -240,6 +258,11 @@ public class Repackager {
 		}
 		else if (startClass != null) {
 			manifest.getMainAttributes().putValue(MAIN_CLASS_ATTRIBUTE, startClass);
+		}
+		if (agentClass != null) {
+			manifest.getMainAttributes().putValue(AGENT_CLASS_ATTRIBUTE, agentClass);
+			manifest.getMainAttributes().putValue(REDEFINE_ATTRIBUTE, VALUE_TRUE);
+			manifest.getMainAttributes().putValue(RETRANSFORM_ATTRIBUTE, VALUE_TRUE);
 		}
 		String bootVersion = getClass().getPackage().getImplementationVersion();
 		manifest.getMainAttributes().putValue(BOOT_VERSION_ATTRIBUTE, bootVersion);

--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
@@ -109,6 +109,13 @@ public class RepackageMojo extends AbstractDependencyFilterMojo {
 	private String mainClass;
 
 	/**
+	 * The name of the java agent class.
+	 * @since 1.2.1
+	 */
+	@Parameter
+	private String agentClass;
+
+	/**
 	 * The type of archive (which corresponds to how the dependencies are laid out inside
 	 * it). Possible values are JAR, WAR, ZIP, DIR, NONE. Defaults to a guess based on the
 	 * archive type.
@@ -156,6 +163,7 @@ public class RepackageMojo extends AbstractDependencyFilterMojo {
 			}
 		};
 		repackager.setMainClass(this.mainClass);
+		repackager.setAgentClass(this.agentClass);
 		if (this.layout != null) {
 			getLog().info("Layout: " + this.layout);
 			repackager.setLayout(this.layout.layout());


### PR DESCRIPTION
That will allow us to add Premain-Class into uber-jar manifest file, which simplifies including agents into Spring Boot application. With such functionality we can configure repackage tasks in Maven and Gradle plugins:
`<agentClass>my.agent.PremainClass</agentClass>` and then just execute our application by typing:
`java -javaagent:myapp.jar -jar myapp.jar`
