### PR TITLE
Fix for empty datasource-name in metrics

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/DataSourcePublicMetrics.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/DataSourcePublicMetrics.java
@@ -102,7 +102,8 @@ public class DataSourcePublicMetrics implements PublicMetrics {
 		if (primary) {
 			return "datasource.primary";
 		}
-		if (name.toLowerCase().endsWith(DATASOURCE_SUFFIX.toLowerCase())) {
+		if (name.length() > DATASOURCE_SUFFIX.length()
+				&& name.toLowerCase().endsWith(DATASOURCE_SUFFIX.toLowerCase())) {
 			name = name.substring(0, name.length() - DATASOURCE_SUFFIX.length());
 		}
 		return "datasource." + name;


### PR DESCRIPTION
If there is more than one DataSource and the non-primary bean-name is 'datasource' an incorrect metric name is chosen.
The metrics are named datasource.active and not datasource.xxx.active (as stated in the docs).
To avoid this, the shortening of the bean-name only occurs if the bean-name is longer than 'datasource' and will be shown as datasource.datasource.active (though this looks a bit ugly).

CLA is 93620140928055712