### PR TITLE
Fix min jdk version requirement in document

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -54,7 +54,7 @@ should also work without issue.
 
 === Building from source
 To build the source you will need to install
-http://maven.apache.org/run-maven/index.html[Apache Maven] v3.0.6 or above and JDK 1.7.
+http://maven.apache.org/run-maven/index.html[Apache Maven] v3.0.6 or above and JDK 1.8.
 
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -93,7 +93,7 @@ requests. If you want to raise an issue, please follow the recommendations bello
 You don't need to build from source to use Spring Boot (binaries in
 http://repo.spring.io[repo.spring.io], but if you want to try out the latest and greatest,
 Spring Boot can be http://maven.apache.org/run-maven/index.html[built with maven]
-v3.0.5 or above. You also need JDK 1.7 (although Boot applications can run on Java 1.6).
+v3.0.5 or above. You also need JDK 1.8 (although Boot applications can run on Java 1.6).
 
 [indent=0]
 ----


### PR DESCRIPTION
Hi all,

I think the min jdk version to `Building from Source` is 1.8 not 1.7.

I check the spring-boot-parent pom.xml file, we use maven-enforcer-plugin to check jdk version is [1.8,)

```
<requireJavaVersion>
	<version>[1.8,)</version>
</requireJavaVersion>
```
```
<requireJavaVersion>
	<version>(1.8,1.9)</version>
</requireJavaVersion>
```
so if you run `mvn clean install` with jdk 7, you will get a error like:

```
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireJavaVersion failed with message:
Detected JDK Version: 1.7.0-79 is not in the allowed range [1.8,).
```

also in `.travis.yml` the jdk version is 1.8.