### PR TITLE
Sanitize all properties from specific PropertySources

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/ConfigurationPropertiesReportEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/ConfigurationPropertiesReportEndpoint.java
@@ -137,7 +137,7 @@ public class ConfigurationPropertiesReportEndpoint extends
 			Map<String, Object> root = new HashMap<String, Object>();
 			String prefix = extractPrefix(context, beanFactoryMetaData, beanName, bean);
 			root.put("prefix", prefix);
-			root.put("properties", sanitize(safeSerialize(mapper, bean, prefix)));
+			root.put("properties", sanitize(prefix, safeSerialize(mapper, bean, prefix)));
 			result.put(beanName, root);
 		}
 		if (context.getParent() != null) {
@@ -248,15 +248,15 @@ public class ConfigurationPropertiesReportEndpoint extends
 	 * information.
 	 */
 	@SuppressWarnings("unchecked")
-	private Map<String, Object> sanitize(Map<String, Object> map) {
+	private Map<String, Object> sanitize(String prefix, Map<String, Object> map) {
 		for (Map.Entry<String, Object> entry : map.entrySet()) {
 			String key = entry.getKey();
 			Object value = entry.getValue();
 			if (value instanceof Map) {
-				map.put(key, sanitize((Map<String, Object>) value));
+				map.put(key, sanitize(prefix, (Map<String, Object>) value));
 			}
 			else {
-				map.put(key, this.sanitizer.sanitize(key, value));
+				map.put(key, this.sanitizer.sanitize(prefix, key, value));
 			}
 		}
 		return map;

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/EnvironmentEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/EnvironmentEndpoint.java
@@ -63,7 +63,8 @@ public class EnvironmentEndpoint extends AbstractEndpoint<Map<String, Object>> {
 				EnumerablePropertySource<?> enumerable = (EnumerablePropertySource<?>) source;
 				Map<String, Object> map = new LinkedHashMap<String, Object>();
 				for (String name : enumerable.getPropertyNames()) {
-					map.put(name, sanitize(name, enumerable.getProperty(name)));
+					map.put(name,
+							sanitize(sourceName, name, enumerable.getProperty(name)));
 				}
 				result.put(sourceName, map);
 			}
@@ -100,8 +101,8 @@ public class EnvironmentEndpoint extends AbstractEndpoint<Map<String, Object>> {
 		}
 	}
 
-	public Object sanitize(String name, Object object) {
-		return this.sanitizer.sanitize(name, object);
+	public Object sanitize(String sourceName, String name, Object object) {
+		return this.sanitizer.sanitize(sourceName, name, object);
 	}
 
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/EnvironmentMvcEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/EnvironmentMvcEndpoint.java
@@ -96,7 +96,7 @@ public class EnvironmentMvcEndpoint extends EndpointMvcAdapter implements
 			if (result == null) {
 				throw new NoSuchPropertyException("No such property: " + name);
 			}
-			return ((EnvironmentEndpoint) getDelegate()).sanitize(name, result);
+			return ((EnvironmentEndpoint) getDelegate()).sanitize("", name, result);
 		}
 
 	}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/SanitizerTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/SanitizerTests.java
@@ -31,19 +31,21 @@ public class SanitizerTests {
 
 	@Test
 	public void defaults() throws Exception {
-		assertEquals(this.sanitizer.sanitize("password", "secret"), "******");
-		assertEquals(this.sanitizer.sanitize("my-password", "secret"), "******");
-		assertEquals(this.sanitizer.sanitize("my-OTHER.paSSword", "secret"), "******");
-		assertEquals(this.sanitizer.sanitize("somesecret", "secret"), "******");
-		assertEquals(this.sanitizer.sanitize("somekey", "secret"), "******");
-		assertEquals(this.sanitizer.sanitize("find", "secret"), "secret");
+		assertEquals(this.sanitizer.sanitize("", "password", "secret"), "******");
+		assertEquals(this.sanitizer.sanitize("", "my-password", "secret"), "******");
+		assertEquals(this.sanitizer.sanitize("", "my-OTHER.paSSword", "secret"), "******");
+		assertEquals(this.sanitizer.sanitize("", "somesecret", "secret"), "******");
+		assertEquals(this.sanitizer.sanitize("", "somekey", "secret"), "******");
+		assertEquals(this.sanitizer.sanitize("", "find", "secret"), "secret");
+
+		assertEquals(this.sanitizer.sanitize("decrypted", "find", "secret"), "******");
 	}
 
 	@Test
 	public void regex() throws Exception {
 		this.sanitizer.setKeysToSanitize(".*lock.*");
-		assertEquals(this.sanitizer.sanitize("verylOCkish", "secret"), "******");
-		assertEquals(this.sanitizer.sanitize("veryokish", "secret"), "secret");
+		assertEquals(this.sanitizer.sanitize("", "verylOCkish", "secret"), "******");
+		assertEquals(this.sanitizer.sanitize("", "veryokish", "secret"), "secret");
 	}
 
 }


### PR DESCRIPTION
Spring cloud puts all deciphered properties into a 'decrypted' PropertySource. It is desirable to sanitize all the properties from the source regardless of the key. By default the properties from the source with the name 'decrypted' get sanitized.

I signed the CLA