### PR TITLE
GH-5517: Fix `MessageChannelMetricWriter` logic

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/MetricsChannelAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/MetricsChannelAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.messaging.MessageChannel;
  * {@link MessageChannel}.
  *
  * @author Dave Syer
+ * @author Artem Bilan
  * @since 1.3.0
  */
 @Configuration
@@ -41,6 +42,7 @@ import org.springframework.messaging.MessageChannel;
 public class MetricsChannelAutoConfiguration {
 
 	@Bean
+	@ExportMetricWriter
 	@ConditionalOnMissingBean
 	public MessageChannelMetricWriter messageChannelMetricWriter(
 			@Qualifier("metricsChannel") MessageChannel channel) {


### PR DESCRIPTION
Fixes GH-5517

Starting with Spring Boot 1.3 the `@ExportMetricWriter` qualifier has been introduced
to mark `MetricWriter`s for the `export` infrastructure.

The `MessageChannelMetricWriter` `@Bean` in the `MetricsChannelAutoConfiguration`
has been missed for the `@ExportMetricWriter`. Therefore we weren't able to receive metrics via `metricsChannel`.

* Add `@ExportMetricWriter` to the `MessageChannelMetricWriter` `@Bean`
* Improve `MetricExportAutoConfigurationTests#defaultExporterWhenMessageChannelAvailable()` test to track changes
and ensure that `metricsChannel` is receiving messages.

**Cherry-pick to 1.3.x**