### PR TITLE
jOOQ dialect name must be in capital case

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -2274,7 +2274,7 @@ your `application.properties`. For example, to specify Postgres you would add:
 
 [source,properties,indent=0]
 ----
-	spring.jooq.sql-dialect=Postgres
+	spring.jooq.sql-dialect=POSTGRES
 ----
 
 More advanced customizations can be achieved by defining your own `@Bean` definitions


### PR DESCRIPTION
`spring.jooq.sql-dialect` property must be in capital case, otherwise we get: `No enum constant org.jooq.SQLDialect.Postgres`. Would be nice if the example was showing working code.