### PR TITLE
Cache Auto-configuration

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -431,6 +431,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>net.sf.ehcache</groupId>
+			<artifactId>ehcache</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>aspectjweaver</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -61,8 +61,23 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.hazelcast</groupId>
+			<artifactId>hazelcast</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.hazelcast</groupId>
+			<artifactId>hazelcast-spring</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>com.samskivert</groupId>
 			<artifactId>jmustache</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>javax.cache</groupId>
+			<artifactId>cache-api</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.context.annotation.Import;
  * Cache store can be auto-detected or specified explicitly via configuration.
  *
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  * @since 1.3.0
  * @see EnableCaching
  */
@@ -46,6 +47,7 @@ import org.springframework.context.annotation.Import;
 @EnableConfigurationProperties(CacheProperties.class)
 @AutoConfigureAfter(RedisAutoConfiguration.class)
 @Import({GenericCacheConfiguration.class,
+		EhCacheCacheConfiguration.class,
 		HazelcastConfiguration.class,
 		JCacheCacheConfiguration.class,
 		RedisCacheConfiguration.class,

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheAspectSupport;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for the cache abstraction. Creates
+ * a {@link CacheManager} if necessary when caching is enabled via {@link EnableCaching}.
+ * <p>
+ * Cache store can be auto-detected or specified explicitly via configuration.
+ *
+ * @author Stephane Nicoll
+ * @since 1.3.0
+ * @see EnableCaching
+ */
+@Configuration
+@ConditionalOnClass(CacheManager.class)
+@ConditionalOnBean(CacheAspectSupport.class)
+@ConditionalOnMissingBean(CacheManager.class)
+@EnableConfigurationProperties(CacheProperties.class)
+@AutoConfigureAfter(RedisAutoConfiguration.class)
+@Import({GenericCacheConfiguration.class,
+		HazelcastConfiguration.class,
+		JCacheCacheConfiguration.class,
+		RedisCacheConfiguration.class,
+		GuavaConfiguration.class,
+		SimpleCacheConfiguration.class,
+		NoOpCacheConfiguration.class,
+		CacheValidationConfiguration.class})
+public class CacheAutoConfiguration {
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheProperties.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.Resource;
+
+/**
+ * Configuration properties for the cache abstraction.
+ *
+ * @author Stephane Nicoll
+ * @since 1.3.0
+ */
+@ConfigurationProperties(prefix = "spring.cache")
+public class CacheProperties {
+
+	/**
+	 * Cache mode (can be "auto", "generic", "hazelcast", "jcache", "redis",
+	 * "guava", "simple" or "none"). Auto-detected according to the
+	 * environment by default.
+	 */
+	private String mode = "auto";
+
+	/**
+	 * The location of the configuration file to use to initialize the cache
+	 * library.
+	 */
+	private Resource config;
+
+	/**
+	 * Comma-separated list of cache names to create if supported by the
+	 * underlying cache manager. Usually, this disables the ability to
+	 * create additional caches on-the-fly.
+	 */
+	private final List<String> cacheNames = new ArrayList<String>();
+
+	private final JCache jcache = new JCache();
+
+	private final Guava guava = new Guava();
+
+	public String getMode() {
+		return mode;
+	}
+
+	public void setMode(String mode) {
+		this.mode = mode;
+	}
+
+	public Resource getConfig() {
+		return config;
+	}
+
+	public void setConfig(Resource config) {
+		this.config = config;
+	}
+
+	public List<String> getCacheNames() {
+		return cacheNames;
+	}
+
+	public JCache getJcache() {
+		return jcache;
+	}
+
+	public Guava getGuava() {
+		return guava;
+	}
+
+	/**
+	 * Resolve the config location if set.
+	 * @return the location or {@code null} if it is not set
+	 * @throws IllegalArgumentException if the config attribute is set to a unknown location
+	 */
+	public Resource resolveConfigLocation() {
+		if (this.config != null) {
+			if (this.config.exists()) {
+				return this.config;
+			}
+			else {
+				throw new IllegalArgumentException("Cache configuration field defined by " +
+						"'spring.cache.config' does not exist " + this.config);
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * JCache (JSR-107) specific cache properties.
+	 */
+	public static class JCache {
+
+		/**
+		 * Fully qualified name of the CachingProvider implementation to use to
+		 * retrieve the JSR-107 compliant cache manager. Only needed if more than
+		 * one JSR-107 implementation is available on the classpath.
+		 */
+		private String provider;
+
+		public String getProvider() {
+			return provider;
+		}
+
+		public void setProvider(String provider) {
+			this.provider = provider;
+		}
+
+	}
+
+	/**
+	 * Guava specific cache properties.
+	 */
+	public static class Guava {
+
+		/**
+		 * The spec to use to create caches. Check CacheBuilderSpec for more details on
+		 * the spec format.
+		 */
+		private String spec;
+
+		public String getSpec() {
+			return spec;
+		}
+
+		public void setSpec(String spec) {
+			this.spec = spec;
+		}
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheProperties.java
@@ -26,15 +26,16 @@ import org.springframework.core.io.Resource;
  * Configuration properties for the cache abstraction.
  *
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  * @since 1.3.0
  */
 @ConfigurationProperties(prefix = "spring.cache")
 public class CacheProperties {
 
 	/**
-	 * Cache mode (can be "auto", "generic", "hazelcast", "jcache", "redis",
-	 * "guava", "simple" or "none"). Auto-detected according to the
-	 * environment by default.
+	 * Cache mode (can be "auto", "generic", "ehcache", "hazelcast",
+	 * "jcache", "redis", "guava", "simple" or "none"). Auto-detected
+	 * according to the environment by default.
 	 */
 	private String mode = "auto";
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheValidationConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheValidationConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Make sure to throw a dedicated exception message if no cache manager could
+ * have been configured. Note that this configuration class is imported if
+ * {@code EnableCaching} has been set and no {@link CacheManager} could have
+ * been auto-configured.
+ *
+ * @author Stephane Nicoll
+ * @since 1.3.0
+ */
+@Configuration
+@ConditionalOnMissingBean(CacheManager.class)
+class CacheValidationConfiguration {
+
+	@Autowired
+	private CacheProperties cacheProperties;
+
+	@Bean
+	public CacheManager cacheManager() {
+		throw new IllegalStateException("No cache manager could be auto-configured, check your " +
+				"configuration (caching mode is '" + this.cacheProperties.getMode() + "')");
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/EhCacheCacheConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/EhCacheCacheConfiguration.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import net.sf.ehcache.CacheManager;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnResource;
+import org.springframework.cache.ehcache.EhCacheCacheManager;
+import org.springframework.cache.ehcache.EhCacheManagerUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ConfigurationCondition;
+import org.springframework.core.io.Resource;
+
+/**
+ * EhCache cache configuration. Only kick in if a configuration file location
+ * is set or if a default configuration file exists.
+ *
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@Configuration
+@ConditionalOnMissingBean(org.springframework.cache.CacheManager.class)
+@ConditionalOnClass({CacheManager.class, EhCacheCacheManager.class})
+@Conditional(EhCacheCacheConfiguration.ConfigAvailableCondition.class)
+@ConditionalOnProperty(prefix = "spring.cache", value = "mode", havingValue = "ehcache", matchIfMissing = true)
+class EhCacheCacheConfiguration {
+
+	@Autowired
+	private CacheProperties properties;
+
+	@Bean
+	public EhCacheCacheManager cacheManager() {
+		Resource location = this.properties.resolveConfigLocation();
+		if (location != null) {
+			return new EhCacheCacheManager(
+					EhCacheManagerUtils.buildCacheManager(location));
+		}
+		return new EhCacheCacheManager(
+				EhCacheManagerUtils.buildCacheManager());
+	}
+
+
+	/**
+	 * Determine if the EhCache configuration is available. This either kick in if a default
+	 * configuration has been found or if property referring to the file to use has been set.
+	 */
+	static class ConfigAvailableCondition extends AnyNestedCondition {
+
+		public ConfigAvailableCondition() {
+			super(ConfigurationCondition.ConfigurationPhase.PARSE_CONFIGURATION);
+		}
+
+		@ConditionalOnProperty(prefix = "spring.cache", name = "config")
+		static class CacheLocationProperty {
+		}
+
+		@ConditionalOnResource(resources = {"classpath:/ehcache.xml"})
+		static class DefaultConfigurationAvailable {
+		}
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/GenericCacheConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/GenericCacheConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import java.util.Collection;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Generic cache configuration based on arbitrary {@link Cache} instances
+ * defined in the context.
+ *
+ * @author Stephane Nicoll
+ * @since 1.3.0
+ */
+@Configuration
+@ConditionalOnMissingBean(CacheManager.class)
+@ConditionalOnBean(Cache.class)
+@ConditionalOnProperty(prefix = "spring.cache", value = "mode", havingValue = "generic", matchIfMissing = true)
+class GenericCacheConfiguration {
+
+	@Bean
+	public SimpleCacheManager cacheManager(Collection<Cache> caches) {
+		SimpleCacheManager cacheManager = new SimpleCacheManager();
+		cacheManager.setCaches(caches);
+		return cacheManager;
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/GuavaConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/GuavaConfiguration.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import java.util.List;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheBuilderSpec;
+import com.google.common.cache.CacheLoader;
+import org.apache.commons.collections.CollectionUtils;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.guava.GuavaCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+/**
+ * Guava cache configuration.
+ *
+ * @author Stephane Nicoll
+ * @since 1.3.0
+ */
+@Configuration
+@ConditionalOnMissingBean(CacheManager.class)
+@ConditionalOnClass(CacheBuilder.class)
+@ConditionalOnProperty(prefix = "spring.cache", value = "mode", havingValue = "guava", matchIfMissing = true)
+class GuavaConfiguration {
+
+	@Autowired
+	private CacheProperties cacheProperties;
+
+	@Autowired(required = false)
+	private CacheBuilder<Object, Object> cacheBuilder;
+
+	@Autowired(required = false)
+	private CacheBuilderSpec cacheBuilderSpec;
+
+	@Autowired(required = false)
+	private CacheLoader<Object, Object> cacheLoader;
+
+	@Bean
+	public GuavaCacheManager cacheManager() {
+		GuavaCacheManager cacheManager = createCacheManager();
+		List<String> cacheNames = this.cacheProperties.getCacheNames();
+		if (!CollectionUtils.isEmpty(cacheNames)) {
+			cacheManager.setCacheNames(cacheNames);
+		}
+		return cacheManager;
+	}
+
+	private GuavaCacheManager createCacheManager() {
+		GuavaCacheManager cacheManager = new GuavaCacheManager();
+		String spec = this.cacheProperties.getGuava().getSpec();
+
+		if (StringUtils.hasText(spec)) {
+			cacheManager.setCacheSpecification(spec);
+		}
+		else if (this.cacheBuilderSpec != null) {
+			cacheManager.setCacheBuilderSpec(this.cacheBuilderSpec);
+		}
+		else if (this.cacheBuilder != null) {
+			cacheManager.setCacheBuilder(this.cacheBuilder);
+		}
+
+		if (this.cacheLoader != null) {
+			cacheManager.setCacheLoader(this.cacheLoader);
+		}
+
+		return cacheManager;
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/HazelcastConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/HazelcastConfiguration.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import java.io.IOException;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spring.cache.HazelcastCacheManager;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ConfigurationCondition;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Hazelcast cache configuration. Only kick in if a configuration file location
+ * is set or if a default configuration file exists (either placed in the default
+ * location or set via the {@value #CONFIG_SYSTEM_PROPERTY} system property).
+ *
+ * @author Stephane Nicoll
+ * @since 1.3.0
+ */
+@Configuration
+@ConditionalOnMissingBean(CacheManager.class)
+@ConditionalOnClass({HazelcastInstance.class, HazelcastCacheManager.class})
+@Conditional(HazelcastConfiguration.ConfigAvailableCondition.class)
+@ConditionalOnProperty(prefix = "spring.cache", value = "mode", havingValue = "hazelcast", matchIfMissing = true)
+class HazelcastConfiguration {
+
+
+	static final String CONFIG_SYSTEM_PROPERTY = "hazelcast.config";
+
+	@Autowired
+	private CacheProperties cacheProperties;
+
+	@Bean
+	public HazelcastCacheManager cacheManager() throws IOException {
+		return new HazelcastCacheManager(createHazelcastInstance());
+	}
+
+	private HazelcastInstance createHazelcastInstance() throws IOException {
+		Resource location = this.cacheProperties.resolveConfigLocation();
+		if (location != null) {
+			Config cfg = new XmlConfigBuilder(location.getURL()).build();
+			return Hazelcast.newHazelcastInstance(cfg);
+		}
+		else {
+			return Hazelcast.newHazelcastInstance();
+		}
+	}
+
+
+	/**
+	 * Determines if the Hazelcast configuration is available. This either kick in if a default
+	 * configuration has been found or if property referring to the file to use has been set.
+	 */
+	static class ConfigAvailableCondition extends AnyNestedCondition {
+
+		public ConfigAvailableCondition() {
+			super(ConfigurationCondition.ConfigurationPhase.PARSE_CONFIGURATION);
+		}
+
+		@ConditionalOnProperty(prefix = "spring.cache", name = "config")
+		static class CacheLocationProperty {
+		}
+
+		@Conditional(BootstrapConfigurationAvailableCondition.class)
+		static class DefaultConfigurationAvailable {
+		}
+
+	}
+
+	static class BootstrapConfigurationAvailableCondition extends SpringBootCondition {
+
+		private final ResourceLoader resourceLoader = new DefaultResourceLoader();
+
+		@Override
+		public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+			if (System.getProperty(CONFIG_SYSTEM_PROPERTY) != null) {
+				return ConditionOutcome.match("System property '" + CONFIG_SYSTEM_PROPERTY + "' is set.");
+			}
+			if (resourceLoader.getResource("file:./hazelcast.xml").exists()) {
+				return ConditionOutcome.match("hazelcast.xml found in the working directory.");
+			}
+			if (resourceLoader.getResource("classpath:/hazelcast.xml").exists()) {
+				return ConditionOutcome.match("hazelcast.xml found in the classpath.");
+			}
+			return ConditionOutcome.noMatch("No hazelcast.xml file found and system property '"
+					+ CONFIG_SYSTEM_PROPERTY + "' is not set.");
+		}
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/JCacheCacheConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/JCacheCacheConfiguration.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.spi.CachingProvider;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.cache.jcache.JCacheCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.StringUtils;
+
+/**
+ * Cache configuration for JSR-107 compliant providers.
+ *
+ * @author Stephane Nicoll
+ * @since 1.3.0
+ */
+@Configuration
+@ConditionalOnMissingBean({org.springframework.cache.CacheManager.class})
+@ConditionalOnClass(Caching.class)
+@Conditional(JCacheCacheConfiguration.JCacheAvailableCondition.class)
+@ConditionalOnProperty(prefix = "spring.cache", value = "mode", havingValue = "jcache", matchIfMissing = true)
+class JCacheCacheConfiguration {
+
+	@Autowired
+	private CacheProperties cacheProperties;
+
+	@Autowired(required = false)
+	private javax.cache.configuration.Configuration<?, ?> defaultCacheConfiguration;
+
+	@Autowired(required = false)
+	private List<JCacheManagerCustomizer> cacheManagerCustomizers;
+
+	@Bean
+	public JCacheCacheManager cacheManager() {
+		CacheManager cacheManager = createCacheManager(this.cacheProperties.getJcache().getProvider());
+		List<String> cacheNames = this.cacheProperties.getCacheNames();
+		if (!CollectionUtils.isEmpty(cacheNames)) {
+			for (String cacheName : cacheNames) {
+				cacheManager.createCache(cacheName, getDefaultCacheConfiguration());
+			}
+		}
+		customize(cacheManager);
+		return new JCacheCacheManager(cacheManager);
+	}
+
+	private CacheManager createCacheManager(String cachingProvider) {
+		if (StringUtils.hasText(cachingProvider)) {
+			return Caching.getCachingProvider(cachingProvider).getCacheManager();
+		}
+		else {
+			return Caching.getCachingProvider().getCacheManager();
+		}
+	}
+
+	private javax.cache.configuration.Configuration<?, ?> getDefaultCacheConfiguration() {
+		if (this.defaultCacheConfiguration != null) {
+			return this.defaultCacheConfiguration;
+		}
+		return new MutableConfiguration<Object, Object>();
+	}
+
+	private void customize(CacheManager cacheManager) {
+		if (this.cacheManagerCustomizers != null) {
+			AnnotationAwareOrderComparator.sort(this.cacheManagerCustomizers);
+			for (JCacheManagerCustomizer customizer : this.cacheManagerCustomizers) {
+				customizer.customize(cacheManager);
+			}
+		}
+	}
+
+	/**
+	 * Determines if JCache is available. This either kick in if a default {@link CachingProvider}
+	 * has been found or if the property referring to the provider to use has been set.
+	 */
+	static class JCacheAvailableCondition extends AnyNestedCondition {
+
+		public JCacheAvailableCondition() {
+			super(ConfigurationPhase.PARSE_CONFIGURATION);
+		}
+
+		@Conditional(DefaultCachingProviderAvailableCondition.class)
+		static class DefaultCachingProviderAvailable {
+		}
+
+		@ConditionalOnProperty(prefix = "spring.cache.jcache", name = "provider")
+		static class CachingProviderProperty {
+		}
+
+	}
+
+	static class DefaultCachingProviderAvailableCondition extends SpringBootCondition {
+
+		@Override
+		public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+			int cachingProvidersCount = getCachingProvidersCount();
+			if (cachingProvidersCount == 1) {
+				return ConditionOutcome.match("Default JSR-107 compliant provider found.");
+			}
+			else {
+				return ConditionOutcome.noMatch("No default JSR-107 compliant provider(s) " +
+						"found (" + cachingProvidersCount + " provider(s) detected).");
+			}
+		}
+
+		private int getCachingProvidersCount() {
+			Iterable<CachingProvider> cachingProviders = Caching.getCachingProviders();
+			if (cachingProviders instanceof Collection<?>) {
+				return ((Collection<?>) cachingProviders).size();
+			}
+			else {
+				int count = 0;
+				Iterator<CachingProvider> it = cachingProviders.iterator();
+				while (it.hasNext()) {
+					count++;
+				}
+				return count;
+			}
+		}
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/JCacheManagerCustomizer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/JCacheManagerCustomizer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import javax.cache.CacheManager;
+import javax.cache.configuration.Configuration;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize the cache
+ * manager before it is used, in particular to create additional caches.
+ *
+ * @author Stephane Nicoll
+ * @since 1.3.0
+ * @see CacheManager#createCache(String, Configuration)
+ */
+public interface JCacheManagerCustomizer {
+
+	/**
+	 * Customize the cache manager.
+	 * @param cacheManager the {@link CacheManager} to customize
+	 */
+	void customize(CacheManager cacheManager);
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/NoOpCacheConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/NoOpCacheConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.support.NoOpCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * No op cache configuration used to disable caching via configuration.
+ *
+ * @author Stephane Nicoll
+ * @since 1.3.0
+ */
+@Configuration
+@ConditionalOnMissingBean(CacheManager.class)
+@ConditionalOnProperty(prefix = "spring.cache", value = "mode", havingValue = "none", matchIfMissing = false)
+class NoOpCacheConfiguration {
+
+	@Bean
+	public NoOpCacheManager cacheManager() {
+		return new NoOpCacheManager();
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/RedisCacheConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/RedisCacheConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.core.RedisTemplate;
+
+/**
+ * Redis cache configuration.
+ *
+ * @author Stephane Nicoll
+ * @since 1.3.0
+ */
+@Configuration
+@ConditionalOnMissingBean(CacheManager.class)
+@ConditionalOnBean(RedisTemplate.class)
+@ConditionalOnProperty(prefix = "spring.cache", value = "mode", havingValue = "redis", matchIfMissing = true)
+class RedisCacheConfiguration {
+
+	@Autowired
+	private CacheProperties cacheProperties;
+
+	@Bean
+	public RedisCacheManager cacheManager(RedisTemplate<?, ?> redisTemplate) {
+		RedisCacheManager cacheManager = new RedisCacheManager(redisTemplate);
+		List<String> cacheNames = this.cacheProperties.getCacheNames();
+		if (!cacheNames.isEmpty()) {
+			cacheManager.setCacheNames(cacheNames);
+		}
+		return cacheManager;
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/SimpleCacheConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/SimpleCacheConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Simplest cache configuration, usually used as a fallback.
+ *
+ * @author Stephane Nicoll
+ * @since 1.3.0
+ */
+@Configuration
+@ConditionalOnMissingBean(CacheManager.class)
+@ConditionalOnProperty(prefix = "spring.cache", value = "mode", havingValue = "simple", matchIfMissing = true)
+class SimpleCacheConfiguration {
+
+	@Autowired
+	private CacheProperties cacheProperties;
+
+	@Bean
+	public ConcurrentMapCacheManager cacheManager() {
+		ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager();
+		List<String> cacheNames = this.cacheProperties.getCacheNames();
+		if (!cacheNames.isEmpty()) {
+			cacheManager.setCacheNames(cacheNames);
+		}
+		return cacheManager;
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/package-info.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for the cache abstraction.
+ */
+package org.springframework.boot.autoconfigure.cache;

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -9,6 +9,7 @@ org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration,\
 org.springframework.boot.autoconfigure.MessageSourceAutoConfiguration,\
 org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration,\
 org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration,\
+org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration,\
 org.springframework.boot.autoconfigure.cloud.CloudAutoConfiguration,\
 org.springframework.boot.autoconfigure.dao.PersistenceExceptionTranslationAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
@@ -1,0 +1,464 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import javax.cache.configuration.CompleteConfiguration;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.expiry.CreatedExpiryPolicy;
+import javax.cache.expiry.Duration;
+
+import com.google.common.cache.CacheBuilder;
+import com.hazelcast.cache.HazelcastCachingProvider;
+import com.hazelcast.spring.cache.HazelcastCacheManager;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.cache.support.MockCachingProvider;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.cache.guava.GuavaCache;
+import org.springframework.cache.guava.GuavaCacheManager;
+import org.springframework.cache.jcache.JCacheCacheManager;
+import org.springframework.cache.support.NoOpCacheManager;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link CacheAutoConfiguration}.
+ *
+ * @author Stephane Nicoll
+ */
+public class CacheAutoConfigurationTests {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void tearDown() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void noEnableCaching() {
+		load(EmptyConfiguration.class);
+
+		thrown.expect(NoSuchBeanDefinitionException.class);
+		this.context.getBean(CacheManager.class);
+	}
+
+	@Test
+	public void cacheManagerBackOff() {
+		load(CustomCacheManagerConfiguration.class);
+		ConcurrentMapCacheManager cacheManager = validateCacheManager(ConcurrentMapCacheManager.class);
+		assertThat(cacheManager.getCacheNames(), contains("custom1"));
+		assertThat(cacheManager.getCacheNames(), hasSize(1));
+	}
+
+	@Test
+	public void notSupportedCachingMode() {
+		thrown.expect(BeanCreationException.class);
+		thrown.expectMessage("cacheManager");
+		thrown.expectMessage("foobar");
+		load(DefaultCacheConfiguration.class, "spring.cache.mode=foobar");
+	}
+
+	@Test
+	public void simpleCacheExplicit() {
+		load(DefaultCacheConfiguration.class, "spring.cache.mode=simple");
+		ConcurrentMapCacheManager cacheManager = validateCacheManager(ConcurrentMapCacheManager.class);
+		assertThat(cacheManager.getCacheNames(), is(empty()));
+	}
+
+	@Test
+	public void simpleCacheExplicitWithCacheNames() {
+		load(DefaultCacheConfiguration.class,
+				"spring.cache.mode=simple",
+				"spring.cache.cacheNames[0]=foo",
+				"spring.cache.cacheNames[1]=bar");
+		ConcurrentMapCacheManager cacheManager = validateCacheManager(ConcurrentMapCacheManager.class);
+		assertThat(cacheManager.getCacheNames(), containsInAnyOrder("foo", "bar"));
+		assertThat(cacheManager.getCacheNames(), hasSize(2));
+	}
+
+	@Test
+	public void genericCacheWithCaches() {
+		load(GenericCacheConfiguration.class);
+
+		SimpleCacheManager cacheManager = validateCacheManager(SimpleCacheManager.class);
+		assertThat(cacheManager.getCache("first"), equalTo(this.context.getBean("firstCache")));
+		assertThat(cacheManager.getCache("second"), equalTo(this.context.getBean("secondCache")));
+		assertThat(cacheManager.getCacheNames(), hasSize(2));
+	}
+
+	@Test
+	public void genericCacheExplicit() {
+		thrown.expect(BeanCreationException.class);
+		thrown.expectMessage("cacheManager");
+		thrown.expectMessage("generic");
+		load(DefaultCacheConfiguration.class,
+				"spring.cache.mode=generic");
+	}
+
+	@Test
+	public void genericCacheExplicitWithCaches() {
+		load(GenericCacheConfiguration.class,
+				"spring.cache.mode=generic");
+
+		SimpleCacheManager cacheManager = validateCacheManager(SimpleCacheManager.class);
+		assertThat(cacheManager.getCache("first"), equalTo(this.context.getBean("firstCache")));
+		assertThat(cacheManager.getCache("second"), equalTo(this.context.getBean("secondCache")));
+		assertThat(cacheManager.getCacheNames(), hasSize(2));
+	}
+
+	@Test
+	public void redisCacheExplicit() {
+		load(RedisCacheConfiguration.class, "spring.cache.mode=redis");
+		RedisCacheManager cacheManager = validateCacheManager(RedisCacheManager.class);
+		assertThat(cacheManager.getCacheNames(), is(empty()));
+	}
+
+	@Test
+	public void redisCacheExplicitWithCaches() {
+		load(RedisCacheConfiguration.class,
+				"spring.cache.mode=redis",
+				"spring.cache.cacheNames[0]=foo",
+				"spring.cache.cacheNames[1]=bar");
+		RedisCacheManager cacheManager = validateCacheManager(RedisCacheManager.class);
+		assertThat(cacheManager.getCacheNames(), containsInAnyOrder("foo", "bar"));
+		assertThat(cacheManager.getCacheNames(), hasSize(2));
+	}
+
+	@Test
+	public void noOpCacheExplicit() {
+		load(DefaultCacheConfiguration.class, "spring.cache.mode=none");
+		NoOpCacheManager cacheManager = validateCacheManager(NoOpCacheManager.class);
+		assertThat(cacheManager.getCacheNames(), is(empty()));
+	}
+
+	@Test
+	public void jCacheCacheNoProviderExplicit() {
+		thrown.expect(BeanCreationException.class);
+		thrown.expectMessage("cacheManager");
+		thrown.expectMessage("jcache");
+		load(DefaultCacheConfiguration.class, "spring.cache.mode=jcache");
+	}
+
+	@Test
+	public void jCacheCacheWithProvider() {
+		String cachingProviderFqn = MockCachingProvider.class.getName();
+		load(DefaultCacheConfiguration.class,
+				"spring.cache.mode=jcache",
+				"spring.cache.jcache.provider=" + cachingProviderFqn);
+		JCacheCacheManager cacheManager = validateCacheManager(JCacheCacheManager.class);
+		assertThat(cacheManager.getCacheNames(), is(empty()));
+	}
+
+	@Test
+	public void jCacheCacheWithCaches() {
+		String cachingProviderFqn = MockCachingProvider.class.getName();
+		load(DefaultCacheConfiguration.class,
+				"spring.cache.mode=jcache",
+				"spring.cache.jcache.provider=" + cachingProviderFqn,
+				"spring.cache.cacheNames[0]=foo",
+				"spring.cache.cacheNames[1]=bar");
+		JCacheCacheManager cacheManager = validateCacheManager(JCacheCacheManager.class);
+		assertThat(cacheManager.getCacheNames(), containsInAnyOrder("foo", "bar"));
+		assertThat(cacheManager.getCacheNames(), hasSize(2));
+	}
+
+	@Test
+	public void jCacheCacheWithCachesAndCustomConfig() {
+		String cachingProviderFqn = MockCachingProvider.class.getName();
+		load(JCacheCustomConfiguration.class,
+				"spring.cache.mode=jcache",
+				"spring.cache.jcache.provider=" + cachingProviderFqn,
+				"spring.cache.cacheNames[0]=one",
+				"spring.cache.cacheNames[1]=two");
+		JCacheCacheManager cacheManager = validateCacheManager(JCacheCacheManager.class);
+		assertThat(cacheManager.getCacheNames(), containsInAnyOrder("one", "two"));
+		assertThat(cacheManager.getCacheNames(), hasSize(2));
+
+		CompleteConfiguration<?, ?> defaultCacheConfiguration = this.context.getBean(CompleteConfiguration.class);
+		verify(cacheManager.getCacheManager()).createCache("one", defaultCacheConfiguration);
+		verify(cacheManager.getCacheManager()).createCache("two", defaultCacheConfiguration);
+	}
+
+	@Test
+	public void jCacheCacheWithUnknownProvider() {
+		String wrongCachingProviderFqn = "org.acme.FooBar";
+
+		thrown.expect(BeanCreationException.class);
+		thrown.expectMessage(wrongCachingProviderFqn);
+		load(DefaultCacheConfiguration.class,
+				"spring.cache.mode=jcache",
+				"spring.cache.jcache.provider=" + wrongCachingProviderFqn);
+	}
+
+	@Test
+	public void hazelcastCacheExplicit() {
+		load(DefaultCacheConfiguration.class,
+				"spring.cache.mode=hazelcast");
+		HazelcastCacheManager cacheManager = validateCacheManager(HazelcastCacheManager.class);
+		// NOTE: the hazelcast implementation know about a cache in a lazy manner.
+		cacheManager.getCache("defaultCache");
+		assertThat(cacheManager.getCacheNames(), containsInAnyOrder("defaultCache"));
+		assertThat(cacheManager.getCacheNames(), hasSize(1));
+	}
+
+	@Test
+	public void hazelcastCacheWithLocation() {
+		load(DefaultCacheConfiguration.class,
+				"spring.cache.mode=hazelcast",
+				"spring.cache.config=org/springframework/boot/autoconfigure/cache/hazelcast-specific.xml");
+		HazelcastCacheManager cacheManager = validateCacheManager(HazelcastCacheManager.class);
+		cacheManager.getCache("foobar");
+		assertThat(cacheManager.getCacheNames(), containsInAnyOrder("foobar"));
+		assertThat(cacheManager.getCacheNames(), hasSize(1));
+	}
+
+	@Test
+	public void hazelcastWithWrongLocation() {
+		thrown.expect(BeanCreationException.class);
+		thrown.expectMessage("foo/bar/unknown.xml");
+		load(DefaultCacheConfiguration.class,
+				"spring.cache.mode=hazelcast",
+				"spring.cache.config=foo/bar/unknown.xml");
+	}
+
+	@Test
+	public void hazelcastAsJCacheWithCaches() {
+		String cachingProviderFqn = HazelcastCachingProvider.class.getName();
+		JCacheCacheManager cacheManager = null;
+		try {
+			load(DefaultCacheConfiguration.class,
+					"spring.cache.mode=jcache",
+					"spring.cache.jcache.provider=" + cachingProviderFqn,
+					"spring.cache.cacheNames[0]=foo",
+					"spring.cache.cacheNames[1]=bar");
+			cacheManager = validateCacheManager(JCacheCacheManager.class);
+			assertThat(cacheManager.getCacheNames(), containsInAnyOrder("foo", "bar"));
+			assertThat(cacheManager.getCacheNames(), hasSize(2));
+		}
+		finally {
+			if (cacheManager != null) {
+				cacheManager.getCacheManager().close();
+			}
+		}
+	}
+
+	@Test
+	public void jCacheCacheWithCachesAndCustomizer() {
+		String cachingProviderFqn = HazelcastCachingProvider.class.getName();
+		JCacheCacheManager cacheManager = null;
+		try {
+			load(JCacheWithCustomizerConfiguration.class,
+					"spring.cache.mode=jcache",
+					"spring.cache.jcache.provider=" + cachingProviderFqn,
+					"spring.cache.cacheNames[0]=foo",
+					"spring.cache.cacheNames[1]=bar");
+			cacheManager = validateCacheManager(JCacheCacheManager.class);
+			assertThat(cacheManager.getCacheNames(), containsInAnyOrder("foo", "custom1")); // see customizer
+			assertThat(cacheManager.getCacheNames(), hasSize(2));
+		}
+		finally {
+			if (cacheManager != null) {
+				cacheManager.getCacheManager().close();
+			}
+		}
+	}
+
+	@Test
+	public void guavaCacheExplicitWithCaches() {
+		load(DefaultCacheConfiguration.class,
+				"spring.cache.mode=guava",
+				"spring.cache.cacheNames=foo");
+		GuavaCacheManager cacheManager = validateCacheManager(GuavaCacheManager.class);
+		Cache foo = cacheManager.getCache("foo");
+		foo.get("1");
+		// See next tests: no spec given so stats should be disabled
+		assertThat(((GuavaCache) foo).getNativeCache().stats().missCount(), equalTo(0L));
+	}
+
+	@Test
+	public void guavaCacheExplicitWithSpec() {
+		load(DefaultCacheConfiguration.class,
+				"spring.cache.mode=guava",
+				"spring.cache.guava.spec=recordStats",
+				"spring.cache.cacheNames[0]=foo",
+				"spring.cache.cacheNames[1]=bar");
+		validateGuavaCacheWithStats();
+	}
+
+	@Test
+	public void guavaCacheExplicitWithCacheBuilder() {
+		load(GuavaCacheBuilderConfiguration.class,
+				"spring.cache.mode=guava",
+				"spring.cache.cacheNames[0]=foo",
+				"spring.cache.cacheNames[1]=bar");
+		validateGuavaCacheWithStats();
+	}
+
+	private void validateGuavaCacheWithStats() {
+		GuavaCacheManager cacheManager = validateCacheManager(GuavaCacheManager.class);
+		assertThat(cacheManager.getCacheNames(), containsInAnyOrder("foo", "bar"));
+		assertThat(cacheManager.getCacheNames(), hasSize(2));
+		Cache foo = cacheManager.getCache("foo");
+		foo.get("1");
+		assertThat(((GuavaCache) foo).getNativeCache().stats().missCount(), equalTo(1L));
+	}
+
+	private <T extends CacheManager> T validateCacheManager(Class<T> type) {
+		CacheManager cacheManager = this.context.getBean(CacheManager.class);
+		assertThat("Wrong cache manager type", cacheManager, is(instanceOf(type)));
+		return type.cast(cacheManager);
+	}
+
+	private void load(Class<?> config, String... environment) {
+		this.context = doLoad(config, environment);
+	}
+
+	private AnnotationConfigApplicationContext doLoad(Class<?> config,
+			String... environment) {
+		AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(applicationContext, environment);
+		applicationContext.register(config);
+		applicationContext.register(CacheAutoConfiguration.class);
+		applicationContext.refresh();
+		return applicationContext;
+	}
+
+
+	@Configuration
+	static class EmptyConfiguration {
+
+	}
+
+	@Configuration
+	@EnableCaching
+	static class DefaultCacheConfiguration {
+
+	}
+
+	@Configuration
+	@EnableCaching
+	static class GenericCacheConfiguration {
+
+		@Bean
+		public Cache firstCache() {
+			return new ConcurrentMapCache("first");
+		}
+
+		@Bean
+		public Cache secondCache() {
+			return new ConcurrentMapCache("second");
+		}
+
+	}
+
+	@Configuration
+	@EnableCaching
+	static class RedisCacheConfiguration {
+
+		@Bean
+		public RedisTemplate<?, ?> redisTemplate() {
+			return mock(RedisTemplate.class);
+		}
+
+	}
+
+	@Configuration
+	@EnableCaching
+	static class JCacheCustomConfiguration {
+
+		@Bean
+		public CompleteConfiguration<?, ?> defaultCacheConfiguration() {
+			return mock(CompleteConfiguration.class);
+		}
+
+	}
+
+	@Configuration
+	@EnableCaching
+	static class JCacheWithCustomizerConfiguration {
+
+		@Bean
+		JCacheManagerCustomizer myCustomizer() {
+			return new JCacheManagerCustomizer() {
+				@Override
+				public void customize(javax.cache.CacheManager cacheManager) {
+					MutableConfiguration<?, ?> config = new MutableConfiguration<Object, Object>();
+					config.setExpiryPolicyFactory(CreatedExpiryPolicy.factoryOf(Duration.TEN_MINUTES));
+					config.setStatisticsEnabled(true);
+					cacheManager.createCache("custom1", config);
+					cacheManager.destroyCache("bar");
+				}
+			};
+		}
+
+	}
+
+	@Configuration
+	@Import({GenericCacheConfiguration.class, RedisCacheConfiguration.class})
+	static class CustomCacheManagerConfiguration {
+
+		@Bean
+		public CacheManager cacheManager() {
+			return new ConcurrentMapCacheManager("custom1");
+		}
+	}
+
+	@Configuration
+	@EnableCaching
+	static class GuavaCacheBuilderConfiguration {
+
+		@SuppressWarnings("unchecked")
+		@Bean
+		CacheBuilder<Object, Object> cacheBuilder() {
+			return CacheBuilder.newBuilder().recordStats();
+		}
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
@@ -38,6 +38,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.cache.ehcache.EhCacheCacheManager;
 import org.springframework.cache.guava.GuavaCache;
 import org.springframework.cache.guava.GuavaCacheManager;
 import org.springframework.cache.jcache.JCacheCacheManager;
@@ -65,6 +66,7 @@ import static org.mockito.Mockito.verify;
  * Tests for {@link CacheAutoConfiguration}.
  *
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  */
 public class CacheAutoConfigurationTests {
 
@@ -234,6 +236,42 @@ public class CacheAutoConfigurationTests {
 		load(DefaultCacheConfiguration.class,
 				"spring.cache.mode=jcache",
 				"spring.cache.jcache.provider=" + wrongCachingProviderFqn);
+	}
+
+	@Test
+	public void ehCacheCacheWithCaches() {
+		load(DefaultCacheConfiguration.class,
+				"spring.cache.mode=ehcache");
+		EhCacheCacheManager cacheManager = null;
+		try {
+			cacheManager = validateCacheManager(EhCacheCacheManager.class);
+			assertThat(cacheManager.getCacheNames(), containsInAnyOrder("cacheTest1", "cacheTest2"));
+			assertThat(cacheManager.getCacheNames(), hasSize(2));
+		}
+		finally {
+			if (cacheManager != null) {
+				cacheManager.getCacheManager().shutdown();
+			}
+		}
+	}
+
+	@Test
+	public void ehCacheCacheWithLocation() {
+		load(DefaultCacheConfiguration.class,
+				"spring.cache.mode=ehcache",
+				"spring.cache.config=cache/ehcache-override.xml");
+		EhCacheCacheManager cacheManager = null;
+		try {
+			cacheManager = validateCacheManager(EhCacheCacheManager.class);
+			assertThat(cacheManager.getCacheNames(),
+					containsInAnyOrder("cacheOverrideTest1", "cacheOverrideTest2"));
+			assertThat(cacheManager.getCacheNames(), hasSize(2));
+		}
+		finally {
+			if (cacheManager != null) {
+				cacheManager.getCacheManager().shutdown();
+			}
+		}
 	}
 
 	@Test

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/support/MockCachingProvider.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/support/MockCachingProvider.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache.support;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.configuration.Configuration;
+import javax.cache.configuration.OptionalFeature;
+import javax.cache.spi.CachingProvider;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * A mock {@link CachingProvider} that exposes a JSR-107 cache manager
+ * for testing purposes.
+ *
+ * @author Stephane Nicoll
+ */
+public class MockCachingProvider implements CachingProvider {
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public CacheManager getCacheManager(URI uri, ClassLoader classLoader, Properties properties) {
+		CacheManager cacheManager = mock(CacheManager.class);
+		final Map<String, Cache> caches = new HashMap<String, Cache>();
+		when(cacheManager.getCacheNames()).thenReturn(caches.keySet());
+		when(cacheManager.getCache(anyString())).thenAnswer(new Answer<Cache>() {
+			@Override
+			public Cache answer(InvocationOnMock invocationOnMock) throws Throwable {
+				String cacheName = (String) invocationOnMock.getArguments()[0];
+				return caches.get(cacheName);
+			}
+		});
+		when(cacheManager.createCache(anyString(), any(Configuration.class))).then(new Answer<Cache>() {
+			@Override
+			public Cache answer(InvocationOnMock invocationOnMock) throws Throwable {
+				String cacheName = (String) invocationOnMock.getArguments()[0];
+				Cache cache = mock(Cache.class);
+				when(cache.getName()).thenReturn(cacheName);
+				caches.put(cacheName, cache);
+				return cache;
+			}
+		});
+		return cacheManager;
+	}
+
+	@Override
+	public ClassLoader getDefaultClassLoader() {
+		return null;
+	}
+
+	@Override
+	public URI getDefaultURI() {
+		return null;
+	}
+
+	@Override
+	public Properties getDefaultProperties() {
+		return new Properties();
+	}
+
+	@Override
+	public CacheManager getCacheManager(URI uri, ClassLoader classLoader) {
+		return getCacheManager(uri, classLoader, getDefaultProperties());
+	}
+
+	@Override
+	public CacheManager getCacheManager() {
+		return getCacheManager(getDefaultURI(), getDefaultClassLoader());
+	}
+
+	@Override
+	public void close() {
+
+	}
+
+	@Override
+	public void close(ClassLoader classLoader) {
+
+	}
+
+	@Override
+	public void close(URI uri, ClassLoader classLoader) {
+
+	}
+
+	@Override
+	public boolean isSupported(OptionalFeature optionalFeature) {
+		return false;
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/resources/META-INF/services/javax.cache.spi.CachingProvider
+++ b/spring-boot-autoconfigure/src/test/resources/META-INF/services/javax.cache.spi.CachingProvider
@@ -1,0 +1,4 @@
+#
+# Test JSR 107 provider for testing purposes only.
+#
+org.springframework.boot.autoconfigure.cache.support.MockCachingProvider

--- a/spring-boot-autoconfigure/src/test/resources/cache/ehcache-override.xml
+++ b/spring-boot-autoconfigure/src/test/resources/cache/ehcache-override.xml
@@ -1,0 +1,10 @@
+<ehcache>
+	<cache name="cacheOverrideTest1"
+	       maxBytesLocalHeap="50m"
+	       timeToLiveSeconds="100">
+	</cache>
+	<cache name="cacheOverrideTest2"
+	       maxBytesLocalHeap="50m"
+	       timeToLiveSeconds="100">
+	</cache>
+</ehcache>

--- a/spring-boot-autoconfigure/src/test/resources/ehcache.xml
+++ b/spring-boot-autoconfigure/src/test/resources/ehcache.xml
@@ -1,0 +1,10 @@
+<ehcache>
+	<cache name="cacheTest1"
+	       maxBytesLocalHeap="50m"
+	       timeToLiveSeconds="100">
+	</cache>
+	<cache name="cacheTest2"
+	       maxBytesLocalHeap="50m"
+	       timeToLiveSeconds="100">
+	</cache>
+</ehcache>

--- a/spring-boot-autoconfigure/src/test/resources/hazelcast.xml
+++ b/spring-boot-autoconfigure/src/test/resources/hazelcast.xml
@@ -1,0 +1,8 @@
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.4.xsd"
+		   xmlns="http://www.hazelcast.com/schema/config"
+		   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<map name="defaultCache"/>
+
+
+</hazelcast>

--- a/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/cache/hazelcast-specific.xml
+++ b/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/cache/hazelcast-specific.xml
@@ -1,0 +1,10 @@
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.4.xsd"
+		   xmlns="http://www.hazelcast.com/schema/config"
+		   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<map name="foobar">
+		<time-to-live-seconds>3600</time-to-live-seconds>
+		<max-idle-seconds>600</max-idle-seconds>
+	</map>
+
+</hazelcast>

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -60,6 +60,7 @@
 		<crashub.version>1.3.1</crashub.version>
 		<derby.version>10.10.2.0</derby.version>
 		<dropwizard-metrics.version>3.1.0</dropwizard-metrics.version>
+		<ehcache.version>2.9.1</ehcache.version>
 		<flyway.version>3.2</flyway.version>
 		<freemarker.version>2.3.22</freemarker.version>
 		<gemfire.version>7.0.2</gemfire.version>
@@ -670,6 +671,11 @@
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>
 				<version>${mysql.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>net.sf.ehcache</groupId>
+				<artifactId>ehcache</artifactId>
+				<version>${ehcache.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>nz.net.ultraq.thymeleaf</groupId>

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -69,6 +69,7 @@
 		<gson.version>2.3.1</gson.version>
 		<h2.version>1.4.185</h2.version>
 		<hamcrest.version>1.3</hamcrest.version>
+		<hazelcast.version>3.4.1</hazelcast.version>
 		<hibernate.version>4.3.8.Final</hibernate.version>
 		<hibernate-entitymanager.version>${hibernate.version}</hibernate-entitymanager.version>
 		<hibernate-validator.version>5.1.3.Final</hibernate-validator.version>
@@ -502,6 +503,16 @@
 				<groupId>com.h2database</groupId>
 				<artifactId>h2</artifactId>
 				<version>${h2.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.hazelcast</groupId>
+				<artifactId>hazelcast</artifactId>
+				<version>${hazelcast.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.hazelcast</groupId>
+				<artifactId>hazelcast-spring</artifactId>
+				<version>${hazelcast.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.jayway.jsonpath</groupId>


### PR DESCRIPTION
Here's the initial support for cache auto-configuration aimed at Spring Boot 1.3 (#2633). This is a joint effort with @eddumelendez

The following cache libraries are supported:
* Generic (via the presence of `org.springframework.cache.Cache` instances  in the context)
* EhCache
* Hazelcast
* JSR-107 compliant provider
* Redis
* Guava
* Simple (i.e. concurrent Map)
* NoOp 

By default, the environment is checked to determine which cache libraries should be used. In the case of ehcache and hazelcast, we check if the library is present of course but also if either a default configuration file is present (`/ehcache.xml`, `/hazelcast.xml`) or if a custom location has been set (via the common `spring.cache.config` property).

The `spring.cache.mode` allows to specify the caching library to use in case of conflict. It should be noted that only `noop` should be set explicitly. Maybe `redis` should be in that situation as well (right now the presence of a `RedisTemplate` enable a cache on redis, not sure this is appropriate).

`spring.cache.cache-names` defines the comma-separated list of caches to create on startup. 

We need to add several samples to showcase how this works (and validate that the conditions work has they should with different classpath content). 


