### PR TITLE
Support for jar:file://... urls

### DIFF
--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarFile.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarFile.java
@@ -356,7 +356,7 @@ public class JarFile extends java.util.jar.JarFile {
 	 * {@link URLStreamHandler} will be located to deal with jar URLs.
 	 */
 	public static void registerUrlProtocolHandler() {
-		String handlers = System.getProperty(PROTOCOL_HANDLER);
+		String handlers = System.getProperty(PROTOCOL_HANDLER, "");
 		System.setProperty(PROTOCOL_HANDLER, ("".equals(handlers) ? HANDLERS_PACKAGE
 				: handlers + "|" + HANDLERS_PACKAGE));
 		resetCachedUrlHandlers();

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
@@ -73,7 +73,11 @@ class JarURLConnection extends java.net.JarURLConnection {
 		// What we pass to super is ultimately ignored
 		super(EMPTY_JAR_URL);
 		this.url = url;
-		String spec = url.getFile().substring(jarFile.getUrl().getFile().length());
+		String urlFile = url.getFile();
+		if (urlFile.startsWith("file://")) {
+			urlFile = "file:" + urlFile.substring("file://".length());
+		}
+		String spec = urlFile.substring(jarFile.getUrl().getFile().length());
 		int separator;
 		while ((separator = spec.indexOf(SEPARATOR)) > 0) {
 			jarFile = getNestedJarFile(jarFile, spec.substring(0, separator));

--- a/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
+++ b/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
@@ -328,6 +328,23 @@ public class JarFileTests {
 	}
 
 	@Test
+	public void createNonNestedUrlFromStringCreatedUsingPath() throws Exception {
+		// gh-5287
+		JarFile.registerUrlProtocolHandler();
+		String spec = "jar:" + this.rootJarFile.toPath().toUri() + "!/2.dat";
+		URL url = new URL(spec);
+		assertThat(url.toString()).isEqualTo(spec);
+		InputStream inputStream = url.openStream();
+		assertThat(inputStream).isNotNull();
+		assertThat(inputStream.read()).isEqualTo(2);
+		JarURLConnection connection = (JarURLConnection) url.openConnection();
+		assertThat(connection.getURL().toString()).isEqualTo(spec);
+		assertThat(connection.getJarFileURL().toURI())
+				.isEqualTo(this.rootJarFile.toURI());
+		assertThat(connection.getEntryName()).isEqualTo("2.dat");
+	}
+
+	@Test
 	public void getDirectoryInputStream() throws Exception {
 		InputStream inputStream = this.jarFile
 				.getInputStream(this.jarFile.getEntry("d/"));


### PR DESCRIPTION
When `jar:file:` urls are created from string
that starts with `jar:file://` `JarURLConnection` no longer works

This change adds support for such urls.
One source for such urls is when `file.toPath().toUri()` is used
instead of `file.toURI()`.

Fixes gh-5287

I have singed CLA