### PR TITLE
Add git.properties to default restart excludes

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
@@ -58,7 +58,7 @@ public class DevToolsProperties {
 	 */
 	public static class Restart {
 
-		private static final String DEFAULT_RESTART_EXCLUDES = "META-INF/maven/**,"
+		private static final String DEFAULT_RESTART_EXCLUDES = "META-INF/maven/**,git.properties,"
 				+ "META-INF/resources/**,resources/**,static/**,public/**,templates/**";
 
 		private static final long DEFAULT_RESTART_POLL_INTERVAL = 1000;


### PR DESCRIPTION
In an application configured to write `git.properties`, such as by following the documentation to use Maven with the `git-commit-id-plugin` plugin, any time `git.properties` is written an application restart results. Having the application restart when git.properties is written is not desirable - IDEs that run Maven plugins automatically (Eclipse, for example) will write out git.properties any time anything is changed, causing any change to result in an application restart. Adding `git.properties` the default restart excludes fixes this problem.