### PR TITLE
Oracle XA data-source classname incorrect in DatabaseDriver.java

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DatabaseDriver.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DatabaseDriver.java
@@ -71,7 +71,7 @@ enum DatabaseDriver {
 	/**
 	 * Oracle
 	 */
-	ORACLE("oracle.jdbc.OracleDriver", "oracle.jdbc.xa.OracleXADataSource"),
+	ORACLE("oracle.jdbc.OracleDriver", "oracle.jdbc.xa.client.OracleXADataSource"),
 
 	/**
 	 * Postres


### PR DESCRIPTION
Oracle XA Datasource is incorrect, it was pointing to the abstract base class which cannot be instantiated. The correct class is oracle.jdbc.xa.client.OracleXADataSource