### PR TITLE
Allow custom repo-locations for InstallCommand

### DIFF
--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/install/InstallCommand.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/install/InstallCommand.java
@@ -18,6 +18,7 @@ package org.springframework.boot.cli.command.install;
 import java.util.List;
 
 import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
 
 import org.springframework.boot.cli.command.Command;
 import org.springframework.boot.cli.command.OptionParsingCommand;
@@ -47,6 +48,16 @@ public class InstallCommand extends OptionParsingCommand {
 
 	private static final class InstallOptionHandler extends CompilerOptionHandler {
 
+		private OptionSpec<String> remoteRepositories;
+
+		@Override
+		protected void doOptions() {
+			this.remoteRepositories = option("remoteRepositories",
+					"Repositories in the format id::url, separated by comma")
+					.withRequiredArg().withValuesSeparatedBy(',');
+
+		}
+
 		@Override
 		@SuppressWarnings("unchecked")
 		protected ExitStatus run(OptionSet options) throws Exception {
@@ -54,7 +65,8 @@ public class InstallCommand extends OptionParsingCommand {
 			Assert.notEmpty(args, "Please specify at least one "
 					+ "dependency, in the form group:artifact:version, to install");
 			try {
-				new Installer(options, this).install(args);
+				new Installer(options, this, this.remoteRepositories.values(options))
+						.install(args);
 			}
 			catch (Exception ex) {
 				String message = ex.getMessage();

--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/install/Installer.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/install/Installer.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
@@ -48,8 +49,13 @@ class Installer {
 
 	public Installer(OptionSet options, CompilerOptionHandler compilerOptionHandler)
 			throws IOException {
+		this(options, compilerOptionHandler, Collections.<String> emptyList());
+	}
+
+	public Installer(OptionSet options, CompilerOptionHandler compilerOptionHandler,
+			List<String> remoteRepositories) throws IOException {
 		this(new GroovyGrabDependencyResolver(createCompilerConfiguration(options,
-				compilerOptionHandler)));
+				compilerOptionHandler, remoteRepositories)));
 	}
 
 	public Installer(DependencyResolver resolver) throws IOException {
@@ -58,9 +64,10 @@ class Installer {
 	}
 
 	private static GroovyCompilerConfiguration createCompilerConfiguration(
-			OptionSet options, CompilerOptionHandler compilerOptionHandler) {
-		List<RepositoryConfiguration> repositoryConfiguration = RepositoryConfigurationFactory
-				.createDefaultRepositoryConfiguration();
+			OptionSet options, CompilerOptionHandler compilerOptionHandler,
+			List<String> remoteRepositories) {
+
+		List<RepositoryConfiguration> repositoryConfiguration = createRepositoryConfiguration(remoteRepositories);
 		return new OptionSetGroovyCompilerConfiguration(options, compilerOptionHandler,
 				repositoryConfiguration) {
 			@Override
@@ -68,6 +75,17 @@ class Installer {
 				return false;
 			}
 		};
+	}
+
+	private static List<RepositoryConfiguration> createRepositoryConfiguration(
+			List<String> remoteRepositories) {
+		if (remoteRepositories.isEmpty()) {
+			return RepositoryConfigurationFactory.createDefaultRepositoryConfiguration();
+		}
+		else {
+			return RepositoryConfigurationFactory
+					.createRepositoryConfiguration(remoteRepositories);
+		}
 	}
 
 	private Properties loadInstallCounts() throws IOException {

--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/RepositoryConfigurationFactory.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/RepositoryConfigurationFactory.java
@@ -80,4 +80,27 @@ public final class RepositoryConfigurationFactory {
 		return new File(System.getProperty("user.home"), ".m2");
 	}
 
+	/**
+	 * Create a repository configuration with the provided urls
+	 * @param remoteRepositories List of Strings in the form id::url
+	 * @return the newly-created repository configuration
+	 */
+	public static List<RepositoryConfiguration> createRepositoryConfiguration(
+			List<String> remoteRepositories) {
+		List<RepositoryConfiguration> repositoryConfiguration = new ArrayList<RepositoryConfiguration>();
+
+		for (String remoteRepository : remoteRepositories) {
+			String[] tokens = remoteRepository.split("::");
+			if (tokens.length != 2) {
+				throw new IllegalArgumentException("Illegal remoteRepository "
+						+ remoteRepository + "! Must be specified as <name>::<url>!");
+			}
+
+			repositoryConfiguration.add(new RepositoryConfiguration(tokens[0], URI
+					.create(tokens[1]), false));
+		}
+
+		return repositoryConfiguration;
+	}
+
 }

--- a/spring-boot-cli/src/test/java/org/springframework/boot/cli/compiler/RepositoryConfigurationFactoryTest.java
+++ b/spring-boot-cli/src/test/java/org/springframework/boot/cli/compiler/RepositoryConfigurationFactoryTest.java
@@ -1,0 +1,40 @@
+package org.springframework.boot.cli.compiler;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.boot.cli.compiler.grape.RepositoryConfiguration;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link RepositoryConfigurationFactory}.
+ * @author Johannes Stelzer
+ */
+public class RepositoryConfigurationFactoryTest {
+
+	@Test
+	public void createRepositoryConfiguration() {
+
+		List<RepositoryConfiguration> repoConfig = RepositoryConfigurationFactory
+				.createRepositoryConfiguration(Arrays.asList(
+						"default::http://repo1.maven.org/maven2/",
+						"custom::http://repo.intern/maven2/"));
+		assertEquals(2, repoConfig.size());
+
+		assertEquals("default", repoConfig.get(0).getName());
+		assertEquals(URI.create("http://repo1.maven.org/maven2/"), repoConfig.get(0)
+				.getUri());
+
+		assertEquals("custom", repoConfig.get(1).getName());
+		assertEquals(URI.create("http://repo.intern/maven2/"), repoConfig.get(1).getUri());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void createRepositoryConfiguration_failure() {
+		RepositoryConfigurationFactory.createRepositoryConfiguration(Arrays
+				.asList("default=http://repo1.maven.org/maven2/"));
+	}
+}


### PR DESCRIPTION
specify with  --remoteRepositories &lt;id&gt;::&lt;url&gt;
e.g. --remoteRepositories spring-ms::http://repo.spring.io/milestone

closes gh-2659

CLA 93620140928055712