### PR TITLE
Add possibility to disable SSL for management server

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcChildContextConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcChildContextConfiguration.java
@@ -68,6 +68,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
  * @author Stephane Nicoll
  * @author Andy Wilkinson
  * @author Eddú Meléndez
+ * @author Henri Kerola
  * @see EndpointWebMvcAutoConfiguration
  */
 @Configuration
@@ -191,6 +192,10 @@ public class EndpointWebMvcChildContextConfiguration {
 			container.setServerHeader(this.server.getServerHeader());
 			container.setAddress(this.managementServerProperties.getAddress());
 			container.addErrorPages(new ErrorPage(this.server.getError().getPath()));
+			// disable SSL if it's explicitly disabled in properties
+			if (!this.managementServerProperties.getSsl().isEnabled()) {
+				container.setSsl(null);
+			}
 		}
 
 	}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ManagementServerProperties.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ManagementServerProperties.java
@@ -33,6 +33,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Dave Syer
  * @author Stephane Nicoll
+ * @author Henri Kerola
  * @see ServerProperties
  */
 @ConfigurationProperties(prefix = "management", ignoreUnknownFields = true)
@@ -78,6 +79,11 @@ public class ManagementServerProperties implements SecurityPrerequisite {
 	private boolean addApplicationContextHeader = true;
 
 	private final Security security = maybeCreateSecurity();
+
+	/**
+	 * SSL configuration.
+	 */
+	private Ssl ssl = new Ssl();
 
 	private Security maybeCreateSecurity() {
 		if (ClassUtils.isPresent(SECURITY_CHECK_CLASS, null)) {
@@ -145,6 +151,14 @@ public class ManagementServerProperties implements SecurityPrerequisite {
 		this.addApplicationContextHeader = addApplicationContextHeader;
 	}
 
+	public Ssl getSsl() {
+		return this.ssl;
+	}
+
+	public void setSsl(Ssl ssl) {
+		this.ssl = ssl;
+	}
+
 	/**
 	 * Security configuration.
 	 */
@@ -180,6 +194,27 @@ public class ManagementServerProperties implements SecurityPrerequisite {
 		public String getRole() {
 			return this.role;
 		}
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+	}
+
+	/**
+	 * SSL configuration.
+	 */
+	public static class Ssl {
+
+		/**
+		 * Use to disable SSL for the management server running on a different
+		 * port than the application using SSL.
+		 */
+		private boolean enabled = true;
 
 		public boolean isEnabled() {
 			return this.enabled;

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/ManagementServerPropertiesAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/ManagementServerPropertiesAutoConfigurationTests.java
@@ -20,13 +20,16 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link ManagementServerPropertiesAutoConfiguration}.
  *
  * @author Phillip Webb
  * @author Stephane Nicoll
+ * @author Henri Kerola
  */
 public class ManagementServerPropertiesAutoConfigurationTests {
 
@@ -35,6 +38,7 @@ public class ManagementServerPropertiesAutoConfigurationTests {
 		ManagementServerProperties properties = new ManagementServerProperties();
 		assertThat(properties.getPort(), nullValue());
 		assertThat(properties.getContextPath(), equalTo(""));
+		assertTrue(properties.getSsl().isEnabled());
 	}
 
 	@Test
@@ -42,8 +46,10 @@ public class ManagementServerPropertiesAutoConfigurationTests {
 		ManagementServerProperties properties = new ManagementServerProperties();
 		properties.setPort(123);
 		properties.setContextPath("/foo");
+		properties.getSsl().setEnabled(false);
 		assertThat(properties.getPort(), equalTo(123));
 		assertThat(properties.getContextPath(), equalTo("/foo"));
+		assertFalse(properties.getSsl().isEnabled());
 	}
 
 	@Test


### PR DESCRIPTION
SSL can be disabled by defining `management.ssl.enabled=false`. This has only effect when the management server is running on a different port than the application using SSL. Fixes gh-4810