### PR TITLE
fix typo in javadoc

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/EnableAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/EnableAutoConfiguration.java
@@ -37,7 +37,7 @@ import org.springframework.core.io.support.SpringFactoriesLoader;
  * Enable auto-configuration of the Spring Application Context, attempting to guess and
  * configure beans that you are likely to need. Auto-configuration classes are usually
  * applied based on your classpath and what beans you have defined. For example, If you
- * have {@code tomat-embedded.jar} on your classpath you are likely to want a
+ * have {@code tomcat-embedded.jar} on your classpath you are likely to want a
  * {@link TomcatEmbeddedServletContainerFactory} (unless you have defined your own
  * {@link EmbeddedServletContainerFactory} bean).
  * <p>


### PR DESCRIPTION
{@code tomat-embedded.jar} --> {@code tomcat-embedded.jar}