### PR TITLE
Fix mess with spring-security versions

### DIFF
--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/CrshAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/CrshAutoConfigurationTests.java
@@ -373,12 +373,11 @@ public class CrshAutoConfigurationTests {
 
 		@Bean
 		public AccessDecisionManager shellAccessDecisionManager() {
-			List<AccessDecisionVoter> voters = new ArrayList<AccessDecisionVoter>();
+			List<AccessDecisionVoter<?>> voters = new ArrayList<AccessDecisionVoter<?>>();
 			RoleVoter voter = new RoleVoter();
 			voter.setRolePrefix("");
 			voters.add(voter);
-			AccessDecisionManager result = new UnanimousBased(voters);
-			return result;
+			return new UnanimousBased(voters);
 		}
 
 	}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -131,13 +131,11 @@
 		<spring-plugin.version>1.2.0.RELEASE</spring-plugin.version>
 		<spring-security.version>4.0.1.RELEASE</spring-security.version>
 		<spring-security-jwt.version>1.0.3.RELEASE</spring-security-jwt.version>
+		<spring-security-oauth2.version>2.0.7.RELEASE</spring-security-oauth2.version>
 		<spring-social.version>1.1.2.RELEASE</spring-social.version>
 		<spring-social-facebook.version>2.0.1.RELEASE</spring-social-facebook.version>
 		<spring-social-linkedin.version>1.0.1.RELEASE</spring-social-linkedin.version>
 		<spring-social-twitter.version>1.1.0.RELEASE</spring-social-twitter.version>
-		<spring-security.version>3.2.5.RELEASE</spring-security.version>
-		<spring-security-oauth2.version>2.0.7.RELEASE</spring-security-oauth2.version>
-		<spring-security-jwt.version>1.0.2.RELEASE</spring-security-jwt.version>
 		<spring-ws.version>2.2.1.RELEASE</spring-ws.version>
 		<statsd-client.version>3.1.0</statsd-client.version>
 		<sendgrid.version>2.1.0</sendgrid.version>


### PR DESCRIPTION
Since 53f67a448f8ef7a47ca5c472c26e1c1a1ef19359 the version of spring-security was defined multiple times (and inconsistently) which caused some funny behaviour (e.g. CSRF tokens weren't inserted into web forms anymore).

(I've signed the CLA)
