### PR TITLE
Expose health detail when security is not applied.

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcAutoConfiguration.java
@@ -176,7 +176,7 @@ public class EndpointWebMvcAutoConfiguration implements ApplicationContextAware,
 	@ConditionalOnEnabledEndpoint("health")
 	public HealthMvcEndpoint healthMvcEndpoint(HealthEndpoint delegate) {
 		Security security = this.managementServerProperties.getSecurity();
-		boolean secure = (security == null || security.isEnabled());
+		boolean secure = (security != null && security.isEnabled());
 		HealthMvcEndpoint healthMvcEndpoint = new HealthMvcEndpoint(delegate, secure);
 		if (this.healthMvcEndpointProperties.getMapping() != null) {
 			healthMvcEndpoint.addStatusMapping(this.healthMvcEndpointProperties


### PR DESCRIPTION
When there's no security, health detail is not exposed unless the following property is set:
```
endpoints.health.sensitive=false
```
I'm not sure whether it's intended or not

but it looks inconsistent with other endpoints like `/autoconfig`, `/beans`, etc. which are also sensitive.