### PR TITLE
Rename a test method to use dir instead folder

### DIFF
--- a/spring-boot/src/test/java/org/springframework/boot/ApplicationTempTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/ApplicationTempTests.java
@@ -55,7 +55,7 @@ public class ApplicationTempTests {
 	}
 
 	@Test
-	public void getSubFolder() throws Exception {
+	public void getSubDir() throws Exception {
 		ApplicationTemp temp = new ApplicationTemp();
 		assertThat(temp.getDir("abc"), equalTo(new File(temp.getDir(), "abc")));
 	}


### PR DESCRIPTION
It looks missed when renaming.