### PR TITLE
Fix sessionRedisTemplate dependency resolution with DevTools and Spri…

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -42,7 +42,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.session.ExpiringSession;
 import org.springframework.util.StringUtils;
 
 /**
@@ -169,7 +168,7 @@ public class LocalDevToolsAutoConfiguration {
 
 			@Bean
 			public RestartCompatibleRedisSerializerConfigurer restartCompatibleRedisSerializerConfigurer(
-					RedisTemplate<String, ExpiringSession> sessionRedisTemplate) {
+					RedisTemplate<?, ?> sessionRedisTemplate) {
 				return new RestartCompatibleRedisSerializerConfigurer(
 						sessionRedisTemplate);
 			}

--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -168,7 +169,7 @@ public class LocalDevToolsAutoConfiguration {
 
 			@Bean
 			public RestartCompatibleRedisSerializerConfigurer restartCompatibleRedisSerializerConfigurer(
-					RedisTemplate<?, ?> sessionRedisTemplate) {
+					@Qualifier("sessionRedisTemplate") RedisTemplate<?, ?> sessionRedisTemplate) {
 				return new RestartCompatibleRedisSerializerConfigurer(
 						sessionRedisTemplate);
 			}

--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/RestartCompatibleRedisSerializerConfigurer.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/RestartCompatibleRedisSerializerConfigurer.java
@@ -26,7 +26,6 @@ import org.springframework.core.serializer.support.SerializingConverter;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.SerializationException;
-import org.springframework.session.ExpiringSession;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -42,12 +41,11 @@ import org.springframework.util.ObjectUtils;
  */
 class RestartCompatibleRedisSerializerConfigurer implements BeanClassLoaderAware {
 
-	private final RedisTemplate<String, ExpiringSession> redisTemplate;
+	private final RedisTemplate<?, ?> redisTemplate;
 
 	private volatile ClassLoader classLoader;
 
-	RestartCompatibleRedisSerializerConfigurer(
-			RedisTemplate<String, ExpiringSession> redisTemplate) {
+	RestartCompatibleRedisSerializerConfigurer(RedisTemplate<?, ?> redisTemplate) {
 		this.redisTemplate = redisTemplate;
 	}
 

--- a/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
+++ b/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
@@ -241,10 +241,23 @@ public class LocalDevToolsAutoConfigurationTests {
 	}
 
 	@Test
-	public void sessionRedisTemplateIsConfiguredWithCustomDeserializers()
+	public void sessionRedisTemplateIsConfiguredWithCustomDeserializers10()
 			throws Exception {
-		SpringApplication application = new SpringApplication(
-				SessionRedisTemplateConfig.class, LocalDevToolsAutoConfiguration.class);
+		sessionRedisTemplateIsConfiguredWithCustomDeserializers(
+				SessionRedisTemplateConfig10.class);
+	}
+
+	@Test
+	public void sessionRedisTemplateIsConfiguredWithCustomDeserializers11()
+			throws Exception {
+		sessionRedisTemplateIsConfiguredWithCustomDeserializers(
+				SessionRedisTemplateConfig11.class);
+	}
+
+	private void sessionRedisTemplateIsConfiguredWithCustomDeserializers(
+			Object sessionConfig) throws Exception {
+		SpringApplication application = new SpringApplication(sessionConfig,
+				LocalDevToolsAutoConfiguration.class);
 		application.setWebEnvironment(false);
 		this.context = application.run();
 		RedisTemplate<?, ?> redisTemplate = this.context.getBean(RedisTemplate.class);
@@ -306,11 +319,23 @@ public class LocalDevToolsAutoConfigurationTests {
 	}
 
 	@Configuration
-	public static class SessionRedisTemplateConfig {
+	public static class SessionRedisTemplateConfig10 {
 
 		@Bean
 		public RedisTemplate<String, ExpiringSession> sessionRedisTemplate() {
 			RedisTemplate<String, ExpiringSession> redisTemplate = new RedisTemplate<String, ExpiringSession>();
+			redisTemplate.setConnectionFactory(mock(RedisConnectionFactory.class));
+			return redisTemplate;
+		}
+
+	}
+
+	@Configuration
+	public static class SessionRedisTemplateConfig11 {
+
+		@Bean
+		public RedisTemplate<Object, Object> sessionRedisTemplate() {
+			RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<Object, Object>();
 			redisTemplate.setConnectionFactory(mock(RedisConnectionFactory.class));
 			return redisTemplate;
 		}

--- a/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
+++ b/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
@@ -260,7 +260,8 @@ public class LocalDevToolsAutoConfigurationTests {
 				LocalDevToolsAutoConfiguration.class);
 		application.setWebEnvironment(false);
 		this.context = application.run();
-		RedisTemplate<?, ?> redisTemplate = this.context.getBean(RedisTemplate.class);
+		RedisTemplate<?, ?> redisTemplate = this.context.getBean("sessionRedisTemplate",
+				RedisTemplate.class);
 		assertThat(redisTemplate.getHashKeySerializer(),
 				is(instanceOf(RestartCompatibleRedisSerializer.class)));
 		assertThat(redisTemplate.getHashValueSerializer(),
@@ -327,7 +328,6 @@ public class LocalDevToolsAutoConfigurationTests {
 			redisTemplate.setConnectionFactory(mock(RedisConnectionFactory.class));
 			return redisTemplate;
 		}
-
 	}
 
 	@Configuration
@@ -339,7 +339,5 @@ public class LocalDevToolsAutoConfigurationTests {
 			redisTemplate.setConnectionFactory(mock(RedisConnectionFactory.class));
 			return redisTemplate;
 		}
-
 	}
-
 }


### PR DESCRIPTION
…ng Session 1.1.0.M1

Previously, when Spring Session 1.1.0.M1 and DevTools were declared as
dependencies the applicaiton failed to start, because sessionRedisTemplate
cloud not be resolved.

This commit relaxes the dependency for sessionRedisTemplate in
restartCompatibleRedisSerializerConfigurer from RedisTemplate<String, ExpiringSession>
to `RedisTemplate<?, ?>`, so now both `RedisTemplate<String, ExpiringSession>` and
`RedisTemplate<Object, Object>` are properly resolved.

Closes gh-4895