### PR TITLE
Auto-configuration for SendGrid's Java client

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -151,6 +151,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.sendgrid</groupId>
+			<artifactId>sendgrid-java</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP-java6</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/sendgrid/SendGridAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/sendgrid/SendGridAutoConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.sendgrid;
+
+import com.sendgrid.SendGrid;
+import org.apache.http.HttpHost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for SendGrid
+ *
+ * @author Maciej Walkowiak
+ * @since 1.2.1
+ */
+@Configuration
+@ConditionalOnClass(SendGrid.class)
+@ConditionalOnProperty(prefix = "sendgrid", value = "username")
+@ConditionalOnMissingBean(SendGrid.class)
+@EnableConfigurationProperties(SendGridProperties.class)
+public class SendGridAutoConfiguration {
+	@Autowired
+	private SendGridProperties properties;
+	@Bean
+	public SendGrid sendGrid() {
+		SendGrid sendGrid = new SendGrid(properties.getUsername(), properties.getPassword());
+
+		if (properties.isProxyConfigured()) {
+			HttpHost proxy = new HttpHost(properties.getProxy().getHost(), properties.getProxy().getPort());
+			CloseableHttpClient http = HttpClientBuilder.create()
+					.setProxy(proxy)
+					.setUserAgent("sendgrid/" + sendGrid.getVersion() + ";java")
+					.build();
+
+			sendGrid.setClient(http);
+		}
+
+		return sendGrid;
+	}
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/sendgrid/SendGridProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/sendgrid/SendGridProperties.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.sendgrid;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * {@link ConfigurationProperties} for SendGrid.
+ *
+ * @author Maciej Walkowiak
+ * @since 1.2.1
+ */
+@ConfigurationProperties(prefix = "sendgrid")
+public class SendGridProperties {
+	/**
+	 * SendGrid username
+	 */
+	private String username;
+
+	/**
+	 * SendGrid password
+	 */
+	private String password;
+
+	/**
+	 * Proxy configuration
+	 */
+	private Proxy proxy;
+
+	public String getUsername() {
+		return username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public Proxy getProxy() {
+		return proxy;
+	}
+
+	public void setProxy(Proxy proxy) {
+		this.proxy = proxy;
+	}
+
+	public boolean isProxyConfigured() {
+		return proxy != null
+				&& proxy.getHost() != null
+				&& proxy.getPort() != null;
+	}
+
+	public static class Proxy {
+		/**
+		 * SendGrid proxy host
+		 */
+		private String host;
+
+		/**
+		 * SendGrid proxy port
+		 */
+		private Integer port;
+
+		public String getHost() {
+			return host;
+		}
+
+		public void setHost(String host) {
+			this.host = host;
+		}
+
+		public Integer getPort() {
+			return port;
+		}
+
+		public void setPort(Integer port) {
+			this.port = port;
+		}
+	}
+}

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -49,6 +49,7 @@ org.springframework.boot.autoconfigure.reactor.ReactorAutoConfiguration,\
 org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration,\
 org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration,\
 org.springframework.boot.autoconfigure.security.FallbackWebSecurityAutoConfiguration,\
+org.springframework.boot.autoconfigure.sendgrid.SendGridAutoConfiguration,\
 org.springframework.boot.autoconfigure.social.SocialWebAutoConfiguration,\
 org.springframework.boot.autoconfigure.social.FacebookAutoConfiguration,\
 org.springframework.boot.autoconfigure.social.LinkedInAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/sendgrid/SendGridAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/sendgrid/SendGridAutoConfigurationTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.sendgrid;
+
+import com.sendgrid.SendGrid;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link SendGridAutoConfiguration}.
+ *
+ * @author Maciej Walkowiak
+ */
+public class SendGridAutoConfigurationTests {
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void close() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void expectedSendGridBeanCreated() {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context, "sendgrid.username:user");
+		EnvironmentTestUtils.addEnvironment(this.context, "sendgrid.password:secret");
+		this.context.register(SendGridAutoConfiguration.class);
+		this.context.refresh();
+
+		SendGrid bean = this.context.getBean(SendGrid.class);
+		assertNotNull(bean);
+	}
+
+	@Test
+	public void autoConfigurationNotFiredWhenPropertiesNotSet() {
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(SendGridAutoConfiguration.class);
+		this.context.refresh();
+
+		try {
+			this.context.getBean(SendGrid.class);
+			fail("Unexpected bean in context of type SendGrid");
+		} catch (NoSuchBeanDefinitionException ignored) {
+		}
+	}
+
+	@Test
+	public void autoConfigurationNotFiredWhenBeanAlreadyCreated() {
+		final String username = "user";
+		final String password = "secret";
+
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context, "sendgrid.username:" + username, "sendgrid.password:" + password);
+		this.context.register(SendGridAutoConfiguration.class, ManualSendGridConfiguration.class);
+		this.context.refresh();
+
+		SendGrid bean = this.context.getBean(SendGrid.class);
+
+		assertNotEquals(username, ReflectionTestUtils.getField(bean, "username"));
+		assertNotEquals(password, ReflectionTestUtils.getField(bean, "password"));
+	}
+
+	@Test
+	public void expectedSendGridBeanWithProxyCreated() {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context, "sendgrid.username:user");
+		EnvironmentTestUtils.addEnvironment(this.context, "sendgrid.password:secret");
+		EnvironmentTestUtils.addEnvironment(this.context, "sendgrid.proxy.host:localhost");
+		EnvironmentTestUtils.addEnvironment(this.context, "sendgrid.proxy.port:5678");
+		this.context.register(SendGridAutoConfiguration.class);
+		this.context.refresh();
+
+		SendGrid bean = this.context.getBean(SendGrid.class);
+		assertNotNull(bean);
+	}
+
+	@Configuration
+	static class ManualSendGridConfiguration {
+
+		@Bean
+		SendGrid sendGrid() {
+			return new SendGrid("manual-user", "manual-secret");
+		}
+	}
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -124,6 +124,7 @@
 		<spring-social-linkedin.version>1.0.1.RELEASE</spring-social-linkedin.version>
 		<spring-social-twitter.version>1.1.0.RELEASE</spring-social-twitter.version>
 		<spring-ws.version>2.2.0.RELEASE</spring-ws.version>
+		<sendgrid.version>2.0.0</sendgrid.version>
 		<sun-mail.version>${javax-mail.version}</sun-mail.version>
 		<thymeleaf.version>2.1.4.RELEASE</thymeleaf.version>
 		<thymeleaf-extras-springsecurity3.version>2.1.1.RELEASE</thymeleaf-extras-springsecurity3.version>
@@ -482,6 +483,11 @@
 				<groupId>com.jayway.jsonpath</groupId>
 				<artifactId>json-path</artifactId>
 				<version>${json-path.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.sendgrid</groupId>
+				<artifactId>sendgrid-java</artifactId>
+				<version>${sendgrid.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.sun.mail</groupId>

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -484,6 +484,12 @@ content into your application; rather pick only the properties that you need.
 	shell.auth.simple.user.password=
 	shell.auth.spring.roles=
 
+	# SENDGRID ({sc-spring-boot-autoconfigure}/sendgrid/SendGridAutoConfiguration.{sc-ext}[SendGridAutoConfiguration])
+	sendgrid.username= # sendgrid account username
+	sendgrid.password= # sendgrid account password
+	sendgrid.proxy.host=
+	sendgrid.proxy.port
+
 	# GIT INFO
 	spring.git.properties= # resource ref to generated git info properties file
 ----

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -488,7 +488,7 @@ content into your application; rather pick only the properties that you need.
 	sendgrid.username= # sendgrid account username
 	sendgrid.password= # sendgrid account password
 	sendgrid.proxy.host=
-	sendgrid.proxy.port
+	sendgrid.proxy.port=
 
 	# GIT INFO
 	spring.git.properties= # resource ref to generated git info properties file

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -55,6 +55,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.sendgrid</groupId>
+			<artifactId>sendgrid-java</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<optional>true</optional>


### PR DESCRIPTION
Pull for #2160. **SendGrid** gets auto-configured if:

- `com.sendgrid.SendGrid` is on classpath
- property: `sendgrid.username` is defined
- additionally auto-configures proxy when `sendgrid.proxy.host` and `sendgrid.proxy.port` is defined

**Documentation** - only *Appendix A. Common application properties* section has been updated with new properties.

**Unit tests** - testing proxy creation could be improved if I could set up some mock HTTP server (for example with [Jadler](https://github.com/jadler-mocking/jadler/wiki)) and see if there are requests coming in. At the moment there is a check if `SendGrid` bean is created but there is no really a way to check if it's created with proxy or not.