### PR TITLE
Support disabling of redis autoconfiguration via config property.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties.Sentinel;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -53,9 +54,11 @@ import org.springframework.util.StringUtils;
  * @author Christoph Strobl
  * @author Phillip Webb
  * @author Eddú Meléndez
+ * @author Simon Buettner
  */
 @Configuration
 @ConditionalOnClass({ JedisConnection.class, RedisOperations.class, Jedis.class })
+@ConditionalOnProperty(prefix = "spring.redis", value = "enabled", matchIfMissing = true)
 @EnableConfigurationProperties
 public class RedisAutoConfiguration {
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -24,9 +24,15 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Dave Syer
  * @author Christoph Strobl
  * @author Eddú Meléndez
+ * @author Simon Buettner
  */
 @ConfigurationProperties(prefix = "spring.redis")
 public class RedisProperties {
+
+	/**
+	 * Enables or disables redis autoconfiguration.
+	 */
+	private boolean enabled = true;
 
 	/**
 	 * Database index used by the connection factory.
@@ -56,6 +62,14 @@ public class RedisProperties {
 	private Pool pool;
 
 	private Sentinel sentinel;
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
 
 	public int getDatabase() {
 		return this.database;

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.test.EnvironmentTestUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -43,6 +44,7 @@ import static org.junit.Assert.assertTrue;
  * @author Christian Dupuis
  * @author Christoph Strobl
  * @author Eddú Meléndez
+ * @author Simon Buettner
  */
 public class RedisAutoConfigurationTests {
 
@@ -65,6 +67,19 @@ public class RedisAutoConfigurationTests {
 		load();
 		assertNotNull(this.context.getBean("redisTemplate", RedisOperations.class));
 		assertNotNull(this.context.getBean(StringRedisTemplate.class));
+	}
+
+	@Test
+	public void testEnabledRedisConfiguration() throws Exception {
+		load("spring.redis.enabled:true");
+		assertNotNull(this.context.getBean("redisTemplate", RedisOperations.class));
+		assertNotNull(this.context.getBean(StringRedisTemplate.class));
+	}
+
+	@Test(expected = NoSuchBeanDefinitionException.class)
+	public void testDisabledRedisConfiguration() throws Exception {
+		load("spring.redis.enabled:false");
+		this.context.getBean("redisTemplate", RedisOperations.class);
 	}
 
 	@Test


### PR DESCRIPTION
Currently you can only disable the redis autoconfiguration using the `exclude` property in the respective spring boot annotations like this `@SpringBootApplication(exclude = RedisAutoConfiguration.class)`. This is needed if you have two redis connections (Spring Boots redis autoconfiguration expects a single bean). This PR introduces a single `enabled` flag that allows an application developer to control the autoconfiguration of redis more easily and in an environment dependent way.

Contribution agreement number: 133520150810110320