### PR TITLE
Prevent restart when META-INF/maven/** changes

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
@@ -29,7 +29,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 @ConfigurationProperties(prefix = "spring.devtools")
 public class DevToolsProperties {
 
-	private static final String DEFAULT_RESTART_EXCLUDES = "META-INF/resources/**,resources/**,static/**,public/**,templates/**";
+	private static final String DEFAULT_RESTART_EXCLUDES = "META-INF/maven/**,META-INF/resources/**,resources/**,static/**,public/**,templates/**";
 
 	private static final long DEFAULT_RESTART_POLL_INTERVAL = 1000;
 

--- a/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/classpath/PatternClassPathRestartStrategyTests.java
+++ b/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/classpath/PatternClassPathRestartStrategyTests.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertThat;
  * Tests for {@link PatternClassPathRestartStrategy}.
  *
  * @author Phillip Webb
+ * @author Andrew Landsverk
  */
 public class PatternClassPathRestartStrategyTests {
 
@@ -66,6 +67,14 @@ public class PatternClassPathRestartStrategyTests {
 		assertRestartRequired(strategy, "src/folder/file.txt", true);
 	}
 
+	@Test
+	public void pomChange() throws Exception {
+		ClassPathRestartStrategy strategy = createStrategy("META-INF/maven/**,META-INF/resources/**,resources/**,static/**,public/**,templates/**,**/pom.properties");
+		assertRestartRequired(strategy, "pom.xml", true);
+		assertRestartRequired(strategy, "META-INF/maven/org.springframework.boot/spring-boot-devtools/pom.xml", false);
+		assertRestartRequired(strategy, "META-INF/maven/org.springframework.boot/spring-boot-devtools/pom.properties", false);
+	}
+	
 	private ClassPathRestartStrategy createStrategy(String pattern) {
 		return new PatternClassPathRestartStrategy(pattern);
 	}


### PR DESCRIPTION
These files are modified by eclipse for some reason
when you change files like Thymeleaf HTML files.

Add META-INF/maven/** to the DEFAULT_RESTART_EXCLUDES
Add another unit test to prevent regression in the future

fixes gh-3295