### PR TITLE
Removed redundant override of the configure method

### DIFF
--- a/spring-boot-samples/spring-boot-sample-jersey/src/main/java/sample/jersey/SampleJerseyApplication.java
+++ b/spring-boot-samples/spring-boot-sample-jersey/src/main/java/sample/jersey/SampleJerseyApplication.java
@@ -23,11 +23,6 @@ import org.springframework.boot.context.web.SpringBootServletInitializer;
 @SpringBootApplication
 public class SampleJerseyApplication extends SpringBootServletInitializer {
 
-	@Override
-	protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
-		return application.sources(SampleJerseyApplication.class);
-	}
-
 	public static void main(String[] args) {
 		new SampleJerseyApplication()
 				.configure(new SpringApplicationBuilder(SampleJerseyApplication.class))


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

Since the `SampleJerseyApplication` class is already passed in the `SpringApplicationBuilder` constructor there is no need to override the configure method of the `SpringBootServletInitializer` class.