### PR TITLE
Enable HTTP OPTIONS when autoconfiguring Spring Data REST

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/rest/RepositoryRestMvcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/rest/RepositoryRestMvcAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.autoconfigure.data.rest;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -27,6 +29,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration;
+import org.springframework.web.servlet.DispatcherServlet;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Spring Data Rest's MVC
@@ -53,6 +56,30 @@ public class RepositoryRestMvcAutoConfiguration {
 	@Bean
 	public SpringBootRepositoryRestConfigurer springBootRepositoryRestConfigurer() {
 		return new SpringBootRepositoryRestConfigurer();
+	}
+
+	/**
+	 * Spring Data REST has {@link org.springframework.http.HttpMethod#OPTIONS} mappings. This post processor
+	 * turns on support in the {@link DispatcherServlet}.
+	 */
+	@Bean
+	public BeanPostProcessor enableOptionsInDispatcherServletPostProcessor() {
+		return new BeanPostProcessor() {
+			@Override
+			public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+				return bean;
+			}
+
+			@Override
+			public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+				if (DispatcherServlet.class.isAssignableFrom(bean.getClass())) {
+					DispatcherServlet dispatcherServlet = (DispatcherServlet) bean;
+					dispatcherServlet.setDispatchOptionsRequest(true);
+				}
+
+				return bean;
+			}
+		};
 	}
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/rest/RepositoryRestMvcAutoConfigurationIntegrationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/rest/RepositoryRestMvcAutoConfigurationIntegrationTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure.data.rest;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Field;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.DispatcherServletAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.HttpMessageConvertersAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+import org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.servlet.DispatcherServlet;
+
+/**
+ * Test Spring Data REST autoconfiguration in fully spun up integration tests.
+ *
+ * @author Greg Turnquist
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = RepositoryRestMvcAutoConfigurationIntegrationTests.TestConfig.class)
+@WebAppConfiguration
+@IntegrationTest("server.port=0")
+public class RepositoryRestMvcAutoConfigurationIntegrationTests {
+
+	@Autowired
+	private AnnotationConfigEmbeddedWebApplicationContext context;
+
+	@Test
+	public void proveOptionsAreEnabledForSpringDataRest() throws IllegalAccessException {
+		DispatcherServlet dispatcherServlet = this.context.getBean(DispatcherServlet.class);
+
+		Field dispatchOptionsRequest = ReflectionUtils.findField(DispatcherServlet.class, "dispatchOptionsRequest");
+		ReflectionUtils.makeAccessible(dispatchOptionsRequest);
+		assertThat((Boolean) dispatchOptionsRequest.get(dispatcherServlet), equalTo(true));
+
+	}
+
+	@Configuration
+	@MinimalWebConfiguration
+	protected static class TestConfig {
+
+	}
+
+	@Target(ElementType.TYPE)
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	@Import({ EmbeddedServletContainerAutoConfiguration.EmbeddedTomcat.class,
+			EmbeddedServletContainerAutoConfiguration.class,
+			ServerPropertiesAutoConfiguration.class,
+			DispatcherServletAutoConfiguration.class, WebMvcAutoConfiguration.class,
+			HttpMessageConvertersAutoConfiguration.class, RepositoryRestMvcAutoConfiguration.class})
+	protected @interface MinimalWebConfiguration {
+
+	}
+
+}


### PR DESCRIPTION
By default, Spring's DispatcherServlet routes OPTIONS requests straight to the container. Spring Data REST has request mappings for HttpMethod.OPTIONS. This patch creates a bean post processor to find DispatcherServlets and turn on the dispatch-to-application feature.