### PR TITLE
Avoid double-registration when a Servlet or Filter implements ServletContextInitializer

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/ServletContextInitializerBeans.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/ServletContextInitializerBeans.java
@@ -119,7 +119,7 @@ class ServletContextInitializerBeans
 		}
 		else {
 			addServletContextInitializerBean(ServletContextInitializer.class, beanName,
-					initializer, beanFactory, null);
+					initializer, beanFactory, initializer);
 		}
 	}
 


### PR DESCRIPTION
I have some Servlet beans that implement `ServletContextInitializer` to handle their own registration. They get double-registered because they don't get added to the `seen` map, so the beans get picked up again and have an unwanted `ServletRegistrationBean` created.
