### PR TITLE
#3955 StackOverflowError when using Embedded Mongo with random port

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
@@ -171,8 +171,8 @@ public class EmbeddedMongoAutoConfiguration {
 			}
 			map.put("local.mongo.port", port);
 		}
-		if (this.context.getParent() != null) {
-			setPortProperty(this.context.getParent(), port);
+		if (context.getParent() != null) {
+			setPortProperty(context.getParent(), port);
 		}
 	}
 


### PR DESCRIPTION
EmbeddedMongoAutoConfiguration had infinite recursive call leading to StackOverflowError.

Method setPortProperty should use context given as parameter instead of using field.