### PR TITLE
Native compression for all embedded containers

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -31,6 +31,8 @@ import org.apache.catalina.valves.RemoteIpValve;
 import org.apache.coyote.AbstractProtocol;
 import org.apache.coyote.ProtocolHandler;
 import org.apache.coyote.http11.AbstractHttp11Protocol;
+import org.springframework.boot.context.embedded.AbstractConfigurableEmbeddedServletContainer;
+import org.springframework.boot.context.embedded.AbstractConfigurableEmbeddedServletContainer.CompressionProperties;
 import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizerBeanPostProcessor;
@@ -99,6 +101,8 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer, Ord
 
 	private final Undertow undertow = new Undertow();
 
+	private CompressionProperties compression = new CompressionProperties();
+
 	@NestedConfigurationProperty
 	private JspServlet jspServlet;
 
@@ -118,6 +122,10 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer, Ord
 
 	public Undertow getUndertow() {
 		return this.undertow;
+	}
+
+	public CompressionProperties getCompression() {
+		return this.compression;
 	}
 
 	public String getContextPath() {
@@ -238,6 +246,10 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer, Ord
 		}
 		if (getJspServlet() != null) {
 			container.setJspServlet(getJspServlet());
+		}
+		if (container instanceof AbstractConfigurableEmbeddedServletContainer) {
+			((AbstractConfigurableEmbeddedServletContainer) container)
+					.setCompression(getCompression());
 		}
 		if (container instanceof TomcatEmbeddedServletContainerFactory) {
 			getTomcat()
@@ -587,7 +599,6 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer, Ord
 			valve.setSuffix(".log");
 			factory.addContextValves(valve);
 		}
-
 	}
 
 	public static class Undertow {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -37,6 +37,7 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -103,6 +104,18 @@ public class ServerPropertiesTests {
 				.getProtocolHeader());
 		assertEquals("10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}", this.properties.getTomcat()
 				.getInternalProxies());
+	}
+
+	@Test
+	public void testCompressionBinding() throws Exception {
+		Map<String, String> map = new HashMap<String, String>();
+		map.put("server.compression.enabled", "true");
+		map.put("server.compression.mimeTypes", "foo/bar");
+		map.put("server.compression.minSize", "228");
+		bindProperties(map);
+		assertTrue(this.properties.getCompression().isEnabled());
+		assertEquals("foo/bar", this.properties.getCompression().getMimeTypes());
+		assertEquals(228, this.properties.getCompression().getMinSize());
 	}
 
 	@Test

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -155,6 +155,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-servlets</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>io.undertow</groupId>
 			<artifactId>undertow-servlet</artifactId>
 			<optional>true</optional>

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractConfigurableEmbeddedServletContainer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractConfigurableEmbeddedServletContainer.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.util.Assert;
@@ -66,6 +67,8 @@ public abstract class AbstractConfigurableEmbeddedServletContainer implements
 	private Ssl ssl;
 
 	private JspServlet jspServlet = new JspServlet();
+
+	private CompressionProperties compression;
 
 	/**
 	 * Create a new {@link AbstractConfigurableEmbeddedServletContainer} instance.
@@ -278,6 +281,14 @@ public abstract class AbstractConfigurableEmbeddedServletContainer implements
 		return this.jspServlet;
 	}
 
+	public CompressionProperties getCompression() {
+		return this.compression;
+	}
+
+	public void setCompression(CompressionProperties compression) {
+		this.compression = compression;
+	}
+
 	/**
 	 * Utility method that can be used by subclasses wishing to combine the specified
 	 * {@link ServletContextInitializer} parameters with those defined in this instance.
@@ -304,6 +315,46 @@ public abstract class AbstractConfigurableEmbeddedServletContainer implements
 				&& this.jspServlet.getRegistered()
 				&& ClassUtils.isPresent(this.jspServlet.getClassName(), getClass()
 						.getClassLoader());
+	}
+
+	public static class CompressionProperties {
+		private boolean enabled = false;
+		private String mimeTypes = "text/html,text/xml,text/plain,text/css";
+		private int minSize = 2048;
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public String getMimeTypes() {
+			return mimeTypes;
+		}
+
+		public void setMimeTypes(String mimeTypes) {
+			this.mimeTypes = mimeTypes;
+		}
+
+		public int getMinSize() {
+			return minSize;
+		}
+
+		public void setMinSize(int minSize) {
+			this.minSize = minSize;
+		}
+
+		public List<String> getMimeTypesList() {
+			List<String> mimeTypesList = new ArrayList<String>();
+			StringTokenizer tok = new StringTokenizer(mimeTypes, ",", false);
+			while (tok.hasMoreTokens()) {
+				mimeTypesList.add(tok.nextToken());
+			}
+			return mimeTypesList;
+		}
+
 	}
 
 }

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
@@ -46,7 +46,9 @@ import org.apache.catalina.loader.WebappLoader;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.catalina.startup.Tomcat.FixContextListener;
 import org.apache.coyote.AbstractProtocol;
+import org.apache.coyote.ProtocolHandler;
 import org.apache.coyote.http11.AbstractHttp11JsseProtocol;
+import org.apache.coyote.http11.AbstractHttp11Protocol;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.embedded.AbstractEmbeddedServletContainerFactory;
 import org.springframework.boot.context.embedded.EmbeddedServletContainer;
@@ -253,6 +255,17 @@ public class TomcatEmbeddedServletContainerFactory extends
 					getSsl());
 			connector.setScheme("https");
 			connector.setSecure(true);
+		}
+
+		if (getCompression() != null && getCompression().isEnabled()) {
+			ProtocolHandler handler = connector.getProtocolHandler();
+			if (handler instanceof AbstractHttp11Protocol) {
+				@SuppressWarnings("rawtypes")
+				AbstractHttp11Protocol protocol = (AbstractHttp11Protocol) handler;
+				protocol.setCompression("on");
+				protocol.setCompressionMinSize(getCompression().getMinSize());
+				protocol.setCompressableMimeTypes(getCompression().getMimeTypes());
+			}
 		}
 
 		for (TomcatConnectorCustomizer customizer : this.tomcatConnectorCustomizers) {

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
@@ -219,7 +219,7 @@ public class UndertowEmbeddedServletContainerFactory extends
 		int port = getPort();
 		Builder builder = createBuilder(port);
 		return new UndertowEmbeddedServletContainer(builder, manager, getContextPath(),
-				port, port >= 0);
+				port, port >= 0, getCompression());
 	}
 
 	private Builder createBuilder(int port) {
@@ -470,7 +470,7 @@ public class UndertowEmbeddedServletContainerFactory extends
 	protected UndertowEmbeddedServletContainer getUndertowEmbeddedServletContainer(
 			Builder builder, DeploymentManager manager, int port) {
 		return new UndertowEmbeddedServletContainer(builder, manager, getContextPath(),
-				port, port >= 0);
+				port, port >= 0, getCompression());
 	}
 
 	@Override

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -27,6 +28,8 @@ import java.security.KeyStore;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.zip.GZIPInputStream;
 
 import javax.net.ssl.SSLException;
 import javax.servlet.GenericServlet;
@@ -36,16 +39,19 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.InputStreamFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.SSLContextBuilder;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContextBuilder;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.InOrder;
+import org.springframework.boot.context.embedded.AbstractConfigurableEmbeddedServletContainer.CompressionProperties;
 import org.springframework.boot.context.embedded.Ssl.ClientAuth;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -58,6 +64,7 @@ import org.springframework.util.SocketUtils;
 import org.springframework.util.StreamUtils;
 import org.springframework.util.concurrent.ListenableFuture;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -65,7 +72,9 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -518,6 +527,79 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 	@Test
 	public void defaultSessionTimeout() throws Exception {
 		assertThat(getFactory().getSessionTimeout(), equalTo(30 * 60));
+	}
+
+	@Test
+	public void compression() throws Exception {
+		assertTrue(internalTestCompression(10000, null));
+	}
+
+	@Test
+	public void noCompressionForSmallResponse() throws Exception {
+		assertFalse(internalTestCompression(100, null));
+	}
+
+	@Test
+	public void noCompressionForMimeType() throws Exception {
+		assertFalse(internalTestCompression(10000, "text/html,text/xml,text/css"));
+	}
+
+	protected String setupFactoryForCompression(int contentSize, String mimeTypes)
+			throws Exception {
+		char[] chars = new char[contentSize];
+		Arrays.fill(chars, 'F');
+		String testContent = new String(chars);
+
+		AbstractEmbeddedServletContainerFactory factory = getFactory();
+
+		FileCopyUtils.copy(testContent,
+				new FileWriter(this.temporaryFolder.newFile("test.txt")));
+		factory.setDocumentRoot(this.temporaryFolder.getRoot());
+		CompressionProperties compression = new CompressionProperties();
+		compression.setEnabled(true);
+		if (mimeTypes != null) {
+			compression.setMimeTypes(mimeTypes);
+		}
+		factory.setCompression(compression);
+
+		this.container = factory.getEmbeddedServletContainer();
+		this.container.start();
+		return testContent;
+	}
+
+	private boolean internalTestCompression(int contentSize, String mimeTypes)
+			throws Exception {
+		String testContent = setupFactoryForCompression(contentSize, mimeTypes);
+
+		class TestGzipInputStreamFactory implements InputStreamFactory {
+
+			final AtomicBoolean requested = new AtomicBoolean(false);
+
+			@Override
+			public InputStream create(InputStream instream) throws IOException {
+				if (requested.get()) {
+					throw new IllegalStateException(
+							"On deflated InputStream already requested");
+				}
+				requested.set(true);
+				return new GZIPInputStream(instream);
+			}
+
+		}
+
+		TestGzipInputStreamFactory gzipTestInputStreamFactory = new TestGzipInputStreamFactory();
+
+		String response = getResponse(
+				getLocalUrl("/test.txt"),
+				new HttpComponentsClientHttpRequestFactory(HttpClientBuilder
+						.create()
+						.setContentDecoderRegistry(
+								singletonMap("gzip",
+										(InputStreamFactory) gzipTestInputStreamFactory))
+						.build()));
+		assertThat(response, equalTo(testContent));
+		boolean wasCompressionUsed = gzipTestInputStreamFactory.requested.get();
+		return wasCompressionUsed;
 	}
 
 	private void addTestTxtFile(AbstractEmbeddedServletContainerFactory factory)

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactoryTests.java
@@ -16,10 +16,16 @@
 
 package org.springframework.boot.context.embedded.jetty;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
@@ -32,8 +38,12 @@ import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.junit.Test;
 import org.mockito.InOrder;
+import org.springframework.boot.context.embedded.AbstractEmbeddedServletContainerFactory;
 import org.springframework.boot.context.embedded.AbstractEmbeddedServletContainerFactoryTests;
+import org.springframework.boot.context.embedded.ServletRegistrationBean;
 import org.springframework.boot.context.embedded.Ssl;
+import org.springframework.boot.context.embedded.AbstractConfigurableEmbeddedServletContainer.CompressionProperties;
+import org.springframework.http.HttpHeaders;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -171,6 +181,38 @@ public class JettyEmbeddedServletContainerFactoryTests extends
 		factory.getJspServlet().setInitParameters(initParameters);
 		this.container = factory.getEmbeddedServletContainer();
 		assertThat(getJspServlet().getInitParameters(), is(equalTo(initParameters)));
+	}
+
+	@Override
+	@SuppressWarnings("serial")
+	// work-around for Jetty issue - https://bugs.eclipse.org/bugs/show_bug.cgi?id=470646
+	protected String setupFactoryForCompression(final int contentSize, String mimeTypes)
+			throws Exception {
+		char[] chars = new char[contentSize];
+		Arrays.fill(chars, 'F');
+		final String testContent = new String(chars);
+
+		AbstractEmbeddedServletContainerFactory factory = getFactory();
+
+		CompressionProperties compression = new CompressionProperties();
+		compression.setEnabled(true);
+		if (mimeTypes != null) {
+			compression.setMimeTypes(mimeTypes);
+		}
+		factory.setCompression(compression);
+
+		this.container = factory.getEmbeddedServletContainer(new ServletRegistrationBean(
+				new HttpServlet() {
+					@Override
+					protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+							throws ServletException, IOException {
+						resp.setContentLength(contentSize);
+						resp.setHeader(HttpHeaders.CONTENT_TYPE, "text/plain");
+						resp.getWriter().print(testContent);
+					}
+				}, "/test.txt"));
+		this.container.start();
+		return testContent;
 	}
 
 	@Override


### PR DESCRIPTION
Currently to enable compression in the container in spring-boot we can enable it natively in Tomcat or use Jetty GzipFilter in Jetty and Undertow. However Jetty authors themselves do not like filter-based approach to the extent that they have even removed this filter from Jetty-servlet (they left it as a deprecated no-operation filter in Jetty 9.3). 

https://github.com/eclipse/jetty.project/blob/master/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/AsyncGzipFilter.java
https://github.com/eclipse/jetty.project/blob/master/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/GzipFilter.java

Both Jetty and Undertow currently have their native ways to enable gzip compression of responses that can be configured in a similar way. This PR introduces this common configuration properties server.compression.enabled, server.compression.mimeTypes and server.compression.minSize.

At first I wanted to propose this as an alternative way of enabling compression in any of the three containers, but since filter-based way is deprecated in the latest Jetty and will not work after upgrade (Jetty 9.3 requires Java 8, so I assume it will be reasonable to upgrade to it together with Spring 5), maybe this way should be promoted already.

My CLA number is 69320131202043142