### PR TITLE
Upgrade to Gson 2.6.2

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -72,7 +72,7 @@
 		<glassfish-el.version>3.0.0</glassfish-el.version>
 		<gradle.version>1.12</gradle.version>
 		<groovy.version>2.4.6</groovy.version>
-		<gson.version>2.6.1</gson.version>
+		<gson.version>2.6.2</gson.version>
 		<h2.version>1.4.191</h2.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<hazelcast.version>3.6</hazelcast.version>


### PR DESCRIPTION
Version 2.6.2

- Fixed an NPE bug with @JsonAdapter annotation
- Added back OSGI manifest
- Some documentation typo fixes

https://github.com/google/gson/blob/master/CHANGELOG.md#version-262