### PR TITLE
Fix Assert isDirectory in addSourceFolder()

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSystemWatcher.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSystemWatcher.java
@@ -114,7 +114,7 @@ public class FileSystemWatcher {
 	 */
 	public synchronized void addSourceFolder(File folder) {
 		Assert.notNull(folder, "Folder must not be null");
-		Assert.isTrue(folder.isDirectory(), "Folder must not be a file");
+		Assert.isFalse(folder.isDirectory(), "Folder must not be a file");
 		checkNotStarted();
 		this.folders.put(folder, null);
 	}


### PR DESCRIPTION
Fix Assert for checking if added source folder is a directory.

Can be reproduced if one adds an additional path in application.properties, for example:
spring.devtools.restart.additional-paths=src/main/webapps
