### PR TITLE
Issue 4593: Resolve issue of inconsistent thread synchronization

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/EmbeddedWebApplicationContext.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/EmbeddedWebApplicationContext.java
@@ -136,7 +136,7 @@ public class EmbeddedWebApplicationContext extends GenericWebApplicationContext 
 	}
 
 	@Override
-	protected void finishRefresh() {
+	protected synchronized void finishRefresh() {
 		super.finishRefresh();
 		startEmbeddedServletContainer();
 		if (this.embeddedServletContainer != null) {
@@ -285,7 +285,7 @@ public class EmbeddedWebApplicationContext extends GenericWebApplicationContext 
 		}
 	}
 
-	private void startEmbeddedServletContainer() {
+	private synchronized void startEmbeddedServletContainer() {
 		if (this.embeddedServletContainer != null) {
 			this.embeddedServletContainer.start();
 		}


### PR DESCRIPTION
FindBugs identified an inconsistent thread synchronization issue for spring-boot in the `EmbeddedWebApplicationContext` class. When `finishRefresh()` was unsynchronized, it was possible for `embeddedServletContainer` to be set to `null` before `publishEvent()` was called. Synchronizing the method makes all accesses of this field consistent.