### PR TITLE
Add missing properties to auth server autoconfig

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/authserver/OAuth2AuthorizationServerConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/authserver/OAuth2AuthorizationServerConfiguration.java
@@ -88,6 +88,16 @@ public class OAuth2AuthorizationServerConfiguration
 						AuthorityUtils.authorityListToSet(this.details.getAuthorities())
 								.toArray(new String[0]))
 				.scopes(this.details.getScope().toArray(new String[0]));
+
+		if (this.details.getAutoApproveScopes() != null) {
+			builder.autoApprove(this.details.getAutoApproveScopes().toArray(new String[0]));
+		}
+		if (this.details.getAccessTokenValiditySeconds() != null) {
+			builder.accessTokenValiditySeconds(this.details.getAccessTokenValiditySeconds());
+		}
+		if (this.details.getRefreshTokenValiditySeconds() != null) {
+			builder.refreshTokenValiditySeconds(this.details.getRefreshTokenValiditySeconds());
+		}
 		if (this.details.getRegisteredRedirectUri() != null) {
 			builder.redirectUris(
 					this.details.getRegisteredRedirectUri().toArray(new String[0]));


### PR DESCRIPTION
The `OAuth2AuthorizationServerConfiguration#configure` method was not setting the `autoApprove`, `accessTokenValiditySeconds`, or `refreshTokenValiditySeconds` properties on the `ClientDetails`.  This pull request sets them correctly and should fix #4306.