### PR TITLE
Update Versions Maven Plugin to 2.2

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -1645,7 +1645,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>versions-maven-plugin</artifactId>
-					<version>2.1</version>
+					<version>2.2</version>
 				</plugin>
 				<plugin>
 					<groupId>pl.project13.maven</groupId>


### PR DESCRIPTION
Please see here for a diff of commits (not the best format for seeing what was fixed/changed but this is the best I could find): https://github.com/mojohaus/versions-maven-plugin/compare/versions-maven-plugin-2.1...versions-maven-plugin-2.2