### PR TITLE
reuse ObjectMappers

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointMBeanExportAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointMBeanExportAutoConfiguration.java
@@ -29,11 +29,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.json.jackson.WrappedObjectMapperProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} to enable JMX export for
@@ -50,6 +53,9 @@ public class EndpointMBeanExportAutoConfiguration {
 	@Autowired
 	EndpointMBeanExportProperties properties = new EndpointMBeanExportProperties();
 
+	@Autowired(required = false)
+	ObjectMapper objectMapper;
+
 	@Bean
 	public EndpointMBeanExporter endpointMBeanExporter(MBeanServer server) {
 		EndpointMBeanExporter mbeanExporter = new EndpointMBeanExporter();
@@ -60,6 +66,10 @@ public class EndpointMBeanExportAutoConfiguration {
 		mbeanExporter.setServer(server);
 		mbeanExporter.setEnsureUniqueRuntimeObjectNames(this.properties.isUniqueNames());
 		mbeanExporter.setObjectNameStaticProperties(this.properties.getStaticNames());
+		if (this.objectMapper != null) {
+			mbeanExporter.setObjectMapperProvider(new WrappedObjectMapperProvider(
+					this.objectMapper));
+		}
 		return mbeanExporter;
 	}
 

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/DataEndpointMBean.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/DataEndpointMBean.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.actuate.endpoint.jmx;
 
 import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.json.jackson.ObjectMapperProvider;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
 
@@ -29,8 +30,9 @@ import org.springframework.jmx.export.annotation.ManagedResource;
 @ManagedResource
 public class DataEndpointMBean extends EndpointMBean {
 
-	public DataEndpointMBean(String beanName, Endpoint<?> endpoint) {
-		super(beanName, endpoint);
+	public DataEndpointMBean(String beanName, Endpoint<?> endpoint,
+			ObjectMapperProvider objectMapperProvider) {
+		super(beanName, endpoint, objectMapperProvider);
 	}
 
 	@ManagedAttribute(description = "Invoke the underlying endpoint")

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBean.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBean.java
@@ -20,12 +20,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.json.jackson.ObjectMapperProvider;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Simple wrapper around {@link Endpoint} implementations to enable JMX export.
@@ -37,12 +36,15 @@ public class EndpointMBean {
 
 	private final Endpoint<?> endpoint;
 
-	private final ObjectMapper mapper = new ObjectMapper();
+	private final ObjectMapperProvider objectMapperProvider;
 
-	public EndpointMBean(String beanName, Endpoint<?> endpoint) {
+	public EndpointMBean(String beanName, Endpoint<?> endpoint,
+			ObjectMapperProvider objectMapperProvider) {
 		Assert.notNull(beanName, "BeanName must not be null");
 		Assert.notNull(endpoint, "Endpoint must not be null");
+		Assert.notNull(objectMapperProvider, "ObjectMapperProvider must not be null");
 		this.endpoint = endpoint;
+		this.objectMapperProvider = objectMapperProvider;
 	}
 
 	@ManagedAttribute(description = "Returns the class of the underlying endpoint")
@@ -69,10 +71,11 @@ public class EndpointMBean {
 		}
 
 		if (result.getClass().isArray() || result instanceof List) {
-			return this.mapper.convertValue(result, List.class);
+			return this.objectMapperProvider.getObjectMapper().convertValue(result,
+					List.class);
 		}
 
-		return this.mapper.convertValue(result, Map.class);
+		return this.objectMapperProvider.getObjectMapper().convertValue(result, Map.class);
 	}
 
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/ShutdownEndpointMBean.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/ShutdownEndpointMBean.java
@@ -18,6 +18,7 @@ package org.springframework.boot.actuate.endpoint.jmx;
 
 import org.springframework.boot.actuate.endpoint.Endpoint;
 import org.springframework.boot.actuate.endpoint.ShutdownEndpoint;
+import org.springframework.boot.json.jackson.ObjectMapperProvider;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedResource;
 
@@ -29,8 +30,9 @@ import org.springframework.jmx.export.annotation.ManagedResource;
 @ManagedResource
 public class ShutdownEndpointMBean extends EndpointMBean {
 
-	public ShutdownEndpointMBean(String beanName, Endpoint<?> endpoint) {
-		super(beanName, endpoint);
+	public ShutdownEndpointMBean(String beanName, Endpoint<?> endpoint,
+			ObjectMapperProvider objectMapperProvider) {
+		super(beanName, endpoint, objectMapperProvider);
 	}
 
 	@ManagedOperation(description = "Shutdown the ApplicationContext")

--- a/spring-boot/src/main/java/org/springframework/boot/json/JacksonJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/JacksonJsonParser.java
@@ -19,21 +19,55 @@ package org.springframework.boot.json;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.boot.json.jackson.ObjectMapperProvider;
+import org.springframework.boot.json.jackson.WrappedObjectMapperProvider;
+import org.springframework.util.Assert;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Thin wrapper to adapt Jackson 2 {@link ObjectMapper} to {@link JsonParser}.
  *
  * @author Dave Syer
+ * @author Dan Paquette
  * @see JsonParserFactory
  */
 public class JacksonJsonParser implements JsonParser {
+
+	private final ObjectMapperProvider objectMapperProvider;
+
+	/**
+	 * Creates an instance that an out of the box {@link ObjectMapper}.
+	 */
+	public JacksonJsonParser() {
+		this(WrappedObjectMapperProvider.createBasicProvider());
+	}
+
+	/**
+	 * Creates an instance using a custom {@link ObjectMapperProvider}.
+	 *
+	 * @param objectMapperProvider
+	 */
+	public JacksonJsonParser(final ObjectMapperProvider objectMapperProvider) {
+		Assert.notNull(objectMapperProvider, "ObjectMapperProvider must not be null");
+		this.objectMapperProvider = objectMapperProvider;
+	}
+
+	/**
+	 * Creates an instance using a custom {@link ObjectMapper}.
+	 *
+	 * @param objectMapper
+	 */
+	public JacksonJsonParser(final ObjectMapper objectMapper) {
+		Assert.notNull(objectMapper, "ObjectMapper must not be null");
+		this.objectMapperProvider = new WrappedObjectMapperProvider(objectMapper);
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public Map<String, Object> parseMap(String json) {
 		try {
-			return new ObjectMapper().readValue(json, Map.class);
+			return this.objectMapperProvider.getObjectMapper().readValue(json, Map.class);
 		}
 		catch (Exception ex) {
 			throw new IllegalArgumentException("Cannot parse JSON", ex);
@@ -44,7 +78,7 @@ public class JacksonJsonParser implements JsonParser {
 	@SuppressWarnings("unchecked")
 	public List<Object> parseList(String json) {
 		try {
-			return new ObjectMapper().readValue(json, List.class);
+			return this.objectMapperProvider.getObjectMapper().readValue(json, List.class);
 		}
 		catch (Exception ex) {
 			throw new IllegalArgumentException("Cannot parse JSON", ex);

--- a/spring-boot/src/main/java/org/springframework/boot/json/jackson/MemoizingObjectMapperProvider.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/jackson/MemoizingObjectMapperProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.json.jackson;
+
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Memoizes the {@link ObjectMapper} created by the delegate {@link ObjectMapperProvider}
+ * <p>
+ * Does not guarantee one time creation from the delegate when used by multiple threads.
+ * </p>
+ *
+ * @author Dan Paquette
+ */
+public class MemoizingObjectMapperProvider implements ObjectMapperProvider {
+
+	private final ObjectMapperProvider delegate;
+	private ObjectMapper mapper;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param delegate The delegate {@link ObjectMapperProvider} used to create new
+	 * {@link ObjectMapper} instances.
+	 */
+	public MemoizingObjectMapperProvider(final ObjectMapperProvider delegate) {
+		Assert.notNull(delegate, "delegate cannot be null");
+		this.delegate = delegate;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.springframework.boot.json.jackson.ObjectMapperProvider#getObjectMapper()
+	 */
+	@Override
+	public ObjectMapper getObjectMapper() {
+		// This may result in multiple creations, but that seemed better than some kind
+		// of synchronization.
+		if (this.mapper == null) {
+			this.mapper = this.delegate.getObjectMapper();
+		}
+		return this.mapper;
+	}
+}

--- a/spring-boot/src/main/java/org/springframework/boot/json/jackson/ObjectMapperProvider.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/jackson/ObjectMapperProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.json.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * An interface to an Object that can provide an {@link ObjectMapper}.
+ *
+ * @author Dan Paquette
+ */
+public interface ObjectMapperProvider {
+
+	ObjectMapper getObjectMapper();
+}

--- a/spring-boot/src/main/java/org/springframework/boot/json/jackson/WrappedObjectMapperProvider.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/jackson/WrappedObjectMapperProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.json.jackson;
+
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * An ObjectMapperProvider that simply wraps an existing ObjectMapper instance.
+ *
+ * @author Dan Paquette
+ */
+public class WrappedObjectMapperProvider implements ObjectMapperProvider {
+
+	private final ObjectMapper mapper;
+
+	/**
+	 *
+	 * @param mapper the ObjectMapper to wrap.
+	 */
+	public WrappedObjectMapperProvider(final ObjectMapper mapper) {
+		Assert.notNull(mapper, "mapper cannot be null");
+		this.mapper = mapper;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.springframework.boot.json.jackson.ObjectMapperProvider#getObjectMapper()
+	 */
+	@Override
+	public ObjectMapper getObjectMapper() {
+		return this.mapper;
+	}
+
+	/**
+	 * Creates a basic ObjectMapperProvider wrapping an out of the box ObjectMapper
+	 * instance.
+	 *
+	 * @return An ObjectMapperProvider instance.
+	 */
+	public static final ObjectMapperProvider createBasicProvider() {
+		return new WrappedObjectMapperProvider(new ObjectMapper());
+	}
+}

--- a/spring-boot/src/test/java/org/springframework/boot/json/JacksonParserTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/json/JacksonParserTests.java
@@ -16,16 +16,83 @@
 
 package org.springframework.boot.json;
 
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.boot.json.jackson.ObjectMapperProvider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 /**
  * Tests for {@link JsonParser}.
  *
  * @author Dave Syer
+ * @author Dan Paquette
  */
+@RunWith(MockitoJUnitRunner.class)
 public class JacksonParserTests extends AbstractJsonParserTests {
+
+	private static final String TEST_LIST_JSON = "[\"value\"]";
+
+	@Mock
+	private ObjectMapperProvider mockObjectMapperProvider;
+
+	@Mock
+	private ObjectMapper mockObjectMapper;
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
 
 	@Override
 	protected JsonParser getParser() {
 		return new JacksonJsonParser();
 	}
 
+	@Test
+	public void testNullObjectMapperProviderParameter() {
+		this.exception.expect(IllegalArgumentException.class);
+		new JacksonJsonParser((ObjectMapperProvider) null);
+	}
+
+	@Test
+	public void testNullObjectMapperParameter() {
+		this.exception.expect(IllegalArgumentException.class);
+		new JacksonJsonParser((ObjectMapper) null);
+	}
+
+	@Test
+	public void testCustomObjectMapper() throws Exception {
+		when(this.mockObjectMapper.readValue(TEST_LIST_JSON, List.class)).thenReturn(
+				Collections.singletonList("value"));
+		JacksonJsonParser parser = new JacksonJsonParser(this.mockObjectMapper);
+		List<Object> parsedList = parser.parseList(TEST_LIST_JSON);
+		assertEquals(1, parsedList.size());
+		assertEquals("value", parsedList.get(0));
+		verify(this.mockObjectMapper, times(1)).readValue(TEST_LIST_JSON, List.class);
+	}
+
+	@Test
+	public void testParseListWithSuppliedObjectMapperProvider() throws Exception {
+		when(this.mockObjectMapperProvider.getObjectMapper()).thenReturn(
+				this.mockObjectMapper);
+		when(this.mockObjectMapper.readValue(TEST_LIST_JSON, List.class)).thenReturn(
+				Collections.singletonList("value"));
+		JacksonJsonParser parser = new JacksonJsonParser(this.mockObjectMapperProvider);
+		List<Object> parsedList = parser.parseList(TEST_LIST_JSON);
+		assertEquals(1, parsedList.size());
+		assertEquals("value", parsedList.get(0));
+		verify(this.mockObjectMapperProvider, times(1)).getObjectMapper();
+		verify(this.mockObjectMapper, times(1)).readValue(TEST_LIST_JSON, List.class);
+	}
 }

--- a/spring-boot/src/test/java/org/springframework/boot/json/jackson/MemoizingObjectMapperProviderTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/json/jackson/MemoizingObjectMapperProviderTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.json.jackson;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Dan Paquette
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MemoizingObjectMapperProviderTests {
+
+	@Mock
+	private ObjectMapperProvider mockDelegate;
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testOnlyCreatedOnce() {
+		when(this.mockDelegate.getObjectMapper()).thenReturn(new ObjectMapper());
+		MemoizingObjectMapperProvider factory = new MemoizingObjectMapperProvider(
+				this.mockDelegate);
+		ObjectMapper firstMapper = factory.getObjectMapper();
+		assertNotNull(firstMapper);
+		assertEquals(firstMapper, factory.getObjectMapper());
+		verify(this.mockDelegate, times(1)).getObjectMapper();
+	}
+
+	@Test
+	public void testNullDelegateThrowsIllegalArgumentException() {
+		this.exception.expect(IllegalArgumentException.class);
+		new MemoizingObjectMapperProvider(null);
+	}
+}

--- a/spring-boot/src/test/java/org/springframework/boot/json/jackson/WrappedObjectMapperProviderTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/json/jackson/WrappedObjectMapperProviderTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.json.jackson;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Dan Paquette
+ */
+public class WrappedObjectMapperProviderTests {
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testNullObjectMapper() {
+		this.exception.expect(IllegalArgumentException.class);
+		new WrappedObjectMapperProvider(null);
+	}
+
+	@Test
+	public void testReturnsSuppliedInstance() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectMapperProvider factory = new WrappedObjectMapperProvider(mapper);
+		assertEquals(mapper, factory.getObjectMapper());
+	}
+}


### PR DESCRIPTION
ObjectMappers in ConfigurationPropertiesReportEndpoint, JacksonJsonParser and EndpointMBeans. Fixes gh-1789