### PR TITLE
Remove possible null pointer dereference of beanFactory

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/LogFileMvcEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/LogFileMvcEndpoint.java
@@ -130,7 +130,7 @@ public class LogFileMvcEndpoint implements MvcEndpoint, EnvironmentAware {
 		}
 		FileSystemResource resource = new FileSystemResource(logFile.toString());
 		if (!resource.exists()) {
-			if (logger.isWarnEnabled()) {
+			if (logger.isDebugEnabled()) {
 				logger.debug("Log file '" + resource + "' does not exist");
 			}
 			return null;

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnExpressionCondition.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnExpressionCondition.java
@@ -51,7 +51,8 @@ class OnExpressionCondition extends SpringBootCondition {
 		// Explicitly allow environment placeholders inside the expression
 		expression = context.getEnvironment().resolvePlaceholders(expression);
 		ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
-		BeanExpressionResolver resolver = beanFactory.getBeanExpressionResolver();
+		BeanExpressionResolver resolver = (beanFactory != null)
+				? beanFactory.getBeanExpressionResolver() : null;
 		BeanExpressionContext expressionContext = (beanFactory != null)
 				? new BeanExpressionContext(beanFactory, null) : null;
 		if (resolver == null) {


### PR DESCRIPTION
There is a possible null pointer dereference of beanFactory in the line `BeanExpressionResolver resolver = beanFactory.getBeanExpressionResolver();` 
