### PR TITLE
Clarify location for Flyway callback scripts

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -1709,6 +1709,9 @@ addition Spring Boot provides a small set of properties in
 {sc-spring-boot-autoconfigure}/flyway/FlywayProperties.{sc-ext}[`FlywayProperties`]
 that can be used to disable the migrations, or switch off the location checking.
 
+If you want to make use of http://flywaydb.org/documentation/callbacks.html[Flyway callbacks], those scripts should also live in the
+`classpath:db/migration` folder.
+
 By default Flyway will autowire the (`@Primary`) `DataSource` in your context and
 use that for migrations. If you like to use a different `DataSource` you can create
 one and mark its `@Bean` as `@FlywayDataSource` - if you do that remember to create


### PR DESCRIPTION
This was frustrating us on a recent project as the Flyway documentation says to put your callback scripts in `<install_dir>/sql` when in fact they should also go in `db/migrations`.