### PR TITLE
Add Neo4J auto-configuration

### DIFF
--- a/spring-boot-actuator/pom.xml
+++ b/spring-boot-actuator/pom.xml
@@ -154,6 +154,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-neo4j</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-redis</artifactId>
 			<optional>true</optional>
 		</dependency>

--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -350,6 +350,17 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-neo4j</artifactId>
+			<optional>true</optional>
+			<exclusions>
+				<exclusion>
+					<artifactId>jcl-over-slf4j</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-redis</artifactId>
 			<optional>true</optional>
 		</dependency>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jRepositoriesAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jRepositoriesAutoConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.neo4j;
+
+import org.neo4j.ogm.session.Neo4jSession;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.neo4j.Neo4jDataAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.neo4j.repository.GraphRepository;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.repository.config.Neo4jRepositoryConfigurationExtension;
+import org.springframework.data.neo4j.repository.support.GraphRepositoryFactoryBean;
+import org.springframework.data.neo4j.server.Neo4jServer;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Spring Data's Neo4j
+ * Repositories.
+ * <p>
+ * Activates when there is no bean of type
+ * {@link org.springframework.data.neo4j.repository.support.GraphRepositoryFactoryBean}
+ * configured in the context, the Spring Data Neo4j
+ * {@link org.springframework.data.neo4j.repository.GraphRepository} type is on the
+ * classpath, the Neo4j client driver API is on the classpath, and there is no other
+ * configured {@link org.springframework.data.neo4j.repository.GraphRepository}.
+ * <p>
+ * Once in effect, the auto-configuration is the equivalent of enabling Neo4j repositories
+ * using the
+ * {@link org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories}
+ * annotation.
+ *
+ * @author Dave Syer
+ * @author Oliver Gierke
+ * @author Josh Long
+ * @see EnableNeo4jRepositories
+ */
+@Configuration
+@ConditionalOnClass({ Neo4jServer.class, Neo4jSession.class, GraphRepository.class })
+@ConditionalOnMissingBean({ GraphRepositoryFactoryBean.class,
+		Neo4jRepositoryConfigurationExtension.class })
+@ConditionalOnProperty(prefix = "spring.data.neo4j.repositories", name = "enabled", havingValue = "true", matchIfMissing = true)
+@Import(Neo4jRepositoriesAutoConfigureRegistrar.class)
+@AutoConfigureAfter(Neo4jDataAutoConfiguration.class)
+public class Neo4jRepositoriesAutoConfiguration {
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jRepositoriesAutoConfigureRegistrar.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jRepositoriesAutoConfigureRegistrar.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.neo4j;
+
+import java.lang.annotation.Annotation;
+
+import org.springframework.boot.autoconfigure.data.AbstractRepositoryConfigurationSourceSupport;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.repository.config.Neo4jRepositoryConfigurationExtension;
+import org.springframework.data.repository.config.RepositoryConfigurationExtension;
+
+/**
+ * {@link ImportBeanDefinitionRegistrar} used to auto-configure Spring Data Neo4j
+ * Repositories.
+ *
+ * @author Dave Syer
+ */
+class Neo4jRepositoriesAutoConfigureRegistrar extends
+		AbstractRepositoryConfigurationSourceSupport {
+
+	@Override
+	protected Class<? extends Annotation> getAnnotation() {
+		return EnableNeo4jRepositories.class;
+	}
+
+	@Override
+	protected Class<?> getConfiguration() {
+		return EnableNeo4jRepositoriesConfiguration.class;
+	}
+
+	@Override
+	protected RepositoryConfigurationExtension getRepositoryConfigurationExtension() {
+		return new Neo4jRepositoryConfigurationExtension();
+	}
+
+	@EnableNeo4jRepositories
+	private static class EnableNeo4jRepositoriesConfiguration {
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/package-info.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Spring Data Neo4j.
+ */
+package org.springframework.boot.autoconfigure.data.neo4j;
+

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDataAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDataAutoConfiguration.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.neo4j;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.RelationshipEntity;
+import org.neo4j.ogm.session.Neo4jSession;
+import org.neo4j.ogm.session.SessionFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.data.annotation.Persistent;
+import org.springframework.data.neo4j.config.Neo4jConfiguration;
+import org.springframework.data.neo4j.conversion.MetaDataDrivenConversionService;
+import org.springframework.data.neo4j.mapping.Neo4jMappingContext;
+import org.springframework.data.neo4j.server.Neo4jServer;
+import org.springframework.data.neo4j.template.Neo4jTemplate;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+
+import java.net.MalformedURLException;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Spring Data's Neo4j support.
+ * <p>
+ * Registers a {@link Neo4jTemplate} bean if no other bean of
+ * the same type is configured.
+ *
+ * @author Michael Hunger
+ * @author Josh Long
+ * @since 1.3.0
+ */
+@Configuration
+@EnableConfigurationProperties(Neo4jProperties.class)
+@ConditionalOnMissingBean(type = "org.springframework.data.neo4j.template.Neo4jTemplate")
+@ConditionalOnClass({ Neo4jServer.class, Neo4jSession.class, Neo4jTemplate.class })
+//@ConditionalOnProperty(name = "", prefix = "spring.data.neo4j", matchIfMissing = true)
+public class Neo4jDataAutoConfiguration extends Neo4jConfiguration implements BeanClassLoaderAware, BeanFactoryAware, EnvironmentAware, ResourceLoaderAware {
+
+	@Autowired
+	private Neo4jProperties properties;
+
+	@Autowired
+	private Environment environment;
+
+	private ClassLoader classLoader;
+	private BeanFactory beanFactory;
+	private ResourceLoader resourceLoader;
+
+	@Bean
+	@Override
+	@ConditionalOnMissingBean(Neo4jServer.class)
+	public Neo4jServer neo4jServer()  {
+		try {
+			Neo4jProperties props = properties == null ?
+					Neo4jProperties.fromEnvironment(environment) : this.properties;
+			return props.createNeo4jServer(environment);
+		} catch (UnknownHostException e) {
+			throw new RuntimeException(e);
+		} catch (MalformedURLException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.beanFactory = beanFactory;
+	}
+
+	@Override
+	public void setBeanClassLoader(ClassLoader classLoader) {
+		this.classLoader = classLoader;
+	}
+
+	@Override
+	@ConditionalOnMissingBean(SessionFactory.class)
+	public SessionFactory getSessionFactory() {
+		Collection<String> packages = getMappingBasePackages(beanFactory);
+		return new SessionFactory(packages.toArray(new String[packages.size()]));
+	}
+
+	@Bean
+	public ConversionService conversionService(SessionFactory factory) {
+		return new MetaDataDrivenConversionService(factory.metaData());
+	}
+
+	@Bean
+//	@ConditionalOnMissingBean(Neo4jTemplate.class)
+	public Neo4jTemplate neo4jTemplate() throws Exception {
+		return new Neo4jTemplate(getSession()); // todo converters
+	}
+
+
+	@Bean
+	@ConditionalOnMissingBean
+	public Neo4jMappingContext neo4jMappingContext()
+			throws ClassNotFoundException {
+		Neo4jMappingContext context = new Neo4jMappingContext(getSessionFactory().metaData());
+		context.setInitialEntitySet(getInitialEntitySet(beanFactory));
+		return context;
+	}
+
+	private Set<Class<?>> getInitialEntitySet(BeanFactory beanFactory)
+			throws ClassNotFoundException {
+		Set<Class<?>> entitySet = new HashSet<Class<?>>();
+		ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(
+				false);
+		scanner.setEnvironment(this.environment);
+		scanner.setResourceLoader(this.resourceLoader);
+		scanner.addIncludeFilter(new AnnotationTypeFilter(NodeEntity.class));
+		scanner.addIncludeFilter(new AnnotationTypeFilter(RelationshipEntity.class));
+		scanner.addIncludeFilter(new AnnotationTypeFilter(Persistent.class));
+		for (String basePackage : getMappingBasePackages(beanFactory)) {
+			if (StringUtils.hasText(basePackage)) {
+				for (BeanDefinition candidate : scanner
+						.findCandidateComponents(basePackage)) {
+					entitySet.add(ClassUtils.forName(candidate.getBeanClassName(),
+							this.classLoader));
+				}
+			}
+		}
+		return entitySet;
+	}
+
+	private static Collection<String> getMappingBasePackages(BeanFactory beanFactory) {
+		try {
+			return AutoConfigurationPackages.get(beanFactory);
+		}
+		catch (IllegalStateException ex) {
+			// no auto-configuration package registered yet
+			return Collections.emptyList();
+		}
+	}
+
+	@Override
+	public void setEnvironment(Environment environment) {
+		this.environment = environment;
+	}
+
+	@Override
+	public void setResourceLoader(ResourceLoader resourceLoader) {
+		this.resourceLoader = resourceLoader;
+	}
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jProperties.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.neo4j;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.env.Environment;
+import org.springframework.data.neo4j.server.Neo4jServer;
+import org.springframework.data.neo4j.server.RemoteServer;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+
+/**
+ * Configuration properties for Neo4j.
+ *
+ * @author Dave Syer
+ * @author Phillip Webb
+ * @author Josh Long
+ * @author Andy Wilkinson
+ * @author Eddú Meléndez
+ * @author Michael Hunger
+ */
+@ConfigurationProperties(prefix = Neo4jProperties.DATA_NEO4J_PREFIX)
+public class Neo4jProperties {
+
+	public static final String DATA_NEO4J_PREFIX = "spring.data.neo4j";
+
+	/**
+	 * Default port used when the configured port is not set.
+	 */
+	public static final int DEFAULT_PORT = 7474;
+	/**
+	 * Default host is localhost
+	 */
+	public static final String DEFAULT_HOST = "localhost";
+	/**
+	 * default URL is http on localhost and port 7474
+	 */
+	public static final String DEFAULT_URL = "http://"+DEFAULT_HOST+":"+DEFAULT_PORT;
+
+	/**
+	 * Neo4j server protocol.
+	 */
+	private String protocol = "http";
+
+	/**
+	 * Neo4j server host.
+	 */
+	private String host;
+
+	/**
+	 * Neo4j server port.
+	 */
+	private Integer port = null;
+
+	/**
+	 * Neo4j database URI. When set, host and port are ignored.
+	 */
+	private String url;
+
+	/**
+	 * Login user of the neo4j server.
+	 */
+	private String username;
+
+	/**
+	 * Login password of the neo4j server.
+	 */
+	private char[] password;
+
+	public String getHost() {
+		return this.host;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public String getUsername() {
+		return this.username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public char[] getPassword() {
+		return this.password;
+	}
+
+	public void setPassword(char[] password) {
+		this.password = password;
+	}
+
+	public void clearPassword() {
+		if (this.password == null) {
+			return;
+		}
+		for (int i = 0; i < this.password.length; i++) {
+			this.password[i] = 0;
+		}
+	}
+
+	public String getUrl() {
+		return this.url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	public Integer getPort() {
+		return this.port;
+	}
+
+	public void setPort(Integer port) {
+		this.port = port;
+	}
+
+	/**
+	 * Creates a {@link Neo4jServer} representation using the given
+	 * {@code environment}. If the configured port is zero, the value of the
+	 * {@code local.neo4j.port} property retrieved from the {@code environment} is used
+	 * to configure the server.
+	 *
+	 * @param environment the environment
+	 * @return the Neo4j server representation
+	 * @throws UnknownHostException if the configured host is unknown
+	 */
+	public Neo4jServer createNeo4jServer(Environment environment) throws UnknownHostException, MalformedURLException {
+		try {
+			String url = hasCustomAddress() ? new URL(this.protocol,determineHost(environment),determinePort(environment),"").toString() :
+					     hasCustomUrl() ? this.url : DEFAULT_URL;
+			if (hasCustomCredentials()) {
+				return new RemoteServer(url,this.username,String.valueOf(this.password));
+			} else {
+				return new RemoteServer(url);
+			}
+		}
+		finally {
+			clearPassword();
+		}
+	}
+
+	private boolean hasCustomAddress() {
+		return this.host != null || this.port != null;
+	}
+	private boolean hasCustomUrl() {
+		return this.url != null;
+	}
+
+	private boolean hasCustomCredentials() {
+		return this.username != null && this.password != null;
+	}
+
+	private int determinePort(Environment environment) {
+		if (this.port == null) {
+			return DEFAULT_PORT;
+		}
+		if (this.port != 0) {
+			return this.port;
+		}
+		if (environment != null) {
+            String localPort = environment.getProperty("local.neo4j.port");
+            if (localPort != null) {
+                return Integer.valueOf(localPort);
+            }
+        }
+		throw new IllegalStateException(
+                "spring.data.neo4j.port=0 and no local neo4j port configuration "
+                        + "is available");
+	}
+	private String determineHost(Environment environment) {
+		if (this.host != null) {
+			return this.host;
+		}
+
+		if (environment != null) {
+            String localHost = environment.getProperty("local.neo4j.host");
+            if (localHost != null) {
+                return localHost;
+            }
+        }
+		return DEFAULT_HOST;
+	}
+
+	public static Neo4jProperties fromEnvironment(Environment env) {
+		Neo4jProperties props = new Neo4jProperties();
+        if (env.containsProperty(DATA_NEO4J_PREFIX+".url"))
+            props.url = env.getProperty(DATA_NEO4J_PREFIX+".url");
+        if (env.containsProperty(DATA_NEO4J_PREFIX+".host"))
+		    props.host = env.getProperty(DATA_NEO4J_PREFIX+".host");
+        if (env.containsProperty(DATA_NEO4J_PREFIX+".port"))
+		    props.port = Integer.parseInt(env.getProperty(DATA_NEO4J_PREFIX + ".port"));
+        if (env.containsProperty(DATA_NEO4J_PREFIX+".protocol"))
+		    props.protocol = env.getProperty(DATA_NEO4J_PREFIX + ".protocol");
+        if (env.containsProperty(DATA_NEO4J_PREFIX+".user"))
+		    props.username = env.getProperty(DATA_NEO4J_PREFIX + ".user");
+        if (env.containsProperty(DATA_NEO4J_PREFIX+".password"))
+		    props.password = env.getProperty(DATA_NEO4J_PREFIX + ".password").toCharArray();
+		return props;
+	}
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/package-info.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Neo4j.
+ */
+package org.springframework.boot.autoconfigure.neo4j;
+

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -71,6 +71,12 @@
     "defaultValue": true
   },
   {
+    "name": "spring.data.neo4j.repositories.enabled",
+    "type": "java.lang.Boolean",
+    "description": "Enable Neo4j repositories.",
+    "defaultValue": true
+  },
+  {
     "name": "spring.data.solr.repositories.enabled",
     "type": "java.lang.Boolean",
     "description": "Enable Solr repositories.",

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -17,6 +17,7 @@ org.springframework.boot.autoconfigure.dao.PersistenceExceptionTranslationAutoCo
 org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfiguration,\
+org.springframework.boot.autoconfigure.data.neo4j.Neo4jRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.solr.SolrRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration,\
@@ -53,6 +54,7 @@ org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfigura
 org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,\
 org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration,\
 org.springframework.boot.autoconfigure.mustache.MustacheAutoConfiguration,\
+org.springframework.boot.autoconfigure.neo4j.Neo4jDataAutoConfiguration,\
 org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,\
 org.springframework.boot.autoconfigure.reactor.ReactorAutoConfiguration,\
 org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/alt/neo4j/CityNeo4jRepository.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/alt/neo4j/CityNeo4jRepository.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.alt.neo4j;
+
+import org.springframework.boot.autoconfigure.data.neo4j.city.City;
+import org.springframework.data.neo4j.repository.GraphRepository;
+
+public interface CityNeo4jRepository extends GraphRepository<City> {
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/MixedNeo4jRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/MixedNeo4jRepositoriesAutoConfigurationTests.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.neo4j;
+
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.TestAutoConfigurationPackage;
+import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.jpa.city.City;
+import org.springframework.boot.autoconfigure.data.jpa.city.CityRepository;
+import org.springframework.boot.autoconfigure.data.neo4j.country.Country;
+import org.springframework.boot.autoconfigure.data.neo4j.country.CountryRepository;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.neo4j.Neo4jAutoConfigurationTests;
+import org.springframework.boot.autoconfigure.neo4j.Neo4jDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.orm.jpa.EntityScan;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportSelector;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for {@link org.springframework.boot.autoconfigure.data.neo4j.Neo4jRepositoriesAutoConfiguration}.
+ *
+ * @author Dave Syer
+ * @author Oliver Gierke
+ */
+public class MixedNeo4jRepositoriesAutoConfigurationTests {
+
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void close() {
+		this.context.close();
+	}
+
+	@Test
+	public void testDefaultRepositoryConfiguration() throws Exception {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.datasource.initialize:false");
+		this.context.register(TestConfiguration.class, BaseConfiguration.class);
+		this.context.refresh();
+		assertNotNull(this.context.getBean(CountryRepository.class));
+	}
+
+	@Test
+	public void testMixedRepositoryConfiguration() throws Exception {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.datasource.initialize:false");
+		this.context.register(MixedConfiguration.class, BaseConfiguration.class);
+		this.context.refresh();
+		assertNotNull(this.context.getBean(CountryRepository.class));
+		assertNotNull(this.context.getBean(CityRepository.class));
+	}
+
+	@Test
+	public void testJpaRepositoryConfigurationWithNeo4jTemplate() throws Exception {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.datasource.initialize:false");
+		this.context.register(JpaConfiguration.class, BaseConfiguration.class);
+		this.context.refresh();
+		assertNotNull(this.context.getBean(CityRepository.class));
+	}
+
+	@Test
+	@Ignore
+	public void testJpaRepositoryConfigurationWithNeo4jOverlap() throws Exception {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.datasource.initialize:false");
+		this.context.register(OverlapConfiguration.class, BaseConfiguration.class);
+		this.context.refresh();
+		assertNotNull(this.context.getBean(CityRepository.class));
+	}
+
+	@Test
+	public void testJpaRepositoryConfigurationWithNeo4jOverlapDisabled() throws Exception {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.datasource.initialize:false",
+				"spring.data.neo4j.repositories.enabled:false");
+		this.context.register(OverlapConfiguration.class, BaseConfiguration.class);
+		this.context.refresh();
+		assertNotNull(this.context.getBean(CityRepository.class));
+	}
+
+	@Configuration
+	@TestAutoConfigurationPackage(Neo4jAutoConfigurationTests.class)
+	// Not this package or its parent
+	@EnableNeo4jRepositories(basePackageClasses = Country.class)
+	protected static class TestConfiguration {
+
+	}
+
+	@Configuration
+	@TestAutoConfigurationPackage(Neo4jAutoConfigurationTests.class)
+	@EnableNeo4jRepositories(basePackageClasses = Country.class)
+	@EntityScan(basePackageClasses = City.class)
+	@EnableJpaRepositories(basePackageClasses = CityRepository.class)
+	protected static class MixedConfiguration {
+
+	}
+
+	@Configuration
+	@TestAutoConfigurationPackage(Neo4jAutoConfigurationTests.class)
+	@EntityScan(basePackageClasses = City.class)
+	@EnableJpaRepositories(basePackageClasses = CityRepository.class)
+	protected static class JpaConfiguration {
+
+	}
+
+	// In this one the Jpa repositories and the autoconfiguration packages overlap, so
+	// Neo4j will try and configure the same repositories
+	@Configuration
+	@TestAutoConfigurationPackage(CityRepository.class)
+	@EnableJpaRepositories(basePackageClasses = CityRepository.class)
+	protected static class OverlapConfiguration {
+
+	}
+
+	@Configuration
+	@Import(Registrar.class)
+	protected static class BaseConfiguration {
+
+	}
+
+	protected static class Registrar implements ImportSelector {
+
+		@Override
+		public String[] selectImports(AnnotationMetadata importingClassMetadata) {
+			List<String> names = new ArrayList<String>();
+			for (Class<?> type : new Class<?>[] { DataSourceAutoConfiguration.class,
+					HibernateJpaAutoConfiguration.class,
+					JpaRepositoriesAutoConfiguration.class,
+					Neo4jDataAutoConfiguration.class,
+					Neo4jRepositoriesAutoConfiguration.class }) {
+				names.add(type.getName());
+			}
+			return names.toArray(new String[names.size()]);
+		}
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jRepositoriesAutoConfigurationTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.neo4j;
+
+import org.junit.After;
+import org.junit.Test;
+import org.neo4j.ogm.mapper.MappingContext;
+import org.neo4j.ogm.metadata.MetaData;
+import org.neo4j.ogm.session.Session;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.TestAutoConfigurationPackage;
+import org.springframework.boot.autoconfigure.data.alt.neo4j.CityNeo4jRepository;
+import org.springframework.boot.autoconfigure.data.empty.EmptyDataPackage;
+import org.springframework.boot.autoconfigure.data.neo4j.city.City;
+import org.springframework.boot.autoconfigure.data.neo4j.city.CityRepository;
+import org.springframework.boot.autoconfigure.neo4j.Neo4jDataAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.mapping.Neo4jMappingContext;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+import org.springframework.data.neo4j.server.Neo4jServer;
+import org.springframework.data.neo4j.server.RemoteServer;
+import org.springframework.data.neo4j.template.Neo4jTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link org.springframework.boot.autoconfigure.data.neo4j.Neo4jRepositoriesAutoConfiguration}.
+ *
+ * @author Dave Syer
+ * @author Oliver Gierke
+ */
+public class Neo4jRepositoriesAutoConfigurationTests {
+
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void close() {
+		this.context.close();
+	}
+
+	@Test
+	public void testDefaultRepositoryConfiguration() throws Exception {
+		prepareApplicationContext(TestConfiguration.class);
+
+		assertNotNull(this.context.getBean(CityRepository.class));
+		Neo4jServer neo4j = this.context.getBean(Neo4jServer.class);
+		assertThat(neo4j, is(instanceOf(RemoteServer.class)));
+		@SuppressWarnings("unchecked")
+		Neo4jMappingContext mappingContext = this.context.getBean(Neo4jMappingContext.class);
+		assertThat(mappingContext.getPersistentEntity(City.class), is(notNullValue()));
+	}
+
+	@Test
+	public void testNoRepositoryConfiguration() throws Exception {
+		prepareApplicationContext(EmptyConfiguration.class);
+
+		Neo4jServer neo4j = this.context.getBean(Neo4jServer.class);
+		assertThat(neo4j, is(instanceOf(RemoteServer.class)));
+	}
+
+	@Test
+	public void doesNotTriggerDefaultRepositoryDetectionIfCustomized() {
+		prepareApplicationContext(CustomizedConfiguration.class);
+
+		assertNotNull(this.context.getBean(CityNeo4jRepository.class));
+	}
+
+	@Test(expected = NoSuchBeanDefinitionException.class)
+	public void autoConfigurationShouldNotKickInEvenIfManualConfigDidNotCreateAnyRepositories() {
+		prepareApplicationContext(SortOfInvalidCustomConfiguration.class);
+
+		this.context.getBean(CityRepository.class);
+	}
+
+	private void prepareApplicationContext(Class<?>... configurationClasses) {
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(configurationClasses);
+		this.context.register(Neo4jDataAutoConfiguration.class,
+				Neo4jRepositoriesAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+	}
+
+	@Configuration
+	@TestAutoConfigurationPackage(City.class)
+	protected static class TestConfiguration {
+
+	}
+
+	@Configuration
+	@TestAutoConfigurationPackage(EmptyDataPackage.class)
+	protected static class EmptyConfiguration {
+
+	}
+
+	@Configuration
+	@TestAutoConfigurationPackage(Neo4jRepositoriesAutoConfigurationTests.class)
+	@EnableNeo4jRepositories(basePackageClasses = CityNeo4jRepository.class)
+	protected static class CustomizedConfiguration {
+
+	}
+
+	@Configuration
+	// To not find any repositories
+	@EnableNeo4jRepositories("foo.bar")
+	@TestAutoConfigurationPackage(Neo4jRepositoriesAutoConfigurationTests.class)
+	protected static class SortOfInvalidCustomConfiguration {
+
+	}
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/city/City.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/city/City.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.neo4j.city;
+
+import org.neo4j.ogm.annotation.GraphId;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.springframework.boot.autoconfigure.data.neo4j.country.Country;
+
+import java.io.Serializable;
+
+@NodeEntity
+public class City implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@GraphId
+	private Long id;
+
+	private String name;
+
+	private String state;
+
+	private Country country;
+
+	private String map;
+
+	public City() {
+	}
+
+	public City(String name, Country country) {
+		this.name = name;
+		this.country = country;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public String getState() {
+		return this.state;
+	}
+
+	public Country getCountry() {
+		return this.country;
+	}
+
+	public String getMap() {
+		return this.map;
+	}
+
+	@Override
+	public String toString() {
+		return getName() + "," + getState() + "," + getCountry();
+	}
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/city/CityRepository.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/city/CityRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.neo4j.city;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.neo4j.repository.GraphRepository;
+
+public interface CityRepository extends GraphRepository<City> {
+
+	Page<City> findAll(Pageable pageable);
+
+	Page<City> findByNameLikeAndCountryLikeAllIgnoringCase(String name, String country,
+														   Pageable pageable);
+
+	City findByNameAndCountryAllIgnoringCase(String name, String country);
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/country/Country.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/country/Country.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.neo4j.country;
+
+import org.neo4j.ogm.annotation.GraphId;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+import java.io.Serializable;
+
+@NodeEntity
+public class Country implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@GraphId
+	private Long id;
+
+	private String name;
+
+	public Country() {
+	}
+
+	public Country(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/country/CountryRepository.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/country/CountryRepository.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.neo4j.country;
+
+import org.springframework.data.neo4j.repository.GraphRepository;
+
+public interface CountryRepository extends GraphRepository<Country> {
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jAutoConfigurationTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.neo4j;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.neo4j.server.Neo4jServer;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link org.springframework.boot.autoconfigure.neo4j.Neo4jDataAutoConfiguration}.
+ *
+ * @author Dave Syer
+ */
+public class Neo4jAutoConfigurationTests {
+
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void close() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Before
+	public void setUp() throws Exception {
+
+	}
+
+	@Test
+	public void clientExists() {
+		this.context = new AnnotationConfigApplicationContext(
+				PropertyPlaceholderAutoConfiguration.class, Neo4jDataAutoConfiguration.class);
+		assertEquals(1, this.context.getBeanNamesForType(Neo4jServer.class).length);
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	public void localhostConfigVariable() {
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(
+				PropertyPlaceholderAutoConfiguration.class, Neo4jDataAutoConfiguration.class);
+		String localhost = "localhost";
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.data.neo4j.host:" + localhost);
+		this.context.refresh();
+		assertEquals("http://" + localhost + ":7474", this.context.getBean(Neo4jServer.class).url());
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	public void hostPortUserVariables() {
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(
+				PropertyPlaceholderAutoConfiguration.class, Neo4jDataAutoConfiguration.class);
+		String url = "https://user:pass@localhost:7473";
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.data.neo4j.url:" + url);
+		this.context.refresh();
+		Neo4jServer server = this.context.getBean(Neo4jServer.class);
+		assertEquals(url, server.url());
+		assertEquals("user", server.username());
+		assertEquals("pass", server.password());
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDataAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDataAutoConfigurationTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.neo4j;
+
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.ogm.session.Neo4jSession;
+import org.neo4j.ogm.session.SessionFactory;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.UnsatisfiedDependencyException;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.neo4j.city.City;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.mapping.model.CamelCaseAbbreviatingFieldNamingStrategy;
+import org.springframework.data.mapping.model.FieldNamingStrategy;
+import org.springframework.data.mapping.model.PropertyNameFieldNamingStrategy;
+import org.springframework.data.mongodb.core.convert.CustomConversions;
+import org.springframework.data.neo4j.conversion.MetaDataDrivenConversionService;
+import org.springframework.data.neo4j.mapping.Neo4jMappingContext;
+import org.springframework.data.neo4j.server.Neo4jServer;
+import org.springframework.data.neo4j.template.Neo4jOperations;
+import org.springframework.data.neo4j.template.Neo4jTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link org.springframework.boot.autoconfigure.neo4j.Neo4jDataAutoConfiguration}.
+ *
+ * @author Josh Long
+ * @author Oliver Gierke
+ */
+public class Neo4jDataAutoConfigurationTests {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void close() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void templateExists() {
+		this.context = new AnnotationConfigApplicationContext(
+				PropertyPlaceholderAutoConfiguration.class, Neo4jDataAutoConfiguration.class);
+		assertEquals(1, this.context.getBeansOfType(Neo4jOperations.class).size());
+	}
+
+	@Test
+	public void sessionFactoryExists() {
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(PropertyPlaceholderAutoConfiguration.class, Neo4jDataAutoConfiguration.class);
+		this.context.refresh();
+		assertEquals(1, this.context.getBeanNamesForType(SessionFactory.class).length);
+	}
+
+	@Test
+	public void customConversions() throws Exception {
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(PropertyPlaceholderAutoConfiguration.class, Neo4jDataAutoConfiguration.class);
+		this.context.register(CustomConversionsConfig.class);
+		this.context.refresh();
+		Neo4jSession template = this.context.getBean(Neo4jSession.class);
+		// TODO
+/*
+		assertTrue(template.context().getConversionService()
+				.canConvert(Neo4jServer.class, Boolean.class));
+*/
+	}
+
+	@Test
+	public void usesAutoConfigurationPackageToPickUpDocumentTypes() {
+		this.context = new AnnotationConfigApplicationContext();
+		String cityPackage = City.class.getPackage().getName();
+		AutoConfigurationPackages.register(this.context, cityPackage);
+		this.context.register(Neo4jDataAutoConfiguration.class);
+		this.context.refresh();
+		assertDomainTypesDiscovered(this.context.getBean(Neo4jMappingContext.class),
+				City.class);
+	}
+
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private static void assertDomainTypesDiscovered(Neo4jMappingContext mappingContext,
+			Class<?>... types) {
+		for (Class<?> type : types) {
+			assertThat(mappingContext.getPersistentEntity(type), is(notNullValue()));
+		}
+	}
+
+	@Configuration
+	static class CustomConversionsConfig {
+
+		@Bean
+		public ConversionService conversionService(SessionFactory factory) {
+			return new MetaDataDrivenConversionService(factory.metaData());
+		}
+
+		@Bean
+		public CustomConversions customConversions() {
+			return new CustomConversions(Arrays.asList(new MyConverter()));
+		}
+	}
+
+	private static class MyConverter implements Converter<Neo4jServer, Boolean> {
+
+		@Override
+		public Boolean convert(Neo4jServer source) {
+			return Boolean.FALSE;
+		}
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jPropertiesTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.neo4j;
+
+import org.junit.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.server.Neo4jServer;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link org.springframework.boot.autoconfigure.neo4j.Neo4jProperties}.
+ *
+ * @author Phillip Webb
+ * @author Andy Wilkinson
+ */
+public class Neo4jPropertiesTests {
+
+	@Test
+	public void canBindCharArrayPassword() {
+		// gh-1572
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(context, "spring.data.neo4j.password:word");
+		context.register(Conf.class);
+		context.refresh();
+		Neo4jProperties properties = context.getBean(Neo4jProperties.class);
+		assertThat(properties.getPassword(), equalTo("word".toCharArray()));
+	}
+
+	@Test
+	public void portCanBeCustomized() throws UnknownHostException, MalformedURLException {
+		Neo4jProperties properties = new Neo4jProperties();
+		properties.setPort(12345);
+		Neo4jServer server = properties.createNeo4jServer(null);
+		assertServerAddress(server, "localhost", 12345);
+	}
+
+	@Test
+	public void hostCanBeCustomized() throws UnknownHostException, MalformedURLException {
+		Neo4jProperties properties = new Neo4jProperties();
+		properties.setHost("neo4j.example.com");
+		Neo4jServer server = properties.createNeo4jServer(null);
+		assertServerAddress(server, "neo4j.example.com", 7474);
+	}
+
+	@Test
+	public void credentialsCanBeCustomized() throws UnknownHostException, MalformedURLException {
+		Neo4jProperties properties = new Neo4jProperties();
+		properties.setUsername("user");
+		properties.setPassword("secret".toCharArray());
+		Neo4jServer server = properties.createNeo4jServer(null);
+		assertNeo4jCredential(server, "user", "secret");
+	}
+
+	@Test
+	public void uriCanBeCustomized() throws UnknownHostException, MalformedURLException {
+		Neo4jProperties properties = new Neo4jProperties();
+		properties.setUrl("https://user:secret@neo4j1.example.com:12345");
+		Neo4jServer server = properties.createNeo4jServer(null);
+		assertServerAddress(server, "neo4j1.example.com", 12345);
+		assertNeo4jCredential(server, "user", "secret");
+	}
+
+	private void assertServerAddress(Neo4jServer server, String expectedHost, int expectedPort) {
+		try {
+			URL url = new URL(server.url());
+			assertThat(url.getHost(), equalTo(expectedHost));
+			assertThat(url.getPort(), equalTo(expectedPort));
+		} catch (MalformedURLException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private void assertNeo4jCredential(Neo4jServer server,
+									   String expectedUsername, String expectedPassword) {
+		assertThat(server.username(), equalTo(expectedUsername));
+		assertThat(server.password(), equalTo(expectedPassword));
+	}
+
+	@Configuration
+	@EnableConfigurationProperties(Neo4jProperties.class)
+	static class Conf {
+
+	}
+
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -130,6 +130,7 @@
 		<spring-cloud-connectors.version>1.2.0.RELEASE</spring-cloud-connectors.version>
 		<spring-batch.version>3.0.5.RELEASE</spring-batch.version>
 		<spring-data-releasetrain.version>Gosling-RELEASE</spring-data-releasetrain.version>
+		<spring-data-neo4j.version>4.0.0.RELEASE</spring-data-neo4j.version>
 		<spring-hateoas.version>0.19.0.RELEASE</spring-hateoas.version>
 		<spring-integration.version>4.2.0.RC1</spring-integration.version>
 		<spring-loaded.version>1.2.4.RELEASE</spring-loaded.version>
@@ -281,6 +282,11 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-data-mongodb</artifactId>
+				<version>1.3.0.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-data-neo4j</artifactId>
 				<version>1.3.0.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
@@ -1707,6 +1713,21 @@
 				<version>${spring-data-releasetrain.version}</version>
 				<scope>import</scope>
 				<type>pom</type>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.data</groupId>
+				<artifactId>spring-data-neo4j</artifactId>
+				<version>${spring-data-neo4j.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging-api</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.hateoas</groupId>

--- a/spring-boot-docs/pom.xml
+++ b/spring-boot-docs/pom.xml
@@ -480,6 +480,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-neo4j</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-redis</artifactId>
 			<optional>true</optional>
 		</dependency>

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -2660,6 +2660,137 @@ Mongo instance's configuration and logging routing.
 
 
 
+[[boot-features-neo4j]]
+=== Neo4j
+http://neo4j.com/[Neo4j] is an open-source NoSQL graph database that uses a
+rich data model of nodes related by first class relationships which is better 
+suited for connected big data than traditional rdbms approaches. 
+Spring Boot offers several conveniences for working with Neo4j, including the
+`spring-boot-starter-data-neo4j` '`Starter POM`'.
+
+
+
+[[boot-features-connecting-to-neo4j]]
+==== Connecting to a Neo4j database
+You can inject an auto-configured `org.neo4j.ogm.session.Neo4jSession` to
+access Neo4j databases. By default the instance will attempt to connect to a Neo4j
+server using the URL `http://localhost:7474`:
+
+[source,java,indent=0]
+----
+	import org.neo4j.ogm.session.Neo4jSession;
+
+	@Component
+	public class MyBean {
+
+		private final Session session;
+
+		@Autowired
+		public MyBean(Session session) {
+			this.session = session;
+		}
+
+		// ...
+
+		public void example() {
+			Iterable result = session.query("MATCH (c:Customer) RETURN count(*)",null);
+			// ...
+		}
+
+	}
+----
+
+You can set `spring.data.neo4j.url` property to change the `url`.
+
+[source,properties,indent=0]
+----
+	spring.data.neo4j.url=http://user:password@host:port
+----
+
+Alternatively, specify a `host`/`port`. For example, you might declare the following in
+your `application.properties`:
+
+[source,properties,indent=0]
+----
+	spring.data.neo4j.host=neo4jserver
+	spring.data.neo4j.port=7474
+----
+
+TIP: If `spring.data.neo4j.port` is not specified the default of `7474` is used. You
+could simply delete this line from the sample above.
+
+TIP: If you aren't using Spring Data Neo4j you can inject `org.neo4j.ogm.Neo4jSession` beans
+instead of using `Neo4jTemplate`.
+
+You can also declare your own `Neo4jTemplate` or `Neo4jSession` bean if you want to take
+complete control of establishing the Neo4j connection.
+
+
+
+[[boot-features-neo4j-template]]
+==== Neo4jTemplate
+Spring Data Neo4j provides a
+{spring-data-neo4j-javadoc}/core/Neo4jTemplate.html[`Neo4jTemplate`] class that is very
+similar in its design to Spring's `JdbcTemplate`. As with `JdbcTemplate` Spring Boot
+auto-configures a bean for you to simply inject:
+
+[source,java,indent=0]
+----
+	import org.springframework.beans.factory.annotation.Autowired;
+	import org.springframework.data.neo4j.template.Neo4jTemplate;
+	import org.springframework.stereotype.Component;
+
+	@Component
+	public class MyBean {
+
+		private final Neo4jTemplate neo4jTemplate;
+
+		@Autowired
+		public MyBean(Neo4jTemplate neo4jTemplate) {
+			this.neo4jTemplate = neo4jTemplate;
+		}
+
+		// ...
+
+	}
+----
+
+See the `Neo4jOperations` Javadoc for complete details.
+
+
+
+[[boot-features-spring-data-neo4j-repositories]]
+==== Spring Data Neo4j repositories
+Spring Data includes repository support for Neo4j. As with the JPA repositories
+discussed earlier, the basic principle is that Cypher queries are constructed for you
+automatically based on method names. They also support annotated finder methods that
+allow you to specify your own custom Cypher queries.
+
+In fact, both Spring Data JPA and Spring Data Neo4j share the same common
+infrastructure; so you could take the JPA example from earlier and, assuming that `City`
+is now a Neo4j data class rather than a JPA `@Entity`, it will work in the same way.
+
+[source,java,indent=0]
+----
+	package com.example.myapp.domain;
+
+	import org.springframework.data.domain.*;
+	import org.springframework.data.repository.*;
+
+	public interface CityRepository extends GraphRepository<City> {
+
+		Page<City> findAll(Pageable pageable);
+
+		City findByNameAndCountry(String name, String country);
+
+	}
+----
+
+TIP: For complete details of Spring Data Neo4j, including its rich object mapping
+technologies, refer to their http://projects.spring.io/spring-data-neo4j/[reference
+documentation].
+
+
 [[boot-features-gemfire]]
 === Gemfire
 https://github.com/spring-projects/spring-data-gemfire[Spring Data Gemfire] provides

--- a/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
+++ b/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
@@ -348,6 +348,9 @@ and Hibernate.
 |`spring-boot-starter-data-mongodb`
 |Support for the MongoDB NoSQL Database, including `spring-data-mongodb`.
 
+|`spring-boot-starter-data-neo4j`
+|Support for the Neo4j Graph Database, including `spring-data-neo4j`.
+
 |`spring-boot-starter-data-rest`
 |Support for exposing Spring Data repositories over REST via `spring-data-rest-webmvc`.
 

--- a/spring-boot-samples/spring-boot-sample-data-neo4j/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-data-neo4j/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<!-- Your own application should inherit from spring-boot-starter-parent -->
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-samples</artifactId>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-sample-data-neo4j</artifactId>
+	<name>Spring Boot Data Neo4j Sample</name>
+	<description>Spring Boot Data Neo4j Sample</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-neo4j</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-samples/spring-boot-sample-data-neo4j/src/main/java/sample/data/neo4j/Customer.java
+++ b/spring-boot-samples/spring-boot-sample-data-neo4j/src/main/java/sample/data/neo4j/Customer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.data.neo4j;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.GraphId;
+
+@NodeEntity
+public class Customer {
+
+	@GraphId
+	private Long id;
+
+	private String firstName;
+	private String lastName;
+
+	public Customer() {
+	}
+
+	public Customer(String firstName, String lastName) {
+		this.firstName = firstName;
+		this.lastName = lastName;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("Customer[id=%s, firstName='%s', lastName='%s']", id,
+				firstName, lastName);
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-data-neo4j/src/main/java/sample/data/neo4j/CustomerRepository.java
+++ b/spring-boot-samples/spring-boot-sample-data-neo4j/src/main/java/sample/data/neo4j/CustomerRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.data.neo4j;
+
+import java.util.List;
+
+import org.springframework.data.neo4j.repository.GraphRepository;
+
+public interface CustomerRepository extends GraphRepository<Customer> {
+
+	public Customer findByFirstName(String firstName);
+
+	public List<Customer> findByLastName(String lastName);
+
+}

--- a/spring-boot-samples/spring-boot-sample-data-neo4j/src/main/java/sample/data/neo4j/SampleNeo4jApplication.java
+++ b/spring-boot-samples/spring-boot-sample-data-neo4j/src/main/java/sample/data/neo4j/SampleNeo4jApplication.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.data.neo4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+
+@SpringBootApplication
+public class SampleNeo4jApplication implements CommandLineRunner {
+
+	@Autowired
+	private CustomerRepository repository;
+
+	@Override
+	public void run(String... args) throws Exception {
+		this.repository.deleteAll();
+
+		// save a couple of customers
+		this.repository.save(new Customer("Alice", "Smith"));
+		this.repository.save(new Customer("Bob", "Smith"));
+
+		// fetch all customers
+		System.out.println("Customers found with findAll():");
+		System.out.println("-------------------------------");
+		for (Customer customer : this.repository.findAll()) {
+			System.out.println(customer);
+		}
+		System.out.println();
+
+		// fetch an individual customer
+		System.out.println("Customer found with findByFirstName('Alice'):");
+		System.out.println("--------------------------------");
+		System.out.println(this.repository.findByFirstName("Alice"));
+
+		System.out.println("Customers found with findByLastName('Smith'):");
+		System.out.println("--------------------------------");
+		for (Customer customer : this.repository.findByLastName("Smith")) {
+			System.out.println(customer);
+		}
+	}
+
+	public static void main(String[] args) throws Exception {
+		SpringApplication.run(SampleNeo4jApplication.class, args);
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-data-neo4j/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-data-neo4j/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.data.neo4j.url=http://localhost:7474
+spring.data.neo4j.repositories=sample.data.neo4j

--- a/spring-boot-samples/spring-boot-sample-data-neo4j/src/test/java/sample/data/neo4j/SampleNeo4jApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-data-neo4j/src/test/java/sample/data/neo4j/SampleNeo4jApplicationTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.data.neo4j;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.OutputCapture;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link SampleNeo4jApplication}.
+ *
+ * @author Dave Syer
+ * @author Andy Wilkinson
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(SampleNeo4jApplication.class)
+@IntegrationTest
+public class SampleNeo4jApplicationTests {
+
+	@ClassRule
+	public static OutputCapture outputCapture = new OutputCapture();
+
+	@Test
+	public void testDefaultSettings() throws Exception {
+		String output = SampleNeo4jApplicationTests.outputCapture.toString();
+		assertTrue("Wrong output: " + output,
+				output.contains("firstName='Alice', lastName='Smith'"));
+	}
+
+}

--- a/spring-boot-starters/spring-boot-starter-data-neo4j/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-data-neo4j/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starters</artifactId>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-starter-data-neo4j</artifactId>
+	<name>Spring Boot Data Neo4j Starter</name>
+	<description>Spring Boot Data Neo4j Starter</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-neo4j</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-boot-starters/spring-boot-starter-data-neo4j/src/main/resources/META-INF/spring.provides
+++ b/spring-boot-starters/spring-boot-starter-data-neo4j/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: spring-data-neo4j


### PR DESCRIPTION
Added Spring Boot auto-configuration for Spring Data Neo4j

There is a

* `Neo4jProperties` (spring.data.neo4j.{host,port,url,protocol,username,password})
* `Neo4jDataAutoConfiguration`,
* `Neo4jRepositoryAutoConfiguration`
* `Neo4jStarter`

And `spring-boot-samples-data-neo4j`