### PR TITLE
Fix binding of Flyway's baselineVersion property from YAML

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,12 @@ public class FlywayAutoConfiguration {
 	@ConfigurationPropertiesBinding
 	public StringToMigrationVersionConverter stringToMigrationVersionConverter() {
 		return new StringToMigrationVersionConverter();
+	}
+
+	@Bean
+	@ConfigurationPropertiesBinding
+	public IntegerToMigrationVersionConverter integerToMigrationVersionConverter() {
+		return new IntegerToMigrationVersionConverter();
 	}
 
 	@Configuration
@@ -177,6 +183,19 @@ public class FlywayAutoConfiguration {
 		@Override
 		public MigrationVersion convert(String source) {
 			return MigrationVersion.fromVersion(source);
+		}
+
+	}
+
+	/**
+	 * Convert an Integer to a {@link MigrationVersion}.
+	 */
+	private static class IntegerToMigrationVersionConverter
+			implements Converter<Integer, MigrationVersion> {
+
+		@Override
+		public MigrationVersion convert(Integer source) {
+			return MigrationVersion.fromVersion(source.toString());
 		}
 
 	}


### PR DESCRIPTION
#4317 fixed the binding of Flyway's ```baselineVersion``` property, however it turns out that this fix does not work when the property is set using YAML config. This is because ```baseline-version: 0``` from YAML is interpreted as an ```Integer``` value so ```StringToMigrationVersionConverter``` introduced in the previous PR is useless in this scenario.

Steps to reproduce the issue:
 - use ```spring-boot-sample-flyway``` app
 - replace the included ```application.properties``` with ```application.yml``` of following content:

```yaml
spring:
  jpa:
    hibernate:
      ddl-auto: validate

  h2:
    console:
      enabled: true

flyway:
  baseline-version: 0
```

Starting the app generates exeception:

```stacktrace
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'flyway': Could not bind properties to Flyway (prefix=flyway, ignoreInvalidFields=false, ignoreUnknownFields=true, ignoreNestedProperties=false); nested exception is org.springframework.validation.BindException: org.springframework.boot.bind.RelaxedDataBinder$RelaxedBeanPropertyBindingResult: 1 errors
Field error in object 'flyway' on field 'baselineVersion': rejected value [0]; codes [typeMismatch.flyway.baselineVersion,typeMismatch.baselineVersion,typeMismatch.org.flywaydb.core.api.MigrationVersion,typeMismatch]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [flyway.baselineVersion,baselineVersion]; arguments []; default message [baselineVersion]]; default message [Failed to convert property value of type [java.lang.Integer] to required type [org.flywaydb.core.api.MigrationVersion] for property 'baselineVersion'; nested exception is java.lang.IllegalStateException: Cannot convert value of type [java.lang.Integer] to required type [org.flywaydb.core.api.MigrationVersion] for property 'baselineVersion': no matching editors or conversion strategy found]
	at org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor.postProcessBeforeInitialization(ConfigurationPropertiesBindingPostProcessor.java:325) ~[classes/:na]
	at org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor.postProcessBeforeInitialization(ConfigurationPropertiesBindingPostProcessor.java:280) ~[classes/:na]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInitialization(AbstractAutowireCapableBeanFactory.java:408) ~[spring-beans-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1570) ~[spring-beans-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:545) ~[spring-beans-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:482) ~[spring-beans-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:306) ~[spring-beans-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230) ~[spring-beans-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:302) ~[spring-beans-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:197) ~[spring-beans-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:296) ~[spring-beans-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:197) ~[spring-beans-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1054) ~[spring-context-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:829) ~[spring-context-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:538) ~[spring-context-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.refresh(EmbeddedWebApplicationContext.java:118) ~[classes/:na]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:766) [classes/:na]
	at org.springframework.boot.SpringApplication.createAndRefreshContext(SpringApplication.java:361) [classes/:na]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:307) [classes/:na]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1180) [classes/:na]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1169) [classes/:na]
	at sample.flyway.SampleFlywayApplication.main(SampleFlywayApplication.java:36) [classes/:na]
Caused by: org.springframework.validation.BindException: org.springframework.boot.bind.RelaxedDataBinder$RelaxedBeanPropertyBindingResult: 1 errors
Field error in object 'flyway' on field 'baselineVersion': rejected value [0]; codes [typeMismatch.flyway.baselineVersion,typeMismatch.baselineVersion,typeMismatch.org.flywaydb.core.api.MigrationVersion,typeMismatch]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [flyway.baselineVersion,baselineVersion]; arguments []; default message [baselineVersion]]; default message [Failed to convert property value of type [java.lang.Integer] to required type [org.flywaydb.core.api.MigrationVersion] for property 'baselineVersion'; nested exception is java.lang.IllegalStateException: Cannot convert value of type [java.lang.Integer] to required type [org.flywaydb.core.api.MigrationVersion] for property 'baselineVersion': no matching editors or conversion strategy found]
	at org.springframework.boot.bind.PropertiesConfigurationFactory.validate(PropertiesConfigurationFactory.java:362) ~[classes/:na]
	at org.springframework.boot.bind.PropertiesConfigurationFactory.doBindPropertiesToTarget(PropertiesConfigurationFactory.java:271) ~[classes/:na]
	at org.springframework.boot.bind.PropertiesConfigurationFactory.bindPropertiesToTarget(PropertiesConfigurationFactory.java:241) ~[classes/:na]
	at org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor.postProcessBeforeInitialization(ConfigurationPropertiesBindingPostProcessor.java:320) ~[classes/:na]
	... 21 common frames omitted
```

This PR adds ```IntegerToMigrationVersionConverter``` to fix the issue.

Please include this in the ```1.3.2.RELEASE``` if possible.

I've signed the CLA.