### PR TITLE
Add support for Infinispan

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -236,6 +236,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.infinispan</groupId>
+			<artifactId>infinispan-spring4</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheType.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheType.java
@@ -42,6 +42,11 @@ public enum CacheType {
 	HAZELCAST(HazelcastCacheConfiguration.class),
 
 	/**
+	 * Infinispan backed caching.
+	 */
+	INFINISPAN(InfinispanCacheConfiguration.class),
+
+	/**
 	 * JCache (JSR-107) backed caching.
 	 */
 	JCACHE(JCacheCacheConfiguration.class),

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/InfinispanCacheConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/InfinispanCacheConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.spring.provider.SpringEmbeddedCacheManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.util.CollectionUtils;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Infinispan cache configuration.
+ *
+ * @author Eddú Meléndez
+ * @since 1.3.0
+ */
+@Configuration
+@ConditionalOnClass(SpringEmbeddedCacheManager.class)
+@ConditionalOnMissingBean(CacheManager.class)
+@Conditional(CacheCondition.class)
+public class InfinispanCacheConfiguration {
+
+	@Autowired
+	private CacheProperties cacheProperties;
+
+	@Bean
+	public CacheManager cacheManager() throws IOException {
+		DefaultCacheManager defaultCacheManager = createCacheManager();
+		List<String> cacheNames = this.cacheProperties.getCacheNames();
+		if (!CollectionUtils.isEmpty(cacheNames)) {
+			for (String cacheName : cacheNames) {
+				defaultCacheManager.startCache(cacheName);
+			}
+		}
+		return new SpringEmbeddedCacheManager(defaultCacheManager);
+	}
+
+	private DefaultCacheManager createCacheManager() throws IOException {
+		Resource location = this.cacheProperties.resolveConfigLocation();
+		if (location != null) {
+			return new DefaultCacheManager(this.cacheProperties.getConfig().getInputStream());
+		}
+		return new DefaultCacheManager();
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
@@ -25,6 +25,7 @@ import javax.cache.configuration.MutableConfiguration;
 import javax.cache.expiry.CreatedExpiryPolicy;
 import javax.cache.expiry.Duration;
 
+import org.infinispan.spring.provider.SpringEmbeddedCacheManager;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -378,6 +379,32 @@ public class CacheAutoConfigurationTests {
 			if (cacheManager != null) {
 				cacheManager.getCacheManager().close();
 			}
+		}
+	}
+
+	@Test
+	public void infinispanCacheWithCaches() {
+		SpringEmbeddedCacheManager cacheManager = null;
+		try {
+			load(DefaultCacheConfiguration.class, "spring.cache.type=infinispan",
+				"spring.cache.cacheNames[0]=foo", "spring.cache.cacheNames[1]=bar");
+			cacheManager = validateCacheManager(SpringEmbeddedCacheManager.class);
+			assertThat(cacheManager.getCacheNames(), containsInAnyOrder("foo", "bar"));
+		} finally {
+			cacheManager.stop();
+		}
+	}
+
+	@Test
+	public void infinispanCacheWithConfig() {
+		SpringEmbeddedCacheManager cacheManager = null;
+		try {
+			load(DefaultCacheConfiguration.class, "spring.cache.type=infinispan",
+				"spring.cache.config=infinispan.xml");
+			cacheManager = validateCacheManager(SpringEmbeddedCacheManager.class);
+			assertThat(cacheManager.getCacheNames(), containsInAnyOrder("foo", "bar"));
+		} finally {
+			cacheManager.stop();
 		}
 	}
 

--- a/spring-boot-autoconfigure/src/test/resources/infinispan.xml
+++ b/spring-boot-autoconfigure/src/test/resources/infinispan.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:infinispan:config:7.1 http://www.infinispan.org/schemas/infinispan-config-7.1.xsd"
+            xmlns="urn:infinispan:config:7.1">
+
+	<!-- ************************************** -->
+	<!-- Corresponds to @Cacheable("cache-name") -->
+	<!-- ************************************** -->
+	<cache-container default-cache="default">
+		<local-cache name="foo"/>
+		<local-cache name="bar" />
+	</cache-container>
+
+</infinispan>

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -82,6 +82,7 @@
 		<hsqldb.version>2.3.2</hsqldb.version>
 		<httpasyncclient.version>4.0.2</httpasyncclient.version>
 		<httpclient.version>4.3.6</httpclient.version>
+		<infinispan.version>7.1.1.Final</infinispan.version>
 		<jackson.version>2.5.1</jackson.version>
 		<janino.version>2.6.1</janino.version>
 		<javassist.version>3.18.1-GA</javassist.version> <!-- Same as Hibernate -->
@@ -1264,6 +1265,11 @@
 				<groupId>org.hsqldb</groupId>
 				<artifactId>hsqldb</artifactId>
 				<version>${hsqldb.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.infinispan</groupId>
+				<artifactId>infinispan-spring4</artifactId>
+				<version>${infinispan.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.javassist</groupId>


### PR DESCRIPTION
Include auto-configuration support for Infinispan. It is possible
to specify the caches to create via `spring.cache.cache-names`.
Provider also allow to set configuration file via `spring.cache.config`.

See gh-2633