### PR TITLE
Ability to extend JarLauncher

### DIFF
--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/ExecutableArchiveLauncher.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/ExecutableArchiveLauncher.java
@@ -41,7 +41,7 @@ public abstract class ExecutableArchiveLauncher extends Launcher {
 
 	private final JavaAgentDetector javaAgentDetector;
 
-	protected ExecutableArchiveLauncher() {
+	public ExecutableArchiveLauncher() {
 		this(new InputArgumentsJavaAgentDetector());
 	}
 

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/ExecutableArchiveLauncher.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/ExecutableArchiveLauncher.java
@@ -41,7 +41,7 @@ public abstract class ExecutableArchiveLauncher extends Launcher {
 
 	private final JavaAgentDetector javaAgentDetector;
 
-	public ExecutableArchiveLauncher() {
+	protected ExecutableArchiveLauncher() {
 		this(new InputArgumentsJavaAgentDetector());
 	}
 
@@ -55,7 +55,7 @@ public abstract class ExecutableArchiveLauncher extends Launcher {
 		this.javaAgentDetector = javaAgentDetector;
 	}
 
-	ExecutableArchiveLauncher(Archive archive) {
+	public ExecutableArchiveLauncher(Archive archive) {
 		this.javaAgentDetector = new InputArgumentsJavaAgentDetector();
 		this.archive = archive;
 	}

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/JarLauncher.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/JarLauncher.java
@@ -31,6 +31,13 @@ public class JarLauncher extends ExecutableArchiveLauncher {
 
 	private static final AsciiBytes LIB = new AsciiBytes("lib/");
 
+	JarLauncher() {
+	}
+
+	public JarLauncher(Archive archive) {
+		super(archive);
+	}
+
 	@Override
 	protected boolean isNestedArchive(Archive.Entry entry) {
 		return !entry.isDirectory() && entry.getName().startsWith(LIB);

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/JarLauncher.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/JarLauncher.java
@@ -31,7 +31,7 @@ public class JarLauncher extends ExecutableArchiveLauncher {
 
 	private static final AsciiBytes LIB = new AsciiBytes("lib/");
 
-	JarLauncher() {
+	public JarLauncher() {
 	}
 
 	public JarLauncher(Archive archive) {

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/Launcher.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/Launcher.java
@@ -54,7 +54,7 @@ public abstract class Launcher {
 	 * called by a subclass {@code public static void main(String[] args)} method.
 	 * @param args the incoming arguments
 	 */
-	protected void launch(String[] args) {
+	public void launch(String[] args) {
 		try {
 			JarFile.registerUrlProtocolHandler();
 			ClassLoader classLoader = createClassLoader(getClassPathArchives());


### PR DESCRIPTION
 - Provide public access to construct `JarLauncher` and `ExecutableArchiveLauncher`
 - Add `public` access to `launch` method in `Launcher` so that this method can be accessed programmatically by a subclass that extends `Launcher`