### PR TITLE
Instantiate MetricRegistryMetricReader as bean

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/MetricsDropwizardAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/MetricsDropwizardAutoConfiguration.java
@@ -56,10 +56,13 @@ public class MetricsDropwizardAutoConfiguration {
 	}
 
 	@Bean
+	public MetricRegistryMetricReader dropwizardMetricReader(MetricRegistry metricRegistry) {
+		return new MetricRegistryMetricReader(metricRegistry);
+	}
+
+	@Bean
 	public MetricReaderPublicMetrics dropwizardPublicMetrics(
-			MetricRegistry metricRegistry) {
-		MetricRegistryMetricReader reader = new MetricRegistryMetricReader(
-				metricRegistry);
+			MetricRegistryMetricReader reader) {
 		return new MetricReaderPublicMetrics(reader);
 	}
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/MetricRepositoryAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/MetricRepositoryAutoConfigurationTests.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import org.springframework.boot.actuate.metrics.CounterService;
 import org.springframework.boot.actuate.metrics.GaugeService;
+import org.springframework.boot.actuate.metrics.Metric;
 import org.springframework.boot.actuate.metrics.buffer.BufferCounterService;
 import org.springframework.boot.actuate.metrics.buffer.BufferGaugeService;
 import org.springframework.boot.actuate.metrics.dropwizard.DropwizardMetricServices;
@@ -84,6 +85,10 @@ public class MetricRepositoryAutoConfigurationTests {
 		@SuppressWarnings("unchecked")
 		Gauge<Double> gauge = (Gauge<Double>) registry.getMetrics().get("gauge.foo");
 		assertEquals(new Double(2.7), gauge.getValue());
+		MetricReader reader = this.context.getBean(MetricReader.class);
+		@SuppressWarnings("unchecked")
+		Metric<Double> metric = (Metric<Double>) reader.findOne("gauge.foo");
+		assertEquals(new Double(2.7), metric.getValue());
 	}
 
 	@Test


### PR DESCRIPTION
The `MetricsDropwizardAutoConfiguration` installs a `DropwizardMetricServices` bean
which implements `GaugeService` and that's why neither `FastMetricServicesConfiguration` nor `LegacyMetricServicesConfiguration` kicks in and a `MetricsReader` is missing. This change makes `MetricRegistryMetricReader` a bean.
