### PR TITLE
Support pattern override by properties for logback configurations

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/logging/AbstractLoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/AbstractLoggingSystem.java
@@ -71,7 +71,7 @@ public abstract class AbstractLoggingSystem extends LoggingSystem {
 			loadConfiguration(initializationContext, config, logFile);
 			return;
 		}
-		loadDefaults(logFile);
+		loadDefaults(initializationContext, logFile);
 	}
 
 	/**
@@ -129,9 +129,10 @@ public abstract class AbstractLoggingSystem extends LoggingSystem {
 
 	/**
 	 * Load sensible defaults for the logging system.
+	 * @param initializationContext the logging initialization context
 	 * @param logFile the file to load or {@code null} if no log file is to be written
 	 */
-	protected abstract void loadDefaults(LogFile logFile);
+	protected abstract void loadDefaults(LoggingInitializationContext initializationContext, LogFile logFile);
 
 	/**
 	 * Load a specific configuration.

--- a/spring-boot/src/main/java/org/springframework/boot/logging/java/JavaLoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/java/JavaLoggingSystem.java
@@ -72,7 +72,7 @@ public class JavaLoggingSystem extends AbstractLoggingSystem {
 	}
 
 	@Override
-	protected void loadDefaults(LogFile logFile) {
+	protected void loadDefaults(LoggingInitializationContext initializationContext, LogFile logFile) {
 		if (logFile != null) {
 			loadConfiguration(getPackagedConfigFile("logging-file.properties"), logFile);
 		}

--- a/spring-boot/src/main/java/org/springframework/boot/logging/log4j/Log4JLoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/log4j/Log4JLoggingSystem.java
@@ -70,7 +70,7 @@ public class Log4JLoggingSystem extends Slf4JLoggingSystem {
 	}
 
 	@Override
-	protected void loadDefaults(LogFile logFile) {
+	protected void loadDefaults(LoggingInitializationContext initializationContext, LogFile logFile) {
 		if (logFile != null) {
 			loadConfiguration(getPackagedConfigFile("log4j-file.properties"), logFile);
 		}

--- a/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -136,7 +136,7 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 	}
 
 	@Override
-	protected void loadDefaults(LogFile logFile) {
+	protected void loadDefaults(LoggingInitializationContext initializationContext, LogFile logFile) {
 		if (logFile != null) {
 			loadConfiguration(getPackagedConfigFile("log4j2-file.xml"), logFile);
 		}

--- a/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
@@ -29,6 +29,7 @@ import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
 import ch.qos.logback.core.util.OptionHelper;
+import org.springframework.boot.logging.LoggingInitializationContext;
 
 /**
  * Default logback configuration used by Spring Boot. Uses {@link LogbackConfigurator} to
@@ -48,11 +49,18 @@ class DefaultLogbackConfiguration {
 	private static final String FILE_LOG_PATTERN = "%d{yyyy-MM-dd HH:mm:ss.SSS} %5p "
 			+ "${PID:- } --- [%t] %-40.40logger{39} : %m%n%wex";
 
+	private static final String CONSOLE_LOG_PATTERN_PROPERTY = "logging.logback.consoleLogPattern";
+
+	private static final String FILE_LOG_PATTERN_PROPERTY = "logging.logback.fileLogPattern";
+
 	private static final Charset UTF8 = Charset.forName("UTF-8");
 
 	private final LogFile logFile;
 
-	public DefaultLogbackConfiguration(LogFile logFile) {
+	private final LoggingInitializationContext initializationContext;
+
+	public DefaultLogbackConfiguration(LoggingInitializationContext initializationContext, LogFile logFile) {
+		this.initializationContext = initializationContext;
 		this.logFile = logFile;
 	}
 
@@ -99,7 +107,9 @@ class DefaultLogbackConfiguration {
 	private Appender<ILoggingEvent> consoleAppender(LogbackConfigurator config) {
 		ConsoleAppender<ILoggingEvent> appender = new ConsoleAppender<ILoggingEvent>();
 		PatternLayoutEncoder encoder = new PatternLayoutEncoder();
-		encoder.setPattern(OptionHelper.substVars(CONSOLE_LOG_PATTERN,
+		String logPattern = initializationContext.getEnvironment().
+				getProperty(CONSOLE_LOG_PATTERN_PROPERTY, CONSOLE_LOG_PATTERN);
+		encoder.setPattern(OptionHelper.substVars(logPattern,
 				config.getContext()));
 		encoder.setCharset(UTF8);
 		config.start(encoder);
@@ -112,7 +122,9 @@ class DefaultLogbackConfiguration {
 			String logFile) {
 		RollingFileAppender<ILoggingEvent> appender = new RollingFileAppender<ILoggingEvent>();
 		PatternLayoutEncoder encoder = new PatternLayoutEncoder();
-		encoder.setPattern(OptionHelper.substVars(FILE_LOG_PATTERN, config.getContext()));
+		String logPattern = initializationContext.getEnvironment()
+				.getProperty(FILE_LOG_PATTERN_PROPERTY, FILE_LOG_PATTERN);
+		encoder.setPattern(OptionHelper.substVars(logPattern, config.getContext()));
 		appender.setEncoder(encoder);
 		config.start(encoder);
 

--- a/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -103,12 +103,12 @@ public class LogbackLoggingSystem extends Slf4JLoggingSystem {
 	}
 
 	@Override
-	protected void loadDefaults(LogFile logFile) {
+	protected void loadDefaults(LoggingInitializationContext initializationContext, LogFile logFile) {
 		LoggerContext context = getLoggerContext();
 		context.stop();
 		context.reset();
 		LogbackConfigurator configurator = new LogbackConfigurator(context);
-		new DefaultLogbackConfiguration(logFile).apply(configurator);
+		new DefaultLogbackConfiguration(initializationContext, logFile).apply(configurator);
 	}
 
 	@Override


### PR DESCRIPTION
Update `AbstractLoggingSystem` to pass `LoggingInitializationContext` to
`loadDefaults()` method to enable environment property gets.
`DefaultLogbackConfiguration` uses this to find properties that can
override the default values defined for the log patterns.

Fixes gh-3367