### PR TITLE
Move `status` in `/trace` endpoint

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
@@ -113,7 +113,7 @@ public class WebRequestTraceFilter extends OncePerRequestFilter implements Order
 			String value = response.getHeader(header);
 			headers.put(header, value);
 		}
-		headers.put("status", "" + response.getStatus());
+		trace.put("status", "" + response.getStatus());
 		@SuppressWarnings("unchecked")
 		Map<String, Object> allHeaders = (Map<String, Object>) trace.get("headers");
 		allHeaders.put("response", headers);


### PR DESCRIPTION
 It would be better to move `status` from `info.headers.response` to `info` in `/trace` endpoint because it's not a header.