### PR TITLE
Upgrade liquibase to 3.4.2

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -109,7 +109,7 @@
 		<json-path.version>2.0.0</json-path.version>
 		<jstl.version>1.2</jstl.version>
 		<junit.version>4.12</junit.version>
-		<liquibase.version>3.4.1</liquibase.version>
+		<liquibase.version>3.4.2</liquibase.version>
 		<log4j.version>1.2.17</log4j.version>
 		<log4j2.version>2.4.1</log4j2.version>
 		<logback.version>1.1.3</logback.version>

--- a/spring-boot/src/main/java/org/springframework/boot/liquibase/LiquibaseServiceLocatorApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/liquibase/LiquibaseServiceLocatorApplicationListener.java
@@ -51,8 +51,6 @@ public class LiquibaseServiceLocatorApplicationListener
 	private static class LiquibasePresent {
 
 		public void replaceServiceLocator() {
-			ServiceLocator.getInstance().addPackageToScan(
-					CommonsLoggingLiquibaseLogger.class.getPackage().getName());
 			ServiceLocator.setInstance(new CustomResolverServiceLocator(
 					new SpringPackageScanClassResolver(logger)));
 		}


### PR DESCRIPTION
- Fixes gh-4591
- Remove 3.4.1 logger workaround (adding package to default service)
- Liquibase relevant issue: CORE-2436