### PR TITLE
Use existing JdbcTemplate for NamedParameterJdbcTemplate, resulting i…

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
@@ -126,8 +126,8 @@ public class DataSourceAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(NamedParameterJdbcOperations.class)
-		public NamedParameterJdbcTemplate namedParameterJdbcTemplate() {
-			return new NamedParameterJdbcTemplate(this.dataSource);
+		public NamedParameterJdbcTemplate namedParameterJdbcTemplate(JdbcTemplate jdbcTemplate) {
+			return new NamedParameterJdbcTemplate(jdbcTemplate);
 		}
 	}
 


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

This should implement #4945 and effectively reuse the existing JdbcOperations to create a NamedParameterJdbcTemplate. Instead of the creation of 2 JdbcTemplate beans, it will reuse it.

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [x] I have signed the CLA

…n only 1 creation of a JdbcTemplate and actually reusing the existing JdbcOperations Fixes gh-4945