### PR TITLE
Add details to event data in AuthenticationAuditListener

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthenticationAuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthenticationAuditListener.java
@@ -61,6 +61,9 @@ public class AuthenticationAuditListener extends AbstractAuthenticationAuditList
 		Map<String, Object> data = new HashMap<String, Object>();
 		data.put("type", event.getException().getClass().getName());
 		data.put("message", event.getException().getMessage());
+		if (event.getAuthentication().getDetails() != null) {
+			data.put("details", event.getAuthentication().getDetails());
+		}
 		publish(new AuditEvent(event.getAuthentication().getName(),
 				"AUTHENTICATION_FAILURE", data));
 	}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/security/AuthenticationAuditListenerTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/security/AuthenticationAuditListenerTests.java
@@ -16,9 +16,19 @@
 
 package org.springframework.boot.actuate.security;
 
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
-
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -29,11 +39,6 @@ import org.springframework.security.authentication.event.InteractiveAuthenticati
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.authentication.switchuser.AuthenticationSwitchUserEvent;
-
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link AuthenticationAuditListener}.
@@ -82,4 +87,32 @@ public class AuthenticationAuditListenerTests {
 		verify(this.publisher).publishEvent((ApplicationEvent) anyObject());
 	}
 
+	@Test
+	public void shouldPassDetailsToAuditEventOnAuthenticationFailureEvent()
+		throws Exception {
+		// given
+		final Object details = new Object();
+		final AuthenticationFailureExpiredEvent event =
+			createAuthenticationFailureEvent(details);
+
+		// when
+		this.listener.onApplicationEvent(event);
+
+		// then
+		final ArgumentCaptor<AuditApplicationEvent> applicationEventArgumentCaptor =
+			ArgumentCaptor.forClass(AuditApplicationEvent.class);
+		verify(this.publisher).publishEvent(applicationEventArgumentCaptor.capture());
+		final Map<String, Object> eventData =
+			applicationEventArgumentCaptor.getValue().getAuditEvent().getData();
+		assertThat(eventData, hasEntry("details", details));
+	}
+
+	private AuthenticationFailureExpiredEvent createAuthenticationFailureEvent(
+		final Object details) {
+		final UsernamePasswordAuthenticationToken authentication =
+			new UsernamePasswordAuthenticationToken("user", "password");
+		authentication.setDetails(details);
+		final BadCredentialsException exception = new BadCredentialsException("Bad user");
+		return new AuthenticationFailureExpiredEvent(authentication, exception);
+	}
 }

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/security/AuthenticationAuditListenerTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/security/AuthenticationAuditListenerTests.java
@@ -16,18 +16,12 @@
 
 package org.springframework.boot.actuate.security;
 
-import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-
 import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+
 import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
@@ -39,6 +33,13 @@ import org.springframework.security.authentication.event.InteractiveAuthenticati
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.authentication.switchuser.AuthenticationSwitchUserEvent;
+
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link AuthenticationAuditListener}.


### PR DESCRIPTION
In method onAuthenticationFailureEvent data can be passed similarly
as in onAuthenticationSuccessEvent method.
Fixes gh-4819