### PR TITLE
Fix problem with binding to Map where input keys are not consistent

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/XADataSourceAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/XADataSourceAutoConfigurationTests.java
@@ -66,7 +66,7 @@ public class XADataSourceAutoConfigurationTests {
 	public void createFromClass() throws Exception {
 		ApplicationContext context = createContext(
 				FromProperties.class,
-				"spring.datasource.xa.data-source-class:org.hsqldb.jdbc.pool.JDBCXADataSource",
+				"spring.datasource.xa.data-source-class-name:org.hsqldb.jdbc.pool.JDBCXADataSource",
 				"spring.datasource.xa.properties.database-name:test");
 		context.getBean(DataSource.class);
 		MockXADataSourceWrapper wrapper = context.getBean(MockXADataSourceWrapper.class);

--- a/spring-boot/src/test/java/org/springframework/boot/bind/RelaxedDataBinderTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/bind/RelaxedDataBinderTests.java
@@ -422,6 +422,46 @@ public class RelaxedDataBinderTests {
 	}
 
 	@Test
+	public void testBindMapWithClashInProperties() throws Exception {
+		Map<String, Object> target = new LinkedHashMap<String, Object>();
+		BindingResult result = bind(target, "vanilla.spam: bar\n"
+				+ "vanilla.spam.value: 123", "vanilla");
+		assertEquals(0, result.getErrorCount());
+		assertEquals("123", target.get("spam.value"));
+	}
+
+	@Test
+	public void testBindMapWithDeepClashInProperties() throws Exception {
+		Map<String, Object> target = new LinkedHashMap<String, Object>();
+		BindingResult result = bind(target, "vanilla.spam.foo: bar\n"
+				+ "vanilla.spam.foo.value: 123", "vanilla");
+		assertEquals(0, result.getErrorCount());
+		@SuppressWarnings("unchecked")
+		Map<String, Object> map = (Map<String, Object>) target.get("spam");
+		assertEquals("123", map.get("foo.value"));
+	}
+
+	@Test
+	public void testBindMapWithDifferentDeepClashInProperties() throws Exception {
+		Map<String, Object> target = new LinkedHashMap<String, Object>();
+		BindingResult result = bind(target, "vanilla.spam.bar: bar\n"
+				+ "vanilla.spam.bar.value: 123", "vanilla");
+		assertEquals(0, result.getErrorCount());
+		@SuppressWarnings("unchecked")
+		Map<String, Object> map = (Map<String, Object>) target.get("spam");
+		assertEquals("123", map.get("bar.value"));
+	}
+
+	@Test
+	public void testBindShallowMap() throws Exception {
+		Map<String, Object> target = new LinkedHashMap<String, Object>();
+		BindingResult result = bind(target, "vanilla.spam: bar\n" + "vanilla.value: 123",
+				"vanilla");
+		assertEquals(0, result.getErrorCount());
+		assertEquals("123", target.get("value"));
+	}
+
+	@Test
 	public void testBindMapNestedMap() throws Exception {
 		Map<String, Object> target = new LinkedHashMap<String, Object>();
 		BindingResult result = bind(target, "spam: bar\n" + "vanilla.foo.value: 123",


### PR DESCRIPTION
If you try to bind a Map to these properties:

  foo: bar
  foo.bar: spam

the only possible outcome is either an error (which is what happens
without this change) or {foo: bar, foo.bar: spam} (which is what
happens after this change).

Fixes gh-2610