### PR TITLE
Deprecate constructors with port parameter in UndertowEmbeddedServletContainer

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainer.java
@@ -87,20 +87,100 @@ public class UndertowEmbeddedServletContainer implements EmbeddedServletContaine
 
 	private boolean started = false;
 
+	/**
+	 * Create a new {@link UndertowEmbeddedServletContainer} instance.
+	 * @param builder the builder
+	 * @param manager the deployment manager
+	 * @param contextPath root the context path
+	 * @param port the port to listen on (not used)
+	 * @param autoStart if the server should be started
+	 * @param compression compression configuration
+	 * @deprecated as of 1.4 in favor of using constructors without port argument
+	 */
+	@Deprecated
 	public UndertowEmbeddedServletContainer(Builder builder, DeploymentManager manager,
 			String contextPath, int port, boolean autoStart, Compression compression) {
-		this(builder, manager, contextPath, port, false, autoStart, compression);
+		this(builder, manager, contextPath, false, autoStart, compression);
 	}
 
+	/**
+	 * Create a new {@link UndertowEmbeddedServletContainer} instance.
+	 * @param builder the builder
+	 * @param manager the deployment manager
+	 * @param contextPath root the context path
+	 * @param port the port to listen on (not used)
+	 * @param useForwardHeaders if x-forward headers should be used
+	 * @param autoStart if the server should be started
+	 * @param compression compression configuration
+	 * @deprecated as of 1.4 in favor of using constructors without port argument
+	 */
+	@Deprecated
 	public UndertowEmbeddedServletContainer(Builder builder, DeploymentManager manager,
 			String contextPath, int port, boolean useForwardHeaders, boolean autoStart,
 			Compression compression) {
-		this(builder, manager, contextPath, port, useForwardHeaders, autoStart,
+		this(builder, manager, contextPath, useForwardHeaders, autoStart, compression, null);
+	}
+
+	/**
+	 * Create a new {@link UndertowEmbeddedServletContainer} instance.
+	 * @param builder the builder
+	 * @param manager the deployment manager
+	 * @param contextPath root the context path
+	 * @param port the port to listen on (not used)
+	 * @param useForwardHeaders if x-forward headers should be used
+	 * @param autoStart if the server should be started
+	 * @param compression compression configuration
+	 * @param serverHeader string to be used in http header
+	 * @deprecated as of 1.4 in favor of using constructors without port argument
+	 */
+	@Deprecated
+	public UndertowEmbeddedServletContainer(Builder builder, DeploymentManager manager,
+			String contextPath, int port, boolean useForwardHeaders, boolean autoStart,
+			Compression compression, String serverHeader) {
+		this(builder, manager, contextPath, useForwardHeaders, autoStart, compression, serverHeader);
+	}
+
+	/**
+	 * Create a new {@link UndertowEmbeddedServletContainer} instance.
+	 * @param builder the builder
+	 * @param manager the deployment manager
+	 * @param contextPath root the context path
+	 * @param autoStart if the server should be started
+	 * @param compression compression configuration
+	 */
+	public UndertowEmbeddedServletContainer(Builder builder, DeploymentManager manager,
+			String contextPath, boolean autoStart, Compression compression) {
+		this(builder, manager, contextPath, false, autoStart, compression);
+	}
+
+	/**
+	 * Create a new {@link UndertowEmbeddedServletContainer} instance.
+	 * @param builder the builder
+	 * @param manager the deployment manager
+	 * @param contextPath root the context path
+	 * @param useForwardHeaders if x-forward headers should be used
+	 * @param autoStart if the server should be started
+	 * @param compression compression configuration
+	 */
+	public UndertowEmbeddedServletContainer(Builder builder, DeploymentManager manager,
+			String contextPath, boolean useForwardHeaders, boolean autoStart,
+			Compression compression) {
+		this(builder, manager, contextPath, useForwardHeaders, autoStart,
 				compression, null);
 	}
 
+	/**
+	 * Create a new {@link UndertowEmbeddedServletContainer} instance.
+	 * @param builder the builder
+	 * @param manager the deployment manager
+	 * @param contextPath root the context path
+	 * @param useForwardHeaders if x-forward headers should be used
+	 * @param autoStart if the server should be started
+	 * @param compression compression configuration
+	 * @param serverHeader string to be used in http header
+	 */
 	public UndertowEmbeddedServletContainer(Builder builder, DeploymentManager manager,
-			String contextPath, int port, boolean useForwardHeaders, boolean autoStart,
+			String contextPath, boolean useForwardHeaders, boolean autoStart,
 			Compression compression, String serverHeader) {
 		this.builder = builder;
 		this.manager = manager;
@@ -231,10 +311,10 @@ public class UndertowEmbeddedServletContainer implements EmbeddedServletContaine
 	}
 
 	private Port getPortFromChannel(BoundChannel channel) {
-		String protocol = ReflectionUtils.findField(channel.getClass(), "ssl") != null
-				? "https" : "http";
 		SocketAddress socketAddress = channel.getLocalAddress();
 		if (socketAddress instanceof InetSocketAddress) {
+			String protocol = ReflectionUtils.findField(channel.getClass(), "ssl") != null
+					? "https" : "http";
 			return new Port(((InetSocketAddress) socketAddress).getPort(), protocol);
 		}
 		return null;

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
@@ -501,8 +501,7 @@ public class UndertowEmbeddedServletContainerFactory
 	protected UndertowEmbeddedServletContainer getUndertowEmbeddedServletContainer(
 			Builder builder, DeploymentManager manager, int port) {
 		return new UndertowEmbeddedServletContainer(builder, manager, getContextPath(),
-				port, isUseForwardHeaders(), port >= 0, getCompression(),
-				getServerHeader());
+				isUseForwardHeaders(), port >= 0, getCompression(), getServerHeader());
 	}
 
 	@Override


### PR DESCRIPTION
Hey,

since commit e927f52f2674fe0dd85ad2a051b1bb9cacaaf975 respectively #2584 the port field in the UndertowEmbeddedServletContainer was removed, but the parameter stayed although it isn't used anymore. This PR removes the unused parameter.

I thought about deprecating the constructor first, but decided against it as the container should be instantiated via the factory and not in a standalone-fashion anyways. But if you want I could do it like that. Just let me know.

- [X] I have signed the CLA

Cheers,
Christoph