### PR TITLE
added readlink -f to jarfolder definition

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -38,7 +38,7 @@ while [[ -L "$jarfile" ]]; do
   jarfile=$(pwd)/$(basename "$jarfile")
 done
 jarfolder="$(dirname "$jarfile")"
-# normalize jarfolder path name
+## normalize jarfolder path name
 jarfolder="$(readlink -f "$jarfolder")"
 
 cd "$WORKING_DIR" || exit 1

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -38,6 +38,9 @@ while [[ -L "$jarfile" ]]; do
   jarfile=$(pwd)/$(basename "$jarfile")
 done
 jarfolder="$(dirname "$jarfile")"
+# normalize jarfolder path name
+jarfolder="$(readlink -f "$jarfolder")"
+
 cd "$WORKING_DIR" || exit 1
 
 # Source any config file


### PR DESCRIPTION
in order to not create different identities for the same file when started from different paths. see #5679

I have signed the CLA