### PR TITLE
Changed run task to bootRun

### DIFF
--- a/spring-boot-samples/spring-boot-sample-simple/build.gradle
+++ b/spring-boot-samples/spring-boot-sample-simple/build.gradle
@@ -25,7 +25,7 @@ jar {
 	version =  '0.0.0'
 }
 
-run {
+bootRun {
   systemProperties = System.properties
 }
 


### PR DESCRIPTION
Applied spring-boot-gradle-plugin version doesn't provide a run task, but bootRun. Trying to build the project with Gradle with the run task in the build.script cause "Could not find method run()" exception.