### PR TITLE
Make exception trying to read file from 'CLASSPATH' non-fatal.

### DIFF
--- a/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessor.java
+++ b/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessor.java
@@ -16,9 +16,10 @@
 
 package org.springframework.boot.configurationprocessor;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -105,6 +106,16 @@ public class ConfigurationMetadataAnnotationProcessor extends AbstractProcessor 
 			logWarning("Field value processing of @ConfigurationProperty meta-data is "
 					+ "not supported");
 		}
+	}
+	
+	private void logError(Throwable e) {
+		this.processingEnv.getMessager().printMessage(Kind.ERROR, stackTrace(e));
+	}
+	
+	private CharSequence stackTrace(Throwable e) {
+		StringWriter trace = new StringWriter();
+		e.printStackTrace(new PrintWriter(trace, true));
+		return trace.toString();
 	}
 
 	private void logWarning(String msg) {
@@ -365,7 +376,8 @@ public class ConfigurationMetadataAnnotationProcessor extends AbstractProcessor 
 				inputStream.close();
 			}
 		}
-		catch (IOException ex) {
+		catch (Exception ex) {
+			logError(ex);
 			return metadata;
 		}
 	}


### PR DESCRIPTION
This change makes it so the exception thrown when trying to read 'additional metadata' file from location 'CLASSPATH' is logged instead of crashing the build.

I am not really sure about this, but I feel like maybe trying to read the json metadata file from 'CLASSPATH' is a bit iffy. I would expect there to possibly to be more than one such file on the classpath and so its not quite clear to me what it means to read 'the' file. 

So rather than catching and logging the exception, perhaps a proper fix should avoid trying to reading this file from location 'CLASSPATH' in the first place.

