### PR TITLE
Added file config props before default props

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
@@ -553,9 +553,16 @@ public class ConfigFileApplicationListener implements EnvironmentPostProcessor,
 			for (PropertySource<?> item : sources) {
 				reorderedSources.add(item);
 			}
-			// Maybe we should add before the DEFAULT_PROPERTIES if it exists?
-			this.environment.getPropertySources()
-					.addLast(new ConfigurationPropertySources(reorderedSources));
+			addConfigurationProperties(new ConfigurationPropertySources(reorderedSources));
+		}
+
+		private void addConfigurationProperties(ConfigurationPropertySources configurationPropertySources) {
+			if (this.environment.getPropertySources().contains(DEFAULT_PROPERTIES)) {
+				this.environment.getPropertySources().addBefore(DEFAULT_PROPERTIES, configurationPropertySources);
+			}
+			else {
+				this.environment.getPropertySources().addLast(configurationPropertySources);
+			}
 		}
 
 	}


### PR DESCRIPTION
# Issue:

I wasn't able to pass the `spring.application.name` property due to the fact that the `default` property place holder resolver was BEFORE the one in `ConfigFileApplicationListener`.

# What I did:

Implemented the `// Maybe we should add before the DEFAULT_PROPERTIES if it exists?` 
If a sample project is needed I can provide the link how to reproduce the issue.

# Technical notes:

Issue is present in **1.3.0.RC1**
**The workaround** is to pass the props via the command line.