### PR TITLE
Add support for configuring logging threshold levels

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -42,6 +42,8 @@ content into your application; rather pick only the properties that you need.
 	logging.pattern.file= # Appender pattern for output to the file. Only supported with the default logback setup.
 	logging.pattern.level= # Appender pattern for log level (default %5p). Only supported with the default logback setup.
 	logging.register-shutdown-hook=false # Register a shutdown hook for the logging system when it is initialized.
+	logging.threshold.console= # Threshold level to filter output to the console. Only supported with the default logback setup.
+	logging.threshold.file= # Threshold level to filter output to the file. Only supported with the default logback setup.
 
 	# AOP
 	spring.aop.auto=true # Add @EnableAspectJAutoProxy.

--- a/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -79,6 +79,18 @@
     "sourceType": "org.springframework.boot.logging.LoggingApplicationListener"
   },
   {
+    "name": "logging.threshold.console",
+    "type": "java.lang.String",
+    "description": "Threshold level to filter output to the console. Only supported with the default logback setup.",
+    "sourceType": "org.springframework.boot.logging.LoggingApplicationListener"
+  },
+  {
+    "name": "logging.threshold.file",
+    "type": "java.lang.String",
+    "description": "Threshold level to filter output to the file. Only supported with the default logback setup.",
+    "sourceType": "org.springframework.boot.logging.LoggingApplicationListener"
+  },
+  {
     "name": "spring.mandatory-file-encoding",
     "sourceType": "org.springframework.boot.context.FileEncodingApplicationListener",
     "type": "java.nio.charset.Charset",

--- a/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -51,6 +51,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -60,6 +61,7 @@ import static org.junit.Assert.assertTrue;
  * @author Dave Syer
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Vedran Pavic
  */
 public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 
@@ -280,6 +282,33 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 				getLineWithText(output, "Hello world").contains("INFO"));
 		assertFalse("Wrong file output pattern:\n" + output,
 				getLineWithText(file, "Hello world").contains("INFO"));
+	}
+
+	@Test
+	public void testConsoleThresholdProperty() throws Exception {
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("logging.threshold.console", "WARN");
+		LoggingInitializationContext loggingInitializationContext = new LoggingInitializationContext(
+				environment);
+		this.loggingSystem.initialize(loggingInitializationContext, null, null);
+		this.logger.info("Hello world");
+		String output = this.output.toString().trim();
+		assertNull(getLineWithText(output, "Hello world"));
+	}
+
+	@Test
+	public void testFileThresholdProperty() throws Exception {
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("logging.threshold.file", "WARN");
+		LoggingInitializationContext loggingInitializationContext = new LoggingInitializationContext(
+				environment);
+		File file = new File(tmpDir(), "logback-test.log");
+		LogFile logFile = getLogFile(file.getPath(), null);
+		this.loggingSystem.initialize(loggingInitializationContext, null, logFile);
+		this.logger.info("Hello world");
+		String output = this.output.toString().trim();
+		assertTrue(getLineWithText(output, "Hello world").contains("INFO"));
+		assertNull(getLineWithText(file, "Hello world"));
 	}
 
 	@Test


### PR DESCRIPTION
This PR adds logging configuration properties that allow setting the level thresholds for console and file appenders.
See #4357 for motivation.

I've signed the CLA.