### PR TITLE
add protocol to MailProperties

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mail/MailProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mail/MailProperties.java
@@ -55,6 +55,11 @@ public class MailProperties {
 	 */
 	private String password;
 
+        /**
+         * Protocol used by the SMTP server.
+         */
+        private String protocol;
+
 	/**
 	 * Default MimeMessage encoding.
 	 */
@@ -106,6 +111,14 @@ public class MailProperties {
 	public void setPassword(String password) {
 		this.password = password;
 	}
+
+        public String getProtocol() {
+                return this.protocol;
+        }
+
+        public void setProtocol(String protocol) {
+                this.protocol = protocol;
+        }
 
 	public Charset getDefaultEncoding() {
 		return this.defaultEncoding;

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mail/MailSenderAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mail/MailSenderAutoConfiguration.java
@@ -79,6 +79,9 @@ public class MailSenderAutoConfiguration {
 		}
 		sender.setUsername(this.properties.getUsername());
 		sender.setPassword(this.properties.getPassword());
+                if (this.properties.getProtocol() != null) {
+                        sender.setProtocol(this.properties.getProtocol());
+                }
 		if (this.properties.getDefaultEncoding() != null) {
 			sender.setDefaultEncoding(this.properties.getDefaultEncoding().name());
 		}


### PR DESCRIPTION
add protocol to MailProperties.
The protocol is needed, for example, if you're using gmail that uses smtps