### PR TITLE
Windows build fixes

### DIFF
--- a/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
@@ -193,7 +193,7 @@ public class SpringApplicationTests {
 				"--banner.location=classpath:test-banner-with-placeholder.txt",
 				"--test.property=123456");
 		assertThat(this.output.toString())
-				.startsWith(String.format("Running a Test!%n%n123456"));
+				.startsWith("Running a Test!\n\n123456");
 	}
 
 	@Test

--- a/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileApplicationListenerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileApplicationListenerTests.java
@@ -606,7 +606,8 @@ public class ConfigFileApplicationListenerTests {
 		String location = new File("src/test/resources/specificlocation.properties")
 				.getAbsolutePath();
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.environment,
-				"spring.config.location=" + location);
+				// java.util.Properties needs the values escaped
+				"spring.config.location=" + location.replaceAll("\\\\", "\\\\\\\\"));
 		this.initializer.postProcessEnvironment(this.environment, this.application);
 		assertThat(this.environment)
 				.has(matchingPropertySource("applicationConfig: [file:"


### PR DESCRIPTION
The test suite fails on Windows, mostly due to IO assumptions I suppose.
- The file used in `customBannerWithProperties()` only contains `lf`, so using `%n` doesn't make much sense
- Since WIndows uses backslashes as separator character, and `java.util.Properties` understands escape sequences, we need to escape those backslashes as well

I was also setting up an AppVeyor build pipeline, based on the Travis settings, so tell me if you want that, or can take a look.


- [x] I have signed the CLA
