### PR TITLE
Remove newline characters in the project description

### DIFF
--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
@@ -261,7 +261,7 @@ public class RepackageMojo extends AbstractDependencyFilterMojo {
 		putIfMissing(properties, "initInfoProvides", this.project.getArtifactId());
 		putIfMissing(properties, "initInfoShortDescription", this.project.getName(),
 				this.project.getArtifactId());
-		putIfMissing(properties, "initInfoDescription", this.project.getDescription(),
+		putIfMissing(properties, "initInfoDescription", this.project.getDescription().replaceAll("\\s+", " "), // Clean up newlines
 				this.project.getName(), this.project.getArtifactId());
 		return properties;
 	}


### PR DESCRIPTION
This fixes an issue in which a multi-line pom description retains its newline characters and the newlines get preserved when the description is inserted into the launch script, causing the shell to attempt to execute the extra lines as though they were shell commands.

For example:
```xml
<description>
    A multi-line pom description that could do something terrible in the launch script:
    rm -r foo
</description>
```