### PR TITLE
Propagates logback log levels to java.util.logging

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/logging/Slf4JLoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/Slf4JLoggingSystem.java
@@ -56,7 +56,7 @@ public abstract class Slf4JLoggingSystem extends AbstractLoggingSystem {
 		}
 	}
 
-	private boolean bridgeHandlerIsAvailable() {
+	protected boolean bridgeHandlerIsAvailable() {
 		return ClassUtils.isPresent(BRIDGE_HANDLER, getClassLoader());
 	}
 

--- a/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import ch.qos.logback.classic.jul.LevelChangePropagator;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
@@ -108,6 +109,7 @@ public class LogbackLoggingSystem extends Slf4JLoggingSystem {
 		LoggerContext context = getLoggerContext();
 		context.stop();
 		context.reset();
+		configureJdkLoggingLevelPropagator();
 		LogbackConfigurator configurator = new LogbackConfigurator(context);
 		new DefaultLogbackConfiguration(initializationContext, logFile)
 				.apply(configurator);
@@ -123,6 +125,7 @@ public class LogbackLoggingSystem extends Slf4JLoggingSystem {
 		LoggerContext loggerContext = getLoggerContext();
 		loggerContext.stop();
 		loggerContext.reset();
+		configureJdkLoggingLevelPropagator();
 		try {
 			configureByResourceUrl(initializationContext, loggerContext,
 					ResourceUtils.getURL(location));
@@ -174,6 +177,17 @@ public class LogbackLoggingSystem extends Slf4JLoggingSystem {
 
 	private void configureJBossLoggingToUseSlf4j() {
 		System.setProperty("org.jboss.logging.provider", "slf4j");
+	}
+
+	private void configureJdkLoggingLevelPropagator() {
+		if (bridgeHandlerIsAvailable()) {
+			LoggerContext loggerContext = getLoggerContext();
+
+			LevelChangePropagator levelChangePropagator = new LevelChangePropagator();
+			levelChangePropagator.setResetJUL(true);
+			levelChangePropagator.setContext(loggerContext);
+			loggerContext.addListener(levelChangePropagator);
+		}
 	}
 
 	@Override

--- a/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -171,6 +171,18 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	@Test
+	public void loggingLevelIsPropagatedToJulI() {
+		this.loggingSystem.beforeInitialize();
+		this.loggingSystem.initialize(this.initializationContext, null, null);
+		this.loggingSystem.setLogLevel(getClass().getName(), LogLevel.DEBUG);
+		java.util.logging.Logger julLogger = java.util.logging.Logger
+				.getLogger(getClass().getName());
+		julLogger.fine("Hello debug world");
+		String output = this.output.toString().trim();
+		assertTrue("Wrong output:\n" + output, output.contains("Hello debug world"));
+	}
+
+	@Test
 	public void jbossLoggingIsConfiguredToUseSlf4j() {
 		this.loggingSystem.beforeInitialize();
 		assertEquals("slf4j", System.getProperty("org.jboss.logging.provider"));


### PR DESCRIPTION
Adds the `LevelChangePropagator` logback listener in order to propagate
Logback's log level changes to `java.util.logging` loggers.

Logback documentation :
http://logback.qos.ch/manual/configuration.html#LevelChangePropagator

Fixes gh-3924