### PR TITLE
Auto-configure MessageConverter for JMS classes

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsAnnotationDrivenConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsAnnotationDrivenConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jms.annotation.EnableJms;
 import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
 import org.springframework.jms.config.JmsListenerConfigUtils;
+import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.jms.support.destination.DestinationResolver;
 import org.springframework.jms.support.destination.JndiDestinationResolver;
 import org.springframework.transaction.jta.JtaTransactionManager;
@@ -44,6 +45,9 @@ class JmsAnnotationDrivenConfiguration {
 
 	@Autowired(required = false)
 	private DestinationResolver destinationResolver;
+
+	@Autowired(required = false)
+	private MessageConverter messageConverter;
 
 	@Autowired(required = false)
 	private JtaTransactionManager transactionManager;
@@ -66,6 +70,9 @@ class JmsAnnotationDrivenConfiguration {
 		}
 		if (this.destinationResolver != null) {
 			factory.setDestinationResolver(this.destinationResolver);
+		}
+		if (this.messageConverter != null) {
+			factory.setMessageConverter(this.messageConverter);
 		}
 		JmsProperties.Listener listener = this.properties.getListener();
 		factory.setAutoStartup(listener.isAutoStartup());

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.jms.core.JmsMessagingTemplate;
 import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.jms.support.destination.DestinationResolver;
 
 /**
@@ -53,6 +54,9 @@ public class JmsAutoConfiguration {
 	@Autowired(required = false)
 	private DestinationResolver destinationResolver;
 
+	@Autowired(required = false)
+	private MessageConverter messageConverter;
+
 	@Bean
 	@ConditionalOnMissingBean
 	public JmsTemplate jmsTemplate() {
@@ -61,6 +65,11 @@ public class JmsAutoConfiguration {
 		if (this.destinationResolver != null) {
 			jmsTemplate.setDestinationResolver(this.destinationResolver);
 		}
+
+		if (this.messageConverter != null) {
+			jmsTemplate.setMessageConverter(this.messageConverter);
+		}
+
 		return jmsTemplate;
 	}
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
@@ -17,6 +17,8 @@
 package org.springframework.boot.autoconfigure.jms;
 
 import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.Message;
 import javax.jms.Session;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
@@ -42,6 +44,8 @@ import org.springframework.jms.config.SimpleJmsListenerContainerFactory;
 import org.springframework.jms.core.JmsMessagingTemplate;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
+import org.springframework.jms.support.converter.MessageConversionException;
+import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.transaction.jta.JtaTransactionManager;
 
 import static org.junit.Assert.assertEquals;
@@ -330,6 +334,16 @@ public class JmsAutoConfigurationTests {
 		ctx.getBean(JmsListenerConfigUtils.JMS_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME);
 	}
 
+	@Test
+	public void testMessageConverterConfigured() {
+		load(TestConfigurationWithMessageConverter.class);
+		MessageConverter messageConverter = this.context.getBean(MessageConverter.class);
+		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
+		assertNotNull(messageConverter);
+		assertNotNull(jmsTemplate);
+		assertSame(messageConverter, jmsTemplate.getMessageConverter());
+	}
+
 	private AnnotationConfigApplicationContext createContext(
 			Class<?>... additionalClasses) {
 		return doLoad(additionalClasses);
@@ -454,6 +468,25 @@ public class JmsAutoConfigurationTests {
 
 	@Configuration
 	protected static class NoEnableJmsConfiguration {
+	}
+
+	@Configuration
+	protected static class TestConfigurationWithMessageConverter {
+
+		@Bean
+		public MessageConverter messageConverter() {
+			return new MessageConverter() {
+				@Override
+				public Message toMessage(Object o, Session session) throws JMSException, MessageConversionException {
+					return null;
+				}
+
+				@Override
+				public Object fromMessage(Message message) throws JMSException, MessageConversionException {
+					return null;
+				}
+			};
+		}
 	}
 
 }


### PR DESCRIPTION
 This commit introduces automatic configuration of the `messageConverter` property for both the `JmsTemplate` and `DefaultJmsListenerContainerFactory`.

 When a `MessageConverter` is configured it will be used to configure both classes.

 Fixes: gh-4282