### PR TITLE
Introduce strategy for running HealthIndicators

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/health/CompositeHealthIndicatorConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/health/CompositeHealthIndicatorConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.CompositeHealthIndicator;
 import org.springframework.boot.actuate.health.HealthAggregator;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.HealthIndicatorRunner;
 import org.springframework.core.ResolvableType;
 
 /**
@@ -31,6 +32,7 @@ import org.springframework.core.ResolvableType;
  * @param <H> the health indicator type
  * @param <S> the bean source type
  * @author Stephane Nicoll
+ * @author Vedran Pavic
  * @since 2.0.0
  */
 public abstract class CompositeHealthIndicatorConfiguration<H extends HealthIndicator, S> {
@@ -38,12 +40,18 @@ public abstract class CompositeHealthIndicatorConfiguration<H extends HealthIndi
 	@Autowired
 	private HealthAggregator healthAggregator;
 
+	@Autowired(required = false)
+	private HealthIndicatorRunner healthIndicatorRunner;
+
 	protected HealthIndicator createHealthIndicator(Map<String, S> beans) {
 		if (beans.size() == 1) {
 			return createHealthIndicator(beans.values().iterator().next());
 		}
 		CompositeHealthIndicator composite = new CompositeHealthIndicator(
 				this.healthAggregator);
+		if (this.healthIndicatorRunner != null) {
+			composite.setHealthIndicatorRunner(this.healthIndicatorRunner);
+		}
 		beans.forEach((name, source) -> composite.addHealthIndicator(name,
 				createHealthIndicator(source)));
 		return composite;

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/AsyncHealthIndicatorRunner.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/AsyncHealthIndicatorRunner.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.health;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link HealthIndicatorRunner} implementation that uses {@link AsyncTaskExecutor} to
+ * invoke {@link HealthIndicator} instances.
+ *
+ * @author Vedran Pavic
+ * @since 2.1.0
+ */
+public class AsyncHealthIndicatorRunner implements HealthIndicatorRunner {
+
+	private static final Log logger = LogFactory.getLog(AsyncHealthIndicatorRunner.class);
+
+	private final AsyncTaskExecutor taskExecutor;
+
+	/**
+	 * Create an {@link AsyncHealthIndicatorRunner} instance.
+	 * @param taskExecutor task executor used to run {@link HealthIndicator}s
+	 */
+	public AsyncHealthIndicatorRunner(AsyncTaskExecutor taskExecutor) {
+		Assert.notNull(taskExecutor, "TaskExecutor must not be null");
+		this.taskExecutor = taskExecutor;
+	}
+
+	@Override
+	public Map<String, Health> run(Map<String, HealthIndicator> healthIndicators) {
+		Map<String, Health> healths = new HashMap<>(healthIndicators.size());
+		Map<String, Future<Health>> futures = new HashMap<>();
+		for (final Map.Entry<String, HealthIndicator> entry : healthIndicators
+				.entrySet()) {
+			Future<Health> future = this.taskExecutor
+					.submit(() -> entry.getValue().health());
+			futures.put(entry.getKey(), future);
+		}
+		for (Map.Entry<String, Future<Health>> entry : futures.entrySet()) {
+			try {
+				healths.put(entry.getKey(), entry.getValue().get());
+			}
+			catch (Exception e) {
+				logger.warn("Error invoking health indicator '" + entry.getKey() + "'",
+						e);
+				healths.put(entry.getKey(), Health.down(e).build());
+			}
+		}
+		return healths;
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthIndicatorRunner.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthIndicatorRunner.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.health;
+
+import java.util.Map;
+
+/**
+ * Strategy interface used by {@link CompositeHealthIndicator} to invoke
+ * {@link HealthIndicator} instances.
+ * <p>
+ * This is useful for customization of invocation in scenarios with many
+ * {@link HealthIndicator} instances in the system and/or resource demanding ones.
+ *
+ * @author Vedran Pavic
+ * @since 2.1.0
+ */
+public interface HealthIndicatorRunner {
+
+	Map<String, Health> run(Map<String, HealthIndicator> healthIndicators);
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/AsyncHealthIndicatorRunnerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/AsyncHealthIndicatorRunnerTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.health;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link AsyncHealthIndicatorRunner}.
+ *
+ * @author Vedran Pavic
+ */
+public class AsyncHealthIndicatorRunnerTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private HealthIndicator one = mock(HealthIndicator.class);
+
+	private HealthIndicator two = mock(HealthIndicator.class);
+
+	@Before
+	public void setUp() {
+		given(this.one.health()).willReturn(new Health.Builder().up().build());
+		given(this.two.health()).willReturn(new Health.Builder().unknown().build());
+	}
+
+	@Test
+	public void createAndRun() {
+		Map<String, HealthIndicator> indicators = new HashMap<>();
+		indicators.put("one", this.one);
+		indicators.put("two", this.two);
+		ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+		taskExecutor.setMaxPoolSize(2);
+		taskExecutor.afterPropertiesSet();
+		HealthIndicatorRunner healthIndicatorRunner = new AsyncHealthIndicatorRunner(
+				taskExecutor);
+		Map<String, Health> healths = healthIndicatorRunner.run(indicators);
+		assertThat(healths.size()).isEqualTo(2);
+		assertThat(healths.get("one").getStatus()).isEqualTo(Status.UP);
+		assertThat(healths.get("two").getStatus()).isEqualTo(Status.UNKNOWN);
+	}
+
+	@Test
+	public void createWithNullTaskExecutor() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("TaskExecutor must not be null");
+		new AsyncHealthIndicatorRunner(null);
+	}
+
+}


### PR DESCRIPTION
This PR introduces strategy for running `HealthIndicator` instances.

The default implementations keep the current invocation pattern, which is sequential, and allows parallel invocation to be configured via properties. This addresses scenarios with many `HealthIndicator`s and/or resource demanding `HealthIndicator` instances (see #2652).

I'll add the documentation updates later, if this enhancement is accepted.

I've signed the CLA.
