### PR TITLE
Issue #2859 - Update GemFire version to match the version pulled in by S...

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -65,7 +65,7 @@
 		<flyway.version>3.2.1</flyway.version>
 		<freemarker.version>2.3.22</freemarker.version>
 		<elasticsearch.version>1.4.4</elasticsearch.version>
-		<gemfire.version>7.0.2</gemfire.version>
+		<gemfire.version>8.0.0</gemfire.version>
 		<glassfish-el.version>3.0.0</glassfish-el.version>
 		<gradle.version>1.12</gradle.version>
 		<groovy.version>2.4.3</groovy.version>


### PR DESCRIPTION
...pring Data GemFire (v1.6) in the Spring Data Fowler Release Train.

See GitHub Issue #2859 (https://github.com/spring-projects/spring-boot/issues/2859) for more details.