### PR TITLE
Add support for configuring lobgack logging via JMX

### DIFF
--- a/spring-boot-project/spring-boot/src/test/resources/logback-jmxconfigurator.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/logback-jmxconfigurator.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+	<include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+	<jmxConfigurator/>
+</configuration>


### PR DESCRIPTION
It would be nice to have support for modifying logging configuration in runtime using JMX.

This PR enables Logback's [JMX Configurator](http://logback.qos.ch/manual/jmxConfig.html) as a part of default logging setup.

I've signed the CLA.
