### PR TITLE
Add spring.mvc.view-controller.* property

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.Servlet;
 
@@ -91,6 +92,7 @@ import org.springframework.web.servlet.view.InternalResourceViewResolver;
  * @author Dave Syer
  * @author Andy Wilkinson
  * @author Sébastien Deleuze
+ * @author Toshiaki Maki
  */
 @Configuration
 @ConditionalOnWebApplication
@@ -294,6 +296,13 @@ public class WebMvcAutoConfiguration {
 			if (page != null) {
 				logger.info("Adding welcome page: " + page);
 				registry.addViewController("/").setViewName("forward:index.html");
+			}
+			if (this.mvcProperties.getViewController() != null) {
+				for (Map.Entry<String, String> entry : this.mvcProperties
+						.getViewController().entrySet()) {
+					registry.addViewController(entry.getKey())
+							.setViewName(entry.getValue());
+				}
 			}
 		}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.web;
 
 import java.util.Locale;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -28,6 +29,7 @@ import org.springframework.validation.DefaultMessageCodesResolver;
  * @author Phillip Webb
  * @author Sébastien Deleuze
  * @author Stephane Nicoll
+ * @author Toshiaki Maki
  * @since 1.1
  */
 @ConfigurationProperties("spring.mvc")
@@ -57,6 +59,12 @@ public class WebMvcProperties {
 	private final Async async = new Async();
 
 	private final View view = new View();
+
+	/**
+	 * Map for the given URL path (or pattern) and pre-configured view.
+	 * @since 1.3
+	 */
+	private Map<String, String> viewController;
 
 	public DefaultMessageCodesResolver.Format getMessageCodesResolverFormat() {
 		return this.messageCodesResolverFormat;
@@ -97,6 +105,14 @@ public class WebMvcProperties {
 
 	public View getView() {
 		return this.view;
+	}
+
+	public Map<String, String> getViewController() {
+		return viewController;
+	}
+
+	public void setViewController(Map<String, String> viewController) {
+		this.viewController = viewController;
 	}
 
 	public static class Async {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfigurationTests.java
@@ -464,7 +464,8 @@ public class WebMvcAutoConfigurationTests {
 	@Test
 	public void configureViewController() {
 		load("spring.mvc.view-controller./:index", "spring.mvc.view-controller.foo:foo",
-				"spring.mvc.view-controller.bar/**:bar");
+				"spring.mvc.view-controller.bar/**:bar",
+				"spring.mvc.view-controller.hello.do:hello");
 		SimpleUrlHandlerMapping handlerMapping = this.context
 				.getBean("viewControllerHandlerMapping", SimpleUrlHandlerMapping.class);
 		Map<String, ?> urlMap = handlerMapping.getUrlMap();
@@ -476,6 +477,8 @@ public class WebMvcAutoConfigurationTests {
 				is("foo"));
 		assertThat(ParameterizableViewController.class.cast(urlMap.get("bar/**"))
 				.getViewName(), is("bar"));
+		assertThat(ParameterizableViewController.class.cast(urlMap.get("hello.do"))
+				.getViewName(), is("hello"));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfigurationTests.java
@@ -62,6 +62,7 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
 import org.springframework.web.servlet.i18n.FixedLocaleResolver;
+import org.springframework.web.servlet.mvc.ParameterizableViewController;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.springframework.web.servlet.resource.AppCacheManifestTransformer;
 import org.springframework.web.servlet.resource.CachingResourceResolver;
@@ -97,6 +98,7 @@ import static org.junit.Assert.assertThat;
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  * @author Brian Clozel
+ * @author Toshiaki Maki
  */
 public class WebMvcAutoConfigurationTests {
 
@@ -457,6 +459,23 @@ public class WebMvcAutoConfigurationTests {
 				.size(), is(equalTo(0)));
 		assertThat(this.context.getBeansOfType(HttpPutFormContentFilter.class).size(),
 				is(equalTo(1)));
+	}
+
+	@Test
+	public void configureViewController() {
+		load("spring.mvc.view-controller./:index", "spring.mvc.view-controller.foo:foo",
+				"spring.mvc.view-controller.bar/**:bar");
+		SimpleUrlHandlerMapping handlerMapping = this.context
+				.getBean("viewControllerHandlerMapping", SimpleUrlHandlerMapping.class);
+		Map<String, ?> urlMap = handlerMapping.getUrlMap();
+		assertThat(
+				ParameterizableViewController.class.cast(urlMap.get("/")).getViewName(),
+				is("index"));
+		assertThat(
+				ParameterizableViewController.class.cast(urlMap.get("foo")).getViewName(),
+				is("foo"));
+		assertThat(ParameterizableViewController.class.cast(urlMap.get("bar/**"))
+				.getViewName(), is("bar"));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -145,6 +145,8 @@ content into your application; rather pick only the properties that you need.
 	spring.mvc.async.request-timeout= # async request timeout in milliseconds
 	spring.mvc.view.prefix= # MVC view prefix
 	spring.mvc.view.suffix= # ... and suffix
+	spring.mvc.view-controller.*= # Map for the given URL path (or pattern) and pre-configured view, e.g. "spring.mvc.view-controller.bar/**=bar"
+
 
 	# SPRING RESOURCES HANDLING ({sc-spring-boot-autoconfigure}/web/ResourceProperties.{sc-ext}[ResourceProperties])
 	spring.resources.cache-period= # cache timeouts in headers sent to browser


### PR DESCRIPTION
Add `spring.mvc.view-controller.*` allowing users to configure the map for the given URL path (or pattern) and pre-configured view.

This commit eliminates creating trivial controllers like the following:

``` java
@Contoller
public class HelloController {
  @RequestMapping("/hello/**")
  public String hello() {
    return "hello";
  }
}
```
by configuring
``` properties
spring.mvc.view-controller./hello/**=hello
```
in `application.properites`