### PR TITLE
Remove side effect of test that made test execution order important

### DIFF
--- a/spring-boot/src/test/java/org/springframework/boot/logging/LoggingApplicationListenerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/logging/LoggingApplicationListenerTests.java
@@ -92,6 +92,7 @@ public class LoggingApplicationListenerTests {
 		if (this.context != null) {
 			this.context.close();
 		}
+		LoggingSystem.get(getClass().getClassLoader()).cleanUp();
 	}
 
 	private String tmpDir() {


### PR DESCRIPTION
I came across when adding another test case to LoggingApplicationListenerTest for a now obsolete PR. 

It appears that in LoggingApplicationListenerTest testcase "overrideConfigBroken" has to be executed after "addLogFileProperty" and "addLogPathProperty", otherwise the latter will fail as the broken logback.xml is still somehow in effect (to reproduce, change test name to xxxoverrideConfigBroken and the tests will fail on java 8). 

With test execution order being rather undetermined this seemed like a potential problem down the road. 
Calling the cleanup on the LoggingSystem after the tests seems to solve the issue. 