### PR TITLE
Improve auditing configuration

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/AuditAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/AuditAutoConfiguration.java
@@ -23,6 +23,8 @@ import org.springframework.boot.actuate.audit.InMemoryAuditEventRepository;
 import org.springframework.boot.actuate.audit.listener.AuditListener;
 import org.springframework.boot.actuate.security.AuthenticationAuditListener;
 import org.springframework.boot.actuate.security.AuthorizationAuditListener;
+import org.springframework.boot.actuate.security.DefaultAuthenticationAuditListener;
+import org.springframework.boot.actuate.security.DefaultAuthorizationAuditListener;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -33,6 +35,7 @@ import org.springframework.context.annotation.Configuration;
  * {@link EnableAutoConfiguration Auto-configuration} for {@link AuditEvent}s.
  *
  * @author Dave Syer
+ * @author Vedran Pavic
  */
 @Configuration
 public class AuditAutoConfiguration {
@@ -47,14 +50,16 @@ public class AuditAutoConfiguration {
 
 	@Bean
 	@ConditionalOnClass(name = "org.springframework.security.authentication.event.AbstractAuthenticationEvent")
+	@ConditionalOnMissingBean(AuthenticationAuditListener.class)
 	public AuthenticationAuditListener authenticationAuditListener() throws Exception {
-		return new AuthenticationAuditListener();
+		return new DefaultAuthenticationAuditListener();
 	}
 
 	@Bean
 	@ConditionalOnClass(name = "org.springframework.security.access.event.AbstractAuthorizationEvent")
+	@ConditionalOnMissingBean(AuthorizationAuditListener.class)
 	public AuthorizationAuditListener authorizationAuditListener() throws Exception {
-		return new AuthorizationAuditListener();
+		return new DefaultAuthorizationAuditListener();
 	}
 
 	@ConditionalOnMissingBean(AuditEventRepository.class)

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthenticationAuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthenticationAuditListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,104 +16,24 @@
 
 package org.springframework.boot.actuate.security;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.springframework.boot.actuate.audit.AuditEvent;
-import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.ApplicationListener;
 import org.springframework.security.authentication.event.AbstractAuthenticationEvent;
-import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
-import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
-import org.springframework.security.web.authentication.switchuser.AuthenticationSwitchUserEvent;
-import org.springframework.util.ClassUtils;
 
 /**
- * {@link ApplicationListener} expose Spring Security {@link AbstractAuthenticationEvent
- * authentication events} as {@link AuditEvent}s.
+ * {@link ApplicationListener} to expose Spring Security
+ * {@link AbstractAuthenticationEvent authentication events} as {@link AuditEvent}s.
  *
  * @author Dave Syer
+ * @author Vedran Pavic
  */
-public class AuthenticationAuditListener implements
+public interface AuthenticationAuditListener extends
 		ApplicationListener<AbstractAuthenticationEvent>, ApplicationEventPublisherAware {
 
-	private static final String WEB_LISTENER_CHECK_CLASS = "org.springframework.security.web.authentication.switchuser.AuthenticationSwitchUserEvent";
+	void setApplicationEventPublisher(ApplicationEventPublisher publisher);
 
-	private ApplicationEventPublisher publisher;
-
-	private WebAuditListener webListener = maybeCreateWebListener();
-
-	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
-		this.publisher = publisher;
-	}
-
-	private static WebAuditListener maybeCreateWebListener() {
-		if (ClassUtils.isPresent(WEB_LISTENER_CHECK_CLASS, null)) {
-			return new WebAuditListener();
-		}
-		return null;
-	}
-
-	@Override
-	public void onApplicationEvent(AbstractAuthenticationEvent event) {
-		if (event instanceof AbstractAuthenticationFailureEvent) {
-			onAuthenticationFailureEvent((AbstractAuthenticationFailureEvent) event);
-		}
-		else if (this.webListener != null && this.webListener.accepts(event)) {
-			this.webListener.process(this, event);
-		}
-		else if (event instanceof AuthenticationSuccessEvent) {
-			onAuthenticationSuccessEvent((AuthenticationSuccessEvent) event);
-		}
-	}
-
-	private void onAuthenticationFailureEvent(AbstractAuthenticationFailureEvent event) {
-		Map<String, Object> data = new HashMap<String, Object>();
-		data.put("type", event.getException().getClass().getName());
-		data.put("message", event.getException().getMessage());
-		publish(new AuditEvent(event.getAuthentication().getName(),
-				"AUTHENTICATION_FAILURE", data));
-	}
-
-	private void onAuthenticationSuccessEvent(AuthenticationSuccessEvent event) {
-		Map<String, Object> data = new HashMap<String, Object>();
-		if (event.getAuthentication().getDetails() != null) {
-			data.put("details", event.getAuthentication().getDetails());
-		}
-		publish(new AuditEvent(event.getAuthentication().getName(),
-				"AUTHENTICATION_SUCCESS", data));
-	}
-
-	private void publish(AuditEvent event) {
-		if (this.publisher != null) {
-			this.publisher.publishEvent(new AuditApplicationEvent(event));
-		}
-	}
-
-	private static class WebAuditListener {
-
-		public void process(AuthenticationAuditListener listener,
-				AbstractAuthenticationEvent input) {
-			if (listener != null) {
-				AuthenticationSwitchUserEvent event = (AuthenticationSwitchUserEvent) input;
-				Map<String, Object> data = new HashMap<String, Object>();
-				if (event.getAuthentication().getDetails() != null) {
-					data.put("details", event.getAuthentication().getDetails());
-				}
-				data.put("target", event.getTargetUser().getUsername());
-				listener.publish(new AuditEvent(event.getAuthentication().getName(),
-						"AUTHENTICATION_SWITCH", data));
-			}
-
-		}
-
-		public boolean accepts(AbstractAuthenticationEvent event) {
-			return event instanceof AuthenticationSwitchUserEvent;
-		}
-
-	}
+	void onApplicationEvent(AbstractAuthenticationEvent event);
 
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthorizationAuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthorizationAuditListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,65 +16,24 @@
 
 package org.springframework.boot.actuate.security;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.springframework.boot.actuate.audit.AuditEvent;
-import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.ApplicationListener;
 import org.springframework.security.access.event.AbstractAuthorizationEvent;
-import org.springframework.security.access.event.AuthenticationCredentialsNotFoundEvent;
-import org.springframework.security.access.event.AuthorizationFailureEvent;
 
 /**
- * {@link ApplicationListener} expose Spring Security {@link AbstractAuthorizationEvent
- * authorization events} as {@link AuditEvent}s.
+ * {@link ApplicationListener} to expose Spring Security
+ * {@link AbstractAuthorizationEvent authorization events} as {@link AuditEvent}s.
  *
  * @author Dave Syer
+ * @author Vedran Pavic
  */
-public class AuthorizationAuditListener implements
+public interface AuthorizationAuditListener extends
 		ApplicationListener<AbstractAuthorizationEvent>, ApplicationEventPublisherAware {
 
-	private ApplicationEventPublisher publisher;
+	void setApplicationEventPublisher(ApplicationEventPublisher publisher);
 
-	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
-		this.publisher = publisher;
-	}
-
-	@Override
-	public void onApplicationEvent(AbstractAuthorizationEvent event) {
-		if (event instanceof AuthenticationCredentialsNotFoundEvent) {
-			onAuthenticationCredentialsNotFoundEvent(
-					(AuthenticationCredentialsNotFoundEvent) event);
-		}
-		else if (event instanceof AuthorizationFailureEvent) {
-			onAuthorizationFailureEvent((AuthorizationFailureEvent) event);
-		}
-	}
-
-	private void onAuthenticationCredentialsNotFoundEvent(
-			AuthenticationCredentialsNotFoundEvent event) {
-		Map<String, Object> data = new HashMap<String, Object>();
-		data.put("type", event.getCredentialsNotFoundException().getClass().getName());
-		data.put("message", event.getCredentialsNotFoundException().getMessage());
-		publish(new AuditEvent("<unknown>", "AUTHENTICATION_FAILURE", data));
-	}
-
-	private void onAuthorizationFailureEvent(AuthorizationFailureEvent event) {
-		Map<String, Object> data = new HashMap<String, Object>();
-		data.put("type", event.getAccessDeniedException().getClass().getName());
-		data.put("message", event.getAccessDeniedException().getMessage());
-		publish(new AuditEvent(event.getAuthentication().getName(),
-				"AUTHORIZATION_FAILURE", data));
-	}
-
-	private void publish(AuditEvent event) {
-		if (this.publisher != null) {
-			this.publisher.publishEvent(new AuditApplicationEvent(event));
-		}
-	}
+	void onApplicationEvent(AbstractAuthorizationEvent event);
 
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/DefaultAuthenticationAuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/DefaultAuthenticationAuditListener.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.security;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.actuate.audit.AuditEvent;
+import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.authentication.event.AbstractAuthenticationEvent;
+import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
+import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.security.web.authentication.switchuser.AuthenticationSwitchUserEvent;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Default implementation of {@link AuthenticationAuditListener}.
+ *
+ * @author Dave Syer
+ * @author Vedran Pavic
+ */
+public class DefaultAuthenticationAuditListener implements AuthenticationAuditListener {
+
+	private static final String WEB_LISTENER_CHECK_CLASS = "org.springframework.security.web.authentication.switchuser.AuthenticationSwitchUserEvent";
+
+	private ApplicationEventPublisher publisher;
+
+	private WebAuditListener webListener = maybeCreateWebListener();
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+		this.publisher = publisher;
+	}
+
+	private static WebAuditListener maybeCreateWebListener() {
+		if (ClassUtils.isPresent(WEB_LISTENER_CHECK_CLASS, null)) {
+			return new WebAuditListener();
+		}
+		return null;
+	}
+
+	@Override
+	public void onApplicationEvent(AbstractAuthenticationEvent event) {
+		if (event instanceof AbstractAuthenticationFailureEvent) {
+			onAuthenticationFailureEvent((AbstractAuthenticationFailureEvent) event);
+		}
+		else if (this.webListener != null && this.webListener.accepts(event)) {
+			this.webListener.process(this, event);
+		}
+		else if (event instanceof AuthenticationSuccessEvent) {
+			onAuthenticationSuccessEvent((AuthenticationSuccessEvent) event);
+		}
+	}
+
+	private void onAuthenticationFailureEvent(AbstractAuthenticationFailureEvent event) {
+		Map<String, Object> data = new HashMap<String, Object>();
+		data.put("type", event.getException().getClass().getName());
+		data.put("message", event.getException().getMessage());
+		publish(new AuditEvent(event.getAuthentication().getName(),
+				"AUTHENTICATION_FAILURE", data));
+	}
+
+	private void onAuthenticationSuccessEvent(AuthenticationSuccessEvent event) {
+		Map<String, Object> data = new HashMap<String, Object>();
+		if (event.getAuthentication().getDetails() != null) {
+			data.put("details", event.getAuthentication().getDetails());
+		}
+		publish(new AuditEvent(event.getAuthentication().getName(),
+				"AUTHENTICATION_SUCCESS", data));
+	}
+
+	private void publish(AuditEvent event) {
+		if (this.publisher != null) {
+			this.publisher.publishEvent(new AuditApplicationEvent(event));
+		}
+	}
+
+	private static class WebAuditListener {
+
+		public void process(DefaultAuthenticationAuditListener listener,
+				AbstractAuthenticationEvent input) {
+			if (listener != null) {
+				AuthenticationSwitchUserEvent event = (AuthenticationSwitchUserEvent) input;
+				Map<String, Object> data = new HashMap<String, Object>();
+				if (event.getAuthentication().getDetails() != null) {
+					data.put("details", event.getAuthentication().getDetails());
+				}
+				data.put("target", event.getTargetUser().getUsername());
+				listener.publish(new AuditEvent(event.getAuthentication().getName(),
+						"AUTHENTICATION_SWITCH", data));
+			}
+
+		}
+
+		public boolean accepts(AbstractAuthenticationEvent event) {
+			return event instanceof AuthenticationSwitchUserEvent;
+		}
+
+	}
+
+}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/DefaultAuthorizationAuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/DefaultAuthorizationAuditListener.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.security;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.actuate.audit.AuditEvent;
+import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.access.event.AbstractAuthorizationEvent;
+import org.springframework.security.access.event.AuthenticationCredentialsNotFoundEvent;
+import org.springframework.security.access.event.AuthorizationFailureEvent;
+
+/**
+ * Default implementation of {@link AuthorizationAuditListener}.
+ *
+ * @author Dave Syer
+ * @author Vedran Pavic
+ */
+public class DefaultAuthorizationAuditListener implements AuthorizationAuditListener {
+
+	private ApplicationEventPublisher publisher;
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+		this.publisher = publisher;
+	}
+
+	@Override
+	public void onApplicationEvent(AbstractAuthorizationEvent event) {
+		if (event instanceof AuthenticationCredentialsNotFoundEvent) {
+			onAuthenticationCredentialsNotFoundEvent(
+					(AuthenticationCredentialsNotFoundEvent) event);
+		}
+		else if (event instanceof AuthorizationFailureEvent) {
+			onAuthorizationFailureEvent((AuthorizationFailureEvent) event);
+		}
+	}
+
+	private void onAuthenticationCredentialsNotFoundEvent(
+			AuthenticationCredentialsNotFoundEvent event) {
+		Map<String, Object> data = new HashMap<String, Object>();
+		data.put("type", event.getCredentialsNotFoundException().getClass().getName());
+		data.put("message", event.getCredentialsNotFoundException().getMessage());
+		publish(new AuditEvent("<unknown>", "AUTHENTICATION_FAILURE", data));
+	}
+
+	private void onAuthorizationFailureEvent(AuthorizationFailureEvent event) {
+		Map<String, Object> data = new HashMap<String, Object>();
+		data.put("type", event.getAccessDeniedException().getClass().getName());
+		data.put("message", event.getAccessDeniedException().getMessage());
+		publish(new AuditEvent(event.getAuthentication().getName(),
+				"AUTHORIZATION_FAILURE", data));
+	}
+
+	private void publish(AuditEvent event) {
+		if (this.publisher != null) {
+			this.publisher.publishEvent(new AuditApplicationEvent(event));
+		}
+	}
+
+}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/AuditAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/AuditAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,12 @@ import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.boot.actuate.audit.InMemoryAuditEventRepository;
 import org.springframework.boot.actuate.security.AuthenticationAuditListener;
 import org.springframework.boot.actuate.security.AuthorizationAuditListener;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.event.AbstractAuthorizationEvent;
+import org.springframework.security.authentication.event.AbstractAuthenticationEvent;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertNotNull;
@@ -34,16 +37,15 @@ import static org.junit.Assert.assertThat;
  * Tests for {@link AuditAutoConfiguration}.
  *
  * @author Dave Syer
+ * @author Vedran Pavic
  */
 public class AuditAutoConfigurationTests {
 
-	private AnnotationConfigApplicationContext context;
+	private AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
 	@Test
 	public void testTraceConfiguration() throws Exception {
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(AuditAutoConfiguration.class);
-		this.context.refresh();
+		registerAndRefresh(AuditAutoConfiguration.class);
 		assertNotNull(this.context.getBean(AuditEventRepository.class));
 		assertNotNull(this.context.getBean(AuthenticationAuditListener.class));
 		assertNotNull(this.context.getBean(AuthorizationAuditListener.class));
@@ -51,15 +53,35 @@ public class AuditAutoConfigurationTests {
 
 	@Test
 	public void ownAutoRepository() throws Exception {
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(Config.class, AuditAutoConfiguration.class);
-		this.context.refresh();
+		registerAndRefresh(CustomAuditEventRepositoryConfiguration.class,
+				AuditAutoConfiguration.class);
 		assertThat(this.context.getBean(AuditEventRepository.class),
 				instanceOf(TestAuditEventRepository.class));
 	}
 
+	@Test
+	public void ownAuthenticationAuditListener() throws Exception {
+		registerAndRefresh(CustomAuthenticationAuditListenerConfiguration.class,
+				AuditAutoConfiguration.class);
+		assertThat(this.context.getBean(AuthenticationAuditListener.class),
+				instanceOf(TestAuthenticationAuditListener.class));
+	}
+
+	@Test
+	public void ownAuthorizationAuditListener() throws Exception {
+		registerAndRefresh(CustomAuthorizationAuditListenerConfiguration.class,
+				AuditAutoConfiguration.class);
+		assertThat(this.context.getBean(AuthorizationAuditListener.class),
+				instanceOf(TestAuthorizationAuditListener.class));
+	}
+
+	private void registerAndRefresh(Class<?>... annotatedClasses) {
+		this.context.register(annotatedClasses);
+		this.context.refresh();
+	}
+
 	@Configuration
-	public static class Config {
+	public static class CustomAuditEventRepositoryConfiguration {
 
 		@Bean
 		public TestAuditEventRepository testAuditEventRepository() {
@@ -69,6 +91,50 @@ public class AuditAutoConfigurationTests {
 	}
 
 	public static class TestAuditEventRepository extends InMemoryAuditEventRepository {
+	}
+
+	@Configuration
+	protected static class CustomAuthenticationAuditListenerConfiguration {
+
+		@Bean
+		public AuthenticationAuditListener authenticationAuditListener() {
+			return new TestAuthenticationAuditListener();
+		}
+
+	}
+
+	protected static class TestAuthenticationAuditListener implements AuthenticationAuditListener {
+
+		@Override
+		public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+		}
+
+		@Override
+		public void onApplicationEvent(AbstractAuthenticationEvent event) {
+		}
+
+	}
+
+	@Configuration
+	protected static class CustomAuthorizationAuditListenerConfiguration {
+
+		@Bean
+		public AuthorizationAuditListener authorizationAuditListener() {
+			return new TestAuthorizationAuditListener();
+		}
+
+	}
+
+	protected static class TestAuthorizationAuditListener implements AuthorizationAuditListener {
+
+		@Override
+		public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+		}
+
+		@Override
+		public void onApplicationEvent(AbstractAuthorizationEvent event) {
+		}
+
 	}
 
 }

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/security/DefaultAuthenticationAuditListenerTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/security/DefaultAuthenticationAuditListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,11 +36,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 /**
- * Tests for {@link AuthenticationAuditListener}.
+ * Tests for {@link DefaultAuthenticationAuditListener}.
  */
-public class AuthenticationAuditListenerTests {
+public class DefaultAuthenticationAuditListenerTests {
 
-	private final AuthenticationAuditListener listener = new AuthenticationAuditListener();
+	private final AuthenticationAuditListener listener = new DefaultAuthenticationAuditListener();
 
 	private final ApplicationEventPublisher publisher = mock(
 			ApplicationEventPublisher.class);

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/security/DefaultAuthorizationAuditListenerTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/security/DefaultAuthorizationAuditListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,11 +34,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 /**
- * Tests for {@link AuthenticationAuditListener}.
+ * Tests for {@link DefaultAuthenticationAuditListener}.
  */
-public class AuthorizationAuditListenerTests {
+public class DefaultAuthorizationAuditListenerTests {
 
-	private final AuthorizationAuditListener listener = new AuthorizationAuditListener();
+	private final AuthorizationAuditListener listener = new DefaultAuthorizationAuditListener();
 
 	private final ApplicationEventPublisher publisher = mock(
 			ApplicationEventPublisher.class);

--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -1324,7 +1324,9 @@ channel and any subscribers you need).
 Spring Boot Actuator has a flexible audit framework that will publish events once Spring
 Security is in play ('`authentication success`', '`failure`' and '`access denied`'
 exceptions by default). This can be very useful for reporting, and also to implement a
-lock-out policy based on authentication failures.
+lock-out policy based on authentication failures. To customize published security events
+you can provide your own implementations of `AuthenticationAuditListener` and
+`AuthorizationAuditListener`.
 
 You can also choose to use the audit services for your own business events. To do that
 you can either inject the existing `AuditEventRepository` into your own components and


### PR DESCRIPTION
Spring Boot's auditing support is somewhat limited due to inability to customize:
* which security events are published
* which data is stored within ```AuditEvent```s

To make such customizations, it is necessary to exclude ```AuditAutoConfiguration``` because there are no other possibilities of replacing the default ```AuthenticationAuditListener``` and ```AuthorizationAuditListener``` implementations. Unfortunately, this also means the ```AuditEventRepository``` auto-configuration is gone.

This PR introduces ```AuthenticationAuditListener``` and ```AuthorizationAuditListener``` interfaces that allow aforementioned customizations, while retaining the current default behavior of audit framework.

I've signed the CLA.