### PR TITLE
Update versions of Docker images used in launch script tests

### DIFF
--- a/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/conf/CentOS/5.11-1bff66c6a3a5/Dockerfile
+++ b/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/conf/CentOS/5.11-1bff66c6a3a5/Dockerfile
@@ -1,4 +1,10 @@
-FROM centos:6.7
+# this Dockerfile uses digest of centos:5.11 image dated Mar 22 2016 to ensure the tests
+# are always executed using the same image since release-named tags (such as 5.11) are
+# actually updated over the time, making the build not repeatable
+#
+# see gh-5397, https://hub.docker.com/r/library/centos/tags/
+
+FROM centos@sha256:7f8a808416f712da6931ac65e4308fede7fe86bcf15364b6f63af88840fe6131
 RUN yum install -y wget && \
     yum install -y system-config-services && \
     yum install -y curl && \

--- a/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/conf/CentOS/6.7-d95b5ca17cc3/Dockerfile
+++ b/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/conf/CentOS/6.7-d95b5ca17cc3/Dockerfile
@@ -1,4 +1,10 @@
-FROM centos:5.11
+# this Dockerfile uses digest of centos:6.7 image dated Mar 22 2016 to ensure the tests
+# are always executed using the same image since release-named tags (such as 5.11) are
+# actually updated over the time, making the build not repeatable
+#
+# see gh-5397, https://hub.docker.com/r/library/centos/tags/
+
+FROM centos@sha256:4f6d8f794af3574eca603b965fc0b63fdf852be29c17d3ab4cad7ec2272b82bd
 RUN yum install -y wget && \
     yum install -y system-config-services && \
     yum install -y curl && \

--- a/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/conf/Ubuntu/trusty-20160317/Dockerfile
+++ b/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/conf/Ubuntu/trusty-20160317/Dockerfile
@@ -1,4 +1,10 @@
-FROM ubuntu:14.04.3
+# this Dockerfile uses trusty-20160317 tag to ensure the tests are always executed using
+# the same image since release-named tags (such as 14.04.4) are actually updated over the
+# time, making the build not repeatable
+#
+# see gh-5397, https://hub.docker.com/r/library/ubuntu/tags/
+
+FROM ubuntu:trusty-20160317
 RUN apt-get install -y software-properties-common && \
     add-apt-repository ppa:webupd8team/java -y && \
     apt-get update && \


### PR DESCRIPTION
This updates the ```Dockerfile``` for Ubuntu based launch script tests to use the ```14.04``` tag instead of specific point release (currently ```14.04.3```).
This will also automatically update the image used by tests to the current point release (```14.04.4``` was released some 3-4 weeks ago) which IMO makes the maintenance of tests easier (no update for futher ```14.04``` point releases is needed).

I've signed the CLA.
