### PR TITLE
Allow to set/fix ContentType and Charset for the Mustache template engine

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheAutoConfiguration.java
@@ -107,6 +107,7 @@ public class MustacheAutoConfiguration {
 			resolver.setSuffix(this.mustache.getSuffix());
 			resolver.setCache(this.mustache.isCache());
 			resolver.setViewNames(this.mustache.getViewNames());
+                        resolver.setCharset(this.mustache.getCharset());
 			resolver.setContentType(this.mustache.getContentType());
 			resolver.setCompiler(mustacheCompiler);
 			resolver.setOrder(Ordered.LOWEST_PRECEDENCE - 10);

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/web/MustacheView.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/web/MustacheView.java
@@ -34,11 +34,7 @@ import com.samskivert.mustache.Template;
  */
 public class MustacheView extends AbstractTemplateView {
 
-	private final Template template;
-
-	public MustacheView(Template template) {
-		this.template = template;
-	}
+	private Template template;
 
 	@Override
 	protected void renderMergedTemplateModel(Map<String, Object> model,
@@ -46,4 +42,7 @@ public class MustacheView extends AbstractTemplateView {
 		this.template.execute(model, response.getWriter());
 	}
 
+        public void setTemplate(Template template) {
+            this.template = template;
+        }
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/web/MustacheViewResolver.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/web/MustacheViewResolver.java
@@ -18,6 +18,7 @@ package org.springframework.boot.autoconfigure.mustache.web;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.Locale;
 
 import org.springframework.beans.propertyeditors.LocaleEditor;
@@ -39,8 +40,9 @@ import com.samskivert.mustache.Template;
 public class MustacheViewResolver extends UrlBasedViewResolver {
 
 	private Compiler compiler = Mustache.compiler();
+        private String charset = "UTF-8"; // default charset ?
 
-	public MustacheViewResolver() {
+        public MustacheViewResolver() {
 		setViewClass(MustacheView.class);
 	}
 
@@ -51,20 +53,30 @@ public class MustacheViewResolver extends UrlBasedViewResolver {
 		this.compiler = compiler;
 	}
 
+        /**
+         *
+         * @param charset the charset to set. Used for reading resources files
+         */
+        public void setCharset(String charset) {
+            this.charset = charset;
+        }
+
 	@Override
 	protected View loadView(String viewName, Locale locale) throws Exception {
 		Resource resource = resolveResource(viewName, locale);
 		if (resource == null) {
 			return null;
 		}
-		MustacheView view = new MustacheView(createTemplate(resource));
+
+		MustacheView view = (MustacheView) buildView(viewName);
+                view.setTemplate(createTemplate(resource));
 		view.setApplicationContext(getApplicationContext());
 		view.setServletContext(getServletContext());
 		return view;
 	}
 
 	private Template createTemplate(Resource resource) throws IOException {
-		return this.compiler.compile(new InputStreamReader(resource.getInputStream()));
+		return this.compiler.compile(new InputStreamReader(resource.getInputStream(), Charset.forName(charset)));
 	}
 
 	private Resource resolveResource(String viewName, Locale locale) {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mustache/MustacheViewResolverTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mustache/MustacheViewResolverTests.java
@@ -42,6 +42,7 @@ public class MustacheViewResolverTests {
 		this.resolver.setServletContext(new MockServletContext());
 		this.resolver.setPrefix("classpath:/mustache-templates/");
 		this.resolver.setSuffix(".html");
+                this.resolver.setCharset("UTF-8");
 	}
 
 	@Test

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mustache/MustacheViewTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mustache/MustacheViewTests.java
@@ -56,8 +56,9 @@ public class MustacheViewTests {
 
 	@Test
 	public void viewResolvesHandlebars() throws Exception {
-		MustacheView view = new MustacheView(Mustache.compiler().compile("Hello {{msg}}"));
-		view.setApplicationContext(this.context);
+		MustacheView view = new MustacheView();
+                view.setTemplate(Mustache.compiler().compile("Hello {{msg}}"));
+                view.setApplicationContext(this.context);
 		view.render(Collections.singletonMap("msg", "World"), this.request, this.response);
 		assertEquals("Hello World", this.response.getContentAsString());
 	}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mustache/MustacheWebIntegrationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mustache/MustacheWebIntegrationTests.java
@@ -135,6 +135,7 @@ public class MustacheWebIntegrationTests {
 			MustacheViewResolver resolver = new MustacheViewResolver();
 			resolver.setPrefix("classpath:/mustache-templates/");
 			resolver.setSuffix(".html");
+                        resolver.setCharset("UTF-8");
 			resolver.setCompiler(Mustache.compiler().withLoader(
 					new MustacheResourceTemplateLoader("classpath:/mustache-templates/",
 							".html")));


### PR DESCRIPTION
- the contentType parameter is now setted into the MustacheView (and then used)
- the charset is used to read template, otherwise unicode characters are not correctly managed.