### PR TITLE
Fix default MBeanServer bean name in metadata and docs.

### DIFF
--- a/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -102,7 +102,7 @@
     "name": "spring.jmx.server",
     "type": "java.lang.String",
     "description": "MBeanServer bean name.",
-    "defaultValue": "mBeanServer"
+    "defaultValue": "mbeanServer"
   },
   {
     "name": "spring.jpa.open-in-view",

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -447,7 +447,7 @@ content into your application; rather pick only the properties that you need.
 	# JMX
 	spring.jmx.default-domain= # JMX domain name
 	spring.jmx.enabled=true # Expose MBeans from Spring
-	spring.jmx.server=mBeanServer # MBeanServer bean name
+	spring.jmx.server=mbeanServer # MBeanServer bean name
 
 	# RABBIT ({sc-spring-boot-autoconfigure}/amqp/RabbitProperties.{sc-ext}[RabbitProperties])
 	spring.rabbitmq.addresses= # connection addresses (e.g. myhost:9999,otherhost:1111)


### PR DESCRIPTION
Although I prefer `mBeanServer` as camelCase,

the default `MBeanServer` bean name is `mbeanServer`, not `mBeanServer`:

https://github.com/spring-projects/spring-boot/blob/master/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfiguration.java#L98