### PR TITLE
Fixed #3024 log4j2 auto-reload does not work with spring boot

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -149,7 +149,13 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 		try {
 			LoggerContext ctx = getLoggerContext();
 			URL url = ResourceUtils.getURL(location);
-			ConfigurationSource source = new ConfigurationSource(url.openStream(), url);
+			ConfigurationSource source;
+			if (ResourceUtils.isFileURL(url)) {
+				source = new ConfigurationSource(url.openStream(),
+						    ResourceUtils.getFile(url));
+			} else {
+				source = new ConfigurationSource(url.openStream(), url);
+			}
 			ctx.start(ConfigurationFactory.getInstance().getConfiguration(source));
 		}
 		catch (Exception ex) {

--- a/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.FileConfigurationMonitor;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -41,6 +42,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -108,7 +110,8 @@ public class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		assertTrue("Wrong output:\n" + output, output.contains(tmpDir() + "/tmp.log"));
 		assertFalse(new File(tmpDir() + "/tmp.log").exists());
 		assertThat(this.loggingSystem.getConfiguration().getConfigurationSource().getFile().getAbsolutePath(), containsString("log4j2-nondefault.xml"));
-		assertThat(this.loggingSystem.getConfiguration().getConfigurationMonitor(), is(notNullValue()));
+        // we assume that "log4j2-nondefault.xml" contains the 'monitorInterval' attribute, so we check that a monitor is created
+		assertThat(this.loggingSystem.getConfiguration().getConfigurationMonitor(), is(instanceOf(FileConfigurationMonitor.class)));
 	}
 
 	@Test

--- a/spring-boot/src/test/resources/log4j2-nondefault.xml
+++ b/spring-boot/src/test/resources/log4j2-nondefault.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration status="WARN" monitorInterval="30">
 	<Properties>
 		<Property name="PID">????</Property>
 		<Property name="LOG_PATTERN">${sys:LOG_FILE} %d{yyyy-MM-dd HH:mm:ss.SSS}] service%X{context} - ${sys:PID} %5p [%t] --- %c{1}: %m%n</Property>


### PR DESCRIPTION
Fixed #3024 log4j2 auto-reload does not work with spring boot

- added switch in case `configLocation` is a file
- added assertions to test cases in order to check existence of ConfigurationSource.file and ConfigurationMonitor
- added test case `configLocation` is reachable via HTTPS

Awaiting [Jürgenization](http://olivergierke.de/2013/03/juergenized)... ;)