### PR TITLE
Fix #4076: Avoid NPE when connecting to Mongo without credentials and not using a URI

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
@@ -18,6 +18,7 @@ package org.springframework.boot.autoconfigure.mongo;
 
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import com.mongodb.MongoClient;
@@ -213,7 +214,7 @@ public class MongoProperties {
 				if (options == null) {
 					options = MongoClientOptions.builder().build();
 				}
-				List<MongoCredential> credentials = null;
+				List<MongoCredential> credentials = Collections.emptyList();
 				if (hasCustomCredentials()) {
 					String database = this.authenticationDatabase == null
 							? getMongoClientDatabase() : this.authenticationDatabase;


### PR DESCRIPTION
This is especially useful for the case of setting `spring.data.mongodb.port=0` to allow `EmbeddedMongoAutoConfiguration` to assign a free port.

Fixes #4076. Also fixes #4051 (which was closed with a documented workaround).