### PR TITLE
plugins: support for overriding layout-provided launcher class

### DIFF
--- a/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/SpringBootPluginExtension.groovy
+++ b/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/SpringBootPluginExtension.groovy
@@ -59,6 +59,11 @@ public class SpringBootPluginExtension {
 		}
 	}
 
+    /**
+     * Launcher class, replaces the default specified by layout. Optional.
+     */
+    String launcherClass;
+
 	/**
 	 * The main class that should be run. Instead of setting this explicitly you can use the
 	 * 'mainClassName' of the project or the 'main' of the 'run' task. If not specified the

--- a/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/repackage/RepackageTask.java
+++ b/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/repackage/RepackageTask.java
@@ -165,6 +165,7 @@ public class RepackageTask extends DefaultTask {
 			}
 			Repackager repackager = new LoggingRepackager(file);
 			setMainClass(repackager);
+			setLauncherClass(repackager);
 			if (this.extension.convertLayout() != null) {
 				repackager.setLayout(this.extension.convertLayout());
 			}
@@ -200,6 +201,12 @@ public class RepackageTask extends DefaultTask {
 			}
 			getLogger().info("Setting mainClass: " + mainClass);
 			repackager.setMainClass(mainClass);
+		}
+
+		private void setLauncherClass(Repackager repackager) {
+			String launcherClass = extension.getLauncherClass();
+			getLogger().info("Setting mainClass: " + launcherClass);
+			repackager.setLauncherClass(launcherClass);
 		}
 	}
 

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Repackager.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Repackager.java
@@ -42,6 +42,8 @@ public class Repackager {
 
 	private static final byte[] ZIP_FILE_HEADER = new byte[] { 'P', 'K', 3, 4 };
 
+	private String launcherClass;
+
 	private String mainClass;
 
 	private boolean backupSource = true;
@@ -56,6 +58,10 @@ public class Repackager {
 		}
 		this.source = source.getAbsoluteFile();
 		this.layout = Layouts.forFile(source);
+	}
+
+	public void setLauncherClass(String launcherClass) {
+		this.launcherClass = launcherClass;
 	}
 
 	/**
@@ -229,7 +235,9 @@ public class Repackager {
 		if (startClass == null) {
 			startClass = findMainMethod(source);
 		}
-		String launcherClassName = this.layout.getLauncherClassName();
+		String launcherClassName = (launcherClass != null)
+				? launcherClass
+				: layout.getLauncherClassName();
 		if (launcherClassName != null) {
 			manifest.getMainAttributes()
 					.putValue(MAIN_CLASS_ATTRIBUTE, launcherClassName);

--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
@@ -101,6 +101,12 @@ public class RepackageMojo extends AbstractDependencyFilterMojo {
 	private String classifier;
 
 	/**
+	 * Name of the launcher class; overrides the one specified by layout.
+	 */
+	@Parameter
+	private String launcherClass;
+
+	/**
 	 * The name of the main class. If not specified the first compiled class found that
 	 * contains a 'main' method will be used.
 	 * @since 1.0
@@ -156,6 +162,7 @@ public class RepackageMojo extends AbstractDependencyFilterMojo {
 			}
 		};
 		repackager.setMainClass(this.mainClass);
+		repackager.setLauncherClass(this.launcherClass);
 		if (this.layout != null) {
 			getLog().info("Layout: " + this.layout);
 			repackager.setLayout(this.layout.layout());


### PR DESCRIPTION
Spring Boot plugins "hijack" application's manifest by redirecting Main-Class attribute to a layout-provided launcher class and embedding some core Spring Boot Loader classes. Original Main-Class attribute is copied to Start-Class attribute which is handled by loader.

The problem is, you might need to customize default launcher behavior, but the plugins do not provide any means.

For wider context, see https://github.com/patrikbeno/spring-boot/wiki/Requirements