### PR TITLE
[#3761 Issue] Add sorting feature to MetricRegistryMetricReader

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/reader/MetricRegistryMetricReader.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/reader/MetricRegistryMetricReader.java
@@ -115,7 +115,7 @@ public class MetricRegistryMetricReader implements MetricReader, MetricRegistryL
 				Set<Metric<?>> metrics = new TreeSet<Metric<?>>(new Comparator<Metric<?>>() {
 					@Override
 					public int compare(Metric<?> metric1, Metric<?> metric2) {
-						return metric2.getName().compareToIgnoreCase(metric2.getName());
+						return metric1.getName().compareToIgnoreCase(metric2.getName());
 					}
 				});
 				for (String name : MetricRegistryMetricReader.this.names.keySet()) {

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/reader/MetricRegistryMetricReader.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/reader/MetricRegistryMetricReader.java
@@ -18,10 +18,12 @@ package org.springframework.boot.actuate.metrics.reader;
 
 import java.beans.PropertyDescriptor;
 import java.util.HashSet;
+import java.util.TreeSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Comparator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -110,7 +112,12 @@ public class MetricRegistryMetricReader implements MetricReader, MetricRegistryL
 		return new Iterable<Metric<?>>() {
 			@Override
 			public Iterator<Metric<?>> iterator() {
-				Set<Metric<?>> metrics = new HashSet<Metric<?>>();
+				Set<Metric<?>> metrics = new TreeSet<Metric<?>>(new Comparator<Metric<?>>() {
+					@Override
+					public int compare(Metric<?> metric1, Metric<?> metric2) {
+						return metric2.getName().compareToIgnoreCase(metric2.getName());
+					}
+				});
 				for (String name : MetricRegistryMetricReader.this.names.keySet()) {
 					Metric<?> metric = findOne(name);
 					if (metric != null) {


### PR DESCRIPTION
The original issue was folowing:
```MetricRegistryMetricReader``` uses simple ```HashSet``` to collect metrics from registry. As result they appear it unpredictable order when exported to ```web/jmx``` view. It would be expected to see metrics ordered by name instead of
```
dw.a.run.snapshot.95thPercentile: 10,
dw.a.run.expexp.snapshot.99thPercentile: 82,
dw.a.run.dump.snapshot.max: 1,
dw.a.run.expexp.snapshot.95thPercentile: 9,
dw.a.run.dump.snapshot.999thPercentile: 1,
dw.a.run.count: 2,
```
Improvements in this PR add sorting fetures to the ```findAll()``` method of ```MetricRegistryMetricReader``` class by using ```TreeSet(Comparator<? super E> comparator)``` insted of  ```HashSet()```.