### PR TITLE
Remove ignored option 'MaxPermSize' in pom file and document

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -67,7 +67,7 @@ The project can be built from the root directory using the standard maven comman
 ----
 
 NOTE: You may need to increase the amount of memory available to Maven by setting
-a `MAVEN_OPTS` environment variable with the value `-Xmx512m -XX:MaxPermSize=128m`
+a `MAVEN_OPTS` environment variable with the value `-Xmx512m`
 
 If you are rebuilding often, you might also want to skip the tests until you are ready
 to submit a pull request:
@@ -118,7 +118,7 @@ Once the build has been prepared, you can run a full build using the following c
 
 NOTE: As for the standard build, you may need to increase the amount of memory available
 to Maven by setting a `MAVEN_OPTS` environment variable with the value
-`-Xmx512m -XX:MaxPermSize=128m`. We generate more artifacts when running the full build
+`-Xmx512m`. We generate more artifacts when running the full build
 (such as Javadoc jars), so you may find the process a little slower than the standard build.
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -101,7 +101,7 @@ v3.0.5 or above. You also need JDK 1.8 (although Boot applications can run on Ja
 ----
 
 NOTE: You may need to increase the amount of memory available to Maven by setting
-a `MAVEN_OPTS` environment variable with the value `-Xmx512m -XX:MaxPermSize=128m`. Remember
+a `MAVEN_OPTS` environment variable with the value `-Xmx512m`. Remember
 to set the corresponding property in your IDE as well if you are building and running
 tests there (e.g. in Eclipse go to `Preferences->Java->Installed JREs` and edit the
 JRE definition so that all processes are launched with those arguments).

--- a/spring-boot-parent/pom.xml
+++ b/spring-boot-parent/pom.xml
@@ -473,7 +473,7 @@
 						<java.security.egd>file:/dev/./urandom</java.security.egd>
 						<java.awt.headless>true</java.awt.headless>
 					</systemPropertyVariables>
-					<argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+					<argLine>-Xmx1024m</argLine>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Hi all,

I found another thing that for jdk 1.8 the option `MaxPermSize` is not supported.

see travis log:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
Running org.springframework.boot.configurationmetadata.DescriptionExtractorTests
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 sec - in org.springframework.boot.configurationmetadata.DescriptionExtractorTests
```

Because the min jdk version for `building from source` is 1.8 so we can remove this option from both pom file and document.