### PR TITLE
Add `defaultValue` property in springProperty tag

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringPropertyAction.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringPropertyAction.java
@@ -32,10 +32,12 @@ import org.springframework.core.env.Environment;
  * properties to be sourced from the Spring environment.
  *
  * @author Phillip Webb
+ * @author Eddú Meléndez
  */
 class SpringPropertyAction extends Action {
 
 	private static final String SOURCE_ATTRIBUTE = "source";
+	private static final String DEFAULT_VALUE_ATTRIBUTE = "defaultValue";
 
 	private final Environment environment;
 
@@ -49,17 +51,21 @@ class SpringPropertyAction extends Action {
 		String name = attributes.getValue(NAME_ATTRIBUTE);
 		String source = attributes.getValue(SOURCE_ATTRIBUTE);
 		Scope scope = ActionUtil.stringToScope(attributes.getValue(SCOPE_ATTRIBUTE));
+		String defaultValue = attributes.getValue(DEFAULT_VALUE_ATTRIBUTE);
 		if (OptionHelper.isEmpty(name) || OptionHelper.isEmpty(source)) {
 			addError(
 					"The \"name\" and \"source\" attributes of <springProperty> must be set");
 		}
-		ActionUtil.setProperty(ic, name, getValue(source), scope);
+		ActionUtil.setProperty(ic, name, getValue(source, defaultValue), scope);
 	}
 
-	private String getValue(String source) {
+	private String getValue(String source, String defaultValue) {
 		if (this.environment == null) {
 			addWarn("No Spring Environment available to resolve " + source);
 			return null;
+		}
+		if (source == null) {
+			return defaultValue;
 		}
 		String value = this.environment.getProperty(source);
 		if (value != null) {

--- a/spring-boot/src/test/java/org/springframework/boot/logging/logback/SpringBootJoranConfiguratorTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/logging/logback/SpringBootJoranConfiguratorTests.java
@@ -140,6 +140,12 @@ public class SpringBootJoranConfiguratorTests {
 		assertThat(this.context.getProperty("MINE")).isEqualTo("test");
 	}
 
+	@Test
+	public void springPropertyWithDefaultValue() throws Exception {
+		initialize("property-defaultValue.xml");
+		assertThat(this.context.getProperty("MINE")).isEqualTo("foo");
+	}
+
 	private void doTestNestedProfile(boolean expected, String... profiles)
 			throws JoranException {
 		this.environment.setActiveProfiles(profiles);

--- a/spring-boot/src/test/resources/org/springframework/boot/logging/logback/property-defaultValue.xml
+++ b/spring-boot/src/test/resources/org/springframework/boot/logging/logback/property-defaultValue.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<include resource="org/springframework/boot/logging/logback/base.xml" />
+	<springProperty scope="context" name="MINE" defaultValue="foo"/>
+</configuration>


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X ] I have signed the CLA

New property `defaultValue` has been added to `springProperty` tag
in Logback.

See gh-5447