### PR TITLE
change method of creating credential so that it defaults to Mongo 3 default of (SCRAM-SHA1).

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
@@ -217,7 +217,7 @@ public class MongoProperties {
 				if (hasCustomCredentials()) {
 					String database = this.authenticationDatabase == null
 							? getMongoClientDatabase() : this.authenticationDatabase;
-					credentials = Arrays.asList(MongoCredential.createMongoCRCredential(
+					credentials = Arrays.asList(MongoCredential.createCredential(
 							this.username, database, this.password));
 				}
 				String host = this.host == null ? "localhost" : this.host;


### PR DESCRIPTION
I believe it makes sense to use the default now. See http://www.kennygorman.com/mongodb-2.8-authentication-changes/. This resolved an error locally after Mongo was upgraded to 3.0.