### PR TITLE
Use ResourceHttpRequestHandler in LogFileMvcEndpoint

### DIFF
--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/LogFileMvcEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/LogFileMvcEndpointTests.java
@@ -18,18 +18,17 @@ package org.springframework.boot.actuate.endpoint.mvc;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import org.springframework.core.io.Resource;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.util.FileCopyUtils;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -39,7 +38,7 @@ import static org.junit.Assert.assertThat;
 /**
  * Tests for {@link LogFileMvcEndpoint}.
  *
- * @author Johannes Stelzer
+ * @author Johannes Edmeier
  * @author Phillip Webb
  */
 public class LogFileMvcEndpointTests {
@@ -63,37 +62,54 @@ public class LogFileMvcEndpointTests {
 	}
 
 	@Test
-	public void notAvailableWithoutLogFile() throws IOException {
-		assertThat(this.mvc.available().getStatusCode(), equalTo(HttpStatus.NOT_FOUND));
+	public void notAvailableWithoutLogFile() throws Exception {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockHttpServletRequest request = new MockHttpServletRequest(
+				HttpMethod.HEAD.name(), "/logfile");
+		this.mvc.invoke(request, response);
+		assertThat(response.getStatus(), equalTo(HttpStatus.NOT_FOUND.value()));
 	}
 
 	@Test
 	public void notAvailableWithMissingLogFile() throws Exception {
 		this.environment.setProperty("logging.file", "no_test.log");
-		assertThat(this.mvc.available().getStatusCode(), equalTo(HttpStatus.NOT_FOUND));
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockHttpServletRequest request = new MockHttpServletRequest(
+				HttpMethod.HEAD.name(), "/logfile");
+		this.mvc.invoke(request, response);
+		assertThat(response.getStatus(), equalTo(HttpStatus.NOT_FOUND.value()));
 	}
 
 	@Test
 	public void availableWithLogFile() throws Exception {
 		this.environment.setProperty("logging.file", this.logFile.getAbsolutePath());
-		assertThat(this.mvc.available().getStatusCode(), equalTo(HttpStatus.OK));
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockHttpServletRequest request = new MockHttpServletRequest(
+				HttpMethod.HEAD.name(), "/logfile");
+		this.mvc.invoke(request, response);
+		assertThat(response.getStatus(), equalTo(HttpStatus.OK.value()));
 	}
 
 	@Test
 	public void notAvailableIfDisabled() throws Exception {
 		this.environment.setProperty("logging.file", this.logFile.getAbsolutePath());
 		this.mvc.setEnabled(false);
-		assertThat(this.mvc.available().getStatusCode(), equalTo(HttpStatus.NOT_FOUND));
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockHttpServletRequest request = new MockHttpServletRequest(
+				HttpMethod.HEAD.name(), "/logfile");
+		this.mvc.invoke(request, response);
+		assertThat(response.getStatus(), equalTo(HttpStatus.NOT_FOUND.value()));
 	}
 
 	@Test
-	public void invokeGetsContent() throws IOException {
+	public void invokeGetsContent() throws Exception {
 		this.environment.setProperty("logging.file", this.logFile.getAbsolutePath());
-		ResponseEntity<?> response = this.mvc.invoke();
-		assertEquals(HttpStatus.OK, response.getStatusCode());
-		InputStream inputStream = ((Resource) response.getBody()).getInputStream();
-		InputStreamReader reader = new InputStreamReader(inputStream);
-		assertEquals("--TEST--", FileCopyUtils.copyToString(reader));
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockHttpServletRequest request = new MockHttpServletRequest(HttpMethod.GET.name(),
+				"/logfile");
+		this.mvc.invoke(request, response);
+		assertThat(response.getStatus(), equalTo(HttpStatus.OK.value()));
+		assertEquals("--TEST--", response.getContentAsString());
 	}
 
 }


### PR DESCRIPTION
With this change the LogFileMvcEndpoint uses a ResourceHttpRequestHandler for serving the logfile.
This gives you support for requesting parts of the logfile via the HTTP Range header.
Also requests with the If-Modified-Since header are correctly handled.

CLA is signed