### PR TITLE
Added solrj 5 support

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/HealthIndicatorAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/HealthIndicatorAutoConfiguration.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import javax.jms.ConnectionFactory;
 import javax.sql.DataSource;
 
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.elasticsearch.client.Client;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.InitializingBean;
@@ -244,18 +244,18 @@ public class HealthIndicatorAutoConfiguration {
 	}
 
 	@Configuration
-	@ConditionalOnBean(SolrServer.class)
+	@ConditionalOnBean(SolrClient.class)
 	@ConditionalOnEnabledHealthIndicator("solr")
 	public static class SolrHealthIndicatorConfiguration extends
-			CompositeHealthIndicatorConfiguration<SolrHealthIndicator, SolrServer> {
+			CompositeHealthIndicatorConfiguration<SolrHealthIndicator, SolrClient> {
 
 		@Autowired
-		private Map<String, SolrServer> solrServers;
+		private Map<String, SolrClient> solrClients;
 
 		@Bean
 		@ConditionalOnMissingBean(name = "solrHealthIndicator")
 		public HealthIndicator solrHealthIndicator() {
-			return createHealthIndicator(this.solrServers);
+			return createHealthIndicator(this.solrClients);
 		}
 
 	}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/SolrHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/SolrHealthIndicator.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.actuate.health;
 
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 
 /**
  * {@link HealthIndicator} for Apache Solr.
@@ -26,15 +26,15 @@ import org.apache.solr.client.solrj.SolrServer;
  */
 public class SolrHealthIndicator extends AbstractHealthIndicator {
 
-	private final SolrServer solrServer;
+	private final SolrClient solrClient;
 
-	public SolrHealthIndicator(SolrServer solrServer) {
-		this.solrServer = solrServer;
+	public SolrHealthIndicator(SolrClient solrClient) {
+		this.solrClient = solrClient;
 	}
 
 	@Override
 	protected void doHealthCheck(Health.Builder builder) throws Exception {
-		Object status = this.solrServer.ping().getResponse().get("status");
+		Object status = this.solrClient.ping().getResponse().get("status");
 		builder.up().withDetail("solrStatus", status);
 	}
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/SolrHealthIndicatorTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/SolrHealthIndicatorTests.java
@@ -18,7 +18,8 @@ package org.springframework.boot.actuate.health;
 
 import java.io.IOException;
 
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
+
 import org.apache.solr.client.solrj.response.SolrPingResponse;
 import org.apache.solr.common.util.NamedList;
 import org.junit.After;
@@ -56,7 +57,7 @@ public class SolrHealthIndicatorTests {
 		this.context = new AnnotationConfigApplicationContext(
 				PropertyPlaceholderAutoConfiguration.class, SolrAutoConfiguration.class,
 				EndpointAutoConfiguration.class, HealthIndicatorAutoConfiguration.class);
-		assertEquals(1, this.context.getBeanNamesForType(SolrServer.class).length);
+		assertEquals(1, this.context.getBeanNamesForType(SolrClient.class).length);
 		SolrHealthIndicator healthIndicator = this.context
 				.getBean(SolrHealthIndicator.class);
 		assertNotNull(healthIndicator);
@@ -64,14 +65,14 @@ public class SolrHealthIndicatorTests {
 
 	@Test
 	public void solrIsUp() throws Exception {
-		SolrServer solrServer = mock(SolrServer.class);
+		SolrClient solrClient = mock(SolrClient.class);
 		SolrPingResponse pingResponse = new SolrPingResponse();
 		NamedList<Object> response = new NamedList<Object>();
 		response.add("status", "OK");
 		pingResponse.setResponse(response);
-		given(solrServer.ping()).willReturn(pingResponse);
+		given(solrClient.ping()).willReturn(pingResponse);
 
-		SolrHealthIndicator healthIndicator = new SolrHealthIndicator(solrServer);
+		SolrHealthIndicator healthIndicator = new SolrHealthIndicator(solrClient);
 		Health health = healthIndicator.health();
 		assertEquals(Status.UP, health.getStatus());
 		assertEquals("OK", health.getDetails().get("solrStatus"));
@@ -79,10 +80,10 @@ public class SolrHealthIndicatorTests {
 
 	@Test
 	public void solrIsDown() throws Exception {
-		SolrServer solrServer = mock(SolrServer.class);
-		given(solrServer.ping()).willThrow(new IOException("Connection failed"));
+		SolrClient solrClient = mock(SolrClient.class);
+		given(solrClient.ping()).willThrow(new IOException("Connection failed"));
 
-		SolrHealthIndicator healthIndicator = new SolrHealthIndicator(solrServer);
+		SolrHealthIndicator healthIndicator = new SolrHealthIndicator(solrClient);
 		Health health = healthIndicator.health();
 		assertEquals(Status.DOWN, health.getStatus());
 		assertTrue(((String) health.getDetails().get("error"))

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/solr/SolrRepositoriesAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/solr/SolrRepositoriesAutoConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.autoconfigure.data.solr;
 
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -33,7 +33,7 @@ import org.springframework.data.solr.repository.support.SolrRepositoryFactoryBea
  * {@link org.springframework.data.solr.repository.support.SolrRepositoryFactoryBean}
  * found in context, and both
  * {@link org.springframework.data.solr.repository.SolrRepository} and
- * {@link org.apache.solr.client.solrj.SolrServer} can be found on classpath.
+ * {@link org.apache.solr.client.solrj.SolrClient} can be found on classpath.
  * </p>
  * If active auto configuration does the same as
  * {@link org.springframework.data.solr.repository.config.EnableSolrRepositories} would
@@ -44,7 +44,7 @@ import org.springframework.data.solr.repository.support.SolrRepositoryFactoryBea
  * @since 1.1.0
  */
 @Configuration
-@ConditionalOnClass({ SolrServer.class, SolrRepository.class })
+@ConditionalOnClass({ SolrClient.class, SolrRepository.class })
 @ConditionalOnMissingBean({ SolrRepositoryFactoryBean.class,
 		SolrRepositoryConfigExtension.class })
 @ConditionalOnProperty(prefix = "spring.data.solr.repositories", name = "enabled", havingValue = "true", matchIfMissing = true)

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/solr/SolrRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/solr/SolrRepositoriesAutoConfigurationTests.java
@@ -16,8 +16,8 @@
 
 package org.springframework.boot.autoconfigure.data.solr;
 
-import org.apache.solr.client.solrj.SolrServer;
-import org.apache.solr.client.solrj.impl.HttpSolrServer;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -56,15 +56,15 @@ public class SolrRepositoriesAutoConfigurationTests {
 		initContext(TestConfiguration.class);
 
 		assertThat(this.context.getBean(CityRepository.class), notNullValue());
-		assertThat(this.context.getBean(SolrServer.class),
-				instanceOf(HttpSolrServer.class));
+		assertThat(this.context.getBean(SolrClient.class),
+				instanceOf(HttpSolrClient.class));
 	}
 
 	@Test
 	public void testNoRepositoryConfiguration() {
 		initContext(EmptyConfiguration.class);
-		assertThat(this.context.getBean(SolrServer.class),
-				instanceOf(HttpSolrServer.class));
+		assertThat(this.context.getBean(SolrClient.class),
+				instanceOf(HttpSolrClient.class));
 	}
 
 	@Test

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -123,13 +123,14 @@
 		<simple-json.version>1.1.1</simple-json.version>
 		<slf4j.version>1.7.12</slf4j.version>
 		<snakeyaml.version>1.16</snakeyaml.version>
-		<solr.version>4.10.4</solr.version>
+		<solr.version>5.3.0</solr.version>
 		<spock.version>1.0-groovy-2.4</spock.version>
 		<spring.version>4.2.1.RELEASE</spring.version>
 		<spring-amqp.version>1.5.0.RELEASE</spring-amqp.version>
 		<spring-cloud-connectors.version>1.2.0.RELEASE</spring-cloud-connectors.version>
 		<spring-batch.version>3.0.5.RELEASE</spring-batch.version>
 		<spring-data-releasetrain.version>Gosling-RELEASE</spring-data-releasetrain.version>
+		<spring.data.solr.version>2.0.0.BUILD-SNAPSHOT</spring.data.solr.version>
 		<spring-hateoas.version>0.19.0.RELEASE</spring-hateoas.version>
 		<spring-integration.version>4.2.0.RELEASE</spring-integration.version>
 		<spring-loaded.version>1.2.4.RELEASE</spring-loaded.version>
@@ -1707,6 +1708,11 @@
 				<version>${spring-data-releasetrain.version}</version>
 				<scope>import</scope>
 				<type>pom</type>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.data</groupId>
+				<artifactId>spring-data-solr</artifactId>
+				<version>${spring.data.solr.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.hateoas</groupId>

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -2684,7 +2684,7 @@ convenient way.
 
 [[boot-features-connecting-to-solr]]
 ==== Connecting to Solr
-You can inject an auto-configured `SolrServer` instance as you would any other Spring
+You can inject an auto-configured `SolrClient` instance as you would any other Spring
 bean. By default the instance will attempt to connect to a server using
 `http://localhost:8983/solr`:
 
@@ -2693,10 +2693,10 @@ bean. By default the instance will attempt to connect to a server using
 	@Component
 	public class MyBean {
 
-		private SolrServer solr;
+		private SolrClient solr;
 
 		@Autowired
-		public MyBean(SolrServer solr) {
+		public MyBean(SolrClient solr) {
 			this.solr = solr;
 		}
 
@@ -2705,7 +2705,7 @@ bean. By default the instance will attempt to connect to a server using
 	}
 ----
 
-If you add a `@Bean` of your own of type `SolrServer` it will replace the default.
+If you add a `@Bean` of your own of type `SolrClient` it will replace the default.
 
 
 


### PR DESCRIPTION
Hi, I made changes to make spring boot auto configure and spring boot actuator compatible with solrj 5.3 utilizing the Spring Data Solr 2.0.0 Build Snapshot.

The only thing to watch out for is that when Spring Data Hopper is released we can remove the explicit call to Spring Data Solr and update the Spring Data Release Train version.

Tell me what you think!