### PR TITLE
loader tools: fix NONE layout (no launcher class, no libraries)

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Layouts.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Layouts.java
@@ -30,6 +30,7 @@ import java.util.Set;
  * @author Phillip Webb
  * @author Dave Syer
  * @author Andy Wilkinson
+ * @author Patrik Beno
  */
 public class Layouts {
 
@@ -96,14 +97,24 @@ public class Layouts {
 	/**
 	 * No layout.
 	 */
-	public static class None extends Jar {
+	public static class None implements Layout {
 
 		@Override
 		public String getLauncherClassName() {
 			return null;
 		}
 
-		@Override
+        @Override
+        public String getLibraryDestination(String libraryName, LibraryScope scope) {
+            return null;
+        }
+
+        @Override
+        public String getClassesLocation() {
+            return "";
+        }
+
+        @Override
 		public boolean isExecutable() {
 			return false;
 		}


### PR DESCRIPTION
Existing NONE Spring Boot layout is an extension of JAR layout and as such it includes all the dependencies in lib/ folder. This is wrong. NONE layout should be empty. Nothing. Void. 

For context, see https://github.com/patrikbeno/spring-boot/wiki/Requirements