### PR TITLE
Add external-file-property to LogFileMvcEndpoint

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcManagementContextConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcManagementContextConfiguration.java
@@ -180,6 +180,12 @@ public class EndpointWebMvcManagementContextConfiguration {
 			if (StringUtils.hasText(config)) {
 				return ConditionOutcome.match("Found logging.path: " + config);
 			}
+			config = environment
+					.resolvePlaceholders("${endpoints.logfile.external-file:}");
+			if (StringUtils.hasText(config)) {
+				return ConditionOutcome
+						.match("Found endpoints.logfile.external-file: " + config);
+			}
 			return ConditionOutcome.noMatch("Found no log file configuration");
 		}
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/LogFileMvcEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/LogFileMvcEndpointTests.java
@@ -110,4 +110,15 @@ public class LogFileMvcEndpointTests {
 		assertThat(response.getContentAsString()).isEqualTo("--TEST--");
 	}
 
+	@Test
+	public void invokeGetsContentExternalFile() throws Exception {
+		this.mvc.setExternalFile(this.logFile);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockHttpServletRequest request = new MockHttpServletRequest(HttpMethod.GET.name(),
+				"/logfile");
+		this.mvc.invoke(request, response);
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+		assertThat("--TEST--").isEqualTo(response.getContentAsString());
+	}
+
 }


### PR DESCRIPTION
In case the launch.script is used to start the boot-application, the logfile is
written by redirect of stdout and -err. The /logfile-endpoint isn't aware of
this file, so this commit adds an property to the logfile-endpoint to serve
external files. When set the specified the file is served in /logfile instead
of logging.file.

closes #4255 

CLA is signed.