### PR TITLE
Fix springProfile with multi profiles separated by comma and whitespace

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringProfileAction.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringProfileAction.java
@@ -67,8 +67,8 @@ class SpringProfileAction extends Action implements InPlayListener {
 	}
 
 	private boolean acceptsProfiles(InterpretationContext ic, Attributes attributes) {
-		String[] profileNames = StringUtils
-				.commaDelimitedListToStringArray(attributes.getValue(NAME_ATTRIBUTE));
+		String[] profileNames = StringUtils.trimArrayElements(StringUtils
+				.commaDelimitedListToStringArray(attributes.getValue(NAME_ATTRIBUTE)));
 		if (profileNames.length != 0) {
 			for (String profileName : profileNames) {
 				OptionHelper.substVars(profileName, ic, this.context);

--- a/spring-boot/src/test/resources/org/springframework/boot/logging/logback/multi-profile-names.xml
+++ b/spring-boot/src/test/resources/org/springframework/boot/logging/logback/multi-profile-names.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 	<include resource="org/springframework/boot/logging/logback/base.xml" />
-	<springProfile name="production,test">
+	<springProfile name="production, test">
 		<logger name="org.springframework.boot.logging.logback" level="TRACE" />
 	</springProfile>
 </configuration>


### PR DESCRIPTION
Previously springProfile supported multi profiles separated by comma but
it doesn´t work if there are whitespaces. Now, springProfile will read
values cleaning whitespaces.

See gh-4445