### PR TITLE
Add KeepAlive and PoolingOptions to cassandra auto-configuration

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraAutoConfiguration.java
@@ -17,6 +17,8 @@
 package org.springframework.boot.autoconfigure.cassandra;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.HostDistance;
+import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.SocketOptions;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
@@ -78,6 +80,7 @@ public class CassandraAutoConfiguration {
 		if (properties.isSsl()) {
 			builder.withSSL();
 		}
+		builder.withPoolingOptions(getPoolingOptions());
 		String points = properties.getContactPoints();
 		builder.addContactPoints(StringUtils.commaDelimitedListToStringArray(points));
 		return builder.build();
@@ -104,7 +107,46 @@ public class CassandraAutoConfiguration {
 		SocketOptions options = new SocketOptions();
 		options.setConnectTimeoutMillis(this.properties.getConnectTimeoutMillis());
 		options.setReadTimeoutMillis(this.properties.getReadTimeoutMillis());
+		if (this.properties.isKeepAlive() != null) {
+			options.setKeepAlive(this.properties.isKeepAlive());
+		}
 		return options;
 	}
 
+	private PoolingOptions getPoolingOptions() {
+		PoolingOptions options = new PoolingOptions();
+		if (this.properties.getCorePoolLocal() != null) {
+			options.setCoreConnectionsPerHost(HostDistance.LOCAL,
+					this.properties.getCorePoolLocal());
+		}
+		if (this.properties.getMaxPoolLocal() != null) {
+			options.setMaxConnectionsPerHost(HostDistance.LOCAL,
+					this.properties.getMaxPoolLocal());
+		}
+		if (this.properties.getCorePoolRemote() != null) {
+			options.setCoreConnectionsPerHost(HostDistance.REMOTE,
+					this.properties.getCorePoolRemote());
+		}
+		if (this.properties.getMaxPoolRemote() != null) {
+			options.setMaxConnectionsPerHost(HostDistance.REMOTE,
+					this.properties.getMaxPoolRemote());
+		}
+		if (this.properties.getNewConnectionThresholdLocal() != null) {
+			options.setNewConnectionThreshold(HostDistance.LOCAL,
+					this.properties.getNewConnectionThresholdLocal());
+		}
+		if (this.properties.getNewConnectionThresholdRemote() != null) {
+			options.setNewConnectionThreshold(HostDistance.REMOTE,
+					this.properties.getNewConnectionThresholdRemote());
+		}
+		if (this.properties.getMaxRequestsPerConnectionLocal() != null) {
+			options.setMaxRequestsPerConnection(HostDistance.LOCAL,
+					this.properties.getMaxRequestsPerConnectionLocal());
+		}
+		if (this.properties.getMaxRequestsPerConnectionRemote() != null) {
+			options.setMaxRequestsPerConnection(HostDistance.REMOTE,
+					this.properties.getMaxRequestsPerConnectionRemote());
+		}
+		return options;
+	}
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
@@ -117,6 +117,53 @@ public class CassandraProperties {
 	 */
 	private boolean ssl = false;
 
+	/**
+	 * Socket option: TCP keepalive.
+	 */
+	private Boolean keepAlive;
+
+	/**
+	 * Pooling option: core number of connections per local host.
+	 */
+	private Integer corePoolLocal;
+
+	/**
+	 * Pooling option: maximum number of connections per local host.
+	 */
+	private Integer maxPoolLocal;
+
+	/**
+	 * Pooling option: core number of connections per remote host.
+	 */
+	private Integer corePoolRemote;
+
+	/**
+	 * Pooling option: maximum number of connections per remote host.
+	 */
+	private Integer maxPoolRemote;
+
+	/**
+	 * Pooling option: threshold that triggers the creation of a new connection to a local
+	 * host.
+	 */
+	private Integer newConnectionThresholdLocal;
+
+	/**
+	 * Pooling option: threshold that triggers the creation of a new connection to a
+	 * remote host.
+	 */
+	private Integer newConnectionThresholdRemote;
+
+	/**
+	 * Pooling option: maximum number of requests per local connection.
+	 */
+	private Integer maxRequestsPerConnectionLocal;
+
+	/**
+	 * Pooling option: maximum number of requests per remote connection.
+	 */
+	private Integer maxRequestsPerConnectionRemote;
+
 	public String getKeyspaceName() {
 		return this.keyspaceName;
 	}
@@ -245,6 +292,78 @@ public class CassandraProperties {
 
 	public void setSsl(boolean ssl) {
 		this.ssl = ssl;
+	}
+
+	public Boolean isKeepAlive() {
+		return this.keepAlive;
+	}
+
+	public void setKeepAlive(Boolean keepAlive) {
+		this.keepAlive = keepAlive;
+	}
+
+	public Integer getCorePoolLocal() {
+		return this.corePoolLocal;
+	}
+
+	public void setCorePoolLocal(Integer corePoolLocal) {
+		this.corePoolLocal = corePoolLocal;
+	}
+
+	public Integer getMaxPoolLocal() {
+		return this.maxPoolLocal;
+	}
+
+	public void setMaxPoolLocal(Integer maxPoolLocal) {
+		this.maxPoolLocal = maxPoolLocal;
+	}
+
+	public Integer getCorePoolRemote() {
+		return this.corePoolRemote;
+	}
+
+	public void setCorePoolRemote(Integer corePoolRemote) {
+		this.corePoolRemote = corePoolRemote;
+	}
+
+	public Integer getMaxPoolRemote() {
+		return this.maxPoolRemote;
+	}
+
+	public void setMaxPoolRemote(Integer maxPoolRemote) {
+		this.maxPoolRemote = maxPoolRemote;
+	}
+
+	public Integer getNewConnectionThresholdLocal() {
+		return this.newConnectionThresholdLocal;
+	}
+
+	public void setNewConnectionThresholdLocal(Integer newConnectionThresholdLocal) {
+		this.newConnectionThresholdLocal = newConnectionThresholdLocal;
+	}
+
+	public Integer getNewConnectionThresholdRemote() {
+		return this.newConnectionThresholdRemote;
+	}
+
+	public void setNewConnectionThresholdRemote(Integer newConnectionThresholdRemote) {
+		this.newConnectionThresholdRemote = newConnectionThresholdRemote;
+	}
+
+	public Integer getMaxRequestsPerConnectionLocal() {
+		return this.maxRequestsPerConnectionLocal;
+	}
+
+	public void setMaxRequestsPerConnectionLocal(Integer maxRequestsPerConnectionLocal) {
+		this.maxRequestsPerConnectionLocal = maxRequestsPerConnectionLocal;
+	}
+
+	public Integer getMaxRequestsPerConnectionRemote() {
+		return this.maxRequestsPerConnectionRemote;
+	}
+
+	public void setMaxRequestsPerConnectionRemote(Integer maxRequestsPerConnectionRemote) {
+		this.maxRequestsPerConnectionRemote = maxRequestsPerConnectionRemote;
 	}
 
 }


### PR DESCRIPTION
Adds possibility to configure KeepAlive and PoolingOptions to cassandra auto-configuration.
