### PR TITLE
Fix namespace declarations in Hazelcast xml's and make them consistent

### DIFF
--- a/spring-boot-actuator/src/test/resources/cache/test-hazelcast.xml
+++ b/spring-boot-actuator/src/test/resources/cache/test-hazelcast.xml
@@ -1,4 +1,8 @@
-<hazelcast>
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.5.xsd"
+		xmlns="http://www.hazelcast.com/schema/config"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
 	<map name="books"/>
 	<map name="players"/>
+
 </hazelcast>

--- a/spring-boot-samples/spring-boot-sample-cache/src/main/resources/hazelcast.xml
+++ b/spring-boot-samples/spring-boot-sample-cache/src/main/resources/hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.4.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.5.xsd"
 		   xmlns="http://www.hazelcast.com/schema/config"
 		   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 


### PR DESCRIPTION
We've recently moved to Hazelcast 3.6 in our project that's based on Spring Boot 1.3.x. After doing the upgrade I wanted to validate compatibility by building Spring Boot against Hazelcast 3.6. This caused  ```CacheStatisticsAutoConfigurationTests.basicHazelcastCacheStatistics``` to fail since it uses [XML config](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-actuator/src/test/resources/cache/test-hazelcast.xml) without namespace declarations which is something Hazelcast seems to be more strict about since 3.6.

This PR makes sure tests will not fail when Hazelcast is upgraded to 3.6 or later.

In addition one other occurence of outdated schema declaration has been fixed.

I've signed the CLA.