### PR TITLE
Enable the restriction of supported TLS protocols and ciphers suites …

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/Ssl.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/Ssl.java
@@ -42,6 +42,11 @@ public class Ssl {
 	private String[] ciphers;
 
 	/**
+	 * Supported SSL protocols.
+	 */
+	private String[] protocols;
+
+	/**
 	 * Alias that identifies the key in the key store.
 	 */
 	private String keyAlias;
@@ -206,6 +211,14 @@ public class Ssl {
 
 	public void setProtocol(String protocol) {
 		this.protocol = protocol;
+	}
+
+	public String[] getProtocols() {
+		return protocols;
+	}
+
+	public void setProtocols(String[] protocols) {
+		this.protocols = protocols;
 	}
 
 	/**

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/Ssl.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/Ssl.java
@@ -214,7 +214,7 @@ public class Ssl {
 	}
 
 	public String[] getProtocols() {
-		return protocols;
+		return this.protocols;
 	}
 
 	public void setProtocols(String[] protocols) {

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactory.java
@@ -207,7 +207,13 @@ public class JettyEmbeddedServletContainerFactory
 	 * @param ssl the ssl details.
 	 */
 	protected void configureSsl(SslContextFactory factory, Ssl ssl) {
+		//Set the default TLS protocol
 		factory.setProtocol(ssl.getProtocol());
+
+		//Assign the supported protocols, if provided
+		if (ssl.getProtocols() != null) {
+			factory.setIncludeProtocols(ssl.getProtocols());
+		}
 		configureSslClientAuth(factory, ssl);
 		configureSslPasswords(factory, ssl);
 		factory.setCertAlias(ssl.getKeyAlias());

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
@@ -314,7 +314,15 @@ public class TomcatEmbeddedServletContainerFactory
 	 */
 	protected void configureSsl(AbstractHttp11JsseProtocol<?> protocol, Ssl ssl) {
 		protocol.setSSLEnabled(true);
+		//Set the default TLS protocol
 		protocol.setSslProtocol(ssl.getProtocol());
+
+		//Assign the supported protocols, if provided
+		if (ssl.getProtocols() != null) {
+			String protocols = StringUtils.arrayToCommaDelimitedString(ssl.getProtocols());
+			protocol.setProperty("sslEnabledProtocols", protocols);
+		}
+
 		configureSslClientAuth(protocol, ssl);
 		protocol.setKeystorePass(ssl.getKeyStorePassword());
 		protocol.setKeyPass(ssl.getKeyPassword());

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
@@ -62,9 +62,9 @@ import io.undertow.servlet.handlers.DefaultServlet;
 import io.undertow.servlet.util.ImmediateInstanceFactory;
 import org.xnio.OptionMap;
 import org.xnio.Options;
+import org.xnio.Sequence;
 import org.xnio.SslClientAuthMode;
 import org.xnio.Xnio;
-import org.xnio.Sequence;
 import org.xnio.XnioWorker;
 
 import org.springframework.boot.context.embedded.AbstractEmbeddedServletContainerFactory;

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
@@ -64,6 +64,7 @@ import org.xnio.OptionMap;
 import org.xnio.Options;
 import org.xnio.SslClientAuthMode;
 import org.xnio.Xnio;
+import org.xnio.Sequence;
 import org.xnio.XnioWorker;
 
 import org.springframework.boot.context.embedded.AbstractEmbeddedServletContainerFactory;
@@ -257,8 +258,15 @@ public class UndertowEmbeddedServletContainerFactory
 			SSLContext sslContext = SSLContext.getInstance(ssl.getProtocol());
 			sslContext.init(getKeyManagers(), getTrustManagers(), null);
 			builder.addHttpsListener(port, getListenAddress(), sslContext);
-			builder.setSocketOption(Options.SSL_CLIENT_AUTH_MODE,
-					getSslClientAuthMode(ssl));
+			builder.setSocketOption(Options.SSL_CLIENT_AUTH_MODE, getSslClientAuthMode(ssl));
+
+			//Configure the supported TLS protocols and Cipher suites
+			if (ssl.getProtocols() != null) {
+				builder.setSocketOption(Options.SSL_ENABLED_PROTOCOLS, Sequence.of(ssl.getProtocols()));
+			}
+			if (ssl.getCiphers() != null) {
+				builder.setSocketOption(Options.SSL_ENABLED_CIPHER_SUITES, Sequence.of(ssl.getCiphers()));
+			}
 		}
 		catch (NoSuchAlgorithmException ex) {
 			throw new IllegalStateException(ex);

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
@@ -538,8 +538,8 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		return getSsl(clientAuth, keyPassword, keyStore, null, null, null);
 	}
 
-	private Ssl getSsl(ClientAuth clientAuth, String keyPassword, String keyStore,
-					   String trustStore, String[] protocols, String[] ciphers) {
+	private Ssl getSsl(ClientAuth clientAuth, String keyPassword, String keyStore, String trustStore,
+						String[] protocols, String[] ciphers) {
 		Ssl ssl = new Ssl();
 		ssl.setClientAuth(clientAuth);
 		if (keyPassword != null) {
@@ -564,28 +564,28 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		return ssl;
 	}
 
-    /**
+	/**
      * @see <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider">
      *     SunJSSE supported Cipher Suites</a>
      */
-    protected void testRestrictedSSLProtocolsAndCipherSuites(String[] protocols, String[] ciphers) throws Exception {
-        AbstractEmbeddedServletContainerFactory factory = getFactory();
-        factory.setSsl(getSsl(null, "password", "src/test/resources/test.jks", null, protocols, ciphers));
+	protected void testRestrictedSSLProtocolsAndCipherSuites(String[] protocols, String[] ciphers) throws Exception {
+		AbstractEmbeddedServletContainerFactory factory = getFactory();
+		factory.setSsl(getSsl(null, "password", "src/test/resources/test.jks", null, protocols, ciphers));
 
-        this.container = factory.getEmbeddedServletContainer(
-                new ServletRegistrationBean(new ExampleServlet(true, false), "/hello"));
-        this.container.start();
+		this.container = factory.getEmbeddedServletContainer(
+				new ServletRegistrationBean(new ExampleServlet(true, false), "/hello"));
+		this.container.start();
 
-        SSLConnectionSocketFactory socketFactory = new SSLConnectionSocketFactory(
-                new SSLContextBuilder().loadTrustMaterial(null, new TrustSelfSignedStrategy()).build());
+		SSLConnectionSocketFactory socketFactory = new SSLConnectionSocketFactory(
+				new SSLContextBuilder().loadTrustMaterial(null, new TrustSelfSignedStrategy()).build());
 
-        HttpClient httpClient = HttpClients.custom().setSSLSocketFactory(socketFactory).build();
-        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+		HttpClient httpClient = HttpClients.custom().setSSLSocketFactory(socketFactory).build();
+		HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
 
-        assertThat(getResponse(getLocalUrl("https", "/hello"), requestFactory), containsString("scheme=https"));
-    }
+		assertThat(getResponse(getLocalUrl("https", "/hello"), requestFactory), containsString("scheme=https"));
+	}
 
-    private String getStoreType(String keyStore) {
+	private String getStoreType(String keyStore) {
 		return (keyStore.endsWith(".p12") ? "pkcs12" : null);
 	}
 
@@ -755,7 +755,7 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 	}
 
 	private boolean doTestCompression(int contentSize, String[] mimeTypes,
-									  String[] excludedUserAgents) throws Exception {
+										String[] excludedUserAgents) throws Exception {
 		String testContent = setUpFactoryForCompression(contentSize, mimeTypes,
 				excludedUserAgents);
 		TestGzipInputStreamFactory inputStreamFactory = new TestGzipInputStreamFactory();
@@ -829,8 +829,8 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 	}
 
 	protected String getResponse(String url,
-								 HttpComponentsClientHttpRequestFactory requestFactory, String... headers)
-			throws IOException, URISyntaxException {
+								HttpComponentsClientHttpRequestFactory requestFactory, String... headers)
+		throws IOException, URISyntaxException {
 		ClientHttpResponse response = getClientResponse(url, requestFactory, headers);
 		try {
 			return StreamUtils.copyToString(response.getBody(), Charset.forName("UTF-8"));
@@ -852,9 +852,9 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		}, headers);
 	}
 
-	protected ClientHttpResponse getClientResponse(String url,
-												   HttpComponentsClientHttpRequestFactory requestFactory, String... headers)
-			throws IOException, URISyntaxException {
+	protected ClientHttpResponse getClientResponse(String url, HttpComponentsClientHttpRequestFactory requestFactory,
+													String... headers)
+		throws IOException, URISyntaxException {
 		ClientHttpRequest request = requestFactory.createRequest(new URI(url),
 				HttpMethod.GET);
 		request.getHeaders().add("Cookie", "JSESSIONID=" + "123");

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
@@ -413,7 +413,7 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		AbstractEmbeddedServletContainerFactory factory = getFactory();
 		addTestTxtFile(factory);
 		factory.setSsl(getSsl(ClientAuth.NEED, null, "classpath:test.p12",
-				"classpath:test.p12"));
+				"classpath:test.p12", null, null));
 		this.container = factory.getEmbeddedServletContainer();
 		this.container.start();
 		KeyStore keyStore = KeyStore.getInstance("pkcs12");
@@ -437,7 +437,7 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		AbstractEmbeddedServletContainerFactory factory = getFactory();
 		addTestTxtFile(factory);
 		factory.setSsl(getSsl(ClientAuth.NEED, "password", "classpath:test.jks",
-				"classpath:test.jks"));
+				"classpath:test.jks", null, null));
 		this.container = factory.getEmbeddedServletContainer();
 		this.container.start();
 		KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
@@ -535,11 +535,11 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 	}
 
 	private Ssl getSsl(ClientAuth clientAuth, String keyPassword, String keyStore) {
-		return getSsl(clientAuth, keyPassword, keyStore, null);
+		return getSsl(clientAuth, keyPassword, keyStore, null, null, null);
 	}
 
 	private Ssl getSsl(ClientAuth clientAuth, String keyPassword, String keyStore,
-			String trustStore) {
+					   String trustStore, String[] protocols, String[] ciphers) {
 		Ssl ssl = new Ssl();
 		ssl.setClientAuth(clientAuth);
 		if (keyPassword != null) {
@@ -555,10 +555,37 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 			ssl.setTrustStorePassword("secret");
 			ssl.setTrustStoreType(getStoreType(trustStore));
 		}
+		if (ciphers != null) {
+			ssl.setCiphers(ciphers);
+		}
+		if (protocols != null) {
+			ssl.setProtocols(protocols);
+		}
 		return ssl;
 	}
 
-	private String getStoreType(String keyStore) {
+    /**
+     * @see <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider">
+     *     SunJSSE supported Cipher Suites</a>
+     */
+    protected void testRestrictedSSLProtocolsAndCipherSuites(String[] protocols, String[] ciphers) throws Exception {
+        AbstractEmbeddedServletContainerFactory factory = getFactory();
+        factory.setSsl(getSsl(null, "password", "src/test/resources/test.jks", null, protocols, ciphers));
+
+        this.container = factory.getEmbeddedServletContainer(
+                new ServletRegistrationBean(new ExampleServlet(true, false), "/hello"));
+        this.container.start();
+
+        SSLConnectionSocketFactory socketFactory = new SSLConnectionSocketFactory(
+                new SSLContextBuilder().loadTrustMaterial(null, new TrustSelfSignedStrategy()).build());
+
+        HttpClient httpClient = HttpClients.custom().setSSLSocketFactory(socketFactory).build();
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+
+        assertThat(getResponse(getLocalUrl("https", "/hello"), requestFactory), containsString("scheme=https"));
+    }
+
+    private String getStoreType(String keyStore) {
 		return (keyStore.endsWith(".p12") ? "pkcs12" : null);
 	}
 
@@ -728,7 +755,7 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 	}
 
 	private boolean doTestCompression(int contentSize, String[] mimeTypes,
-			String[] excludedUserAgents) throws Exception {
+									  String[] excludedUserAgents) throws Exception {
 		String testContent = setUpFactoryForCompression(contentSize, mimeTypes,
 				excludedUserAgents);
 		TestGzipInputStreamFactory inputStreamFactory = new TestGzipInputStreamFactory();
@@ -743,7 +770,7 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 	}
 
 	protected String setUpFactoryForCompression(int contentSize, String[] mimeTypes,
-			String[] excludedUserAgents) throws Exception {
+												String[] excludedUserAgents) throws Exception {
 		char[] chars = new char[contentSize];
 		Arrays.fill(chars, 'F');
 		String testContent = new String(chars);
@@ -802,8 +829,8 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 	}
 
 	protected String getResponse(String url,
-			HttpComponentsClientHttpRequestFactory requestFactory, String... headers)
-					throws IOException, URISyntaxException {
+								 HttpComponentsClientHttpRequestFactory requestFactory, String... headers)
+			throws IOException, URISyntaxException {
 		ClientHttpResponse response = getClientResponse(url, requestFactory, headers);
 		try {
 			return StreamUtils.copyToString(response.getBody(), Charset.forName("UTF-8"));
@@ -826,8 +853,8 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 	}
 
 	protected ClientHttpResponse getClientResponse(String url,
-			HttpComponentsClientHttpRequestFactory requestFactory, String... headers)
-					throws IOException, URISyntaxException {
+												   HttpComponentsClientHttpRequestFactory requestFactory, String... headers)
+			throws IOException, URISyntaxException {
 		ClientHttpRequest request = requestFactory.createRequest(new URI(url),
 				HttpMethod.GET);
 		request.getHeaders().add("Cookie", "JSESSIONID=" + "123");

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactoryTests.java
@@ -138,6 +138,52 @@ public class JettyEmbeddedServletContainerFactoryTests
 				equalTo(new String[] { "ALPHA", "BRAVO", "CHARLIE" }));
 	}
 
+	@Test
+	public void sslEnabledMultiProtocolsConfiguration() throws Exception {
+		Ssl ssl = new Ssl();
+		ssl.setKeyStore("src/test/resources/test.jks");
+		ssl.setKeyStorePassword("secret");
+		ssl.setKeyPassword("password");
+		ssl.setCiphers(new String[] { "ALPHA", "BRAVO", "CHARLIE" });
+		ssl.setProtocols(new String[]{ "TLSv1.1", "TLSv1.2" });
+
+		JettyEmbeddedServletContainerFactory factory = getFactory();
+		factory.setSsl(ssl);
+
+		this.container = factory.getEmbeddedServletContainer();
+		this.container.start();
+
+		JettyEmbeddedServletContainer jettyContainer = (JettyEmbeddedServletContainer) this.container;
+		ServerConnector connector = (ServerConnector) jettyContainer.getServer().getConnectors()[0];
+		SslConnectionFactory connectionFactory = connector.getConnectionFactory(SslConnectionFactory.class);
+
+		assertThat(connectionFactory.getSslContextFactory().getIncludeProtocols(),
+				equalTo(new String[] { "TLSv1.1", "TLSv1.2" }));
+	}
+
+	@Test
+	public void sslEnabledProtocolsConfiguration() throws Exception {
+		Ssl ssl = new Ssl();
+		ssl.setKeyStore("src/test/resources/test.jks");
+		ssl.setKeyStorePassword("secret");
+		ssl.setKeyPassword("password");
+		ssl.setCiphers(new String[] { "ALPHA", "BRAVO", "CHARLIE" });
+		ssl.setProtocols(new String[]{ "TLSv1.1" });
+
+		JettyEmbeddedServletContainerFactory factory = getFactory();
+		factory.setSsl(ssl);
+
+		this.container = factory.getEmbeddedServletContainer();
+		this.container.start();
+
+		JettyEmbeddedServletContainer jettyContainer = (JettyEmbeddedServletContainer) this.container;
+		ServerConnector connector = (ServerConnector) jettyContainer.getServer().getConnectors()[0];
+		SslConnectionFactory connectionFactory = connector.getConnectionFactory(SslConnectionFactory.class);
+
+		assertThat(connectionFactory.getSslContextFactory().getIncludeProtocols(),
+				equalTo(new String[] { "TLSv1.1" }));
+	}
+
 	private void assertTimeout(JettyEmbeddedServletContainerFactory factory,
 			int expected) {
 		this.container = factory.getEmbeddedServletContainer();

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactoryTests.java
@@ -264,6 +264,46 @@ public class TomcatEmbeddedServletContainerFactoryTests
 	}
 
 	@Test
+	public void sslEnabledMultipleProtocolsConfiguration() throws Exception {
+		Ssl ssl = new Ssl();
+		ssl.setKeyStore("test.jks");
+		ssl.setKeyStorePassword("secret");
+		ssl.setProtocols(new String[]{ "TLSv1.1", "TLSv1.2" });
+		ssl.setCiphers(new String[] { "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", "BRAVO" });
+
+		TomcatEmbeddedServletContainerFactory factory = getFactory();
+		factory.setSsl(ssl);
+
+		this.container = factory.getEmbeddedServletContainer(sessionServletRegistration());
+		Tomcat tomcat = ((TomcatEmbeddedServletContainer) this.container).getTomcat();
+		Connector connector = tomcat.getConnector();
+
+		AbstractHttp11JsseProtocol<?> jsseProtocol = (AbstractHttp11JsseProtocol<?>) connector.getProtocolHandler();
+		assertThat(jsseProtocol.getSslProtocol(), equalTo("TLS"));
+		assertThat(jsseProtocol.getProperty("sslEnabledProtocols"), equalTo("TLSv1.1,TLSv1.2"));
+	}
+
+	@Test
+	public void sslEnabledProtocolsConfiguration() throws Exception {
+		Ssl ssl = new Ssl();
+		ssl.setKeyStore("test.jks");
+		ssl.setKeyStorePassword("secret");
+		ssl.setProtocols(new String[]{"TLSv1.2"});
+		ssl.setCiphers(new String[] { "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", "BRAVO" });
+
+		TomcatEmbeddedServletContainerFactory factory = getFactory();
+		factory.setSsl(ssl);
+
+		this.container = factory.getEmbeddedServletContainer(sessionServletRegistration());
+		Tomcat tomcat = ((TomcatEmbeddedServletContainer) this.container).getTomcat();
+		Connector connector = tomcat.getConnector();
+
+		AbstractHttp11JsseProtocol<?> jsseProtocol = (AbstractHttp11JsseProtocol<?>) connector.getProtocolHandler();
+		assertThat(jsseProtocol.getSslProtocol(), equalTo("TLS"));
+		assertThat(jsseProtocol.getProperty("sslEnabledProtocols"), equalTo("TLSv1.2"));
+	}
+
+	@Test
 	public void primaryConnectorPortClashThrowsIllegalStateException()
 			throws InterruptedException, IOException {
 		final int port = SocketUtils.findAvailableTcpPort(40000);

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactoryTests.java
@@ -26,11 +26,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.net.ssl.SSLHandshakeException;
+
 import io.undertow.Undertow.Builder;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.DeploymentManager;
 import io.undertow.servlet.api.ServletContainer;
+
 import org.junit.Test;
+
 import org.mockito.InOrder;
 
 import org.springframework.boot.context.embedded.AbstractEmbeddedServletContainerFactory;
@@ -41,8 +45,6 @@ import org.springframework.boot.context.embedded.MimeMappings.Mapping;
 import org.springframework.boot.context.embedded.ServletRegistrationBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import javax.net.ssl.SSLHandshakeException;
 
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayWithSize;

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactoryTests.java
@@ -42,6 +42,8 @@ import org.springframework.boot.context.embedded.ServletRegistrationBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import javax.net.ssl.SSLHandshakeException;
+
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
@@ -192,6 +194,31 @@ public class UndertowEmbeddedServletContainerFactoryTests
 		File accessLog = new File(accessLogDirectory, "access_log.log");
 		awaitFile(accessLog);
 		assertThat(accessLogDirectory.listFiles(), is(arrayContaining(accessLog)));
+	}
+
+	@Test(expected = SSLHandshakeException.class)
+	public void sslRestrictedProtocolsEmptyCipherFailure() throws Exception {
+		testRestrictedSSLProtocolsAndCipherSuites(new String[]{"TLSv1.2"}, new String[]{"TLS_EMPTY_RENEGOTIATION_INFO_SCSV"});
+	}
+
+	@Test(expected = SSLHandshakeException.class)
+	public void sslRestrictedProtocolsECDHETLS1Failure() throws Exception {
+		testRestrictedSSLProtocolsAndCipherSuites(new String[]{"TLSv1"}, new String[]{"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"});
+	}
+
+	@Test
+	public void sslRestrictedProtocolsECDHESuccess() throws Exception {
+		testRestrictedSSLProtocolsAndCipherSuites(new String[]{"TLSv1.2"}, new String[]{"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"});
+	}
+
+	@Test
+	public void sslRestrictedProtocolsRSATLS12Success() throws Exception {
+		testRestrictedSSLProtocolsAndCipherSuites(new String[]{"TLSv1.2"}, new String[]{"TLS_RSA_WITH_AES_128_CBC_SHA256"});
+	}
+
+	@Test(expected = SSLHandshakeException.class)
+	public void sslRestrictedProtocolsRSATLS11Failure() throws Exception {
+		testRestrictedSSLProtocolsAndCipherSuites(new String[]{"TLSv1.1"}, new String[]{"TLS_RSA_WITH_AES_128_CBC_SHA256"});
 	}
 
 	@Override


### PR DESCRIPTION
This enables the restriction of supported TLS protocols and ciphers suites while configuring the  `UndertowEmbeddedServletContainerFactory`, populating the default Ssl configuration object, without having to go through the Customizers logic.