### PR TITLE
add trustStore profile to propagate trustStore settings to surefire. …

### DIFF
--- a/spring-boot-cli/pom.xml
+++ b/spring-boot-cli/pom.xml
@@ -31,6 +31,27 @@
 				<spring.profiles.active>integration</spring.profiles.active>
 			</properties>
 		</profile>
+		<profile>
+			<id>trustStore</id>
+			<activation>
+				<property>
+					<name>javax.net.ssl.trustStore</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<systemPropertyVariables>
+								<javax.net.ssl.trustStore>${javax.net.ssl.trustStore}</javax.net.ssl.trustStore>
+							</systemPropertyVariables>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 	<dependencies>
 		<!-- Compile -->


### PR DESCRIPTION
…This accounts for the case in which a user wants to build spring-boot while configured to retrieve artifacts from a repository manager over HTTPS with a self-signed certificate.
