### PR TITLE
VcapApplicationListener Boolean Credentials

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/cloudfoundry/VcapApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/cloudfoundry/VcapApplicationListener.java
@@ -211,6 +211,9 @@ public class VcapApplicationListener implements
 			else if (value instanceof Number) {
 				properties.put(key, value.toString());
 			}
+			else if (value instanceof Boolean) {
+				properties.put(key, value.toString());
+			}
 			else if (value instanceof Map) {
 				// Need a compound key
 				@SuppressWarnings("unchecked")

--- a/spring-boot/src/test/java/org/springframework/boot/cloudfoundry/VcapApplicationListenerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/cloudfoundry/VcapApplicationListenerTests.java
@@ -111,12 +111,15 @@ public class VcapApplicationListenerTests {
 								+ "\"plan\":\"10mb\",\"credentials\":{"
 								+ "\"name\":\"d04fb13d27d964c62b267bbba1cffb9da\","
 								+ "\"hostname\":\"mysql-service-public.clqg2e2w3ecf.us-east-1.rds.amazonaws.com\","
+								+ "\"ssl\":true,\"location\":null,"
 								+ "\"host\":\"mysql-service-public.clqg2e2w3ecf.us-east-1.rds.amazonaws.com\","
 								+ "\"port\":3306,\"user\":\"urpRuqTf8Cpe6\",\"username\":"
 								+ "\"urpRuqTf8Cpe6\",\"password\":\"pxLsGVpsC9A5S\"}}]}");
 		this.initializer.onApplicationEvent(this.event);
 		assertEquals("mysql", getProperty("vcap.services.mysql.name"));
 		assertEquals("3306", getProperty("vcap.services.mysql.credentials.port"));
+		assertEquals("true", getProperty("vcap.services.mysql.credentials.ssl"));
+		assertEquals("", getProperty("vcap.services.mysql.credentials.location"));
 	}
 
 	@Test


### PR DESCRIPTION
Previously, the `VcapApplicationListener` would discard any service credential value that wasn't a `String`, `Number`, `Map`, `Collection`, or `null`.  This was particularly a problem for services that exposed a value as a JSON boolean.  This change takes booleans in the credential payload into account, converting them to `String`s so that they will pass through the properties system properly.  There's no real downside to this as Spring will coerce them back into `Boolean`s if needed, by the application.