### PR TITLE
Fixing wrong class reference banner in docs

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -78,7 +78,7 @@ brackets and prefixed with `v`). For example `(v{spring-boot-version})`.
 {sc-spring-boot}/ansi/AnsiPropertySource.{sc-ext}[`AnsiPropertySource`] for details.
 |===
 
-TIP: The `SpringBootApplication.setBanner(...)` method can be used if you want to generate
+TIP: The `SpringApplication.setBanner(...)` method can be used if you want to generate
 a banner programmatically. Use the `org.springframework.boot.Banner` interface and
 implement your own `printBanner()` method.
 


### PR DESCRIPTION
`SpringBootApplication` is the annotation, it does not have the `setBanner()` method. [`SpringApplication`](http://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/SpringApplication.html#setBanner-org.springframework.boot.Banner-)  does, so I suppose this is a small error in [the docs](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-spring-application.html).
