### PR TITLE
Add display-name option

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -79,6 +79,11 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer, Ord
 	 */
 	private String contextPath;
 
+	/**
+	 * Display name of the application.
+	 */
+	private String displayName;
+
 	@NestedConfigurationProperty
 	private Ssl ssl;
 
@@ -116,6 +121,14 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer, Ord
 
 	public void setContextPath(String contextPath) {
 		this.contextPath = contextPath;
+	}
+
+	public String getDisplayName() {
+		return this.displayName;
+	}
+
+	public void setDisplayName(String displayName) {
+		this.displayName = displayName;
 	}
 
 	public String getServletPath() {
@@ -200,6 +213,9 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer, Ord
 		}
 		if (getContextPath() != null) {
 			container.setContextPath(getContextPath());
+		}
+		if (getDisplayName() != null) {
+			container.setDisplayName(getDisplayName());
 		}
 		if (getSessionTimeout() != null) {
 			container.setSessionTimeout(getSessionTimeout());

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -113,6 +113,14 @@ public class ServerPropertiesTests {
 	}
 
 	@Test
+	public void testCustomizeDisplayName() throws Exception {
+		ConfigurableEmbeddedServletContainer factory = mock(ConfigurableEmbeddedServletContainer.class);
+		this.properties.setDisplayName("TestName");
+		this.properties.customize(factory);
+		verify(factory).setDisplayName("TestName");
+	}
+
+	@Test
 	public void testCustomizeTomcatPort() throws Exception {
 		ConfigurableEmbeddedServletContainer factory = mock(ConfigurableEmbeddedServletContainer.class);
 		this.properties.setPort(8080);
@@ -134,6 +142,18 @@ public class ServerPropertiesTests {
 		map.put("server.tomcat.maxHttpHeaderSize", "9999");
 		bindProperties(map);
 		assertEquals(9999, this.properties.getTomcat().getMaxHttpHeaderSize());
+	}
+
+	@Test
+	public void customizeTomcatDisplayName() throws Exception {
+		Map<String, String> map = new HashMap<String, String>();
+		map.put("server.display-name", "MyBootApp");
+		bindProperties(map);
+
+		TomcatEmbeddedServletContainerFactory container = new TomcatEmbeddedServletContainerFactory();
+		this.properties.customize(container);
+
+		assertEquals("MyBootApp", container.getDisplayName());
 	}
 
 	@Test

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -58,6 +58,7 @@ content into your application; rather pick only the properties that you need.
 	server.context-parameters.*= # Servlet context init parameters, e.g. server.context-parameters.a=alpha
 	server.context-path= # the context path, defaults to '/'
 	server.servlet-path= # the servlet path, defaults to '/'
+	server.display-name= # the display name of the application
 	server.ssl.enabled=true # if SSL support is enabled
 	server.ssl.client-auth= # want or need
 	server.ssl.key-alias=

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractConfigurableEmbeddedServletContainer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractConfigurableEmbeddedServletContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.util.Assert;
  *
  * @author Phillip Webb
  * @author Dave Syer
+ * @author Stephane Nicoll
  * @see AbstractEmbeddedServletContainerFactory
  */
 public abstract class AbstractConfigurableEmbeddedServletContainer implements
@@ -41,6 +42,8 @@ public abstract class AbstractConfigurableEmbeddedServletContainer implements
 			.toSeconds(30);
 
 	private String contextPath = "";
+
+	private String displayName;
 
 	private boolean registerDefaultServlet = true;
 
@@ -118,6 +121,15 @@ public abstract class AbstractConfigurableEmbeddedServletContainer implements
 	 */
 	public String getContextPath() {
 		return this.contextPath;
+	}
+
+	@Override
+	public void setDisplayName(String displayName) {
+		this.displayName = displayName;
+	}
+
+	public String getDisplayName() {
+		return this.displayName;
 	}
 
 	@Override

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/ConfigurableEmbeddedServletContainer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/ConfigurableEmbeddedServletContainer.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
  * {@link EmbeddedServletContainerFactory}.
  *
  * @author Dave Syer
+ * @author Stephane Nicoll
  * @see EmbeddedServletContainerFactory
  * @see EmbeddedServletContainerCustomizer
  */
@@ -39,6 +40,12 @@ public interface ConfigurableEmbeddedServletContainer {
 	 * @param contextPath the contextPath to set
 	 */
 	void setContextPath(String contextPath);
+
+	/**
+	 * Sets the display name of the application deployed in the embedded servlet container.
+	 * @param displayName the displayName to set
+	 */
+	void setDisplayName(String displayName);
 
 	/**
 	 * Sets the port that the embedded servlet container should listen on. If not

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactory.java
@@ -231,6 +231,10 @@ public class JettyEmbeddedServletContainerFactory extends
 		}
 		String contextPath = getContextPath();
 		context.setContextPath(StringUtils.hasLength(contextPath) ? contextPath : "/");
+		String displayName = getDisplayName();
+		if (displayName != null) {
+			context.setDisplayName(displayName);
+		}
 		configureDocumentRoot(context);
 		if (isRegisterDefaultServlet()) {
 			addDefaultServlet(context);

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
@@ -160,6 +160,10 @@ public class TomcatEmbeddedServletContainerFactory extends
 		docBase = (docBase != null ? docBase : createTempDir("tomcat-docbase"));
 		TomcatEmbeddedContext context = new TomcatEmbeddedContext();
 		context.setName(getContextPath());
+		String displayName = getDisplayName();
+		if (displayName != null) {
+			context.setDisplayName(displayName);
+		}
 		context.setPath(getContextPath());
 		context.setDocBase(docBase.getAbsolutePath());
 		context.addLifecycleListener(new FixContextListener());

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
@@ -325,6 +325,10 @@ public class UndertowEmbeddedServletContainerFactory extends
 				initializers);
 		deployment.setClassLoader(getServletClassLoader());
 		deployment.setContextPath(getContextPath());
+		String displayName = getDisplayName();
+		if (displayName != null) {
+			deployment.setDisplayName(displayName);
+		}
 		deployment.setDeploymentName("spring-boot");
 		if (isRegisterDefaultServlet()) {
 			deployment.addServlet(Servlets.servlet("default", DefaultServlet.class));


### PR DESCRIPTION
Allow the display-name of the application to be customized when deployed
in an embedded container via the `server.display-name` property.

Closes gh-2600