### PR TITLE
Suggestion for improvement to documentation

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-boot-docs/src/main/asciidoc/getting-started.adoc
@@ -702,8 +702,8 @@ Java does not provide any standard way to load nested jar files (i.e. jar files 
 themselves contained within a jar). This can be problematic if you are looking to
 distribute a self-contained application.
 
-To solve this problem, many developers use "`shaded`" jars. A shaded jar simply packages
-all classes, from all jars, into a single "`uber jar`". The problem with shaded jars is that
+To solve this problem, many developers use "`uber`" jars. An uber jar simply packages
+all classes, from all jars, into a single archive. The problem with this approach is that
 it becomes hard to see which libraries you are actually using in your application. It can
 also be problematic if the the same filename is used (but with different content) in
 multiple jars.


### PR DESCRIPTION
Documentation discusses shaded jars and uber jars as though the terms were interchangeable, but the "shading" concept refers more specifically to the renaming of some subset of the project's dependencies, usually to sidestep the "jar hell" issue in some way, e.g. when some OSS project releases incompatible versions of the same FQ class. I have reworded the section in question to avoid the shading notion altogether.

