### PR TITLE
VcapApplicationListener Number Credentials

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/cloudfoundry/VcapApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/cloudfoundry/VcapApplicationListener.java
@@ -213,6 +213,9 @@ public class VcapApplicationListener implements
 			if (value instanceof String) {
 				properties.put(key, value);
 			}
+			else if (value instanceof Number) {
+				properties.put(key, value.toString());
+			}
 			else if (value instanceof Map) {
 				// Need a compound key
 				@SuppressWarnings("unchecked")

--- a/spring-boot/src/test/java/org/springframework/boot/cloudfoundry/VcapApplicationListenerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/cloudfoundry/VcapApplicationListenerTests.java
@@ -75,6 +75,8 @@ public class VcapApplicationListenerTests {
 		this.initializer.onApplicationEvent(this.event);
 		assertEquals("mysql",
 				this.context.getEnvironment().getProperty("vcap.services.mysql.name"));
+		assertEquals("3306",
+				this.context.getEnvironment().getProperty("vcap.services.mysql.credentials.port"));
 	}
 
 	@Test
@@ -86,5 +88,7 @@ public class VcapApplicationListenerTests {
 		this.initializer.onApplicationEvent(this.event);
 		assertEquals("mysql",
 				this.context.getEnvironment().getProperty("vcap.services.mysql.name"));
+		assertEquals("3306",
+				this.context.getEnvironment().getProperty("vcap.services.mysql.credentials.port"));
 	}
 }


### PR DESCRIPTION
Previously, the `VcapApplicationListener` would discard any service credential value that wasn't a `String`.  This was particularly a problem for services that exposed a port as a JSON `Number`.  This
change takes numbers in the credential payload into account, converting them to `String`s so that they will pass through the properties system properly.  There's no real downside to this as Spring will coerce them back into `Number`s if needed, by the application.