### PR TITLE
Fix incorrect default value for executable flag in Gradle plugin docs

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/build-tool-plugins.adoc
+++ b/spring-boot-docs/src/main/asciidoc/build-tool-plugins.adoc
@@ -392,7 +392,7 @@ want the other Boot features but not this one)
 
 |`executable`
 |Boolean flag to indicate if jar files are fully executable on Unix like operating
- systems. Defaults to `true`.
+ systems. Defaults to `false`.
 
 |`embeddedLaunchScript`
 |The embedded launch script to prepend to the front of the jar if it is fully executable.


### PR DESCRIPTION
[Documentation](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#build-tool-plugins-gradle-repackage-configuration) states ```true``` as the default value while ```SpringBootPluginExtension:118``` says otherwise.