### PR TITLE
Fix for launch.script restart not working due to premature exit.

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -144,7 +144,7 @@ stop() {
   isRunning $pid || { echoRed "Not running (process ${pid} not found)"; exit 1; }
   kill -HUP $pid &> /dev/null || { echoRed "Unable to kill process ${pid}"; exit 1; }
   for i in $(seq 1 20); do
-    isRunning ${pid} || { echoGreen "Stopped [$pid]"; rm -f $pid_file; exit 0; }
+    isRunning ${pid} || { echoGreen "Stopped [$pid]"; rm -f $pid_file; return 0; }
     sleep 1
   done
   echoRed "Unable to kill process ${pid}";


### PR DESCRIPTION
This is a suggested fix for the restart action not working due to a premature call to exit. What I've done is simply to use return instead. There are a number of other cases where I can see this being an alternative to keep most side effects out of the called functions - this is however left out of this PR.

Fixes #3199