### PR TITLE
Configure CassandraHealthIndicator to actually be used

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/HealthIndicatorAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/HealthIndicatorAutoConfiguration.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import javax.jms.ConnectionFactory;
 import javax.sql.DataSource;
 
+import com.datastax.driver.core.Cluster;
 import org.apache.solr.client.solrj.SolrServer;
 import org.elasticsearch.client.Client;
 
@@ -29,6 +30,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.ApplicationHealthIndicator;
+import org.springframework.boot.actuate.health.CassandraHealthIndicator;
 import org.springframework.boot.actuate.health.CompositeHealthIndicator;
 import org.springframework.boot.actuate.health.DataSourceHealthIndicator;
 import org.springframework.boot.actuate.health.DiskSpaceHealthIndicator;
@@ -48,9 +50,11 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
+import org.springframework.boot.autoconfigure.cassandra.CassandraAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.data.cassandra.CassandraDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
@@ -66,6 +70,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.ResolvableType;
+import org.springframework.data.cassandra.core.CassandraOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -78,15 +83,17 @@ import org.springframework.mail.javamail.JavaMailSenderImpl;
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Tommy Ludwig
  * @since 1.1.0
  */
 @Configuration
 @AutoConfigureBefore({ EndpointAutoConfiguration.class })
-@AutoConfigureAfter({ DataSourceAutoConfiguration.class, MongoAutoConfiguration.class,
-		MongoDataAutoConfiguration.class, RedisAutoConfiguration.class,
-		RabbitAutoConfiguration.class, SolrAutoConfiguration.class,
-		MailSenderAutoConfiguration.class, JmsAutoConfiguration.class,
-		ElasticsearchAutoConfiguration.class })
+@AutoConfigureAfter({ CassandraAutoConfiguration.class,
+		CassandraDataAutoConfiguration.class, DataSourceAutoConfiguration.class,
+		MongoAutoConfiguration.class, MongoDataAutoConfiguration.class,
+		RedisAutoConfiguration.class, RabbitAutoConfiguration.class,
+		SolrAutoConfiguration.class, MailSenderAutoConfiguration.class,
+		JmsAutoConfiguration.class, ElasticsearchAutoConfiguration.class })
 @EnableConfigurationProperties({ HealthIndicatorAutoConfigurationProperties.class })
 public class HealthIndicatorAutoConfiguration {
 
@@ -149,6 +156,23 @@ public class HealthIndicatorAutoConfiguration {
 			}
 		}
 
+	}
+
+	@Configuration
+	@ConditionalOnClass(Cluster.class)
+	@ConditionalOnBean(CassandraOperations.class)
+	@ConditionalOnEnabledHealthIndicator("cassandra")
+	public static class CassandraHealthIndicatorConfiguration extends
+			CompositeHealthIndicatorConfiguration<CassandraHealthIndicator, CassandraOperations> {
+
+		@Autowired
+		private Map<String, CassandraOperations> cassandraOperations;
+
+		@Bean
+		@ConditionalOnMissingBean(name = "cassandraHealthIndicator")
+		public HealthIndicator cassandraHealthIndicator() {
+			return createHealthIndicator(this.cassandraOperations);
+		}
 	}
 
 	@Configuration

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CassandraHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CassandraHealthIndicator.java
@@ -20,7 +20,7 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.querybuilder.Select;
 
-import org.springframework.data.cassandra.core.CassandraAdminOperations;
+import org.springframework.data.cassandra.core.CassandraOperations;
 import org.springframework.util.Assert;
 
 /**
@@ -32,16 +32,15 @@ import org.springframework.util.Assert;
  */
 public class CassandraHealthIndicator extends AbstractHealthIndicator {
 
-	private CassandraAdminOperations cassandraAdminOperations;
+	private CassandraOperations cassandraOperations;
 
 	/**
 	 * Create a new {@link CassandraHealthIndicator} instance.
-	 * @param cassandraAdminOperations the Cassandra admin operations
+	 * @param cassandraOperations the Cassandra operations
 	 */
-	public CassandraHealthIndicator(CassandraAdminOperations cassandraAdminOperations) {
-		Assert.notNull(cassandraAdminOperations,
-				"CassandraAdminOperations must not be null");
-		this.cassandraAdminOperations = cassandraAdminOperations;
+	public CassandraHealthIndicator(CassandraOperations cassandraOperations) {
+		Assert.notNull(cassandraOperations, "CassandraOperations must not be null");
+		this.cassandraOperations = cassandraOperations;
 	}
 
 	@Override
@@ -49,7 +48,7 @@ public class CassandraHealthIndicator extends AbstractHealthIndicator {
 		try {
 			Select select = QueryBuilder.select("release_version").from("system",
 					"local");
-			ResultSet results = this.cassandraAdminOperations.query(select);
+			ResultSet results = this.cassandraOperations.query(select);
 			if (results.isExhausted()) {
 				builder.up();
 				return;

--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -263,6 +263,9 @@ The following `HealthIndicators` are auto-configured by Spring Boot when appropr
 |===
 |Name |Description
 
+|{sc-spring-boot-actuator}/health/CassandraHealthIndicator.{sc-ext}[`CassandraHealthIndicator`]
+|Checks that a Cassandra database is up.
+
 |{sc-spring-boot-actuator}/health/DiskSpaceHealthIndicator.{sc-ext}[`DiskSpaceHealthIndicator`]
 |Checks for low disk space.
 


### PR DESCRIPTION
The `CassandraHealthIndicator` existed, but it did not seem to be used
since it was missing from `HealthIndicatorAutoConfiguration`. This commit
adds it to the auto-configuration and updates the corresponding
documentation.

Additionally, the `HealthIndicator` was using `CassandraAdminOperations`,
which is not made available by `CassandraDataAutoConfiguration`, and
therefore the health indicator would not show up by default. The same
query that was used with `CassandraAdminOperations` works with
`CassandraOperations`, which is configured by the existing
auto-configuration. This commit changes the `HealthIndicator` to use
`CassandraOperations` so that it is included in the /health endpoint by
default in an application using Cassandra with minimal configuration.

I am not really familiar with Cassandra or Spring Data's support of it, so if there was a good reason the `HealthIndicator` was using the `CassandraAdminOperations`, please feel free to ignore that portion of this pull request. Regardless, the `CassandraHealthIndicator` never would show up in the /health endpoint.

I have signed the CLA.