### PR TITLE
Enabled server.maxHttpHeaderSize and server.maxHttpPostSize configuration

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -843,7 +843,7 @@ public class ServerProperties
 
 		@SuppressWarnings("rawtypes")
 		private void customizeMaxHttpHeaderSize(
-				TomcatEmbeddedServletContainerFactory factory, int maxHttpHeaderSize) {
+				TomcatEmbeddedServletContainerFactory factory, final int maxHttpHeaderSize) {
 			factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
 
 				@Override
@@ -859,7 +859,7 @@ public class ServerProperties
 		}
 
 		private void customizeMaxHttpPostSize(
-				TomcatEmbeddedServletContainerFactory factory, int maxHttpPostSize) {
+				TomcatEmbeddedServletContainerFactory factory, final int maxHttpPostSize) {
 			factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
 				@Override
 				public void customize(Connector connector) {
@@ -962,7 +962,7 @@ public class ServerProperties
 		}
 
 		private void customizeMaxHttpHeaderSize(
-				JettyEmbeddedServletContainerFactory factory, int maxHttpHeaderSize) {
+				JettyEmbeddedServletContainerFactory factory, final int maxHttpHeaderSize) {
 			factory.addServerCustomizers(new JettyServerCustomizer() {
 				@Override
 				public void customize(Server server) {
@@ -983,7 +983,7 @@ public class ServerProperties
 		}
 
 		private void customizeMaxHttpPostSize(
-				JettyEmbeddedServletContainerFactory factory, int maxHttpPostSize) {
+				JettyEmbeddedServletContainerFactory factory, final int maxHttpPostSize) {
 			factory.addServerCustomizers(new JettyServerCustomizer() {
 
 				@Override
@@ -1123,7 +1123,7 @@ public class ServerProperties
 		}
 
 		private void customizeMaxHttpHeaderSize(
-				UndertowEmbeddedServletContainerFactory factory, int maxHttpHeaderSize) {
+				UndertowEmbeddedServletContainerFactory factory, final int maxHttpHeaderSize) {
 			factory.addBuilderCustomizers(new UndertowBuilderCustomizer() {
 				@Override
 				public void customize(Builder builder) {
@@ -1133,7 +1133,7 @@ public class ServerProperties
 		}
 
 		private void customizeMaxHttpPostSize(
-				UndertowEmbeddedServletContainerFactory factory, int maxHttpPostSize) {
+				UndertowEmbeddedServletContainerFactory factory, final int maxHttpPostSize) {
 			factory.addBuilderCustomizers(new UndertowBuilderCustomizer() {
 				@Override
 				public void customize(Builder builder) {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -43,8 +43,6 @@ import org.apache.coyote.http11.AbstractHttp11Protocol;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
-import org.eclipse.jetty.server.HttpConfiguration.Customizer;
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
@@ -966,15 +964,15 @@ public class ServerProperties
 			factory.addServerCustomizers(new JettyServerCustomizer() {
 				@Override
 				public void customize(Server server) {
-					JettyMaxHttpHeaderSizeCustomizer customizer = new JettyMaxHttpHeaderSizeCustomizer(
-							maxHttpHeaderSize);
 					org.eclipse.jetty.server.Connector[] connectors = server.getConnectors();
 					for (org.eclipse.jetty.server.Connector connector : connectors) {
-						for (ConnectionFactory connectionFactory : connector
-								.getConnectionFactories()) {
+						for (ConnectionFactory connectionFactory : connector.getConnectionFactories()) {
 							if (connectionFactory instanceof HttpConfiguration.ConnectionFactory) {
-								((HttpConfiguration.ConnectionFactory) connectionFactory)
-										.getHttpConfiguration().addCustomizer(customizer);
+								HttpConfiguration httpConfig =
+									((HttpConfiguration.ConnectionFactory) connectionFactory)
+										.getHttpConfiguration();
+								httpConfig.setRequestHeaderSize(maxHttpHeaderSize);
+								httpConfig.setResponseHeaderSize(maxHttpHeaderSize);
 							}
 						}
 					}
@@ -1009,23 +1007,6 @@ public class ServerProperties
 				}
 
 			});
-		}
-
-	}
-
-	private static class JettyMaxHttpHeaderSizeCustomizer implements Customizer {
-
-		private int headerSize;
-
-		JettyMaxHttpHeaderSizeCustomizer(int headerSize) {
-			this.headerSize = headerSize;
-		}
-
-		@Override
-		public void customize(org.eclipse.jetty.server.Connector connector,
-				HttpConfiguration channelConfig, Request request) {
-			channelConfig.setRequestHeaderSize(this.headerSize);
-			channelConfig.setResponseHeaderSize(this.headerSize);
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -30,6 +30,9 @@ import javax.servlet.SessionCookieConfig;
 import javax.servlet.SessionTrackingMode;
 import javax.validation.constraints.NotNull;
 
+import io.undertow.Undertow.Builder;
+import io.undertow.UndertowOptions;
+
 import org.apache.catalina.Context;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.valves.AccessLogValve;
@@ -37,6 +40,15 @@ import org.apache.catalina.valves.RemoteIpValve;
 import org.apache.coyote.AbstractProtocol;
 import org.apache.coyote.ProtocolHandler;
 import org.apache.coyote.http11.AbstractHttp11Protocol;
+import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConfiguration.Customizer;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.HandlerCollection;
+import org.eclipse.jetty.server.handler.HandlerWrapper;
 
 import org.springframework.boot.autoconfigure.web.ServerProperties.Session.Cookie;
 import org.springframework.boot.cloud.CloudPlatform;
@@ -50,11 +62,14 @@ import org.springframework.boot.context.embedded.JspServlet;
 import org.springframework.boot.context.embedded.ServletContextInitializer;
 import org.springframework.boot.context.embedded.Ssl;
 import org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainerFactory;
+import org.springframework.boot.context.embedded.jetty.JettyServerCustomizer;
 import org.springframework.boot.context.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.context.embedded.tomcat.TomcatContextCustomizer;
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.boot.context.embedded.undertow.UndertowBuilderCustomizer;
 import org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServletContainerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.core.Ordered;
@@ -73,6 +88,7 @@ import org.springframework.util.StringUtils;
  * @author Marcos Barbero
  * @author Eddú Meléndez
  * @author Quinten De Swaef
+ * @author Venil Noronha
  */
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = true)
 public class ServerProperties
@@ -121,6 +137,16 @@ public class ServerProperties
 	 * Value to use for the server header (uses servlet container default if empty).
 	 */
 	private String serverHeader;
+
+	/**
+	 * Maximum size in bytes of the HTTP message header.
+	 */
+	private int maxHttpHeaderSize = 0; // bytes
+
+	/**
+	 * Maximum size in bytes of the HTTP post content.
+	 */
+	private int maxHttpPostSize = 0; // bytes
 
 	private Session session = new Session();
 
@@ -317,6 +343,22 @@ public class ServerProperties
 
 	public void setServerHeader(String serverHeader) {
 		this.serverHeader = serverHeader;
+	}
+
+	public int getMaxHttpHeaderSize() {
+		return this.maxHttpHeaderSize;
+	}
+
+	public void setMaxHttpHeaderSize(int maxHttpHeaderSize) {
+		this.maxHttpHeaderSize = maxHttpHeaderSize;
+	}
+
+	public int getMaxHttpPostSize() {
+		return this.maxHttpPostSize;
+	}
+
+	public void setMaxHttpPostSize(int maxHttpPostSize) {
+		this.maxHttpPostSize = maxHttpPostSize;
 	}
 
 	protected final boolean getOrDeduceUseForwardHeaders() {
@@ -612,10 +654,23 @@ public class ServerProperties
 			this.minSpareThreads = minSpareThreads;
 		}
 
+		/**
+		 * Get the max http header size.
+		 * @return the max http header size.
+		 * @deprecated in favor of {@code server.maxHttpHeaderSize}
+		 */
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "server.maxHttpHeaderSize")
 		public int getMaxHttpHeaderSize() {
 			return this.maxHttpHeaderSize;
 		}
 
+		/**
+		 * Set the max http header size.
+		 * @param maxHttpHeaderSize the max http header size.
+		 * @deprecated in favor of {@code server.maxHttpHeaderSize}
+		 */
+		@Deprecated
 		public void setMaxHttpHeaderSize(int maxHttpHeaderSize) {
 			this.maxHttpHeaderSize = maxHttpHeaderSize;
 		}
@@ -701,8 +756,14 @@ public class ServerProperties
 			if (this.minSpareThreads > 0) {
 				customizeMinThreads(factory);
 			}
-			if (this.maxHttpHeaderSize > 0) {
-				customizeMaxHttpHeaderSize(factory);
+			if (serverProperties.getMaxHttpHeaderSize() > 0) {
+				customizeMaxHttpHeaderSize(factory, serverProperties.getMaxHttpHeaderSize());
+			}
+			else if (this.maxHttpHeaderSize > 0) {
+				customizeMaxHttpHeaderSize(factory, this.maxHttpHeaderSize);
+			}
+			if (serverProperties.getMaxHttpPostSize() > 0) {
+				customizeMaxHttpPostSize(factory, serverProperties.getMaxHttpPostSize());
 			}
 			if (this.accesslog.enabled) {
 				customizeAccessLog(factory);
@@ -782,7 +843,7 @@ public class ServerProperties
 
 		@SuppressWarnings("rawtypes")
 		private void customizeMaxHttpHeaderSize(
-				TomcatEmbeddedServletContainerFactory factory) {
+				TomcatEmbeddedServletContainerFactory factory, int maxHttpHeaderSize) {
 			factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
 
 				@Override
@@ -790,10 +851,20 @@ public class ServerProperties
 					ProtocolHandler handler = connector.getProtocolHandler();
 					if (handler instanceof AbstractHttp11Protocol) {
 						AbstractHttp11Protocol protocol = (AbstractHttp11Protocol) handler;
-						protocol.setMaxHttpHeaderSize(Tomcat.this.maxHttpHeaderSize);
+						protocol.setMaxHttpHeaderSize(maxHttpHeaderSize);
 					}
 				}
 
+			});
+		}
+
+		private void customizeMaxHttpPostSize(
+				TomcatEmbeddedServletContainerFactory factory, int maxHttpPostSize) {
+			factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
+				@Override
+				public void customize(Connector connector) {
+					connector.setMaxPostSize(maxHttpPostSize);
+				}
 			});
 		}
 
@@ -882,6 +953,79 @@ public class ServerProperties
 		void customizeJetty(ServerProperties serverProperties,
 				JettyEmbeddedServletContainerFactory factory) {
 			factory.setUseForwardHeaders(serverProperties.getOrDeduceUseForwardHeaders());
+			if (serverProperties.getMaxHttpHeaderSize() > 0) {
+				customizeMaxHttpHeaderSize(factory, serverProperties.getMaxHttpHeaderSize());
+			}
+			if (serverProperties.getMaxHttpPostSize() > 0) {
+				customizeMaxHttpPostSize(factory, serverProperties.getMaxHttpPostSize());
+			}
+		}
+
+		private void customizeMaxHttpHeaderSize(
+				JettyEmbeddedServletContainerFactory factory, int maxHttpHeaderSize) {
+			factory.addServerCustomizers(new JettyServerCustomizer() {
+				@Override
+				public void customize(Server server) {
+					JettyMaxHttpHeaderSizeCustomizer customizer = new JettyMaxHttpHeaderSizeCustomizer(
+							maxHttpHeaderSize);
+					org.eclipse.jetty.server.Connector[] connectors = server.getConnectors();
+					for (org.eclipse.jetty.server.Connector connector : connectors) {
+						for (ConnectionFactory connectionFactory : connector
+								.getConnectionFactories()) {
+							if (connectionFactory instanceof HttpConfiguration.ConnectionFactory) {
+								((HttpConfiguration.ConnectionFactory) connectionFactory)
+										.getHttpConfiguration().addCustomizer(customizer);
+							}
+						}
+					}
+				}
+			});
+		}
+
+		private void customizeMaxHttpPostSize(
+				JettyEmbeddedServletContainerFactory factory, int maxHttpPostSize) {
+			factory.addServerCustomizers(new JettyServerCustomizer() {
+
+				@Override
+				public void customize(Server server) {
+					setHandlerMaxHttpPostSize(maxHttpPostSize, server.getHandlers());
+				}
+
+				private void setHandlerMaxHttpPostSize(int maxHttpPostSize,
+						Handler... handlers) {
+					for (Handler handler : handlers) {
+						if (handler instanceof ContextHandler) {
+							((ContextHandler) handler).setMaxFormContentSize(maxHttpPostSize);
+						}
+						else if (handler instanceof HandlerWrapper) {
+							setHandlerMaxHttpPostSize(maxHttpPostSize,
+									((HandlerWrapper) handler).getHandler());
+						}
+						else if (handler instanceof HandlerCollection) {
+							setHandlerMaxHttpPostSize(maxHttpPostSize,
+									((HandlerCollection) handler).getHandlers());
+						}
+					}
+				}
+
+			});
+		}
+
+	}
+
+	private static class JettyMaxHttpHeaderSizeCustomizer implements Customizer {
+
+		private int headerSize;
+
+		JettyMaxHttpHeaderSizeCustomizer(int headerSize) {
+			this.headerSize = headerSize;
+		}
+
+		@Override
+		public void customize(org.eclipse.jetty.server.Connector connector,
+				HttpConfiguration channelConfig, Request request) {
+			channelConfig.setRequestHeaderSize(this.headerSize);
+			channelConfig.setResponseHeaderSize(this.headerSize);
 		}
 
 	}
@@ -970,6 +1114,32 @@ public class ServerProperties
 			factory.setAccessLogPattern(this.accesslog.pattern);
 			factory.setAccessLogEnabled(this.accesslog.enabled);
 			factory.setUseForwardHeaders(serverProperties.getOrDeduceUseForwardHeaders());
+			if (serverProperties.getMaxHttpHeaderSize() > 0) {
+				customizeMaxHttpHeaderSize(factory, serverProperties.getMaxHttpHeaderSize());
+			}
+			if (serverProperties.getMaxHttpPostSize() > 0) {
+				customizeMaxHttpPostSize(factory, serverProperties.getMaxHttpPostSize());
+			}
+		}
+
+		private void customizeMaxHttpHeaderSize(
+				UndertowEmbeddedServletContainerFactory factory, int maxHttpHeaderSize) {
+			factory.addBuilderCustomizers(new UndertowBuilderCustomizer() {
+				@Override
+				public void customize(Builder builder) {
+					builder.setServerOption(UndertowOptions.MAX_HEADER_SIZE, maxHttpHeaderSize);
+				}
+			});
+		}
+
+		private void customizeMaxHttpPostSize(
+				UndertowEmbeddedServletContainerFactory factory, int maxHttpPostSize) {
+			factory.addBuilderCustomizers(new UndertowBuilderCustomizer() {
+				@Override
+				public void customize(Builder builder) {
+					builder.setServerOption(UndertowOptions.MAX_ENTITY_SIZE, (long) maxHttpPostSize);
+				}
+			});
 		}
 
 		public static class Accesslog {


### PR DESCRIPTION
I've added `maxHttpHeaderSize` and `maxHttpPostSize` properties to `ServerProperties` to configure the underlying `Tomcat`, `Jetty` and `Undertow` containers accordingly. I've also marked `server.tomcat.maxHttpHeaderSize` deprecated in favor of `server.maxHttpHeaderSize`. See #5637 for the original issue.

- [x] I have signed the CLA

Please review and merge. My CLA number is 149720151120072904.

Thanks,
Venil Noronha