### PR TITLE
Fix missing import in EhCache auto-config

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/EhCacheCacheConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/EhCacheCacheConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.autoconfigure.cache;
 
+import net.sf.ehcache.Cache;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -35,7 +36,7 @@ import org.springframework.core.io.Resource;
  * @since 1.3.0
  */
 @Configuration
-@ConditionalOnClass(EhCacheCacheManager.class)
+@ConditionalOnClass({Cache.class, EhCacheCacheManager.class})
 @ConditionalOnMissingBean(CacheManager.class)
 @Conditional({ CacheCondition.class,
 		EhCacheCacheConfiguration.ConfigAvailableCondition.class })


### PR DESCRIPTION
Add Cache class from ehcache dependency as a conditional in order
to remove ehcache dependency when hazelcast want to be used.

See gh-2633