### PR TITLE
Use fast exceptions in findResource(s) in LaunchedURLClassLoader

### DIFF
--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/LaunchedURLClassLoader.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/LaunchedURLClassLoader.java
@@ -82,7 +82,13 @@ public class LaunchedURLClassLoader extends URLClassLoader {
 			if (name.equals("") && hasURLs()) {
 				return getURLs()[0];
 			}
-			return super.findResource(name);
+			Handler.setUseFastConnectionExceptions(true);
+			try {
+				return super.findResource(name);
+			}
+			finally {
+				Handler.setUseFastConnectionExceptions(false);
+			}
 		}
 		catch (IllegalArgumentException ex) {
 			return null;
@@ -94,7 +100,13 @@ public class LaunchedURLClassLoader extends URLClassLoader {
 		if (name.equals("") && hasURLs()) {
 			return Collections.enumeration(Arrays.asList(getURLs()));
 		}
-		return super.findResources(name);
+		Handler.setUseFastConnectionExceptions(true);
+		try {
+			return super.findResources(name);
+		}
+		finally {
+			Handler.setUseFastConnectionExceptions(false);
+		}
 	}
 
 	private boolean hasURLs() {
@@ -291,6 +303,6 @@ public class LaunchedURLClassLoader extends URLClassLoader {
 			return this.localResources.nextElement();
 		}
 
-	};
+	}
 
 }


### PR DESCRIPTION
Some libraries like aspectj are using findResource to see the raw bytecode of a class.
It will even call findResource for every method of every class of beans that are post processed.
This can be significant performance hit on startup when LaunchedURLClassLoader is used and there are a lot of nested jars.

Related gh-3640
Fix gh-4557