### PR TITLE
adding sha-bang

### DIFF
--- a/spring-boot-cli/src/main/content/shell-completion/bash/spring
+++ b/spring-boot-cli/src/main/content/shell-completion/bash/spring
@@ -1,3 +1,4 @@
+#!/bin/bash
 # bash completion for spring
 # Installation: source this file locally in a terminal or from
 # ~/.bashrc or put it in /etc/bash_completions.d (debian)


### PR DESCRIPTION
I am not sure why but adding shell completion to my /etc/profile.d broke xdm when starting. By placing sha-bang in the script, I was able to avoid this

     * Caching service dependencies ...                  [ ok ]                 
     * Stopping xdm ...                                                         
     * start-stop-daemon: no matching processes found    [ ok ]                 
     * Setting up xdm ...                                                       
        /opt/spring-1.2.5.RELEASE/shell-completion/bash/spring: line 16: syntax error near unexpected token `<'
        /opt/spring-1.2.5.RELEASE/shell-completion/bash/spring: line 16: `      done < <(spring hint ${cword} ${words[*] [ ok ]

And now my computer starts xdm normally.