### PR TITLE
Rename method to clarify which connector is being created

### DIFF
--- a/spring-boot-samples/spring-boot-sample-tomcat-multi-connectors/src/main/java/sample/tomcat/multiconnector/SampleTomcatTwoConnectorsApplication.java
+++ b/spring-boot-samples/spring-boot-sample-tomcat-multi-connectors/src/main/java/sample/tomcat/multiconnector/SampleTomcatTwoConnectorsApplication.java
@@ -42,11 +42,11 @@ public class SampleTomcatTwoConnectorsApplication {
 	@Bean
 	public EmbeddedServletContainerFactory servletContainer() {
 		TomcatEmbeddedServletContainerFactory tomcat = new TomcatEmbeddedServletContainerFactory();
-		tomcat.addAdditionalTomcatConnectors(createSslConnector());
+		tomcat.addAdditionalTomcatConnectors(createNonSslConnector());
 		return tomcat;
 	}
 
-	private Connector createSslConnector() {
+	private Connector createNonSslConnector() {
 		Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
 		connector.setPort(port());
 		return connector;


### PR DESCRIPTION
The current method name (`createSslConnector`) is misleading, as the SSL connector is actually the one that is set up by the configuration in application.properties. The additional connector that is being configured manually in this example is the standard HTTP connector, as described [in the documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/howto-embedded-servlet-containers.html#howto-configure-ssl).