### PR TITLE
Make OPTIONS/TRACE request handling configurable

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/DispatcherServletAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/DispatcherServletAutoConfiguration.java
@@ -91,6 +91,10 @@ public class DispatcherServletAutoConfiguration {
 		@Bean(name = DEFAULT_DISPATCHER_SERVLET_BEAN_NAME)
 		public DispatcherServlet dispatcherServlet() {
 			DispatcherServlet dispatcherServlet = new DispatcherServlet();
+			dispatcherServlet.setDispatchOptionsRequest(
+					this.webMvcProperties.isDispatchOptionsRequest());
+			dispatcherServlet.setDispatchTraceRequest(
+					this.webMvcProperties.isDispatchTraceRequest());
 			dispatcherServlet.setThrowExceptionIfNoHandlerFound(
 					this.webMvcProperties.isThrowExceptionIfNoHandlerFound());
 			return dispatcherServlet;

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcProperties.java
@@ -49,6 +49,16 @@ public class WebMvcProperties {
 	private String dateFormat;
 
 	/**
+	 * If TRACE requests should go through the regular dispatching chain.
+	 */
+	private boolean dispatchTraceRequest = false;
+
+	/**
+	 * If OPTIONS requests should go through the regular dispatching chain.
+	 */
+	private boolean dispatchOptionsRequest = false;
+
+	/**
 	 * If the content of the "default" model should be ignored during redirect scenarios.
 	 */
 	private boolean ignoreDefaultModelOnRedirect = true;
@@ -103,6 +113,22 @@ public class WebMvcProperties {
 	public void setThrowExceptionIfNoHandlerFound(
 			boolean throwExceptionIfNoHandlerFound) {
 		this.throwExceptionIfNoHandlerFound = throwExceptionIfNoHandlerFound;
+	}
+
+	public boolean isDispatchOptionsRequest() {
+		return this.dispatchOptionsRequest;
+	}
+
+	public void setDispatchOptionsRequest(boolean dispatchOptionsRequest) {
+		this.dispatchOptionsRequest = dispatchOptionsRequest;
+	}
+
+	public boolean isDispatchTraceRequest() {
+		return this.dispatchTraceRequest;
+	}
+
+	public void setDispatchTraceRequest(boolean dispatchTraceRequest) {
+		this.dispatchTraceRequest = dispatchTraceRequest;
 	}
 
 	public Async getAsync() {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/DispatcherServletAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/DispatcherServletAutoConfigurationTests.java
@@ -155,10 +155,18 @@ public class DispatcherServletAutoConfigurationTests {
 				DispatcherServletAutoConfiguration.class);
 		EnvironmentTestUtils.addEnvironment(this.context,
 				"spring.mvc.throw-exception-if-no-handler-found:true");
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.mvc.dispatch-options-request:true");
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.mvc.dispatch-trace-request:true");
 		this.context.refresh();
 		DispatcherServlet bean = this.context.getBean(DispatcherServlet.class);
 		assertEquals(true, new DirectFieldAccessor(bean)
 				.getPropertyValue("throwExceptionIfNoHandlerFound"));
+		assertEquals(true, new DirectFieldAccessor(bean)
+				.getPropertyValue("dispatchOptionsRequest"));
+		assertEquals(true, new DirectFieldAccessor(bean)
+				.getPropertyValue("dispatchTraceRequest"));
 	}
 
 	@Configuration

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -153,6 +153,8 @@ content into your application; rather pick only the properties that you need.
 	spring.mvc.message-codes-resolver-format= # PREFIX_ERROR_CODE / POSTFIX_ERROR_CODE
 	spring.mvc.ignore-default-model-on-redirect=true # if the content of the "default" model should be ignored redirects
 	spring.mvc.throw-exception-if-no-handler-found=false # if a "NoHandlerFoundException" should be thrown if no Handler was found to process a request
+	spring.mvc.dispatch-trace-request=false # if TRACE requests should go through the regular dispatching chain
+	spring.mvc.dispatch-options-request=false # if OPTIONS requests should go through the regular dispatching chain
 	spring.mvc.async.request-timeout= # async request timeout in milliseconds
 	spring.mvc.view.prefix= # MVC view prefix
 	spring.mvc.view.suffix= # ... and suffix


### PR DESCRIPTION
Added properties to WebMvcAutoConfiguration allowing to control whether
TRACE/OPTIONS requests should go through the regular dispatching chain.

I have signed the CLA.