### PR TITLE
Support property classes with SNAKE_CASE setters

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/bind/PropertiesConfigurationFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/bind/PropertiesConfigurationFactory.java
@@ -287,12 +287,15 @@ public class PropertiesConfigurationFactory<T>
 				if (!name.equals("class")) {
 					RelaxedNames relaxedNames = RelaxedNames.forCamelCase(name);
 					if (prefixes == null) {
+						names.add(name);
 						for (String relaxedName : relaxedNames) {
 							names.add(relaxedName);
 						}
 					}
 					else {
 						for (String prefix : prefixes) {
+							names.add(prefix + "." + name);
+							names.add(prefix + "_" + name);
 							for (String relaxedName : relaxedNames) {
 								names.add(prefix + "." + relaxedName);
 								names.add(prefix + "_" + relaxedName);

--- a/spring-boot/src/test/java/org/springframework/boot/bind/PropertiesConfigurationFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/bind/PropertiesConfigurationFactoryTests.java
@@ -135,6 +135,34 @@ public class PropertiesConfigurationFactoryTests {
 	}
 
 	@Test
+	public void testBindWithSnakeCaseSetter() throws Exception {
+		this.targetName = null;
+		MutablePropertySources propertySources = new MutablePropertySources();
+		propertySources.addLast(new SystemEnvironmentPropertySource("systemEnvironment",
+				Collections.<String, Object>singletonMap("MY_LINE", "blah")));
+		propertySources.addLast(new RandomValuePropertySource());
+		setupFactory();
+		this.factory.setPropertySources(propertySources);
+		this.factory.afterPropertiesSet();
+		Foo foo = this.factory.getObject();
+		assertEquals("blah", foo.getMY_LINE());
+	}
+
+	@Test
+	public void testBindWithPrefixAndSnakeCaseSetter() throws Exception {
+		this.targetName = "foo";
+		MutablePropertySources propertySources = new MutablePropertySources();
+		propertySources.addLast(new SystemEnvironmentPropertySource("systemEnvironment",
+				Collections.<String, Object>singletonMap("foo.MY_LINE", "blah")));
+		propertySources.addLast(new RandomValuePropertySource());
+		setupFactory();
+		this.factory.setPropertySources(propertySources);
+		this.factory.afterPropertiesSet();
+		Foo foo = this.factory.getObject();
+		assertEquals("blah", foo.getMY_LINE());
+	}
+
+	@Test
 	public void testBindWithDelimitedPrefixUsingMatchingDelimiter() throws Exception {
 		this.targetName = "env_foo";
 		this.ignoreUnknownFields = false;
@@ -195,6 +223,8 @@ public class PropertiesConfigurationFactoryTests {
 
 		private String fooBar;
 
+		private String line;
+
 		public String getSpringFooBaz() {
 			return this.spring_foo_baz;
 		}
@@ -225,6 +255,14 @@ public class PropertiesConfigurationFactoryTests {
 
 		public void setFooBar(String fooBar) {
 			this.fooBar = fooBar;
+		}
+
+		public void setMY_LINE(String line) {
+			this.line = line;
+		}
+
+		public String getMY_LINE() {
+			return this.line;
 		}
 
 	}


### PR DESCRIPTION
A property class with a setter based on SNAKE_CASE like
"setMY_PROP(...)" will not pickup a property from the
available sources named "MY_PROP". This behavior was
expected before.

Fixes gh-4915
See gh-3402