### PR TITLE
Fix logic in ConfigFileEnvironmentPostProcessor affecting files loaded

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileEnvironmentPostProcessor.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileEnvironmentPostProcessor.java
@@ -299,17 +299,15 @@ public class ConfigFileEnvironmentPostProcessor implements EnvironmentPostProces
 				maybeActivateProfiles(
 						this.environment.getProperty(ACTIVE_PROFILES_PROPERTY));
 			}
-			else {
-				// Pre-existing active profiles set via Environment.setActiveProfiles()
-				// are additional profiles and config files are allowed to add more if
-				// they want to, so don't call addActiveProfiles() here.
-				List<String> list = new ArrayList<String>(
-						Arrays.asList(this.environment.getActiveProfiles()));
-				// Reverse them so the order is the same as from getProfilesForValue()
-				// (last one wins when properties are eventually resolved)
-				Collections.reverse(list);
-				this.profiles.addAll(list);
-			}
+			// Pre-existing active profiles set via Environment.setActiveProfiles()
+			// are additional profiles and config files are allowed to add more if
+			// they want to, so don't call addActiveProfiles() here.
+			List<String> list = new ArrayList<String>(
+					Arrays.asList(this.environment.getActiveProfiles()));
+			// Reverse them so the order is the same as from getProfilesForValue()
+			// (last one wins when properties are eventually resolved)
+			Collections.reverse(list);
+			this.profiles.addAll(list);
 
 			if (this.profiles.isEmpty()) {
 				for (String defaultProfile : this.environment.getDefaultProfiles()) {

--- a/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileEnvironmentPostProcessorTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileEnvironmentPostProcessorTests.java
@@ -435,6 +435,18 @@ public class ConfigFileEnvironmentPostProcessorTests {
 	}
 
 	@Test
+	public void profilesAddedToEnvironmentAndViaProperty() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.environment,
+				"spring.profiles.active:foo");
+		this.environment.addActiveProfile("dev");
+		this.initializer.postProcessEnvironment(this.environment, this.application);
+		assertThat(this.environment.getActiveProfiles(),
+				equalTo(new String[] { "foo", "dev" }));
+		assertThat(this.environment.getProperty("my.property"),
+				equalTo("fromdevpropertiesfile"));
+	}
+
+	@Test
 	public void yamlProfileCanBeChanged() throws Exception {
 		EnvironmentTestUtils.addEnvironment(this.environment,
 				"spring.profiles.active:prod");


### PR DESCRIPTION
The problem fixed here is that the Loader keeps track of the profiles it is
going to look at for loading files, but ignores any that were already
active in the Environment if the listener is called initially with
spring.profiles.active not empty.