### PR TITLE
Register MBean only for enabled endpoints

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBeanExporter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBeanExporter.java
@@ -154,7 +154,8 @@ public class EndpointMBeanExporter extends MBeanExporter implements SmartLifecyc
 	protected void locateAndRegisterEndpoints() {
 		Map<String, Endpoint> endpoints = this.beanFactory.getBeansOfType(Endpoint.class);
 		for (Map.Entry<String, Endpoint> endpointEntry : endpoints.entrySet()) {
-			if (!this.registeredEndpoints.contains(endpointEntry.getValue())) {
+			if (!this.registeredEndpoints.contains(endpointEntry.getValue())
+			        && endpointEntry.getValue().isEnabled()) {
 				registerEndpoint(endpointEntry.getKey(), endpointEntry.getValue());
 				this.registeredEndpoints.add(endpointEntry.getValue());
 			}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBeanExporterTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBeanExporterTests.java
@@ -45,8 +45,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link EndpointMBeanExporter}
@@ -80,6 +82,36 @@ public class EndpointMBeanExporterTests {
 		assertEquals(3, mbeanInfo.getOperations().length);
 		assertEquals(3, mbeanInfo.getAttributes().length);
 	}
+
+	@Test
+    public void testSkipRegistrationOfDisabledEndpoint() throws Exception {
+        this.context = new GenericApplicationContext();
+        this.context.registerBeanDefinition("endpointMbeanExporter",
+                new RootBeanDefinition(EndpointMBeanExporter.class));
+        MutablePropertyValues mvp = new MutablePropertyValues();
+        mvp.add("enabled", Boolean.FALSE);
+        this.context.registerBeanDefinition("endpoint1", new RootBeanDefinition(
+                TestEndpoint.class,null,mvp));
+        this.context.refresh();
+        MBeanExporter mbeanExporter = this.context.getBean(EndpointMBeanExporter.class);
+        assertFalse(mbeanExporter.getServer().isRegistered(
+                getObjectName("endpoint1", this.context)));
+    }
+
+	@Test
+    public void testRegistrationOfEnabledEndpoint() throws Exception {
+        this.context = new GenericApplicationContext();
+        this.context.registerBeanDefinition("endpointMbeanExporter",
+                new RootBeanDefinition(EndpointMBeanExporter.class));
+        MutablePropertyValues mvp = new MutablePropertyValues();
+        mvp.add("enabled", Boolean.TRUE);
+        this.context.registerBeanDefinition("endpoint1", new RootBeanDefinition(
+                TestEndpoint.class,null,mvp));
+        this.context.refresh();
+        MBeanExporter mbeanExporter = this.context.getBean(EndpointMBeanExporter.class);
+        assertTrue(mbeanExporter.getServer().isRegistered(
+                getObjectName("endpoint1", this.context)));
+    }
 
 	@Test
 	public void testRegistrationTwoEndpoints() throws Exception {


### PR DESCRIPTION
Honor the enabled property of endpoints. Consistent with
MVC endpoint behavior.

Fixes gh-2873