### PR TITLE
Fix broken link in docs

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -113,7 +113,7 @@ content into your application; rather pick only the properties that you need.
 	# HTTP message conversion
 	spring.http.converters.preferred-json-mapper= # the preferred JSON mapper to use for HTTP message conversion. Set to "gson" to force the use of Gson when both it and Jackson are on the classpath.
 
-	# HTTP response compression ({sc-spring-boot-autoconfigure/web/GzipFilterProperties.{sc-ext}[GzipFilterProperties])
+	# HTTP response compression ({sc-spring-boot-autoconfigure}/web/GzipFilterProperties.{sc-ext}[GzipFilterProperties])
 	spring.http.gzip.bufferSize= # size of the output buffer in bytes
 	spring.http.gzip.minGzipSize= # minimum content length required for compression to occur
 	spring.http.gzip.deflateCompressionLevel= # the level used for deflate compression (0-9)


### PR DESCRIPTION
Fixes a small broken link in reference docs.

I've signed the CLA

![doc-link](https://cloud.githubusercontent.com/assets/4712580/6547834/7004340a-c5a1-11e4-80a3-808a4c881bf6.png)
