### PR TITLE
Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/HealthIndicatorAutoConfigurationProperties.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/HealthIndicatorAutoConfigurationProperties.java
@@ -39,7 +39,7 @@ public class HealthIndicatorAutoConfigurationProperties {
 	}
 
 	public void setOrder(List<String> statusOrder) {
-		if (statusOrder != null && statusOrder.size() > 0) {
+		if (statusOrder != null && !statusOrder.isEmpty()) {
 			this.order = statusOrder;
 		}
 	}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/OrderedHealthAggregator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/OrderedHealthAggregator.java
@@ -76,7 +76,7 @@ public class OrderedHealthAggregator extends AbstractHealthAggregator {
 			}
 		}
 		// If no status is given return UNKNOWN
-		if (filteredCandidates.size() == 0) {
+		if (filteredCandidates.isEmpty()) {
 			return Status.UNKNOWN;
 		}
 		// Sort given Status instances by configured order

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/AnyNestedCondition.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/AnyNestedCondition.java
@@ -50,7 +50,7 @@ public abstract class AnyNestedCondition extends AbstractNestedCondition {
 
 	@Override
 	protected ConditionOutcome getFinalMatchOutcome(MemberMatchOutcomes memberOutcomes) {
-		return new ConditionOutcome(memberOutcomes.getMatches().size() > 0,
+		return new ConditionOutcome(!memberOutcomes.getMatches().isEmpty(),
 				"nested any match resulted in " + memberOutcomes.getMatches()
 						+ " matches and " + memberOutcomes.getNonMatches()
 						+ " non matches");

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnResourceCondition.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnResourceCondition.java
@@ -47,7 +47,7 @@ class OnResourceCondition extends SpringBootCondition {
 					? this.defaultResourceLoader : context.getResourceLoader();
 			List<String> locations = new ArrayList<String>();
 			collectValues(locations, attributes.get("resources"));
-			Assert.isTrue(locations.size() > 0,
+			Assert.isTrue(!locations.isEmpty(),
 					"@ConditionalOnResource annotations must specify at least one resource location");
 			for (String location : locations) {
 				if (!loader

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/logging/AutoConfigurationReportLoggingInitializer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/logging/AutoConfigurationReportLoggingInitializer.java
@@ -106,7 +106,7 @@ public class AutoConfigurationReportLoggingInitializer
 			this.report = ConditionEvaluationReport
 					.get(this.applicationContext.getBeanFactory());
 		}
-		if (this.report.getConditionAndOutcomesBySource().size() > 0) {
+		if (!this.report.getConditionAndOutcomesBySource().isEmpty()) {
 			if (isCrashReport && this.logger.isInfoEnabled()
 					&& !this.logger.isDebugEnabled()) {
 				this.logger.info("\n\nError starting ApplicationContext. "

--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/core/HintCommand.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/core/HintCommand.java
@@ -57,7 +57,7 @@ public class HintCommand extends AbstractCommand {
 			if (index == 0) {
 				showCommandHints(starting);
 			}
-			else if ((arguments.size() > 0) && (starting.length() > 0)) {
+			else if (!arguments.isEmpty() && (starting.length() > 0)) {
 				String command = arguments.remove(0);
 				showCommandOptionHints(command, Collections.unmodifiableList(arguments),
 						starting);

--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/ProjectGenerationRequest.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/ProjectGenerationRequest.java
@@ -385,7 +385,7 @@ class ProjectGenerationRequest {
 			if (types.size() == 1) {
 				return types.values().iterator().next();
 			}
-			else if (types.size() == 0) {
+			else if (types.isEmpty()) {
 				throw new ReportableException("No type found with build '" + this.build
 						+ "' and format '" + this.format
 						+ "' check the service capabilities (--list)");

--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/options/SourceOptions.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/options/SourceOptions.java
@@ -96,7 +96,7 @@ public class SourceOptions {
 		}
 		this.args = Collections.unmodifiableList(
 				nonOptionArguments.subList(sourceArgCount, nonOptionArguments.size()));
-		Assert.isTrue(sources.size() > 0, "Please specify at least one file");
+		Assert.isTrue(!sources.isEmpty(), "Please specify at least one file");
 		this.sources = Collections.unmodifiableList(sources);
 	}
 

--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/ExtendedGroovyClassLoader.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/ExtendedGroovyClassLoader.java
@@ -187,7 +187,7 @@ public class ExtendedGroovyClassLoader extends GroovyClassLoader {
 			if (urls.isEmpty()) {
 				findGroovyJarsFromClassPath(parent, urls);
 			}
-			Assert.state(urls.size() > 0, "Unable to find groovy JAR");
+			Assert.state(!urls.isEmpty(), "Unable to find groovy JAR");
 			return new ArrayList<URL>(urls).toArray(new URL[urls.size()]);
 		}
 

--- a/spring-boot-samples/spring-boot-sample-websocket-jetty/src/main/java/samples/websocket/jetty/snake/SnakeTimer.java
+++ b/spring-boot-samples/spring-boot-sample-websocket-jetty/src/main/java/samples/websocket/jetty/snake/SnakeTimer.java
@@ -42,7 +42,7 @@ public class SnakeTimer {
 	private static final ConcurrentHashMap<Integer, Snake> snakes = new ConcurrentHashMap<Integer, Snake>();
 
 	public static synchronized void addSnake(Snake snake) {
-		if (snakes.size() == 0) {
+		if (snakes.isEmpty()) {
 			startTimer();
 		}
 		snakes.put(Integer.valueOf(snake.getId()), snake);
@@ -54,7 +54,7 @@ public class SnakeTimer {
 
 	public static synchronized void removeSnake(Snake snake) {
 		snakes.remove(Integer.valueOf(snake.getId()));
-		if (snakes.size() == 0) {
+		if (snakes.isEmpty()) {
 			stopTimer();
 		}
 	}

--- a/spring-boot-samples/spring-boot-sample-websocket-tomcat/src/main/java/samples/websocket/tomcat/snake/SnakeTimer.java
+++ b/spring-boot-samples/spring-boot-sample-websocket-tomcat/src/main/java/samples/websocket/tomcat/snake/SnakeTimer.java
@@ -42,7 +42,7 @@ public class SnakeTimer {
 	private static final ConcurrentHashMap<Integer, Snake> snakes = new ConcurrentHashMap<Integer, Snake>();
 
 	public static synchronized void addSnake(Snake snake) {
-		if (snakes.size() == 0) {
+		if (snakes.isEmpty()) {
 			startTimer();
 		}
 		snakes.put(Integer.valueOf(snake.getId()), snake);
@@ -54,7 +54,7 @@ public class SnakeTimer {
 
 	public static synchronized void removeSnake(Snake snake) {
 		snakes.remove(Integer.valueOf(snake.getId()));
-		if (snakes.size() == 0) {
+		if (snakes.isEmpty()) {
 			stopTimer();
 		}
 	}

--- a/spring-boot-samples/spring-boot-sample-websocket-undertow/src/main/java/samples/websocket/undertow/snake/SnakeTimer.java
+++ b/spring-boot-samples/spring-boot-sample-websocket-undertow/src/main/java/samples/websocket/undertow/snake/SnakeTimer.java
@@ -42,7 +42,7 @@ public class SnakeTimer {
 	private static final ConcurrentHashMap<Integer, Snake> snakes = new ConcurrentHashMap<Integer, Snake>();
 
 	public static synchronized void addSnake(Snake snake) {
-		if (snakes.size() == 0) {
+		if (snakes.isEmpty()) {
 			startTimer();
 		}
 		snakes.put(Integer.valueOf(snake.getId()), snake);
@@ -54,7 +54,7 @@ public class SnakeTimer {
 
 	public static synchronized void removeSnake(Snake snake) {
 		snakes.remove(Integer.valueOf(snake.getId()));
-		if (snakes.size() == 0) {
+		if (snakes.isEmpty()) {
 			stopTimer();
 		}
 	}

--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/PropertiesMergingResourceTransformer.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/PropertiesMergingResourceTransformer.java
@@ -73,7 +73,7 @@ public class PropertiesMergingResourceTransformer implements ResourceTransformer
 
 	@Override
 	public boolean hasTransformedResource() {
-		return this.data.size() > 0;
+		return !this.data.isEmpty();
 	}
 
 	@Override

--- a/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
@@ -499,7 +499,7 @@ public class ConfigFileApplicationListener implements EnvironmentPostProcessor,
 				}
 				return;
 			}
-			if (profiles.size() > 0) {
+			if (!profiles.isEmpty()) {
 				addProfiles(profiles);
 				this.logger.debug("Activated profiles "
 						+ StringUtils.collectionToCommaDelimitedString(profiles));

--- a/spring-boot/src/main/java/org/springframework/boot/context/config/DelegatingApplicationContextInitializer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/config/DelegatingApplicationContextInitializer.java
@@ -52,7 +52,7 @@ public class DelegatingApplicationContextInitializer implements
 	public void initialize(ConfigurableApplicationContext context) {
 		ConfigurableEnvironment environment = context.getEnvironment();
 		List<Class<?>> initializerClasses = getInitializerClasses(environment);
-		if (initializerClasses.size() > 0) {
+		if (!initializerClasses.isEmpty()) {
 			applyInitializerClasses(context, initializerClasses);
 		}
 	}

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractFilterRegistrationBean.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractFilterRegistrationBean.java
@@ -261,13 +261,13 @@ abstract class AbstractFilterRegistrationBean extends RegistrationBean {
 					DEFAULT_URL_MAPPINGS);
 		}
 		else {
-			if (servletNames.size() > 0) {
+			if (!servletNames.isEmpty()) {
 				this.logger.info("Mapping filter: '" + registration.getName()
 						+ "' to servlets: " + servletNames);
 				registration.addMappingForServletNames(dispatcherTypes, this.matchAfter,
 						servletNames.toArray(new String[servletNames.size()]));
 			}
-			if (this.urlPatterns.size() > 0) {
+			if (!this.urlPatterns.isEmpty()) {
 				this.logger.info("Mapping filter: '" + registration.getName()
 						+ "' to urls: " + this.urlPatterns);
 				registration.addMappingForUrlPatterns(dispatcherTypes, this.matchAfter,

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/RegistrationBean.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/RegistrationBean.java
@@ -137,7 +137,7 @@ public abstract class RegistrationBean implements ServletContextInitializer, Ord
 				"Registration is null. Was something already registered for name=["
 						+ this.name + "]?");
 		registration.setAsyncSupported(this.asyncSupported);
-		if (this.initParameters.size() > 0) {
+		if (!this.initParameters.isEmpty()) {
 			registration.setInitParameters(this.initParameters);
 		}
 	}

--- a/spring-boot/src/main/java/org/springframework/boot/context/web/SpringBootServletInitializer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/web/SpringBootServletInitializer.java
@@ -119,7 +119,7 @@ public abstract class SpringBootServletInitializer implements WebApplicationInit
 				.findAnnotation(getClass(), Configuration.class) != null) {
 			application.getSources().add(getClass());
 		}
-		Assert.state(application.getSources().size() > 0,
+		Assert.state(!application.getSources().isEmpty(),
 				"No SpringApplication sources have been defined. Either override the "
 						+ "configure method or add an @Configuration annotation");
 		// Ensure error pages are registered

--- a/spring-boot/src/main/java/org/springframework/boot/test/SpringApplicationContextLoader.java
+++ b/spring-boot/src/main/java/org/springframework/boot/test/SpringApplicationContextLoader.java
@@ -123,7 +123,7 @@ public class SpringApplicationContextLoader extends AbstractContextLoader {
 		Set<Object> sources = new LinkedHashSet<Object>();
 		sources.addAll(Arrays.asList(mergedConfig.getClasses()));
 		sources.addAll(Arrays.asList(mergedConfig.getLocations()));
-		Assert.state(sources.size() > 0, "No configuration classes "
+		Assert.state(!sources.isEmpty(), "No configuration classes "
 				+ "or locations found in @SpringApplicationConfiguration. "
 				+ "For default configuration detection to work you need "
 				+ "Spring 4.0.3 or better (found " + SpringVersion.getVersion() + ").");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
Using Collection.size() to test for emptiness works, but using Collection.isEmpty() makes the code more readable and can be more performant. The time complexity of any isEmpty() method implementation should be O(1) whereas some implementations of size() can be O\(n).

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1155

Please let me know if you have any questions.

Kirill Vlasov