### PR TITLE
Move ApplicationEventPublisherAware implementation to abstract audit listeners

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AbstractAuthenticationAuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AbstractAuthenticationAuditListener.java
@@ -17,6 +17,8 @@
 package org.springframework.boot.actuate.security;
 
 import org.springframework.boot.actuate.audit.AuditEvent;
+import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.ApplicationListener;
 import org.springframework.security.authentication.event.AbstractAuthenticationEvent;
@@ -31,5 +33,22 @@ import org.springframework.security.authentication.event.AbstractAuthenticationE
  */
 public abstract class AbstractAuthenticationAuditListener implements
 		ApplicationListener<AbstractAuthenticationEvent>, ApplicationEventPublisherAware {
+
+	private ApplicationEventPublisher publisher;
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+		this.publisher = publisher;
+	}
+
+	protected ApplicationEventPublisher getPublisher() {
+		return this.publisher;
+	}
+
+	protected void publish(AuditEvent event) {
+		if (getPublisher() != null) {
+			getPublisher().publishEvent(new AuditApplicationEvent(event));
+		}
+	}
 
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AbstractAuthorizationAuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AbstractAuthorizationAuditListener.java
@@ -17,6 +17,8 @@
 package org.springframework.boot.actuate.security;
 
 import org.springframework.boot.actuate.audit.AuditEvent;
+import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.ApplicationListener;
 import org.springframework.security.access.event.AbstractAuthorizationEvent;
@@ -31,5 +33,22 @@ import org.springframework.security.access.event.AbstractAuthorizationEvent;
  */
 public abstract class AbstractAuthorizationAuditListener implements
 		ApplicationListener<AbstractAuthorizationEvent>, ApplicationEventPublisherAware {
+
+	private ApplicationEventPublisher publisher;
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+		this.publisher = publisher;
+	}
+
+	protected ApplicationEventPublisher getPublisher() {
+		return this.publisher;
+	}
+
+	protected void publish(AuditEvent event) {
+		if (getPublisher() != null) {
+			getPublisher().publishEvent(new AuditApplicationEvent(event));
+		}
+	}
 
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthenticationAuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthenticationAuditListener.java
@@ -20,8 +20,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.boot.actuate.audit.AuditEvent;
-import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.event.AbstractAuthenticationEvent;
 import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
@@ -29,7 +27,7 @@ import org.springframework.security.web.authentication.switchuser.Authentication
 import org.springframework.util.ClassUtils;
 
 /**
- * Default implementation of {@link AuthenticationAuditListener}.
+ * Default implementation of {@link AbstractAuthenticationAuditListener}.
  *
  * @author Dave Syer
  */
@@ -37,14 +35,7 @@ public class AuthenticationAuditListener extends AbstractAuthenticationAuditList
 
 	private static final String WEB_LISTENER_CHECK_CLASS = "org.springframework.security.web.authentication.switchuser.AuthenticationSwitchUserEvent";
 
-	private ApplicationEventPublisher publisher;
-
 	private WebAuditListener webListener = maybeCreateWebListener();
-
-	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
-		this.publisher = publisher;
-	}
 
 	private static WebAuditListener maybeCreateWebListener() {
 		if (ClassUtils.isPresent(WEB_LISTENER_CHECK_CLASS, null)) {
@@ -81,12 +72,6 @@ public class AuthenticationAuditListener extends AbstractAuthenticationAuditList
 		}
 		publish(new AuditEvent(event.getAuthentication().getName(),
 				"AUTHENTICATION_SUCCESS", data));
-	}
-
-	private void publish(AuditEvent event) {
-		if (this.publisher != null) {
-			this.publisher.publishEvent(new AuditApplicationEvent(event));
-		}
 	}
 
 	private static class WebAuditListener {

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthorizationAuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthorizationAuditListener.java
@@ -20,25 +20,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.boot.actuate.audit.AuditEvent;
-import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.event.AbstractAuthorizationEvent;
 import org.springframework.security.access.event.AuthenticationCredentialsNotFoundEvent;
 import org.springframework.security.access.event.AuthorizationFailureEvent;
 
 /**
- * Default implementation of {@link AuthorizationAuditListener}.
+ * Default implementation of {@link AbstractAuthorizationAuditListener}.
  *
  * @author Dave Syer
  */
 public class AuthorizationAuditListener extends AbstractAuthorizationAuditListener {
-
-	private ApplicationEventPublisher publisher;
-
-	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
-		this.publisher = publisher;
-	}
 
 	@Override
 	public void onApplicationEvent(AbstractAuthorizationEvent event) {
@@ -65,12 +56,6 @@ public class AuthorizationAuditListener extends AbstractAuthorizationAuditListen
 		data.put("message", event.getAccessDeniedException().getMessage());
 		publish(new AuditEvent(event.getAuthentication().getName(),
 				"AUTHORIZATION_FAILURE", data));
-	}
-
-	private void publish(AuditEvent event) {
-		if (this.publisher != null) {
-			this.publisher.publishEvent(new AuditApplicationEvent(event));
-		}
 	}
 
 }


### PR DESCRIPTION
While adopting our project to changes from #4406, some room for further improvements was noticed.

Since newly created abstract audit listener classes implement ```ApplicationEventPublisherAware```, ```ApplicationEventPublisher``` related code could safely be moved from implementation to abstract audit listener classes. IMO this would also make those classes more useful.

I've signed the CLA.