### PR TITLE
Improvements for the init script

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -87,8 +87,13 @@ else
     exit 1
 fi
 
+# source config file to set RUN_ARGS and/or JAVA_OPTS
+if [[ -r "/$(dirname "$jarfile")/${identity}.conf" ]]; then
+    source "/$(dirname "$jarfile")/${identity}.conf"
+fi
+
 # Build actual command to execute
-command="$javaexe -jar -Dsun.misc.URLClassPath.disableJarChecking=true $jarfile $@"
+command="$javaexe -jar -Dsun.misc.URLClassPath.disableJarChecking=true $JAVA_OPTS $jarfile $RUN_ARGS $@"
 
 # Action functions
 start() {

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -9,6 +9,16 @@
 #   :: Spring Boot Startup Script ::
 #
 
+### BEGIN INIT INFO
+# Provides:          spring-boot-application
+# Required-Start:    $remote_fs $syslog $network
+# Required-Stop:     $remote_fs $syslog $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Spring Boot Application
+# Description:       Spring Boot Application 
+### END INIT INFO
+
 [[ -n "$DEBUG" ]] && set -x
 
 WORKING_DIR="$(pwd)"


### PR DESCRIPTION
Two separate commits with the following improvements:

1) if present source ${identity}.conf (next to the jar-file) before building the command using JAVA_OPTS and RUN_ARGS. So the .conf file can be used to specify JVM-options and default run-arguments

2) Add LSB-Header to the init-script. Though specifiying spring-boot-application as provides / short descriptions seems a bit odd.

CLA is signed,