### PR TITLE
configure JRE that is different from compiler target level

### DIFF
--- a/spring-boot-actuator/pom.xml
+++ b/spring-boot-actuator/pom.xml
@@ -303,4 +303,20 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<!-- specify the JRE level that is used on the classpath for compilation, to allow smooth import into Eclipse/STS IDE -->
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<configuration>
+						<java.classpath.jre>1.8</java.classpath.jre>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+
 </project>

--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -563,4 +563,20 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<!-- specify the JRE level that is used on the classpath for compilation, to allow smooth import into Eclipse/STS IDE -->
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<configuration>
+						<java.classpath.jre>1.7</java.classpath.jre>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+
 </project>

--- a/spring-boot-devtools/pom.xml
+++ b/spring-boot-devtools/pom.xml
@@ -74,4 +74,20 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<!-- specify the JRE level that is used on the classpath for compilation, to allow smooth import into Eclipse/STS IDE -->
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<configuration>
+						<java.classpath.jre>1.7</java.classpath.jre>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+
 </project>

--- a/spring-boot-tools/spring-boot-loader-tools/pom.xml
+++ b/spring-boot-tools/spring-boot-loader-tools/pom.xml
@@ -137,5 +137,20 @@
 				</configuration>
 			</plugin>
 		</plugins>
+
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<!-- specify the JRE level that is used on the classpath for compilation, to allow smooth import into Eclipse/STS IDE -->
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<configuration>
+						<java.classpath.jre>1.7</java.classpath.jre>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+
 	</build>
+
 </project>

--- a/spring-boot-tools/spring-boot-loader/pom.xml
+++ b/spring-boot-tools/spring-boot-loader/pom.xml
@@ -82,4 +82,20 @@
 			</build>
 		</profile>
 	</profiles>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<!-- specify the JRE level that is used on the classpath for compilation, to allow smooth import into Eclipse/STS IDE -->
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<configuration>
+						<java.classpath.jre>1.7</java.classpath.jre>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+
 </project>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -266,5 +266,19 @@
 				</executions>
 			</plugin>
 		</plugins>
+
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<!-- specify the JRE level that is used on the classpath for compilation, to allow smooth import into Eclipse/STS IDE -->
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<configuration>
+						<java.classpath.jre>1.7</java.classpath.jre>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
+
 </project>


### PR DESCRIPTION
second attempt to specify the JRE level that is needed to compile the projects in case it is different from the compiler target level - to allow a smooth import of the projects into the STS IDE.

I moved the configuration into the pluginManagement section, but wasn't able to make this more specific than this. Couldn't figure out how to create my own custom section there and get that to work in the IDE, therefore used the maven-compiler section. Feels like a good match, since this is very much related to the compiler.

Hope this is fine.