### PR TITLE
Expose Hibernate Statistics

### DIFF
--- a/spring-boot-actuator/pom.xml
+++ b/spring-boot-actuator/pom.xml
@@ -138,6 +138,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-entitymanager</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.infinispan</groupId>
 			<artifactId>infinispan-spring4-embedded</artifactId>
 			<optional>true</optional>
@@ -155,6 +160,11 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-orm</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/PublicMetricsAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/PublicMetricsAutoConfiguration.java
@@ -20,15 +20,19 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import javax.persistence.EntityManagerFactory;
 import javax.servlet.Servlet;
 import javax.sql.DataSource;
 
 import org.apache.catalina.startup.Tomcat;
 
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.cache.CacheStatisticsProvider;
 import org.springframework.boot.actuate.endpoint.CachePublicMetrics;
 import org.springframework.boot.actuate.endpoint.DataSourcePublicMetrics;
+import org.springframework.boot.actuate.endpoint.HibernatePublicMetrics;
 import org.springframework.boot.actuate.endpoint.MetricReaderPublicMetrics;
 import org.springframework.boot.actuate.endpoint.PublicMetrics;
 import org.springframework.boot.actuate.endpoint.RichGaugeReaderPublicMetrics;
@@ -164,5 +168,18 @@ public class PublicMetricsAutoConfiguration {
 		}
 
 	}
+
+	@Configuration
+	@ConditionalOnClass({SessionFactory.class, Statistics.class})
+	static class HibernateMetricsConfiguraton {
+
+		@Bean
+		@ConditionalOnMissingBean
+		@ConditionalOnBean({EntityManagerFactory.class})
+		public HibernatePublicMetrics hibernateMetrics() {
+			return new HibernatePublicMetrics();
+		}
+	}
+
 
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/HibernatePublicMetrics.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/HibernatePublicMetrics.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.endpoint;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceException;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * A {@link PublicMetrics} implementation that provides Hibernate metrics. It exposes the same stats as would be
+ * exposed when calling {@code Statistics#logSummary}.
+ *
+ * @author Marten Deinum
+ * @since 2.0.0
+ */
+public class HibernatePublicMetrics implements PublicMetrics {
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	private final Map<String, EntityManagerFactory> metadataByPrefix = new HashMap<>();
+
+	@PostConstruct
+	public void initialize() {
+		EntityManagerFactory primaryEntityManagerFactory = getPrimaryEntityManagerFactory();
+		for (Map.Entry<String, EntityManagerFactory> entry : this.applicationContext.getBeansOfType(EntityManagerFactory.class).entrySet()) {
+			String beanName = entry.getKey();
+			EntityManagerFactory bean = entry.getValue();
+			if (hasStatisticsEnabled(bean)) {
+				String prefix = createPrefix(beanName, bean, bean.equals(primaryEntityManagerFactory));
+				this.metadataByPrefix.put(prefix, bean);
+			}
+		}
+	}
+
+	private String createPrefix(String name, EntityManagerFactory bean, boolean primary) {
+		return primary ? "hibernate.primary" : "hibernate." + name;
+	}
+
+	private boolean hasStatisticsEnabled(EntityManagerFactory emf) {
+		Statistics stats = getStatistics(emf);
+		return (stats != null && stats.isStatisticsEnabled());
+	}
+
+	/**
+	 * Get the {@code Statistics} object from the underlying {@code SessionFactory}. If it isn't hibernate that is
+	 * used return {@code null}.
+	 *
+	 * @param emf a {@code EntityManagerFactory}
+	 * @return the {@code Statistics} from the underlying {@code SessionFactory} or {@code null}.
+	 */
+	private Statistics getStatistics(EntityManagerFactory emf) {
+		try {
+			SessionFactory sf = emf.unwrap(SessionFactory.class);
+			return sf.getStatistics();
+		}
+		catch (PersistenceException pe) {
+			return null;
+		}
+	}
+
+
+	private <T extends Number> void addMetric(Set<Metric<?>> metrics, String name, T value) {
+		if (value != null) {
+			metrics.add(new Metric<T>(name, value));
+		}
+	}
+
+	@Override
+	public Collection<Metric<?>> metrics() {
+
+		Set<Metric<?>> metrics = new LinkedHashSet<Metric<?>>();
+
+		for (Map.Entry<String, EntityManagerFactory> entry : metadataByPrefix.entrySet()) {
+			Statistics stats = getStatistics(entry.getValue());
+			String prefix = entry.getKey();
+			prefix = (prefix.endsWith(".") ? prefix : prefix + ".");
+			addMetric(metrics, prefix + "start-time", stats.getStartTime());
+
+			// Session stats
+			addMetric(metrics, prefix + "sessions.open", stats.getSessionOpenCount());
+			addMetric(metrics, prefix + "sessions.close", stats.getSessionCloseCount());
+
+			// Transaction stats
+			addMetric(metrics, prefix + "transactions", stats.getTransactionCount());
+			addMetric(metrics, prefix + "transactions.success", stats.getSuccessfulTransactionCount());
+
+			addMetric(metrics, prefix + "optimistic_failure_count", stats.getOptimisticFailureCount());
+			addMetric(metrics, prefix + "flushes", stats.getFlushCount());
+			addMetric(metrics, prefix + "connections.obtained", stats.getConnectCount());
+
+			// Statements
+			addMetric(metrics, prefix + "statements.prepared", stats.getPrepareStatementCount());
+			addMetric(metrics, prefix + "statements.closed", stats.getCloseStatementCount());
+
+			// Second Level Caching
+			addMetric(metrics, prefix + "cache.second_level.hits", stats.getSecondLevelCacheHitCount());
+			addMetric(metrics, prefix + "cache.second_level.misses", stats.getSecondLevelCacheMissCount());
+			addMetric(metrics, prefix + "cache.second_level.puts", stats.getSecondLevelCachePutCount());
+
+			// Entity information
+			addMetric(metrics, prefix + "entities.deleted", stats.getEntityDeleteCount());
+			addMetric(metrics, prefix + "entities.fetched", stats.getEntityFetchCount());
+			addMetric(metrics, prefix + "entities.inserted", stats.getEntityInsertCount());
+			addMetric(metrics, prefix + "entities.loaded", stats.getEntityLoadCount());
+			addMetric(metrics, prefix + "entities.updated", stats.getOptimisticFailureCount());
+
+			// Collections
+			addMetric(metrics, prefix + "collections.removed", stats.getCollectionRemoveCount());
+			addMetric(metrics, prefix + "collections.fetched", stats.getCollectionFetchCount());
+			addMetric(metrics, prefix + "collections.loaded", stats.getCollectionLoadCount());
+			addMetric(metrics, prefix + "collections.recreated", stats.getCollectionRecreateCount());
+			addMetric(metrics, prefix + "collections.updated", stats.getCollectionUpdateCount());
+
+			// Natural Id cache
+			addMetric(metrics, prefix + "cache.natural_id.hits", stats.getNaturalIdCacheHitCount());
+			addMetric(metrics, prefix + "cache.natural_id.misses", stats.getNaturalIdCacheMissCount());
+			addMetric(metrics, prefix + "cache.natural_id.puts", stats.getNaturalIdCachePutCount());
+			addMetric(metrics, prefix + "query.natural_id.execution.count", stats.getNaturalIdQueryExecutionCount());
+			addMetric(metrics, prefix + "query.natural_id.execution.max_time", stats.getNaturalIdQueryExecutionMaxTime());
+
+			// Query stats
+			addMetric(metrics, prefix + "query.execution.count", stats.getQueryExecutionCount());
+			addMetric(metrics, prefix + "query.execution.max_time", stats.getQueryExecutionMaxTime());
+
+			// Update timestamp cache
+			addMetric(metrics, prefix + "cache.update_timestamps.hits", stats.getUpdateTimestampsCacheHitCount());
+			addMetric(metrics, prefix + "cache.update_timestamps.misses", stats.getUpdateTimestampsCacheMissCount());
+			addMetric(metrics, prefix + "cache.update_timestamps.puts", stats.getUpdateTimestampsCachePutCount());
+
+			// Query Caching
+			addMetric(metrics, prefix + "cache.query.hits", stats.getQueryCacheHitCount());
+			addMetric(metrics, prefix + "cache.query.misses", stats.getQueryCacheMissCount());
+			addMetric(metrics, prefix + "cache.query.puts", stats.getQueryCachePutCount());
+		}
+		return metrics;
+	}
+
+	/**
+	 * Attempt to locate the primary {@link EntityManagerFactory} (i.e. either the only one
+	 * available or the one amongst the candidates marked as {@link Primary}. Return
+	 * {@code null} if no primary could be found.
+	 *
+	 * @return The detected primary {@code EntityManagerFactory} or {@code null}
+	 */
+	private EntityManagerFactory getPrimaryEntityManagerFactory() {
+		try {
+			return this.applicationContext.getBean(EntityManagerFactory.class);
+		}
+		catch (NoSuchBeanDefinitionException ex) {
+			return null;
+		}
+	}
+}
+

--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -1032,7 +1032,40 @@ for all supported data sources; you can add additional `DataSourcePoolMetadataPr
 beans if your favorite data source isn't supported out of the box. See
 `DataSourcePoolMetadataProvidersConfiguration` for examples.
 
+[[production-ready-hibernate-metrics]]
+=== Hibernate metrics
+The following metrics are exposed for each supported `EntityManagerFactory` defined in your
+application:
 
+* The start time of each `EntityManagerFactory` (`hibernate.xxx.start-time`)
+* The number of sessions opened (`hibernate.xxx.sessions.open`)
+* The number of sessions closed (`hibernate.xxx.sessions.close`)
+* The total number of transactions (`hibernate.xxx.transactions`)
+* The total number of succesful transactions (`hibernate.xxx.transactions.success`)
+* The number of optimistic locking failures (`hibernate.xxx.optimistic_failure_count`)
+* The number of flushes (`hibernate.xxx.flushes`)
+* The number of connections obtained (`hibernate.xxx.connections.obtained`)
+* The number of statements prepared (`hibernate.xxx.statements.prepared`)
+* The number of statements closed (`hibernate.xxx.statements.closed`)
+* The second level cache hits/misses/puts (`hibernate.xxx.cache.second_level.[hits|misses|puts]`)
+* The natural id cache hits/misses/puts (`hibernate.xxx.cache.natural_id.[hits|misses|puts]`)
+* The query cache hits/misses/puts (`hibernate.xxx.query.natural_id.[hits|misses|puts]`)
+* The timestamp cache hits/misses/puts (`hibernate.xxx.query.update_timestamps.[hits|misses|puts]`)
+* The number of entities deleted/fetched/inserted/loaded/updated (`hibernate.xxx.entities.[deleted|fetched|inserted|loaded|updated]`)
+* The number of collections removed/fetched/loaded/recreated/updated (`hibernate.xxx.collections.[removed|fetched|loaded|recreated|updated]`)
+* The query execution count and max execution time (`hibernate.xxx.query.[count|max_time]`)
+
+
+All Hibernate metrics share the `hibernate.` prefix. The prefix is further qualified for
+each `EntityManagerFactory`:
+
+* If the `EntityManagerFactory` is the primary one (that is either the only available
+`EntityManagerFactory` or the one flagged `@Primary` amongst existing ones), the prefix
+is `hibernate.primary.`.
+* In all other cases, the name of the bean is used.
+
+It is possible to override part or all of those defaults by registering a bean with a
+customized version of `HibernatePublicMetrics`.
 
 [[production-ready-datasource-cache]]
 === Cache metrics


### PR DESCRIPTION
When hibernate is on the classpath and an `EntityManagerFactory` is configured then
register a `HibernateMetrics` bean so that the statistics from hibernate get published
to the metrics endpoint.

The exposed statistics are the same as those that would be exposed using `Statistics.logSummary`
from hibernate itself.

Issue: #2157
