### PR TITLE
Allow customization of default SimpleRabbitListenerContainerFactory

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAnnotationDrivenConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAnnotationDrivenConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.config.RabbitListenerConfigUtils;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.boot.autoconfigure.amqp.RabbitProperties.Listener;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -41,6 +42,22 @@ class RabbitAnnotationDrivenConfiguration {
 			ConnectionFactory connectionFactory, RabbitProperties config) {
 		SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
 		factory.setConnectionFactory(connectionFactory);
+		Listener listenerConfig = config.getListener();
+		if (listenerConfig.getAckMode() != null) {
+		    factory.setAcknowledgeMode(listenerConfig.getAckMode());
+		}
+		if (listenerConfig.getConcurrency() != null) {
+		    factory.setConcurrentConsumers(listenerConfig.getConcurrency());
+		}
+		if (listenerConfig.getMaxConcurrency() != null) {
+		    factory.setMaxConcurrentConsumers(listenerConfig.getMaxConcurrency());
+		}
+		if( listenerConfig.getPrefetch() != null) {
+		    factory.setPrefetchCount(listenerConfig.getPrefetch());
+		}
+		if( listenerConfig.getTxSize() != null) {
+		    factory.setTxSize(listenerConfig.getTxSize());
+		}
 		return factory;
 	}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashSet;
 import java.util.Properties;
 import java.util.Set;
 
+import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.StringUtils;
 
@@ -73,6 +74,11 @@ public class RabbitProperties {
 	 * Requested heartbeat timeout, in seconds; zero for none.
 	 */
 	private Integer requestedHeartbeat;
+
+	/**
+	 * Listener container configuration.
+	 */
+	private final Listener listener =  new Listener();
 
 	public String getHost() {
 		if (this.addresses == null) {
@@ -180,7 +186,11 @@ public class RabbitProperties {
 		this.requestedHeartbeat = requestedHeartbeat;
 	}
 
-	public static class Ssl {
+	public Listener getListener() {
+        return listener;
+    }
+
+    public static class Ssl {
 
 		/**
 		 * Enable SSL support.
@@ -270,5 +280,64 @@ public class RabbitProperties {
 			return properties;
 		}
 
+	}
+
+	public static class Listener {
+
+	    /**
+	     * Acknowledge mode of container.
+	     */
+	    private AcknowledgeMode ackMode;
+
+	    /**
+	     * Minimum number of consumers.
+	     */
+	    private Integer concurrency;
+
+	    /**
+	     * Maximum number of consumers.
+	     */
+	    private Integer maxConcurrency;
+
+	    /**
+	     * Message prefetch count.
+	     */
+	    private Integer prefetch;
+
+	    /**
+	     * Number of messages in a transaction.
+	     */
+	    private Integer txSize;
+
+        public AcknowledgeMode getAckMode() {
+            return ackMode;
+        }
+        public void setAckMode(AcknowledgeMode ackMode) {
+            this.ackMode = ackMode;
+        }
+        public Integer getConcurrency() {
+            return concurrency;
+        }
+        public void setConcurrency(Integer concurrency) {
+            this.concurrency = concurrency;
+        }
+        public Integer getMaxConcurrency() {
+            return maxConcurrency;
+        }
+        public void setMaxConcurrency(Integer maxConcurrency) {
+            this.maxConcurrency = maxConcurrency;
+        }
+        public Integer getPrefetch() {
+            return prefetch;
+        }
+        public void setPrefetch(Integer prefetch) {
+            this.prefetch = prefetch;
+        }
+        public Integer getTxSize() {
+            return txSize;
+        }
+        public void setTxSize(Integer txSize) {
+            this.txSize = txSize;
+        }
 	}
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -23,6 +23,7 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.config.RabbitListenerConfigUtils;
@@ -227,6 +228,28 @@ public class RabbitAutoConfigurationTests {
 				"spring.rabbitmq.ssl.trustStore=bar",
 				"spring.rabbitmq.ssl.trustStorePassword=secret");
 	}
+
+	@Test
+    public void testRabbitListenerContainerFactoryOverrides() {
+        load(TestConfiguration.class, "spring.rabbitmq.listener.prefetch:20",
+                "spring.rabbitmq.listener.ackMode:MANUAL",
+                "spring.rabbitmq.listener.concurrency:10",
+                "spring.rabbitmq.listener.maxConcurrency:10",
+                "spring.rabbitmq.listener.txSize:20");
+        SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory = this.context
+                .getBean("rabbitListenerContainerFactory",
+                        SimpleRabbitListenerContainerFactory.class);
+        assertEquals(new Integer(20),(Integer)
+                new DirectFieldAccessor(rabbitListenerContainerFactory).getPropertyValue("prefetchCount"));
+        assertEquals(AcknowledgeMode.MANUAL,(AcknowledgeMode)
+                new DirectFieldAccessor(rabbitListenerContainerFactory).getPropertyValue("acknowledgeMode"));
+        assertEquals(new Integer(10),(Integer)
+                new DirectFieldAccessor(rabbitListenerContainerFactory).getPropertyValue("concurrentConsumers"));
+        assertEquals(new Integer(10),(Integer)
+                new DirectFieldAccessor(rabbitListenerContainerFactory).getPropertyValue("maxConcurrentConsumers"));
+        assertEquals(new Integer(20),(Integer)
+                new DirectFieldAccessor(rabbitListenerContainerFactory).getPropertyValue("txSize"));
+    }
 
 	private com.rabbitmq.client.ConnectionFactory getTargetConnectionFactory() {
 		CachingConnectionFactory connectionFactory = this.context


### PR DESCRIPTION
Add spring.rabbitmq.listener configuration properties for ackMode,
concurrency, maxConcurrency, prefetch, and txSize.