### PR TITLE
use existing spring-framework APIs (and a constant) to solve formerly untested Windows bug

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
@@ -54,6 +54,7 @@ import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.util.Assert;
+import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.BindException;
 
@@ -455,10 +456,10 @@ public class ConfigFileApplicationListener implements
 				for (String path : asResolvedSet(
 						this.environment.getProperty(CONFIG_LOCATION_PROPERTY), null)) {
 					if (!path.contains("$")) {
-						if (!path.contains(":")) {
-							path = "file:" + path;
-						}
 						path = StringUtils.cleanPath(path);
+						if (!ResourceUtils.isUrl(path)) {
+							path = ResourceUtils.FILE_URL_PREFIX + path;
+						}
 					}
 					locations.add(path);
 				}

--- a/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileApplicationListenerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileApplicationListenerTests.java
@@ -459,6 +459,16 @@ public class ConfigFileApplicationListenerTests {
 	}
 
 	@Test
+	public void absoluteResourceDefaultsToFile() throws Exception {
+		String location = new File("src/test/resources/specificlocation.properties").getAbsolutePath();
+		EnvironmentTestUtils.addEnvironment(this.environment, "spring.config.location:"
+				+ location);
+		this.initializer.onApplicationEvent(this.event);
+		assertThat(this.environment, containsPropertySource("applicationConfig: [file:"
+				+ location.replace(File.separatorChar, '/') + "]"));
+	}
+
+	@Test
 	public void propertySourceAnnotation() throws Exception {
 		SpringApplication application = new SpringApplication(WithPropertySource.class);
 		application.setWebEnvironment(false);


### PR DESCRIPTION
I originally tracked this bug down due to the failure on Windows of one of the spring-cloud-commons tests.