### PR TITLE
Introduce <useTestClasspath> configuration to spring-boot:run to allow r...

### DIFF
--- a/spring-boot-tools/spring-boot-maven-plugin/src/it/run-use-test-classpath/pom.xml
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/it/run-use-test-classpath/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.boot.maven.it</groupId>
+	<artifactId>run-use-test-classpath</artifactId>
+	<version>0.0.1.BUILD-SNAPSHOT</version>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<useTestClasspath>true</useTestClasspath>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<version>@spring.version@</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-boot-tools/spring-boot-maven-plugin/src/it/run-use-test-classpath/src/main/java/org/test/SampleApplication.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/it/run-use-test-classpath/src/main/java/org/test/SampleApplication.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.test;
+
+import java.lang.Class;
+import java.lang.ClassNotFoundException;
+import java.lang.Exception;
+import java.lang.IllegalStateException;
+
+public class SampleApplication {
+
+	public static void main(String[] args) {
+
+		Class<?> appContext = null;
+		try {
+			appContext = Class.forName("org.springframework.context.ApplicationContext");
+		} catch (ClassNotFoundException e) {
+			throw new IllegalStateException("Test dependencies not added to classpath", e);
+		}
+		System.out.println("I haz been run");
+	}
+
+}

--- a/spring-boot-tools/spring-boot-maven-plugin/src/it/run-use-test-classpath/verify.groovy
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/it/run-use-test-classpath/verify.groovy
@@ -1,0 +1,3 @@
+def file = new File(basedir, "build.log")
+return file.text.contains("I haz been run")
+

--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunMojo.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunMojo.java
@@ -131,6 +131,13 @@ public class RunMojo extends AbstractDependencyFilterMojo {
 	private File classesDirectory;
 
 	/**
+	 * Flag to include the test classpath when running.
+	 * @since 1.3
+	 */
+	@Parameter(property = "useTestClasspath", defaultValue = "false")
+	private Boolean useTestClasspath;
+
+	/**
 	 * Flag to indicate if the run processes should be forked. By default process forking
 	 * is only used if an agent or jvmArguments are specified.
 	 * @since 1.2
@@ -312,7 +319,7 @@ public class RunMojo extends AbstractDependencyFilterMojo {
 
 	private void addDependencies(List<URL> urls) throws MalformedURLException,
 			MojoExecutionException {
-		FilterArtifacts filters = getFilters(new TestArtifactFilter());
+		FilterArtifacts filters = this.useTestClasspath ? getFilters() : getFilters(new TestArtifactFilter());
 		Set<Artifact> artifacts = filterDependencies(this.project.getArtifacts(), filters);
 		for (Artifact artifact : artifacts) {
 			if (artifact.getFile() != null) {

--- a/spring-boot-tools/spring-boot-maven-plugin/src/site/apt/usage.apt.vm
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/site/apt/usage.apt.vm
@@ -140,3 +140,8 @@ mvn spring-boot:run
   in such a way that any dependency that is excluded in the plugin's configuration gets excluded
   from the classpath as well. See {{{./examples/exclude-dependency.html}Exclude a dependency}} for
   more details.
+
+  Sometimes it is useful to include test dependencies when running the application. For example,
+  if you want to run your application in a test mode that uses stub classes. If you wish to do this,
+  you can set the <<<useTestClasspath>>> parameter to true. This only applies to the run goal. The
+  repackage goal will never add test dependencies to the resulting JAR/WAR.


### PR DESCRIPTION
...unning with test dependencies added to the classpath.

Plugins such as maven-jetty-plugin have this option and we need it in order to migrate projects to spring-boot with embedded Jetty.