### PR TITLE
JSON parser consistency

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.json;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
@@ -31,6 +31,7 @@ import org.springframework.util.StringUtils;
  * YAML are supported).
  *
  * @author Dave Syer
+ * @author Jean de Klerk
  * @since 1.2.0
  * @see JsonParserFactory
  */
@@ -38,30 +39,24 @@ public class BasicJsonParser implements JsonParser {
 
 	@Override
 	public Map<String, Object> parseMap(String json) {
-		if (json != null) {
-			json = json.trim();
-			if (json.startsWith("{")) {
-				return parseMapInternal(json);
-			}
-			else if (json.equals("")) {
-				return new HashMap<String, Object>();
-			}
+		json = json.trim();
+		if (json.startsWith("{")) {
+			return parseMapInternal(json);
 		}
-		return null;
+		else {
+			throw new IllegalArgumentException("Cannot parse JSON");
+		}
 	}
 
 	@Override
 	public List<Object> parseList(String json) {
-		if (json != null) {
-			json = json.trim();
-			if (json.startsWith("[")) {
-				return parseListInternal(json);
-			}
-			else if (json.trim().equals("")) {
-				return new ArrayList<Object>();
-			}
+		json = json.trim();
+		if (json.startsWith("[")) {
+			return parseListInternal(json);
 		}
-		return null;
+		else {
+			throw new IllegalArgumentException("Cannot parse JSON");
+		}
 	}
 
 	private List<Object> parseListInternal(String json) {

--- a/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
@@ -38,24 +38,24 @@ public class BasicJsonParser implements JsonParser {
 
 	@Override
 	public Map<String, Object> parseMap(String json) {
-		json = json.trim();
-		if (json.startsWith("{")) {
-			return parseMapInternal(json);
+		if (json != null) {
+			json = json.trim();
+			if (json.startsWith("{")) {
+				return parseMapInternal(json);
+			}
 		}
-		else {
-			throw new IllegalArgumentException("Cannot parse JSON");
-		}
+		throw new IllegalArgumentException("Cannot parse JSON");
 	}
 
 	@Override
 	public List<Object> parseList(String json) {
-		json = json.trim();
-		if (json.startsWith("[")) {
-			return parseListInternal(json);
+		if (json != null) {
+			json = json.trim();
+			if (json.startsWith("[")) {
+				return parseListInternal(json);
+			}
 		}
-		else {
-			throw new IllegalArgumentException("Cannot parse JSON");
-		}
+		throw new IllegalArgumentException("Cannot parse JSON");
 	}
 
 	private List<Object> parseListInternal(String json) {

--- a/spring-boot/src/main/java/org/springframework/boot/json/GsonJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/GsonJsonParser.java
@@ -35,25 +35,23 @@ public class GsonJsonParser implements JsonParser {
 	private Gson gson = new GsonBuilder().create();
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public Map<String, Object> parseMap(String json) {
 		if (json == null || json.equals("") || json.startsWith("[")) {
 			throw new IllegalArgumentException("Cannot parse JSON");
 		}
 
-		@SuppressWarnings("unchecked")
-		Map<String, Object> value = this.gson.fromJson(json, Map.class);
-		return value;
+		return this.gson.fromJson(json, Map.class);
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public List<Object> parseList(String json) {
 		if (json == null || json.equals("") || json.startsWith("{")) {
 			throw new IllegalArgumentException("Cannot parse JSON");
 		}
 
-		@SuppressWarnings("unchecked")
-		List<Object> value = this.gson.fromJson(json, List.class);
-		return value;
+		return this.gson.fromJson(json, List.class);
 	}
 
 }

--- a/spring-boot/src/main/java/org/springframework/boot/json/GsonJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/GsonJsonParser.java
@@ -26,6 +26,7 @@ import com.google.gson.GsonBuilder;
  * Thin wrapper to adapt {@link Gson} to a {@link JsonParser}.
  *
  * @author Dave Syer
+ * @author Jean de Klerk
  * @since 1.2.0
  * @see JsonParserFactory
  */
@@ -35,6 +36,10 @@ public class GsonJsonParser implements JsonParser {
 
 	@Override
 	public Map<String, Object> parseMap(String json) {
+		if (json == null || json.equals("") || json.startsWith("[")) {
+			throw new IllegalArgumentException("Cannot parse JSON");
+		}
+
 		@SuppressWarnings("unchecked")
 		Map<String, Object> value = this.gson.fromJson(json, Map.class);
 		return value;
@@ -42,6 +47,10 @@ public class GsonJsonParser implements JsonParser {
 
 	@Override
 	public List<Object> parseList(String json) {
+		if (json == null || json.equals("") || json.startsWith("{")) {
+			throw new IllegalArgumentException("Cannot parse JSON");
+		}
+
 		@SuppressWarnings("unchecked")
 		List<Object> value = this.gson.fromJson(json, List.class);
 		return value;

--- a/spring-boot/src/main/java/org/springframework/boot/json/GsonJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/GsonJsonParser.java
@@ -37,21 +37,25 @@ public class GsonJsonParser implements JsonParser {
 	@Override
 	@SuppressWarnings("unchecked")
 	public Map<String, Object> parseMap(String json) {
-		if (json == null || json.equals("") || json.startsWith("[")) {
-			throw new IllegalArgumentException("Cannot parse JSON");
+		if (json != null) {
+			json = json.trim();
+			if (json.startsWith("{")) {
+				return this.gson.fromJson(json, Map.class);
+			}
 		}
-
-		return this.gson.fromJson(json, Map.class);
+		throw new IllegalArgumentException("Cannot parse JSON");
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public List<Object> parseList(String json) {
-		if (json == null || json.equals("") || json.startsWith("{")) {
-			throw new IllegalArgumentException("Cannot parse JSON");
+		if (json != null) {
+			json = json.trim();
+			if (json.startsWith("[")) {
+				return this.gson.fromJson(json, List.class);
+			}
 		}
-
-		return this.gson.fromJson(json, List.class);
+		throw new IllegalArgumentException("Cannot parse JSON");
 	}
 
 }

--- a/spring-boot/src/main/java/org/springframework/boot/json/JsonSimpleJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/JsonSimpleJsonParser.java
@@ -34,10 +34,10 @@ import org.json.simple.parser.ParseException;
 public class JsonSimpleJsonParser implements JsonParser {
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public Map<String, Object> parseMap(String json) {
 		Map<String, Object> map = new LinkedHashMap<String, Object>();
 		try {
-			@SuppressWarnings("unchecked")
 			Map<String, Object> value = (Map<String, Object>) new JSONParser()
 					.parse(json);
 			map.putAll(value);
@@ -49,10 +49,10 @@ public class JsonSimpleJsonParser implements JsonParser {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public List<Object> parseList(String json) {
 		List<Object> nested = new ArrayList<Object>();
 		try {
-			@SuppressWarnings("unchecked")
 			List<Object> value = (List<Object>) new JSONParser().parse(json);
 			nested.addAll(value);
 		}

--- a/spring-boot/src/main/java/org/springframework/boot/json/JsonSimpleJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/JsonSimpleJsonParser.java
@@ -16,8 +16,6 @@
 
 package org.springframework.boot.json;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +26,7 @@ import org.json.simple.parser.ParseException;
  * Thin wrapper to adapt {@link org.json.simple.JSONObject} to a {@link JsonParser}.
  *
  * @author Dave Syer
+ * @author Jean de Klerk
  * @since 1.2.0
  * @see JsonParserFactory
  */
@@ -36,30 +35,23 @@ public class JsonSimpleJsonParser implements JsonParser {
 	@Override
 	@SuppressWarnings("unchecked")
 	public Map<String, Object> parseMap(String json) {
-		Map<String, Object> map = new LinkedHashMap<String, Object>();
 		try {
-			Map<String, Object> value = (Map<String, Object>) new JSONParser()
-					.parse(json);
-			map.putAll(value);
+			return (Map<String, Object>) new JSONParser().parse(json);
 		}
 		catch (ParseException ex) {
 			throw new IllegalArgumentException("Cannot parse JSON", ex);
 		}
-		return map;
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public List<Object> parseList(String json) {
-		List<Object> nested = new ArrayList<Object>();
 		try {
-			List<Object> value = (List<Object>) new JSONParser().parse(json);
-			nested.addAll(value);
+			return (List<Object>) new JSONParser().parse(json);
 		}
 		catch (ParseException ex) {
 			throw new IllegalArgumentException("Cannot parse JSON", ex);
 		}
-		return nested;
 	}
 
 }

--- a/spring-boot/src/main/java/org/springframework/boot/json/YamlJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/YamlJsonParser.java
@@ -33,21 +33,25 @@ public class YamlJsonParser implements JsonParser {
 	@Override
 	@SuppressWarnings("unchecked")
 	public Map<String, Object> parseMap(String json) {
-		if (json == null || json.equals("") || json.startsWith("[")) {
-			throw new IllegalArgumentException("Cannot parse JSON");
+		if (json != null) {
+			json = json.trim();
+			if (json.startsWith("{")) {
+				return new Yaml().loadAs(json, Map.class);
+			}
 		}
-
-		return new Yaml().loadAs(json, Map.class);
+		throw new IllegalArgumentException("Cannot parse JSON");
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public List<Object> parseList(String json) {
-		if (json == null || json.equals("") || json.startsWith("{")) {
-			throw new IllegalArgumentException("Cannot parse JSON");
+		if (json != null) {
+			json = json.trim();
+			if (json.startsWith("[")) {
+				return new Yaml().loadAs(json, List.class);
+			}
 		}
-
-		return new Yaml().loadAs(json, List.class);
+		throw new IllegalArgumentException("Cannot parse JSON");
 	}
 
 }

--- a/spring-boot/src/main/java/org/springframework/boot/json/YamlJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/YamlJsonParser.java
@@ -25,6 +25,7 @@ import org.yaml.snakeyaml.Yaml;
  * Thin wrapper to adapt Snake {@link Yaml} to {@link JsonParser}.
  *
  * @author Dave Syer
+ * @author Jean de Klerk
  * @see JsonParserFactory
  */
 public class YamlJsonParser implements JsonParser {
@@ -32,12 +33,20 @@ public class YamlJsonParser implements JsonParser {
 	@Override
 	@SuppressWarnings("unchecked")
 	public Map<String, Object> parseMap(String json) {
+		if (json == null || json.equals("") || json.startsWith("[")) {
+			throw new IllegalArgumentException("Cannot parse JSON");
+		}
+
 		return new Yaml().loadAs(json, Map.class);
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public List<Object> parseList(String json) {
+		if (json == null || json.equals("") || json.startsWith("{")) {
+			throw new IllegalArgumentException("Cannot parse JSON");
+		}
+
 		return new Yaml().loadAs(json, List.class);
 	}
 

--- a/spring-boot/src/test/java/org/springframework/boot/json/AbstractJsonParserTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/json/AbstractJsonParserTests.java
@@ -94,39 +94,39 @@ public abstract class AbstractJsonParserTests {
 	}
 
 	@Test
-    public void mapWithNullThrowsARuntimeException() {
-        this.thrown.expect(RuntimeException.class);
-        this.parser.parseMap(null);
-    }
+	public void mapWithNullThrowsARuntimeException() {
+		this.thrown.expect(RuntimeException.class);
+		this.parser.parseMap(null);
+	}
 
-    @Test
-    public void listWithNullThrowsARuntimeException() {
-        this.thrown.expect(RuntimeException.class);
-        this.parser.parseList(null);
-    }
+	@Test
+	public void listWithNullThrowsARuntimeException() {
+		this.thrown.expect(RuntimeException.class);
+		this.parser.parseList(null);
+	}
 
-    @Test
-    public void mapWithEmptyStringThrowsARuntimeException() {
-        this.thrown.expect(RuntimeException.class);
-        this.parser.parseMap("");
-    }
+	@Test
+	public void mapWithEmptyStringThrowsARuntimeException() {
+		this.thrown.expect(RuntimeException.class);
+		this.parser.parseMap("");
+	}
 
-    @Test
-    public void listWithEmptyStringThrowsARuntimeException() {
-        this.thrown.expect(RuntimeException.class);
-        this.parser.parseList("");
-    }
+	@Test
+	public void listWithEmptyStringThrowsARuntimeException() {
+		this.thrown.expect(RuntimeException.class);
+		this.parser.parseList("");
+	}
 
-    @Test
-    public void mapWithListThrowsARuntimeException() {
-        this.thrown.expect(RuntimeException.class);
-        this.parser.parseMap("[]");
-    }
+	@Test
+	public void mapWithListThrowsARuntimeException() {
+		this.thrown.expect(RuntimeException.class);
+		this.parser.parseMap("[]");
+	}
 
-    @Test
-    public void listWithMapThrowsARuntimeException() {
-        this.thrown.expect(RuntimeException.class);
-        this.parser.parseList("{}");
-    }
+	@Test
+	public void listWithMapThrowsARuntimeException() {
+		this.thrown.expect(RuntimeException.class);
+		this.parser.parseList("{}");
+	}
 
 }

--- a/spring-boot/src/test/java/org/springframework/boot/json/AbstractJsonParserTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/json/AbstractJsonParserTests.java
@@ -129,4 +129,30 @@ public abstract class AbstractJsonParserTests {
 		this.parser.parseList("{}");
 	}
 
+	@Test
+	public void listWithLeadingWhitespace() {
+		List<Object> list = this.parser.parseList("\n\t[\"foo\"]");
+		assertEquals(1, list.size());
+		assertEquals("foo", list.get(0));
+	}
+
+	@Test
+	public void mapWithLeadingWhitespace() {
+		Map<String, Object> map = this.parser.parseMap("\n\t{\"foo\":\"bar\"}");
+		assertEquals(1, map.size());
+		assertEquals("bar", map.get("foo"));
+	}
+
+	@Test
+	public void mapWithLeadingWhitespaceListThrowsARuntimeException() {
+		this.thrown.expect(RuntimeException.class);
+		this.parser.parseMap("\n\t[]");
+	}
+
+	@Test
+	public void listWithLeadingWhitespaceMapThrowsARuntimeException() {
+		this.thrown.expect(RuntimeException.class);
+		this.parser.parseList("\n\t{}");
+	}
+
 }

--- a/spring-boot/src/test/java/org/springframework/boot/json/AbstractJsonParserTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/json/AbstractJsonParserTests.java
@@ -35,7 +35,7 @@ public abstract class AbstractJsonParserTests {
 	protected abstract JsonParser getParser();
 
 	@Test
-	public void testSimpleMap() {
+	public void simpleMap() {
 		Map<String, Object> map = this.parser.parseMap("{\"foo\":\"bar\",\"spam\":1}");
 		assertEquals(2, map.size());
 		assertEquals("bar", map.get("foo"));
@@ -43,7 +43,7 @@ public abstract class AbstractJsonParserTests {
 	}
 
 	@Test
-	public void testDoubleValue() {
+	public void doubleValue() {
 		Map<String, Object> map = this.parser.parseMap("{\"foo\":\"bar\",\"spam\":1.23}");
 		assertEquals(2, map.size());
 		assertEquals("bar", map.get("foo"));
@@ -51,27 +51,27 @@ public abstract class AbstractJsonParserTests {
 	}
 
 	@Test
-	public void testEmptyMap() {
+	public void emptyMap() {
 		Map<String, Object> map = this.parser.parseMap("{}");
 		assertEquals(0, map.size());
 	}
 
 	@Test
-	public void testSimpleList() {
+	public void simpleList() {
 		List<Object> list = this.parser.parseList("[\"foo\",\"bar\",1]");
 		assertEquals(3, list.size());
 		assertEquals("bar", list.get(1));
 	}
 
 	@Test
-	public void testEmptyList() {
+	public void emptyList() {
 		List<Object> list = this.parser.parseList("[]");
 		assertEquals(0, list.size());
 	}
 
 	@SuppressWarnings("unchecked")
 	@Test
-	public void testListOfMaps() {
+	public void listOfMaps() {
 		List<Object> list = this.parser
 				.parseList("[{\"foo\":\"bar\",\"spam\":1},{\"foo\":\"baz\",\"spam\":2}]");
 		assertEquals(2, list.size());
@@ -80,7 +80,7 @@ public abstract class AbstractJsonParserTests {
 
 	@SuppressWarnings("unchecked")
 	@Test
-	public void testMapOfLists() {
+	public void mapOfLists() {
 		Map<String, Object> map = this.parser.parseMap(
 				"{\"foo\":[{\"foo\":\"bar\",\"spam\":1},{\"foo\":\"baz\",\"spam\":2}]}");
 		assertEquals(1, map.size());

--- a/spring-boot/src/test/java/org/springframework/boot/json/AbstractJsonParserTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/json/AbstractJsonParserTests.java
@@ -19,7 +19,9 @@ package org.springframework.boot.json;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -27,8 +29,12 @@ import static org.junit.Assert.assertEquals;
  * Base for {@link JsonParser} tests.
  *
  * @author Dave Syer
+ * @author Jean de Klerk
  */
 public abstract class AbstractJsonParserTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
 
 	private final JsonParser parser = getParser();
 
@@ -86,5 +92,41 @@ public abstract class AbstractJsonParserTests {
 		assertEquals(1, map.size());
 		assertEquals(2, ((List<Object>) map.get("foo")).size());
 	}
+
+	@Test
+    public void mapWithNullThrowsARuntimeException() {
+        this.thrown.expect(RuntimeException.class);
+        this.parser.parseMap(null);
+    }
+
+    @Test
+    public void listWithNullThrowsARuntimeException() {
+        this.thrown.expect(RuntimeException.class);
+        this.parser.parseList(null);
+    }
+
+    @Test
+    public void mapWithEmptyStringThrowsARuntimeException() {
+        this.thrown.expect(RuntimeException.class);
+        this.parser.parseMap("");
+    }
+
+    @Test
+    public void listWithEmptyStringThrowsARuntimeException() {
+        this.thrown.expect(RuntimeException.class);
+        this.parser.parseList("");
+    }
+
+    @Test
+    public void mapWithListThrowsARuntimeException() {
+        this.thrown.expect(RuntimeException.class);
+        this.parser.parseMap("[]");
+    }
+
+    @Test
+    public void listWithMapThrowsARuntimeException() {
+        this.thrown.expect(RuntimeException.class);
+        this.parser.parseList("{}");
+    }
 
 }

--- a/spring-boot/src/test/java/org/springframework/boot/json/JsonJsonParserTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/json/JsonJsonParserTests.java
@@ -17,7 +17,7 @@
 package org.springframework.boot.json;
 
 /**
- * Tests for {@link JsonSimpleJsonParser}.
+ * Tests for {@link JsonJsonParser}.
  *
  * @author Dave Syer
  */
@@ -25,7 +25,7 @@ public class JsonJsonParserTests extends AbstractJsonParserTests {
 
 	@Override
 	protected JsonParser getParser() {
-		return new JsonSimpleJsonParser();
+		return new JsonJsonParser();
 	}
 
 }

--- a/spring-boot/src/test/java/org/springframework/boot/json/JsonSimpleJsonParserTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/json/JsonSimpleJsonParserTests.java
@@ -17,15 +17,15 @@
 package org.springframework.boot.json;
 
 /**
- * Tests for {@link JsonJsonParser}.
+ * Tests for {@link JsonSimpleJsonParser}.
  *
  * @author Dave Syer
  */
-public class SimpleJsonJsonParserTests extends AbstractJsonParserTests {
+public class JsonSimpleJsonParserTests extends AbstractJsonParserTests {
 
 	@Override
 	protected JsonParser getParser() {
-		return new JsonJsonParser();
+		return new JsonSimpleJsonParser();
 	}
 
 }


### PR DESCRIPTION
- Consistently handle nulls and empty strings for parseList and parseMap
- Tests for the aforementioned
- AbstractJsonParserTests test methods renamed to JUnit 4 convention (testFoo() -> @Test foo())