### PR TITLE
Introduce HealthIndicatorRegistry

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.boot.actuate.autoconfigure;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,8 +45,9 @@ import org.springframework.boot.actuate.endpoint.PublicMetrics;
 import org.springframework.boot.actuate.endpoint.RequestMappingEndpoint;
 import org.springframework.boot.actuate.endpoint.ShutdownEndpoint;
 import org.springframework.boot.actuate.endpoint.TraceEndpoint;
+import org.springframework.boot.actuate.health.DefaultHealthIndicatorRegistry;
 import org.springframework.boot.actuate.health.HealthAggregator;
-import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.HealthIndicatorRegistry;
 import org.springframework.boot.actuate.health.OrderedHealthAggregator;
 import org.springframework.boot.actuate.trace.InMemoryTraceRepository;
 import org.springframework.boot.actuate.trace.TraceRepository;
@@ -81,6 +81,7 @@ import org.springframework.web.servlet.handler.AbstractHandlerMethodMapping;
  * @author Christian Dupuis
  * @author Stephane Nicoll
  * @author Eddú Meléndez
+ * @author Vedran Pavic
  */
 @Configuration
 @AutoConfigureAfter({ FlywayAutoConfiguration.class, LiquibaseAutoConfiguration.class })
@@ -94,7 +95,7 @@ public class EndpointAutoConfiguration {
 	private HealthAggregator healthAggregator = new OrderedHealthAggregator();
 
 	@Autowired(required = false)
-	private Map<String, HealthIndicator> healthIndicators = new HashMap<String, HealthIndicator>();
+	private HealthIndicatorRegistry healthIndicatorRegistry = new DefaultHealthIndicatorRegistry();
 
 	@Autowired(required = false)
 	private Collection<PublicMetrics> publicMetrics;
@@ -111,7 +112,7 @@ public class EndpointAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public HealthEndpoint healthEndpoint() {
-		return new HealthEndpoint(this.healthAggregator, this.healthIndicators);
+		return new HealthEndpoint(this.healthAggregator, this.healthIndicatorRegistry);
 	}
 
 	@Bean

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DefaultHealthIndicatorRegistry.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DefaultHealthIndicatorRegistry.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.health;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Default implementation of {@link HealthIndicatorRegistry}.
+ *
+ * @author Vedran Pavic
+ */
+public class DefaultHealthIndicatorRegistry implements HealthIndicatorRegistry {
+
+	private static final Log logger = LogFactory.getLog(DefaultHealthIndicatorRegistry.class);
+
+	private final Map<String, HealthIndicator> healthIndicators =
+			new HashMap<String, HealthIndicator>();
+
+	private DefaultHealthIndicatorRegistryProperties properties;
+
+	private ExecutorService executor;
+
+	/**
+	 * Create a {@link DefaultHealthIndicatorRegistry} instance.
+	 * @param properties the configuration properties
+	 */
+	public DefaultHealthIndicatorRegistry(DefaultHealthIndicatorRegistryProperties properties) {
+		Assert.notNull(properties, "Properties must not be null");
+		this.properties = properties;
+		if (this.properties.isRunInParallel()) {
+			this.executor = Executors.newFixedThreadPool(
+					this.properties.getThreadCount(), new WorkerThreadFactory());
+		}
+	}
+
+	/**
+	 * Create a {@link DefaultHealthIndicatorRegistry} instance.
+	 */
+	public DefaultHealthIndicatorRegistry() {
+		this(new DefaultHealthIndicatorRegistryProperties());
+	}
+
+	@Override
+	public void register(String name, HealthIndicator healthIndicator) {
+		synchronized (this.healthIndicators) {
+			this.healthIndicators.put(name, healthIndicator);
+		}
+	}
+
+	@Override
+	public void unregister(String name) {
+		synchronized (this.healthIndicators) {
+			this.healthIndicators.remove(name);
+		}
+	}
+
+	@Override
+	public Set<String> getRegisteredNames() {
+		return Collections.unmodifiableSet(new HashSet<String>(this.healthIndicators.keySet()));
+	}
+
+	@Override
+	public Health runHealthIndicator(String name) {
+		HealthIndicator healthIndicator = this.healthIndicators.get(name);
+		Assert.notNull(healthIndicator, "HealthIndicator " + name + " does not exist");
+		return healthIndicator.health();
+	}
+
+	@Override
+	public Map<String, Health> runHealthIndicators() {
+		Map<String, Health> healths = new HashMap<String, Health>();
+		if (this.properties.isRunInParallel()) {
+			Assert.notNull(this.executor, "Executor must not be null");
+			Map<String, Future<Health>> futures = new HashMap<String, Future<Health>>();
+			for (final Map.Entry<String, HealthIndicator> entry : this.healthIndicators.entrySet()) {
+				Future<Health> future = this.executor.submit(new Callable<Health>() {
+					@Override
+					public Health call() throws Exception {
+						return entry.getValue().health();
+					}
+				});
+				futures.put(entry.getKey(), future);
+			}
+			for (Map.Entry<String, Future<Health>> entry : futures.entrySet()) {
+				try {
+					healths.put(entry.getKey(), entry.getValue().get());
+				}
+				catch (Exception e) {
+					logger.warn("Error invoking health indicator '" + entry.getKey() + "'", e);
+					healths.put(entry.getKey(), Health.down(e).build());
+				}
+			}
+		}
+		else {
+			for (Map.Entry<String, HealthIndicator> entry : this.healthIndicators.entrySet()) {
+				healths.put(entry.getKey(), entry.getValue().health());
+			}
+		}
+		return healths;
+	}
+
+	/**
+	 * {@link ThreadFactory} to create the worker threads.
+	 */
+	private static class WorkerThreadFactory implements ThreadFactory {
+
+		private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+		@Override
+		public Thread newThread(Runnable r) {
+			Thread thread = new Thread(r);
+			thread.setName(ClassUtils.getShortName(getClass()) +
+					"-" + this.threadNumber.getAndIncrement());
+			return thread;
+		}
+
+	}
+
+}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DefaultHealthIndicatorRegistryProperties.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DefaultHealthIndicatorRegistryProperties.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.health;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * External configuration properties for {@link DefaultHealthIndicatorRegistry}.
+ *
+ * @author Vedran Pavic
+ */
+@ConfigurationProperties("management.health.registry")
+public class DefaultHealthIndicatorRegistryProperties {
+
+	/**
+	 * Flag to indicate the health indicators should run in parallel.
+	 */
+	private boolean runInParallel = false;
+
+	/**
+	 * Number of threads used to run health indicators in parallel.
+	 */
+	private int threadCount = 2;
+
+	public boolean isRunInParallel() {
+		return this.runInParallel;
+	}
+
+	public void setRunInParallel(boolean runInParallel) {
+		this.runInParallel = runInParallel;
+	}
+
+	public int getThreadCount() {
+		return this.threadCount;
+	}
+
+	public void setThreadCount(int threadCount) {
+		this.threadCount = threadCount;
+	}
+
+}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthIndicatorRegistry.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthIndicatorRegistry.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.health;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A registry of {@link HealthIndicator} instances.
+ *
+ * @author Vedran Pavic
+ */
+public interface HealthIndicatorRegistry {
+
+	/**
+	 * Register the health indicator with given name.
+	 * @param name the health indicator name
+	 * @param healthIndicator the health indicator to register
+	 */
+	void register(String name, HealthIndicator healthIndicator);
+
+	/**
+	 * Unregister the health indicator with given name.
+	 * @param name the health indicator name
+	 */
+	void unregister(String name);
+
+	/**
+	 * Return names of all currently registered health indicators.
+	 * @return the health indicator names
+	 */
+	Set<String> getRegisteredNames();
+
+	/**
+	 * Return an indication of health for given health indicator name.
+	 * @param name the health indicator name
+	 * @return the health
+	 */
+	Health runHealthIndicator(String name);
+
+	/**
+	 * Return a map of healths for all registered health indicators.
+	 * @return the map of healths
+	 */
+	Map<String, Health> runHealthIndicators();
+
+}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/HealthMvcEndpointAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/HealthMvcEndpointAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,10 @@ import org.junit.Test;
 
 import org.springframework.boot.actuate.endpoint.mvc.HealthMvcEndpoint;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.DefaultHealthIndicatorRegistry;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Health.Builder;
+import org.springframework.boot.actuate.health.HealthIndicatorRegistry;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration;
@@ -42,6 +44,7 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Dave Syer
  * @author Andy Wilkinson
+ * @author Vedran Pavic
  */
 public class HealthMvcEndpointAutoConfigurationTests {
 
@@ -92,6 +95,13 @@ public class HealthMvcEndpointAutoConfigurationTests {
 		@Bean
 		public TestHealthIndicator testHealthIndicator() {
 			return new TestHealthIndicator();
+		}
+
+		@Bean
+		public HealthIndicatorRegistry healthIndicatorRegistry() {
+			DefaultHealthIndicatorRegistry registry = new DefaultHealthIndicatorRegistry();
+			registry.register("test", testHealthIndicator());
+			return registry;
 		}
 
 	}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/HealthEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/HealthEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package org.springframework.boot.actuate.endpoint;
 
-import java.util.Map;
-
 import org.junit.Test;
 
+import org.springframework.boot.actuate.health.DefaultHealthIndicatorRegistry;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthAggregator;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.HealthIndicatorRegistry;
 import org.springframework.boot.actuate.health.OrderedHealthAggregator;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertThat;
  *
  * @author Phillip Webb
  * @author Christian Dupuis
+ * @author Vedran Pavic
  */
 public class HealthEndpointTests extends AbstractEndpointTests<HealthEndpoint> {
 
@@ -56,8 +57,8 @@ public class HealthEndpointTests extends AbstractEndpointTests<HealthEndpoint> {
 
 		@Bean
 		public HealthEndpoint endpoint(HealthAggregator healthAggregator,
-				Map<String, HealthIndicator> healthIndicators) {
-			return new HealthEndpoint(healthAggregator, healthIndicators);
+				HealthIndicatorRegistry healthIndicatorRegistry) {
+			return new HealthEndpoint(healthAggregator, healthIndicatorRegistry);
 		}
 
 		@Bean
@@ -75,5 +76,11 @@ public class HealthEndpointTests extends AbstractEndpointTests<HealthEndpoint> {
 		public HealthAggregator healthAggregator() {
 			return new OrderedHealthAggregator();
 		}
+
+		@Bean
+		public HealthIndicatorRegistry healthIndicatorRegistry() {
+			return new DefaultHealthIndicatorRegistry();
+		}
+
 	}
 }

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/DefaultHealthIndicatorRegistryTest.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/DefaultHealthIndicatorRegistryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.health;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Tests for {@link DefaultHealthIndicatorRegistry}.
+ *
+ * @author Vedran Pavic
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultHealthIndicatorRegistryTest {
+
+	@Mock
+	private HealthIndicator one;
+
+	@Mock
+	private HealthIndicator two;
+
+	private DefaultHealthIndicatorRegistry registry;
+
+	private DefaultHealthIndicatorRegistryProperties properties = new DefaultHealthIndicatorRegistryProperties();
+
+	@Before
+	public void setup() {
+		given(this.one.health()).willReturn(new Health.Builder().up().build());
+		given(this.two.health()).willReturn(new Health.Builder().unknown().build());
+
+		this.registry = new DefaultHealthIndicatorRegistry(this.properties);
+	}
+
+	@Test
+	public void createAndRunAll() {
+		this.registry.register("one", this.one);
+		this.registry.register("two", this.two);
+		Map<String, Health> healths = this.registry.runHealthIndicators();
+		assertThat(healths.size(), equalTo(2));
+		assertThat(healths.get("one").getStatus(), equalTo(Status.UP));
+		assertThat(healths.get("two").getStatus(), equalTo(Status.UNKNOWN));
+	}
+
+	@Test
+	public void createAndRunAllInParallel() {
+		this.properties.setRunInParallel(true);
+		this.registry.register("one", this.one);
+		this.registry.register("two", this.two);
+		Map<String, Health> healths = this.registry.runHealthIndicators();
+		assertThat(healths.size(), equalTo(2));
+		assertThat(healths.get("one").getStatus(), equalTo(Status.UP));
+		assertThat(healths.get("two").getStatus(), equalTo(Status.UNKNOWN));
+	}
+
+	@Test
+	public void createAndRunSingle() {
+		this.registry.register("one", this.one);
+		Health health = this.registry.runHealthIndicator("one");
+		assertThat(health.getStatus(), equalTo(Status.UP));
+	}
+
+	@Test
+	public void testUnregister() {
+		this.registry.register("one", this.one);
+		this.registry.register("two", this.two);
+		Map<String, Health> healths = this.registry.runHealthIndicators();
+		assertThat(healths.size(), equalTo(2));
+		this.registry.unregister("two");
+		healths = this.registry.runHealthIndicators();
+		assertThat(healths.size(), equalTo(1));
+	}
+
+}

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -831,6 +831,8 @@ content into your application; rather pick only the properties that you need.
 	management.health.mongo.enabled=true # Enable MongoDB health check.
 	management.health.rabbit.enabled=true # Enable RabbitMQ health check.
 	management.health.redis.enabled=true # Enable Redis health check.
+	management.health.registry.run-in-parallel=false # Flag to indicate the health indicators should run in parallel.
+	management.health.registry.thread-count=2 # Number of threads used to run health indicators in parallel.
 	management.health.solr.enabled=true # Enable Solr health check.
 	management.health.status.order=DOWN, OUT_OF_SERVICE, UNKNOWN, UP # Comma-separated list of health statuses in order of severity.
 

--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -255,9 +255,10 @@ returned, and for an authenticated connection additional details are also displa
 <<production-ready-health-access-restrictions>> for HTTP details).
 
 Health information is collected from all
-{sc-spring-boot-actuator}/health/HealthIndicator.{sc-ext}[`HealthIndicator`] beans defined
-in your `ApplicationContext`. Spring Boot includes a number of auto-configured
-`HealthIndicators` and you can also write your own.
+{sc-spring-boot-actuator}/health/HealthIndicator.{sc-ext}[`HealthIndicator`] instances
+registered with {sc-spring-boot-actuator}/health/HealthIndicatorRegistry.{sc-ext}[`HealthIndicatorRegistry`].
+Spring Boot includes a number of auto-configured `HealthIndicators` and you can also write
+your own.
 
 
 
@@ -346,6 +347,9 @@ additional details to be displayed.
 NOTE: The identifier for a given `HealthIndicator` is the name of the bean without the
 `HealthIndicator` suffix if it exists. In the example above, the health information will
 be available in an entry named `my`.
+
+Additionally, you can register (and unregister) `HealthIndicator` instances in runtime
+using {sc-spring-boot-actuator}/health/HealthIndicatorRegistry.{sc-ext}[`HealthIndicatorRegistry`].
 
 In addition to Spring Boot's predefined {sc-spring-boot-actuator}/health/Status.{sc-ext}[`Status`]
 types, it is also possible for `Health` to return a custom `Status` that represents a


### PR DESCRIPTION
This PR introduces `HealthIndicatorRegistry` which handles registration and invocation of `HealthIndicator` instances. Registering new `HealthIndicator` instances (as well as unregistering) is now possible in runtime (see #4894).

The default implementation offers the option to run the registered health indicators in parallel therefore improving the performance of `HealthEndpoint` invocations in scenarios with multiple expensive `HealthIndicators` (see #2652).