### PR TITLE
Provide dependency management for jackson-dataformat-cbor and jackson-dataformat-smile

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -604,7 +604,17 @@
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.dataformat</groupId>
+				<artifactId>jackson-dataformat-cbor</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.dataformat</groupId>
 				<artifactId>jackson-dataformat-csv</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.dataformat</groupId>
+				<artifactId>jackson-dataformat-smile</artifactId>
 				<version>${jackson.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 
It would be nice to provide dependency management for `jackson-dataformat-cbor` and `jackson-dataformat-smile`.

For example, the latest version of Elasticsearch Java client is using `jackson-dataformat-cbor` and `jackson-dataformat-smile`, so you're adding it, you will get mixed versions of Jackson libraries.
<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA