### PR TITLE
Add autoconfiguration for Redis Cluster (Spring Data Redis 1.7.0)

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,12 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties.Cluster;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties.Sentinel;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisNode;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
@@ -76,6 +78,9 @@ public class RedisAutoConfiguration {
 		@Autowired(required = false)
 		private RedisSentinelConfiguration sentinelConfiguration;
 
+		@Autowired(required = false)
+		private RedisClusterConfiguration clusterConfiguration;
+
 		protected final JedisConnectionFactory applyProperties(
 				JedisConnectionFactory factory) {
 			factory.setHostName(this.properties.getHost());
@@ -102,6 +107,34 @@ public class RedisAutoConfiguration {
 				return config;
 			}
 			return null;
+		}
+
+		/**
+		 * Create {@link RedisClusterConfiguration} from {@link RedisProperties.Cluster}.
+		 * 
+		 * 
+		 * @return {@literal null} if no {@link RedisProperties.Cluster} set.
+		 * 
+		 */
+		protected final RedisClusterConfiguration getClusterConfiguration() {
+
+			if (this.clusterConfiguration != null) {
+				return this.clusterConfiguration;
+			}
+
+			if (this.properties.getCluster() == null) {
+				return null;
+			}
+
+			Cluster clusterProperties = this.properties.getCluster();
+			RedisClusterConfiguration config = new RedisClusterConfiguration(
+					clusterProperties.getNodes());
+
+			if (clusterProperties.getMaxRedirects() != null) {
+				config.setMaxRedirects(config.getMaxRedirects().intValue());
+			}
+
+			return config;
 		}
 
 		private List<RedisNode> createSentinels(Sentinel sentinel) {
@@ -135,9 +168,21 @@ public class RedisAutoConfiguration {
 		@ConditionalOnMissingBean(RedisConnectionFactory.class)
 		public JedisConnectionFactory redisConnectionFactory()
 				throws UnknownHostException {
-			return applyProperties(new JedisConnectionFactory(getSentinelConfig()));
+			return applyProperties(createJedisConnectionFactory());
 		}
 
+		private JedisConnectionFactory createJedisConnectionFactory() {
+
+			if (getSentinelConfig() != null) {
+				return new JedisConnectionFactory(getSentinelConfig());
+			}
+
+			if (getClusterConfiguration() != null) {
+				return new JedisConnectionFactory(getClusterConfiguration());
+			}
+
+			return new JedisConnectionFactory();
+		}
 	}
 
 	/**
@@ -156,10 +201,18 @@ public class RedisAutoConfiguration {
 		}
 
 		private JedisConnectionFactory createJedisConnectionFactory() {
-			if (this.properties.getPool() != null) {
-				return new JedisConnectionFactory(getSentinelConfig(), jedisPoolConfig());
+
+			JedisPoolConfig poolConfig = this.properties.getPool() != null ? jedisPoolConfig()
+					: new JedisPoolConfig();
+
+			if (getSentinelConfig() != null) {
+				return new JedisConnectionFactory(getSentinelConfig(), poolConfig);
 			}
-			return new JedisConnectionFactory(getSentinelConfig());
+			if (getClusterConfiguration() != null) {
+				return new JedisConnectionFactory(getClusterConfiguration(), poolConfig);
+			}
+
+			return new JedisConnectionFactory(poolConfig);
 		}
 
 		private JedisPoolConfig jedisPoolConfig() {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.boot.autoconfigure.data.redis;
+
+import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -56,6 +58,8 @@ public class RedisProperties {
 	private Pool pool;
 
 	private Sentinel sentinel;
+
+	private Cluster cluster;
 
 	public int getDatabase() {
 		return this.database;
@@ -111,6 +115,14 @@ public class RedisProperties {
 
 	public void setPool(Pool pool) {
 		this.pool = pool;
+	}
+
+	public Cluster getCluster() {
+		return cluster;
+	}
+
+	public void setCluster(Cluster cluster) {
+		this.cluster = cluster;
 	}
 
 	/**
@@ -173,6 +185,42 @@ public class RedisProperties {
 
 		public void setMaxWait(int maxWait) {
 			this.maxWait = maxWait;
+		}
+	}
+
+	/**
+	 * Cluster properties.
+	 * 
+	 */
+	public static class Cluster {
+
+		/**
+		 * List of host:port pairs. This setting points to an "initial" list of cluster
+		 * nodes and is required to have at least one entry.
+		 */
+		private List<String> nodes;
+
+		/**
+		 * Maximum number of "redirects". Limits the number of redirects to follow when
+		 * executing commands across the cluster. Leave empty to use driver specific
+		 * settings.
+		 */
+		private Integer maxRedirects;
+
+		public List<String> getNodes() {
+			return nodes;
+		}
+
+		public void setNodes(List<String> nodes) {
+			this.nodes = nodes;
+		}
+
+		public Integer getMaxRedirects() {
+			return maxRedirects;
+		}
+
+		public void setMaxRedirects(Integer maxRedirects) {
+			this.maxRedirects = maxRedirects;
 		}
 	}
 

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -651,6 +651,8 @@ content into your application; rather pick only the properties that you need.
 	spring.mongodb.embedded.version=2.6.10 # Version of Mongo to use.
 
 	# REDIS ({sc-spring-boot-autoconfigure}/redis/RedisProperties.{sc-ext}[RedisProperties])
+	spring.redis.cluster.nodes= # List of host:port pairs pointing to an intial collection of cluster nodes. Requires at least one node to connect to the cluster.
+	spring.redis.cluster.max-redirects= # Maximum number of redirects to follow when executing commands across the cluster. Leave empty to use the driver specific value.
 	spring.redis.database=0 # Database index used by the connection factory.
 	spring.redis.host=localhost # Redis server host.
 	spring.redis.password= # Login password of the redis server.


### PR DESCRIPTION
Update the `RedisProperties` and `RedisAutoConfiguration` to support required configuration parameters for an initial collection of _cluster nodes_ as well as the _maximum number of redirects_ when drivers communicate with the cluster.

**DO NOT MERGE** unless switching to the Spring Data Hopper Release, which is not out there yet.
**NOTE** undo version changes (to current 1.7.0.BUILD-SNAPSHOT) by dropping the first commit of this PR.

----

Spring Data Redis 1.7.0 introduces Cluster support (see: [DATAREDIS-315](https://jira.spring.io/browse/DATAREDIS-315)) which will be available with the GA Release of [Hopper](https://github.com/spring-projects/spring-data-commons/wiki/Release-Train-Hopper).