### PR TITLE
Use right version from spring-boot-dependencies

### DIFF
--- a/spring-boot-samples/spring-boot-sample-data-jpa/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-data-jpa/pom.xml
@@ -47,7 +47,7 @@
 					<dependency>
 						<groupId>org.springframework</groupId>
 						<artifactId>springloaded</artifactId>
-						<version>1.2.0.RELEASE</version>
+						<version>${spring-loaded.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/spring-boot-samples/spring-boot-sample-web-groovy-templates/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-web-groovy-templates/pom.xml
@@ -38,7 +38,7 @@
 					<dependency>
 						<groupId>org.springframework</groupId>
 						<artifactId>springloaded</artifactId>
-						<version>1.2.0.RELEASE</version>
+						<version>${spring-loaded.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/spring-boot-samples/spring-boot-sample-web-ui/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-web-ui/pom.xml
@@ -38,7 +38,7 @@
 					<dependency>
 						<groupId>org.springframework</groupId>
 						<artifactId>springloaded</artifactId>
-						<version>1.2.0.RELEASE</version>
+						<version>${spring-loaded.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>


### PR DESCRIPTION
Fix #3800 

The Spring Loaded version is hard code in sample's pom.xml file. 
We should the version from spring-boot-dependencies.

The same issue for `spring-boot-sample-web-groovy-templates` and `spring-boot-sample-data-jpa`.