### PR TITLE
Use servlet path for static welcome pages

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
@@ -151,7 +151,7 @@ public class WebMvcAutoConfiguration {
 		@Autowired
 		private WebMvcProperties mvcProperties = new WebMvcProperties();
 
-		@Autowired
+		@Autowired(required = false)
 		private ServerProperties serverProperties = new ServerProperties();
 
 		@Autowired

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
@@ -145,14 +145,14 @@ public class WebMvcAutoConfiguration {
 		@Value("${spring.view.suffix:}")
 		private String suffix = "";
 
-		@Value("${server.servlet-path:}")
-		private String servletPath = "";
-
 		@Autowired
 		private ResourceProperties resourceProperties = new ResourceProperties();
 
 		@Autowired
 		private WebMvcProperties mvcProperties = new WebMvcProperties();
+
+		@Autowired
+		private ServerProperties serverProperties = new ServerProperties();
 
 		@Autowired
 		private ListableBeanFactory beanFactory;
@@ -284,32 +284,13 @@ public class WebMvcAutoConfiguration {
 						// Ignore
 					}
 					// Use forward: prefix so that no view resolution is done
-					String viewName;
-
-					if (StringUtils.isEmpty(servletPath)) {
-						viewName = "forward:/index.html";
-					}
-					else {
-						servletPath = stripServletPath(servletPath);
-						logger.debug("Use servlet path for welcome path: " + servletPath);
-						viewName = "forward:" + servletPath + "/index.html";
-						registry.addViewController("").setViewName(viewName);
-					}
+					String viewName = "forward:" + serverProperties.getServletPrefix()
+							+ "/index.html";
 
 					registry.addViewController("/").setViewName(viewName);
 					return;
 				}
 			}
-		}
-
-		private String stripServletPath(String servletPath) {
-
-			int end = servletPath.length();
-
-			while (end != 0 && "/*".indexOf(servletPath.charAt(end - 1)) != -1) {
-				end--;
-			}
-			return servletPath.substring(0, end);
 		}
 
 		@Configuration

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
@@ -145,6 +145,9 @@ public class WebMvcAutoConfiguration {
 		@Value("${spring.view.suffix:}")
 		private String suffix = "";
 
+		@Value("${server.servlet-path:}")
+		private String servletPath = "";
+
 		@Autowired
 		private ResourceProperties resourceProperties = new ResourceProperties();
 
@@ -281,10 +284,32 @@ public class WebMvcAutoConfiguration {
 						// Ignore
 					}
 					// Use forward: prefix so that no view resolution is done
-					registry.addViewController("/").setViewName("forward:/index.html");
+					String viewName;
+
+					if (StringUtils.isEmpty(servletPath)) {
+						viewName = "forward:/index.html";
+					}
+					else {
+						servletPath = stripServletPath(servletPath);
+						logger.debug("Use servlet path for welcome path: " + servletPath);
+						viewName = "forward:" + servletPath + "/index.html";
+						registry.addViewController("").setViewName(viewName);
+					}
+
+					registry.addViewController("/").setViewName(viewName);
 					return;
 				}
 			}
+		}
+
+		private String stripServletPath(String servletPath) {
+
+			int end = servletPath.length();
+
+			while (end != 0 && "/*".indexOf(servletPath.charAt(end - 1)) != -1) {
+				end--;
+			}
+			return servletPath.substring(0, end);
 		}
 
 		@Configuration


### PR DESCRIPTION
This is a first suggestion to use the servlet path when registering the view controllers for the static welcome pages.

Example:

In application.properties:
server.servlet-path=/test

Calls to http://localhost:8080/test/ now work, but calls to http://localhost:8080/test still get a 404 (i'm still working on that).

CLA is signed.

fixes gh-2351