### PR TITLE
Allow EnableAutoConfiguration to load spring contexts by factory name

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/EnableAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/EnableAutoConfiguration.java
@@ -53,7 +53,7 @@ import org.springframework.core.io.support.SpringFactoriesLoader;
  * can be searched.
  * <p>
  * Auto-configuration classes are regular Spring {@link Configuration} beans. They are
- * located using the {@link SpringFactoriesLoader} mechanism (keyed against this class).
+ * located using the {@link SpringFactoriesLoader} mechanism (keyed against {@link #factoryName()}).
  * Generally auto-configuration beans are {@link Conditional @Conditional} beans (most
  * often using {@link ConditionalOnClass @ConditionalOnClass} and
  * {@link ConditionalOnMissingBean @ConditionalOnMissingBean} annotations).
@@ -78,4 +78,9 @@ public @interface EnableAutoConfiguration {
 	 */
 	Class<?>[] exclude() default {};
 
+	/**
+	 * Set the factory name used as key by {@link SpringFactoriesLoader} mechanism.
+	 * @return the factory name in spring.properties files
+	 */
+	Class<?> factoryName() default EnableAutoConfiguration.class;
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/EnableAutoConfigurationImportSelector.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/EnableAutoConfigurationImportSelector.java
@@ -69,7 +69,7 @@ class EnableAutoConfigurationImportSelector implements DeferredImportSelector,
 
 			// Find all possible auto configuration classes, filtering duplicates
 			List<String> factories = new ArrayList<String>(new LinkedHashSet<String>(
-					SpringFactoriesLoader.loadFactoryNames(attributes.getClass("factoryName"),
+					SpringFactoriesLoader.loadFactoryNames(Class.forName(attributes.getString("factoryName")),
 							this.beanClassLoader)));
 
 			// Remove those specifically disabled
@@ -84,6 +84,8 @@ class EnableAutoConfigurationImportSelector implements DeferredImportSelector,
 			return factories.toArray(new String[factories.size()]);
 		}
 		catch (IOException ex) {
+			throw new IllegalStateException(ex);
+		} catch (ClassNotFoundException ex) {
 			throw new IllegalStateException(ex);
 		}
 	}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/EnableAutoConfigurationImportSelector.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/EnableAutoConfigurationImportSelector.java
@@ -69,7 +69,7 @@ class EnableAutoConfigurationImportSelector implements DeferredImportSelector,
 
 			// Find all possible auto configuration classes, filtering duplicates
 			List<String> factories = new ArrayList<String>(new LinkedHashSet<String>(
-					SpringFactoriesLoader.loadFactoryNames(EnableAutoConfiguration.class,
+					SpringFactoriesLoader.loadFactoryNames(attributes.getClass("factoryName"),
 							this.beanClassLoader)));
 
 			// Remove those specifically disabled

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/EnableAutoConfigurationImportSelectorTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/EnableAutoConfigurationImportSelectorTests.java
@@ -67,7 +67,7 @@ public class EnableAutoConfigurationImportSelectorTests {
 	@Test
 	public void importsAreSelected() {
 		configureExclusions();
-		configureFactoryKey(EnableAutoConfiguration.class);
+		configureFactoryKey(EnableAutoConfiguration.class.getName());
 		
 		String[] imports = this.importSelector.selectImports(this.annotationMetadata);
 		assertThat(
@@ -82,7 +82,7 @@ public class EnableAutoConfigurationImportSelectorTests {
 	@Test
 	public void exclusionsAreApplied() {
 		configureExclusions(FreeMarkerAutoConfiguration.class.getName());
-		configureFactoryKey(EnableAutoConfiguration.class);
+		configureFactoryKey(EnableAutoConfiguration.class.getName());
 		
 		String[] imports = this.importSelector.selectImports(this.annotationMetadata);
 		assertThat(imports.length,
@@ -94,7 +94,7 @@ public class EnableAutoConfigurationImportSelectorTests {
 	@Test
 	public void factoryKeyIsAppliedButNotFound() {
 		configureExclusions();
-		configureFactoryKey(this.getClass());
+		configureFactoryKey(this.getClass().getName());
 		
 		String[] imports = this.importSelector.selectImports(this.annotationMetadata);
 		assertThat(imports.length,
@@ -104,7 +104,7 @@ public class EnableAutoConfigurationImportSelectorTests {
 	@Test
 	public void factoryKeyIsApplied() {
 		configureExclusions();
-		configureFactoryKey(TemplateAvailabilityProvider.class); // Just as a test without modifying current spring.factories for test purposes
+		configureFactoryKey(TemplateAvailabilityProvider.class.getName()); // Just as a test without modifying current spring.factories for test purposes
 		
 		String[] imports = this.importSelector.selectImports(this.annotationMetadata);
 		assertThat(imports.length,
@@ -119,18 +119,21 @@ public class EnableAutoConfigurationImportSelectorTests {
 		given(this.annotationAttributes.getStringArray("exclude")).willReturn(exclusions);
 	}
 	
-	private void configureFactoryKey(Class factoryKeyClass) {
+	private void configureFactoryKey(String factoryKeyClass) {
 		given(
 				this.annotationMetadata.getAnnotationAttributes(
 						EnableAutoConfiguration.class.getName(), true))
 						.willReturn(this.annotationAttributes);
 
-		given(this.annotationAttributes.getClass("factoryName"))
-		.willReturn(factoryKeyClass);
+		given(this.annotationAttributes.getString("factoryName")).willReturn(factoryKeyClass);
 	}
 
 	private List<String> getAutoConfigurationClassNames() {
-		return SpringFactoriesLoader.loadFactoryNames(this.annotationAttributes.getClass("factoryName"),
-				getClass().getClassLoader());
+		try {
+			return SpringFactoriesLoader.loadFactoryNames(Class.forName(this.annotationAttributes.getString("factoryName")),
+					getClass().getClassLoader());
+		} catch (ClassNotFoundException ex) {
+			throw new IllegalStateException(ex);
+		}
 	}
 }


### PR DESCRIPTION
Despite auto-configuration being an awesome feature offered by spring-boot,  I have found myself blocked when I tried to write my own set of configuration classes, not depending on the default list.

I was forced either to register my classes on the `EnableAutoConfiguration` factoryName in `spring.properties`, excluding unnecessary configurations one by one, or to rewrite the feature (import selector, ordering, exclusion), depriving myself of the future improvements that could be made.

This PR allows developers to write their own set of auto-configuration classes for their spring-boot powered application, registered on a specific factory name.

Default behaviour is not changed.

I signed the CLA.