### PR TITLE
Prefer HikariCP over Tomcat

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBuilder.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBuilder.java
@@ -29,8 +29,8 @@ import org.springframework.util.ClassUtils;
 
 /**
  * Convenience class for building a {@link DataSource} with common implementations and
- * properties. If Tomcat, HikariCP or Commons DBCP are on the classpath one of them will
- * be selected (in that order with Tomcat first). In the interest of a uniform interface,
+ * properties. If HikariCP, Tomcat or Commons DBCP are on the classpath one of them will
+ * be selected (in that order with HikariCP first). In the interest of a uniform interface,
  * and so that there can be a fallback to an embedded database if one can be detected on
  * the classpath, only a small set of common configuration properties are supported. To
  * inject additional properties into the result you can downcast it, or use
@@ -42,8 +42,8 @@ import org.springframework.util.ClassUtils;
 public class DataSourceBuilder {
 
 	private static final String[] DATA_SOURCE_TYPE_NAMES = new String[] {
-			"org.apache.tomcat.jdbc.pool.DataSource",
 			"com.zaxxer.hikari.HikariDataSource",
+			"org.apache.tomcat.jdbc.pool.DataSource",
 			"org.apache.commons.dbcp.BasicDataSource",
 			"org.apache.commons.dbcp2.BasicDataSource" };
 


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [x] I have signed the CLA

As Tomcat delivers its JDBC Pool in the Apache Tomcat distribution, its get picked up by default without this commit. If an user explicitly adds HikariCP to the classpath, its save to assume that he wants to use it.