### PR TITLE
Stronger Sanitizer default for sensitive keys

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
@@ -34,7 +34,7 @@ class Sanitizer {
 	private Pattern[] keysToSanitize;
 
 	public Sanitizer() {
-		setKeysToSanitize(new String[] { "password", "secret", "key" });
+		setKeysToSanitize(new String[] { "password", "secret", "key", "vcap_services", ".*credentials.*" });
 	}
 
 	/**

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/EnvironmentEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/EnvironmentEndpointTests.java
@@ -68,12 +68,38 @@ public class EnvironmentEndpointTests extends AbstractEndpointTests<EnvironmentE
 	public void testKeySanitization() throws Exception {
 		System.setProperty("dbPassword", "123456");
 		System.setProperty("apiKey", "123456");
+		System.setProperty("mySecret", "123456");
+		System.setProperty("vcap_services", "123456");
 		EnvironmentEndpoint report = getEndpointBean();
 		Map<String, Object> env = report.invoke();
 		assertEquals("******",
 				((Map<String, Object>) env.get("systemProperties")).get("dbPassword"));
 		assertEquals("******",
 				((Map<String, Object>) env.get("systemProperties")).get("apiKey"));
+		assertEquals("******",
+				((Map<String, Object>) env.get("systemProperties")).get("mySecret"));
+		assertEquals("******",
+				((Map<String, Object>) env.get("systemProperties")).get("vcap_services"));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testKeySanitizationCredentialsPattern() throws Exception {
+		System.setProperty("vcap.services.amqp-free.credentials.uri", "123456");
+		System.setProperty("credentials.http_api_uri", "123456");
+		System.setProperty("vcap.services.cleardb-free.credentials", "123456");
+		System.setProperty("vcap.mycredentials.uri", "123456");
+		EnvironmentEndpoint report = getEndpointBean();
+		Map<String, Object> env = report.invoke();
+		assertEquals("******",
+				((Map<String, Object>) env.get("systemProperties")).get("vcap.services.amqp-free.credentials.uri"));
+		assertEquals("******",
+				((Map<String, Object>) env.get("systemProperties")).get("credentials.http_api_uri"));
+		assertEquals("******",
+				((Map<String, Object>) env.get("systemProperties")).get("vcap.services.cleardb-free.credentials"));
+		assertEquals("******",
+				((Map<String, Object>) env.get("systemProperties")).get("vcap.mycredentials.uri"));
+
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Add the CloudFoundry vcap_services key, as well as a regular expression to sanitize any key containing the word credentials.

Fixes gh-3248