### PR TITLE
Update all GVM references to SDKMAN!

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-boot-docs/src/main/asciidoc/getting-started.adoc
@@ -287,15 +287,15 @@ classpath is set correctly).
 
 
 
-[[getting-started-gvm-cli-installation]]
-==== Installation with GVM
-GVM (the Groovy Environment Manager) can be used for managing multiple versions of
-various Groovy and Java binary packages, including Groovy itself and the Spring Boot CLI.
-Get `gvm` from http://gvmtool.net and install Spring Boot with
+[[getting-started-sdkman-cli-installation]]
+==== Installation with SDKMAN!
+SDKMAN! (The Software Development Kit Manager) can be used for managing multiple versions of
+various binary SDKs, including Groovy and the Spring Boot CLI.
+Get SDKMAN! from http://sdkman.io and install Spring Boot with
 
 [indent=0,subs="verbatim,quotes,attributes"]
 ----
-	$ gvm install springboot
+	$ sdk install springboot
 	$ spring --version
 	Spring Boot v{spring-boot-version}
 ----
@@ -305,21 +305,21 @@ built, follow these extra instructions.
 
 [indent=0,subs="verbatim,quotes,attributes"]
 ----
-	$ gvm install springboot dev /path/to/spring-boot/spring-boot-cli/target/spring-boot-cli-{spring-boot-version}-bin/spring-{spring-boot-version}/
-	$ gvm use springboot dev
+	$ sdk install springboot dev /path/to/spring-boot/spring-boot-cli/target/spring-boot-cli-{spring-boot-version}-bin/spring-{spring-boot-version}/
+	$ sdk default springboot dev
 	$ spring --version
 	Spring CLI v{spring-boot-version}
 ----
 
-This will install a local instance of `spring` called the `dev` instance inside your gvm
-repository. It points at your target build location, so every time you rebuild Spring
+This will install a local instance of `spring` called the `dev` instance.
+It points at your target build location, so every time you rebuild Spring
 Boot, `spring` will be up-to-date.
 
 You can see it by doing this:
 
 [indent=0,subs="verbatim,quotes,attributes"]
 ----
-	$ gvm ls springboot
+	$ sdk ls springboot
 
 	================================================================================
 	Available Springboot Versions
@@ -374,11 +374,11 @@ http://en.wikipedia.org/wiki/Zsh[zsh] shells. You can `source` the script (also 
 `spring`) in any shell, or put it in your personal or system-wide bash completion
 initialization. On a Debian system the system-wide scripts are in `/shell-completion/bash`
 and all scripts in that directory are executed when a new shell starts. To run the script
-manually, e.g. if you have installed using `GVM`
+manually, e.g. if you have installed using SDKMAN!
 
 [indent=0]
 ----
-	$ . ~/.gvm/springboot/current/shell-completion/bash/spring
+	$ . ~/.sdkman/springboot/current/shell-completion/bash/spring
 	$ spring <HIT TAB HERE>
 	  grab  help  jar  run  test  version
 ----

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-cli.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-cli.adoc
@@ -13,8 +13,8 @@ a new project or write your own command for it.
 
 [[cli-installation]]
 == Installing the CLI
-The Spring Boot CLI can be installed manually; using GVM (the Groovy Environment
-Manually) or using Homebrew or MacPorts if you are an OSX user. See
+The Spring Boot CLI can be installed manually; using SDKMAN! (the SDK Manager)
+or using Homebrew or MacPorts if you are an OSX user. See
 _<<getting-started.adoc#getting-started-installing-the-cli>>_
 in the "`Getting started`" section for comprehensive installation instructions.
 


### PR DESCRIPTION
Since **GVM** has undergone a name change to **SDKMAN!**, we should probably change the docs accordingly.