### PR TITLE
Replacing StringBuffer with lock-free StringBuilder

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnBeanCondition.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnBeanCondition.java
@@ -74,7 +74,7 @@ class OnBeanCondition extends SpringBootCondition implements ConfigurationCondit
 	@Override
 	public ConditionOutcome getMatchOutcome(ConditionContext context,
 			AnnotatedTypeMetadata metadata) {
-		StringBuffer matchMessage = new StringBuffer();
+		StringBuilder matchMessage = new StringBuilder();
 		if (metadata.isAnnotated(ConditionalOnBean.class.getName())) {
 			BeanSearchSpec spec = new BeanSearchSpec(context, metadata,
 					ConditionalOnBean.class);
@@ -83,8 +83,8 @@ class OnBeanCondition extends SpringBootCondition implements ConfigurationCondit
 				return ConditionOutcome
 						.noMatch("@ConditionalOnBean " + spec + " found no beans");
 			}
-			matchMessage.append(
-					"@ConditionalOnBean " + spec + " found the following " + matching);
+			matchMessage.append("@ConditionalOnBean ").append(spec)
+					.append(" found the following ").append(matching);
 		}
 		if (metadata.isAnnotated(ConditionalOnSingleCandidate.class.getName())) {
 			BeanSearchSpec spec = new SingleCandidateBeanSearchSpec(context, metadata,
@@ -99,8 +99,8 @@ class OnBeanCondition extends SpringBootCondition implements ConfigurationCondit
 						+ " found no primary candidate amongst the" + " following "
 						+ matching);
 			}
-			matchMessage.append("@ConditionalOnSingleCandidate " + spec + " found "
-					+ "a primary candidate amongst the following " + matching);
+			matchMessage.append("@ConditionalOnSingleCandidate ").append(spec)
+					.append(" found a primary candidate amongst the following ").append(matching);
 		}
 		if (metadata.isAnnotated(ConditionalOnMissingBean.class.getName())) {
 			BeanSearchSpec spec = new BeanSearchSpec(context, metadata,
@@ -111,7 +111,8 @@ class OnBeanCondition extends SpringBootCondition implements ConfigurationCondit
 						+ " found the following " + matching);
 			}
 			matchMessage.append(matchMessage.length() == 0 ? "" : " ");
-			matchMessage.append("@ConditionalOnMissingBean " + spec + " found no beans");
+			matchMessage.append("@ConditionalOnMissingBean ").append(spec)
+					.append(" found no beans");
 		}
 		return ConditionOutcome.match(matchMessage.toString());
 	}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnClassCondition.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnClassCondition.java
@@ -44,7 +44,7 @@ class OnClassCondition extends SpringBootCondition {
 	public ConditionOutcome getMatchOutcome(ConditionContext context,
 			AnnotatedTypeMetadata metadata) {
 
-		StringBuffer matchMessage = new StringBuffer();
+		StringBuilder matchMessage = new StringBuilder();
 
 		MultiValueMap<String, Object> onClasses = getAttributes(metadata,
 				ConditionalOnClass.class);
@@ -56,8 +56,8 @@ class OnClassCondition extends SpringBootCondition {
 						.noMatch("required @ConditionalOnClass classes not found: "
 								+ StringUtils.collectionToCommaDelimitedString(missing));
 			}
-			matchMessage.append("@ConditionalOnClass classes found: "
-					+ StringUtils.collectionToCommaDelimitedString(
+			matchMessage.append("@ConditionalOnClass classes found: ")
+					.append(StringUtils.collectionToCommaDelimitedString(
 							getMatchingClasses(onClasses, MatchType.PRESENT, context)));
 		}
 
@@ -72,9 +72,9 @@ class OnClassCondition extends SpringBootCondition {
 								+ StringUtils.collectionToCommaDelimitedString(present));
 			}
 			matchMessage.append(matchMessage.length() == 0 ? "" : " ");
-			matchMessage.append("@ConditionalOnMissing classes not found: "
-					+ StringUtils.collectionToCommaDelimitedString(getMatchingClasses(
-							onMissingClasses, MatchType.MISSING, context)));
+			matchMessage.append("@ConditionalOnMissing classes not found: ")
+					.append(StringUtils.collectionToCommaDelimitedString(getMatchingClasses(
+					onMissingClasses, MatchType.MISSING, context)));
 		}
 
 		return ConditionOutcome.match(matchMessage.toString());

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnPropertyCondition.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnPropertyCondition.java
@@ -83,8 +83,8 @@ class OnPropertyCondition extends SpringBootCondition {
 
 		StringBuilder message = new StringBuilder("@ConditionalOnProperty ");
 		if (!missingProperties.isEmpty()) {
-			message.append("missing required properties "
-					+ expandNames(prefix, missingProperties) + " ");
+			message.append("missing required properties ").append(expandNames(prefix, missingProperties))
+					.append(" ");
 		}
 		if (!nonMatchingProperties.isEmpty()) {
 			String expected = StringUtils.hasLength(havingValue) ? havingValue : "!false";
@@ -113,7 +113,7 @@ class OnPropertyCondition extends SpringBootCondition {
 	}
 
 	private String expandNames(String prefix, List<String> names) {
-		StringBuffer expanded = new StringBuffer();
+		StringBuilder expanded = new StringBuilder();
 		for (String name : names) {
 			expanded.append(expanded.length() == 0 ? "" : ", ");
 			expanded.append(prefix);

--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/shell/CommandCompleter.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/shell/CommandCompleter.java
@@ -127,7 +127,7 @@ public class CommandCompleter extends StringsCompleter {
 		private final String usage;
 
 		OptionHelpLine(OptionHelp optionHelp) {
-			StringBuffer options = new StringBuffer();
+			StringBuilder options = new StringBuilder();
 			for (String option : optionHelp.getOptions()) {
 				options.append(options.length() == 0 ? "" : ", ");
 				options.append(option);

--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/livereload/ConnectionInputStream.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/livereload/ConnectionInputStream.java
@@ -44,7 +44,7 @@ class ConnectionInputStream extends FilterInputStream {
 	 */
 	public String readHeader() throws IOException {
 		byte[] buffer = new byte[BUFFER_SIZE];
-		StringBuffer content = new StringBuffer(BUFFER_SIZE);
+		StringBuilder content = new StringBuilder(BUFFER_SIZE);
 		while (content.indexOf(HEADER_END) == -1) {
 			int amountRead = checkedRead(buffer, 0, BUFFER_SIZE);
 			content.append(new String(buffer, 0, amountRead));

--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractRunMojo.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractRunMojo.java
@@ -401,7 +401,7 @@ public abstract class AbstractRunMojo extends AbstractDependencyFilterMojo {
 	}
 
 	private void logArguments(String message, String[] args) {
-		StringBuffer sb = new StringBuffer(message);
+		StringBuilder sb = new StringBuilder(message);
 		for (String arg : args) {
 			sb.append(arg).append(" ");
 		}


### PR DESCRIPTION
I was surprised to notice that classes like OnClassCondition, OnBeanCondition or OnPropertyCondition are using StringBuffer for string concatenation, so I have alter that to StringBuilder instead plus I've also modified any other relevant places in code.

The motivation is that StringBuffer is using synchronization for every of it's public method, while StringBuilder does not, so it does not make any sense to use that class in places that can be considered thread safe like method local variables for instance.

Besides that I fixed the code that does String concatenation when passing argument to the append method, to remove unnecessary object creation.

There isn't really any issue/ticket created for this PR, since this does not provided any functionality only internal implementation changes, though the StringBuilder should give a slight positive impact on the performance.

- [X] I have signed the CLA
