### PR TITLE
Update custom HealthIndicator docs

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -223,9 +223,9 @@ additional details to be displayed.
 		public Health health() {
 			int errorCode = check(); // perform some specific health check
 			if (errorCode != 0) {
-				return Health.down().withDetail("Error Code", errorCode);
+				return Health.down().withDetail("Error Code", errorCode).build();
 			}
-			return Health.up();
+			return Health.up().build();
 		}
 
 	}


### PR DESCRIPTION
The [custom health indicator documentation](http://docs.spring.io/spring-boot/docs/1.2.0.RELEASE/reference/htmlsingle/#_writing_custom_healthindicators) shows that it should be possible to simply return ```Health.up()```, but this is no longer valid since the introduction of the new ```Health.builder``` changes with 057e149

This pull request updates the documentation to use the builder rather than the old mechanism.

I've signed the CLA