### PR TITLE
#3798 Spring Batch Autoconfig does not set tablePrefix for JobRepository

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BasicBatchConfigurer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BasicBatchConfigurer.java
@@ -140,6 +140,10 @@ class BasicBatchConfigurer implements BatchConfigurer {
 			logger.warn("JPA does not support custom isolation levels, so locks may not be taken when launching Jobs");
 			factory.setIsolationLevelForCreate("ISOLATION_DEFAULT");
 		}
+		String tablePrefix = this.properties.getTablePrefix();
+		if (StringUtils.hasText(tablePrefix)) {
+			factory.setTablePrefix(tablePrefix);
+		}
 		factory.setTransactionManager(getTransactionManager());
 		factory.afterPropertiesSet();
 		return factory.getObject();


### PR DESCRIPTION
Added tablePrefix for JobRepository as it is already set for JobExporer