### PR TITLE
Added confirms/returns & mandatory properties to RabbitMQ AutoConfig properties

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -121,6 +121,8 @@ public class RabbitAutoConfiguration {
 			CachingConnectionFactory connectionFactory = new CachingConnectionFactory(
 					factory.getObject());
 			connectionFactory.setAddresses(config.getAddresses());
+			connectionFactory.setPublisherConfirms(config.isPublisherConfirms());
+			connectionFactory.setPublisherReturns(config.isPublisherReturns());
 			if (config.getCache().getChannel().getSize() != null) {
 				connectionFactory
 						.setChannelCacheSize(config.getCache().getChannel().getSize());
@@ -181,6 +183,9 @@ public class RabbitAutoConfiguration {
 			if (template.getReplyTimeout() != null) {
 				rabbitTemplate.setReplyTimeout(template.getReplyTimeout());
 			}
+			if (template.isMandatory() || this.properties.isPublisherReturns()) {
+				rabbitTemplate.setMandatory(true);
+			}
 			return rabbitTemplate;
 		}
 
@@ -191,7 +196,6 @@ public class RabbitAutoConfiguration {
 		public AmqpAdmin amqpAdmin(ConnectionFactory connectionFactory) {
 			return new RabbitAdmin(connectionFactory);
 		}
-
 
 	}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -79,6 +79,16 @@ public class RabbitProperties {
 	private Integer requestedHeartbeat;
 
 	/**
+	 * Enable publisher confirms.
+	 */
+	private boolean publisherConfirms = false;
+
+	/**
+	 * Enable publisher returns.
+	 */
+	private boolean publisherReturns = false;
+
+	/**
 	 * Cache configuration.
 	 */
 	private final Cache cache = new Cache();
@@ -194,6 +204,22 @@ public class RabbitProperties {
 
 	public void setRequestedHeartbeat(Integer requestedHeartbeat) {
 		this.requestedHeartbeat = requestedHeartbeat;
+	}
+
+	public boolean isPublisherConfirms() {
+		return this.publisherConfirms;
+	}
+
+	public void setPublisherConfirms(boolean publisherConfirms) {
+		this.publisherConfirms = publisherConfirms;
+	}
+
+	public boolean isPublisherReturns() {
+		return this.publisherReturns;
+	}
+
+	public void setPublisherReturns(boolean publisherReturns) {
+		this.publisherReturns = publisherReturns;
 	}
 
 	public Cache getCache() {
@@ -477,6 +503,12 @@ public class RabbitProperties {
 		 */
 		private Long replyTimeout;
 
+		/**
+		 * Whether or not unroutable messages should be returned. Default is false, but
+		 * will be set to true if publisherReturns enabled on the connection factory
+		 */
+		private boolean mandatory = false;
+
 		public Retry getRetry() {
 			return this.retry;
 		}
@@ -497,6 +529,14 @@ public class RabbitProperties {
 			this.replyTimeout = replyTimeout;
 		}
 
+		public boolean isMandatory() {
+			return this.mandatory;
+		}
+
+		public void setMandatory(boolean mandatory) {
+			this.mandatory = mandatory;
+		}
+
 	}
 
 	public static class Retry {
@@ -512,8 +552,7 @@ public class RabbitProperties {
 		private int maxAttempts = 3;
 
 		/**
-		 * Interval between the first and second attempt to publish or deliver
-		 * a message.
+		 * Interval between the first and second attempt to publish or deliver a message.
 		 */
 		private long initialInterval = 1000L;
 


### PR DESCRIPTION
Regarding #3945 

Implemented the following properties:

```
spring.rabbitmq.publisherConfirms (default: false)
spring.rabbitmq.publisherReturns (default: false)
spring.rabbitmq.template.mandatory (default: false)
```

Mandatory flag is implicitly set to "true" when the `publisherReturns` is "true". I used the config value rather than the property from the `ConnectionFactory` because that value is private. Also you'd still need to use a custom configured `RabbitTemplate` to set the `returnCallback`/`confirmCallback`. Not ideal, but it's a starting point. Looking forward to feedback.

_Note: A couple of minor formatting changes snuck in since Eclipse auto formatted lines beyond 90 chars. First time submitting a PR for this project, don't know if that's a big issue or not._