### PR TITLE
Add useAlwaysMessageFormat configuration key

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/MessageSourceAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/MessageSourceAutoConfiguration.java
@@ -80,6 +80,12 @@ public class MessageSourceAutoConfiguration {
 	 */
 	private boolean fallbackToSystemLocale = true;
 
+	/**
+	 * Set whether to always apply the MessageFormat rules, parsing even
+	 * messages without arguments.
+	 */
+	private boolean alwaysUseMessageFormat = false;
+
 	@Bean
 	public MessageSource messageSource() {
 		ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
@@ -92,6 +98,7 @@ public class MessageSourceAutoConfiguration {
 		}
 		messageSource.setFallbackToSystemLocale(this.fallbackToSystemLocale);
 		messageSource.setCacheSeconds(this.cacheSeconds);
+		messageSource.setAlwaysUseMessageFormat(this.alwaysUseMessageFormat);
 		return messageSource;
 	}
 
@@ -125,6 +132,14 @@ public class MessageSourceAutoConfiguration {
 
 	public void setFallbackToSystemLocale(boolean fallbackToSystemLocale) {
 		this.fallbackToSystemLocale = fallbackToSystemLocale;
+	}
+
+	public boolean isAlwaysUseMessageFormat() {
+		return this.alwaysUseMessageFormat;
+	}
+
+	public void setAlwaysUseMessageFormat(boolean alwaysUseMessageFormat) {
+		this.alwaysUseMessageFormat = alwaysUseMessageFormat;
 	}
 
 	protected static class ResourceBundleCondition extends SpringBootCondition {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/MessageSourceAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/MessageSourceAutoConfigurationTests.java
@@ -117,6 +117,21 @@ public class MessageSourceAutoConfigurationTests {
 	}
 
 	@Test
+	public void testFormatMessageDefault() throws Exception {
+		load("spring.messages.basename:test/messages");
+		assertThat(this.context.getBean(MessageSourceAutoConfiguration.class)
+				.isAlwaysUseMessageFormat()).isFalse();
+	}
+
+	@Test
+	public void testFormatMessageOn() throws Exception {
+		load("spring.messages.basename:test/messages",
+				"spring.messages.always-use-message-format:true");
+		assertThat(this.context.getBean(MessageSourceAutoConfiguration.class)
+				.isAlwaysUseMessageFormat()).isTrue();
+	}
+
+	@Test
 	public void existingMessageSourceIsPreferred() {
 		this.context = new AnnotationConfigApplicationContext();
 		this.context.register(CustomMessageSource.class,

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -113,6 +113,7 @@ content into your application; rather pick only the properties that you need.
 	spring.messages.cache-seconds=-1 # Loaded resource bundle files cache expiration, in seconds. When set to -1, bundles are cached forever.
 	spring.messages.encoding=UTF-8 # Message bundles encoding.
 	spring.messages.fallback-to-system-locale=true # Set whether to fall back to the system Locale if no files for a specific Locale have been found.
+    spring.messages.always-use-message-format=false # Set whether to always apply the MessageFormat rules, parsing even messages without arguments.
 
 	# OUTPUT
 	spring.output.ansi.enabled=detect # Configure the ANSI output (can be "detect", "always", "never").


### PR DESCRIPTION
Allow to configure the `useAlwaysMessageFormat` attribute of
`MessageSource` via configuration.

See gh-5483