### PR TITLE
fix java.lang.IllegalArgumentException when using spring-data-elasast…

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchAutoConfiguration.java
@@ -78,7 +78,7 @@ public class ElasticsearchAutoConfiguration implements DisposableBean {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean
+	@ConditionalOnMissingBean(Client.class)
 	public Client elasticsearchClient() {
 		try {
 			return createClient();


### PR DESCRIPTION
Updated ElasticsearchAutoConfiguration to pass the validation checks during auto configuration with spring-data-elasticsearch Hopper-Release 

```
@Bean
	@ConditionalOnMissingBean(Client.class)
	public Client elasticsearchClient() {
		try {
			return createClient();
		}
		catch (Exception ex) {
			throw new IllegalStateException(ex);
		}
	}
```

see https://github.com/spring-projects/spring-boot/issues/5624