### PR TITLE
Support setting webAllowOthers for the H2 Web Console

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleAutoConfiguration.java
@@ -61,7 +61,11 @@ public class H2ConsoleAutoConfiguration {
 	public ServletRegistrationBean h2Console() {
 		String path = this.properties.getPath();
 		String urlMapping = (path.endsWith("/") ? path + "*" : path + "/*");
-		return new ServletRegistrationBean(new WebServlet(), urlMapping);
+		ServletRegistrationBean registration = new ServletRegistrationBean(new WebServlet(), urlMapping);
+		if (properties.getWebAllowOthers()) {
+			registration.addInitParameter("webAllowOthers", "true");
+		}
+		return registration;
 	}
 
 	@Configuration

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleProperties.java
@@ -42,6 +42,11 @@ public class H2ConsoleProperties {
 	 */
 	private boolean enabled = false;
 
+	/**
+	 * Allow remote access.
+	 */
+	private boolean webAllowOthers = false;
+
 	public String getPath() {
 		return this.path;
 	}
@@ -58,4 +63,11 @@ public class H2ConsoleProperties {
 		this.enabled = enabled;
 	}
 
+	public boolean getWebAllowOthers() {
+		return webAllowOthers;
+	}
+
+	public void setWebAllowOthers(boolean webAllowOthers) {
+		this.webAllowOthers = webAllowOthers;
+	}
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/h2/H2ConsoleAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/h2/H2ConsoleAutoConfigurationTests.java
@@ -25,6 +25,7 @@ import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.context.embedded.ServletRegistrationBean;
 import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.Bean;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
@@ -70,6 +71,8 @@ public class H2ConsoleAutoConfigurationTests {
 		assertThat(this.context.getBeansOfType(ServletRegistrationBean.class)).hasSize(1);
 		assertThat(this.context.getBean(ServletRegistrationBean.class).getUrlMappings())
 				.contains("/h2-console/*");
+		assertThat(this.context.getBean(ServletRegistrationBean.class).getInitParameters()).
+				doesNotContainKey("webAllowOthers");
 	}
 
 	@Test
@@ -102,6 +105,20 @@ public class H2ConsoleAutoConfigurationTests {
 		assertThat(this.context.getBeansOfType(ServletRegistrationBean.class)).hasSize(1);
 		assertThat(this.context.getBean(ServletRegistrationBean.class).getUrlMappings())
 				.contains("/custom/*");
+	}
+
+	@Test
+	public void propertySetsWebAllowOthersInitParameter() {
+		this.context.register(H2ConsoleAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.h2.console.enabled:true", "spring.h2.console.web-allow-others=true");
+		this.context.refresh();
+		assertThat(this.context.getBeansOfType(ServletRegistrationBean.class)).hasSize(1);
+		assertThat(this.context.getBean(ServletRegistrationBean.class).getUrlMappings())
+				.contains("/h2-console/*");
+		assertThat(this.context.getBean(ServletRegistrationBean.class).getInitParameters()).
+				containsEntry("webAllowOthers", "true");
+
 	}
 
 }


### PR DESCRIPTION
 This commit adds a configuration option for the webAllowOthers option
 for the H2 WebServlet. It will only be added it the spring.h2.console.webAllowOthers
 is set to true, else it will be ignored.

Fixes: gh-5416

I've signed the Spring ICLA. 