### PR TITLE
Improve AbstractHealthAggregator to allow customization of aggregated details

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/AbstractHealthAggregator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/AbstractHealthAggregator.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.actuate.health;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -26,6 +25,7 @@ import java.util.Map;
  * aggregating the {@link Status} instances and not deal with contextual details etc.
  *
  * @author Christian Dupuis
+ * @author Vedran Pavic
  * @since 1.1.0
  */
 public abstract class AbstractHealthAggregator implements HealthAggregator {
@@ -33,12 +33,11 @@ public abstract class AbstractHealthAggregator implements HealthAggregator {
 	@Override
 	public final Health aggregate(Map<String, Health> healths) {
 		List<Status> statusCandidates = new ArrayList<Status>();
-		Map<String, Object> details = new LinkedHashMap<String, Object>();
 		for (Map.Entry<String, Health> entry : healths.entrySet()) {
-			details.put(entry.getKey(), entry.getValue());
 			statusCandidates.add(entry.getValue().getStatus());
 		}
-		return new Health.Builder(aggregateStatus(statusCandidates), details).build();
+		return new Health.Builder(
+				aggregateStatus(statusCandidates), aggregateDetails(healths)).build();
 	}
 
 	/**
@@ -48,5 +47,13 @@ public abstract class AbstractHealthAggregator implements HealthAggregator {
 	 * @return a single status
 	 */
 	protected abstract Status aggregateStatus(List<Status> candidates);
+
+	/**
+	 * Return the map of 'aggregate' details that should be used from the specified
+	 * healths.
+	 * @param healths the health instances to aggregate
+	 * @return a map of details
+	 */
+	protected abstract Map<String, Object> aggregateDetails(Map<String, Health> healths);
 
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/OrderedHealthAggregator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/OrderedHealthAggregator.java
@@ -20,7 +20,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.util.Assert;
 
@@ -32,6 +34,7 @@ import org.springframework.util.Assert;
  * can be set by calling {@link #setStatusOrder(List)}.
  *
  * @author Christian Dupuis
+ * @author Vedran Pavic
  * @since 1.1.0
  */
 public class OrderedHealthAggregator extends AbstractHealthAggregator {
@@ -82,6 +85,11 @@ public class OrderedHealthAggregator extends AbstractHealthAggregator {
 		// Sort given Status instances by configured order
 		Collections.sort(filteredCandidates, new StatusComparator(this.statusOrder));
 		return filteredCandidates.get(0);
+	}
+
+	@Override
+	protected Map<String, Object> aggregateDetails(Map<String, Health> healths) {
+		return new LinkedHashMap<String, Object>(healths);
 	}
 
 	/**


### PR DESCRIPTION
ATM ```AbstractHealthAggregator``` allows customization of how aggregated status is calculated, but does not allow users to specify their own representation of aggregated details. And due to ```aggregate``` method being declared as ```final``` there is no elegant way of making such customization.

This PR adds ```abstract``` method to allow the subclasses to define how aggregated details are constructed.

Motivation:
In our current project we integrate with a proprietary external system. To monitor the connection(s) to this system we have implemented custom ```HealthIndicator```. Usually there are multiple instances of this system, with number of instances being determined in runtime. To represent the health of connection we use ```CompositeHealthIndicator``` which is composed of multiple instances of our custom ```HealthIndicator``` which, by default (```OrderedHealthAggregator``` is being used), results in the following health output:

```
{
    // other health checks omitted for brevity
    "custom": {
        "custom_1": {
            "status": "UP", 
            ...
        }, 
        "custom_2": {
            "status": "UP", 
            ...
        }, 
        "custom_3": {
            "status": "UP", 
            ...
        }, 
        "status": "UP"
    }, 
    "status": "UP"
}
```

However, due to dynamic nature of number of nested ```HealthIndicator```s the desired representation of details would be an array:

```
{
    // other health checks omitted for brevity
    "custom": {
        "nodes": [
            {
                "status": "UP", 
                ...
            }, 
            {
                "status": "UP", 
                ...
            }, 
            {
                "status": "UP", 
                ...
            }
        ], 
        "status": "UP"
    }, 
    "status": "UP"
}
```

I've signed the CLA.