### PR TITLE
Fix Elasticsearch health indicator

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/ElasticsearchHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/ElasticsearchHealthIndicator.java
@@ -31,6 +31,8 @@ import org.elasticsearch.client.Requests;
  */
 public class ElasticsearchHealthIndicator extends AbstractHealthIndicator {
 
+	private final static String[] ALL_INDICES = { "_all" };
+
 	private final Client client;
 
 	private final ElasticsearchHealthIndicatorProperties properties;
@@ -47,8 +49,10 @@ public class ElasticsearchHealthIndicator extends AbstractHealthIndicator {
 		ClusterHealthResponse response = this.client
 				.admin()
 				.cluster()
-				.health(Requests.clusterHealthRequest(indices.isEmpty() ? null : indices
-						.toArray(new String[indices.size()])))
+				.health(Requests.clusterHealthRequest(indices.isEmpty()
+																											? ALL_INDICES
+																											: indices.toArray(new String[indices.size()])))
+
 				.actionGet(this.properties.getResponseTimeout());
 
 		switch (response.getStatus()) {

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/ElasticsearchHealthIndicatorProperties.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/ElasticsearchHealthIndicatorProperties.java
@@ -45,6 +45,10 @@ public class ElasticsearchHealthIndicatorProperties {
 		return this.indices;
 	}
 
+	public void setIndices(List<String> indices) {
+		this.indices = indices;
+	}
+
 	public long getResponseTimeout() {
 		return this.responseTimeout;
 	}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/ElasticsearchHealthIndicatorTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/ElasticsearchHealthIndicatorTests.java
@@ -82,7 +82,7 @@ public class ElasticsearchHealthIndicatorTests {
 		given(this.cluster.health(requestCaptor.capture())).willReturn(responseFuture);
 		Health health = this.indicator.health();
 		assertThat(responseFuture.getTimeout, is(100L));
-		assertThat(requestCaptor.getValue().indices(), is(nullValue()));
+		assertThat(requestCaptor.getValue().indices(), is(arrayContaining("_all")));
 		assertThat(health.getStatus(), is(Status.UP));
 	}
 


### PR DESCRIPTION
After the polishing of the ElasticsearchHealthIndicator added in gh-2399 the actual health check won't work anymore.

- the indices property cannot be set from configuration files, because setIndices() is missing
- Elasticsearch cannot handle "null" if the health of all indices should be checked; "_all" should be used instead