### PR TITLE
Fix package name for mainClassName in build.gradle of spring-boot-sample-web-ui

### DIFF
--- a/spring-boot-samples/spring-boot-sample-web-ui/build.gradle
+++ b/spring-boot-samples/spring-boot-sample-web-ui/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'spring-boot'
 
-mainClassName = "sample.ui.SampleWebUiApplication"
+mainClassName = "sample.web.ui.SampleWebUiApplication"
 
 springBoot {
     classifier = 'exec'


### PR DESCRIPTION
The package name for the main class in build.gradle is incorrectly set to:
`mainClassName = "sample.ui.SampleWebUiApplication"`

It should be set to:
`mainClassName = "sample.web.ui.SampleWebUiApplication"`