### PR TITLE
Fix the do_stop command in the launch script

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -166,7 +166,7 @@ stop() {
 }
 
 do_stop() {
-  kill -HUP $1 &> /dev/null || { echoRed "Unable to kill process $1"; return 1; }
+  kill $1 &> /dev/null || { echoRed "Unable to kill process $1"; return 1; }
   for i in $(seq 1 60); do
     isRunning $1 || { echoGreen "Stopped [$1]"; rm -f $2; return 0; }
     sleep 1


### PR DESCRIPTION
The HUP signal was being used to stop the service and
for some reason, sometimes it was being ignored.
This commit change forces the use of the TERM signal
(the default signal of kill).

 Fixes gh-4378