### PR TITLE
Create new log4j2 logger config when setLevel is called for logger th…

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -52,6 +52,7 @@ import org.springframework.util.ResourceUtils;
  * @author Daniel Fullarton
  * @author Andy Wilkinson
  * @author Alexander Heusingfeld
+ * @author Vladmir Tsanev
  * @since 1.2.0
  */
 public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
@@ -184,7 +185,13 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 
 	@Override
 	public void setLogLevel(String loggerName, LogLevel level) {
-		getLoggerConfig(loggerName).setLevel(LEVELS.get(level));
+		final LoggerConfig loggerConfig = getLoggerConfig(loggerName);
+		if (loggerName != null && !loggerConfig.getName().equals(loggerName)) {
+			LoggerConfig newLoggerConfig = new LoggerConfig(loggerName, LEVELS.get(level), true);
+			getLoggerContext().getConfiguration().addLogger(loggerName, newLoggerConfig);
+		} else {
+			loggerConfig.setLevel(LEVELS.get(level));
+		}
 		getLoggerContext().updateLoggers();
 	}
 

--- a/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
@@ -52,6 +52,7 @@ import static org.junit.Assert.assertTrue;
  * @author Daniel Fullarton
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Vladimir Tsanev
  */
 public class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 
@@ -128,6 +129,21 @@ public class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		this.logger.debug("Hello");
 		assertThat(StringUtils.countOccurrencesOf(this.output.toString(), "Hello"),
 				equalTo(1));
+	}
+
+	@Test
+	public void testSetLevelDoesNotAffectRootLevel() throws Exception {
+		this.loggingSystem.beforeInitialize();
+		this.loggingSystem.initialize(null, null, null);
+		final String loggerName = "some.undefined.logger";
+		Logger logger = LogManager.getLogger(loggerName);
+		Logger rootLogger = LogManager.getRootLogger();
+		logger.debug("Hello");
+		rootLogger.debug("Hello");
+		loggingSystem.setLogLevel(loggerName, LogLevel.DEBUG);
+		logger.debug("Hello");
+		rootLogger.debug("Hello");
+		assertThat(StringUtils.countOccurrencesOf(this.output.toString(), "Hello"), equalTo(1));
 	}
 
 	@Test


### PR DESCRIPTION
…at is not configured.

Seems that Configuration#getLoggerConfig(String) will return the parent configuration if th specified logger name is not explicitly configured in log4j2 configuration. And setting the log level will change some parent logger level.
For that reason a new additive LoggerConfig has to be created for the specified logger and then added to the configuration.

Fixes gh-3550