### PR TITLE
Allow to extend UserInfoTokenServices with a custom Principal

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/UserInfoTokenServices.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/UserInfoTokenServices.java
@@ -99,7 +99,7 @@ public class UserInfoTokenServices implements ResourceServerTokenServices {
 		return new OAuth2Authentication(request, token);
 	}
 
-	private Object getPrincipal(Map<String, Object> map) {
+	protected Object getPrincipal(Map<String, Object> map) {
 		for (String key : PRINCIPAL_KEYS) {
 			if (map.containsKey(key)) {
 				return map.get(key);


### PR DESCRIPTION
I would suggest a very easy but handy improvement which allows to make `org.springframework.boot.autoconfigure.security.oauth2.resource.UserInfoTokenServices` extendable. If you change `private Object getPrincipal(Map<String, Object> map)` to be `protected` then overriding this method would allow to get a custom authenticated principal from the authorized request parameters with e.g. `@AuthenticationPrincipal` annotation so that resource server gets all the custom user info without an explicit second call to authorization server's `/user` endpoint.