### PR TITLE
Fix undertow access_log file name

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
@@ -384,7 +384,7 @@ public class UndertowEmbeddedServletContainerFactory
 		try {
 			createAccessLogDirectoryIfNecessary();
 			AccessLogReceiver accessLogReceiver = new DefaultAccessLogReceiver(
-					createWorker(), this.accessLogDirectory, "access_log");
+					createWorker(), this.accessLogDirectory, "access_log.");
 			String formatString = (this.accessLogPattern != null) ? this.accessLogPattern
 					: "common";
 			return new AccessLogHandler(handler, accessLogReceiver, formatString,


### PR DESCRIPTION
Undertow 1.3.7 changed the default access log file suffix from '.log' to just 'log'. Thus we need to adapt the file name pattern to include the missing dot. 

Otherwise the resulting access log file will be called `access_loglog` instead of `access_log.log`.