### PR TITLE
Fixed link to Groovy Markup Template Enginge

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -1112,7 +1112,7 @@ and JSPs. Many other templating engines also ship their own Spring MVC integrati
 Spring Boot includes auto-configuration support for the following templating engines:
 
  * http://freemarker.org/docs/[FreeMarker]
- * http://beta.groovy-lang.org/docs/groovy-2.3.0/html/documentation/markup-template-engine.html[Groovy]
+ * http://docs.groovy-lang.org/docs/next/html/documentation/template-engines.html#_the_markuptemplateengine[Groovy]
  * http://www.thymeleaf.org[Thymeleaf]
  * http://velocity.apache.org[Velocity]
 


### PR DESCRIPTION
Was using a beta link which now 404s, added link to official Groovy docs.