### PR TITLE
Disable Accept-Charset Header in String converter

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/HttpMessageConvertersAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/HttpMessageConvertersAutoConfiguration.java
@@ -144,7 +144,9 @@ public class HttpMessageConvertersAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		public StringHttpMessageConverter stringHttpMessageConverter() {
-			return new StringHttpMessageConverter(this.encodingProperties.getCharset());
+			StringHttpMessageConverter converter = new StringHttpMessageConverter(this.encodingProperties.getCharset());
+			converter.setWriteAcceptCharset(false);
+			return converter;
 		}
 
 	}


### PR DESCRIPTION
This commit prevents the `Accept-Charset` from being written by the
StringHttpMessageConverter. This feature is enabled by default in the
framework and writes a *quite long* response header with all charsets
supported by the server.

Note: I didn't introduce a new key in HttpEncodingProperties,
since this feature IMO would just add noise and confuse developers.

Ping @snicoll who found out about this issue first.