### PR TITLE
Fix ordering of Math.abs() call

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/config/RandomValuePropertySource.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/config/RandomValuePropertySource.java
@@ -110,11 +110,11 @@ public class RandomValuePropertySource extends PropertySource<Random> {
 	private long getNextLongInRange(String range) {
 		String[] tokens = StringUtils.commaDelimitedListToStringArray(range);
 		if (tokens.length == 1) {
-			return Math.abs(getSource().nextLong()) % Long.parseLong(tokens[0]);
+			return Math.abs(getSource().nextLong() % Long.parseLong(tokens[0]));
 		}
 		long lowerBound = Long.parseLong(tokens[0]);
 		long upperBound = Long.parseLong(tokens[1]) - lowerBound;
-		return lowerBound + Math.abs(getSource().nextLong()) % upperBound;
+		return lowerBound + Math.abs(getSource().nextLong() % upperBound);
 	}
 
 	private Object getRandomBytes() {

--- a/spring-boot/src/test/java/org/springframework/boot/context/config/RandomValuePropertySourceTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/config/RandomValuePropertySourceTests.java
@@ -16,7 +16,10 @@
 
 package org.springframework.boot.context.config;
 
+import java.util.Random;
+
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -81,6 +84,22 @@ public class RandomValuePropertySourceTests {
 	public void longMax() {
 		Long value = (Long) this.source.getProperty("random.long(10)");
 		assertNotNull(value);
+		assertTrue(value < 10L);
+	}
+
+	@Test
+	public void longOverflow() {
+		RandomValuePropertySource source = Mockito.spy(this.source);
+		Mockito.when(source.getSource()).thenReturn(new Random() {
+			@Override
+			public long nextLong() {
+				// constant that used to become -8, now becomes 8
+				return Long.MIN_VALUE;
+			}
+		});
+		Long value = (Long) source.getProperty("random.long(10)");
+		assertNotNull(value);
+		assertTrue(value >= 0L);
 		assertTrue(value < 10L);
 	}
 }


### PR DESCRIPTION
Currently, when the random source returns Long.MIN_VALUE, the sign bit can't be unset.
So the random value stays negative.

I take it that I will have to sign the CLA if you want to incorporate this?