### PR TITLE
add mainApplicationClass accessor to SpringApplication

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -856,6 +856,14 @@ public class SpringApplication {
 	}
 
 	/**
+	 * Retrieve the configured main application class.
+	 * @return the currently set main application {@link Class}, if any
+	 */
+	public Class<?> getMainApplicationClass() {
+		return this.mainApplicationClass;
+	}
+
+	/**
 	 * Set a specific main application class that will be used as a log source and to
 	 * obtain version information. By default the main application class will be deduced.
 	 * Can be set to {@code null} if there is no explicit application class.


### PR DESCRIPTION
This would permit spring-boot extensions to use the `mainApplicationClass`, e.g. to reuse the Implementation-Version beyond the banner.