### PR TITLE
Enabled setting of trusted packages via ActiveMQProperties

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQConnectionFactoryFactory.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQConnectionFactoryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.boot.autoconfigure.jms.activemq;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
 
+import org.springframework.boot.autoconfigure.jms.activemq.ActiveMQProperties.Packages;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -26,6 +27,7 @@ import org.springframework.util.StringUtils;
  * in {@link ActiveMQProperties}.
  *
  * @author Phillip Webb
+ * @author Venil Noronha
  * @since 1.2.0
  */
 class ActiveMQConnectionFactoryFactory {
@@ -57,11 +59,20 @@ class ActiveMQConnectionFactoryFactory {
 		String brokerUrl = determineBrokerUrl();
 		String user = this.properties.getUser();
 		String password = this.properties.getPassword();
+		T activeMqConnectionFactory;
 		if (StringUtils.hasLength(user) && StringUtils.hasLength(password)) {
-			return factoryClass.getConstructor(String.class, String.class, String.class)
+			activeMqConnectionFactory =
+				factoryClass.getConstructor(String.class, String.class, String.class)
 					.newInstance(user, password, brokerUrl);
 		}
-		return factoryClass.getConstructor(String.class).newInstance(brokerUrl);
+		else {
+			activeMqConnectionFactory =
+				factoryClass.getConstructor(String.class).newInstance(brokerUrl);
+		}
+		Packages packages = this.properties.getPackages();
+		activeMqConnectionFactory.setTrustAllPackages(packages.isTrustAll());
+		activeMqConnectionFactory.setTrustedPackages(packages.getTrusted());
+		return activeMqConnectionFactory;
 	}
 
 	String determineBrokerUrl() {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQProperties.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.autoconfigure.jms.activemq;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
@@ -25,6 +28,7 @@ import org.springframework.boot.context.properties.DeprecatedConfigurationProper
  * @author Greg Turnquist
  * @author Stephane Nicoll
  * @author Aurélien Leboulanger
+ * @author Venil Noronha
  */
 @ConfigurationProperties(prefix = "spring.activemq")
 public class ActiveMQProperties {
@@ -51,6 +55,8 @@ public class ActiveMQProperties {
 	private String password;
 
 	private Pool pool = new Pool();
+
+	private Packages packages = new Packages();
 
 	public String getBrokerUrl() {
 		return this.brokerUrl;
@@ -113,6 +119,14 @@ public class ActiveMQProperties {
 		this.pool = pool;
 	}
 
+	public Packages getPackages() {
+		return this.packages;
+	}
+
+	public void setPackages(Packages packages) {
+		this.packages = packages;
+	}
+
 	public static class Pool {
 
 		/**
@@ -166,6 +180,32 @@ public class ActiveMQProperties {
 
 		public void setExpiryTimeout(long expiryTimeout) {
 			this.expiryTimeout = expiryTimeout;
+		}
+
+	}
+
+	public static class Packages {
+
+		/** Whether security check for trusted packages should be turned off. */
+		private boolean trustAll = false;
+
+		/** The packages to trust. */
+		private List<String> trusted = new ArrayList<String>();
+
+		public boolean isTrustAll() {
+			return this.trustAll;
+		}
+
+		public void setTrustAll(boolean trustAll) {
+			this.trustAll = trustAll;
+		}
+
+		public List<String> getTrusted() {
+			return this.trusted;
+		}
+
+		public void setTrusted(List<String> trusted) {
+			this.trusted = trusted;
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQPropertiesTests.java
@@ -16,15 +16,19 @@
 
 package org.springframework.boot.autoconfigure.jms.activemq;
 
+import org.apache.activemq.ActiveMQConnectionFactory;
+
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 
 /**
  * Tests for {@link ActiveMQProperties} and {@link ActiveMQConnectionFactoryFactory}.
  *
  * @author Stephane Nicoll
  * @author Aurélien Leboulanger
+ * @author Venil Noronha
  */
 public class ActiveMQPropertiesTests {
 
@@ -60,6 +64,26 @@ public class ActiveMQPropertiesTests {
 		this.properties.setInMemory(false);
 		assertThat(new ActiveMQConnectionFactoryFactory(this.properties)
 				.determineBrokerUrl()).isEqualTo("vm://foo-bar");
+	}
+
+	@Test
+	public void testPackagesTrustAllSetToTrue() {
+		this.properties.getPackages().setTrustAll(true);
+		assertThat(new ActiveMQConnectionFactoryFactory(this.properties)
+				.createConnectionFactory(ActiveMQConnectionFactory.class)
+				.isTrustAllPackages()).isEqualTo(true);
+	}
+
+	@Test
+	public void testPackagesToTrust() {
+		this.properties.getPackages().setTrustAll(false);
+		this.properties.getPackages().getTrusted().add("trusted.package");
+		ActiveMQConnectionFactory factory =
+			new ActiveMQConnectionFactoryFactory(this.properties)
+				.createConnectionFactory(ActiveMQConnectionFactory.class);
+		assertThat(factory.isTrustAllPackages()).isEqualTo(false);
+		assertThat(factory.getTrustedPackages().size()).isEqualTo(1);
+		assertThat(factory.getTrustedPackages().get(0)).isEqualTo("trusted.package");
 	}
 
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

As per issue #5631 and the ActiveMQ [documentation](http://activemq.apache.org/objectmessage.html), I've added `spring.activemq.packages.trustAll` and `spring.activemq.packages.trusted` to `ActiveMQProperties` and accordingly used it during factory creation in `ActiveMQConnectionFactoryFactory`.

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

Kindly review and merge. My CLA number is 149720151120072904.

Thanks,
Venil Noronha