### PR TITLE
Upgrade Spring Cloud Connectors to 1.1.1.RELEASE

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -113,7 +113,7 @@
 		<spock.version>0.7-groovy-2.0</spock.version>
 		<spring.version>4.1.4.RELEASE</spring.version>
 		<spring-amqp.version>1.4.2.RELEASE</spring-amqp.version>
-		<spring-cloud-connectors.version>1.1.0.RELEASE</spring-cloud-connectors.version>
+		<spring-cloud-connectors.version>1.1.1.RELEASE</spring-cloud-connectors.version>
 		<spring-batch.version>3.0.2.RELEASE</spring-batch.version>
 		<spring-data-releasetrain.version>Evans-SR1</spring-data-releasetrain.version>
 		<spring-hateoas.version>0.16.0.RELEASE</spring-hateoas.version>


### PR DESCRIPTION
We released SCC 1.1.1.RELEASE last night