### PR TITLE
Fix documentation example

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -813,7 +813,7 @@ as `@Valid` to trigger its validation. For example, building upon the above
 
 		// ... getters and setters
 
-		private static class RemoteAddress {
+		public static class RemoteAddress {
 
 			@NotEmpty
 			public String hostname;


### PR DESCRIPTION
Previously, the nested private static class would cause an error at startup stating that it was not accessible when trying to bind the property from the environment. The nested class should be public.

Sample stack trace:

```
org.springframework.beans.NullValueInNestedPathException: Invalid property 'remoteAddress' of bean class [com.mycompany.ConnectionSettings]: Could not instantiate property type [com.mycompany.ConnectionSettings$RemoteAddress] to auto-grow nested property path: org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.mycompany.ConnectionSettings$RemoteAddress]: Is the constructor accessible?; nested exception is java.lang.IllegalAccessException: Class org.springframework.beans.BeanUtils can not access a member of class com.mycompany.ConnectionSettings$RemoteAddress with modifiers "private"
	at org.springframework.beans.AbstractNestablePropertyAccessor.newValue(AbstractNestablePropertyAccessor.java:921) ~[spring-beans-4.2.1.RELEASE.jar:4.2.1.RELEASE]
	at org.springframework.beans.AbstractNestablePropertyAccessor.createDefaultPropertyValue(AbstractNestablePropertyAccessor.java:887) ~[spring-beans-4.2.1.RELEASE.jar:4.2.1.RELEASE]
	at org.springframework.beans.AbstractNestablePropertyAccessor.setDefaultValue(AbstractNestablePropertyAccessor.java:875) ~[spring-beans-4.2.1.RELEASE.jar:4.2.1.RELEASE]
	at org.springframework.beans.AbstractNestablePropertyAccessor.getNestedPropertyAccessor(AbstractNestablePropertyAccessor.java:839) ~[spring-beans-4.2.1.RELEASE.jar:4.2.1.RELEASE]
	at org.springframework.beans.AbstractNestablePropertyAccessor.getPropertyAccessorForPropertyPath(AbstractNestablePropertyAccessor.java:813) ~[spring-beans-4.2.1.RELEASE.jar:4.2.1.RELEASE]
	at org.springframework.beans.AbstractNestablePropertyAccessor.setPropertyValue(AbstractNestablePropertyAccessor.java:270) ~[spring-beans-4.2.1.RELEASE.jar:4.2.1.RELEASE]
	at org.springframework.boot.bind.RelaxedDataBinder$RelaxedBeanWrapper.setPropertyValue(RelaxedDataBinder.java:698) ~[spring-boot-1.3.0.RC1.jar:1.3.0.RC1]
	at org.springframework.beans.AbstractPropertyAccessor.setPropertyValues(AbstractPropertyAccessor.java:95) ~[spring-beans-4.2.1.RELEASE.jar:4.2.1.RELEASE]
	at org.springframework.validation.DataBinder.applyPropertyValues(DataBinder.java:834) ~[spring-context-4.2.1.RELEASE.jar:4.2.1.RELEASE]
	at org.springframework.validation.DataBinder.doBind(DataBinder.java:730) ~[spring-context-4.2.1.RELEASE.jar:4.2.1.RELEASE]
	at org.springframework.boot.bind.RelaxedDataBinder.doBind(RelaxedDataBinder.java:128) ~[spring-boot-1.3.0.RC1.jar:1.3.0.RC1]
	at org.springframework.validation.DataBinder.bind(DataBinder.java:715) ~[spring-context-4.2.1.RELEASE.jar:4.2.1.RELEASE]
	at org.springframework.boot.bind.PropertiesConfigurationFactory.doBindPropertiesToTarget(PropertiesConfigurationFactory.java:267) ~[spring-boot-1.3.0.RC1.jar:1.3.0.RC1]
	at org.springframework.boot.bind.PropertiesConfigurationFactory.bindPropertiesToTarget(PropertiesConfigurationFactory.java:240) ~[spring-boot-1.3.0.RC1.jar:1.3.0.RC1]
	at org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor.postProcessBeforeInitialization(ConfigurationPropertiesBindingPostProcessor.java:319) ~[spring-boot-1.3.0.RC1.jar:1.3.0.RC1]
	... 24 common frames omitted
```

I have signed the CLA previously.