### PR TITLE
Rabbit requested heartbeat auto-configuration

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -107,22 +107,16 @@ public class RabbitAutoConfiguration {
 		private RabbitProperties config;
 		
 		@Bean
-		public ConnectionFactory rabbitConnectionFactory(RabbitConnectionFactoryBean factoryBean) {			
-			com.rabbitmq.client.ConnectionFactory connectionFactory = null;
-			try {
-				connectionFactory = factoryBean.getObject();
-			} catch (Exception e) {
-				throw new IllegalStateException("Unable to create ConnectionFactory",e);
-			}			
-			CachingConnectionFactory factory = new CachingConnectionFactory(connectionFactory);			
+		public ConnectionFactory rabbitConnectionFactory(com.rabbitmq.client.ConnectionFactory connectionFactory) {
+			CachingConnectionFactory factory = new CachingConnectionFactory(connectionFactory);
 			String addresses = config.getAddresses();
 			factory.setAddresses(addresses);			
 			return factory;
 		}
-		
-		@Bean 
-		public RabbitConnectionFactoryBean rabbitConnectionFactoryBean(){
-			RabbitConnectionFactoryBean factoryBean = new RabbitConnectionFactoryBean();			
+
+		@Bean
+		public RabbitConnectionFactoryBean nativeRabbitConnectionFactory(){
+			RabbitConnectionFactoryBean factoryBean = new RabbitConnectionFactoryBean();
 			if (config.getHost() != null) {
 				factoryBean.setHost(config.getHost());
 				factoryBean.setPort(config.getPort());

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -60,6 +60,11 @@ public class RabbitProperties {
 	 * Comma-separated list of addresses to which the client should connect to.
 	 */
 	private String addresses;
+	
+	/**
+	 * Requested heartbeat to send to broker, in seconds.
+	 */
+	private int requestedHeartbeat = 0;
 
 	public String getHost() {
 		if (this.addresses == null) {
@@ -153,6 +158,14 @@ public class RabbitProperties {
 
 	public void setVirtualHost(String virtualHost) {
 		this.virtualHost = ("".equals(virtualHost) ? "/" : virtualHost);
+	}
+
+	public int getRequestedHeartbeat() {
+		return this.requestedHeartbeat;
+	}
+
+	public void setRequestedHeartbeat(int requestedHeartbeat) {
+		this.requestedHeartbeat = requestedHeartbeat;
 	}
 
 }


### PR DESCRIPTION
Add requestedHearbeat property that can be set via
"spring.rabbitmq.requested-heartbeat". Refactor auto-configuration to
use RabbitConnectionFactoryBean to create the connection factory.

Fixes gh-2676