### PR TITLE
Secure actuator when all endpoints are sensitive

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ManagementWebSecurityAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ManagementWebSecurityAutoConfiguration.java
@@ -67,6 +67,7 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.AnyRequestMatcher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.ObjectUtils;
@@ -332,7 +333,8 @@ public class ManagementWebSecurityAutoConfiguration {
 				for (String path : this.endpointPaths.getPaths(endpointHandlerMapping)) {
 					matchers.add(new AntPathRequestMatcher(server.getPath(path)));
 				}
-				return (matchers.isEmpty() ? AnyRequestMatcher.INSTANCE
+				return (matchers.isEmpty()
+						? new NegatedRequestMatcher(AnyRequestMatcher.INSTANCE)
 						: new OrRequestMatcher(matchers));
 			}
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/ManagementWebSecurityAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/ManagementWebSecurityAutoConfigurationTests.java
@@ -61,6 +61,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * Tests for {@link ManagementWebSecurityAutoConfiguration}.
@@ -229,6 +232,28 @@ public class ManagementWebSecurityAutoConfigurationTests {
 				MockMvcRequestBuilders.get("/beans").header("authorization", "Basic xxx"))
 				.andExpect(MockMvcResultMatchers.status().isUnauthorized())
 				.andExpect(springAuthenticateRealmHeader());
+	}
+
+	// gh-4368
+	@Test
+	public void testMarkAllEndpointsSensitive() throws Exception {
+		this.context = new AnnotationConfigWebApplicationContext();
+		this.context.setServletContext(new MockServletContext());
+		this.context.register(WebConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"endpoints.health.sensitive:true", "endpoints.info.sensitive:true");
+		this.context.refresh();
+
+		MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.context) //
+				.apply(springSecurity()) //
+				.build();
+
+		mockMvc //
+				.perform(get("/health")) //
+				.andExpect(status().isUnauthorized());
+		mockMvc //
+				.perform(get("/info")) //
+				.andExpect(status().isUnauthorized());
 	}
 
 	private ResultMatcher springAuthenticateRealmHeader() {


### PR DESCRIPTION
Previously if every actuator endpoint was marked as sensitive, then all
endpoints were marked as permitted.

This commit ensures that if all endpoints are marked as sensitive, then
all the endpoints are secured.

Fixes gh-4368