### PR TITLE
Remove a duplicate test

### DIFF
--- a/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/DevToolsDataSourceAutoConfigurationTests.java
+++ b/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/DevToolsDataSourceAutoConfigurationTests.java
@@ -68,19 +68,6 @@ public class DevToolsDataSourceAutoConfigurationTests {
 	}
 
 	@Test
-	public void nonEmbeddedInMemoryDatabaseIsShutDown() throws SQLException {
-		ConfigurableApplicationContext context = createContextWithDriver("org.h2.Driver",
-				DataSourceConfiguration.class);
-		DataSource dataSource = context.getBean(DataSource.class);
-		Connection connection = mock(Connection.class);
-		given(dataSource.getConnection()).willReturn(connection);
-		Statement statement = mock(Statement.class);
-		given(connection.createStatement()).willReturn(statement);
-		context.close();
-		verify(statement).execute("SHUTDOWN");
-	}
-
-	@Test
 	public void nonEmbeddedInMemoryDatabaseConfiguredWithDriverIsShutDown()
 			throws SQLException {
 		ConfigurableApplicationContext context = createContextWithDriver("org.h2.Driver",


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 
`nonEmbeddedInMemoryDatabaseIsShutDown()` is the same as `nonEmbeddedInMemoryDatabaseConfiguredWithDriverIsShutDown()`. It looks accidentally duplicated.
<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

