### PR TITLE
Upgrade to ActiveMQ 5.12.1

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -46,7 +46,7 @@
 		<!-- Spring Boot -->
 		<spring-boot.version>1.3.0.BUILD-SNAPSHOT</spring-boot.version>
 		<!-- Third Party -->
-		<activemq.version>5.12.0</activemq.version>
+		<activemq.version>5.12.1</activemq.version>
 		<antlr2.version>2.7.7</antlr2.version>
 		<artemis.version>1.1.0</artemis.version>
 		<aspectj.version>1.8.7</aspectj.version>


### PR DESCRIPTION
I check the activeMQ 5.12.1'[change log](https://issues.apache.org/jira/secure/ReleaseNote.jspa?version=12333269&styleName=Html&projectId=12311210&Create=Create&atl_token=A5KQ-2QAV-T4JA-FDED%7C9d65b8d205f00eb2faa86e0bc49446661b8fed22%7Clout). There is no big change and the activemq sample works well after update activemq.

Fix #4216