### PR TITLE
support WebServer args in H2ConsoleAutoConfiguration

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleAutoConfiguration.java
@@ -58,7 +58,11 @@ public class H2ConsoleAutoConfiguration {
 	public ServletRegistrationBean h2Console() {
 		String path = this.properties.getPath();
 		String urlMapping = (path.endsWith("/") ? path + "*" : path + "/*");
-		return new ServletRegistrationBean(new WebServlet(), urlMapping);
+		ServletRegistrationBean bean = new ServletRegistrationBean(new WebServlet(), urlMapping);
+		for (String setting : this.properties.getSettings()) {
+			bean.addInitParameter(setting, "");
+		}
+		return bean;
 	}
 
 	@Configuration

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleProperties.java
@@ -16,8 +16,13 @@
 
 package org.springframework.boot.autoconfigure.h2;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+
+import org.h2.server.web.WebServer;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -42,6 +47,11 @@ public class H2ConsoleProperties {
 	 */
 	private boolean enabled = false;
 
+	/**
+	 * {@link WebServer#init(String...)} parameters. See <a href="http://www.h2database.com/html/tutorial.html#console_settings">Settings of the H2 Console</a> for valid values
+	 */
+	private List<String> settings;
+
 	public String getPath() {
 		return this.path;
 	}
@@ -56,6 +66,17 @@ public class H2ConsoleProperties {
 
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
+	}
+
+	public List<String> getSettings() {
+		if (this.settings == null) {
+			this.settings = new ArrayList<String>(0);
+		}
+		return this.settings;
+	}
+
+	public void setSettings(List<String> settings) {
+		this.settings = settings;
 	}
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/h2/H2ConsoleAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/h2/H2ConsoleAutoConfigurationTests.java
@@ -104,4 +104,15 @@ public class H2ConsoleAutoConfigurationTests {
 				.contains("/custom/*");
 	}
 
+	@Test
+	public void customSettings() {
+		this.context.register(H2ConsoleAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.h2.console.enabled:true", "spring.h2.console.settings:webAllowOthers,webSSL");
+		this.context.refresh();
+		assertThat(this.context.getBeansOfType(ServletRegistrationBean.class)).hasSize(1);
+		assertThat(this.context.getBean(ServletRegistrationBean.class).getUrlMappings())
+				.contains("/h2-console/*");
+		assertThat(this.context.getBean(ServletRegistrationBean.class).getInitParameters()).hasSize(2);
+	}
 }


### PR DESCRIPTION
added support for [H2 console settings](http://www.h2database.com/html/tutorial.html#console_settings) via `spring.h2.console.settings`