### PR TITLE
Set resource cache period to zero when Devtools is enabled

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsPropertyDefaultsPostProcessor.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsPropertyDefaultsPostProcessor.java
@@ -46,6 +46,7 @@ public class DevToolsPropertyDefaultsPostProcessor implements EnvironmentPostPro
 		properties.put("spring.mustache.cache", "false");
 		properties.put("server.session.persistent", "true");
 		properties.put("spring.h2.console.enabled", "true");
+		properties.put("spring.resources.cache-period", "0");
 		PROPERTIES = Collections.unmodifiableMap(properties);
 	}
 

--- a/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
+++ b/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
@@ -28,6 +28,7 @@ import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.ResourceProperties;
 import org.springframework.boot.devtools.classpath.ClassPathChangedEvent;
 import org.springframework.boot.devtools.classpath.ClassPathFileSystemWatcher;
 import org.springframework.boot.devtools.filewatch.ChangedFiles;
@@ -87,6 +88,13 @@ public class LocalDevToolsAutoConfigurationTests {
 		TemplateResolver resolver = this.context.getBean(TemplateResolver.class);
 		resolver.initialize();
 		assertThat(resolver.isCacheable(), equalTo(false));
+	}
+
+	@Test
+	public void resourceCachePeriodIsZero() throws Exception {
+		this.context = initializeAndRun(WebResourcesConfig.class);
+		ResourceProperties properties = this.context.getBean(ResourceProperties.class);
+		assertThat(properties.getCachePeriod(), equalTo(0));
 	}
 
 	@Test
@@ -242,4 +250,9 @@ public class LocalDevToolsAutoConfigurationTests {
 
 	}
 
+	@Configuration
+	@Import({ LocalDevToolsAutoConfiguration.class, ResourceProperties.class })
+	public static class WebResourcesConfig {
+
+	}
 }


### PR DESCRIPTION
resolve #3739

I always set spring.resources.cache-period to zero when I write code and debug the spring web application. It's very useful to set this value to zero. (or -1).