### PR TITLE
IndexOutOfBoundsException when resolving List<Object> properties

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/bind/RelaxedDataBinder.java
+++ b/spring-boot/src/main/java/org/springframework/boot/bind/RelaxedDataBinder.java
@@ -343,7 +343,9 @@ public class RelaxedDataBinder extends DataBinder {
 			return;
 		}
 		Object extend = new LinkedHashMap<String, Object>();
-		if (!elementDescriptor.isMap() && path.isArrayIndex(index + 1)) {
+		if (!elementDescriptor.isMap() &&
+			(((path.size() > (index + 1)) && path.isArrayIndex(index + 1)) ||
+			((path.size() == (index + 1)) && path.isArrayIndex(index)))) {
 			extend = new ArrayList<Object>();
 		}
 		wrapper.setPropertyValue(path.prefix(index + 1), extend);
@@ -589,6 +591,10 @@ public class RelaxedDataBinder extends DataBinder {
 
 		public boolean isProperty(int index) {
 			return this.nodes.get(index) instanceof PropertyNode;
+		}
+
+		public int size() {
+			return this.nodes.size();
 		}
 
 		@Override


### PR DESCRIPTION
Using the following simple spring-boot application results in an `IndexOutOfBoundsException` in the `RelaxedDataBinder`.

Application.java
```java
package spring_props;

import org.springframework.beans.factory.annotation.Autowired;
import org.springframework.boot.SpringApplication;
import org.springframework.boot.autoconfigure.SpringBootApplication;
import org.springframework.boot.context.properties.EnableConfigurationProperties;

@SpringBootApplication
@EnableConfigurationProperties
public class Application {

    @Autowired
    TestSettings settings;

    public static void main(String[] args) {
        SpringApplication.run(Application.class, args);
    }

}
```

TestSettings.java
```java
package spring_props;

import java.util.List;

import org.springframework.boot.context.properties.ConfigurationProperties;
import org.springframework.stereotype.Component;

@Component
@ConfigurationProperties("test")
public class TestSettings {

    private List<Object> objects;

    public List<Object> getObjects() {
        return objects;
    }

    public void setObjects(List<Object> objects) {
        this.objects = objects;
    }

}
```

application.properties
```
test.objects[0]: teststring
```