### PR TITLE
Adding excludedAgents property for compression

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/Compression.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/Compression.java
@@ -37,7 +37,12 @@ public class Compression {
 			"text/css" };
 
 	/**
-	 * Minimum response size that is required for compression to be performed
+	 * Comma-separated list of user agents for which responses should not be compressed.
+	 */
+	private String[] excludedAgents = null;
+
+	/**
+	 * Minimum response size that is required for compression to be performed.
 	 */
 	private int minResponseSize = 2048;
 
@@ -65,4 +70,11 @@ public class Compression {
 		this.minResponseSize = minSize;
 	}
 
+	public String[] getExcludedAgents() {
+		return this.excludedAgents;
+	}
+
+	public void setExcludedAgents(String[] excludedAgents) {
+		this.excludedAgents = excludedAgents;
+	}
 }

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactory.java
@@ -588,6 +588,12 @@ public class JettyEmbeddedServletContainerFactory extends
 						.invoke(handler,
 								new HashSet<String>(Arrays.asList(compression
 										.getMimeTypes())));
+				if (compression.getExcludedAgents() != null) {
+					ReflectionUtils.findMethod(handlerClass, "setExcluded", Set.class)
+							.invoke(handler,
+									new HashSet<String>(Arrays.asList(compression
+											.getExcludedAgents())));
+				}
 				return handler;
 			}
 			catch (Exception ex) {
@@ -605,6 +611,10 @@ public class JettyEmbeddedServletContainerFactory extends
 			gzipHandler.setMinGzipSize(compression.getMinResponseSize());
 			gzipHandler.setMimeTypes(new HashSet<String>(Arrays.asList(compression
 					.getMimeTypes())));
+			if (compression.getExcludedAgents() != null) {
+				gzipHandler.setExcluded(new HashSet<String>(Arrays.asList(compression
+						.getExcludedAgents())));
+			}
 			return gzipHandler;
 		}
 
@@ -623,6 +633,11 @@ public class JettyEmbeddedServletContainerFactory extends
 				ReflectionUtils.findMethod(handlerClass, "setIncludedMimeTypes",
 						String[].class).invoke(handler,
 						new Object[] { compression.getMimeTypes() });
+				if (compression.getExcludedAgents() != null) {
+					ReflectionUtils.findMethod(handlerClass, "setExcludedAgentPatterns",
+							String[].class).invoke(handler,
+							new Object[] { compression.getExcludedAgents() });
+				}
 				return handler;
 			}
 			catch (Exception ex) {

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
@@ -280,6 +280,10 @@ public class TomcatEmbeddedServletContainerFactory extends
 			protocol.setCompressionMinSize(compression.getMinResponseSize());
 			protocol.setCompressableMimeTypes(StringUtils
 					.arrayToCommaDelimitedString(compression.getMimeTypes()));
+			if (getCompression().getExcludedAgents() != null) {
+				protocol.setNoCompressionUserAgents(StringUtils
+						.arrayToCommaDelimitedString(getCompression().getExcludedAgents()));
+			}
 		}
 	}
 

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
@@ -531,35 +531,43 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 
 	@Test
 	public void compression() throws Exception {
-		assertTrue(doTestCompression(10000, null));
+		assertTrue(doTestCompression(10000, null, null));
 	}
 
 	@Test
 	public void noCompressionForSmallResponse() throws Exception {
-		assertFalse(doTestCompression(100, null));
+		assertFalse(doTestCompression(100, null, null));
 	}
 
 	@Test
 	public void noCompressionForMimeType() throws Exception {
 		String[] mimeTypes = new String[] { "text/html", "text/xml", "text/css" };
-		assertFalse(doTestCompression(10000, mimeTypes));
+		assertFalse(doTestCompression(10000, mimeTypes, null));
 	}
 
-	private boolean doTestCompression(int contentSize, String[] mimeTypes)
-			throws Exception {
-		String testContent = setUpFactoryForCompression(contentSize, mimeTypes);
+	@Test
+	public void noCompressionForUserAgent() throws Exception {
+		assertFalse(doTestCompression(10000, null, new String[] { "testUserAgent" }));
+	}
+
+	private boolean doTestCompression(int contentSize, String[] mimeTypes,
+			String[] excludedUserAgents) throws Exception {
+		String testContent = setUpFactoryForCompression(contentSize, mimeTypes,
+				excludedUserAgents);
 		TestGzipInputStreamFactory inputStreamFactory = new TestGzipInputStreamFactory();
 		Map<String, InputStreamFactory> contentDecoderMap = singletonMap("gzip",
 				(InputStreamFactory) inputStreamFactory);
-		String response = getResponse(getLocalUrl("/test.txt"),
+		String response = getResponse(
+				getLocalUrl("/test.txt"),
 				new HttpComponentsClientHttpRequestFactory(HttpClientBuilder.create()
+						.setUserAgent("testUserAgent")
 						.setContentDecoderRegistry(contentDecoderMap).build()));
 		assertThat(response, equalTo(testContent));
 		return inputStreamFactory.wasCompressionUsed();
 	}
 
-	protected String setUpFactoryForCompression(int contentSize, String[] mimeTypes)
-			throws Exception {
+	protected String setUpFactoryForCompression(int contentSize, String[] mimeTypes,
+			String[] excludedUserAgents) throws Exception {
 		char[] chars = new char[contentSize];
 		Arrays.fill(chars, 'F');
 		String testContent = new String(chars);
@@ -571,6 +579,9 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		compression.setEnabled(true);
 		if (mimeTypes != null) {
 			compression.setMimeTypes(mimeTypes);
+		}
+		if (excludedUserAgents != null) {
+			compression.setExcludedAgents(excludedUserAgents);
 		}
 		factory.setCompression(compression);
 		this.container = factory.getEmbeddedServletContainer();

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactoryTests.java
@@ -186,8 +186,8 @@ public class JettyEmbeddedServletContainerFactoryTests extends
 	@Override
 	@SuppressWarnings("serial")
 	// Workaround for Jetty issue - https://bugs.eclipse.org/bugs/show_bug.cgi?id=470646
-	protected String setUpFactoryForCompression(final int contentSize, String[] mimeTypes)
-			throws Exception {
+	protected String setUpFactoryForCompression(final int contentSize,
+			String[] mimeTypes, String[] excludedUserAgents) throws Exception {
 		char[] chars = new char[contentSize];
 		Arrays.fill(chars, 'F');
 		final String testContent = new String(chars);
@@ -196,6 +196,9 @@ public class JettyEmbeddedServletContainerFactoryTests extends
 		compression.setEnabled(true);
 		if (mimeTypes != null) {
 			compression.setMimeTypes(mimeTypes);
+		}
+		if (excludedUserAgents != null) {
+			compression.setExcludedAgents(excludedUserAgents);
 		}
 		factory.setCompression(compression);
 		this.container = factory.getEmbeddedServletContainer(new ServletRegistrationBean(


### PR DESCRIPTION
Yet another compression property that is present in both Jetty and Tomcat and can be reproduced with Undetow low-level API

Note: importing eclipse-code-formatter.xml into Eclipse Mars (released recently) breaks the indentations, so this PR is not formatted properly. Going to fix this later.