### PR TITLE
Added support for detecting the DB2 Universal JDBC driver.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DatabaseDriver.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DatabaseDriver.java
@@ -87,7 +87,12 @@ enum DatabaseDriver {
 	 * SQL Server.
 	 */
 	SQLSERVER("com.microsoft.sqlserver.jdbc.SQLServerDriver",
-			"com.microsoft.sqlserver.jdbc.SQLServerXADataSource");
+			"com.microsoft.sqlserver.jdbc.SQLServerXADataSource"),
+
+	/**
+	 * DB2 Server.
+	 */
+	DB2("com.ibm.db2.jcc.DB2Driver", "com.ibm.db2.jcc.DB2XADataSource");
 
 	private final String driverClassName;
 


### PR DESCRIPTION
This commit adds support for the DB2 Universal JDBC Driver. 

Based on the `jdbc:db2` URL prefix it will set the correct driver. 

Fixes: gh-4114