### PR TITLE
Added support for detecting the DB2 AS400 Driver

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DataSourceHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DataSourceHealthIndicator.java
@@ -207,6 +207,14 @@ public class DataSourceHealthIndicator extends AbstractHealthIndicator implement
 
 		},
 
+		AS400("DB2 UDB for AS/400", "SELECT 1 FROM SYSIBM.SYSDUMMY1") {
+			@Override
+			protected boolean matchesProduct(String product) {
+				return super.matchesProduct(product)
+						|| product.toLowerCase().contains("as/400");
+			}
+		},
+
 		INFORMIX("Informix Dynamic Server", "select count(*) from systables"),
 
 		FIREBIRD("Firebird", "SELECT 1 FROM RDB$DATABASE") {

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/DataSourceHealthIndicatorTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/DataSourceHealthIndicatorTests.java
@@ -116,6 +116,8 @@ public class DataSourceHealthIndicatorTests {
 		assertThat(Product.forProduct("Apache Derby"), equalTo(Product.DERBY));
 		assertThat(Product.forProduct("DB2"), equalTo(Product.DB2));
 		assertThat(Product.forProduct("DB2/LINUXX8664"), equalTo(Product.DB2));
+		assertThat(Product.forProduct("DB2 UDB for AS/400"), equalTo(Product.AS400));
+		assertThat(Product.forProduct("DB3 XDB fur AS/400"), equalTo(Product.AS400));
 		assertThat(Product.forProduct("Informix Dynamic Server"),
 				equalTo(Product.INFORMIX));
 		assertThat(Product.forProduct("Firebird 2.5.WI"), equalTo(Product.FIREBIRD));

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DatabaseDriver.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DatabaseDriver.java
@@ -87,7 +87,12 @@ enum DatabaseDriver {
 	 * SQL Server.
 	 */
 	SQLSERVER("com.microsoft.sqlserver.jdbc.SQLServerDriver",
-			"com.microsoft.sqlserver.jdbc.SQLServerXADataSource");
+			"com.microsoft.sqlserver.jdbc.SQLServerXADataSource"),
+
+	/**
+	 * DB2 AS400 Server.
+	 */
+	AS400("com.ibm.as400.access.AS400JDBCDriver", "com.ibm.as400.access.AS400JDBCXADataSource");
 
 	private final String driverClassName;
 


### PR DESCRIPTION
 With this commit support for the JTOpen AS400 Driver is added. Based on the URL jdbc:as400 it
 will set the driver and validation query.

Fixes: gh-4115