### PR TITLE
Fix spring.profiles.active with multi profiles separated by

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
@@ -95,6 +95,7 @@ import org.springframework.validation.BindException;
  * @author Phillip Webb
  * @author Stephane Nicoll
  * @author Andy Wilkinson
+ * @author Eddú Meléndez
  */
 public class ConfigFileApplicationListener implements EnvironmentPostProcessor,
 		ApplicationListener<ApplicationEvent>, Ordered {
@@ -582,8 +583,8 @@ public class ConfigFileApplicationListener implements EnvironmentPostProcessor,
 
 		private Set<String> asResolvedSet(String value, String fallback) {
 			List<String> list = Arrays
-					.asList(StringUtils.commaDelimitedListToStringArray(value != null
-							? this.environment.resolvePlaceholders(value) : fallback));
+					.asList(StringUtils.trimArrayElements(StringUtils.commaDelimitedListToStringArray(value != null
+							? this.environment.resolvePlaceholders(value) : fallback)));
 			Collections.reverse(list);
 			return new LinkedHashSet<String>(list);
 		}

--- a/spring-boot/src/test/resources/testsetmultiprofiles.yml
+++ b/spring-boot/src/test/resources/testsetmultiprofiles.yml
@@ -1,0 +1,17 @@
+---
+spring:
+  profiles:
+    active: dev, healthcheck
+my:
+  property: fromyamlfile
+  property2: fromyamlfile
+---
+spring:
+  profiles: dev
+my:
+  property: fromdevprofile
+---
+spring:
+  profiles: healthcheck
+my:
+  property2: fromhealthcheckprofile


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [x] I have signed the CLA

comma and whitespace

Previously `spring.profiles.active` supported multi profiles
separated by comma but it doesn't work if there are whitespaces.
Now, `spring.profiles.active` will read values cleaning spaces.

See gh-5442