### PR TITLE
Add new properties to setup credentials in schema and data scripts ex…

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -41,6 +41,7 @@ import org.springframework.util.StringUtils;
  * @author Maciej Walkowiak
  * @author Stephane Nicoll
  * @author Benedikt Ritter
+ * @author Eddú Meléndez
  * @since 1.1.0
  */
 @ConfigurationProperties(prefix = "spring.datasource")
@@ -104,9 +105,29 @@ public class DataSourceProperties
 	private String schema;
 
 	/**
+	 * User of the database to execute DDL scripts.
+	 */
+	private String schemaUsername;
+
+	/**
+	 * Password of the database to execute DDL scripts.
+	 */
+	private String schemaPassword;
+
+	/**
 	 * Data (DML) script resource reference.
 	 */
 	private String data;
+
+	/**
+	 * User of the database to execute DML scripts.
+	 */
+	private String dataUsername;
+
+	/**
+	 * Password of the database to execute DML scripts.
+	 */
+	private String dataPassword;
 
 	/**
 	 * Do not stop if an error occurs while initializing the database.
@@ -338,12 +359,44 @@ public class DataSourceProperties
 		this.schema = schema;
 	}
 
+	public String getSchemaUsername() {
+		return this.schemaUsername;
+	}
+
+	public void setSchemaUsername(String schemaUsername) {
+		this.schemaUsername = schemaUsername;
+	}
+
+	public String getSchemaPassword() {
+		return this.schemaPassword;
+	}
+
+	public void setSchemaPassword(String schemaPassword) {
+		this.schemaPassword = schemaPassword;
+	}
+
 	public String getData() {
 		return this.data;
 	}
 
 	public void setData(String script) {
 		this.data = script;
+	}
+
+	public String getDataUsername() {
+		return this.dataUsername;
+	}
+
+	public void setDataUsername(String dataUsername) {
+		this.dataUsername = dataUsername;
+	}
+
+	public String getDataPassword() {
+		return this.dataPassword;
+	}
+
+	public void setDataPassword(String dataPassword) {
+		this.dataPassword = dataPassword;
 	}
 
 	public boolean isContinueOnError() {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceInitializerTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceInitializerTests.java
@@ -25,6 +25,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -197,6 +198,50 @@ public class DataSourceInitializerTests {
 			SQLException sqlException = ex.getSQLException();
 			int expectedCode = -5501; // user lacks privilege or object not found
 			assertThat(sqlException.getErrorCode()).isEqualTo(expectedCode);
+		}
+	}
+
+	@Test
+	public void testDataSourceInitializedWithSchemaCredentials() {
+		this.context.register(DataSourceAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.datasource.initialize:true",
+				"spring.datasource.sqlScriptEncoding:UTF-8",
+				"spring.datasource.schema:" + ClassUtils
+						.addResourcePathToPackagePath(getClass(), "encoding-schema.sql"),
+				"spring.datasource.data:" + ClassUtils
+						.addResourcePathToPackagePath(getClass(), "encoding-data.sql"),
+				"spring.datasource.schema-username:admin",
+				"spring.datasource.schema-password:admin");
+		try {
+			this.context.refresh();
+			fail("User does not exist");
+		}
+		catch (Exception ex) {
+			assertThat(ex).isInstanceOf(UnsatisfiedDependencyException.class);
+		}
+	}
+
+	@Test
+	public void testDataSourceInitializedWithDataCredentials() {
+		this.context.register(DataSourceAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.datasource.initialize:true",
+				"spring.datasource.sqlScriptEncoding:UTF-8",
+				"spring.datasource.schema:" + ClassUtils
+						.addResourcePathToPackagePath(getClass(), "encoding-schema.sql"),
+				"spring.datasource.data:" + ClassUtils
+						.addResourcePathToPackagePath(getClass(), "encoding-data.sql"),
+				"spring.datasource.data-username:admin",
+				"spring.datasource.data-password:admin");
+		try {
+			this.context.refresh();
+			fail("User does not exist");
+		}
+		catch (Exception ex) {
+			assertThat(ex).isInstanceOf(UnsatisfiedDependencyException.class);
 		}
 	}
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourcePropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourcePropertiesTests.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Maciej Walkowiak
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  */
 public class DataSourcePropertiesTests {
 
@@ -97,6 +98,24 @@ public class DataSourcePropertiesTests {
 		properties.afterPropertiesSet();
 		assertThat(properties.getPassword()).isEqualTo("bar");
 		assertThat(properties.determinePassword()).isEqualTo("bar");
+	}
+
+	@Test
+	public void determineCredentialsForSchemaScripts() {
+		DataSourceProperties properties = new DataSourceProperties();
+		properties.setSchemaUsername("foo");
+		properties.setSchemaPassword("bar");
+		assertThat(properties.getSchemaUsername()).isEqualTo("foo");
+		assertThat(properties.getSchemaPassword()).isEqualTo("bar");
+	}
+
+	@Test
+	public void determineCredentialsForDataScripts() {
+		DataSourceProperties properties = new DataSourceProperties();
+		properties.setDataUsername("foo");
+		properties.setDataPassword("bar");
+		assertThat(properties.getDataUsername()).isEqualTo("foo");
+		assertThat(properties.getDataPassword()).isEqualTo("bar");
 	}
 
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

…ecution

Previous to this commit, just one user can perform the scripts execution.
Now, different users can be defined to perform DML or DML scripts.

See gh-5402