### PR TITLE
spring-boot-actuator-docs should not have a transitive dependency on h2

### DIFF
--- a/spring-boot-actuator-docs/pom.xml
+++ b/spring-boot-actuator-docs/pom.xml
@@ -32,6 +32,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
When you add spring-boot-actuator-docs as dependency using Spring Boot 1.3 you also get h2 as dependency. This may lead to conflicts with other (embedded) database drivers or the DataSourceAutoConfiguration support in Spring Boot.

For example: If you use flyway and hsqldb for your integration tests and have a dependency on spring-boot-actuator-docs, flyway will pick h2 instead of hsqldb.

This patch will make sure h2 is added with test scope.