### PR TITLE
Allow to configure stack trace addition to Model via properties

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/StackTracePolicy.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/StackTracePolicy.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.autoconfigure.web;
 
 /**

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/StackTracePolicy.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/StackTracePolicy.java
@@ -1,0 +1,25 @@
+package org.springframework.boot.autoconfigure.web;
+
+/**
+ * An Enumeration of stacktrace policies for the {@link ErrorController} to
+ * determine whether to add stacktrace information to the model or not
+ *
+ * @author Michael Stummvoll
+ */
+public enum StackTracePolicy {
+	/**
+	 * Always add stacktrace information to the model
+	 */
+	ALWAYS,
+
+	/**
+	 * Never add stacktrace information to the model
+	 */
+	NEVER,
+
+	/**
+	 * Add stacktrace information to the model depending on the "trace" request
+	 * parameter
+	 */
+	REQUEST
+}


### PR DESCRIPTION
Hi,

the logic to add the stacktrace to the model in case of errors is currently the following:

- If the response is HTML, don't add a stack trace
- else add the stack trace, if the request contains the parameter trace

I would like to improve this because of two reasons:

- In development environment you may want to add stacktrace information to both, html and non-html-models
- In production you may want to remove the ability of exposing stacktraces completly, even for non-html-responses

So I made the behavior configurable via two new properties, error.trace and error.trace.html, which can either be `ALWAYS`, `NEVER` or `REQUEST`. I preserved the current behavior as sensible default.

Please review and consider merging the PR.

Thanks,
Michael