### PR TITLE
Add autoconfiguration check for non empty list of factories

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/EnableAutoConfigurationImportSelector.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/EnableAutoConfigurationImportSelector.java
@@ -140,8 +140,11 @@ public class EnableAutoConfigurationImportSelector
 	 */
 	protected List<String> getCandidateConfigurations(AnnotationMetadata metadata,
 			AnnotationAttributes attributes) {
-		return SpringFactoriesLoader.loadFactoryNames(
+		List<String> configurations = SpringFactoriesLoader.loadFactoryNames(
 				getSpringFactoriesLoaderFactoryClass(), getBeanClassLoader());
+		Assert.notEmpty(configurations,
+				"No auto configuration factories available. Please check your packaging to assure that the META-INF/spring.factories file is correct.");
+		return configurations;
 	}
 
 	/**


### PR DESCRIPTION
It was seeen that if a different plugin was used to package Spring Boot
that the project would load but no autoconfiguration actually took
place and many features were mysteriously not working.  Adding a check
to ensure that some factories are always loaded as this is expected.

Fixes gh-5465