### PR TITLE
Remove redundant conditionals.

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointAutoConfiguration.java
@@ -173,7 +173,6 @@ public class EndpointAutoConfiguration {
 
 	@Configuration
 	@ConditionalOnBean(Flyway.class)
-	@ConditionalOnClass(Flyway.class)
 	static class FlywayEndpointConfiguration {
 
 		@Bean
@@ -186,7 +185,6 @@ public class EndpointAutoConfiguration {
 
 	@Configuration
 	@ConditionalOnBean(SpringLiquibase.class)
-	@ConditionalOnClass(SpringLiquibase.class)
 	static class LiquibaseEndpointConfiguration {
 
 		@Bean


### PR DESCRIPTION
`@ConditionalOnBean` includes `@ConditionalOnClass`

so having `@ConditionalOnClass` with the same type as `@ConditionalOnBean` looks redundant.