### PR TITLE
Remove unnecessary `@After` in a test

### DIFF
--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/LogFileMvcEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/LogFileMvcEndpointTests.java
@@ -62,11 +62,6 @@ public class LogFileMvcEndpointTests {
 		this.mvc.setEnvironment(this.environment);
 	}
 
-	@After
-	public void after() {
-		new File("test.log").delete();
-	}
-
 	@Test
 	public void notAvailableWithoutLogFile() throws IOException {
 		assertThat(this.mvc.available().getStatusCode(), equalTo(HttpStatus.NOT_FOUND));


### PR DESCRIPTION
It's trying to delete a wrong file

and the correct file will be deleted automatically thanks to the `TemporaryFolder`.