### PR TITLE
Typo in javadoc for Tomcat nested configuration

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/EmbeddedServletContainerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/EmbeddedServletContainerAutoConfiguration.java
@@ -65,7 +65,7 @@ import org.springframework.util.ObjectUtils;
 public class EmbeddedServletContainerAutoConfiguration {
 
 	/**
-	 * Nested configuration for if Tomcat is being used.
+	 * Nested configuration if Tomcat is being used.
 	 */
 	@Configuration
 	@ConditionalOnClass({ Servlet.class, Tomcat.class })


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

Removed misplaced "for" in javadoc for Tomcat nested configuration.