### PR TITLE
Add managed dependency for hibernate-java8

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -1492,6 +1492,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate</groupId>
+				<artifactId>hibernate-java8</artifactId>
+				<version>${hibernate.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-jpamodelgen</artifactId>
 				<version>${hibernate.version}</version>
 			</dependency>


### PR DESCRIPTION
The import POM contains dependency version management for most of the Hibernate modules, but not [the Java 8 extension module added to handle JSR-310 types](https://hibernate.atlassian.net/browse/HHH-8844). This adds an entry for it.

The extension module is available only in Hibernate 5, however, so I don't know whether you'll want to include it before baselining the Spring Boot dependencies to the new major.