### PR TITLE
Repackager: pluggable layouts

### DIFF
--- a/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/SpringBootPluginExtension.groovy
+++ b/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/SpringBootPluginExtension.groovy
@@ -41,27 +41,6 @@ import org.springframework.boot.loader.tools.Layouts
  */
 public class SpringBootPluginExtension {
 
-	enum LayoutType {
-
-		JAR(new Layouts.Jar()),
-
-		WAR(new Layouts.War()),
-
-		ZIP(new Layouts.Expanded()),
-
-		DIR(new Layouts.Expanded()),
-
-		MODULE(new Layouts.Module()),
-
-		NONE(new Layouts.None());
-
-		Layout layout;
-
-		private LayoutType(Layout layout) {
-			this.layout = layout;
-		}
-	}
-
 	/**
 	 * The main class that should be run. Instead of setting this explicitly you can use the
 	 * 'mainClassName' of the project or the 'main' of the 'run' task. If not specified the
@@ -102,14 +81,14 @@ public class SpringBootPluginExtension {
 	 * PropertiesLauncher. Gradle will coerce literal String values to the
 	 * correct type.
 	 */
-	LayoutType layout;
+	String layout;
 
 	/**
 	 * Convenience method for use in a custom task.
 	 * @return the Layout to use or null if not explicitly set
 	 */
 	Layout convertLayout() {
-		(layout == null ? null : layout.layout)
+        Layouts.resolve(layout)
 	}
 
 	/**

--- a/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/SpringBootPluginExtension.groovy
+++ b/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/SpringBootPluginExtension.groovy
@@ -41,7 +41,12 @@ import org.springframework.boot.loader.tools.Layouts
  */
 public class SpringBootPluginExtension {
 
-	/**
+    /**
+     * Launcher class, replaces the default specified by layout. Optional.
+     */
+    String launcherClass;
+
+    /**
 	 * The main class that should be run. Instead of setting this explicitly you can use the
 	 * 'mainClassName' of the project or the 'main' of the 'run' task. If not specified the
 	 * value from the MANIFEST will be used, or if no manifest entry is the archive will be

--- a/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/SpringBootPluginExtension.groovy
+++ b/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/SpringBootPluginExtension.groovy
@@ -41,12 +41,12 @@ import org.springframework.boot.loader.tools.Layouts
  */
 public class SpringBootPluginExtension {
 
-    /**
-     * Launcher class, replaces the default specified by layout. Optional.
-     */
-    String launcherClass;
+	/**
+	 * Launcher class, replaces the default specified by layout. Optional.
+	 */
+	String launcherClass;
 
-    /**
+	/**
 	 * The main class that should be run. Instead of setting this explicitly you can use the
 	 * 'mainClassName' of the project or the 'main' of the 'run' task. If not specified the
 	 * value from the MANIFEST will be used, or if no manifest entry is the archive will be

--- a/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/repackage/RepackageTask.java
+++ b/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/repackage/RepackageTask.java
@@ -174,6 +174,7 @@ public class RepackageTask extends DefaultTask {
 			}
 			Repackager repackager = new LoggingRepackager(file);
 			setMainClass(repackager);
+			repackager.setLauncherClass(this.extension.getLauncherClass());
 			repackager.setLayout(this.extension.convertLayout());
 			repackager.setBackupSource(this.extension.isBackupSource());
 			try {

--- a/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/repackage/RepackageTask.java
+++ b/spring-boot-tools/spring-boot-gradle-plugin/src/main/groovy/org/springframework/boot/gradle/repackage/RepackageTask.java
@@ -32,6 +32,7 @@ import org.gradle.api.tasks.bundling.Jar;
 import org.springframework.boot.gradle.SpringBootPluginExtension;
 import org.springframework.boot.loader.tools.DefaultLaunchScript;
 import org.springframework.boot.loader.tools.LaunchScript;
+import org.springframework.boot.loader.tools.Layout;
 import org.springframework.boot.loader.tools.Repackager;
 import org.springframework.util.FileCopyUtils;
 
@@ -173,9 +174,7 @@ public class RepackageTask extends DefaultTask {
 			}
 			Repackager repackager = new LoggingRepackager(file);
 			setMainClass(repackager);
-			if (this.extension.convertLayout() != null) {
-				repackager.setLayout(this.extension.convertLayout());
-			}
+			repackager.setLayout(this.extension.convertLayout());
 			repackager.setBackupSource(this.extension.isBackupSource());
 			try {
 				LaunchScript launchScript = getLaunchScript();

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Layouts.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Layouts.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.loader.tools;
 
+import org.springframework.boot.loader.tools.layout.BaseLayout;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
@@ -155,6 +157,11 @@ public class Layouts {
 		}
 
 	}
+
+	/**
+	 * This is what NONE should be.
+	 */
+	public static class Null extends BaseLayout {}
 
 	/**
 	 * Executable WAR layout.

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Layouts.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Layouts.java
@@ -33,6 +33,36 @@ import java.util.Set;
  */
 public class Layouts {
 
+	static private Class<? extends Layout> defaultLayout = Layouts.Jar.class;
+
+	static private Map<String, Class<?>> map = new HashMap<String, Class<?>>() {{
+		for (Class<?> cls : Layouts.class.getClasses()) {
+			if (Layout.class.isAssignableFrom(cls)) {
+				put(toSimpleLayoutName(cls), (Class) cls);
+			}
+		}
+	}};
+
+	static public Layout resolve(String name) throws RuntimeException {
+		try {
+			Class<?> cls = null;
+			if (cls == null) { cls = map.get(name); };
+			if (cls == null) { cls = Class.forName(name); }
+			if (cls == null) { cls = defaultLayout; }
+			return (Layout) cls.newInstance();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(String.format(
+					"Cannot resolve layout `%s`. Provide a fully qualified class name or of the following: %s",
+					name, map.keySet()
+			), e);
+		}
+	}
+
+	static private String toSimpleLayoutName(Class<?> cls) {
+		return cls.getSimpleName().toUpperCase();
+	}
+
 	/**
 	 * Return the a layout for the given source file.
 	 * @param file the source file
@@ -90,8 +120,11 @@ public class Layouts {
 		public String getLauncherClassName() {
 			return "org.springframework.boot.loader.PropertiesLauncher";
 		}
-
 	}
+
+	public static class Zip extends Expanded {}
+
+	public static class Dir extends Expanded {}
 
 	/**
 	 * No layout.

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Layouts.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Layouts.java
@@ -43,17 +43,30 @@ public class Layouts {
 		}
 	}};
 
+	/**
+	 * Resolves and instantiates named layout.
+	 * If name is undefined, default layout is returned (JAR).
+	 * If given name refers to one of the layout aliases (JAR, ZIP, etc), it is returned.
+	 * Otherwise, assume layout name is an actual class name, and try to load it.
+	 * @param name
+	 * @return
+	 * @throws RuntimeException
+	 */
 	static public Layout resolve(String name) throws RuntimeException {
 		try {
+			if (name == null) { return defaultLayout.newInstance(); }
+
 			Class<?> cls = null;
-			if (cls == null) { cls = map.get(name); };
+			if (cls == null) { cls = map.get(name); }
 			if (cls == null) { cls = Class.forName(name); }
-			if (cls == null) { cls = defaultLayout; }
+
 			return (Layout) cls.newInstance();
 		}
 		catch (Exception e) {
 			throw new RuntimeException(String.format(
-					"Cannot resolve layout `%s`. Provide a fully qualified class name or of the following: %s",
+					"Cannot resolve layout `%s`. " +
+					"Provide a fully qualified name of the class implementing Layout interface, " +
+					"or one of the following: %s",
 					name, map.keySet()
 			), e);
 		}

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Repackager.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Repackager.java
@@ -44,6 +44,8 @@ public class Repackager {
 
 	private static final byte[] ZIP_FILE_HEADER = new byte[] { 'P', 'K', 3, 4 };
 
+	private String launcherClass;
+
 	private String mainClass;
 
 	private boolean backupSource = true;
@@ -58,6 +60,10 @@ public class Repackager {
 		}
 		this.source = source.getAbsoluteFile();
 		this.layout = Layouts.forFile(source);
+	}
+
+	public void setLauncherClass(String launcherClass) {
+		this.launcherClass = launcherClass;
 	}
 
 	/**
@@ -258,7 +264,9 @@ public class Repackager {
 		if (startClass == null) {
 			startClass = findMainMethod(source);
 		}
-		String launcherClassName = this.layout.getLauncherClassName();
+		String launcherClassName = (launcherClass != null)
+				? launcherClass
+				: layout.getLauncherClassName();
 		if (launcherClassName != null) {
 			manifest.getMainAttributes()
 					.putValue(MAIN_CLASS_ATTRIBUTE, launcherClassName);

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/layout/BaseLayout.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/layout/BaseLayout.java
@@ -1,0 +1,29 @@
+package org.springframework.boot.loader.tools.layout;
+
+import org.springframework.boot.loader.tools.Layout;
+import org.springframework.boot.loader.tools.LibraryScope;
+
+/**
+ * @author <a href="mailto:patrikbeno@gmail.com">Patrik Beno</a>
+ */
+public class BaseLayout implements Layout {
+	@Override
+	public String getLauncherClassName() {
+		return null;
+	}
+
+	@Override
+	public String getLibraryDestination(String libraryName, LibraryScope scope) {
+		return null;
+	}
+
+	@Override
+	public String getClassesLocation() {
+		return "";
+	}
+
+	@Override
+	public boolean isExecutable() {
+		return false;
+	}
+}

--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
@@ -118,7 +118,7 @@ public class RepackageMojo extends AbstractDependencyFilterMojo {
 	 * @since 1.0
 	 */
 	@Parameter
-	private LayoutType layout;
+	private String layout;
 
 	/**
 	 * A list of the libraries that must be unpacked from fat jars in order to run.
@@ -182,10 +182,9 @@ public class RepackageMojo extends AbstractDependencyFilterMojo {
 			}
 		};
 		repackager.setMainClass(this.mainClass);
-		if (this.layout != null) {
-			getLog().info("Layout: " + this.layout);
-			repackager.setLayout(this.layout.layout());
-		}
+
+		getLog().info("Layout: " + this.layout);
+		repackager.setLayout(Layouts.resolve(this.layout));
 
 		Set<Artifact> artifacts = filterDependencies(this.project.getArtifacts(),
 				getFilters());

--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
@@ -104,6 +104,12 @@ public class RepackageMojo extends AbstractDependencyFilterMojo {
 	private String classifier;
 
 	/**
+	 * Name of the launcher class; overrides the one specified by layout.
+	 */
+	@Parameter
+	private String launcherClass;
+
+	/**
 	 * The name of the main class. If not specified the first compiled class found that
 	 * contains a 'main' method will be used.
 	 * @since 1.0
@@ -182,6 +188,7 @@ public class RepackageMojo extends AbstractDependencyFilterMojo {
 			}
 		};
 		repackager.setMainClass(this.mainClass);
+		repackager.setLauncherClass(this.launcherClass);
 
 		getLog().info("Layout: " + this.layout);
 		repackager.setLayout(Layouts.resolve(this.layout));


### PR DESCRIPTION
Repackager: layouts refactoring. Layouts are now pluggable: specify fully qualified name of the class implementing the Layout interface, or use known legacy aliases (JAR, ZIP, DIR, ...)

This effectivelly obsoletes #2619 and #2620.

Thanks @philwebb for idea.

This is initial draft. Submitting early because of those obsoleted requests that are being reviewed.
