### PR TITLE
Remove Docker container after launch script test execution

### DIFF
--- a/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
+++ b/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
@@ -206,24 +206,29 @@ public class SysVinitLaunchScriptIT {
 		DockerClient docker = createClient();
 		String imageId = buildImage(docker);
 		String container = createContainer(docker, imageId, script);
-		copyFilesToContainer(docker, container, script);
-		docker.startContainerCmd(container).exec();
-		StringBuilder output = new StringBuilder();
-		AttachContainerResultCallback resultCallback = docker
-				.attachContainerCmd(container).withStdOut(true).withStdErr(true)
-				.withFollowStream(true).withLogs(true)
-				.exec(new AttachContainerResultCallback() {
+		try {
+			copyFilesToContainer(docker, container, script);
+			docker.startContainerCmd(container).exec();
+			StringBuilder output = new StringBuilder();
+			AttachContainerResultCallback resultCallback = docker
+					.attachContainerCmd(container).withStdOut(true).withStdErr(true)
+					.withFollowStream(true).withLogs(true)
+					.exec(new AttachContainerResultCallback() {
 
-					@Override
-					public void onNext(Frame item) {
-						output.append(new String(item.getPayload()));
-						super.onNext(item);
-					}
+						@Override
+						public void onNext(Frame item) {
+							output.append(new String(item.getPayload()));
+							super.onNext(item);
+						}
 
-				});
-		resultCallback.awaitCompletion(60, TimeUnit.SECONDS).close();
-		docker.waitContainerCmd(container).exec();
-		return output.toString();
+					});
+			resultCallback.awaitCompletion(60, TimeUnit.SECONDS).close();
+			docker.waitContainerCmd(container).exec();
+			return output.toString();
+		}
+		finally {
+			docker.removeContainerCmd(container).exec();
+		}
 	}
 
 	private DockerClient createClient() {


### PR DESCRIPTION
```SysVinitLaunchScriptIT``` creates a new Docker container for each test execution and does not remove it afterwards. This leaves many containers on the disk which uses a lot of disk space (see output of ```docker ps -a```) and is quite tedious to clean up.

This PR adds the removal of container after it has served its purpose.

I've signed the CLA.