### PR TITLE
Access spring properties in logging configuration

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/logging/LoggingApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/LoggingApplicationListener.java
@@ -55,6 +55,7 @@ import org.springframework.util.StringUtils;
  * <li>{@code LOG_FILE} is set to the value of path of the log file that should be written
  * (if any).</li>
  * <li>{@code PID} is set to the value of the current process ID if it can be determined.</li>
+ * <li>Any spring property starting with prefix {@code logging.properties.} (stripped of the prefix)</li>
  * </ul>
  *
  * @author Dave Syer
@@ -86,6 +87,11 @@ public class LoggingApplicationListener implements GenericApplicationListener {
 	 * The name of the System property that contains the process ID.
 	 */
 	public static final String PID_KEY = "PID";
+
+    /**
+     * The prefix of Spring properties that contain additional values to be set as system properties.
+     */
+	public static final String PROPERTIES_PREFIX = "logging.properties.";
 
 	private static MultiValueMap<LogLevel, String> LOG_LEVEL_LOGGERS;
 	static {
@@ -181,6 +187,7 @@ public class LoggingApplicationListener implements GenericApplicationListener {
 			System.setProperty(PID_KEY, new ApplicationPid().toString());
 		}
 		initializeEarlyLoggingLevel(environment);
+		initializeSystemProperties(environment);
 		initializeSystem(environment, this.loggingSystem);
 		initializeFinalLoggingLevels(environment, this.loggingSystem);
 	}
@@ -193,6 +200,14 @@ public class LoggingApplicationListener implements GenericApplicationListener {
 			if (environment.containsProperty("trace")) {
 				this.springBootLogging = LogLevel.TRACE;
 			}
+		}
+	}
+
+	private void initializeSystemProperties(ConfigurableEnvironment environment) {
+        Map<String, Object> subProperties = new RelaxedPropertyResolver(environment)
+                .getSubProperties(PROPERTIES_PREFIX);
+        for (Entry<String, Object> entry : subProperties.entrySet()) {
+			System.setProperty(entry.getKey(), entry.getValue().toString());
 		}
 	}
 

--- a/spring-boot/src/test/java/org/springframework/boot/logging/LoggingApplicationListenerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/logging/LoggingApplicationListenerTests.java
@@ -93,6 +93,7 @@ public class LoggingApplicationListenerTests {
 		if (this.context != null) {
 			this.context.close();
 		}
+		LoggingSystem.get(getClass().getClassLoader()).cleanUp();
 	}
 
 	private String tmpDir() {

--- a/spring-boot/src/test/java/org/springframework/boot/logging/LoggingApplicationListenerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/logging/LoggingApplicationListenerTests.java
@@ -89,6 +89,7 @@ public class LoggingApplicationListenerTests {
 		System.clearProperty("LOG_FILE");
 		System.clearProperty("LOG_PATH");
 		System.clearProperty("PID");
+		System.clearProperty("ADDITIONAL_PROPERTY");
 		if (this.context != null) {
 			this.context.close();
 		}
@@ -126,6 +127,7 @@ public class LoggingApplicationListenerTests {
 		assertTrue("Wrong output:\n" + output, output.contains("Hello world"));
 		assertFalse("Wrong output:\n" + output, output.contains("???"));
 		assertTrue("Wrong output:\n" + output, output.startsWith("LOG_FILE_IS_UNDEFINED"));
+		assertTrue("Wrong output:\n" + output, output.contains("ADDITIONAL_PROPERTY_IS_UNDEFINED"));
 		assertTrue("Wrong output:\n" + output, output.endsWith("BOOTBOOT"));
 	}
 
@@ -187,6 +189,19 @@ public class LoggingApplicationListenerTests {
 		logger.info("Hello world");
 		String output = this.outputCapture.toString().trim();
 		assertTrue("Wrong output:\n" + output, output.startsWith("target/foo/spring.log"));
+	}
+
+	@Test
+	public void addAdditionalProperty() {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"logging.config: classpath:logback-nondefault.xml",
+				"logging.path: target/foo/",
+				"logging.properties.ADDITIONAL_PROPERTY: foo-bar");
+		this.initializer.initialize(this.context.getEnvironment(),
+				this.context.getClassLoader());
+		Log logger = LogFactory.getLog(LoggingApplicationListenerTests.class);
+		logger.info("Hello world");
+		assertThat(this.outputCapture.toString(), containsString("foo-bar"));
 	}
 
 	@Test

--- a/spring-boot/src/test/java/org/springframework/boot/logging/LoggingApplicationListenerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/logging/LoggingApplicationListenerTests.java
@@ -195,7 +195,6 @@ public class LoggingApplicationListenerTests {
 	public void addAdditionalProperty() {
 		EnvironmentTestUtils.addEnvironment(this.context,
 				"logging.config: classpath:logback-nondefault.xml",
-				"logging.path: target/foo/",
 				"logging.properties.ADDITIONAL_PROPERTY: foo-bar");
 		this.initializer.initialize(this.context.getEnvironment(),
 				this.context.getClassLoader());

--- a/spring-boot/src/test/resources/logback-nondefault.xml
+++ b/spring-boot/src/test/resources/logback-nondefault.xml
@@ -2,7 +2,7 @@
 <configuration>
 	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>${LOG_FILE} [%t] ${PID:-????} %c{1}: %m%n BOOTBOOT</pattern>
+			<pattern>${LOG_FILE} [%t] ${PID:-????} %c{1} ${ADDITIONAL_PROPERTY}: %m%n BOOTBOOT</pattern>
 		</encoder>
 	</appender>
 	<root level="INFO">


### PR DESCRIPTION
Makes spring properties starting with prefix "logging.properties."
available as system properties (without the prefix) before the logging
system is initialized so they can be used in logging configurations
that support them (e.g. logback).

Closes gh-1788