### PR TITLE
Update MariaDB database details

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DatabaseDriver.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DatabaseDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ enum DatabaseDriver {
 	/**
 	 * Maria DB.
 	 */
-	MARIADB("org.mariadb.jdbc.Driver", "org.mariadb.jdbc.MySQLDataSource"),
+	MARIADB("org.mariadb.jdbc.Driver", "org.mariadb.jdbc.MariaDbDataSource"),
 
 	/**
 	 * Google App Engine.


### PR DESCRIPTION
[```org.mariadb.jdbc.MySQLDataSource``` is deprecated](https://github.com/MariaDB/mariadb-connector-j/blob/master/src/main/java/org/mariadb/jdbc/MySQLDataSource.java) since ```1.3.0```.

Related to #4482.

I've signed the CLA.