### PR TITLE
Update pom.xml

### DIFF
--- a/spring-boot-samples/spring-boot-sample-tomcat-jsp/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-tomcat-jsp/pom.xml
@@ -32,11 +32,6 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.tomcat.embed</groupId>
-			<artifactId>tomcat-embed-jasper</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>jstl</artifactId>
 		</dependency>


### PR DESCRIPTION
Did not appear that jasper needed to be marked as provided, at least for this sample to work.

Based on my limited amount of research here, we need to mark the tomcat starters as provided to keep from having runtime conflicts when running within a container, and we need to mark the servlets jstl dependency as provided to prevent an IDE from marking the JSP pages with errors.  But I didn't find a concrete case for jasper.

Suggest that we may wish to comment these 'provided' dependencies to give an explanation as to why they are excluded.

thx,
k