### PR TITLE
Make the build work for Windows

### DIFF
--- a/spring-boot-parent/src/checkstyle/checkstyle.xml
+++ b/spring-boot-parent/src/checkstyle/checkstyle.xml
@@ -7,7 +7,9 @@
 		<property name="headerFile" value="${checkstyle.header.file}" />
 		<property name="fileExtensions" value="java" />
 	</module>
-	<module name="NewlineAtEndOfFile" />
+	<module name="NewlineAtEndOfFile">
+		<property name="lineSeparator" value="lf"/>
+	</module>
 
 	<!-- TreeWalker Checks -->
 	<module name="TreeWalker">


### PR DESCRIPTION
Checkstyle by default uses the system line separator.
Which works for Mac, Linux..
But doesn't for Windows.

This makes Checkstyle happy again.
Let me know whether I need to sign the CLA for this.