### PR TITLE
Don't print directory name on stdout (by popd in launcher shell script).

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -221,7 +221,7 @@ run() {
   pushd "$(dirname "$jarfile")" > /dev/null
   $command
   result=$?
-  popd
+  popd > /dev/null
   return "$result"
 }
 


### PR DESCRIPTION
Starting an executable ./target/my.project-1.0.jar always prints the current working directory as last output to stdout.

This is caused by a call to popd in the run() function of launcher shell script. pushd and popd both print directory names to stdout. pushd already has a "> /dev/null" but popd has not.

The superfluous directory name is confusing as it seems to come from nowhere and might become troublesome if one tries to write a CLI only programm whose output should be piped to another program.