### PR TITLE
Added com.fasterxml.jackson.module:jackson-module-jaxb-annotations

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -660,6 +660,11 @@
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.module</groupId>
+				<artifactId>jackson-module-jaxb-annotations</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.module</groupId>
 				<artifactId>jackson-module-parameter-names</artifactId>
 				<version>${jackson.version}</version>
 			</dependency>


### PR DESCRIPTION
I'm building an application, which is mostly based on Spring Boot v.1.3.3.RELEASE & Apache Camel v.2.17.0

Got next exception while marshalling Java object to JSON:
```
org.apache.camel.CamelExecutionException: Exception occurred during execution on the exchange: Exchange[ID-MacBook-Pro-Igor-local-59351-1459789580656-0-2]
	at org.apache.camel.util.ObjectHelper.wrapCamelExecutionException(ObjectHelper.java:1696) ~[camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.impl.DefaultExchange.setException(DefaultExchange.java:348) ~[camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.processor.MarshalProcessor.process(MarshalProcessor.java:74) ~[camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.management.InstrumentationProcessor.process(InstrumentationProcessor.java:77) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.processor.RedeliveryErrorHandler.process(RedeliveryErrorHandler.java:468) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:190) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.processor.Pipeline.process(Pipeline.java:121) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.processor.Pipeline.process(Pipeline.java:83) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:190) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.component.direct.DirectProducer.process(DirectProducer.java:62) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.processor.SendProcessor.process(SendProcessor.java:145) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.management.InstrumentationProcessor.process(InstrumentationProcessor.java:77) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.processor.RedeliveryErrorHandler.process(RedeliveryErrorHandler.java:468) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:190) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.processor.Pipeline.process(Pipeline.java:121) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.processor.Pipeline.process(Pipeline.java:83) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:190) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.component.timer.TimerConsumer.sendTimerExchange(TimerConsumer.java:192) [camel-core-2.17.0.jar:2.17.0]
	at org.apache.camel.component.timer.TimerConsumer$1.run(TimerConsumer.java:76) [camel-core-2.17.0.jar:2.17.0]
	at java.util.TimerThread.mainLoop(Timer.java:555) [na:1.8.0_74]
	at java.util.TimerThread.run(Timer.java:505) [na:1.8.0_74]
Caused by: java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.introspect.AnnotatedMember.getType()Lcom/fasterxml/jackson/databind/JavaType;
	at com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector._fullSerializationType(JaxbAnnotationIntrospector.java:1606) ~[jackson-module-jaxb-annotations-2.7.2.jar:2.7.2]
	at com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector._findContentAdapter(JaxbAnnotationIntrospector.java:1557) ~[jackson-module-jaxb-annotations-2.7.2.jar:2.7.2]
	at com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector.findSerializationContentConverter(JaxbAnnotationIntrospector.java:880) ~[jackson-module-jaxb-annotations-2.7.2.jar:2.7.2]
	at com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair.findSerializationContentConverter(AnnotationIntrospectorPair.java:388) ~[jackson-databind-2.6.5.jar:2.6.5]
	at com.fasterxml.jackson.databind.ser.std.StdSerializer.findConvertingContentSerializer(StdSerializer.java:266) ~[jackson-databind-2.6.5.jar:2.6.5]
	at com.fasterxml.jackson.databind.ser.std.MapSerializer.createContextual(MapSerializer.java:339) ~[jackson-databind-2.6.5.jar:2.6.5]
	at com.fasterxml.jackson.databind.SerializerProvider.handlePrimaryContextualization(SerializerProvider.java:916) ~[jackson-databind-2.6.5.jar:2.6.5]
	at com.fasterxml.jackson.databind.SerializerProvider.findPrimaryPropertySerializer(SerializerProvider.java:617) ~[jackson-databind-2.6.5.jar:2.6.5]
	at com.fasterxml.jackson.databind.ser.impl.PropertySerializerMap.findAndAddPrimarySerializer(PropertySerializerMap.java:72) ~[jackson-databind-2.6.5.jar:2.6.5]
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter._findAndAddDynamic(BeanPropertyWriter.java:854) ~[jackson-databind-2.6.5.jar:2.6.5]
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:671) ~[jackson-databind-2.6.5.jar:2.6.5]
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:675) ~[jackson-databind-2.6.5.jar:2.6.5]
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:157) ~[jackson-databind-2.6.5.jar:2.6.5]
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:130) ~[jackson-databind-2.6.5.jar:2.6.5]
	at com.fasterxml.jackson.databind.ObjectWriter$Prefetch.serialize(ObjectWriter.java:1387) ~[jackson-databind-2.6.5.jar:2.6.5]
	at com.fasterxml.jackson.databind.ObjectWriter._configAndWriteValue(ObjectWriter.java:1088) ~[jackson-databind-2.6.5.jar:2.6.5]
	at com.fasterxml.jackson.databind.ObjectWriter.writeValue(ObjectWriter.java:926) ~[jackson-databind-2.6.5.jar:2.6.5]
	at org.apache.camel.component.jackson.JacksonDataFormat.marshal(JacksonDataFormat.java:154) ~[camel-jackson-2.17.0.jar:2.17.0]
	at org.apache.camel.processor.MarshalProcessor.process(MarshalProcessor.java:69) ~[camel-core-2.17.0.jar:2.17.0]
	... 18 common frames omitted
```

As I've identified, next modules have version 2.6.5 (as managed by org.springframework.boot:spring-boot-dependencies:1.3.3.RELEASE):
 - com.fasterxml.jackson.core:jackson-annotations
 - com.fasterxml.jackson.core:jackson-core
 - com.fasterxml.jackson.core:jackson-databind

While the subjected module (com.fasterxml.jackson.module:jackson-module-jaxb-annotations) has version 2.7.2 (from org.apache.camel:camel-jackson:2.17.0) and it's incompatible with 2.6.5.

I specified the correct version myself, but to improve spring-boot I'd like to add the appropriate dependency here.