### PR TITLE
Upgrade to xml-apis 1.4.01

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -151,7 +151,7 @@
 		<velocity.version>1.7</velocity.version>
 		<velocity-tools.version>2.0</velocity-tools.version>
 		<wsdl4j.version>1.6.3</wsdl4j.version>
-		<xml-apis.version>1.3.04</xml-apis.version>
+		<xml-apis.version>1.4.01</xml-apis.version>
 	</properties>
 	<prerequisites>
 		<maven>3.0.2</maven>


### PR DESCRIPTION
`nekohtml:1.9.22` depends on `xercesImpl:2.11.0`

and `xercesImpl:2.11.0` depends on `xml-apis:1.4.01`.

`spring-boot-dependencies` has `xml-apis:1.3.04`.

It causes `java.lang.ClassNotFoundException: org.w3c.dom.ElementTraversal`.

This is a sample project reproducing the problem:

https://github.com/izeye/samples-spring-boot-branches/tree/thymeleaf

It would be good to upgrade `xml-apis` to `1.4.01` unless upgrading it breaks anything else.