### PR TITLE
Add missing import in ArtemisAutoConfiguration

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisAutoConfiguration.java
@@ -46,7 +46,8 @@ import org.springframework.context.annotation.Import;
 @ConditionalOnClass({ ConnectionFactory.class, ActiveMQConnectionFactory.class })
 @ConditionalOnMissingBean(ConnectionFactory.class)
 @EnableConfigurationProperties(ArtemisProperties.class)
-@Import({ ArtemisXAConnectionFactoryConfiguration.class,
+@Import({ ArtemisEmbeddedServerConfiguration.class,
+		ArtemisXAConnectionFactoryConfiguration.class,
 		ArtemisConnectionFactoryConfiguration.class })
 public class ArtemisAutoConfiguration {
 


### PR DESCRIPTION
Missing configuration was added to provided artemis embedded.

See gh-4226