### PR TITLE
let GroovyTemplateProperties extend AbstractTemplateViewResolver.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/groovy/template/GroovyTemplateAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/groovy/template/GroovyTemplateAutoConfiguration.java
@@ -79,7 +79,7 @@ public class GroovyTemplateAutoConfiguration {
 		public void checkTemplateLocationExists() {
 			if (this.properties.isCheckTemplateLocation() && !isUsingGroovyAllJar()) {
 				TemplateLocation location = new TemplateLocation(
-						this.properties.getPrefix());
+						this.properties.getResourceLoaderPath());
 				Assert.state(location.exists(this.applicationContext),
 						"Cannot find template location: " + location
 								+ " (please add some templates, check your Groovy "
@@ -115,7 +115,7 @@ public class GroovyTemplateAutoConfiguration {
 		@ConfigurationProperties(prefix = "spring.groovy.template.configuration")
 		public GroovyMarkupConfigurer groovyMarkupConfigurer() {
 			GroovyMarkupConfigurer configurer = new GroovyMarkupConfigurer();
-			configurer.setResourceLoaderPath(this.properties.getPrefix());
+			configurer.setResourceLoaderPath(this.properties.getResourceLoaderPath());
 			configurer.setCacheTemplates(this.properties.isCache());
 			if (this.templateEngine != null) {
 				configurer.setTemplateEngine(this.templateEngine);
@@ -139,19 +139,8 @@ public class GroovyTemplateAutoConfiguration {
 		@ConditionalOnMissingBean(name = "groovyMarkupViewResolver")
 		public GroovyMarkupViewResolver groovyMarkupViewResolver() {
 			GroovyMarkupViewResolver resolver = new GroovyMarkupViewResolver();
-			configureViewResolver(resolver);
+			this.properties.applyToViewResolver(resolver);
 			return resolver;
-		}
-
-		private void configureViewResolver(UrlBasedViewResolver resolver) {
-			resolver.setSuffix(this.properties.getSuffix());
-			resolver.setCache(this.properties.isCache());
-			resolver.setContentType(this.properties.getContentType());
-			resolver.setViewNames(this.properties.getViewNames());
-			resolver.setRequestContextAttribute("spring");
-			// This resolver acts as a fallback resolver (e.g. like a
-			// InternalResourceViewResolver) so it needs to have low precedence
-			resolver.setOrder(Ordered.LOWEST_PRECEDENCE - 6);
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/groovy/template/GroovyTemplateProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/groovy/template/GroovyTemplateProperties.java
@@ -16,46 +16,43 @@
 
 package org.springframework.boot.autoconfigure.groovy.template;
 
-import org.springframework.boot.autoconfigure.template.AbstractViewResolverProperties;
+import org.springframework.boot.autoconfigure.template.AbstractTemplateViewResolverProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * {@link ConfigurationProperties} for configuring Groovy templates.
  *
  * @author Dave Syer
+ * @author Marten Deinum
  * @since 1.1.0
  */
 @ConfigurationProperties(prefix = "spring.groovy.template", ignoreUnknownFields = true)
-public class GroovyTemplateProperties extends AbstractViewResolverProperties {
+public class GroovyTemplateProperties extends AbstractTemplateViewResolverProperties {
 
-	public static final String DEFAULT_PREFIX = "classpath:/templates/";
+	public static final String DEFAULT_REQUEST_CONTEXT_ATTRIBUTE="spring";
+
+	public static final String DEFAULT_RESOURCE_LOADER_PATH = "classpath:/templates/";
+
+	public static final String DEFAULT_PREFIX = "";
 
 	public static final String DEFAULT_SUFFIX = ".tpl";
 
 	/**
-	 * Prefix that gets prepended to view names when building a URL.
+	 * Template path.
 	 */
-	private String prefix = DEFAULT_PREFIX;
+	private String resourceLoaderPath = DEFAULT_RESOURCE_LOADER_PATH;
 
-	/**
-	 * Suffix that gets appended to view names when building a URL.
-	 */
-	private String suffix = DEFAULT_SUFFIX;
 
-	public String getPrefix() {
-		return this.prefix;
+	public GroovyTemplateProperties() {
+		super(DEFAULT_PREFIX, DEFAULT_SUFFIX);
+		setRequestContextAttribute(DEFAULT_REQUEST_CONTEXT_ATTRIBUTE);
 	}
 
-	public void setPrefix(String prefix) {
-		this.prefix = prefix;
+	public String getResourceLoaderPath() {
+		return resourceLoaderPath;
 	}
 
-	public String getSuffix() {
-		return this.suffix;
+	public void setResourceLoaderPath(String resourceLoaderPath) {
+		this.resourceLoaderPath = resourceLoaderPath;
 	}
-
-	public void setSuffix(String suffix) {
-		this.suffix = suffix;
-	}
-
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/groovy/template/GroovyTemplateAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/groovy/template/GroovyTemplateAutoConfigurationTests.java
@@ -81,7 +81,7 @@ public class GroovyTemplateAutoConfigurationTests {
 	@Test
 	public void emptyTemplateLocation() {
 		new File("target/test-classes/templates/empty-directory").mkdir();
-		registerAndRefreshContext("spring.groovy.template.prefix:"
+		registerAndRefreshContext("spring.groovy.template.resource-loader-path:"
 				+ "classpath:/templates/empty-directory/");
 	}
 
@@ -132,7 +132,7 @@ public class GroovyTemplateAutoConfigurationTests {
 
 	@Test
 	public void customPrefix() throws Exception {
-		registerAndRefreshContext("spring.groovy.template.prefix:classpath:/templates/prefix/");
+		registerAndRefreshContext("spring.groovy.template.prefix:prefix/");
 		MockHttpServletResponse response = render("prefixed");
 		String result = response.getContentAsString();
 		assertThat(result, containsString("prefixed"));
@@ -148,7 +148,7 @@ public class GroovyTemplateAutoConfigurationTests {
 
 	@Test
 	public void customTemplateLoaderPath() throws Exception {
-		registerAndRefreshContext("spring.groovy.template.prefix:classpath:/custom-templates/");
+		registerAndRefreshContext("spring.groovy.template.resource-loader-path:classpath:/custom-templates/");
 		MockHttpServletResponse response = render("custom");
 		String result = response.getContentAsString();
 		assertThat(result, containsString("custom"));

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -205,8 +205,9 @@ content into your application; rather pick only the properties that you need.
 	spring.groovy.template.configuration.*= # See GroovyMarkupConfigurer
 	spring.groovy.template.content-type=text/html
 	spring.groovy.template.enabled=true # enable MVC view resolution
-	spring.groovy.template.prefix=classpath:/templates/
-	spring.groovy.template.suffix=.tpl
+	spring.groovy.template.prefix=
+	spring.groovy.template.resource-loader-path=classpath:/templates/
+    spring.groovy.template.suffix=.tpl
 	spring.groovy.template.view-names= # whitelist of view names that can be resolved
 
 	# VELOCITY TEMPLATES ({sc-spring-boot-autoconfigure}/velocity/VelocityAutoConfiguration.{sc-ext}[VelocityAutoConfiguration])

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -1263,7 +1263,7 @@ templates will be picked up automatically from `src/main/resources/templates`.
 TIP: IntelliJ IDEA orders the classpath differently depending on how you run your
 application. Running your application in the IDE via its main method will result in a
 different ordering to when you run your application using Maven or Gradle or from its
-pacakaged jar. This can cause Spring Boot to fail to find the templates on the classpath.
+packaged jar. This can cause Spring Boot to fail to find the templates on the classpath.
 If you're affected by this problem you can reorder the classpath in the IDE to place the
 module's classes and resources first. Alternatively, you can configure the template prefix
 to search every templates directory on the classpath: `classpath*:/templates/`.


### PR DESCRIPTION
To be able to easily set the `exposeRequestAttributes` (amongst others) the `GroovyTemplateProperties`
now extends `AbstractTemplateViewResolve`r. This is also in line with the other templating solutions like
Freemarker and Velocity.

Fixes: #3365 