### PR TITLE
Use start-stop-daemon only if all options are supported

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -131,6 +131,9 @@ do_start() {
     chown "$run_user" "$pid_file"
     chown "$run_user" "$log_file"
     if which start-stop-daemon >/dev/null; then
+      hasMinimalStartStopDaemonVersion=$( start-stop-daemon --version | awk '{ match($0, /[0-9]+\.[0-9]+\.[0-9]+/, a) } END { print a[0], "*"; print "1.16.5" }' | sort -V -r | awk 'NR==1 && $2=="*" { print "true" }' )
+    fi
+    if [[ -n $hasMinimalStartStopDaemonVersion ]]; then
       start-stop-daemon --start --quiet \
         --chuid $run_user \
         --name $identity \


### PR DESCRIPTION
Depending on the existence of start-stop-daemon isn't enough, as several options are not supported by older versions. The first version shipped by dpkg that consumes all options used here is 1.16.5 (--no-close has been introduced in dpkgs repository with commit 3de1552).

SLES11 is shipping start-stop-daemon in version 0.3.1 as part of the package sysvinit:
```
start-stop-daemon --help
start-stop-daemon for Debian Linux - small and fast C version written by
Marek Michalkiewicz <marekm@i17linuxb.ists.pwr.wroc.pl>, public domain.
version 0.3.1, 1996-07-19

Usage:
    start-stop-daemon -S|--start options ... -- arguments ...
    start-stop-daemon -K|--stop options ...
    start-stop-daemon -H|--help
    start-stop-daemon -V|--version

Options (at least one of --exec|--pidfile|--user is required):
    -x|--exec <executable>       program to start/check if it is running
    -p|--pidfile <pid-file>      pid file to check
    -u|--user <username>|<uid>   stop this user's processes
    -n|--name <process-name>     start/stop processes with this name
    -s|--signal <signal>         signal to send (default 15)
    -t|--test                    test mode, don't do anything
    -o|--oknodo                  exit status 0 (not 1) if nothing done
    -q|--quiet  |  -v, --verbose

Exit status:  0 = done  1 = nothing done (=> 0 if --oknodo)  2 = trouble
```