### PR TITLE
Update systemd service documentation

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/deployment.adoc
+++ b/spring-boot-docs/src/main/asciidoc/deployment.adoc
@@ -459,6 +459,7 @@ can add the following script in `/etc/systemd/system/myapp.service`:
 	[Service]
 	User=myapp
 	ExecStart=/var/myapp/myapp.jar
+	SuccessExitStatus=143
 
 	[Install]
 	WantedBy=multi-user.target
@@ -516,6 +517,11 @@ the default behavior in a script or on the command line:
 |if not empty will set the `-x` flag on the shell process, making it easy to see the logic
  in the script.
 |===
+
+Note that `PID_FOLDER`, `LOG_FOLDER` and `LOG_FILENAME` variables are valid for `init.d`
+service only. With `systemd` the equivalent customizations are made using '`service`'
+script. Check the http://www.freedesktop.org/software/systemd/man/systemd.service.html[Service unit configuration man page]
+for more details.
 
 In addition, the following properties can be changed when the script is written by using
 the `embeddedLaunchScriptProperties` option of the Spring Boot Maven or Gradle plugins.


### PR DESCRIPTION
Related to #4277 (and [this comment](https://github.com/spring-projects/spring-boot/issues/4277#issuecomment-150716187) in specific), the documentation is misleading in regards to console logging redirection with ```systemd``` service.

See:
https://unix.stackexchange.com/questions/20399/view-stdout-stderr-of-systemd-service
http://www.kibinlabs.com/systemd-logging-tricks/

Additionally, the JVM exits with code 143 on ```SIGTERM```. This causes ```systemd``` to think the service failed:

```shell
vedran@vedran-ws:~$ sudo service spring-boot-hello-world stop
vedran@vedran-ws:~$ sudo service spring-boot-hello-world status 
● spring-boot-hello-world.service - spring-boot-hello-world
   Loaded: loaded (/etc/systemd/system/spring-boot-hello-world.service; disabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Tue 2015-10-27 23:12:43 CET; 8min ago
  Process: 10520 ExecStart=/home/vedran/spring-boot-hello-world.jar (code=exited, status=143)
 Main PID: 10520 (code=exited, status=143)
```

After adding ```SuccessExitStatus=143``` to service script:

```shell
vedran@vedran-ws:~$ sudo service spring-boot-hello-world stop
vedran@vedran-ws:~$ sudo service spring-boot-hello-world status 
● spring-boot-hello-world.service - spring-boot-hello-world
   Loaded: loaded (/etc/systemd/system/spring-boot-hello-world.service; disabled; vendor preset: enabled)
   Active: inactive (dead)
```