### PR TITLE
fixed table endpoints layout

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -70,6 +70,7 @@ The following endpoints are available:
 |`actuator`
 |Provides a hypermedia-based "`discovery page`" for the other endpoints. Requires Spring
 HATEOAS to be on the classpath.
+|true
 
 |`autoconfig`
 |Displays an auto-configuration report showing all auto-configuration candidates and the


### PR DESCRIPTION
The missing ```|true``` statement broke the table