### PR TITLE
gh-3830: Don't restart non-restartable batch jobs

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherCommandLineRunner.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherCommandLineRunner.java
@@ -144,7 +144,7 @@ public class JobLauncherCommandLineRunner implements CommandLineRunner,
 					parameters = incrementer.getNext(new JobParameters());
 				}
 			}
-			else if (isStoppedOrFailed(previousExecution)) {
+			else if (isStoppedOrFailed(previousExecution) && job.isRestartable()) {
 				// Retry a failed or stopped execution
 				parameters = previousExecution.getJobParameters();
 				// Non-identifying additional parameters can be added to a retry


### PR DESCRIPTION
gh-3830: Do not restart non-restartable batch jobs if they have been stopped or
failed.