### PR TITLE
Error message for keystore/truststore classpath resource w/ Tomcat

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/EmbeddedServletContainerException.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/EmbeddedServletContainerException.java
@@ -24,6 +24,10 @@ package org.springframework.boot.context.embedded;
 @SuppressWarnings("serial")
 public class EmbeddedServletContainerException extends RuntimeException {
 
+	public EmbeddedServletContainerException(String message) {
+		super(message);
+	}
+
 	public EmbeddedServletContainerException(String message, Throwable cause) {
 		super(message, cause);
 	}


### PR DESCRIPTION
Tomcat does not support keystore/truststore resources that are not
directly on the file system. Added a more descriptive error message when
a user chooses a classpath resource for a keystore/truststore when using
Tomcat.

Fixes gh-2635