### PR TITLE
Add Firebird specific health query

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DataSourceHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DataSourceHealthIndicator.java
@@ -203,13 +203,22 @@ public class DataSourceHealthIndicator extends AbstractHealthIndicator implement
 
 		},
 
-		INFORMIX("Informix Dynamic Server", "select count(*) from systables");
+		INFORMIX("Informix Dynamic Server", "select count(*) from systables"),
+
+		FIREBIRD("Firebird", "SELECT 1 FROM RDB$DATABASE") {
+
+			@Override
+			protected boolean matchesProduct(String product) {
+				return super.matchesProduct(product)
+						||	product.toLowerCase().startsWith("firebird");
+			}
+		};
 
 		private final String product;
 
 		private final String query;
 
-		private Product(String product, String query) {
+		Product(String product, String query) {
 			this.product = product;
 			this.query = query;
 		}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/DataSourceHealthIndicatorTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/DataSourceHealthIndicatorTests.java
@@ -110,6 +110,8 @@ public class DataSourceHealthIndicatorTests {
 		assertThat(Product.forProduct("DB2/LINUXX8664"), equalTo(Product.DB2));
 		assertThat(Product.forProduct("Informix Dynamic Server"),
 				equalTo(Product.INFORMIX));
+		assertThat(Product.forProduct("Firebird 2.5.WI"), equalTo(Product.FIREBIRD));
+		assertThat(Product.forProduct("Firebird 2.1.LI"), equalTo(Product.FIREBIRD));
 	}
 
 }


### PR DESCRIPTION
I've added firebird support for datasource check. It uses system table [RDB$DATABASE](http://ibexpert.net/ibe/index.php?n=Doc.SystemObjects).
Although the more convenient way is to use MON$DATABASE table which was made specifically for this purpose, it was introduced only in firebird 2.1.