### PR TITLE
add chkconfig comment

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -8,6 +8,8 @@
 #   =========|_|==============|___/=/_/_/_/
 #   :: Spring Boot Startup Script ::
 #
+# chkconfig: 345 99 01
+# description: Spring Boot Startup Script
 
 [[ -n "$DEBUG" ]] && set -x
 


### PR DESCRIPTION
to solve the  "Service doesn't support chkconfig" error when executing chkconfig command