### PR TITLE
Remove a redundant check in test code

### DIFF
--- a/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataMatchers.java
+++ b/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataMatchers.java
@@ -230,9 +230,6 @@ public class ConfigurationMetadataMatchers {
 			if (itemHint == null) {
 				return false;
 			}
-			if (this.name != null && !this.name.equals(itemHint.getName())) {
-				return false;
-			}
 			for (ValueHintMatcher value : this.values) {
 				if (!value.matches(itemHint)) {
 					return false;


### PR DESCRIPTION
The removed check looks redundant with the check in `getFirstHintWithName()`.