### PR TITLE
Check url inside the jar

### DIFF
--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
@@ -74,7 +74,12 @@ class JarURLConnection extends java.net.JarURLConnection {
 		super(EMPTY_JAR_URL);
 		this.url = url;
 		String spec = url.getFile().substring(jarFile.getUrl().getFile().length());
-		int separator;
+
+		int separator = spec.indexOf("!/");
+		if (separator == -1) {
+			throw new MalformedURLException("no !/ found in url spec:" + spec);
+		}
+
 		while ((separator = spec.indexOf(SEPARATOR)) > 0) {
 			jarFile = getNestedJarFile(jarFile, spec.substring(0, separator));
 			spec = spec.substring(separator + SEPARATOR.length());

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
@@ -75,16 +75,12 @@ class JarURLConnection extends java.net.JarURLConnection {
 		this.url = url;
 
 		if (!url.getFile().contains(jarFile.getUrl().getFile())) {
-			throw new IllegalArgumentException("this jar "+ jarFile.getUrl().getFile() +" file can't contains url " + url.getFile());
+			throw new IllegalArgumentException("this jar file "+ jarFile.getUrl().getFile() +" can't contains url " + url.getFile());
 		}
 
 		String spec = url.getFile().substring(jarFile.getUrl().getFile().length());
 
-		int separator = spec.indexOf("!/");
-		if (separator == -1) {
-			throw new MalformedURLException("no !/ found in url spec:" + spec);
-		}
-
+		int separator;
 		while ((separator = spec.indexOf(SEPARATOR)) > 0) {
 			jarFile = getNestedJarFile(jarFile, spec.substring(0, separator));
 			spec = spec.substring(separator + SEPARATOR.length());

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
@@ -73,6 +73,11 @@ class JarURLConnection extends java.net.JarURLConnection {
 		// What we pass to super is ultimately ignored
 		super(EMPTY_JAR_URL);
 		this.url = url;
+
+		if (!url.getFile().contains(jarFile.getUrl().getFile())) {
+			throw new IllegalArgumentException("this jar "+ jarFile.getUrl().getFile() +" file can't contains url " + url.getFile());
+		}
+
 		String spec = url.getFile().substring(jarFile.getUrl().getFile().length());
 
 		int separator = spec.indexOf("!/");

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
@@ -75,7 +75,8 @@ class JarURLConnection extends java.net.JarURLConnection {
 		this.url = url;
 
 		if (!url.getFile().startsWith(jarFile.getUrl().getFile())) {
-			throw new IllegalArgumentException("this jar file "+ jarFile.getUrl().getFile() +" can't contains url " + url.getFile());
+			throw new IllegalArgumentException("this jar file " + jarFile.getUrl().getFile()
+					+ " can't contains url " + url.getFile());
 		}
 
 		String spec = url.getFile().substring(jarFile.getUrl().getFile().length());

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
@@ -74,7 +74,7 @@ class JarURLConnection extends java.net.JarURLConnection {
 		super(EMPTY_JAR_URL);
 		this.url = url;
 
-		if (!url.getFile().contains(jarFile.getUrl().getFile())) {
+		if (!url.getFile().startsWith(jarFile.getUrl().getFile())) {
 			throw new IllegalArgumentException("this jar file "+ jarFile.getUrl().getFile() +" can't contains url " + url.getFile());
 		}
 

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
@@ -79,7 +79,6 @@ class JarURLConnection extends java.net.JarURLConnection {
 		}
 
 		String spec = url.getFile().substring(jarFile.getUrl().getFile().length());
-
 		int separator;
 		while ((separator = spec.indexOf(SEPARATOR)) > 0) {
 			jarFile = getNestedJarFile(jarFile, spec.substring(0, separator));


### PR DESCRIPTION
In case when url created from absolute path like '/some/path/', url parser replace jar-url with absolute path so code works incorrectly. 
