### PR TITLE
Feature: Undertow access_log configuration by application.yml(properties)

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -56,6 +56,7 @@ import org.springframework.util.StringUtils;
  * @author Stephane Nicoll
  * @author Andy Wilkinson
  * @author Ivan Sopov
+ * @author Marcos Barbero
  */
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = false)
 public class ServerProperties implements EmbeddedServletContainerCustomizer, Ordered {
@@ -578,6 +579,21 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer, Ord
 
 		private Boolean directBuffers;
 
+		/**
+		 * Format pattern for access logs.
+		 */
+		private String accessLogPattern;
+
+		/**
+		 * Enable access log.
+		 */
+		private boolean accessLogEnabled = false;
+
+		/**
+		 * Undertow access log directory. If not specified a temporary directory will be used.
+		 */
+		private File accessLogDir;
+
 		public Integer getBufferSize() {
 			return this.bufferSize;
 		}
@@ -618,12 +634,39 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer, Ord
 			this.directBuffers = directBuffers;
 		}
 
+		public String getAccessLogPattern() {
+			return accessLogPattern;
+		}
+
+		public void setAccessLogPattern(String accessLogPattern) {
+			this.accessLogPattern = accessLogPattern;
+		}
+
+		public boolean isAccessLogEnabled() {
+			return accessLogEnabled;
+		}
+
+		public void setAccessLogEnabled(boolean accessLogEnabled) {
+			this.accessLogEnabled = accessLogEnabled;
+		}
+
+		public File getAccessLogDir() {
+			return accessLogDir;
+		}
+
+		public void setAccessLogDir(File accessLogDir) {
+			this.accessLogDir = accessLogDir;
+		}
+
 		void customizeUndertow(UndertowEmbeddedServletContainerFactory factory) {
 			factory.setBufferSize(this.bufferSize);
 			factory.setBuffersPerRegion(this.buffersPerRegion);
 			factory.setIoThreads(this.ioThreads);
 			factory.setWorkerThreads(this.workerThreads);
 			factory.setDirectBuffers(this.directBuffers);
+			factory.setAccessLogDirectory(this.accessLogDir);
+			factory.setAccessLogPattern(this.accessLogPattern);
+			factory.setAccessLogEnabled(this.accessLogEnabled);
 		}
 
 	}

--- a/spring-boot-samples/spring-boot-sample-undertow/src/test/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-undertow/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+server.undertow.access-log-enabled=true
+server.undertow.access-log-pattern=combined

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactory.java
@@ -32,6 +32,7 @@ import org.apache.commons.logging.LogFactory;
  *
  * @author Phillip Webb
  * @author Dave Syer
+ * @author Marcos Barbero
  */
 public abstract class AbstractEmbeddedServletContainerFactory extends
 		AbstractConfigurableEmbeddedServletContainer implements
@@ -76,6 +77,25 @@ public abstract class AbstractEmbeddedServletContainerFactory extends
 			this.logger.debug("Document root: " + file);
 		}
 		return file;
+	}
+
+	/**
+	 * Returns the absolute temp dir for given web server.
+	 * @param prefix webserver name
+	 * @return The temp dir for given web server.
+	 */
+	protected File createTempDir(String prefix) {
+		try {
+			File tempFolder = File.createTempFile(prefix + ".", "." + getPort());
+			tempFolder.delete();
+			tempFolder.mkdir();
+			tempFolder.deleteOnExit();
+			return tempFolder;
+		}
+		catch (IOException ex) {
+			throw new EmbeddedServletContainerException(
+					String.format("Unable to create %s tempdir", prefix), ex);
+		}
 	}
 
 	private File getExplodedWarFileDocumentRoot() {

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
@@ -79,6 +79,7 @@ import org.springframework.util.StringUtils;
  * @author Brock Mills
  * @author Stephane Nicoll
  * @author Andy Wilkinson
+ * @author Marcos Barbero
  * @see #setPort(int)
  * @see #setContextLifecycleListeners(Collection)
  * @see TomcatEmbeddedServletContainer
@@ -380,20 +381,6 @@ public class TomcatEmbeddedServletContainerFactory extends
 	protected TomcatEmbeddedServletContainer getTomcatEmbeddedServletContainer(
 			Tomcat tomcat) {
 		return new TomcatEmbeddedServletContainer(tomcat, getPort() >= 0);
-	}
-
-	private File createTempDir(String prefix) {
-		try {
-			File tempFolder = File.createTempFile(prefix + ".", "." + getPort());
-			tempFolder.delete();
-			tempFolder.mkdir();
-			tempFolder.deleteOnExit();
-			return tempFolder;
-		}
-		catch (IOException ex) {
-			throw new EmbeddedServletContainerException(
-					"Unable to create Tomcat tempdir", ex);
-		}
 	}
 
 	@Override


### PR DESCRIPTION
Providing access_log configuration for Undertow at application.yml(properties) like the configuration available for Tomcat.
```
server.undertow.access-log-enabled: true
server.undertow.access-log-pattern: common #default
server.undertow.access-log-dir:  #default value temp dir
```