### PR TITLE
added realpath to jarfolder definition

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -37,7 +37,9 @@ while [[ -L "$jarfile" ]]; do
   cd "$(dirname "$jarfile")" || exit 1
   jarfile=$(pwd)/$(basename "$jarfile")
 done
+# Normalized, absolute path to jar-file
 jarfolder="$(realpath $(dirname "$jarfile"))"
+
 cd "$WORKING_DIR" || exit 1
 
 # Source any config file

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -37,7 +37,7 @@ while [[ -L "$jarfile" ]]; do
   cd "$(dirname "$jarfile")" || exit 1
   jarfile=$(pwd)/$(basename "$jarfile")
 done
-jarfolder="$(dirname "$jarfile")"
+jarfolder="$(realpath $(dirname "$jarfile"))"
 cd "$WORKING_DIR" || exit 1
 
 # Source any config file


### PR DESCRIPTION
added realpath to jarfolder definition in order to not create different identities for the same file when started from different paths. see #5679