### PR TITLE
Update the maven sniffer signature

### DIFF
--- a/spring-boot-parent/pom.xml
+++ b/spring-boot-parent/pom.xml
@@ -585,7 +585,7 @@
 					<signature>
 						<groupId>org.codehaus.mojo.signature</groupId>
 						<artifactId>java16</artifactId>
-						<version>1.0</version>
+						<version>1.1</version>
 					</signature>
 					<annotations>
 						<annotation>org.springframework.lang.UsesJava8</annotation>


### PR DESCRIPTION
I noticed that we're not using the newest version of the signature.

- [X] I have signed the CLA

