### PR TITLE
Elasticsearch autoconfiguration for spring-boot-rest

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchAutoConfiguration.java
@@ -32,6 +32,7 @@ import org.elasticsearch.node.NodeBuilder;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -50,12 +51,13 @@ import org.springframework.util.StringUtils;
  * @since 1.1.0
  */
 @Configuration
-@ConditionalOnClass({ Client.class, TransportClientFactoryBean.class,
-		NodeClientFactoryBean.class })
+@ConditionalOnClass({Client.class, TransportClientFactoryBean.class,
+		NodeClientFactoryBean.class})
 @EnableConfigurationProperties(ElasticsearchProperties.class)
 public class ElasticsearchAutoConfiguration implements DisposableBean {
 
 	private static final Map<String, String> DEFAULTS;
+
 	static {
 		Map<String, String> defaults = new LinkedHashMap<String, String>();
 		defaults.put("http.enabled", String.valueOf(false));
@@ -71,11 +73,11 @@ public class ElasticsearchAutoConfiguration implements DisposableBean {
 	private Releasable releasable;
 
 	@Bean
+	@ConditionalOnMissingBean
 	public Client elasticsearchClient() {
 		try {
 			return createClient();
-		}
-		catch (Exception ex) {
+		} catch (Exception ex) {
 			throw new IllegalStateException(ex);
 		}
 	}
@@ -127,20 +129,17 @@ public class ElasticsearchAutoConfiguration implements DisposableBean {
 				}
 				try {
 					this.releasable.close();
-				}
-				catch (NoSuchMethodError ex) {
+				} catch (NoSuchMethodError ex) {
 					// Earlier versions of Elasticsearch had a different method name
 					ReflectionUtils.invokeMethod(
 							ReflectionUtils.findMethod(Releasable.class, "release"),
 							this.releasable);
 				}
-			}
-			catch (final Exception ex) {
+			} catch (final Exception ex) {
 				if (logger.isErrorEnabled()) {
 					logger.error("Error closing Elasticsearch client: ", ex);
 				}
 			}
 		}
 	}
-
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchDataAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchDataAutoConfiguration.java
@@ -24,12 +24,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Spring Data's Elasticsearch
  * support.
- * <p>
  * Registers a {@link ElasticsearchTemplate} if no other bean of the same type is
  * configured.
  *
@@ -39,14 +41,29 @@ import org.springframework.data.elasticsearch.repository.config.EnableElasticsea
  * @since 1.1.0
  */
 @Configuration
-@ConditionalOnClass({ Client.class, ElasticsearchTemplate.class })
+@ConditionalOnClass({Client.class, ElasticsearchTemplate.class})
 @AutoConfigureAfter(ElasticsearchAutoConfiguration.class)
 public class ElasticsearchDataAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ElasticsearchTemplate elasticsearchTemplate(Client client) {
-		return new ElasticsearchTemplate(client);
+	public ElasticsearchTemplate elasticsearchTemplate(Client client, ElasticsearchConverter converter) {
+		try {
+			return new ElasticsearchTemplate(client, converter);
+		} catch (Exception ex) {
+			throw new IllegalStateException(ex);
+		}
 	}
 
+	@Bean
+	@ConditionalOnMissingBean
+	public ElasticsearchConverter elasticsearchConverter(SimpleElasticsearchMappingContext mappingContext) {
+		return new MappingElasticsearchConverter(mappingContext);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public SimpleElasticsearchMappingContext mappingContext() {
+		return new SimpleElasticsearchMappingContext();
+	}
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchDataAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchDataAutoConfigurationTests.java
@@ -22,6 +22,8 @@ import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfigurati
 import org.springframework.boot.test.EnvironmentTestUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
 
 import static org.junit.Assert.assertEquals;
 
@@ -53,6 +55,34 @@ public class ElasticsearchDataAutoConfigurationTests {
 		this.context.refresh();
 		assertEquals(1,
 				this.context.getBeanNamesForType(ElasticsearchTemplate.class).length);
+	}
+
+	@Test
+	public void mappingContextExists() {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.data.elasticsearch.properties.path.data:target/data",
+				"spring.data.elasticsearch.properties.path.logs:target/logs");
+		this.context.register(PropertyPlaceholderAutoConfiguration.class,
+				ElasticsearchAutoConfiguration.class,
+				ElasticsearchDataAutoConfiguration.class);
+		this.context.refresh();
+		assertEquals(1,
+				this.context.getBeanNamesForType(SimpleElasticsearchMappingContext.class).length);
+	}
+
+	@Test
+	public void converterExists() {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.data.elasticsearch.properties.path.data:target/data",
+				"spring.data.elasticsearch.properties.path.logs:target/logs");
+		this.context.register(PropertyPlaceholderAutoConfiguration.class,
+				ElasticsearchAutoConfiguration.class,
+				ElasticsearchDataAutoConfiguration.class);
+		this.context.refresh();
+		assertEquals(1,
+				this.context.getBeanNamesForType(ElasticsearchConverter.class).length);
 	}
 
 }


### PR DESCRIPTION
Hi 

I have added missing beans required in spring-boot-rest to work out of the box with spring-boot-elasticsearch.
Also this change has dependency in spring-date-elasticearch https://jira.spring.io/browse/DATAES-137, commit https://github.com/spring-projects/spring-data-elasticsearch/commit/6cdc765b24bf5c91e012d0ca2b1a1b31e331b03e 
