### PR TITLE
Autoconfiguration for embedded Redis.

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -91,6 +91,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.github.kstyrc</groupId>
+			<artifactId>embedded-redis</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>javax.cache</groupId>
 			<artifactId>cache-api</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/redis/EmbeddedRedisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/redis/EmbeddedRedisAutoConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.redis;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import redis.clients.jedis.Jedis;
+
+import redis.embedded.RedisServer;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Embedded Redis.
+ *
+ * @author Amer Aljovic
+ */
+@Configuration
+@ConditionalOnClass({ Jedis.class, RedisServer.class })
+public class EmbeddedRedisAutoConfiguration {
+
+	@Autowired
+	RedisProperties redisProperties;
+
+	@Bean (initMethod = "start", destroyMethod = "stop")
+	public RedisServer redisServer() throws IOException {
+		return new RedisServer(this.redisProperties.getPort());
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -56,6 +56,7 @@ org.springframework.boot.autoconfigure.mustache.MustacheAutoConfiguration,\
 org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,\
 org.springframework.boot.autoconfigure.reactor.ReactorAutoConfiguration,\
 org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration,\
+org.springframework.boot.autoconfigure.redis.EmbeddedRedisAutoConfiguration,\
 org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration,\
 org.springframework.boot.autoconfigure.security.SecurityFilterAutoConfiguration,\
 org.springframework.boot.autoconfigure.security.FallbackWebSecurityAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/redis/EmbeddedRedisAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/redis/EmbeddedRedisAutoConfigurationTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.redis;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.util.SocketUtils;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for {@link EmbeddedRedisAutoConfiguration}.
+ *
+ * @author Amer Aljovic
+ */
+public class EmbeddedRedisAutoConfigurationTests {
+
+	private AnnotationConfigApplicationContext context;
+
+	@Before
+	public void setup() {
+		this.context = new AnnotationConfigApplicationContext();
+	}
+
+	@After
+	public void close() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void testDefaultRedisConfiguration() throws Exception {
+		int redisPort = SocketUtils.findAvailableTcpPort();
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.redis.port=" + redisPort);
+		this.context.register(RedisAutoConfiguration.class, EmbeddedRedisAutoConfiguration.class);
+		this.context.refresh();
+		StringRedisTemplate redis = this.context.getBean(StringRedisTemplate.class);
+		RedisConnection connection = redis.getConnectionFactory().getConnection();
+		assertNotNull(connection);
+	}
+
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -64,6 +64,7 @@
 		<dropwizard-metrics.version>3.1.2</dropwizard-metrics.version>
 		<ehcache.version>2.10.0</ehcache.version>
 		<embedded-mongo.version>1.50.0</embedded-mongo.version>
+		<embedded-redis.version>0.6</embedded-redis.version>
 		<flyway.version>3.2.1</flyway.version>
 		<freemarker.version>2.3.23</freemarker.version>
 		<elasticsearch.version>1.5.2</elasticsearch.version>
@@ -679,6 +680,11 @@
 				<groupId>de.flapdoodle.embed</groupId>
 				<artifactId>de.flapdoodle.embed.mongo</artifactId>
 				<version>${embedded-mongo.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.github.kstyrc</groupId>
+				<artifactId>embedded-redis</artifactId>
+				<version>${embedded-redis.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
Hi, I added support for embedded Redis server. 

It scans the classpath for the Embedded Redis libraty and if present, starts an embedded Redis server on port specified in `spring.redis.port`. 