### PR TITLE
Add MessagePack support

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -401,6 +401,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.msgpack</groupId>
+			<artifactId>jackson-dataformat-msgpack</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-acl</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/msgpack/MessagePackAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/msgpack/MessagePackAutoConfiguration.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.msgpack;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.msgpack.jackson.dataformat.MessagePackFactory;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.web.HttpMessageConvertersAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.client.RestTemplate;
+
+
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for MessagePack.
+ * @author Toshiaki Maki
+ * @since 1.3.2
+ */
+@Configuration
+@ConditionalOnClass({ HttpMessageConverter.class, RestTemplate.class, MessagePackFactory.class, ObjectMapper.class })
+@AutoConfigureBefore(HttpMessageConvertersAutoConfiguration.class)
+public class MessagePackAutoConfiguration {
+
+	@Autowired(required = false)
+	RestTemplate restTemplate;
+
+	@ConditionalOnMissingBean
+	@Bean
+	public MessagePackHttpMessageConverter messagePackHttpMessageConverter() {
+		return new MessagePackHttpMessageConverter();
+	}
+
+	@Bean
+	public InitializingBean messagePackRestTemplateInitializer() {
+		return new InitializingBean() {
+			@Override
+			public void afterPropertiesSet() throws Exception {
+				if (MessagePackAutoConfiguration.this.restTemplate != null) {
+					List<HttpMessageConverter<?>> converters = MessagePackAutoConfiguration.this.restTemplate
+							.getMessageConverters();
+					HttpMessageConverter<?> converter = CollectionUtils.findValueOfType(
+							converters, MessagePackHttpMessageConverter.class);
+					if (converter == null) {
+						converters.add(messagePackHttpMessageConverter());
+					}
+				}
+			}
+		};
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/msgpack/MessagePackAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/msgpack/MessagePackAutoConfiguration.java
@@ -31,46 +31,49 @@ import org.springframework.boot.autoconfigure.web.HttpMessageConvertersAutoConfi
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.client.RestTemplate;
 
 
-
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for MessagePack.
+ *
  * @author Toshiaki Maki
  * @since 1.3.2
  */
 @Configuration
-@ConditionalOnClass({ HttpMessageConverter.class, RestTemplate.class, MessagePackFactory.class, ObjectMapper.class })
+@ConditionalOnClass({HttpMessageConverter.class, RestTemplate.class, MessagePackFactory.class, ObjectMapper.class, Jackson2ObjectMapperBuilder.class})
 @AutoConfigureBefore(HttpMessageConvertersAutoConfiguration.class)
 public class MessagePackAutoConfiguration {
 
-	@Autowired(required = false)
-	RestTemplate restTemplate;
+    @Autowired(required = false)
+    RestTemplate restTemplate;
+    @Autowired
+    Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder;
 
-	@ConditionalOnMissingBean
-	@Bean
-	public MessagePackHttpMessageConverter messagePackHttpMessageConverter() {
-		return new MessagePackHttpMessageConverter();
-	}
+    @ConditionalOnMissingBean
+    @Bean
+    public MessagePackHttpMessageConverter messagePackHttpMessageConverter() {
+        return new MessagePackHttpMessageConverter(jackson2ObjectMapperBuilder);
+    }
 
-	@Bean
-	public InitializingBean messagePackRestTemplateInitializer() {
-		return new InitializingBean() {
-			@Override
-			public void afterPropertiesSet() throws Exception {
-				if (MessagePackAutoConfiguration.this.restTemplate != null) {
-					List<HttpMessageConverter<?>> converters = MessagePackAutoConfiguration.this.restTemplate
-							.getMessageConverters();
-					HttpMessageConverter<?> converter = CollectionUtils.findValueOfType(
-							converters, MessagePackHttpMessageConverter.class);
-					if (converter == null) {
-						converters.add(messagePackHttpMessageConverter());
-					}
-				}
-			}
-		};
-	}
+    @Bean
+    public InitializingBean messagePackRestTemplateInitializer() {
+        return new InitializingBean() {
+            @Override
+            public void afterPropertiesSet() throws Exception {
+                if (MessagePackAutoConfiguration.this.restTemplate != null) {
+                    List<HttpMessageConverter<?>> converters = MessagePackAutoConfiguration.this.restTemplate
+                            .getMessageConverters();
+                    HttpMessageConverter<?> converter = CollectionUtils.findValueOfType(
+                            converters, MessagePackHttpMessageConverter.class);
+                    if (converter == null) {
+                        converters.add(messagePackHttpMessageConverter());
+                    }
+                }
+            }
+        };
+    }
 
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/msgpack/MessagePackHttpMessageConverter.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/msgpack/MessagePackHttpMessageConverter.java
@@ -21,18 +21,27 @@ import org.msgpack.jackson.dataformat.MessagePackFactory;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 
 /**
  * Implementation of {@link org.springframework.http.converter.HttpMessageConverter} that
  * can read and write <a href="http://msgpack.org/">MessagePack</a>.
+ *
  * @author Toshiaki Maki
  * @since 1.3.2
  */
 public class MessagePackHttpMessageConverter
-		extends AbstractJackson2HttpMessageConverter {
-	public MessagePackHttpMessageConverter() {
-		super(new ObjectMapper(new MessagePackFactory()),
-				new MediaType("application", "x-msgpack"));
-	}
+        extends AbstractJackson2HttpMessageConverter {
+    public MessagePackHttpMessageConverter(Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder) {
+        super(configureObjectMapper(jackson2ObjectMapperBuilder, new ObjectMapper(new MessagePackFactory())),
+                new MediaType("application", "x-msgpack"));
+    }
+
+    private static ObjectMapper configureObjectMapper(Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder,
+                                                      ObjectMapper objectMapper) {
+        // Apply default values provided by Jackson2ObjectMapperBuilder
+        jackson2ObjectMapperBuilder.configure(objectMapper);
+        return objectMapper;
+    }
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/msgpack/MessagePackHttpMessageConverter.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/msgpack/MessagePackHttpMessageConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.msgpack;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.msgpack.jackson.dataformat.MessagePackFactory;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+
+
+/**
+ * Implementation of {@link org.springframework.http.converter.HttpMessageConverter} that
+ * can read and write <a href="http://msgpack.org/">MessagePack</a>.
+ * @author Toshiaki Maki
+ * @since 1.3.2
+ */
+public class MessagePackHttpMessageConverter
+		extends AbstractJackson2HttpMessageConverter {
+	public MessagePackHttpMessageConverter() {
+		super(new ObjectMapper(new MessagePackFactory()),
+				new MediaType("application", "x-msgpack"));
+	}
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/msgpack/package-info.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/msgpack/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for MessagePack.
+ */
+package org.springframework.boot.autoconfigure.msgpack;

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -56,6 +56,7 @@ org.springframework.boot.autoconfigure.jooq.JooqAutoConfiguration,\
 org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration,\
 org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration,\
 org.springframework.boot.autoconfigure.mail.MailSenderValidatorAutoConfiguration,\
+org.springframework.boot.autoconfigure.msgpack.MessagePackAutoConfiguration,\
 org.springframework.boot.autoconfigure.mobile.DeviceResolverAutoConfiguration,\
 org.springframework.boot.autoconfigure.mobile.DeviceDelegatingViewResolverAutoConfiguration,\
 org.springframework.boot.autoconfigure.mobile.SitePreferenceAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/msgpack/MessagePackAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/msgpack/MessagePackAutoConfigurationTests.java
@@ -23,11 +23,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.mock.http.MockHttpInputMessage;
 import org.springframework.mock.http.MockHttpOutputMessage;
 import org.springframework.web.client.RestTemplate;
@@ -59,7 +61,7 @@ public class MessagePackAutoConfigurationTests {
 
 	@Test
 	public void testMessagePackReadBytes() throws Exception {
-		this.context.register(MessagePackAutoConfiguration.class);
+		this.context.register(MessagePackAutoConfiguration.class, JacksonAutoConfiguration.class);
 		this.context.refresh();
 		HttpMessageConverter converter = this.context
 				.getBean("messagePackHttpMessageConverter", HttpMessageConverter.class);
@@ -76,7 +78,7 @@ public class MessagePackAutoConfigurationTests {
 
 	@Test
 	public void testMessagePackWriteBytes() throws Exception {
-		this.context.register(MessagePackAutoConfiguration.class);
+		this.context.register(MessagePackAutoConfiguration.class, JacksonAutoConfiguration.class);
 		this.context.refresh();
 		HttpMessageConverter converter = this.context
 				.getBean("messagePackHttpMessageConverter", HttpMessageConverter.class);
@@ -96,7 +98,7 @@ public class MessagePackAutoConfigurationTests {
 	public void testRestTempleIncludingAutoMessagePackMessageConverter()
 			throws Exception {
 		this.context.register(MessagePackAutoConfiguration.class,
-				RestTemplateConfig.class);
+				RestTemplateConfig.class, JacksonAutoConfiguration.class);
 		this.context.refresh();
 		RestTemplate restTemplate = this.context.getBean(RestTemplate.class);
 		assertThat(
@@ -109,7 +111,7 @@ public class MessagePackAutoConfigurationTests {
 	public void testRestTempleIncludingManualMessagePackMessageConverter()
 			throws Exception {
 		this.context.register(MessagePackAutoConfiguration.class,
-				MessagePackConfiguredRestTemplateConfig.class);
+				MessagePackConfiguredRestTemplateConfig.class, JacksonAutoConfiguration.class);
 		this.context.refresh();
 		RestTemplate restTemplate = this.context.getBean(RestTemplate.class);
 		assertThat(restTemplate.getMessageConverters().get(0),
@@ -127,11 +129,11 @@ public class MessagePackAutoConfigurationTests {
 	@Configuration
 	static class MessagePackConfiguredRestTemplateConfig {
 		@Bean
-		public RestTemplate restTemplate() {
+		public RestTemplate restTemplate(Jackson2ObjectMapperBuilder builder) {
 			RestTemplate restTemplate = new RestTemplate();
 			// add first
 			restTemplate.getMessageConverters().add(0,
-					new MessagePackHttpMessageConverter());
+					new MessagePackHttpMessageConverter(builder));
 			return restTemplate;
 		}
 	}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/msgpack/MessagePackAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/msgpack/MessagePackAutoConfigurationTests.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.msgpack;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.mock.http.MockHttpInputMessage;
+import org.springframework.mock.http.MockHttpOutputMessage;
+import org.springframework.web.client.RestTemplate;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link MessagePackAutoConfiguration}.
+ *
+ * @author Toshiaki Maki
+ * @since 1.3.2
+ */
+public class MessagePackAutoConfigurationTests {
+	AnnotationConfigApplicationContext context;
+
+	@Before
+	public void setUp() {
+		this.context = new AnnotationConfigApplicationContext();
+	}
+
+	@After
+	public void tearDown() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void testMessagePackReadBytes() throws Exception {
+		this.context.register(MessagePackAutoConfiguration.class);
+		this.context.refresh();
+		HttpMessageConverter converter = this.context
+				.getBean("messagePackHttpMessageConverter", HttpMessageConverter.class);
+
+		byte[] body = { -126, -93, 102, 111, 111, -91, 104, 101, 108, 108, 111, -93, 98,
+				97, 114, -91, 119, 111, 114, 108, 100 };
+		MockHttpInputMessage request = new MockHttpInputMessage(body);
+		request.getHeaders().setContentType(new MediaType("application", "x-msgpack"));
+		Map map = (Map) converter.read(Map.class, request);
+		assertThat(map.size(), is(2));
+		assertThat(map.get("foo"), is((Object) "hello"));
+		assertThat(map.get("bar"), is((Object) "world"));
+	}
+
+	@Test
+	public void testMessagePackWriteBytes() throws Exception {
+		this.context.register(MessagePackAutoConfiguration.class);
+		this.context.refresh();
+		HttpMessageConverter converter = this.context
+				.getBean("messagePackHttpMessageConverter", HttpMessageConverter.class);
+
+		Map<String, Object> obj = new LinkedHashMap<String, Object>();
+		obj.put("foo", "hello");
+		obj.put("bar", "world");
+		MockHttpOutputMessage response = new MockHttpOutputMessage();
+		converter.write(obj, new MediaType("application", "x-msgpack"), response);
+
+		byte[] body = { -126, -93, 102, 111, 111, -91, 104, 101, 108, 108, 111, -93, 98,
+				97, 114, -91, 119, 111, 114, 108, 100 };
+		assertThat(response.getBodyAsBytes(), is(body));
+	}
+
+	@Test
+	public void testRestTempleIncludingAutoMessagePackMessageConverter()
+			throws Exception {
+		this.context.register(MessagePackAutoConfiguration.class,
+				RestTemplateConfig.class);
+		this.context.refresh();
+		RestTemplate restTemplate = this.context.getBean(RestTemplate.class);
+		assertThat(
+				restTemplate.getMessageConverters()
+						.get(restTemplate.getMessageConverters().size() - 1),
+				is(instanceOf(MessagePackHttpMessageConverter.class)));
+	}
+
+	@Test
+	public void testRestTempleIncludingManualMessagePackMessageConverter()
+			throws Exception {
+		this.context.register(MessagePackAutoConfiguration.class,
+				MessagePackConfiguredRestTemplateConfig.class);
+		this.context.refresh();
+		RestTemplate restTemplate = this.context.getBean(RestTemplate.class);
+		assertThat(restTemplate.getMessageConverters().get(0),
+				is(instanceOf(MessagePackHttpMessageConverter.class)));
+	}
+
+	@Configuration
+	static class RestTemplateConfig {
+		@Bean
+		public RestTemplate restTemplate() {
+			return new RestTemplate();
+		}
+	}
+
+	@Configuration
+	static class MessagePackConfiguredRestTemplateConfig {
+		@Bean
+		public RestTemplate restTemplate() {
+			RestTemplate restTemplate = new RestTemplate();
+			// add first
+			restTemplate.getMessageConverters().add(0,
+					new MessagePackHttpMessageConverter());
+			return restTemplate;
+		}
+	}
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -114,7 +114,7 @@
 		<log4j2.version>2.4.1</log4j2.version>
 		<logback.version>1.1.3</logback.version>
 		<mariadb.version>1.2.3</mariadb.version>
-		<msgpack.version>0.7.1</msgpack.version>
+		<msgpack.version>0.8.0</msgpack.version>
 		<mockito.version>1.10.19</mockito.version>
 		<mongodb.version>2.13.3</mongodb.version>
 		<mysql.version>5.1.38</mysql.version>

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -114,6 +114,7 @@
 		<log4j2.version>2.4.1</log4j2.version>
 		<logback.version>1.1.3</logback.version>
 		<mariadb.version>1.2.3</mariadb.version>
+		<msgpack.version>0.7.1</msgpack.version>
 		<mockito.version>1.10.19</mockito.version>
 		<mongodb.version>2.13.3</mongodb.version>
 		<mysql.version>5.1.38</mysql.version>
@@ -1621,6 +1622,11 @@
 				<groupId>org.mariadb.jdbc</groupId>
 				<artifactId>mariadb-java-client</artifactId>
 				<version>${mariadb.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.msgpack</groupId>
+				<artifactId>jackson-dataformat-msgpack</artifactId>
+				<version>${msgpack.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mockito</groupId>

--- a/spring-boot-samples/pom.xml
+++ b/spring-boot-samples/pom.xml
@@ -67,6 +67,7 @@
 		<module>spring-boot-sample-metrics-dropwizard</module>
 		<module>spring-boot-sample-metrics-opentsdb</module>
 		<module>spring-boot-sample-metrics-redis</module>
+		<module>spring-boot-sample-msgpack</module>
 		<module>spring-boot-sample-parent-context</module>
 		<module>spring-boot-sample-profile</module>
 		<module>spring-boot-sample-property-validation</module>

--- a/spring-boot-samples/spring-boot-sample-msgpack/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-msgpack/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<!-- Your own application should inherit from spring-boot-starter-parent -->
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-samples</artifactId>
+		<version>1.3.2.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-sample-msgpack</artifactId>
+	<name>Spring Boot MessagePack Sample</name>
+	<description>Spring Boot MessagePack Sample</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-tomcat</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.msgpack</groupId>
+			<artifactId>jackson-dataformat-msgpack</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-samples/spring-boot-sample-msgpack/src/main/java/sample/msgpack/CalcController.java
+++ b/spring-boot-samples/spring-boot-sample-msgpack/src/main/java/sample/msgpack/CalcController.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.msgpack;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CalcController {
+
+	@RequestMapping("/calc")
+	public CalcResult calc(@RequestParam("left") int left,
+			@RequestParam("right") int right) {
+		return new CalcResult(left, right, left + right);
+	}
+}

--- a/spring-boot-samples/spring-boot-sample-msgpack/src/main/java/sample/msgpack/CalcResult.java
+++ b/spring-boot-samples/spring-boot-sample-msgpack/src/main/java/sample/msgpack/CalcResult.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.msgpack;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CalcResult {
+	private final int left;
+	private final int right;
+	private final long result;
+
+	@JsonCreator
+	public CalcResult(@JsonProperty("left") int left, @JsonProperty("right") int right,
+			@JsonProperty("result") long result) {
+		this.left = left;
+		this.right = right;
+		this.result = result;
+	}
+
+	public int getLeft() {
+		return left;
+	}
+
+	public int getRight() {
+		return right;
+	}
+
+	public long getResult() {
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+
+		CalcResult that = (CalcResult) o;
+
+		if (left != that.left)
+			return false;
+		if (right != that.right)
+			return false;
+		return result == that.result;
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result1 = left;
+		result1 = 31 * result1 + right;
+		result1 = 31 * result1 + (int) (result ^ (result >>> 32));
+		return result1;
+	}
+}

--- a/spring-boot-samples/spring-boot-sample-msgpack/src/main/java/sample/msgpack/HelloController.java
+++ b/spring-boot-samples/spring-boot-sample-msgpack/src/main/java/sample/msgpack/HelloController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class HelloController {
 	@RequestMapping("/")
 	public Map<String, Object> hello() {
-		Map<String, Object> obj = new LinkedHashMap<>();
+		Map<String, Object> obj = new LinkedHashMap<String, Object>();
 		obj.put("foo", "hello");
 		obj.put("bar", "world");
 		return obj;

--- a/spring-boot-samples/spring-boot-sample-msgpack/src/main/java/sample/msgpack/HelloController.java
+++ b/spring-boot-samples/spring-boot-sample-msgpack/src/main/java/sample/msgpack/HelloController.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.msgpack;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+	@RequestMapping("/")
+	public Map<String, Object> hello() {
+		Map<String, Object> obj = new LinkedHashMap<>();
+		obj.put("foo", "hello");
+		obj.put("bar", "world");
+		return obj;
+	}
+}

--- a/spring-boot-samples/spring-boot-sample-msgpack/src/main/java/sample/msgpack/SampleMessagePackApplication.java
+++ b/spring-boot-samples/spring-boot-sample-msgpack/src/main/java/sample/msgpack/SampleMessagePackApplication.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.msgpack;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
+
+@SpringBootApplication
+public class SampleMessagePackApplication {
+
+	public static void main(String[] args) throws Exception {
+		SpringApplication.run(SampleMessagePackApplication.class, args);
+	}
+
+	@Bean
+	RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/spring-boot-samples/spring-boot-sample-msgpack/src/test/java/sample/msgpack/SampleMessagePackApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-msgpack/src/test/java/sample/msgpack/SampleMessagePackApplicationTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.msgpack;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Integration tests for MessagePack.
+ *
+ * @author Toshiaki Maki
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(SampleMessagePackApplication.class)
+@WebIntegrationTest(randomPort = true)
+@DirtiesContext
+public class SampleMessagePackApplicationTests {
+
+	@Value("${local.server.port}")
+	private int port;
+	@Autowired
+	RestTemplate restTemplate;
+
+	ParameterizedTypeReference<Map<String, Object>> mapTypeRef = new ParameterizedTypeReference<Map<String, Object>>() {
+
+	};
+
+	@Test
+	public void testHelloMessagePackAsBytes() throws Exception {
+		RequestEntity req = RequestEntity.get(URI.create("http://localhost:" + this.port))
+				.accept(MediaType.parseMediaType("application/x-msgpack")).build();
+		ResponseEntity<byte[]> entity = restTemplate.exchange(req, byte[].class);
+		assertThat(entity.getStatusCode(), is(HttpStatus.OK));
+		assertThat(entity.getHeaders().getContentType().getType(), is("application"));
+		assertThat(entity.getHeaders().getContentType().getSubtype(), is("x-msgpack"));
+		byte[] body = { -126, -93, 102, 111, 111, -91, 104, 101, 108, 108, 111, -93, 98,
+				97, 114, -91, 119, 111, 114, 108, 100 }; // less than JSON
+		assertThat(entity.getBody(), is(body));
+	}
+
+	@Test
+	public void testHelloJsonAsBytes() throws Exception {
+		RequestEntity req = RequestEntity.get(URI.create("http://localhost:" + this.port))
+				.accept(MediaType.parseMediaType("application/json")).build();
+		ResponseEntity<byte[]> entity = restTemplate.exchange(req, byte[].class);
+		assertThat(entity.getStatusCode(), is(HttpStatus.OK));
+		assertThat(entity.getHeaders().getContentType().getType(), is("application"));
+		assertThat(entity.getHeaders().getContentType().getSubtype(), is("json"));
+		byte[] body = { 123, 34, 102, 111, 111, 34, 58, 34, 104, 101, 108, 108, 111, 34,
+				44, 34, 98, 97, 114, 34, 58, 34, 119, 111, 114, 108, 100, 34, 125 };
+		assertThat(entity.getBody(), is(body));
+	}
+
+	@Test
+	public void testHelloMessagePackAsObject() throws Exception {
+		RequestEntity req = RequestEntity.get(URI.create("http://localhost:" + this.port))
+				.accept(MediaType.parseMediaType("application/x-msgpack")).build();
+		ResponseEntity<Map<String, Object>> entity = restTemplate.exchange(req,
+				mapTypeRef);
+		assertThat(entity.getStatusCode(), is(HttpStatus.OK));
+		assertThat(entity.getHeaders().getContentType().getType(), is("application"));
+		assertThat(entity.getHeaders().getContentType().getSubtype(), is("x-msgpack"));
+		Map<String, Object> obj = new LinkedHashMap<>();
+		obj.put("foo", "hello");
+		obj.put("bar", "world");
+		assertThat(entity.getBody(), is(obj));
+	}
+
+	@Test
+	public void testHelloJsonAsObject() throws Exception {
+		RequestEntity req = RequestEntity.get(URI.create("http://localhost:" + this.port))
+				.accept(MediaType.parseMediaType("application/json")).build();
+		ResponseEntity<Map<String, Object>> entity = restTemplate.exchange(req,
+				mapTypeRef);
+		assertThat(entity.getStatusCode(), is(HttpStatus.OK));
+		assertThat(entity.getHeaders().getContentType().getType(), is("application"));
+		assertThat(entity.getHeaders().getContentType().getSubtype(), is("json"));
+		Map<String, Object> obj = new LinkedHashMap<>();
+		obj.put("foo", "hello");
+		obj.put("bar", "world");
+		assertThat(entity.getBody(), is(obj));
+	}
+
+	@Test
+	public void testCalcMessagePackAsObject() throws Exception {
+		RequestEntity req = RequestEntity
+				.get(URI.create(
+						"http://localhost:" + this.port + "/calc?left=100&right=200"))
+				.accept(MediaType.parseMediaType("application/x-msgpack")).build();
+		ResponseEntity<CalcResult> entity = restTemplate.exchange(req, CalcResult.class);
+		assertThat(entity.getStatusCode(), is(HttpStatus.OK));
+		assertThat(entity.getHeaders().getContentType().getType(), is("application"));
+		assertThat(entity.getHeaders().getContentType().getSubtype(), is("x-msgpack"));
+		assertThat(entity.getBody(), is(new CalcResult(100, 200, 300)));
+	}
+
+	@Test
+	public void testCalcJsonObject() throws Exception {
+		RequestEntity req = RequestEntity
+				.get(URI.create(
+						"http://localhost:" + this.port + "/calc?left=100&right=200"))
+				.accept(MediaType.parseMediaType("application/json")).build();
+		ResponseEntity<CalcResult> entity = restTemplate.exchange(req, CalcResult.class);
+		assertThat(entity.getStatusCode(), is(HttpStatus.OK));
+		assertThat(entity.getHeaders().getContentType().getType(), is("application"));
+		assertThat(entity.getHeaders().getContentType().getSubtype(), is("json"));
+		assertThat(entity.getBody(), is(new CalcResult(100, 200, 300)));
+	}
+}

--- a/spring-boot-samples/spring-boot-sample-msgpack/src/test/java/sample/msgpack/SampleMessagePackApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-msgpack/src/test/java/sample/msgpack/SampleMessagePackApplicationTests.java
@@ -93,7 +93,7 @@ public class SampleMessagePackApplicationTests {
 		assertThat(entity.getStatusCode(), is(HttpStatus.OK));
 		assertThat(entity.getHeaders().getContentType().getType(), is("application"));
 		assertThat(entity.getHeaders().getContentType().getSubtype(), is("x-msgpack"));
-		Map<String, Object> obj = new LinkedHashMap<>();
+		Map<String, Object> obj = new LinkedHashMap<String, Object>();
 		obj.put("foo", "hello");
 		obj.put("bar", "world");
 		assertThat(entity.getBody(), is(obj));
@@ -108,7 +108,7 @@ public class SampleMessagePackApplicationTests {
 		assertThat(entity.getStatusCode(), is(HttpStatus.OK));
 		assertThat(entity.getHeaders().getContentType().getType(), is("application"));
 		assertThat(entity.getHeaders().getContentType().getSubtype(), is("json"));
-		Map<String, Object> obj = new LinkedHashMap<>();
+		Map<String, Object> obj = new LinkedHashMap<String, Object>();
 		obj.put("foo", "hello");
 		obj.put("bar", "world");
 		assertThat(entity.getBody(), is(obj));


### PR DESCRIPTION
Added AutoConfigure for [MessagePack](https://github.com/msgpack/msgpack-java).
MessagePack is an efficient binary serialization format. It's like JSON but fast and small.

This PR supports MessagePack by adding `HttpMessageConverter` for MessagePack to Spring MVC and `RestTemplate`.

Only HTTP clients have to do is specifying `Accept` header with `application/x-msgpack`  to access the MessagePack format.

This format would be helpful for the communication between services.
