### PR TITLE
#5752 - Updates docs to include ServletConfig and ServletContext params in property resolution

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -333,6 +333,8 @@ sensible overriding of values, properties are considered in the following order:
 
 . Command line arguments.
 . Properties from `SPRING_APPLICATION_JSON` (inline JSON embedded in an environment variable or system property)
+. `ServletConfig` init parameters.
+. `ServletContext` init parameters.
 . JNDI attributes from `java:comp/env`.
 . Java System properties (`System.getProperties()`).
 . OS environment variables.


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

#5752 - Updates docs to include ServletConfig and ServletContext params in the hierarchy of property resolution for externalized configuration