### PR TITLE
Prevent from creating `GsonHttpMessageConvertersConfiguration` bean when...

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/GsonHttpMessageConvertersConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/GsonHttpMessageConvertersConfiguration.java
@@ -36,6 +36,7 @@ import com.google.gson.Gson;
  * @since 1.2.2
  */
 @Configuration
+@ConditionalOnClass(Gson.class)
 class GsonHttpMessageConvertersConfiguration {
 
 	@Configuration


### PR DESCRIPTION
... `Gson` class is missing.

It would be good not to register `GsonHttpMessageConvertersConfiguration` bean when `Gson` class is missing.