### PR TITLE
Add the possibility to enable JNDI namin on tomcat startup

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -16,20 +16,6 @@
 
 package org.springframework.boot.autoconfigure.web;
 
-import java.io.File;
-import java.net.InetAddress;
-import java.nio.charset.Charset;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.SessionCookieConfig;
-import javax.servlet.SessionTrackingMode;
-import javax.validation.constraints.NotNull;
-
 import org.apache.catalina.Context;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.valves.AccessLogValve;
@@ -56,6 +42,19 @@ import org.springframework.boot.context.properties.DeprecatedConfigurationProper
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.core.Ordered;
 import org.springframework.util.StringUtils;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.SessionCookieConfig;
+import javax.servlet.SessionTrackingMode;
+import javax.validation.constraints.NotNull;
+import java.io.File;
+import java.net.InetAddress;
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * {@link ConfigurationProperties} for a web server (e.g. port and path settings). Will be
@@ -528,6 +527,11 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer, Ord
 		 * Character encoding to use to decode the URI.
 		 */
 		private Charset uriEncoding;
+		
+		/**
+		* If JNDI naming will be enabled on startup, false by default
+		*/
+		private boolean namingEnabled;
 
 		public int getMaxThreads() {
 			return this.maxThreads;
@@ -547,6 +551,10 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer, Ord
 
 		public Accesslog getAccesslog() {
 			return this.accesslog;
+		}
+
+		public boolean getNamingEnabled() {
+			return this.namingEnabled;
 		}
 
 		/**
@@ -654,6 +662,10 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer, Ord
 		public void setUriEncoding(Charset uriEncoding) {
 			this.uriEncoding = uriEncoding;
 		}
+		
+		public void setNamingEnabled(boolean enableNaming) {
+			this.namingEnabled = enableNaming;
+		}
 
 		void customizeTomcat(TomcatEmbeddedServletContainerFactory factory) {
 			if (getBasedir() != null) {
@@ -673,6 +685,10 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer, Ord
 			if (getUriEncoding() != null) {
 				factory.setUriEncoding(getUriEncoding());
 			}
+			if (namingEnabled) {
+				factory.setNamingEnabled(true);
+			}
+
 		}
 
 		private void customizeBackgroundProcessorDelay(

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
@@ -16,24 +16,6 @@
 
 package org.springframework.boot.context.embedded.tomcat;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Method;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
-import javax.servlet.ServletContainerInitializer;
-import javax.servlet.ServletContext;
-
 import org.apache.catalina.Context;
 import org.apache.catalina.Host;
 import org.apache.catalina.Lifecycle;
@@ -71,6 +53,23 @@ import org.springframework.util.ReflectionUtils;
 import org.springframework.util.ResourceUtils;
 import org.springframework.util.StreamUtils;
 import org.springframework.util.StringUtils;
+
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.ServletContext;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * {@link EmbeddedServletContainerFactory} that can be used to create
@@ -118,6 +117,8 @@ public class TomcatEmbeddedServletContainerFactory extends
 
 	private Charset uriEncoding = DEFAULT_CHARSET;
 
+    private boolean namingEnabled = false;
+
 	/**
 	 * Create a new {@link TomcatEmbeddedServletContainerFactory} instance.
 	 */
@@ -160,6 +161,9 @@ public class TomcatEmbeddedServletContainerFactory extends
 		for (Connector additionalConnector : this.additionalTomcatConnectors) {
 			tomcat.getService().addConnector(additionalConnector);
 		}
+        if (namingEnabled) {
+            tomcat.enableNaming();
+        }
 		prepareContext(tomcat.getHost(), initializers);
 		return getTomcatEmbeddedServletContainer(tomcat);
 	}
@@ -269,8 +273,8 @@ public class TomcatEmbeddedServletContainerFactory extends
 	private void customizeSsl(Connector connector) {
 		ProtocolHandler handler = connector.getProtocolHandler();
 		Assert.state(handler instanceof AbstractHttp11JsseProtocol,
-				"To use SSL, the connector's protocol handler must be an "
-						+ "AbstractHttp11JsseProtocol subclass");
+                "To use SSL, the connector's protocol handler must be an "
+                        + "AbstractHttp11JsseProtocol subclass");
 		configureSsl((AbstractHttp11JsseProtocol<?>) handler, getSsl());
 		connector.setScheme("https");
 		connector.setSecure(true);
@@ -652,7 +656,23 @@ public class TomcatEmbeddedServletContainerFactory extends
 		return this.uriEncoding;
 	}
 
-	private static class TomcatErrorPage {
+    /**
+     * Returns if tomcat will enable JNDI naming on startup
+     * @return if JNDI is enabled  , false by default
+     */
+    public boolean isNamingEnabled() {
+        return namingEnabled;
+    }
+
+    /**
+     * Tell Tomcat to enable JNDI naming on startup, false by default
+     * @param namingEnabled
+     */
+    public void setNamingEnabled(boolean namingEnabled) {
+        this.namingEnabled = namingEnabled;
+    }
+
+    private static class TomcatErrorPage {
 
 		private final String location;
 


### PR DESCRIPTION
By setting the property
```server.tomcat.namingEnabled=true``` Tomcat connector will start with JNDI enabled, as the default opposite. 

