### PR TITLE
Stop file watcher as soon as a change is detected

### DIFF
--- a/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/autoconfigure/LocalDeveloperToolsAutoConfiguration.java
+++ b/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/autoconfigure/LocalDeveloperToolsAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.developertools.classpath.ClassPathChangedEvent;
 import org.springframework.boot.developertools.classpath.ClassPathFileSystemWatcher;
 import org.springframework.boot.developertools.classpath.ClassPathRestartStrategy;
 import org.springframework.boot.developertools.classpath.PatternClassPathRestartStrategy;
+import org.springframework.boot.developertools.filewatch.FileSystemWatcher;
 import org.springframework.boot.developertools.livereload.LiveReloadServer;
 import org.springframework.boot.developertools.restart.ConditionalOnInitializedRestarter;
 import org.springframework.boot.developertools.restart.RestartScope;
@@ -103,11 +104,13 @@ public class LocalDeveloperToolsAutoConfiguration {
 		@Autowired
 		private DeveloperToolsProperties properties;
 
+		private FileSystemWatcher fileSystemWatcher = new FileSystemWatcher();
+
 		@Bean
 		@ConditionalOnMissingBean
 		public ClassPathFileSystemWatcher classPathFileSystemWatcher() {
 			URL[] urls = Restarter.getInstance().getInitialUrls();
-			return new ClassPathFileSystemWatcher(classPathRestartStrategy(), urls);
+			return new ClassPathFileSystemWatcher(fileSystemWatcher,  classPathRestartStrategy(), urls);
 		}
 
 		@Bean
@@ -120,6 +123,7 @@ public class LocalDeveloperToolsAutoConfiguration {
 		@EventListener
 		public void onClassPathChanged(ClassPathChangedEvent event) {
 			if (event.isRestartRequired()) {
+				fileSystemWatcher.stop();
 				Restarter.getInstance().restart();
 			}
 		}

--- a/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/classpath/ClassPathFileSystemWatcher.java
+++ b/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/classpath/ClassPathFileSystemWatcher.java
@@ -72,11 +72,11 @@ public class ClassPathFileSystemWatcher implements InitializingBean, DisposableB
 	 * @param restartStrategy the classpath restart strategy
 	 * @param urls the URLs to watch
 	 */
-	protected ClassPathFileSystemWatcher(FileSystemWatcher fileSystemWatcher,
+	public ClassPathFileSystemWatcher(FileSystemWatcher fileSystemWatcher,
 			ClassPathRestartStrategy restartStrategy, URL[] urls) {
 		Assert.notNull(fileSystemWatcher, "FileSystemWatcher must not be null");
 		Assert.notNull(urls, "Urls must not be null");
-		this.fileSystemWatcher = new FileSystemWatcher();
+		this.fileSystemWatcher = fileSystemWatcher;
 		this.restartStrategy = restartStrategy;
 		addUrls(urls);
 	}

--- a/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/filewatch/FileSystemWatcher.java
+++ b/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/filewatch/FileSystemWatcher.java
@@ -199,11 +199,13 @@ public class FileSystemWatcher {
 		Thread thread = this.watchThread;
 		if (thread != null) {
 			this.remainingScans.set(remainingScans);
-			try {
-				thread.join();
-			}
-			catch (InterruptedException ex) {
-				Thread.currentThread().interrupt();
+			if (Thread.currentThread() != thread) {
+				try {
+					thread.join();
+				}
+				catch (InterruptedException ex) {
+					Thread.currentThread().interrupt();
+				}
 			}
 			this.watchThread = null;
 		}

--- a/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/restart/Restarter.java
+++ b/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/restart/Restarter.java
@@ -462,8 +462,10 @@ public class Restarter {
 			RestartInitializer initializer, boolean restartOnInitialize) {
 		if (instance == null) {
 			synchronized (Restarter.class) {
-				instance = new Restarter(Thread.currentThread(), args,
-						forceReferenceCleanup, initializer);
+				if (instance == null) {
+					instance = new Restarter(Thread.currentThread(), args,
+							forceReferenceCleanup, initializer);
+				}
 			}
 			instance.initialize(restartOnInitialize);
 		}


### PR DESCRIPTION
The FileWatcher sometimes generates multiple events for a single
change and if there is a slow shutdown hook the second one can
come in before the context is closed, leaving it in a tricky
state. This change attempts to stop the file watcher as soon
as it detects a change (the stop() method is called in the
listener, which normally happens in the same thread as the
scan).

Fixes gh-3097