### PR TITLE
HttpPutContentForm filter auto configuration

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.boot.autoconfigure.web.ResourceProperties.Strategy;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.web.OrderedHiddenHttpMethodFilter;
+import org.springframework.boot.context.web.OrderedHttpPutFormContentFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -57,6 +58,7 @@ import org.springframework.validation.MessageCodesResolver;
 import org.springframework.web.accept.ContentNegotiationManager;
 import org.springframework.web.context.request.RequestContextListener;
 import org.springframework.web.filter.HiddenHttpMethodFilter;
+import org.springframework.web.filter.HttpPutFormContentFilter;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.View;
@@ -109,6 +111,11 @@ public class WebMvcAutoConfiguration {
 		return new OrderedHiddenHttpMethodFilter();
 	}
 
+	@Bean
+	@ConditionalOnMissingBean(HttpPutFormContentFilter.class)
+	public HttpPutFormContentFilter httpPutFormContentFilter() {
+		return new OrderedHttpPutFormContentFilter();
+	}
 	// Defined as a nested config to ensure WebMvcConfigurerAdapter is not read when not
 	// on the classpath
 	@Configuration

--- a/spring-boot/src/main/java/org/springframework/boot/context/web/OrderedHttpPutFormContentFilter.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/web/OrderedHttpPutFormContentFilter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.context.web;
+
+import org.springframework.core.Ordered;
+import org.springframework.web.filter.HttpPutFormContentFilter;
+
+/**
+ * {@link HttpPutFormContentFilter} that also implements {@link Ordered}.
+ *
+ * @author Joao Pedro Evangelista
+ * @since 1.3.0
+ */
+public class OrderedHttpPutFormContentFilter extends HttpPutFormContentFilter implements Ordered {
+
+	/**
+	 * Higher order to ensure the filter is applied before Spring Security.
+	 */
+	public static final int DEFAULT_ORDER = Ordered.HIGHEST_PRECEDENCE + 10;
+
+	private int order = DEFAULT_ORDER;
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	/**
+	 * Set the order for this filter.
+	 * @param order the order to set
+	 */
+	public void setOrder(int order) {
+		this.order = order;
+	}
+
+}


### PR DESCRIPTION
Adds HttpPutFormContentFilter with an Ordered implementation to be applied before Spring Security filter chain on `WebMvcAutoConfiguration` similarly is done for `HiddenHttpMethodFilter` allowing PUT url form encoded requests

This fixes gh-3643