### PR TITLE
Add spring.jersey.path property

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfiguration.java
@@ -47,6 +47,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.WebApplicationInitializer;
 import org.springframework.web.filter.RequestContextFilter;
 
@@ -55,6 +56,7 @@ import org.springframework.web.filter.RequestContextFilter;
  *
  * @author Dave Syer
  * @author Andy Wilkinson
+ * @author Eddú Meléndez
  */
 @Configuration
 @ConditionalOnClass(name = { "org.glassfish.jersey.server.spring.SpringComponentProvider",
@@ -76,8 +78,13 @@ public class JerseyAutoConfiguration implements WebApplicationInitializer {
 
 	@PostConstruct
 	public void path() {
-		this.path = findPath(AnnotationUtils.findAnnotation(this.config.getClass(),
-				ApplicationPath.class));
+		if (StringUtils.hasLength(this.jersey.getPath())) {
+			this.path = parsePath(this.jersey.getPath());
+		}
+		else {
+			this.path = findPath(AnnotationUtils.findAnnotation(this.config.getClass(),
+					ApplicationPath.class));
+		}
 	}
 
 	@Bean
@@ -143,9 +150,15 @@ public class JerseyAutoConfiguration implements WebApplicationInitializer {
 			return "/*";
 		}
 		String path = annotation.value();
-		if (!path.startsWith("/")) {
-			path = "/" + path;
-		}
-		return path.equals("/") ? "/*" : path + "/*";
+
+		return parsePath(path);
 	}
+
+	private static String parsePath(String applicationPath) {
+		if (!applicationPath.startsWith("/")) {
+			applicationPath = "/" + applicationPath;
+		}
+		return applicationPath.equals("/") ? "/*" : applicationPath + "/*";
+	}
+
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jersey/JerseyProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jersey/JerseyProperties.java
@@ -25,6 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * {@link ConfigurationProperties} for Jersey.
  *
  * @author Dave Syer
+ * @author Eddú Meléndez
  * @since 1.2.0
  */
 @ConfigurationProperties("spring.jersey")
@@ -41,6 +42,11 @@ public class JerseyProperties {
 	private Map<String, String> init = new HashMap<String, String>();
 
 	private Filter filter = new Filter();
+
+	/**
+	 * Path at which the application will be available.
+	 */
+	private String path;
 
 	public Filter getFilter() {
 		return this.filter;
@@ -64,6 +70,14 @@ public class JerseyProperties {
 
 	public void setInit(Map<String, String> init) {
 		this.init = init;
+	}
+
+	public String getPath() {
+		return this.path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
 	}
 
 	public enum Type {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfigurationWithoutApplicationPathTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfigurationWithoutApplicationPathTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jersey;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.jersey.JerseyAutoConfigurationCustomServletPathTests.Application;
+import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link JerseyAutoConfiguration} when using custom application path.
+ *
+ * @author Eddú Meléndez
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(Application.class)
+@IntegrationTest({ "server.port=0", "spring.jersey.path=/rest" })
+@WebAppConfiguration
+public class JerseyAutoConfigurationWithoutApplicationPathTests {
+
+	@Value("${local.server.port}")
+	private int port;
+
+	private RestTemplate restTemplate = new TestRestTemplate();
+
+	@Test
+	public void contextLoads() {
+		ResponseEntity<String> entity = this.restTemplate.getForEntity(
+				"http://localhost:" + this.port + "/rest/hello", String.class);
+		assertEquals(HttpStatus.OK, entity.getStatusCode());
+	}
+
+	@MinimalWebConfiguration
+	@Path("/hello")
+	public static class Application extends ResourceConfig {
+
+		@Value("${message:World}")
+		private String msg;
+
+		@GET
+		public String message() {
+			return "Hello " + this.msg;
+		}
+
+		public Application() {
+			register(Application.class);
+		}
+
+		public static void main(String[] args) {
+			SpringApplication.run(Application.class, args);
+		}
+
+	}
+
+	@Target(ElementType.TYPE)
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	@Import({ EmbeddedServletContainerAutoConfiguration.class,
+			ServerPropertiesAutoConfiguration.class, JerseyAutoConfiguration.class,
+			PropertyPlaceholderAutoConfiguration.class })
+	protected @interface MinimalWebConfiguration {
+	}
+
+}


### PR DESCRIPTION
As an alternative for ApplicationPath annotation, spring.jersey.path
property is added.