### PR TITLE
Stop removing the PID file before stopping the service

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -160,7 +160,7 @@ do_start() {
 stop() {
   [[ -f $pid_file ]] || { echoYellow "Not running (pidfile not found)"; return 0; }
   pid=$(cat "$pid_file")
-  isRunning $pid || { echoYellow "Not running (process ${pid}. Removing stale pid file)"; rm -f "$pid_file"; return 0; }
+  isRunning $pid || { echoYellow "Not running (process ${pid}). Removing stale pid file."; rm -f "$pid_file"; return 0; }
   do_stop $pid $pid_file
 }
 

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -160,7 +160,6 @@ do_start() {
 stop() {
   [[ -f $pid_file ]] || { echoYellow "Not running (pidfile not found)"; return 0; }
   pid=$(cat "$pid_file")
-  rm -f "$pid_file"
   isRunning $pid || { echoYellow "Not running (process ${pid} not found)"; return 0; }
   do_stop $pid $pid_file
 }

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -160,7 +160,7 @@ do_start() {
 stop() {
   [[ -f $pid_file ]] || { echoYellow "Not running (pidfile not found)"; return 0; }
   pid=$(cat "$pid_file")
-  isRunning $pid || { echoYellow "Not running (process ${pid} not found)"; return 0; }
+  isRunning $pid || { echoYellow "Not running (process ${pid}. Removing stale pid file)"; rm -f "$pid_file"; return 0; }
   do_stop $pid $pid_file
 }
 


### PR DESCRIPTION
The pid file was being removed at the beginning of the stop method and when the service
wasn't able to stop during the first run, it wasn't possible to use the launch script anymore

Fixes gh-4369