### PR TITLE
Added ability to set DispatcherServlet registration order using 'spring.mvc.dispatch-servlet-order' property

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/DispatcherServletAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/DispatcherServletAutoConfiguration.java
@@ -108,6 +108,7 @@ public class DispatcherServletAutoConfiguration {
 			if (this.multipartConfig != null) {
 				registration.setMultipartConfig(this.multipartConfig);
 			}
+			registration.setOrder(this.webMvcProperties.getDispatchServletOrder());
 			return registration;
 		}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcProperties.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.Ordered;
 import org.springframework.http.MediaType;
 import org.springframework.validation.DefaultMessageCodesResolver;
 
@@ -60,6 +61,11 @@ public class WebMvcProperties {
 	 * Dispatch OPTIONS requests to the FrameworkServlet doService method.
 	 */
 	private boolean dispatchOptionsRequest = false;
+
+	/**
+	 * Dispatch servlet registration order.
+	 */
+	private int dispatchServletOrder = Ordered.LOWEST_PRECEDENCE;
 
 	/**
 	 * If the content of the "default" model should be ignored during redirect scenarios.
@@ -153,6 +159,14 @@ public class WebMvcProperties {
 
 	public View getView() {
 		return this.view;
+	}
+
+	public void setDispatchServletOrder(int dispatchServletOrder) {
+		this.dispatchServletOrder = dispatchServletOrder;
+	}
+
+	public int getDispatchServletOrder() {
+		return this.dispatchServletOrder;
 	}
 
 	public static class Async {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/DispatcherServletAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/DispatcherServletAutoConfigurationTests.java
@@ -169,6 +169,19 @@ public class DispatcherServletAutoConfigurationTests {
 				new DirectFieldAccessor(bean).getPropertyValue("dispatchTraceRequest"));
 	}
 
+	@Test
+	public void dispatcherServletRegistrationConfig() {
+		this.context = new AnnotationConfigWebApplicationContext();
+		this.context.setServletContext(new MockServletContext());
+		this.context.register(ServerPropertiesAutoConfiguration.class,
+				DispatcherServletAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.mvc.dispatch-servlet-order:123");
+		this.context.refresh();
+		ServletRegistrationBean bean = this.context.getBean(ServletRegistrationBean.class);
+		assertEquals(123, bean.getOrder());
+	}
+
 	@Configuration
 	protected static class MultipartConfiguration {
 


### PR DESCRIPTION
It would me nice to be able to change the default order without any line of code.

My use-case:

I have multiple Servlet registration beans for servlets in order: `CustomServlet1`, `CustomServlet2`, `LegacyWebFrameworkServlet` and `DispatcherServlet`. Requests to custom servlets work as expected but `LegacyWebFrameworkServlet` eats all of the requests and doesn't allow Spring's `DispatcherServlet` to proceed any requests.
