### PR TITLE
Redis connection pool disabling

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
@@ -44,6 +44,7 @@ import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -55,6 +56,7 @@ import org.springframework.util.StringUtils;
  * @author Christoph Strobl
  * @author Phillip Webb
  * @author Eddú Meléndez
+ * @author Venil Noronha
  */
 @Configuration
 @ConditionalOnClass({ JedisConnection.class, RedisOperations.class, Jedis.class })
@@ -92,7 +94,15 @@ public class RedisAutoConfiguration {
 			if (this.properties.getTimeout() > 0) {
 				factory.setTimeout(this.properties.getTimeout());
 			}
+			factory.setUsePool(getUsePool());
 			return factory;
+		}
+
+		private boolean getUsePool() {
+			return ClassUtils.isPresent("org.apache.commons.pool2.impl.GenericObjectPool",
+					getClass().getClassLoader())
+					&& (this.properties.getPool() == null || !Boolean.FALSE
+							.equals(this.properties.getPool().getEnabled()));
 		}
 
 		protected final RedisSentinelConfiguration getSentinelConfig() {
@@ -173,6 +183,7 @@ public class RedisAutoConfiguration {
 			}
 			return new JedisConnectionFactory();
 		}
+
 	}
 
 	/**

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
@@ -20,7 +20,6 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.pool2.impl.GenericObjectPool;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPoolConfig;
 
@@ -28,7 +27,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties.Cluster;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties.Sentinel;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -44,7 +42,6 @@ import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -70,9 +67,10 @@ public class RedisAutoConfiguration {
 	}
 
 	/**
-	 * Base class for Redis configurations.
+	 * Redis connection configuration.
 	 */
-	protected static abstract class AbstractRedisConfiguration {
+	@Configuration
+	protected static class RedisConnectionConfiguration {
 
 		@Autowired
 		protected RedisProperties properties;
@@ -82,6 +80,13 @@ public class RedisAutoConfiguration {
 
 		@Autowired(required = false)
 		private RedisClusterConfiguration clusterConfiguration;
+
+		@Bean
+		@ConditionalOnMissingBean(RedisConnectionFactory.class)
+		public JedisConnectionFactory redisConnectionFactory()
+				throws UnknownHostException {
+			return applyProperties(createJedisConnectionFactory());
+		}
 
 		protected final JedisConnectionFactory applyProperties(
 				JedisConnectionFactory factory) {
@@ -94,18 +99,36 @@ public class RedisAutoConfiguration {
 			if (this.properties.getTimeout() > 0) {
 				factory.setTimeout(this.properties.getTimeout());
 			}
-			factory.setUsePool(getUsePool());
+			boolean usePool = this.properties.getPool() == null
+					|| !Boolean.FALSE.equals(this.properties.getPool().getEnabled());
+			factory.setUsePool(usePool);
 			return factory;
 		}
 
-		private boolean getUsePool() {
-			return ClassUtils.isPresent("org.apache.commons.pool2.impl.GenericObjectPool",
-					getClass().getClassLoader())
-					&& (this.properties.getPool() == null || !Boolean.FALSE
-							.equals(this.properties.getPool().getEnabled()));
+		private JedisConnectionFactory createJedisConnectionFactory() {
+			JedisPoolConfig poolConfig = this.properties.getPool() != null
+					? jedisPoolConfig() : new JedisPoolConfig();
+
+			if (getSentinelConfig() != null) {
+				return new JedisConnectionFactory(getSentinelConfig(), poolConfig);
+			}
+			if (getClusterConfiguration() != null) {
+				return new JedisConnectionFactory(getClusterConfiguration(), poolConfig);
+			}
+			return new JedisConnectionFactory(poolConfig);
 		}
 
-		protected final RedisSentinelConfiguration getSentinelConfig() {
+		private JedisPoolConfig jedisPoolConfig() {
+			JedisPoolConfig config = new JedisPoolConfig();
+			RedisProperties.Pool props = this.properties.getPool();
+			config.setMaxTotal(props.getMaxActive());
+			config.setMaxIdle(props.getMaxIdle());
+			config.setMinIdle(props.getMinIdle());
+			config.setMaxWaitMillis(props.getMaxWait());
+			return config;
+		}
+
+		private RedisSentinelConfiguration getSentinelConfig() {
 			if (this.sentinelConfiguration != null) {
 				return this.sentinelConfiguration;
 			}
@@ -123,7 +146,7 @@ public class RedisAutoConfiguration {
 		 * Create a {@link RedisClusterConfiguration} if necessary.
 		 * @return {@literal null} if no cluster settings are set.
 		 */
-		protected final RedisClusterConfiguration getClusterConfiguration() {
+		private RedisClusterConfiguration getClusterConfiguration() {
 			if (this.clusterConfiguration != null) {
 				return this.clusterConfiguration;
 			}
@@ -155,73 +178,6 @@ public class RedisAutoConfiguration {
 				}
 			}
 			return nodes;
-		}
-
-	}
-
-	/**
-	 * Redis connection configuration.
-	 */
-	@Configuration
-	@ConditionalOnMissingClass("org.apache.commons.pool2.impl.GenericObjectPool")
-	protected static class RedisConnectionConfiguration
-			extends AbstractRedisConfiguration {
-
-		@Bean
-		@ConditionalOnMissingBean(RedisConnectionFactory.class)
-		public JedisConnectionFactory redisConnectionFactory()
-				throws UnknownHostException {
-			return applyProperties(createJedisConnectionFactory());
-		}
-
-		private JedisConnectionFactory createJedisConnectionFactory() {
-			if (getSentinelConfig() != null) {
-				return new JedisConnectionFactory(getSentinelConfig());
-			}
-			if (getClusterConfiguration() != null) {
-				return new JedisConnectionFactory(getClusterConfiguration());
-			}
-			return new JedisConnectionFactory();
-		}
-
-	}
-
-	/**
-	 * Redis pooled connection configuration.
-	 */
-	@Configuration
-	@ConditionalOnClass(GenericObjectPool.class)
-	protected static class RedisPooledConnectionConfiguration
-			extends AbstractRedisConfiguration {
-
-		@Bean
-		@ConditionalOnMissingBean(RedisConnectionFactory.class)
-		public JedisConnectionFactory redisConnectionFactory()
-				throws UnknownHostException {
-			return applyProperties(createJedisConnectionFactory());
-		}
-
-		private JedisConnectionFactory createJedisConnectionFactory() {
-			JedisPoolConfig poolConfig = this.properties.getPool() != null
-					? jedisPoolConfig() : new JedisPoolConfig();
-
-			if (getSentinelConfig() != null) {
-				return new JedisConnectionFactory(getSentinelConfig(), poolConfig);
-			}
-			if (getClusterConfiguration() != null) {
-				return new JedisConnectionFactory(getClusterConfiguration(), poolConfig);
-			}
-			return new JedisConnectionFactory(poolConfig);
-		}
-
-		private JedisPoolConfig jedisPoolConfig() {
-			JedisPoolConfig config = new JedisPoolConfig();
-			RedisProperties.Pool props = this.properties.getPool();
-			config.setMaxTotal(props.getMaxActive());
-			config.setMaxIdle(props.getMaxIdle());
-			config.setMinIdle(props.getMinIdle());
-			config.setMaxWaitMillis(props.getMaxWait());
-			return config;
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -26,6 +26,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Dave Syer
  * @author Christoph Strobl
  * @author Eddú Meléndez
+ * @author Venil Noronha
  */
 @ConfigurationProperties(prefix = "spring.redis")
 public class RedisProperties {
@@ -131,6 +132,11 @@ public class RedisProperties {
 	public static class Pool {
 
 		/**
+		 * Whether connection pooling should be enabled.
+		 */
+		private Boolean enabled;
+
+		/**
 		 * Max number of "idle" connections in the pool. Use a negative value to indicate
 		 * an unlimited number of idle connections.
 		 */
@@ -154,6 +160,14 @@ public class RedisProperties {
 		 * to block indefinitely.
 		 */
 		private int maxWait = -1;
+
+		public Boolean getEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(Boolean enabled) {
+			this.enabled = enabled;
+		}
 
 		public int getMaxIdle() {
 			return this.maxIdle;

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Christian Dupuis
  * @author Christoph Strobl
  * @author Eddú Meléndez
+ * @author Venil Noronha
  */
 public class RedisAutoConfigurationTests {
 
@@ -82,6 +83,15 @@ public class RedisAutoConfigurationTests {
 				.isEqualTo("foo");
 		assertThat(this.context.getBean(JedisConnectionFactory.class).getPoolConfig()
 				.getMaxIdle()).isEqualTo(1);
+	}
+
+	@Test
+	public void testRedisConfigurationWithoutPool() throws Exception {
+		load("spring.redis.host:foo", "spring.redis.pool.enabled:false");
+		assertThat(this.context.getBean(JedisConnectionFactory.class).getHostName())
+				.isEqualTo("foo");
+		assertThat(this.context.getBean(JedisConnectionFactory.class).getUsePool())
+				.isEqualTo(false);
 	}
 
 	@Test


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

`JedisConnectionFactory`'s `usePool` field is now being set based on the presence of `GenericObjectPool` on classpath and the newly introduced `spring.redis.pool.enabled` property. See #5718 for more info.

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

Thanks,
Venil Noronha