### PR TITLE
Add auto-configuration for Apache CXF

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -171,6 +171,16 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-frontend-jaxws</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-transports-http</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-solrj</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cxf/CxfAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cxf/CxfAutoConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cxf;
+
+import java.util.Map;
+
+import org.apache.cxf.bus.spring.SpringBus;
+import org.apache.cxf.transport.servlet.CXFServlet;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
+import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Apache CXF.
+ *
+ * @author Vedran Pavic
+ * @since 1.4.0
+ */
+@Configuration
+@ConditionalOnWebApplication
+@ConditionalOnClass(CXFServlet.class)
+@ConditionalOnMissingBean(SpringBus.class)
+@EnableConfigurationProperties(CxfProperties.class)
+@AutoConfigureAfter(EmbeddedServletContainerAutoConfiguration.class)
+public class CxfAutoConfiguration {
+
+	private final CxfProperties properties;
+
+	public CxfAutoConfiguration(CxfProperties properties) {
+		this.properties = properties;
+	}
+
+	@Bean
+	public ServletRegistrationBean messageDispatcherServlet() {
+		String path = this.properties.getPath();
+		String urlMapping = (path.endsWith("/") ? path + "*" : path + "/*");
+		ServletRegistrationBean registration = new ServletRegistrationBean(
+				new CXFServlet(), urlMapping);
+		CxfProperties.Servlet servletProperties = this.properties.getServlet();
+		registration.setLoadOnStartup(servletProperties.getLoadOnStartup());
+		for (Map.Entry<String, String> entry : servletProperties.getInit().entrySet()) {
+			registration.addInitParameter(entry.getKey(), entry.getValue());
+		}
+		return registration;
+	}
+
+	@Configuration
+	@ImportResource("classpath:META-INF/cxf/cxf.xml")
+	protected static class CxfConfiguration {
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cxf/CxfProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cxf/CxfProperties.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cxf;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * {@link ConfigurationProperties} for Apache CXF.
+ *
+ * @author Vedran Pavic
+ * @since 1.4.0
+ */
+@ConfigurationProperties("spring.cxf")
+public class CxfProperties {
+
+	/**
+	 * Path that serves as the base URI for the services.
+	 */
+	@NotNull
+	@Pattern(regexp = "/[^?#]*", message = "Path must start with /")
+	private String path = "/services";
+
+	private final Servlet servlet = new Servlet();
+
+	public String getPath() {
+		return this.path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+	}
+
+	public Servlet getServlet() {
+		return this.servlet;
+	}
+
+	public static class Servlet {
+
+		/**
+		 * Servlet init parameters to pass to Apache CXF.
+		 */
+		private Map<String, String> init = new HashMap<String, String>();
+
+		/**
+		 * Load on startup priority of the Apache CXF servlet.
+		 */
+		private int loadOnStartup = -1;
+
+		public Map<String, String> getInit() {
+			return this.init;
+		}
+
+		public void setInit(Map<String, String> init) {
+			this.init = init;
+		}
+
+		public int getLoadOnStartup() {
+			return this.loadOnStartup;
+		}
+
+		public void setLoadOnStartup(int loadOnStartup) {
+			this.loadOnStartup = loadOnStartup;
+		}
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cxf/package-info.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cxf/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Apache CXF.
+ */
+package org.springframework.boot.autoconfigure.cxf;

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -20,6 +20,7 @@ org.springframework.boot.autoconfigure.cassandra.CassandraAutoConfiguration,\
 org.springframework.boot.autoconfigure.cloud.CloudAutoConfiguration,\
 org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration,\
 org.springframework.boot.autoconfigure.couchbase.CouchbaseAutoConfiguration,\
+org.springframework.boot.autoconfigure.cxf.CxfAutoConfiguration,\
 org.springframework.boot.autoconfigure.dao.PersistenceExceptionTranslationAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.cassandra.CassandraDataAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.cassandra.CassandraRepositoriesAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cxf/CxfAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cxf/CxfAutoConfigurationTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cxf;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CxfAutoConfiguration}.
+ *
+ * @author Vedran Pavic
+ */
+public class CxfAutoConfigurationTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private AnnotationConfigWebApplicationContext context;
+
+	@After
+	public void close() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void defaultConfiguration() {
+		load(CxfAutoConfiguration.class);
+		assertThat(this.context.getBeansOfType(ServletRegistrationBean.class)).hasSize(1);
+	}
+
+	@Test
+	public void customPathMustBeginWithASlash() {
+		this.thrown.expect(BeanCreationException.class);
+		this.thrown.expectMessage("Path must start with /");
+		load(CxfAutoConfiguration.class, "spring.cxf.path=invalid");
+	}
+
+	@Test
+	public void customPathWithTrailingSlash() {
+		load(CxfAutoConfiguration.class, "spring.cxf.path=/valid/");
+		assertThat(this.context.getBean(ServletRegistrationBean.class).getUrlMappings())
+				.contains("/valid/*");
+	}
+
+	@Test
+	public void customPath() {
+		load(CxfAutoConfiguration.class, "spring.cxf.path=/valid");
+		assertThat(this.context.getBeansOfType(ServletRegistrationBean.class)).hasSize(1);
+		assertThat(this.context.getBean(ServletRegistrationBean.class).getUrlMappings())
+				.contains("/valid/*");
+	}
+
+	@Test
+	public void customLoadOnStartup() {
+		load(CxfAutoConfiguration.class, "spring.cxf.servlet.load-on-startup=1");
+		ServletRegistrationBean registrationBean = this.context
+				.getBean(ServletRegistrationBean.class);
+		assertThat(ReflectionTestUtils.getField(registrationBean, "loadOnStartup"))
+				.isEqualTo(1);
+	}
+
+	@Test
+	public void customInitParameters() {
+		load(CxfAutoConfiguration.class, "spring.cxf.servlet.init.key1=value1",
+				"spring.cxf.servlet.init.key2=value2");
+		ServletRegistrationBean registrationBean = this.context
+				.getBean(ServletRegistrationBean.class);
+		assertThat(registrationBean.getInitParameters()).containsEntry("key1", "value1");
+		assertThat(registrationBean.getInitParameters()).containsEntry("key2", "value2");
+	}
+
+	private void load(Class<?> config, String... environment) {
+		AnnotationConfigWebApplicationContext ctx = new AnnotationConfigWebApplicationContext();
+		ctx.setServletContext(new MockServletContext());
+		EnvironmentTestUtils.addEnvironment(ctx, environment);
+		ctx.register(config);
+		ctx.refresh();
+		this.context = ctx;
+	}
+
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -65,6 +65,7 @@
 		<couchbase-client.version>2.2.5</couchbase-client.version>
 		<couchbase-cache-client.version>2.0.0</couchbase-cache-client.version>
 		<crashub.version>1.3.2</crashub.version>
+		<cxf.version>3.1.6</cxf.version>
 		<derby.version>10.12.1.1</derby.version>
 		<dom4j.version>1.6.1</dom4j.version>
 		<dropwizard-metrics.version>3.1.2</dropwizard-metrics.version>
@@ -295,6 +296,11 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-cloud-connectors</artifactId>
+				<version>1.4.0.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-cxf</artifactId>
 				<version>1.4.0.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
@@ -1182,6 +1188,16 @@
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-pool2</artifactId>
 				<version>${commons-pool2.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.cxf</groupId>
+				<artifactId>cxf-rt-frontend-jaxws</artifactId>
+				<version>${cxf.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.cxf</groupId>
+				<artifactId>cxf-rt-transports-http</artifactId>
+				<version>${cxf.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.derby</groupId>
@@ -2289,6 +2305,11 @@
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-maven-plugin</artifactId>
 					<version>1.4.0.BUILD-SNAPSHOT</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.cxf</groupId>
+					<artifactId>cxf-codegen-plugin</artifactId>
+					<version>${cxf.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -229,6 +229,11 @@ content into your application; rather pick only the properties that you need.
 	server.undertow.io-threads= # Number of I/O threads to create for the worker.
 	server.undertow.worker-threads= # Number of worker threads.
 
+	# CXF ({sc-spring-boot-autoconfigure}/cxf/CxfProperties.{sc-ext}[CxfProperties])
+	spring.cxf.path=/services # Path that serves as the base URI for the services.
+	spring.cxf.servlet.init= # Servlet init parameters to pass to Apache CXF.
+	spring.cxf.servlet.load-on-startup=-1 # Load on startup priority of the Apache CXF servlet.
+
 	# FREEMARKER ({sc-spring-boot-autoconfigure}/freemarker/FreeMarkerAutoConfiguration.{sc-ext}[FreeMarkerAutoConfiguration])
 	spring.freemarker.allow-request-override=false # Set whether HttpServletRequest attributes are allowed to override (hide) controller generated model attributes of the same name.
 	spring.freemarker.allow-session-override=false # Set whether HttpSession attributes are allowed to override (hide) controller generated model attributes of the same name.

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -5012,6 +5012,18 @@ The {spring-ws-reference}[Spring Web Services features] can be easily accessed v
 
 
 
+[[boot-features-cxf]]
+== CXF
+https://cxf.apache.org/[Apache CXF] is an open source services framework. CXF helps you
+build and develop services using frontend programming APIs, like JAX-WS and JAX-RS. Spring
+Boot offers basic auto-configuration for the JAX-WS services so that all is required is
+defining your `Endpoints`.
+
+The Apache CXF JAX-WS features can be easily accessed via the `spring-boot-starter-cxf`
+module.
+
+
+
 [[boot-features-developing-auto-configuration]]
 == Creating your own auto-configuration
 If you work in a company that develops shared libraries, or if you work on an open-source

--- a/spring-boot-samples/pom.xml
+++ b/spring-boot-samples/pom.xml
@@ -32,6 +32,7 @@
 		<module>spring-boot-sample-atmosphere</module>
 		<module>spring-boot-sample-batch</module>
 		<module>spring-boot-sample-cache</module>
+		<module>spring-boot-sample-cxf</module>
 		<module>spring-boot-sample-data-cassandra</module>
 		<module>spring-boot-sample-data-couchbase</module>
 		<module>spring-boot-sample-data-elasticsearch</module>

--- a/spring-boot-samples/spring-boot-sample-cxf/README.adoc
+++ b/spring-boot-samples/spring-boot-sample-cxf/README.adoc
@@ -1,0 +1,11 @@
+== Spring Boot - Samples - Apache CXF
+
+This sample project demonstrates Apache CXF auto-configuration with Spring Boot.
+
+The sample uses Maven. It can be built and run from the command line:
+
+----
+$ mvn spring-boot:run
+----
+
+http://localhost:8080/services will now display the list of available services and their WSDL's.

--- a/spring-boot-samples/spring-boot-sample-cxf/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-cxf/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<!-- Your own application should inherit from spring-boot-starter-parent -->
+		<artifactId>spring-boot-samples</artifactId>
+		<groupId>org.springframework.boot</groupId>
+		<version>1.4.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-sample-cxf</artifactId>
+	<name>Spring Boot Apache CXF Sample</name>
+	<description>Spring Boot Apache CXF Sample</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cxf</artifactId>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.cxf</groupId>
+				<artifactId>cxf-codegen-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>generate-sources</id>
+						<phase>generate-sources</phase>
+						<configuration>
+							<wsdlOptions>
+								<wsdlOption>
+									<wsdl>${basedir}/src/main/resources/wsdl/GreeterService.wsdl</wsdl>
+								</wsdlOption>
+							</wsdlOptions>
+						</configuration>
+						<goals>
+							<goal>wsdl2java</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-samples/spring-boot-sample-cxf/src/main/java/sample/cxf/GreeterPortTypeImpl.java
+++ b/spring-boot-samples/spring-boot-sample-cxf/src/main/java/sample/cxf/GreeterPortTypeImpl.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.cxf;
+
+import javax.jws.WebService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@WebService(targetNamespace = "http://sample/cxf",
+		serviceName = "GreeterService", portName = "GreeterPort",
+		wsdlLocation = "wsdl/GreeterService.wsdl",
+		endpointInterface = "sample.cxf.GreeterPortType")
+public class GreeterPortTypeImpl implements GreeterPortType {
+
+	private static final Logger logger = LoggerFactory.getLogger(
+			GreeterPortTypeImpl.class);
+
+	@Override
+	public String greet(String name) {
+		logger.info("Greeting {}...", name);
+		return "Hello " + name + "!";
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cxf/src/main/java/sample/cxf/SampleCxfApplication.java
+++ b/spring-boot-samples/spring-boot-sample-cxf/src/main/java/sample/cxf/SampleCxfApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.cxf;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SampleCxfApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SampleCxfApplication.class, args);
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cxf/src/main/java/sample/cxf/ServiceConfig.java
+++ b/spring-boot-samples/spring-boot-sample-cxf/src/main/java/sample/cxf/ServiceConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.cxf;
+
+import javax.xml.ws.Endpoint;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.jaxws.EndpointImpl;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ServiceConfig {
+
+	private Bus bus;
+
+	public ServiceConfig(Bus bus) {
+		this.bus = bus;
+	}
+
+	@Bean
+	public Endpoint greeterServiceEndpoint() {
+		EndpointImpl endpoint = new EndpointImpl(this.bus, new GreeterPortTypeImpl());
+		endpoint.publish("/GreeterService");
+		return endpoint;
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-cxf/src/main/resources/wsdl/GreeterService.wsdl
+++ b/spring-boot-samples/spring-boot-sample-cxf/src/main/resources/wsdl/GreeterService.wsdl
@@ -1,0 +1,41 @@
+<definitions name="GreeterService"
+		targetNamespace="http://sample/cxf"
+		xmlns="http://schemas.xmlsoap.org/wsdl/"
+		xmlns:tns="http://sample/cxf"
+		xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<message name="GreetRequest">
+		<part name="name" type="xsd:string"/>
+	</message>
+
+	<message name="GreetResponse">
+		<part name="greeting" type="xsd:string"/>
+	</message>
+
+	<portType name="GreeterPortType">
+		<operation name="greet">
+			<input message="tns:GreetRequest"/>
+			<output message="tns:GreetResponse"/>
+		</operation>
+	</portType>
+
+	<binding name="GreeterBinding" type="tns:GreeterPortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<operation name="greet">
+			<soap:operation soapAction="greet"/>
+			<input>
+				<soap:body use="literal"/>
+			</input>
+			<output>
+				<soap:body use="literal"/>
+			</output>
+		</operation>
+	</binding>
+
+	<service name="GreeterService">
+		<port name="GreeterPort" binding="tns:GreeterBinding">
+			<soap:address location="http://localhost:8080/services/GreeterService"/>
+		</port>
+	</service>
+</definitions>

--- a/spring-boot-starters/pom.xml
+++ b/spring-boot-starters/pom.xml
@@ -27,6 +27,7 @@
 		<module>spring-boot-starter-batch</module>
 		<module>spring-boot-starter-cache</module>
 		<module>spring-boot-starter-cloud-connectors</module>
+		<module>spring-boot-starter-cxf</module>
 		<module>spring-boot-starter-data-cassandra</module>
 		<module>spring-boot-starter-data-couchbase</module>
 		<module>spring-boot-starter-data-elasticsearch</module>

--- a/spring-boot-starters/spring-boot-starter-cxf/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-cxf/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starters</artifactId>
+		<version>1.4.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-starter-cxf</artifactId>
+	<name>Spring Boot Apache CXF Starter</name>
+	<description>Starter for using Apache CXF</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-frontend-jaxws</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-transports-http</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-boot-starters/spring-boot-starter-cxf/src/main/resources/META-INF/spring.provides
+++ b/spring-boot-starters/spring-boot-starter-cxf/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: cxf-rt-frontend-jaxws,cxf-rt-transports-http


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 
This PR adds auto-configuration for Apache CXF which registers ```CXFServlet``` and CXF's default configuration.

Servlet is by default mapped to ```/services/*``` and it allows configuration via properties for mapping, servlet ```loadOnStartup``` and servlet init params.

Manually importing CXF's default configuration (```cxf-core-3.1.6.jar!/META-INF/cxf/cxf.xml```), or simply providing ```SpringBus``` bean, disables the auto-configuration.

I've also added ```spring-boot-starter-cxf``` as well as ```spring-boot-sample-cxf``` application was also updated to demonstrate the auto-configuration capabilities.

Note that this is focused around JAX-WS support and was made as consistent as possible with Spring WS auto-configuration support proposed in #5645.

~~I'll add the documentation after the review.~~
<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA