### PR TITLE
Catch more general error for hibernate 4.2

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfiguration.java
@@ -148,7 +148,8 @@ public class HibernateJpaAutoConfiguration extends JpaBaseConfiguration {
 					jtaTransactionManager));
 		}
 		catch (LinkageError ex) {
-			// Can happen if Hibernate 4.2 is used
+			// NoClassDefFoundError can happen if Hibernate 4.2 is used
+			// And some container (e.g. JBoss EAP 6) wraps it up by its super class LinkageError
 			if (!isUsingJndi()) {
 				throw new IllegalStateException("Unable to set Hibernate JTA "
 						+ "platform, are you using the correct "

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfiguration.java
@@ -147,7 +147,7 @@ public class HibernateJpaAutoConfiguration extends JpaBaseConfiguration {
 			vendorProperties.put(JTA_PLATFORM, new SpringJtaPlatform(
 					jtaTransactionManager));
 		}
-		catch (NoClassDefFoundError ex) {
+		catch (LinkageError ex) {
 			// Can happen if Hibernate 4.2 is used
 			if (!isUsingJndi()) {
 				throw new IllegalStateException("Unable to set Hibernate JTA "


### PR DESCRIPTION
JBoss EAP 6 class loader warps NoClassDefFoundError as cause of an LinkageError.