### PR TITLE
Calling String.toString() is a redundant operation.

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/livereload/ConnectionInputStream.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/livereload/ConnectionInputStream.java
@@ -49,7 +49,7 @@ class ConnectionInputStream extends FilterInputStream {
 			int amountRead = checkedRead(buffer, 0, BUFFER_SIZE);
 			content.append(new String(buffer, 0, amountRead));
 		}
-		return content.substring(0, content.indexOf(HEADER_END)).toString();
+		return content.substring(0, content.indexOf(HEADER_END));
 	}
 
 	/**


### PR DESCRIPTION
Calling `String.toString()` is a redundant operation. The operation `substring`  returns already a string.