### PR TITLE
Issue 3136: maven plug-in to create output directory if does not exist

### DIFF
--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
@@ -213,6 +213,11 @@ public class RepackageMojo extends AbstractDependencyFilterMojo {
 		if (classifier.length() > 0 && !classifier.startsWith("-")) {
 			classifier = "-" + classifier;
 		}
+
+		if (!this.outputDirectory.exists()) {
+			this.outputDirectory.mkdirs();
+		}
+
 		return new File(this.outputDirectory, this.finalName + classifier + "."
 				+ this.project.getArtifact().getArtifactHandler().getExtension());
 	}


### PR DESCRIPTION
Hi guys,

just wrote those 2 lines to provide the enhancement describe in [issue 3136](https://github.com/spring-projects/spring-boot/issues/3136).
 
I had a quick think about unit testing the method but to do so I'd like to change the modifier from private to protected so that I can call it from the test class. Is it something that might help or you prefer a more integration approach?

Cheers,
Luigi