### PR TITLE
 Configure default transaction isolation when using hibernate

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/JpaBaseConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/JpaBaseConfiguration.java
@@ -38,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
-import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.JpaVendorAdapter;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.persistenceunit.PersistenceUnitManager;
@@ -56,6 +55,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
  * @author Phillip Webb
  * @author Dave Syer
  * @author Oliver Gierke
+ * @author Arnost Havelka
  */
 @EnableConfigurationProperties(JpaProperties.class)
 @Import(DataSourceInitializedPublisher.Registrar.class)
@@ -80,7 +80,9 @@ public abstract class JpaBaseConfiguration implements BeanFactoryAware {
 	@Bean
 	@ConditionalOnMissingBean(PlatformTransactionManager.class)
 	public PlatformTransactionManager transactionManager() {
-		return new JpaTransactionManager();
+		return new SpringBootJpaTransactionManager(jpaProperties);
+// #3301 due to setup the default isolation level in the transaction manager
+//		return new JpaTransactionManager();
 	}
 
 	@Bean

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/SpringBootJpaTransactionManager.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/SpringBootJpaTransactionManager.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure.orm.jpa;
+
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+/**
+ * Spring Boot customization of JpaTransactionManager to apply configured default isolation level (see {@link JpaProperties}).
+ * 
+ * @author Arnost Havelka
+ */
+@SuppressWarnings("serial")
+public class SpringBootJpaTransactionManager extends JpaTransactionManager {
+
+	private boolean customizeIsolationLevel = false; 
+	
+	private int isolationLevel = TransactionDefinition.ISOLATION_DEFAULT;
+
+	public SpringBootJpaTransactionManager(JpaProperties jpaProperties) {
+		// verify definition JPA properties
+		if (jpaProperties == null) {
+			return;
+		}
+		// define customization properties
+		isolationLevel = jpaProperties.getDefaultIsolationLevel();
+		customizeIsolationLevel = TransactionDefinition.ISOLATION_DEFAULT != isolationLevel;
+		
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.orm.jpa.JpaTransactionManager#doBegin(java.lang.Object, org.springframework.transaction.TransactionDefinition)
+	 */
+	@Override
+	protected void doBegin(Object transaction, TransactionDefinition definition) {
+		if (customizeIsolationLevel && definition.getIsolationLevel() == TransactionDefinition.ISOLATION_DEFAULT) {
+			// override isolation level (as configured)
+			DefaultTransactionDefinition dtd = new DefaultTransactionDefinition(definition);
+			dtd.setIsolationLevel(isolationLevel);
+			// proceed with configured isolation level
+			super.doBegin(transaction, dtd);
+		} else {
+			// proceed with default/original isolation level
+			super.doBegin(transaction, definition);
+		}
+		
+	}
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfigurationTests.java
@@ -16,6 +16,14 @@
 
 package org.springframework.boot.autoconfigure.orm.jpa;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.Map;
 
 import javax.sql.DataSource;
@@ -25,7 +33,9 @@ import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.UserTransaction;
 
+import org.hibernate.Session;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
@@ -36,12 +46,7 @@ import org.springframework.boot.orm.jpa.hibernate.SpringJtaPlatform;
 import org.springframework.boot.test.EnvironmentTestUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Tests for {@link HibernateJpaAutoConfiguration}.
@@ -160,6 +165,34 @@ public class HibernateJpaAutoConfigurationTests extends AbstractJpaAutoConfigura
 				equalTo(TestJtaPlatform.class.getName()));
 	}
 
+	@Test
+	@Transactional()
+	@Ignore // not working properly in this dummy setup
+	public void testDefaultIsolationLevel() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.datasource.data:classpath:/city.sql",
+				"spring.datasource.schema:classpath:/ddl.sql",
+				// default isolation level:
+				"spring.jpa.defaultIsolationLevel:4");
+		setupTestConfiguration();
+		this.context.refresh();
+		// validate defined isolation level
+		LocalContainerEntityManagerFactoryBean bean = this.context
+				.getBean(LocalContainerEntityManagerFactoryBean.class);
+		
+		Session session = bean.nativeEntityManagerFactory.createEntityManager().unwrap(Session.class);
+		session.doWork(new org.hibernate.jdbc.Work() {
+			@Override
+			public void execute(Connection connection) throws SQLException {
+				assertThat(connection.getTransactionIsolation(), equalTo(4));
+			}
+		});
+		
+		DataSource datasource = bean.getDataSource();
+		assertThat(datasource.getConnection().getTransactionIsolation(), equalTo(4));
+	}
+	
+	
 	public static class TestJtaPlatform implements JtaPlatform {
 
 		@Override

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/JpaPropertiesConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/JpaPropertiesConfigurationTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.orm.jpa;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.TestAutoConfigurationPackage;
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.test.City;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Tests for {@link JpaProperties}.
+ *
+ * @author Arnost Havelka
+ */
+public class JpaPropertiesConfigurationTests {
+
+	protected AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+	@After
+	public void close() {
+		this.context.close();
+	}
+
+	@Test
+	public void testHibernateIsolationConnectionConstant() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.jpa.defaultIsolationLevel:4");
+		this.context.register(TestConfiguration.class,
+				EmbeddedDataSourceConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class,
+				HibernateJpaAutoConfiguration.class);
+		this.context.refresh();
+		// validate properties
+		JpaProperties bean = this.context.getBean(JpaProperties.class);
+		assertThat(bean.getDefaultIsolationLevel(), equalTo(4));
+	}
+
+	@Test
+	public void testHibernateIsolationTextValue() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.jpa.defaultIsolationLevel:serializable");
+		this.context.register(TestConfiguration.class,
+				EmbeddedDataSourceConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class,
+				HibernateJpaAutoConfiguration.class);
+		this.context.refresh();
+		JpaProperties bean = this.context.getBean(JpaProperties.class);
+		assertThat(bean.getDefaultIsolationLevel(), equalTo(8));
+	}
+
+	@Test
+	public void testHibernateIsolationConnectionWrong() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.jpa.defaultIsolationLevel:10");
+		this.context.register(TestConfiguration.class,
+				EmbeddedDataSourceConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class,
+				HibernateJpaAutoConfiguration.class);
+		this.context.refresh();
+		JpaProperties bean = this.context.getBean(JpaProperties.class);
+		assertThat(bean.getDefaultIsolationLevel(), equalTo(-1)); // eauals to default isolation
+	}
+	
+	@Configuration
+	@TestAutoConfigurationPackage(City.class)
+	protected static class TestConfiguration {
+
+	}
+}


### PR DESCRIPTION
Fix of issue #3301

When configuration item `spring.jpa.defaultIsolationLevel` is present then transaction manager takes defined isolation level as default (instead of -1). Values can be literals ("none", "read_uncommited", "read_commited", "repeatable_read" and "serializable") or values (0, 1, 2, 4 and 8).

What's remaining:
* log warning when wrong values is ignored (which was in my one of previous versions)
* fix test HibernateJpaAutoConfigurationTests#testDefaultIsolationLevel (I do not understand completely the testing setup --> regular spring test is workinh)
* update documentation
* update STS yml editor to support this configuration item

I can fix the warn logging and documentation when pull request is considered usefull.