### PR TITLE
Add a SpringBootVersion class like SpringVersion

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/SpringBootVersion.java
+++ b/spring-boot/src/main/java/org/springframework/boot/SpringBootVersion.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot;
+
+/**
+ * Class that exposes the Spring Boot version. Fetches the "Implementation-Version"
+ * manifest attribute from the jar file.
+ *
+ * <p>
+ * Note that some ClassLoaders do not expose the package metadata, hence this class might
+ * not be able to determine the Spring Boot version in all environments. Consider using a
+ * reflection-based check instead: For example, checking for the presence of a specific
+ * Spring Boot method that you intend to call.
+ */
+public class SpringBootVersion {
+
+	/**
+	 * Return the full version string of the present Spring Boot codebase, or {@code null}
+	 * if it cannot be determined.
+	 * @see Package#getImplementationVersion()
+	 */
+	public static String getBootVersion() {
+		Package pkg = SpringApplication.class.getPackage();
+		return pkg != null ? pkg.getImplementationVersion() : null;
+	}
+
+}


### PR DESCRIPTION
Provides a static utility method to get the Spring Boot version based on the implementation version of `SpringApplication`'s package . It is similar to @jhoeller's [SpringVersion](spring-framework/spring-core/src/main/java/org/springframework/core/SpringVersion.java) class and `getVersion()` method except specifically for Spring Boot. Javadoc taken pretty much verbatim due to similarity.