### PR TITLE
Doc for validation of nested properties

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -780,6 +780,32 @@ annotations to your `@ConfigurationProperties` class:
 
 	}
 ----
+In order to validate values of nested properties, you must annotate the static nested
+class as `@Valid`. For example, building upon the above `@ConfigurationProperties` class:
+
+[source,java,indent=0]
+----
+	@Component
+	@ConfigurationProperties(prefix="connection")
+	public class ConnectionSettings {
+
+		@NotNull
+		@Valid
+		private InetAddress remoteAddress;
+
+		// ... getters and setters
+
+		private static class InetAddress {
+
+			@NotEmpty
+			public String hostname;
+
+			// ... getters and setters
+
+		}
+
+	}
+----
 
 You can also add a custom Spring `Validator` by creating a bean definition called
 `configurationPropertiesValidator`.


### PR DESCRIPTION
Documentation for issue [Validation of @ConfigurationProperties does not happen for nested properties](https://github.com/spring-projects/spring-boot/issues/3510).
In a custom ConfigurationProperties class with nested properties, it is necessary to annotate the static nested class as Valid in order to validate its values.