### PR TITLE
Provide dependency management for `nekohtml`.

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -103,6 +103,7 @@
 		<mockito.version>1.10.19</mockito.version>
 		<mongodb.version>2.12.5</mongodb.version>
 		<mysql.version>5.1.34</mysql.version>
+		<nekohtml.version>1.9.21</nekohtml.version>
 		<reactor.version>1.1.5.RELEASE</reactor.version>
 		<reactor-spring.version>1.1.3.RELEASE</reactor-spring.version>
 		<servlet-api.version>3.1.0</servlet-api.version>
@@ -569,6 +570,11 @@
 				<groupId>commons-pool</groupId>
 				<artifactId>commons-pool</artifactId>
 				<version>${commons-pool.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>net.sourceforge.nekohtml</groupId>
+				<artifactId>nekohtml</artifactId>
+				<version>${nekohtml.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
To use `LEGACYHTML5` mode in Thymeleaf,

`nekohtml` is necessary.

It would be good to provide dependency management for `nekohtml`.