### PR TITLE
Fix HTTP health endpoint access restrictions table layout

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -610,10 +610,7 @@ users full access to the health endpoint in a secure application. To do so, set
 `sensitive` flag value "`false`" indicated in bold):
 
 |====
-|`management.security.enabled`
-|`endpoints.health.sensitive`
-|Unauthenticated
-|Authenticated
+|`management.security.enabled` |`endpoints.health.sensitive` |Unauthenticated |Authenticated
 
 |false
 |**false**


### PR DESCRIPTION
HTTP health endpoint access restrictions table layout has been messed up after ```1.3.0.RC1```:
* [```1.3.0.M5```](http://docs.spring.io/spring-boot/docs/1.3.0.M5/reference/htmlsingle/#production-ready-health-access-restrictions)
* [```1.3.0.RC1```](http://docs.spring.io/spring-boot/docs/1.3.0.RC1/reference/htmlsingle/#production-ready-health-access-restrictions)