### PR TITLE
Make *FailureAnalyzer classes public

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/BeanCurrentlyInCreationFailureAnalyzer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/BeanCurrentlyInCreationFailureAnalyzer.java
@@ -33,7 +33,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Andy Wilkinson
  */
-class BeanCurrentlyInCreationFailureAnalyzer
+public class BeanCurrentlyInCreationFailureAnalyzer
 		extends AbstractFailureAnalyzer<BeanCurrentlyInCreationException> {
 
 	@Override

--- a/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/PortInUseFailureAnalyzer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/PortInUseFailureAnalyzer.java
@@ -26,7 +26,7 @@ import org.springframework.boot.diagnostics.FailureAnalysis;
  *
  * @author Andy Wilkinson
  */
-class PortInUseFailureAnalyzer extends AbstractFailureAnalyzer<PortInUseException> {
+public class PortInUseFailureAnalyzer extends AbstractFailureAnalyzer<PortInUseException> {
 
 	@Override
 	protected FailureAnalysis analyze(Throwable rootFailure, PortInUseException cause) {


### PR DESCRIPTION
I'm seeing the following exception because they are package-private:

```
Caused by: java.lang.IllegalAccessException: Class org.springframework.core.io.support.SpringFactoriesLoader can not access a member of class org.springframework.boot.diagnostics.analyzer.PortInUseFailureAnalyzer with modifiers ""
```