### PR TITLE
Improve error reporting when driver class can not be loaded.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -161,7 +161,7 @@ public class DataSourceProperties implements BeanClassLoaderAware, EnvironmentAw
 
 	public String getDriverClassName() {
 		if (StringUtils.hasText(this.driverClassName)) {
-			Assert.state(ClassUtils.isPresent(this.driverClassName, null),
+			Assert.state(driverClassIsLoadable(),
 					"Cannot load driver class: " + this.driverClassName);
 			return this.driverClassName;
 		}
@@ -180,6 +180,20 @@ public class DataSourceProperties implements BeanClassLoaderAware, EnvironmentAw
 					this.environment, "driver class");
 		}
 		return driverClassName;
+	}
+
+	private boolean driverClassIsLoadable() {
+		try {
+			ClassUtils.forName(this.driverClassName, null);
+			return true;
+		}
+		catch (UnsupportedClassVersionError ucve) {
+			// driver library has been compiled with a later JDK, propagate error
+			throw ucve;
+		}
+		catch (Throwable t) {
+			return false;
+		}
 	}
 
 	public void setDriverClassName(String driverClassName) {


### PR DESCRIPTION
`ClassUtils.isPresent(String, ClassLoader)` swallows all Throwables when
trying to load a class by name. For this reason `UnsupportedClassVersionError`
will also be swallowed when user code is trying to use a driver library
which has been compiled with a later JDK than the one the application is
running with. All the user would see was "Cannot load driver class".
This change simply propagates the `UnsupportedClassVersionNumberError` so
that it is easier for users to find the root cause of the problem.

Fixes gh-4082.