### PR TITLE
Fix binding of Flyway's baselineVersion property

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
@@ -21,6 +21,7 @@ import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -33,9 +34,11 @@ import org.springframework.boot.autoconfigure.data.jpa.EntityManagerFactoryDepen
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.orm.jpa.AbstractEntityManagerFactoryBean;
@@ -47,6 +50,7 @@ import org.springframework.util.Assert;
  *
  * @author Dave Syer
  * @author Phillip Webb
+ * @author Vedran Pavic
  * @since 1.1.0
  */
 @Configuration
@@ -56,6 +60,12 @@ import org.springframework.util.Assert;
 @AutoConfigureAfter({ DataSourceAutoConfiguration.class,
 		HibernateJpaAutoConfiguration.class })
 public class FlywayAutoConfiguration {
+
+	@Bean
+	@ConfigurationPropertiesBinding
+	public StringToMigrationVersionConverter stringToMigrationVersionConverter() {
+		return new StringToMigrationVersionConverter();
+	}
 
 	@Configuration
 	@ConditionalOnMissingBean(Flyway.class)
@@ -154,6 +164,18 @@ public class FlywayAutoConfiguration {
 
 		public FlywayJpaDependencyConfiguration() {
 			super("flyway");
+		}
+
+	}
+
+	/**
+	 * Converts a String to a {@link MigrationVersion}.
+	 */
+	private static class StringToMigrationVersionConverter implements Converter<String, MigrationVersion> {
+
+		@Override
+		public MigrationVersion convert(String source) {
+			return MigrationVersion.fromVersion(source);
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import javax.sql.DataSource;
 
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
 import org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform;
 import org.junit.After;
 import org.junit.Before;
@@ -56,6 +57,7 @@ import static org.junit.Assert.assertThat;
  * @author Dave Syer
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Vedran Pavic
  */
 public class FlywayAutoConfigurationTests {
 
@@ -193,6 +195,16 @@ public class FlywayAutoConfigurationTests {
 		registerAndRefresh(CustomFlywayWithJpaConfiguration.class,
 				EmbeddedDataSourceConfiguration.class, FlywayAutoConfiguration.class,
 				PropertyPlaceholderAutoConfiguration.class);
+	}
+
+	@Test
+	public void overrideBaselineVersion() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.context, "flyway.baseline-version=0");
+		registerAndRefresh(EmbeddedDataSourceConfiguration.class,
+				FlywayAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		Flyway flyway = this.context.getBean(Flyway.class);
+		assertThat(flyway.getBaselineVersion(), equalTo(MigrationVersion.fromVersion("0")));
 	}
 
 	private void registerAndRefresh(Class<?>... annotatedClasses) {


### PR DESCRIPTION
Spring Boot is unable to bind Flyway's ```baselineVersion``` property due to setter accepting a ```MigrationVersion``` object.

Issue can be reproduced using ```spring-boot-sample-flyway```. Starting an app with ```flyway.baseline-version=0``` results in following error:

```stacktrace
2015-10-27 20:22:33.185 ERROR 31680 --- [           main] o.s.b.b.PropertiesConfigurationFactory   : Properties configuration failed validation
2015-10-27 20:22:33.186 ERROR 31680 --- [           main] o.s.b.b.PropertiesConfigurationFactory   : Field error in object 'flyway' on field 'baselineVersion': rejected value [0]; codes [typeMismatch.flyway.baselineVersion,typeMismatch.baselineVersion,typeMismatch.org.flywaydb.core.api.MigrationVersion,typeMismatch]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [flyway.baselineVersion,baselineVersion]; arguments []; default message [baselineVersion]]; default message [Failed to convert property value of type 'java.lang.String' to required type 'org.flywaydb.core.api.MigrationVersion' for property 'baselineVersion'; nested exception is java.lang.IllegalStateException: Cannot convert value of type [java.lang.String] to required type [org.flywaydb.core.api.MigrationVersion] for property 'baselineVersion': no matching editors or conversion strategy found]
2015-10-27 20:22:33.190  WARN 31680 --- [           main] ationConfigEmbeddedWebApplicationContext : Exception encountered during context initialization - cancelling refresh attempt
org.springframework.validation.BindException: org.springframework.boot.bind.RelaxedDataBinder$RelaxedBeanPropertyBindingResult: 1 errors
Field error in object 'flyway' on field 'baselineVersion': rejected value [0]; codes [typeMismatch.flyway.baselineVersion,typeMismatch.baselineVersion,typeMismatch.org.flywaydb.core.api.MigrationVersion,typeMismatch]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [flyway.baselineVersion,baselineVersion]; arguments []; default message [baselineVersion]]; default message [Failed to convert property value of type 'java.lang.String' to required type 'org.flywaydb.core.api.MigrationVersion' for property 'baselineVersion'; nested exception is java.lang.IllegalStateException: Cannot convert value of type [java.lang.String] to required type [org.flywaydb.core.api.MigrationVersion] for property 'baselineVersion': no matching editors or conversion strategy found]
	at org.springframework.boot.bind.PropertiesConfigurationFactory.validate(PropertiesConfigurationFactory.java:350) ~[spring-boot-1.3.0.BUILD-SNAPSHOT.jar:1.3.0.BUILD-SNAPSHOT]
	at org.springframework.boot.bind.PropertiesConfigurationFactory.doBindPropertiesToTarget(PropertiesConfigurationFactory.java:269) ~[spring-boot-1.3.0.BUILD-SNAPSHOT.jar:1.3.0.BUILD-SNAPSHOT]
	at org.springframework.boot.bind.PropertiesConfigurationFactory.bindPropertiesToTarget(PropertiesConfigurationFactory.java:240) ~[spring-boot-1.3.0.BUILD-SNAPSHOT.jar:1.3.0.BUILD-SNAPSHOT]
	at org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor.postProcessBeforeInitialization(ConfigurationPropertiesBindingPostProcessor.java:319) ~[spring-boot-1.3.0.BUILD-SNAPSHOT.jar:1.3.0.BUILD-SNAPSHOT]
	... 27 common frames omitted
Wrapped by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'flyway': Could not bind properties to Flyway (prefix=flyway, ignoreInvalidFields=false, ignoreUnknownFields=true, ignoreNestedProperties=false); nested exception is org.springframework.validation.BindException: org.springframework.boot.bind.RelaxedDataBinder$RelaxedBeanPropertyBindingResult: 1 errors
Field error in object 'flyway' on field 'baselineVersion': rejected value [0]; codes [typeMismatch.flyway.baselineVersion,typeMismatch.baselineVersion,typeMismatch.org.flywaydb.core.api.MigrationVersion,typeMismatch]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [flyway.baselineVersion,baselineVersion]; arguments []; default message [baselineVersion]]; default message [Failed to convert property value of type 'java.lang.String' to required type 'org.flywaydb.core.api.MigrationVersion' for property 'baselineVersion'; nested exception is java.lang.IllegalStateException: Cannot convert value of type [java.lang.String] to required type [org.flywaydb.core.api.MigrationVersion] for property 'baselineVersion': no matching editors or conversion strategy found]
	at org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor.postProcessBeforeInitialization(ConfigurationPropertiesBindingPostProcessor.java:324) ~[spring-boot-1.3.0.BUILD-SNAPSHOT.jar:1.3.0.BUILD-SNAPSHOT]
	at org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor.postProcessBeforeInitialization(ConfigurationPropertiesBindingPostProcessor.java:278) ~[spring-boot-1.3.0.BUILD-SNAPSHOT.jar:1.3.0.BUILD-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInitialization(AbstractAutowireCapableBeanFactory.java:408) ~[spring-beans-4.2.3.BUILD-SNAPSHOT.jar:4.2.3.BUILD-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1570) ~[spring-beans-4.2.3.BUILD-SNAPSHOT.jar:4.2.3.BUILD-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:545) ~[spring-beans-4.2.3.BUILD-SNAPSHOT.jar:4.2.3.BUILD-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:482) ~[spring-beans-4.2.3.BUILD-SNAPSHOT.jar:4.2.3.BUILD-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:305) ~[spring-beans-4.2.3.BUILD-SNAPSHOT.jar:4.2.3.BUILD-SNAPSHOT]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230) ~[spring-beans-4.2.3.BUILD-SNAPSHOT.jar:4.2.3.BUILD-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:301) ~[spring-beans-4.2.3.BUILD-SNAPSHOT.jar:4.2.3.BUILD-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:196) ~[spring-beans-4.2.3.BUILD-SNAPSHOT.jar:4.2.3.BUILD-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:295) ~[spring-beans-4.2.3.BUILD-SNAPSHOT.jar:4.2.3.BUILD-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:196) ~[spring-beans-4.2.3.BUILD-SNAPSHOT.jar:4.2.3.BUILD-SNAPSHOT]
	at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1048) ~[spring-context-4.2.3.BUILD-SNAPSHOT.jar:4.2.3.BUILD-SNAPSHOT]
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:825) ~[spring-context-4.2.3.BUILD-SNAPSHOT.jar:4.2.3.BUILD-SNAPSHOT]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:537) ~[spring-context-4.2.3.BUILD-SNAPSHOT.jar:4.2.3.BUILD-SNAPSHOT]
	at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.refresh(EmbeddedWebApplicationContext.java:118) [spring-boot-1.3.0.BUILD-SNAPSHOT.jar:1.3.0.BUILD-SNAPSHOT]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:761) [spring-boot-1.3.0.BUILD-SNAPSHOT.jar:1.3.0.BUILD-SNAPSHOT]
	at org.springframework.boot.SpringApplication.doRun(SpringApplication.java:356) [spring-boot-1.3.0.BUILD-SNAPSHOT.jar:1.3.0.BUILD-SNAPSHOT]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:295) [spring-boot-1.3.0.BUILD-SNAPSHOT.jar:1.3.0.BUILD-SNAPSHOT]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1085) [spring-boot-1.3.0.BUILD-SNAPSHOT.jar:1.3.0.BUILD-SNAPSHOT]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1074) [spring-boot-1.3.0.BUILD-SNAPSHOT.jar:1.3.0.BUILD-SNAPSHOT]
	at sample.flyway.SampleFlywayApplication.main(SampleFlywayApplication.java:36) [classes/:na]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_66]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_66]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_66]
	at java.lang.reflect.Method.invoke(Method.java:497) ~[na:1.8.0_66]
	at org.springframework.boot.maven.AbstractRunMojo$LaunchRunner.run(AbstractRunMojo.java:467) [spring-boot-maven-plugin-1.3.0.BUILD-SNAPSHOT.jar:1.3.0.BUILD-SNAPSHOT]
	at java.lang.Thread.run(Thread.java:745) [na:1.8.0_66]
```

See also flyway/flyway#1065.

This PR fixes the issue by adding a ```@ConfigurationPropertiesBinding``` ```Converter```.

I've signed the CLA.