### PR TITLE
Document Custom dependency version in Gradle

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -1935,7 +1935,8 @@ automatically compile your code whenever a file is saved.
 
 
 [[howto-customize-dependency-versions-with-maven]]
-=== Customize dependency versions with Maven
+[[howto-customize-dependency-versions]]
+=== Customize dependency versions
 If you use a Maven build that inherits directly or indirectly from `spring-boot-dependencies`
 (for instance `spring-boot-starter-parent`) but you want to override a specific
 third-party dependency you can add appropriate `<properties>` elements. Browse
@@ -1958,7 +1959,14 @@ the artifact yourself instead of overriding the property	.
 WARNING: Each Spring Boot release is designed and tested against a specific set of
 third-party dependencies. Overriding versions may cause compatibility issues.
 
+To override dependency versions in Gradle, you can specify a version as shown below:
 
+[source,groovy,indent=0]
+----
+	ext['slf4j.version'] = '1.7.5'
+----
+
+For additional information, refer to the https://github.com/spring-gradle-plugins/dependency-management-plugin[Gradle Dependency Management Plugin documentation].
 
 [[howto-create-an-executable-jar-with-maven]]
 === Create an executable JAR with Maven


### PR DESCRIPTION
This adds documentation on how to leverage Gradle's resolution
strategy to specify dependency versions.