### PR TITLE
Fix bad equality check in EndpointWebMvcHypermediaManagementContextConfiguration

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcHypermediaManagementContextConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcHypermediaManagementContextConfiguration.java
@@ -105,7 +105,7 @@ public class EndpointWebMvcHypermediaManagementContextConfiguration {
 	@Bean
 	public HalJsonMvcEndpoint halJsonMvcEndpoint(
 			ManagementServletContext managementServletContext,
-			ResourceProperties resources, ResourceLoader resourceLoader) {
+			ResourceLoader resourceLoader) {
 		if (HalBrowserMvcEndpoint.getHalBrowserLocation(resourceLoader) != null) {
 			return new HalBrowserMvcEndpoint(managementServletContext);
 		}
@@ -128,8 +128,7 @@ public class EndpointWebMvcHypermediaManagementContextConfiguration {
 			ManagementServerProperties management, DocsMvcEndpoint endpoint) {
 		String path = management.getContextPath() + endpoint.getPath()
 				+ "/#spring_boot_actuator__{rel}";
-		if (server.getPort() == management.getPort() && management.getPort() != null
-				&& management.getPort() != 0) {
+		if (server.getPort().equals(management.getPort()) && management.getPort() != 0) {
 			path = server.getPath(path);
 		}
 		return new DefaultCurieProvider("boot", new UriTemplate(path));


### PR DESCRIPTION
This surely was a bug.

I also removed unused argument in ```halJsonMvcEndpoint``` ```@Bean```.