### PR TITLE
Adding Eclipse 4.5 new workspace folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .settings
 .metadata
 .factorypath
+.recommenders
 bin
 build
 lib/


### PR DESCRIPTION
Current .gitignore already supports using root of the project as root of the Eclipse workspace - it has ".metadata" as ignored pattern. Newest fresh Eclipse (without any third-party plugins) also creates ".recommenders" folder in the root of the workspace.