### PR TITLE
Reversed enablement logic for security header configurers.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/SpringBootWebSecurityConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/SpringBootWebSecurityConfiguration.java
@@ -118,17 +118,17 @@ public class SpringBootWebSecurityConfiguration {
 			writer.setRequestMatcher(AnyRequestMatcher.INSTANCE);
 			configurer.addHeaderWriter(writer);
 		}
-		if (headers.isContentType()) {
-			configurer.contentTypeOptions();
+		if (!headers.isContentType()) {
+			configurer.contentTypeOptions().disable();
 		}
-		if (headers.isXss()) {
-			configurer.xssProtection();
+		if (!headers.isXss()) {
+			configurer.xssProtection().disable();
 		}
-		if (headers.isCache()) {
-			configurer.cacheControl();
+		if (!headers.isCache()) {
+			configurer.cacheControl().disable();
 		}
-		if (headers.isFrame()) {
-			configurer.frameOptions();
+		if (!headers.isFrame()) {
+			configurer.frameOptions().disable();
 		}
 	}
 


### PR DESCRIPTION
Explicitly disable security headers if corresponding configuration property is
false.

Fixes gh-3517

I have signed the contributors agreement.