### PR TITLE
Allow Jacksons ObjectMapper.locale to be set via spring.jackson.locale

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
@@ -162,6 +162,7 @@ public class JacksonAutoConfiguration {
 			configureDateFormat(builder);
 			configurePropertyNamingStrategy(builder);
 			configureModules(builder);
+			configureLocale(builder);
 			return builder;
 		}
 
@@ -235,6 +236,13 @@ public class JacksonAutoConfiguration {
 			Collection<Module> moduleBeans = getBeans(this.applicationContext,
 					Module.class);
 			builder.modulesToInstall(moduleBeans.toArray(new Module[moduleBeans.size()]));
+		}
+
+		private void configureLocale(Jackson2ObjectMapperBuilder builder) {
+			String locale = this.jacksonProperties.getLocale();
+			if (locale != null) {
+				builder.locale(locale);
+			}
 		}
 
 		private static <T> Collection<T> getBeans(ListableBeanFactory beanFactory,

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonProperties.java
@@ -95,6 +95,11 @@ public class JacksonProperties {
 	 */
 	private TimeZone timeZone = null;
 
+	/**
+	 * Locale used for formatting.
+	 */
+	private String locale;
+
 	public String getDateFormat() {
 		return this.dateFormat;
 	}
@@ -153,6 +158,14 @@ public class JacksonProperties {
 
 	public void setTimeZone(TimeZone timeZone) {
 		this.timeZone = timeZone;
+	}
+
+	public String getLocale() {
+		return this.locale;
+	}
+
+	public void setLocale(String locale) {
+		this.locale = locale;
 	}
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfigurationTests.java
@@ -381,6 +381,7 @@ public class JacksonAutoConfigurationTests {
 				"spring.jackson.time-zone:America/Los_Angeles");
 		EnvironmentTestUtils.addEnvironment(this.context,
 				"spring.jackson.date-format:zzzz");
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.jackson.locale:en");
 		this.context.refresh();
 		ObjectMapper objectMapper = this.context.getBean(
 				Jackson2ObjectMapperBuilder.class).build();
@@ -400,6 +401,21 @@ public class JacksonAutoConfigurationTests {
 				Jackson2ObjectMapperBuilder.class).build();
 		Date date = new Date(1436966242231L);
 		assertEquals("\"GMT+10:00\"", objectMapper.writeValueAsString(date));
+	}
+
+	@Test
+	public void customLocale() throws JsonProcessingException {
+		this.context.register(JacksonAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.jackson.locale:de");
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.jackson.date-format:zzzz");
+		this.context.refresh();
+		ObjectMapper objectMapper = this.context
+				.getBean(Jackson2ObjectMapperBuilder.class).build();
+
+		DateTime dateTime = new DateTime(1436966242231L, DateTimeZone.UTC);
+		assertEquals("\"Koordinierte Universalzeit\"",
+				objectMapper.writeValueAsString(dateTime));
 	}
 
 	@Configuration


### PR DESCRIPTION
To fix the default-locale reliance in JacksonAutoConfigurationTests.customTimeZoneFormattingADateTime() allow the ObjectMapper locale to be set via properties.
Otherwise the spring-boot-autoconfigure module won't build on my german laptop.