### PR TITLE
Add cache samples

### DIFF
--- a/spring-boot-samples/README.adoc
+++ b/spring-boot-samples/README.adoc
@@ -16,6 +16,18 @@
   -- A production features sample with no web application
 * link:spring-boot-sample-actuator-log4j[spring-boot-sample-actuator-log4j]
   -- A production features sample using log4j for logging (instead of logback)
+* link:spring-boot-sample-cache-ehcache[spring-boot-sample-cache-ehcache]
+  -- Example show how Spring Boot can enable caching provided by `ehcache` and `@EnableCaching`
+* link:spring-boot-sample-cache-guava[spring-boot-sample-cache-guava]
+  -- Example show how Spring Boot can enable caching provided by `guava` and `@EnableCaching`
+* link:spring-boot-sample-cache-hazelcast[spring-boot-sample-cache-hazelcast]
+  -- Example show how Spring Boot can enable caching provided by `hazelcast` and `@EnableCaching`
+* link:spring-boot-sample-cache-jcache[spring-boot-sample-cache-jcache]
+  -- Example show how Spring Boot can enable caching provided by `jcache` but implemented by
+  `hazelcast` and `@EnableCaching`
+* link:spring-boot-sample-cache-redis[spring-boot-sample-cache-redis]
+  -- Example show how Spring Boot can enable caching provided by `redis` and `@EnableCaching`
+  Redis instance is needed. Docker: `docker run --name redis -d redis`
 * link:spring-boot-sample-web-ui[spring-boot-sample-web-ui]
   -- A thymeleaf web application
 * link:spring-boot-sample-web-static[spring-boot-sample-web-static]

--- a/spring-boot-samples/pom.xml
+++ b/spring-boot-samples/pom.xml
@@ -30,6 +30,11 @@
 		<module>spring-boot-sample-aop</module>
 		<module>spring-boot-sample-atmosphere</module>
 		<module>spring-boot-sample-batch</module>
+		<module>spring-boot-sample-cache-ehcache</module>
+		<module>spring-boot-sample-cache-guava</module>
+		<module>spring-boot-sample-cache-hazelcast</module>
+		<module>spring-boot-sample-cache-jcache</module>
+		<module>spring-boot-sample-cache-redis</module>
 		<module>spring-boot-sample-data-elasticsearch</module>
 		<module>spring-boot-sample-data-gemfire</module>
 		<module>spring-boot-sample-data-jpa</module>

--- a/spring-boot-samples/spring-boot-sample-cache-ehcache/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-cache-ehcache/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>spring-boot-samples</artifactId>
+		<groupId>org.springframework.boot</groupId>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>spring-boot-sample-cache-ehcache</artifactId>
+	<name>Spring Boot Cache EhCache Sample</name>
+	<description>Spring Boot Cache EhCache Sample</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.sf.ehcache</groupId>
+			<artifactId>ehcache</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+
+</project>

--- a/spring-boot-samples/spring-boot-sample-cache-ehcache/src/main/java/sample/CountryService.java
+++ b/spring-boot-samples/spring-boot-sample-cache-ehcache/src/main/java/sample/CountryService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@Component
+public class CountryService {
+
+	@Cacheable("countries")
+	public List<String> countries() {
+		System.out.println("Loading countries");
+		return Arrays.asList("Perú", "United States");
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-ehcache/src/main/java/sample/SampleEhCacheCacheApplication.java
+++ b/spring-boot-samples/spring-boot-sample-cache-ehcache/src/main/java/sample/SampleEhCacheCacheApplication.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@EnableCaching
+@SpringBootApplication
+public class SampleEhCacheCacheApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SampleEhCacheCacheApplication.class);
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-ehcache/src/main/java/sample/Startup.java
+++ b/spring-boot-samples/spring-boot-sample-cache-ehcache/src/main/java/sample/Startup.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@Component
+public class Startup implements CommandLineRunner {
+
+	@Autowired
+	private CountryService countryService;
+
+	@Override
+	public void run(String... args) throws Exception {
+		System.out.println("---- calling country service");
+		System.out.println(countryService.countries());
+		System.out.println("---- calling country service again from cache.");
+		System.out.println(countryService.countries());
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-ehcache/src/main/resources/application-override.properties
+++ b/spring-boot-samples/spring-boot-sample-cache-ehcache/src/main/resources/application-override.properties
@@ -1,0 +1,1 @@
+spring.cache.config=/cache/ehcache-override.xml

--- a/spring-boot-samples/spring-boot-sample-cache-ehcache/src/main/resources/cache/ehcache-override.xml
+++ b/spring-boot-samples/spring-boot-sample-cache-ehcache/src/main/resources/cache/ehcache-override.xml
@@ -1,0 +1,8 @@
+<ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="ehcache.xsd" updateCheck="true" monitoring="autodetect"
+         dynamicConfig="true">
+	<cache name="countries"
+	       maxBytesLocalHeap="50m"
+	       timeToLiveSeconds="100">
+	</cache>
+</ehcache>

--- a/spring-boot-samples/spring-boot-sample-cache-ehcache/src/main/resources/ehcache.xml
+++ b/spring-boot-samples/spring-boot-sample-cache-ehcache/src/main/resources/ehcache.xml
@@ -1,0 +1,8 @@
+<ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="ehcache.xsd" updateCheck="true" monitoring="autodetect"
+         dynamicConfig="true">
+	<cache name="countries"
+	       maxBytesLocalHeap="50m"
+	       timeToLiveSeconds="100">
+	</cache>
+</ehcache>

--- a/spring-boot-samples/spring-boot-sample-cache-ehcache/src/test/java/sample/AbstractEhCacheCacheTests.java
+++ b/spring-boot-samples/spring-boot-sample-cache-ehcache/src/test/java/sample/AbstractEhCacheCacheTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.ehcache.EhCacheCacheManager;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = {SampleEhCacheCacheApplication.class})
+public abstract class AbstractEhCacheCacheTests {
+
+	@Autowired
+	private CacheManager cacheManager;
+
+	@Autowired
+	private EhCacheCacheManager ehCacheManager;
+
+	@After
+	public void tearDown() {
+		if (this.ehCacheManager != null) {
+			this.ehCacheManager.getCacheManager().shutdown();
+		}
+	}
+
+	@Test
+	public void testCacheManagerInstance() {
+		assertThat(this.cacheManager, instanceOf(EhCacheCacheManager.class));
+	}
+
+	@Test
+	public void testCacheManager() {
+		assertThat(this.cacheManager.getCacheNames(), contains("countries"));
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-ehcache/src/test/java/sample/SampleEhCacheCacheApplicationOverrideTests.java
+++ b/spring-boot-samples/spring-boot-sample-cache-ehcache/src/test/java/sample/SampleEhCacheCacheApplicationOverrideTests.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = {SampleEhCacheCacheApplication.class})
+@ActiveProfiles("override")
+public class SampleEhCacheCacheApplicationOverrideTests extends AbstractEhCacheCacheTests {
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-ehcache/src/test/java/sample/SampleEhCacheCacheApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-cache-ehcache/src/test/java/sample/SampleEhCacheCacheApplicationTests.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = {SampleEhCacheCacheApplication.class})
+public class SampleEhCacheCacheApplicationTests extends AbstractEhCacheCacheTests {
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-guava/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-cache-guava/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>spring-boot-samples</artifactId>
+		<groupId>org.springframework.boot</groupId>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>spring-boot-sample-cache-guava</artifactId>
+	<name>Spring Boot Cache Guava Sample</name>
+	<description>Spring Boot Guava JCache Sample</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>18.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/spring-boot-samples/spring-boot-sample-cache-guava/src/main/java/sample/CountryService.java
+++ b/spring-boot-samples/spring-boot-sample-cache-guava/src/main/java/sample/CountryService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@Component
+public class CountryService {
+
+	@Cacheable("countries")
+	public List<String> countries() {
+		System.out.println("Loading countries");
+		return Arrays.asList("Perú", "United States");
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-guava/src/main/java/sample/SampleGuavaCacheApplication.java
+++ b/spring-boot-samples/spring-boot-sample-cache-guava/src/main/java/sample/SampleGuavaCacheApplication.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@EnableCaching
+@SpringBootApplication
+public class SampleGuavaCacheApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SampleGuavaCacheApplication.class);
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-guava/src/main/java/sample/Startup.java
+++ b/spring-boot-samples/spring-boot-sample-cache-guava/src/main/java/sample/Startup.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@Component
+public class Startup implements CommandLineRunner {
+
+	@Autowired
+	private CountryService countryService;
+
+	@Override
+	public void run(String... args) throws Exception {
+		System.out.println("---- calling country service");
+		System.out.println(countryService.countries());
+		System.out.println("---- calling country service again from cache.");
+		System.out.println(countryService.countries());
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-guava/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-cache-guava/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.cache.cache-names=spring-projects

--- a/spring-boot-samples/spring-boot-sample-cache-guava/src/test/java/sample/SampleGuavaCacheApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-cache-guava/src/test/java/sample/SampleGuavaCacheApplicationTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.guava.GuavaCacheManager;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = {SampleGuavaCacheApplication.class})
+public class SampleGuavaCacheApplicationTests {
+
+	@Autowired
+	private CacheManager cacheManager;
+
+	@Test
+	public void testCacheManagerInstance() {
+		assertThat(this.cacheManager, instanceOf(GuavaCacheManager.class));
+	}
+
+	@Test
+	public void testCacheManager() {
+		assertThat(this.cacheManager.getCacheNames(), contains("countries"));
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-hazelcast/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-cache-hazelcast/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>spring-boot-samples</artifactId>
+		<groupId>org.springframework.boot</groupId>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>spring-boot-sample-cache-hazelcast</artifactId>
+	<name>Spring Boot Cache Hazelcast Sample</name>
+	<description>Spring Boot Cache Hazelcast Sample</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.hazelcast</groupId>
+			<artifactId>hazelcast</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.hazelcast</groupId>
+			<artifactId>hazelcast-spring</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+
+</project>

--- a/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/main/java/sample/CountryService.java
+++ b/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/main/java/sample/CountryService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@Component
+public class CountryService {
+
+	@Cacheable("countries")
+	public List<String> countries() {
+		System.out.println("Loading countries");
+		return Arrays.asList("Perú", "United States");
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/main/java/sample/SampleHazelcastCacheApplication.java
+++ b/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/main/java/sample/SampleHazelcastCacheApplication.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@EnableCaching
+@SpringBootApplication
+public class SampleHazelcastCacheApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SampleHazelcastCacheApplication.class);
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/main/java/sample/Startup.java
+++ b/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/main/java/sample/Startup.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@Component
+public class Startup implements CommandLineRunner {
+
+	@Autowired
+	private CountryService countryService;
+
+	@Override
+	public void run(String... args) throws Exception {
+		System.out.println("---- calling country service");
+		System.out.println(countryService.countries());
+		System.out.println("---- calling country service again from cache.");
+		System.out.println(countryService.countries());
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/main/resources/application-override.properties
+++ b/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/main/resources/application-override.properties
@@ -1,0 +1,1 @@
+spring.cache.config=cache/hazelcast-override.xml

--- a/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/main/resources/cache/hazelcast-override.xml
+++ b/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/main/resources/cache/hazelcast-override.xml
@@ -1,0 +1,7 @@
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.4.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<map name="boot-starters"/>
+
+</hazelcast>

--- a/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/main/resources/hazelcast.xml
+++ b/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/main/resources/hazelcast.xml
@@ -1,0 +1,7 @@
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.4.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<map name="spring-data-modules"/>
+
+</hazelcast>

--- a/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/test/java/sample/AbstractHazelcastCacheTests.java
+++ b/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/test/java/sample/AbstractHazelcastCacheTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import com.hazelcast.spring.cache.HazelcastCacheManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = {SampleHazelcastCacheApplication.class})
+public abstract class AbstractHazelcastCacheTests {
+
+	@Autowired
+	private CacheManager cacheManager;
+
+	@Test
+	public void testCacheManagerInstance() {
+		assertThat(this.cacheManager, instanceOf(HazelcastCacheManager.class));
+	}
+
+	@Test
+	public void testCacheManager() {
+		assertThat(this.cacheManager.getCacheNames(), contains("countries"));
+	}
+}

--- a/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/test/java/sample/SampleHazelcastCacheApplicationOverrideTests.java
+++ b/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/test/java/sample/SampleHazelcastCacheApplicationOverrideTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@ActiveProfiles("override")
+public class SampleHazelcastCacheApplicationOverrideTests extends AbstractHazelcastCacheTests {
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/test/java/sample/SampleHazelcastCacheApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-cache-hazelcast/src/test/java/sample/SampleHazelcastCacheApplicationTests.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+public class SampleHazelcastCacheApplicationTests extends AbstractHazelcastCacheTests {
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-jcache/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-cache-jcache/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>spring-boot-samples</artifactId>
+		<groupId>org.springframework.boot</groupId>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>spring-boot-sample-cache-jcache</artifactId>
+	<name>Spring Boot Cache JCache Sample</name>
+	<description>Spring Boot Cache JCache Sample</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.cache</groupId>
+			<artifactId>cache-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.sf.ehcache</groupId>
+			<artifactId>ehcache</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.hazelcast</groupId>
+			<artifactId>hazelcast</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.hazelcast</groupId>
+			<artifactId>hazelcast-spring</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/spring-boot-samples/spring-boot-sample-cache-jcache/src/main/java/sample/CountryService.java
+++ b/spring-boot-samples/spring-boot-sample-cache-jcache/src/main/java/sample/CountryService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@Component
+public class CountryService {
+
+	@Cacheable("countries")
+	public List<String> countries() {
+		System.out.println("Loading countries");
+		return Arrays.asList("Perú", "United States");
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-jcache/src/main/java/sample/SampleJCacheCacheApplication.java
+++ b/spring-boot-samples/spring-boot-sample-cache-jcache/src/main/java/sample/SampleJCacheCacheApplication.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@EnableCaching
+@SpringBootApplication
+public class SampleJCacheCacheApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SampleJCacheCacheApplication.class);
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-jcache/src/main/java/sample/Startup.java
+++ b/spring-boot-samples/spring-boot-sample-cache-jcache/src/main/java/sample/Startup.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@Component
+public class Startup implements CommandLineRunner {
+
+	@Autowired
+	private CountryService countryService;
+
+	@Override
+	public void run(String... args) throws Exception {
+		System.out.println("---- calling country service");
+		System.out.println(countryService.countries());
+		System.out.println("---- calling country service again from cache.");
+		System.out.println(countryService.countries());
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-jcache/src/main/resources/application-hazelcast.properties
+++ b/spring-boot-samples/spring-boot-sample-cache-jcache/src/main/resources/application-hazelcast.properties
@@ -1,0 +1,3 @@
+spring.cache.type=jcache
+spring.cache.jcache.provider=com.hazelcast.cache.HazelcastCachingProvider
+spring.cache.config=/sample/hazelcast.xml

--- a/spring-boot-samples/spring-boot-sample-cache-jcache/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-cache-jcache/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.cache.type=jcache
+spring.cache.cacheNames[0]=countries

--- a/spring-boot-samples/spring-boot-sample-cache-jcache/src/main/resources/ehcache.xml
+++ b/spring-boot-samples/spring-boot-sample-cache-jcache/src/main/resources/ehcache.xml
@@ -1,0 +1,6 @@
+<ehcache>
+	<cache name="countries"
+	       maxBytesLocalHeap="50m"
+	       timeToLiveSeconds="100">
+	</cache>
+</ehcache>

--- a/spring-boot-samples/spring-boot-sample-cache-jcache/src/main/resources/sample/hazelcast.xml
+++ b/spring-boot-samples/spring-boot-sample-cache-jcache/src/main/resources/sample/hazelcast.xml
@@ -1,0 +1,7 @@
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.4.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<map name="countries"/>
+
+</hazelcast>

--- a/spring-boot-samples/spring-boot-sample-cache-jcache/src/test/java/sample/AbstractJcacheCacheTest.java
+++ b/spring-boot-samples/spring-boot-sample-cache-jcache/src/test/java/sample/AbstractJcacheCacheTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.jcache.JCacheCacheManager;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = {SampleJCacheCacheApplication.class})
+public abstract class AbstractJcacheCacheTest {
+
+	@Autowired
+	private CacheManager cacheManager;
+
+	@Test
+	public void testCacheManagerInstance() {
+		assertThat(this.cacheManager, instanceOf(JCacheCacheManager.class));
+	}
+
+	@Test
+	public void testCacheManager() {
+		assertThat(this.cacheManager.getCacheNames(), contains("countries"));
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-jcache/src/test/java/sample/SampleJCacheApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-cache-jcache/src/test/java/sample/SampleJCacheApplicationTests.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+public class SampleJCacheApplicationTests extends AbstractJcacheCacheTest {
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-jcache/src/test/java/sample/SampleJCacheHazelcastApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-cache-jcache/src/test/java/sample/SampleJCacheHazelcastApplicationTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@ActiveProfiles("hazelcast")
+public class SampleJCacheHazelcastApplicationTests extends AbstractJcacheCacheTest {
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-redis/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-cache-redis/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>spring-boot-samples</artifactId>
+		<groupId>org.springframework.boot</groupId>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>spring-boot-sample-cache-redis</artifactId>
+	<name>Spring Boot Cache Redis Sample</name>
+	<description>Spring Boot Cache Redis Sample</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-redis</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+
+</project>

--- a/spring-boot-samples/spring-boot-sample-cache-redis/src/main/java/sample/CountryService.java
+++ b/spring-boot-samples/spring-boot-sample-cache-redis/src/main/java/sample/CountryService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@Component
+public class CountryService {
+
+	@Cacheable("countries")
+	public List<String> countries() {
+		System.out.println("Loading countries");
+		return Arrays.asList("Perú", "United States");
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-redis/src/main/java/sample/SampleRedisCacheApplication.java
+++ b/spring-boot-samples/spring-boot-sample-cache-redis/src/main/java/sample/SampleRedisCacheApplication.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@EnableCaching
+@SpringBootApplication
+public class SampleRedisCacheApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SampleRedisCacheApplication.class);
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-redis/src/main/java/sample/Startup.java
+++ b/spring-boot-samples/spring-boot-sample-cache-redis/src/main/java/sample/Startup.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@Component
+public class Startup implements CommandLineRunner {
+
+	@Autowired
+	private CountryService countryService;
+
+	@Override
+	public void run(String... args) throws Exception {
+		System.out.println("---- calling country service");
+		System.out.println(countryService.countries());
+		System.out.println("---- calling country service again from cache.");
+		System.out.println(countryService.countries());
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache-redis/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-cache-redis/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.cache.cacheNames[0]=countries

--- a/spring-boot-samples/spring-boot-sample-cache-redis/src/test/java/sample/SampleRedisCacheApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-cache-redis/src/test/java/sample/SampleRedisCacheApplicationTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = {SampleRedisCacheApplication.class})
+public class SampleRedisCacheApplicationTests {
+
+	@Autowired
+	private CacheManager cacheManager;
+
+	@Test
+	public void testCacheManagerInstance() {
+		assertThat(this.cacheManager, instanceOf(RedisCacheManager.class));
+	}
+
+	@Test
+	public void testCacheManager() {
+		assertThat(this.cacheManager.getCacheNames(), contains("countries"));
+	}
+
+	@Configuration
+	static class RedisCacheConfiguration {
+
+		@Bean
+		public RedisTemplate<?, ?> redisTemplate() {
+			return mock(RedisTemplate.class);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Show the minimal configuration to support caching in spring-boot
applications.

* EhCache
* Guava
* Hazelcast
* JCache (Using `Hazelcast` as a providers)
* Redis

See gh-2633