### PR TITLE
Change `spring.jmx.mbean-server` to `spring.jmx.server` in docs.

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -445,7 +445,7 @@ content into your application; rather pick only the properties that you need.
 	# JMX
 	spring.jmx.default-domain= # JMX domain name
 	spring.jmx.enabled=true # Expose MBeans from Spring
-	spring.jmx.mbean-server=mBeanServer # MBeanServer bean name
+	spring.jmx.server=mBeanServer # MBeanServer bean name
 
 	# RABBIT ({sc-spring-boot-autoconfigure}/amqp/RabbitProperties.{sc-ext}[RabbitProperties])
 	spring.rabbitmq.addresses= # connection addresses (e.g. myhost:9999,otherhost:1111)


### PR DESCRIPTION
`spring.jmx.server` is correct based on the following code:

https://github.com/spring-projects/spring-boot/blob/master/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfiguration.java#L77