### PR TITLE
Adding a shutdown hook to the StartMojo so the forked child process is terminated if the parent maven build dies

### DIFF
--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StartMojo.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StartMojo.java
@@ -105,8 +105,14 @@ public class StartMojo extends AbstractRunMojo {
 
 	private RunProcess runProcess(List<String> args) throws MojoExecutionException {
 		try {
-			RunProcess runProcess = new RunProcess(new JavaExecutable().toString());
+			final RunProcess runProcess = new RunProcess(new JavaExecutable().toString());
 			runProcess.run(false, args.toArray(new String[args.size()]));
+			Runtime.getRuntime().addShutdownHook(new Thread() {
+				@Override
+				public void start() {
+					runProcess.kill();
+				}
+			});
 			return runProcess;
 		}
 		catch (Exception ex) {


### PR DESCRIPTION
Response to issue: https://github.com/spring-projects/spring-boot/issues/4620 