### PR TITLE
Add auto-configuration for Spring Web Services

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -513,6 +513,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.ws</groupId>
+			<artifactId>spring-ws-core</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.thymeleaf</groupId>
 			<artifactId>thymeleaf</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ws/WsAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ws/WsAutoConfiguration.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.ws;
+
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
+import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.ws.config.annotation.DelegatingWsConfiguration;
+import org.springframework.ws.config.annotation.WsConfigurationSupport;
+import org.springframework.ws.transport.http.MessageDispatcherServlet;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Spring Web Services.
+ *
+ * @author Vedran Pavic
+ * @since 1.4.0
+ */
+@Configuration
+@ConditionalOnWebApplication
+@ConditionalOnClass(MessageDispatcherServlet.class)
+@ConditionalOnMissingBean(WsConfigurationSupport.class)
+@EnableConfigurationProperties(WsProperties.class)
+@AutoConfigureAfter(EmbeddedServletContainerAutoConfiguration.class)
+public class WsAutoConfiguration {
+
+	private WsProperties properties;
+
+	public WsAutoConfiguration(WsProperties properties) {
+		this.properties = properties;
+	}
+
+	@Bean
+	public ServletRegistrationBean messageDispatcherServlet(
+			ApplicationContext applicationContext) {
+		MessageDispatcherServlet servlet = new MessageDispatcherServlet();
+		servlet.setApplicationContext(applicationContext);
+		String path = this.properties.getPath();
+		String urlMapping = (path.endsWith("/") ? path + "*" : path + "/*");
+		ServletRegistrationBean registration = new ServletRegistrationBean(
+				servlet, urlMapping);
+		registration.setLoadOnStartup(this.properties.getServlet().getLoadOnStartup());
+		for (Map.Entry<String, String> entry : this.properties.getInit().entrySet()) {
+			registration.addInitParameter(entry.getKey(), entry.getValue());
+		}
+		return registration;
+	}
+
+	@Configuration
+	@Import(DelegatingWsConfiguration.class)
+	protected static class WsConfiguration {
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ws/WsProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ws/WsProperties.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.ws;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * {@link ConfigurationProperties} for Spring Web Services.
+ *
+ * @author Vedran Pavic
+ * @since 1.4.0
+ */
+@ConfigurationProperties("spring.ws")
+public class WsProperties {
+
+	/**
+	 * Path that serves as the base URI for the services.
+	 */
+	@NotNull
+	@Pattern(regexp = "/[^?#]*", message = "Path must start with /")
+	private String path = "/services";
+
+	/**
+	 * Init parameters to pass to Spring Web Services via the servlet.
+	 */
+	private Map<String, String> init = new HashMap<String, String>();
+
+	private final Servlet servlet = new Servlet();
+
+	public String getPath() {
+		return this.path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+	}
+
+	public Map<String, String> getInit() {
+		return this.init;
+	}
+
+	public void setInit(Map<String, String> init) {
+		this.init = init;
+	}
+
+	public Servlet getServlet() {
+		return this.servlet;
+	}
+
+	public static class Servlet {
+
+		/**
+		 * Load on startup priority of the Spring Web Services servlet.
+		 */
+		private int loadOnStartup = -1;
+
+		public int getLoadOnStartup() {
+			return this.loadOnStartup;
+		}
+
+		public void setLoadOnStartup(int loadOnStartup) {
+			this.loadOnStartup = loadOnStartup;
+		}
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ws/package-info.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ws/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Spring Web Services.
+ */
+package org.springframework.boot.autoconfigure.ws;

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -96,7 +96,8 @@ org.springframework.boot.autoconfigure.web.MultipartAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration,\
 org.springframework.boot.autoconfigure.websocket.WebSocketAutoConfiguration,\
-org.springframework.boot.autoconfigure.websocket.WebSocketMessagingAutoConfiguration
+org.springframework.boot.autoconfigure.websocket.WebSocketMessagingAutoConfiguration,\
+org.springframework.boot.autoconfigure.ws.WsAutoConfiguration
 
 # Template availability providers
 org.springframework.boot.autoconfigure.template.TemplateAvailabilityProvider=\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ws/WsAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ws/WsAutoConfigurationTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.ws;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link WsAutoConfiguration}.
+ *
+ * @author Vedran Pavic
+ */
+public class WsAutoConfigurationTests {
+
+	private AnnotationConfigWebApplicationContext context = new AnnotationConfigWebApplicationContext();
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Before
+	public void setupContext() {
+		this.context.setServletContext(new MockServletContext());
+	}
+
+	@After
+	public void close() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void defaultConfiguration() {
+		registerAndRefresh(WsAutoConfiguration.class);
+
+		assertThat(this.context.getBeansOfType(ServletRegistrationBean.class)).hasSize(1);
+	}
+
+	@Test
+	public void customPathMustBeginWithASlash() {
+		this.thrown.expect(BeanCreationException.class);
+		this.thrown.expectMessage("Path must start with /");
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.ws.path=invalid");
+		registerAndRefresh(WsAutoConfiguration.class);
+	}
+
+	@Test
+	public void customPathWithTrailingSlash() {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.ws.path=/valid/");
+		registerAndRefresh(WsAutoConfiguration.class);
+
+		assertThat(this.context.getBean(ServletRegistrationBean.class).getUrlMappings())
+				.contains("/valid/*");
+	}
+
+	@Test
+	public void customPath() {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.ws.path=/valid");
+		registerAndRefresh(WsAutoConfiguration.class);
+
+		assertThat(this.context.getBeansOfType(ServletRegistrationBean.class)).hasSize(1);
+		assertThat(this.context.getBean(ServletRegistrationBean.class).getUrlMappings())
+				.contains("/valid/*");
+	}
+
+	@Test
+	public void customLoadOnStartup() {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.ws.servlet.load-on-startup=1");
+		registerAndRefresh(WsAutoConfiguration.class);
+
+		ServletRegistrationBean registrationBean = this.context
+				.getBean(ServletRegistrationBean.class);
+		assertThat(ReflectionTestUtils.getField(registrationBean, "loadOnStartup"))
+				.isEqualTo(1);
+	}
+
+	@Test
+	public void customInitParameters() {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.ws.init.key1=value1", "spring.ws.init.key2=value2");
+		registerAndRefresh(WsAutoConfiguration.class);
+
+		ServletRegistrationBean registrationBean = this.context
+				.getBean(ServletRegistrationBean.class);
+		assertThat(registrationBean.getInitParameters()).containsEntry("key1", "value1");
+		assertThat(registrationBean.getInitParameters()).containsEntry("key2", "value2");
+	}
+
+	private void registerAndRefresh(Class<?>... annotatedClasses) {
+		this.context.register(annotatedClasses);
+		this.context.refresh();
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-ws/src/main/java/sample/ws/WebServiceConfig.java
+++ b/spring-boot-samples/spring-boot-sample-ws/src/main/java/sample/ws/WebServiceConfig.java
@@ -16,29 +16,16 @@
 
 package sample.ws;
 
-import org.springframework.boot.context.embedded.ServletRegistrationBean;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.ws.config.annotation.EnableWs;
 import org.springframework.ws.config.annotation.WsConfigurerAdapter;
-import org.springframework.ws.transport.http.MessageDispatcherServlet;
 import org.springframework.ws.wsdl.wsdl11.DefaultWsdl11Definition;
 import org.springframework.xml.xsd.SimpleXsdSchema;
 import org.springframework.xml.xsd.XsdSchema;
 
-@EnableWs
 @Configuration
 public class WebServiceConfig extends WsConfigurerAdapter {
-
-	@Bean
-	public ServletRegistrationBean dispatcherServlet(
-			ApplicationContext applicationContext) {
-		MessageDispatcherServlet servlet = new MessageDispatcherServlet();
-		servlet.setApplicationContext(applicationContext);
-		return new ServletRegistrationBean(servlet, "/services/*");
-	}
 
 	@Bean(name = "holiday")
 	public DefaultWsdl11Definition defaultWsdl11Definition(XsdSchema countriesSchema) {


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR adds auto-configuration for Spring Web Services which registers ```MessageDispatcherServlet``` and the configuration equivalent of ```@EnableWs```. See #1045.

Servlet is by default mapped to ```/services/*``` and it allows configuration via properties for mapping, servlet ```loadOnStartup``` and servlet init params. Configuration is also customizable using ```WsConfigurer``` beans.

Using ```@EnableWs``` disables the auto-configuration.

The ```spring-boot-sample-ws``` application was also updated to demonstrate the auto-configuration capabilites.

I'll add the documentation after the review.

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA
