### PR TITLE
Add Labels and Parameters properties to LiquibaseAutoConfiguration.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -100,6 +100,8 @@ public class LiquibaseAutoConfiguration {
 			liquibase.setDefaultSchema(this.properties.getDefaultSchema());
 			liquibase.setDropFirst(this.properties.isDropFirst());
 			liquibase.setShouldRun(this.properties.isEnabled());
+			liquibase.setLabels(this.properties.getLabels());
+			liquibase.setChangeLogParameters(this.properties.getParameters());
 			return liquibase;
 		}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.autoconfigure.liquibase;
 
+import java.util.Map;
+
 import javax.validation.constraints.NotNull;
 
 import liquibase.integration.spring.SpringLiquibase;
@@ -77,6 +79,16 @@ public class LiquibaseProperties {
 	 * is used.
 	 */
 	private String url;
+
+	/**
+	 * Comma-separated list of runtime labels to use.
+	 */
+	private String labels;
+
+	/**
+	 * A map of Change Log Parameters.
+	 */
+	private Map<String, String> parameters;
 
 	public String getChangeLog() {
 		return this.changeLog;
@@ -148,6 +160,22 @@ public class LiquibaseProperties {
 
 	public void setUrl(String url) {
 		this.url = url;
+	}
+
+	public String getLabels() {
+		return this.labels;
+	}
+
+	public void setLabels(String labels) {
+		this.labels = labels;
+	}
+
+	public Map<String, String> getParameters() {
+		return this.parameters;
+	}
+
+	public void setParameters(Map<String, String> parameters) {
+		this.parameters = parameters;
 	}
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import liquibase.integration.spring.SpringLiquibase;
 
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -193,8 +192,7 @@ public class LiquibaseAutoConfigurationTests {
 
 		// SpringLiquibase parameters field is protected. Using reflection to get the
 		// value.
-		Object parametersValue = FieldUtils.readDeclaredField(liquibase, "parameters",
-				true);
+		Object parametersValue = ReflectionTestUtils.getField(liquibase, "parameters");
 		@SuppressWarnings("unchecked")
 		Map<String, String> parameters = (Map<String, String>) parametersValue;
 		assertTrue(parameters.containsKey("foo"));

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -472,12 +472,14 @@ content into your application; rather pick only the properties that you need.
 	liquibase.change-log=classpath:/db/changelog/db.changelog-master.yaml
 	liquibase.check-change-log-location=true # check the change log location exists
 	liquibase.contexts= # runtime contexts to use
+	liquibase.labels= # runtime labels to use
 	liquibase.default-schema= # default database schema to use
 	liquibase.drop-first=false
 	liquibase.enabled=true
 	liquibase.url= # specific JDBC url (if not set the default datasource is used)
 	liquibase.user= # user name for liquibase.url
 	liquibase.password= # password for liquibase.url
+	liquibase.parameters= # A Map of Change Log Parameters.
 
 	# JMX
 	spring.jmx.default-domain= # JMX domain name


### PR DESCRIPTION
Liquibase Labels and Parameters options are not present in LiquibaseProperties. 
I need change this options at runtime using another Bean as property source, so i added that to LiquibaseAutoConfiguration.
Refs:
 * http://www.liquibase.org/2014/11/contexts-vs-labels.html
 * http://www.liquibase.org/documentation/changelog_parameters.html