### PR TITLE
Make hit/miss ratio for EhCache look better.

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/cache/EhCacheStatisticsProvider.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/cache/EhCacheStatisticsProvider.java
@@ -37,8 +37,8 @@ public class EhCacheStatisticsProvider implements CacheStatisticsProvider<EhCach
 		statistics.setSize(ehCacheStatistics.getSize());
 		Double hitRatio = ehCacheStatistics.cacheHitRatio();
 		if (!hitRatio.isNaN()) {
-			statistics.setHitRatio(hitRatio);
-			statistics.setMissRatio(1 - hitRatio);
+			statistics.setHitRatio(hitRatio > 1 ? 1 : hitRatio);
+			statistics.setMissRatio(hitRatio > 1 ? 0 : 1 - hitRatio);
 		}
 		return statistics;
 	}


### PR DESCRIPTION
EhCache's hit/miss ratio could be as follows:

```
  "cache.persons.hit.ratio" : 1.000019269809123,
  "cache.persons.miss.ratio" : -1.9269809123034776E-5,
```

We usually expect hit/miss ratio between 0 and 1 inclusive, not greater than 1 or negative.

You can reproduce it with `ApplicationTests.test()` in the following project:

https://github.com/izeye/samples-spring-boot-branches/tree/cache