### PR TITLE
Use maven wrapper in travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ services:
 sudo: false
 install: true
 before_script:
-- mvn install -q -U -DskipTests=true -Dmaven.test.redirectTestOutputToFile=true || true
-- mvn install -q -U -DskipTests=true -Dmaven.test.redirectTestOutputToFile=true
-script: mvn install -q -nsu -Dmaven.test.redirectTestOutputToFile=true -P '!integration'
+- ./mvnw install -q -U -DskipTests=true -Dmaven.test.redirectTestOutputToFile=true || true
+- ./mvnw install -q -U -DskipTests=true -Dmaven.test.redirectTestOutputToFile=true
+script: ./mvnw install -q -nsu -Dmaven.test.redirectTestOutputToFile=true -P '!integration'


### PR DESCRIPTION
I notice that we have maven wrapper in project, so I think it's better to use maven wrapper to run test in travis server.