### PR TITLE
A new spring-boot-starter-camel module with sample also.

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -52,6 +52,7 @@
 		<atomikos.version>3.9.3</atomikos.version>
 		<bitronix.version>2.1.4</bitronix.version>
 		<caffeine.version>2.2.2</caffeine.version>
+		<camel.version>2.16.2</camel.version>
 		<cassandra-driver.version>2.1.9</cassandra-driver.version>
 		<commons-beanutils.version>1.9.2</commons-beanutils.version>
 		<commons-collections.version>3.2.2</commons-collections.version>
@@ -275,6 +276,11 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-cache</artifactId>
+				<version>1.4.0.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-camel</artifactId>
 				<version>1.4.0.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
@@ -1086,6 +1092,26 @@
 				<groupId>org.apache.activemq</groupId>
 				<artifactId>artemis-jms-server</artifactId>
 				<version>${artemis.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-parent</artifactId>
+				<version>${camel.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-core</artifactId>
+				<version>${camel.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-spring</artifactId>
+				<version>${camel.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-spring-boot</artifactId>
+				<version>${camel.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>

--- a/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
+++ b/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
@@ -399,6 +399,9 @@ The following application starters are provided by Spring Boot under the
 |`spring-boot-starter-cache`
 |Support for Spring's Cache abstraction.
 
+|`spring-boot-starter-camel`
+|Support for integration using Apache Camel.
+
 |`spring-boot-starter-cloud-connectors`
 |Support for "`Spring Cloud Connectors`" which simplifies connecting to services in cloud
 platforms like Cloud Foundry and Heroku.

--- a/spring-boot-samples/pom.xml
+++ b/spring-boot-samples/pom.xml
@@ -32,6 +32,7 @@
 		<module>spring-boot-sample-atmosphere</module>
 		<module>spring-boot-sample-batch</module>
 		<module>spring-boot-sample-cache</module>
+		<module>spring-boot-sample-camel</module>
 		<module>spring-boot-sample-data-cassandra</module>
 		<module>spring-boot-sample-data-couchbase</module>
 		<module>spring-boot-sample-data-elasticsearch</module>

--- a/spring-boot-samples/spring-boot-sample-camel/README.adoc
+++ b/spring-boot-samples/spring-boot-sample-camel/README.adoc
@@ -1,0 +1,21 @@
+= Spring Boot Camel Sample
+
+This example shows how to work with a simple Apache Camel application using Spring Boot.
+
+The example generates messages using timer trigger, writes them to the standard output.
+
+== Camel routes
+
+The Camel route is located in the `SampleCamelRouter` class. In this class the route
+starts from a timer, that triggers every 2nd second and calls a Spring Bean `SampleBean`
+which returns a message, that is routed to a log endpoint which logs the message using the system logger.
+
+== Using Camel components
+
+Apache Camel provides 200+ components which you can use to integrate and route messages between many systems
+and data formats. To use any of these Camel components, add the component as a dependency to your project.
+
+== More information
+
+You can find more information about Apache Camel at the website: http://camel.apache.org/
+

--- a/spring-boot-samples/spring-boot-sample-camel/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-camel/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<!-- Your own application should inherit from spring-boot-starter-parent -->
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-samples</artifactId>
+		<version>1.4.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-sample-camel</artifactId>
+	<name>Spring Boot Camel Sample</name>
+	<description>Spring Boot Apache Camel Sample</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-camel</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-samples/spring-boot-sample-camel/src/main/java/sample/camel/SampleBean.java
+++ b/spring-boot-samples/spring-boot-sample-camel/src/main/java/sample/camel/SampleBean.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.springframework.stereotype.Component;
+
+@Component("myBean")
+public class SampleBean {
+
+    public String saySomething() {
+        return "I'm Spring bean!";
+    }
+
+}

--- a/spring-boot-samples/spring-boot-sample-camel/src/main/java/sample/camel/SampleCamelApplication.java
+++ b/spring-boot-samples/spring-boot-sample-camel/src/main/java/sample/camel/SampleCamelApplication.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.apache.camel.spring.boot.CamelSpringBootApplicationController;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+@SpringBootApplication
+public class SampleCamelApplication {
+
+    public static void main(String[] args) {
+        ConfigurableApplicationContext ctx = new SpringApplicationBuilder().sources(SampleCamelApplication.class).run(args);
+
+        // keep the JVM running as Camel uses only daemon threads in the sample
+        CamelSpringBootApplicationController controller = ctx.getBean(CamelSpringBootApplicationController.class);
+        controller.blockMainThread();
+    }
+
+}

--- a/spring-boot-samples/spring-boot-sample-camel/src/main/java/sample/camel/SampleCamelRouter.java
+++ b/spring-boot-samples/spring-boot-sample-camel/src/main/java/sample/camel/SampleCamelRouter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class SampleCamelRouter extends RouteBuilder {
+
+    @Override
+    public void configure() {
+        from("timer:{{timer.name}}?period={{timer.period}}")
+                .transform(method("myBean", "saySomething"))
+                .to("log:out");
+    }
+
+}

--- a/spring-boot-samples/spring-boot-sample-camel/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-camel/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.main.sources: sample.camel.SampleCamelRouter
+
+timer.name = myTimer
+timer.period = 2000

--- a/spring-boot-samples/spring-boot-sample-camel/src/test/java/sample/cache/SampleCacheApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-camel/src/test/java/sample/cache/SampleCacheApplicationTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.cache;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.NotifyBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import sample.camel.SampleCamelApplication;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(SampleCamelApplication.class)
+public class SampleCacheApplicationTests {
+
+	@Autowired
+	private CamelContext camelContext;
+
+    @Test
+    public void shouldProduceMessages() throws InterruptedException {
+        // we expect that one or more messages is automatic done by the Camel
+        // route as it uses a timer to trigger
+        NotifyBuilder notify = new NotifyBuilder(camelContext).whenDone(1).create();
+
+        assertTrue(notify.matches(10, TimeUnit.SECONDS));
+    }
+
+}

--- a/spring-boot-starters/pom.xml
+++ b/spring-boot-starters/pom.xml
@@ -26,6 +26,7 @@
 		<module>spring-boot-starter-artemis</module>
 		<module>spring-boot-starter-batch</module>
 		<module>spring-boot-starter-cache</module>
+		<module>spring-boot-starter-camel</module>
 		<module>spring-boot-starter-cloud-connectors</module>
 		<module>spring-boot-starter-data-cassandra</module>
 		<module>spring-boot-starter-data-couchbase</module>

--- a/spring-boot-starters/spring-boot-starter-camel/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-camel/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starters</artifactId>
+		<version>1.4.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-starter-camel</artifactId>
+	<name>Spring Boot Camel Starter</name>
+	<description>Spring Boot Apache Camel Starter</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-spring-boot</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-boot-starters/spring-boot-starter-camel/src/main/resources/META-INF/spring.provides
+++ b/spring-boot-starters/spring-boot-starter-camel/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: camel-spring-boot


### PR DESCRIPTION
Ticket is #5425

This allows Spring Boot users to get easily started with Spring Boot and add Camel to their application.
This PR includes two new modules

- spring-boot-starter-camel
- spring-boot-sample-camel

The former is similar to all the other starters with a simple maven pom.xml file that provides camel-spring-boot.
The latter is a sample that uses starter-camel with a little sample project with Spring Boot and Apache Camel.

The Apache Camel project already includes a camel-spring-boot module that integrates with Spring Boot and does
the discoveries of Camel routes and add those into the Spring framework. And listens on the spring events
to start/stop Camel accordingly to Spring.

Signed-off-by: Claus Ibsen <claus.ibsen@gmail.com>