### PR TITLE
Remove spring-jms and spring-ws-support from Spring WS starter

### DIFF
--- a/spring-boot-starters/spring-boot-starter-ws/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-ws/pom.xml
@@ -28,19 +28,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
-			<artifactId>spring-jms</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
 			<artifactId>spring-oxm</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.ws</groupId>
 			<artifactId>spring-ws-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.ws</groupId>
-			<artifactId>spring-ws-support</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-starters/spring-boot-starter-ws/src/main/resources/META-INF/spring.provides
+++ b/spring-boot-starters/spring-boot-starter-ws/src/main/resources/META-INF/spring.provides
@@ -1,1 +1,1 @@
-provides: spring-ws-core,spring-ws-support
+provides: spring-ws-core


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This resolves #5698.

Using JMS as SOAP transport (or any other alternative transport) is not that common of a use case to warrant inclusion in the starter. In addition to this, the new Spring WS auto-configuration support is focused on the usual HTTP transport and does not make use of these dependencies.

Using an alternative transport requires manual configuration anyway so it makes sense to also manually add these dependencies in such use cases.

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA