### PR TITLE
Use a JndiDestinationResolver when JNDI ConnectionFactory is used

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JndiConnectionFactoryAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JndiConnectionFactoryAutoConfiguration.java
@@ -35,6 +35,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.support.destination.DestinationResolver;
+import org.springframework.jms.support.destination.JndiDestinationResolver;
 import org.springframework.jndi.JndiLocatorDelegate;
 import org.springframework.util.StringUtils;
 
@@ -65,6 +67,14 @@ public class JndiConnectionFactoryAutoConfiguration {
 					ConnectionFactory.class);
 		}
 		return findJndiConnectionFactory();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(DestinationResolver.class)
+	public DestinationResolver destinationResolver() {
+		JndiDestinationResolver destinationResolver = new JndiDestinationResolver();
+		destinationResolver.setResourceRef(true);
+		return destinationResolver;
 	}
 
 	private ConnectionFactory findJndiConnectionFactory() {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JndiConnectionFactoryAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JndiConnectionFactoryAutoConfiguration.java
@@ -74,6 +74,7 @@ public class JndiConnectionFactoryAutoConfiguration {
 	public DestinationResolver destinationResolver() {
 		JndiDestinationResolver destinationResolver = new JndiDestinationResolver();
 		destinationResolver.setResourceRef(true);
+		destinationResolver.setFallbackToDynamicDestination(true);
 		return destinationResolver;
 	}
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JndiConnectionFactoryAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JndiConnectionFactoryAutoConfigurationTest.java
@@ -1,0 +1,109 @@
+package org.springframework.boot.autoconfigure.jms;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jms.support.destination.DestinationResolver;
+import org.springframework.jms.support.destination.JndiDestinationResolver;
+import org.springframework.mock.jndi.SimpleNamingContextBuilder;
+
+import javax.jms.ConnectionFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for the {@link JndiConnectionFactoryAutoConfiguration}.
+ *
+ * @author Marten Deinum
+ * @since 1.3.0
+ */
+public class JndiConnectionFactoryAutoConfigurationTest {
+
+    private AnnotationConfigApplicationContext context;
+
+    @After
+    public void close() {
+        if (this.context != null) {
+            this.context.close();
+        }
+
+        if (SimpleNamingContextBuilder.getCurrentContextBuilder() != null) {
+            SimpleNamingContextBuilder.getCurrentContextBuilder().clear();
+            SimpleNamingContextBuilder.getCurrentContextBuilder().deactivate();
+        }
+    }
+
+    @Test
+    public void jndiAvailableAndConnectionFactory() throws Exception {
+        ConnectionFactory cf = mock(ConnectionFactory.class);
+
+        SimpleNamingContextBuilder.emptyActivatedContextBuilder().bind("java:/JmsXA", cf);
+        load(EmptyConfiguration.class);
+
+        ConnectionFactory cfFromContext = this.context.getBean(ConnectionFactory.class);
+        DestinationResolver destinationResolver = this.context.getBean(DestinationResolver.class);
+        assertThat(cfFromContext, is(cf));
+        assertThat(destinationResolver, is(instanceOf(JndiDestinationResolver.class)));
+    }
+
+    @Test
+    public void jndiAvailableWithoutConnectionFactory() throws Exception {
+        SimpleNamingContextBuilder.emptyActivatedContextBuilder();
+        load(EmptyConfiguration.class);
+
+        assertThat(this.context.getBeansOfType(ConnectionFactory.class).size(), is(0));
+    }
+
+    @Test
+    public void jndiAvailableWithcustomConfiguration() throws Exception {
+        ConnectionFactory cf = mock(ConnectionFactory.class);
+
+        SimpleNamingContextBuilder.emptyActivatedContextBuilder().bind("java:/JmsXA", cf);
+
+        load(CustomConnectionFactoryConfiguration.class);
+
+
+        ConnectionFactory cfFromContext = this.context.getBean(ConnectionFactory.class);
+
+        assertThat(cfFromContext, is(not(cf)));
+        assertThat(this.context.getBeansOfType(DestinationResolver.class).size(), is(0));
+    }
+
+
+    private void load(Class<?> config, String... environment) {
+        this.context = doLoad(config, environment);
+    }
+
+    private AnnotationConfigApplicationContext doLoad(Class<?> config,
+                                                      String... environment) {
+        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+        applicationContext.register(config);
+        applicationContext.register(JndiConnectionFactoryAutoConfiguration.class,
+                JmsAutoConfiguration.class);
+        EnvironmentTestUtils.addEnvironment(applicationContext, environment);
+        applicationContext.refresh();
+        return applicationContext;
+    }
+
+    @Configuration
+    static class EmptyConfiguration {
+
+    }
+
+    @Configuration
+    static class CustomConnectionFactoryConfiguration {
+
+        @Bean
+        public ConnectionFactory connectionFactory() {
+            return mock(ConnectionFactory.class);
+        }
+    }
+
+}


### PR DESCRIPTION
When using a `ConnectionFactory` from JNDI it makes sense to register a `JndiDestinationResolver` for lookup of the destinations from JNDI as well.

fixes: gh-4037