### PR TITLE
Fixed the check whether Log4j2 is available on the classpath

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/log4j2/Log4J2RestartListener.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/log4j2/Log4J2RestartListener.java
@@ -38,7 +38,7 @@ public class Log4J2RestartListener implements RestartListener {
 
 	@Override
 	public void beforeRestart() {
-		if (ClassUtils.isPresent("org.apache.logging.log4j.LogManager",
+		if (ClassUtils.isPresent("org.apache.logging.log4j.core.impl.Log4jContextFactory",
 				getClass().getClassLoader())) {
 			prepareLog4J2ForRestart();
 		}

--- a/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystem.java
@@ -43,7 +43,7 @@ public abstract class LoggingSystem {
 		Map<String, String> systems = new LinkedHashMap<String, String>();
 		systems.put("ch.qos.logback.core.Appender",
 				"org.springframework.boot.logging.logback.LogbackLoggingSystem");
-		systems.put("org.apache.logging.log4j.LogManager",
+		systems.put("org.apache.logging.log4j.core.impl.Log4jContextFactory",
 				"org.springframework.boot.logging.log4j2.Log4J2LoggingSystem");
 		systems.put("org.apache.log4j.PropertyConfigurator",
 				"org.springframework.boot.logging.log4j.Log4JLoggingSystem");


### PR DESCRIPTION
In Spring Boot 1.3.1 the class 'org.apache.logging.log4j.LogManager'
is used to check which logging backend is in use. But this class is
part of the log4j-api.jar and not part of the log4j-core.jar.
That means the check is invalid, as it does not detect the actual
core implementation of Log4j2 correctly.
When you want to redirect Log4j2 logging via SLF4J, a NPE occurs
each time the application is reloaded by the devtools, because the
class Log4j2RestartListener tries to shutdown Log4j2 resources.
This is done by accessing some internal shutdown method via
reflection. The method that is being looked for does not exist
when the log4j-api.jar is available only on the classpath,
resulting in a NPE. This causes the application to stop,
disappearing from the Spring Boot Dashboard in Eclipse (fixes #4822 )