### PR TITLE
Make response headers optional in /trace endpoint

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
@@ -170,8 +170,10 @@ public class WebRequestTraceFilter extends OncePerRequestFilter implements Order
 
 	@SuppressWarnings("unchecked")
 	protected void enhanceTrace(Map<String, Object> trace, HttpServletResponse response) {
-		Map<String, Object> headers = (Map<String, Object>) trace.get("headers");
-		headers.put("response", getResponseHeaders(response));
+		if (isIncluded(Include.RESPONSE_HEADERS)) {
+			Map<String, Object> headers = (Map<String, Object>) trace.get("headers");
+			headers.put("response", getResponseHeaders(response));
+		}
 	}
 
 	private Map<String, String> getResponseHeaders(HttpServletResponse response) {


### PR DESCRIPTION
This looks missed accidentally.