### PR TITLE
Remove the explicit `spring-context` dependency in `spring-boot-start…

### DIFF
--- a/spring-boot-starters/spring-boot-starter-cache/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-cache/pom.xml
@@ -24,10 +24,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
 			<artifactId>spring-context-support</artifactId>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
…er-cache`

Because `spring-boot-starter-cache` already has it by `spring-boot-starter` transitively.

https://github.com/spring-projects/spring-boot/blob/master/spring-boot-starters/spring-boot-starter/pom.xml
https://github.com/spring-projects/spring-boot/blob/master/spring-boot/pom.xml