### PR TITLE
Fix typo on Dropwizard metrics-core dependency

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -1240,7 +1240,7 @@ repositories, and don't want to export their values.
 [[production-ready-dropwizard-metrics]]
 === Dropwizard Metrics
 A default `MetricRegistry` Spring bean will be created when you declare a dependency to
-the `io.dropwizard.metrics:metric-core` library; you can also register you own `@Bean`
+the `io.dropwizard.metrics:metrics-core` library; you can also register you own `@Bean`
 instance if you need customizations. Users of the
 https://dropwizard.github.io/metrics/[Dropwizard '`Metrics`' library] will find that
 Spring Boot metrics are automatically published to `com.codahale.metrics.MetricRegistry`.


### PR DESCRIPTION
The artifactId is `metric-core`, should be `metrics-core`