### PR TITLE
Fix for 4820: Change redirect in initscript to support old bash

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -165,7 +165,7 @@ do_start() {
     pid=$(cat "$pid_file")
   else
     checkPermissions || return $?
-    $command &>> "$log_file" &
+    $command >> "$log_file" 2>&1 &
     pid=$!
     disown $pid
     echo "$pid" > "$pid_file"


### PR DESCRIPTION
&>> syntax is bash version 4. 
This fix allows to support older versions.
CLA is signed.