### PR TITLE
Add statsd autoconfiguration.

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/StatsdAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/StatsdAutoConfiguration.java
@@ -1,0 +1,42 @@
+package org.springframework.boot.actuate.autoconfigure;
+
+import com.timgroup.statsd.NonBlockingStatsDClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.metrics.statsd.StatsdMetricWriter;
+import org.springframework.boot.actuate.metrics.writer.MetricWriter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for the
+ * Statsd integration. Exports a {@link StatsdMetricWriter} which
+ * pushes metrics to the configured statsd server.
+ *
+ * @author Simon Buettner
+ */
+@Configuration
+@ConditionalOnClass(NonBlockingStatsDClient.class)
+@AutoConfigureBefore(MetricExportAutoConfiguration.class)
+@EnableConfigurationProperties(StatsdProperties.class)
+public class StatsdAutoConfiguration {
+
+    @Autowired
+    StatsdProperties statsdProperties;
+
+    @Bean
+    @ConditionalOnProperty(prefix = "statsd", name = {"host", "port"})
+    @ExportMetricWriter
+    public MetricWriter statsdMetricWriter() {
+        return new StatsdMetricWriter(
+            statsdProperties.getPrefix(),
+            statsdProperties.getHost(),
+            statsdProperties.getPort()
+        );
+    }
+
+}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/StatsdProperties.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/StatsdProperties.java
@@ -1,0 +1,47 @@
+package org.springframework.boot.actuate.autoconfigure;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the Statsd metrics writer.
+ *
+ * @author Simon Buettner
+ * @since 1.3.0
+ */
+@ConfigurationProperties(prefix = "statsd")
+public class StatsdProperties {
+
+    private static Log logger = LogFactory.getLog(StatsdProperties.class);
+
+    private String host;
+
+    private int port;
+
+    private String prefix;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/StatsdAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/StatsdAutoConfigurationTests.java
@@ -1,0 +1,70 @@
+package org.springframework.boot.actuate.autoconfigure;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.actuate.metrics.statsd.StatsdMetricWriter;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link StatsdAutoConfiguration}.
+ *
+ * @author Simon Buettner
+ */
+public class StatsdAutoConfigurationTests {
+
+    MockEnvironment env;
+
+    AnnotationConfigApplicationContext context;
+
+    @Before
+    public void before() {
+        env = new MockEnvironment();
+        context = new AnnotationConfigApplicationContext();
+    }
+
+    @After
+    public void after() {
+        context.close();
+    }
+
+    @Test
+    public void testConditionalAnnotationWithMissingPropertyValues() throws Exception {
+        context.register(StatsdAutoConfiguration.class);
+        context.refresh();
+
+        assertFalse(context.containsBean("statsdMetricWriter"));
+        assertTrue(context.getBeansOfType(StatsdMetricWriter.class).isEmpty());
+    }
+
+    @Test
+    public void testMinimalStatsdAutoConfiguration() throws Exception {
+        env.setProperty("statsd.host", "localhost");
+        env.setProperty("statsd.port", "1234");
+
+        context.setEnvironment(env);
+        context.register(StatsdAutoConfiguration.class);
+        context.refresh();
+
+        assertTrue(context.containsBean("statsdMetricWriter"));
+        assertNotNull(context.getBean(StatsdMetricWriter.class));
+    }
+
+    @Test
+    public void testStatsdAutoConfiguratioWithPrefix() throws Exception {
+        env.setProperty("statsd.host", "localhost");
+        env.setProperty("statsd.port", "1234");
+        env.setProperty("statsd.prefix", "statsdprefix");
+
+        context.setEnvironment(env);
+        context.register(StatsdAutoConfiguration.class);
+        context.refresh();
+
+        assertTrue(context.containsBean("statsdMetricWriter"));
+        assertNotNull(context.getBean(StatsdMetricWriter.class));
+    }
+
+}

--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -1157,6 +1157,10 @@ MetricWriter metricWriter() {
 }
 ----
 
+==== Statsd autoconfiguration
+If the `statsd.host` and `statsd.port` properties are found in your environment a `StatsMetricWriter` will be
+autoconfigured using the provided values. You can also define a custom prefix which will be used to store your
+metrics using the `statsd.prefix` property.
 
 [[production-ready-metric-writers-export-to-jmx]]
 ==== Example: Export to JMX


### PR DESCRIPTION
This PR adds a simple autoconfiguration for the `StatsdMetricWriter`. Tests are included along with a short documentation. CLA has been signed: 133520150810110320