### PR TITLE
Undertow enable request wrappers

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
@@ -350,6 +350,7 @@ public class UndertowEmbeddedServletContainerFactory
 		configureErrorPages(deployment);
 		deployment.setServletStackTraces(ServletStackTraces.NONE);
 		deployment.setResourceManager(getDocumentRootResourceManager());
+		deployment.setAllowNonStandardWrappers(true);
 		configureMimeMappings(deployment);
 		for (UndertowDeploymentInfoCustomizer customizer : this.deploymentInfoCustomizers) {
 			customizer.customize(deployment);


### PR DESCRIPTION
Hi,

I have a small request related to https://github.com/spring-cloud/spring-cloud-netflix/pull/582 and https://github.com/spring-cloud/spring-cloud-netflix/issues/524. I would like to enable by default the request wrapper in Undertow. This has a particular use case - Netflix Zuul proxy, which wraps the request/response for forwarding. Other cases probably include url rewriting and similar solutions. This setting is required to disable Undertow checks that are very selective and does not manifest themselves in every situation, but generally break the exception propagation. Enabling that in Spring Cloud directly would unnecessary couple the code with particular container so I though it would be better to directly do this here.