### PR TITLE
Tag Docker images created by launch script integration tests

### DIFF
--- a/spring-boot-integration-tests/spring-boot-launch-script-tests/README.adoc
+++ b/spring-boot-integration-tests/spring-boot-launch-script-tests/README.adoc
@@ -65,11 +65,12 @@ $ mvn -Pdocker clean verify
 The first time the tests are run, Docker will create the container images that are used to
 run the tests. This can take several minutes, particularly if you have a slow network
 connection. Subsequent runs will be faster as the images are cached locally. You can run
-`docker images` to see a list of the cached images.
+`docker images` to see a list of the cached images. Images created by these tests will be
+tagged with `spring-boot-it` prefix to easily distinguish them.
 
 == Cleaning up
 
 If you want to reclaim the disk space used by the cached images (at the expense of having
 to wait for them to be downloaded and rebuilt the next time you run the tests), you can
-use `docker images` to list the images and `docker rmi <image>` to delete them. See
-`docker rmi --help` for further details.
+use `docker images` to list the images and `docker rmi <image>` to delete them (look for
+`spring-boot-it` tag). See `docker rmi --help` for further details.

--- a/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
+++ b/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
@@ -244,7 +244,8 @@ public class SysVinitLaunchScriptIT {
 		BuildImageResultCallback resultCallback = new BuildImageResultCallback();
 		String dockerfile = "src/test/resources/conf/" + this.os + "/" + this.version
 				+ "/Dockerfile";
-		docker.buildImageCmd(new File(dockerfile)).exec(resultCallback);
+		String tag = "spring-boot-it/" + this.os.toLowerCase() + ":" + this.version;
+		docker.buildImageCmd(new File(dockerfile)).withTag(tag).exec(resultCallback);
 		String imageId = resultCallback.awaitImageId();
 		return imageId;
 	}


### PR DESCRIPTION
This makes the maintenance of local Docker images easier, and reduces the risk of users accidentaly deleting Docker images created by launch script integration tests which increases execution time of subsequent test runs. Previously these images couldn't be easily distinguished from other untagged images.

Output of ```docker images``` command after implementing this change:

```shell
REPOSITORY              TAG                 IMAGE ID            CREATED             SIZE
spring-boot-it/ubuntu   14.04.3             2d83279ad9f4        About an hour ago   816.3 MB
spring-boot-it/centos   6.7                 fd91675e4afe        About an hour ago   763.5 MB
spring-boot-it/centos   5.11                51073a11b787        About an hour ago   865.5 MB
```

I've signed the CLA.
