### PR TITLE
Add banner bean

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -36,6 +36,7 @@ content into your application; rather pick only the properties that you need.
 	banner.image.hight= # Height of the banner image in chars (default based on image height)
 	banner.image.margin= # Left hand image margin in chars (default 2)
 	banner.image.invert= # If images should be inverted for dark terminal themes (default false)
+    banner.bean.name=springBanner # The of the bean under which the banner is registered, an empty property disables registration of the bean.
 
 	# LOGGING
 	logging.config= # Location of the logging configuration file. For instance `classpath:logback.xml` for Logback

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -36,7 +36,6 @@ content into your application; rather pick only the properties that you need.
 	banner.image.hight= # Height of the banner image in chars (default based on image height)
 	banner.image.margin= # Left hand image margin in chars (default 2)
 	banner.image.invert= # If images should be inverted for dark terminal themes (default false)
-    banner.bean.name=springBanner # The of the bean under which the banner is registered, an empty property disables registration of the bean.
 
 	# LOGGING
 	logging.config= # Location of the logging configuration file. For instance `classpath:logback.xml` for Logback

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -94,6 +94,9 @@ You can also use the `spring.main.banner-mode` property to determine if the bann
 to be printed on `System.out` (`console`), using the configured logger (`log`) or not
 at all (`off`).
 
+The printed banner will be registered as a singleton bean under the name `springBanner`.
+This can be turned of by setting `banner.bean.name` to a blank value.
+
 [NOTE]
 ====
 YAML maps `off` to `false` so make sure to add quotes if you want to disable the

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -94,8 +94,7 @@ You can also use the `spring.main.banner-mode` property to determine if the bann
 to be printed on `System.out` (`console`), using the configured logger (`log`) or not
 at all (`off`).
 
-The printed banner will be registered as a singleton bean under the name `springBanner`.
-This can be turned off by setting `banner.bean.name` to a blank value.
+The printed banner will be registered as a singleton bean under the name `springBootBanner`.
 
 [NOTE]
 ====

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -95,7 +95,7 @@ to be printed on `System.out` (`console`), using the configured logger (`log`) o
 at all (`off`).
 
 The printed banner will be registered as a singleton bean under the name `springBanner`.
-This can be turned of by setting `banner.bean.name` to a blank value.
+This can be turned off by setting `banner.bean.name` to a blank value.
 
 [NOTE]
 ====

--- a/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -139,6 +139,7 @@ import org.springframework.web.context.support.StandardServletEnvironment;
  * @author Stephane Nicoll
  * @author Jeremy Rickard
  * @author Craig Burke
+ * @author Michael Simons
  * @see #run(Object, String[])
  * @see #run(Object[], String[])
  * @see #SpringApplication(Object...)
@@ -171,6 +172,11 @@ public class SpringApplication {
 	 * Banner location property key.
 	 */
 	public static final String BANNER_LOCATION_PROPERTY = SpringApplicationBannerPrinter.BANNER_LOCATION_PROPERTY;
+
+	/**
+	 * Banner bean name property key.
+	 */
+	public static final String BANNER_BEAN_NAME_PROPERTY = "banner.bean.name";
 
 	private static final String CONFIGURABLE_WEB_ENVIRONMENT_CLASS = "org.springframework.web.context.ConfigurableWebEnvironment";
 
@@ -304,11 +310,12 @@ public class SpringApplication {
 					args);
 			ConfigurableEnvironment environment = prepareEnvironment(listeners,
 					applicationArguments);
+			Banner printedBanner = null;
 			if (this.bannerMode != Banner.Mode.OFF) {
-				printBanner(environment);
+				printedBanner = printBanner(environment);
 			}
 			context = createApplicationContext();
-			prepareContext(context, environment, listeners, applicationArguments);
+			prepareContext(context, environment, listeners, applicationArguments, printedBanner);
 			refreshContext(context);
 			afterRefresh(context, applicationArguments);
 			listeners.finished(context, null);
@@ -340,7 +347,8 @@ public class SpringApplication {
 
 	private void prepareContext(ConfigurableApplicationContext context,
 			ConfigurableEnvironment environment, SpringApplicationRunListeners listeners,
-			ApplicationArguments applicationArguments) {
+			ApplicationArguments applicationArguments,
+			Banner printedBanner) {
 		context.setEnvironment(environment);
 		postProcessApplicationContext(context);
 		applyInitializers(context);
@@ -353,6 +361,10 @@ public class SpringApplication {
 		// Add boot specific singleton beans
 		context.getBeanFactory().registerSingleton("springApplicationArguments",
 				applicationArguments);
+		String bannerBeanName = environment.getProperty(BANNER_BEAN_NAME_PROPERTY, String.class, "springBanner").trim();
+		if (printedBanner != null && bannerBeanName.length() != 0) {
+			context.getBeanFactory().registerSingleton(bannerBeanName, banner);
+		}
 
 		// Load the sources
 		Set<Object> sources = getSources();
@@ -536,19 +548,22 @@ public class SpringApplication {
 	 * banner.location=classpath:banner.txt, banner.charset=UTF-8. If the banner file does
 	 * not exist or cannot be printed, a simple default is created.
 	 * @param environment the environment
+	 * @return The banner that was printed to the console
 	 * @see #setBannerMode
 	 */
-	protected void printBanner(Environment environment) {
+	protected Banner printBanner(Environment environment) {
 		ResourceLoader resourceLoader = this.resourceLoader != null ? this.resourceLoader
 				: new DefaultResourceLoader(getClassLoader());
-		SpringApplicationBannerPrinter banner = new SpringApplicationBannerPrinter(resourceLoader,
+		SpringApplicationBannerPrinter bannerPrinter = new SpringApplicationBannerPrinter(resourceLoader,
 				this.banner);
+		Banner banner;
 		if (this.bannerMode == Mode.LOG) {
-			banner.print(environment, this.mainApplicationClass, logger);
+			banner = bannerPrinter.print(environment, this.mainApplicationClass, logger);
 		}
 		else {
-			banner.print(environment, this.mainApplicationClass, System.out);
+			banner = bannerPrinter.print(environment, this.mainApplicationClass, System.out);
 		}
+		return banner;
 	}
 
 	/**

--- a/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -173,11 +173,6 @@ public class SpringApplication {
 	 */
 	public static final String BANNER_LOCATION_PROPERTY = SpringApplicationBannerPrinter.BANNER_LOCATION_PROPERTY;
 
-	/**
-	 * Banner bean name property key.
-	 */
-	public static final String BANNER_BEAN_NAME_PROPERTY = "banner.bean.name";
-
 	private static final String CONFIGURABLE_WEB_ENVIRONMENT_CLASS = "org.springframework.web.context.ConfigurableWebEnvironment";
 
 	private static final String SYSTEM_PROPERTY_JAVA_AWT_HEADLESS = "java.awt.headless";
@@ -361,9 +356,8 @@ public class SpringApplication {
 		// Add boot specific singleton beans
 		context.getBeanFactory().registerSingleton("springApplicationArguments",
 				applicationArguments);
-		String bannerBeanName = environment.getProperty(BANNER_BEAN_NAME_PROPERTY, String.class, "springBanner").trim();
-		if (printedBanner != null && bannerBeanName.length() != 0) {
-			context.getBeanFactory().registerSingleton(bannerBeanName, banner);
+		if (printedBanner != null) {
+			context.getBeanFactory().registerSingleton("springBootBanner", banner);
 		}
 
 		// Load the sources

--- a/spring-boot/src/main/java/org/springframework/boot/SpringApplicationBannerPrinter.java
+++ b/spring-boot/src/main/java/org/springframework/boot/SpringApplicationBannerPrinter.java
@@ -55,7 +55,7 @@ class SpringApplicationBannerPrinter {
 		this.fallbackBanner = fallbackBanner;
 	}
 
-	public void print(Environment environment, Class<?> sourceClass, Log logger) {
+	public Banner print(Environment environment, Class<?> sourceClass, Log logger) {
 		Banner banner = getBanner(environment, this.fallbackBanner);
 		try {
 			logger.info(createStringFromBanner(banner, environment, sourceClass));
@@ -63,11 +63,13 @@ class SpringApplicationBannerPrinter {
 		catch (UnsupportedEncodingException ex) {
 			logger.warn("Failed to create String for banner", ex);
 		}
+		return banner;
 	}
 
-	public void print(Environment environment, Class<?> sourceClass, PrintStream out) {
+	public Banner print(Environment environment, Class<?> sourceClass, PrintStream out) {
 		Banner banner = getBanner(environment, this.fallbackBanner);
 		banner.printBanner(environment, sourceClass, out);
+		return banner;
 	}
 
 	private Banner getBanner(Environment environment, Banner definedBanner) {

--- a/spring-boot/src/test/java/org/springframework/boot/BannerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/BannerTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot;
 
 import java.io.PrintStream;
+import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Rule;
@@ -34,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Phillip Webb
  * @author Michael Stummvoll
+ * @author Michael Simons
  */
 public class BannerTests {
 
@@ -72,6 +74,46 @@ public class BannerTests {
 		application.setBanner(new DummyBanner());
 		this.context = application.run();
 		assertThat(this.out.toString()).contains("My Banner");
+	}
+
+	@Test
+	public void testBannerInContext() throws Exception {
+		SpringApplication application = new SpringApplication(Config.class);
+		application.setWebEnvironment(false);
+		this.context = application.run();
+		assertThat(this.context.containsBean("springBanner")).isTrue();
+	}
+
+	@Test
+	public void testCustomBannerInContext() throws Exception {
+		SpringApplication application = new SpringApplication(Config.class);
+		application.setWebEnvironment(false);
+		final DummyBanner dummyBanner = new DummyBanner();
+		application.setBanner(dummyBanner);
+		this.context = application.run();
+		assertThat(this.context.getBean("springBanner")).isEqualTo(dummyBanner);
+	}
+
+	@Test
+	public void testChangeBannerBeanNameInContext() throws Exception {
+		final Properties properties = new Properties();
+		properties.put(SpringApplication.BANNER_BEAN_NAME_PROPERTY, "foobar");
+		SpringApplication application = new SpringApplication(Config.class);
+		application.setDefaultProperties(properties);
+		application.setWebEnvironment(false);
+		this.context = application.run();
+		assertThat(this.context.containsBean("foobar")).isTrue();
+	}
+
+	@Test
+	public void testDisableBannerInContext() throws Exception {
+		final Properties properties = new Properties();
+		properties.put(SpringApplication.BANNER_BEAN_NAME_PROPERTY, "");
+		SpringApplication application = new SpringApplication(Config.class);
+		application.setDefaultProperties(properties);
+		application.setWebEnvironment(false);
+		this.context = application.run();
+		assertThat(this.context.containsBean("springBanner")).isFalse();
 	}
 
 	static class DummyBanner implements Banner {

--- a/spring-boot/src/test/java/org/springframework/boot/BannerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/BannerTests.java
@@ -17,12 +17,12 @@
 package org.springframework.boot;
 
 import java.io.PrintStream;
-import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.springframework.boot.Banner.Mode;
 import org.springframework.boot.testutil.InternalOutputCapture;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
@@ -81,7 +81,7 @@ public class BannerTests {
 		SpringApplication application = new SpringApplication(Config.class);
 		application.setWebEnvironment(false);
 		this.context = application.run();
-		assertThat(this.context.containsBean("springBanner")).isTrue();
+		assertThat(this.context.containsBean("springBootBanner")).isTrue();
 	}
 
 	@Test
@@ -91,29 +91,16 @@ public class BannerTests {
 		final DummyBanner dummyBanner = new DummyBanner();
 		application.setBanner(dummyBanner);
 		this.context = application.run();
-		assertThat(this.context.getBean("springBanner")).isEqualTo(dummyBanner);
-	}
-
-	@Test
-	public void testChangeBannerBeanNameInContext() throws Exception {
-		final Properties properties = new Properties();
-		properties.put(SpringApplication.BANNER_BEAN_NAME_PROPERTY, "foobar");
-		SpringApplication application = new SpringApplication(Config.class);
-		application.setDefaultProperties(properties);
-		application.setWebEnvironment(false);
-		this.context = application.run();
-		assertThat(this.context.containsBean("foobar")).isTrue();
+		assertThat(this.context.getBean("springBootBanner")).isEqualTo(dummyBanner);
 	}
 
 	@Test
 	public void testDisableBannerInContext() throws Exception {
-		final Properties properties = new Properties();
-		properties.put(SpringApplication.BANNER_BEAN_NAME_PROPERTY, "");
 		SpringApplication application = new SpringApplication(Config.class);
-		application.setDefaultProperties(properties);
+		application.setBannerMode(Mode.OFF);
 		application.setWebEnvironment(false);
 		this.context = application.run();
-		assertThat(this.context.containsBean("springBanner")).isFalse();
+		assertThat(this.context.containsBean("springBootBanner")).isFalse();
 	}
 
 	static class DummyBanner implements Banner {


### PR DESCRIPTION
If the banner hasn't been turned off and was printed to either the log or the console, add it as a singleton to the application context.
The name of the bean can be configured, which i have documented in the docs.
This way the feature can also be turned off.

I've changed changed the return value of SpringApplicationBannerPrinter#print, but that shouldn't cause problems as the class is only package level visible. I've also added a new parameter to SpringApplication#prepareContext, but this method is private.

- [x] I have signed the CLA