### PR TITLE
Remove System.out.println()

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/FileWatchingFailureHandler.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/FileWatchingFailureHandler.java
@@ -67,7 +67,6 @@ class FileWatchingFailureHandler implements FailureHandler {
 
 		@Override
 		public void onChange(Set<ChangedFiles> changeSet) {
-			System.out.println("Changes");
 			this.latch.countDown();
 		}
 


### PR DESCRIPTION
I guess it's accidentally included.