### PR TITLE
Add link to Hazelcast documentation

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -3419,7 +3419,7 @@ You could also specify the `hazelcast.xml` configuration file to use via configu
 Otherwise, Spring Boot tries to find the Hazelcast configuration from the default
 locations, that is `hazelcast.xml` in the working directory or at the root of the
 classpath. We also check if the `hazelcast.config` system property is set. Check the
-Hazelcast documentation for more details.
+http://docs.hazelcast.org/docs/latest/manual/html-single/[Hazelcast documentation] for more details.
 
 NOTE: Spring Boot also has an
 <<boot-features-caching-provider-hazelcast,explicit caching support for Hazelcast>>. The


### PR DESCRIPTION
Currently Spring Boot's documentation of its Hazelcast auto-configuration references the official documentation but does not provide a link. This pull request adds a link to the latest official Hazelcast documentation.