### PR TITLE
Scan spring.resources.staticLocations for favicon

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ResourceProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ResourceProperties.java
@@ -33,6 +33,7 @@ import org.springframework.core.io.ResourceLoader;
  * @author Phillip Webb
  * @author Brian Clozel
  * @author Dave Syer
+ * @author Venil Noronha
  * @since 1.1.0
  */
 @ConfigurationProperties(prefix = "spring.resources", ignoreUnknownFields = false)
@@ -117,10 +118,9 @@ public class ResourceProperties implements ResourceLoaderAware {
 	}
 
 	List<Resource> getFaviconLocations() {
-		List<Resource> locations = new ArrayList<Resource>(
-				CLASSPATH_RESOURCE_LOCATIONS.length + 1);
+		List<Resource> locations = new ArrayList<Resource>(staticLocations.length + 1);
 		if (this.resourceLoader != null) {
-			for (String location : CLASSPATH_RESOURCE_LOCATIONS) {
+			for (String location : staticLocations) {
 				locations.add(this.resourceLoader.getResource(location));
 			}
 		}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfigurationTests.java
@@ -91,6 +91,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Stephane Nicoll
  * @author Brian Clozel
  * @author Eddú Meléndez
+ * @author Venil Noronha
  */
 public class WebMvcAutoConfigurationTests {
 
@@ -398,7 +399,7 @@ public class WebMvcAutoConfigurationTests {
 		assertThat(this.context.getBeansOfType(SimpleUrlHandlerMapping.class)
 				.get("faviconHandlerMapping")).isNotNull();
 		Map<String, List<Resource>> mappingLocations = getFaviconMappingLocations();
-		assertThat(mappingLocations.get("/**/favicon.ico")).hasSize(5);
+		assertThat(mappingLocations.get("/**/favicon.ico")).hasSize(6);
 	}
 
 	@Test


### PR DESCRIPTION
`ResourceProperties.getFaviconLocations()` now considers `staticLocations` instead of `CLASSPATH_RESOURCE_LOCATIONS` to locate the favicon. See #5751 for more info.

<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

Thanks,
Venil Noronha