### PR TITLE
Rename JavaLoggerSystemTests and polish some Javadoc.

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/logging/AbstractLoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/AbstractLoggingSystem.java
@@ -78,7 +78,7 @@ public abstract class AbstractLoggingSystem extends LoggingSystem {
 	 * Return any self initialization config that has been applied. By default this method
 	 * checks {@link #getStandardConfigLocations()} and assumes that any file that exists
 	 * will have been applied.
-	 * @return the self initialization configor {@code null}
+	 * @return the self initialization config or {@code null}
 	 */
 	protected String getSelfInitializationConfig() {
 		return findConfig(getStandardConfigLocations());
@@ -113,7 +113,7 @@ public abstract class AbstractLoggingSystem extends LoggingSystem {
 	/**
 	 * Return the spring config locations for this system. By default this method returns
 	 * a set of locations based on {@link #getStandardConfigLocations()}.
-	 * @return the standard config locations
+	 * @return the spring config locations
 	 * @see #getSpringInitializationConfig()
 	 */
 	protected String[] getSpringConfigLocations() {

--- a/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystem.java
@@ -54,7 +54,7 @@ public abstract class LoggingSystem {
 	/**
 	 * Reset the logging system to be limit output. This method may be called before
 	 * {@link #initialize(LoggingInitializationContext, String, LogFile)} to reduce
-	 * logging noise until the system has been fully Initialized.
+	 * logging noise until the system has been fully initialized.
 	 */
 	public abstract void beforeInitialize();
 

--- a/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringProfileAction.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringProfileAction.java
@@ -32,7 +32,7 @@ import ch.qos.logback.core.joran.spi.Interpreter;
 import ch.qos.logback.core.util.OptionHelper;
 
 /**
- * Lockback {@link Action} to support {@code <springProfile>} tags. Allows section of a
+ * Logback {@link Action} to support {@code <springProfile>} tags. Allows section of a
  * logback configuration to only be enabled when a specific profile is active.
  *
  * @author Phillip Webb

--- a/spring-boot/src/test/java/org/springframework/boot/logging/java/JavaLoggingSystemTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/logging/java/JavaLoggingSystemTests.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertTrue;
  * @author Dave Syer
  * @author Phillip Webb
  */
-public class JavaLoggerSystemTests extends AbstractLoggingSystemTests {
+public class JavaLoggingSystemTests extends AbstractLoggingSystemTests {
 
 	private static final FileFilter SPRING_LOG_FILTER = new FileFilter() {
 


### PR DESCRIPTION
Rename `JavaLoggerSystemTests` to align with the testing target.