### PR TITLE
Docs: Fix typo in jOOQ example code

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -2245,8 +2245,8 @@ application `DataSource`. To use the `DSLContext` you can just `@Autowire` it:
 		private final DSLContext create;
 
 		@Autowired
-		public JooqExample(DSLContext dlsContext) {
-			this.create = dlsContext;
+		public JooqExample(DSLContext dslContext) {
+			this.create = dslContext;
 		}
 
 	}


### PR DESCRIPTION
Looks like someone swapped the letters by accident. 