### PR TITLE
Make the logger logger private static final

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/listener/AuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/listener/AuditListener.java
@@ -31,7 +31,7 @@ import org.springframework.context.ApplicationListener;
  */
 public class AuditListener implements ApplicationListener<AuditApplicationEvent> {
 
-	private static Log logger = LogFactory.getLog(AuditListener.class);
+	private static final Log logger = LogFactory.getLog(AuditListener.class);
 
 	private final AuditEventRepository auditEventRepository;
 

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ShellProperties.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ShellProperties.java
@@ -41,7 +41,7 @@ import org.springframework.util.StringUtils;
 @ConfigurationProperties(prefix = "shell", ignoreUnknownFields = true)
 public class ShellProperties {
 
-	private static Log logger = LogFactory.getLog(ShellProperties.class);
+	private static final Log logger = LogFactory.getLog(ShellProperties.class);
 
 	/**
 	 * Authentication type. Auto-detected according to the environment (i.e. if Spring
@@ -418,7 +418,7 @@ public class ShellProperties {
 	public static class SimpleAuthenticationProperties
 			extends CrshShellAuthenticationProperties {
 
-		private static Log logger = LogFactory
+		private static final Log logger = LogFactory
 				.getLog(SimpleAuthenticationProperties.class);
 
 		private User user = new User();

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBeanExporter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBeanExporter.java
@@ -66,7 +66,7 @@ public class EndpointMBeanExporter extends MBeanExporter
 	 */
 	public static final String DEFAULT_DOMAIN = "org.springframework.boot";
 
-	private static Log logger = LogFactory.getLog(EndpointMBeanExporter.class);
+	private static final Log logger = LogFactory.getLog(EndpointMBeanExporter.class);
 
 	private final AnnotationJmxAttributeSource attributeSource = new AnnotationJmxAttributeSource();
 

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DiskSpaceHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DiskSpaceHealthIndicator.java
@@ -33,7 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class DiskSpaceHealthIndicator extends AbstractHealthIndicator {
 
-	private static Log logger = LogFactory.getLog(DiskSpaceHealthIndicator.class);
+	private static final Log logger = LogFactory.getLog(DiskSpaceHealthIndicator.class);
 
 	private final DiskSpaceHealthIndicatorProperties properties;
 

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/jmx/JmxMetricWriter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/jmx/JmxMetricWriter.java
@@ -48,7 +48,7 @@ import org.springframework.jmx.export.naming.ObjectNamingStrategy;
 @ManagedResource(description = "MetricWriter for pushing metrics to JMX MBeans.")
 public class JmxMetricWriter implements MetricWriter {
 
-	private static Log logger = LogFactory.getLog(JmxMetricWriter.class);
+	private static final Log logger = LogFactory.getLog(JmxMetricWriter.class);
 
 	private final ConcurrentMap<String, MetricValue> values = new ConcurrentHashMap<String, MetricValue>();
 

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/reader/MetricRegistryMetricReader.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/reader/MetricRegistryMetricReader.java
@@ -55,7 +55,7 @@ import org.springframework.util.StringUtils;
  */
 public class MetricRegistryMetricReader implements MetricReader, MetricRegistryListener {
 
-	private static Log logger = LogFactory.getLog(MetricRegistryMetricReader.class);
+	private static final Log logger = LogFactory.getLog(MetricRegistryMetricReader.class);
 
 	private static final Map<Class<?>, Set<String>> numberKeys = new ConcurrentHashMap<Class<?>, Set<String>>();
 

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
@@ -48,7 +48,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  */
 public class WebRequestTraceFilter extends OncePerRequestFilter implements Ordered {
 
-	private final Log logger = LogFactory.getLog(WebRequestTraceFilter.class);
+	private static final Log logger = LogFactory.getLog(WebRequestTraceFilter.class);
 
 	private boolean dumpRequests = false;
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationPackages.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationPackages.java
@@ -48,7 +48,7 @@ import org.springframework.util.StringUtils;
  */
 public abstract class AutoConfigurationPackages {
 
-	private static Log logger = LogFactory.getLog(AutoConfigurationPackages.class);
+	private static final Log logger = LogFactory.getLog(AutoConfigurationPackages.class);
 
 	private static final String BEAN = AutoConfigurationPackages.class.getName();
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BasicBatchConfigurer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BasicBatchConfigurer.java
@@ -45,7 +45,7 @@ import org.springframework.util.StringUtils;
 @Component
 public class BasicBatchConfigurer implements BatchConfigurer {
 
-	private static Log logger = LogFactory.getLog(BasicBatchConfigurer.class);
+	private static final Log logger = LogFactory.getLog(BasicBatchConfigurer.class);
 
 	private final BatchProperties properties;
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherCommandLineRunner.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherCommandLineRunner.java
@@ -66,7 +66,7 @@ import org.springframework.util.StringUtils;
 public class JobLauncherCommandLineRunner
 		implements CommandLineRunner, ApplicationEventPublisherAware {
 
-	private static Log logger = LogFactory.getLog(JobLauncherCommandLineRunner.class);
+	private static final Log logger = LogFactory.getLog(JobLauncherCommandLineRunner.class);
 
 	private JobParametersConverter converter = new DefaultJobParametersConverter();
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/BeanTypeRegistry.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/BeanTypeRegistry.java
@@ -63,7 +63,7 @@ import org.springframework.util.StringUtils;
  */
 abstract class BeanTypeRegistry {
 
-	static Log logger = LogFactory.getLog(BeanTypeRegistry.class);
+	private static final Log logger = LogFactory.getLog(BeanTypeRegistry.class);
 
 	static final String FACTORY_BEAN_OBJECT_TYPE = "factoryBeanObjectType";
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchAutoConfiguration.java
@@ -66,7 +66,7 @@ public class ElasticsearchAutoConfiguration implements DisposableBean {
 		DEFAULTS = Collections.unmodifiableMap(defaults);
 	}
 
-	private static Log logger = LogFactory.getLog(ElasticsearchAutoConfiguration.class);
+	private static final Log logger = LogFactory.getLog(ElasticsearchAutoConfiguration.class);
 
 	@Autowired
 	private ElasticsearchProperties properties;

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
@@ -94,7 +94,7 @@ public class JacksonAutoConfiguration {
 			DateTimeSerializer.class, JacksonJodaDateFormat.class })
 	static class JodaDateTimeJacksonConfiguration {
 
-		private final Log log = LogFactory.getLog(JodaDateTimeJacksonConfiguration.class);
+		private static final Log log = LogFactory.getLog(JodaDateTimeJacksonConfiguration.class);
 
 		@Autowired
 		private JacksonProperties jacksonProperties;

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
@@ -67,7 +67,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 @Import({ Registrar.class, DataSourcePoolMetadataProvidersConfiguration.class })
 public class DataSourceAutoConfiguration {
 
-	private static Log logger = LogFactory.getLog(DataSourceAutoConfiguration.class);
+	private static final Log logger = LogFactory.getLog(DataSourceAutoConfiguration.class);
 
 	/**
 	 * Determines if the {@code dataSource} being used by Spring was created from

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceInitializer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceInitializer.java
@@ -46,7 +46,7 @@ import org.springframework.util.StringUtils;
  */
 class DataSourceInitializer implements ApplicationListener<DataSourceInitializedEvent> {
 
-	private static Log logger = LogFactory.getLog(DataSourceInitializer.class);
+	private static final Log logger = LogFactory.getLog(DataSourceInitializer.class);
 
 	@Autowired
 	private ConfigurableApplicationContext applicationContext;

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisEmbeddedConfigurationFactory.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisEmbeddedConfigurationFactory.java
@@ -35,7 +35,7 @@ import org.apache.commons.logging.LogFactory;
  */
 class ArtemisEmbeddedConfigurationFactory {
 
-	private Log logger = LogFactory.getLog(ArtemisEmbeddedConfigurationFactory.class);
+	private static final Log logger = LogFactory.getLog(ArtemisEmbeddedConfigurationFactory.class);
 
 	private final ArtemisProperties.Embedded properties;
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/hornetq/HornetQEmbeddedConfigurationFactory.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/hornetq/HornetQEmbeddedConfigurationFactory.java
@@ -37,7 +37,7 @@ import org.springframework.boot.autoconfigure.jms.hornetq.HornetQProperties.Embe
  */
 class HornetQEmbeddedConfigurationFactory {
 
-	private Log logger = LogFactory.getLog(HornetQEmbeddedConfigurationFactory.class);
+	private static final Log logger = LogFactory.getLog(HornetQEmbeddedConfigurationFactory.class);
 
 	private final Embedded properties;
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mobile/DeviceDelegatingViewResolverAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mobile/DeviceDelegatingViewResolverAutoConfiguration.java
@@ -53,7 +53,7 @@ import org.springframework.web.servlet.view.InternalResourceViewResolver;
 @AutoConfigureAfter({ WebMvcAutoConfiguration.class, ThymeleafAutoConfiguration.class })
 public class DeviceDelegatingViewResolverAutoConfiguration {
 
-	private static Log logger = LogFactory
+	private static final Log logger = LogFactory
 			.getLog(DeviceDelegatingViewResolverAutoConfiguration.class);
 
 	private static abstract class AbstractDelegateConfiguration {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/AuthenticationManagerConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/AuthenticationManagerConfiguration.java
@@ -69,7 +69,7 @@ import org.springframework.util.ReflectionUtils;
 @Order(0)
 public class AuthenticationManagerConfiguration {
 
-	private static Log logger = LogFactory
+	private static final Log logger = LogFactory
 			.getLog(AuthenticationManagerConfiguration.class);
 
 	@Bean

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/BootGlobalAuthenticationConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/BootGlobalAuthenticationConfiguration.java
@@ -60,7 +60,7 @@ public class BootGlobalAuthenticationConfiguration {
 	private static class BootGlobalAuthenticationConfigurationAdapter
 			extends GlobalAuthenticationConfigurerAdapter {
 
-		private static Log logger = LogFactory
+		private static final Log logger = LogFactory
 				.getLog(BootGlobalAuthenticationConfiguration.class);
 
 		private final ApplicationContext context;

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
@@ -132,7 +132,7 @@ public class WebMvcAutoConfiguration {
 	@EnableConfigurationProperties({ WebMvcProperties.class, ResourceProperties.class })
 	public static class WebMvcAutoConfigurationAdapter extends WebMvcConfigurerAdapter {
 
-		private static Log logger = LogFactory.getLog(WebMvcConfigurerAdapter.class);
+		private static final Log logger = LogFactory.getLog(WebMvcConfigurerAdapter.class);
 
 		@Autowired
 		private ResourceProperties resourceProperties = new ResourceProperties();

--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/livereload/Connection.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/livereload/Connection.java
@@ -38,7 +38,7 @@ import org.springframework.util.Base64Utils;
  */
 class Connection {
 
-	private static Log logger = LogFactory.getLog(Connection.class);
+	private static final Log logger = LogFactory.getLog(Connection.class);
 
 	private static final Pattern WEBSOCKET_KEY_PATTERN = Pattern
 			.compile("^Sec-WebSocket-Key:(.*)$", Pattern.MULTILINE);

--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/livereload/LiveReloadServer.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/livereload/LiveReloadServer.java
@@ -49,7 +49,7 @@ public class LiveReloadServer {
 	 */
 	public static final int DEFAULT_PORT = 35729;
 
-	private static Log logger = LogFactory.getLog(LiveReloadServer.class);
+	private static final Log logger = LogFactory.getLog(LiveReloadServer.class);
 
 	private static final int READ_TIMEOUT = (int) TimeUnit.SECONDS.toMillis(4);
 

--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/client/HttpTunnelConnection.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/client/HttpTunnelConnection.java
@@ -52,7 +52,7 @@ import org.springframework.util.Assert;
  */
 public class HttpTunnelConnection implements TunnelConnection {
 
-	private static Log logger = LogFactory.getLog(HttpTunnelConnection.class);
+	private static final Log logger = LogFactory.getLog(HttpTunnelConnection.class);
 
 	private final URI uri;
 

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/PropertiesLauncher.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/PropertiesLauncher.java
@@ -74,7 +74,7 @@ import org.springframework.boot.loader.util.SystemPropertyUtils;
  */
 public class PropertiesLauncher extends Launcher {
 
-	private final Logger logger = Logger.getLogger(Launcher.class.getName());
+	private static final Logger logger = Logger.getLogger(Launcher.class.getName());
 
 	/**
 	 * Properties key for main class. As a manifest entry can also be specified as

--- a/spring-boot/src/main/java/org/springframework/boot/context/ConfigurationWarningsApplicationContextInitializer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/ConfigurationWarningsApplicationContextInitializer.java
@@ -46,7 +46,7 @@ import org.springframework.util.StringUtils;
 public class ConfigurationWarningsApplicationContextInitializer
 		implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
-	private static Log logger = LogFactory
+	private static final Log logger = LogFactory
 			.getLog(ConfigurationWarningsApplicationContextInitializer.class);
 
 	@Override

--- a/spring-boot/src/main/java/org/springframework/boot/context/FileEncodingApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/FileEncodingApplicationListener.java
@@ -46,7 +46,7 @@ import org.springframework.core.Ordered;
 public class FileEncodingApplicationListener
 		implements ApplicationListener<ApplicationEnvironmentPreparedEvent>, Ordered {
 
-	private static Log logger = LogFactory.getLog(FileEncodingApplicationListener.class);
+	private static final Log logger = LogFactory.getLog(FileEncodingApplicationListener.class);
 
 	@Override
 	public int getOrder() {

--- a/spring-boot/src/main/java/org/springframework/boot/context/config/RandomValuePropertySource.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/config/RandomValuePropertySource.java
@@ -53,7 +53,7 @@ public class RandomValuePropertySource extends PropertySource<Random> {
 
 	private static final String PREFIX = "random.";
 
-	private static Log logger = LogFactory.getLog(RandomValuePropertySource.class);
+	private static final Log logger = LogFactory.getLog(RandomValuePropertySource.class);
 
 	public RandomValuePropertySource(String name) {
 		super(name, new Random());

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/ServletListenerRegistrationBean.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/ServletListenerRegistrationBean.java
@@ -59,7 +59,7 @@ import org.springframework.util.ClassUtils;
 public class ServletListenerRegistrationBean<T extends EventListener>
 		extends RegistrationBean {
 
-	private static Log logger = LogFactory.getLog(ServletListenerRegistrationBean.class);
+	private static final Log logger = LogFactory.getLog(ServletListenerRegistrationBean.class);
 
 	private static final Set<Class<?>> SUPPORTED_TYPES;
 

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/ServletRegistrationBean.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/ServletRegistrationBean.java
@@ -52,7 +52,7 @@ import org.springframework.util.ObjectUtils;
  */
 public class ServletRegistrationBean extends RegistrationBean {
 
-	private static Log logger = LogFactory.getLog(ServletRegistrationBean.class);
+	private static final Log logger = LogFactory.getLog(ServletRegistrationBean.class);
 
 	private static final String[] DEFAULT_MAPPINGS = { "/*" };
 

--- a/spring-boot/src/main/java/org/springframework/boot/context/web/ErrorPageFilter.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/web/ErrorPageFilter.java
@@ -61,7 +61,7 @@ import org.springframework.web.util.NestedServletException;
 public class ErrorPageFilter extends AbstractConfigurableEmbeddedServletContainer
 		implements Filter, NonEmbeddedServletContainerFactory {
 
-	private static Log logger = LogFactory.getLog(ErrorPageFilter.class);
+	private static final Log logger = LogFactory.getLog(ErrorPageFilter.class);
 
 	// From RequestDispatcher but not referenced to remain compatible with Servlet 2.5
 

--- a/spring-boot/src/main/java/org/springframework/boot/env/PropertySourcesLoader.java
+++ b/spring-boot/src/main/java/org/springframework/boot/env/PropertySourcesLoader.java
@@ -40,7 +40,7 @@ import org.springframework.util.StringUtils;
  */
 public class PropertySourcesLoader {
 
-	private static Log logger = LogFactory.getLog(PropertySourcesLoader.class);
+	private static final Log logger = LogFactory.getLog(PropertySourcesLoader.class);
 
 	private final MutablePropertySources propertySources;
 

--- a/spring-boot/src/main/java/org/springframework/boot/liquibase/LiquibaseServiceLocatorApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/liquibase/LiquibaseServiceLocatorApplicationListener.java
@@ -35,7 +35,7 @@ import org.springframework.util.ClassUtils;
 public class LiquibaseServiceLocatorApplicationListener
 		implements ApplicationListener<ApplicationStartedEvent> {
 
-	static final Log logger = LogFactory
+	private static final Log logger = LogFactory
 			.getLog(LiquibaseServiceLocatorApplicationListener.class);
 
 	@Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1312 - Loggers should be "private static final" and should share a naming convention

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1312


Please let me know if you have any questions.

Kirill Vlasov