### PR TITLE
Add additional Jackson2ObjectMapperBuilder customization

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/Jackson2ObjectMapperBuilderCustomizer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/Jackson2ObjectMapperBuilderCustomizer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+/**
+ * Callback interface that can be implemented by beans wishing to further customize the
+ * ${@link ObjectMapper} via ${@link Jackson2ObjectMapperBuilder} retaining its default
+ * auto-configuration.
+ *
+ * @author Grzegorz Poznachowski
+ * @since 1.4.0
+ */
+public interface Jackson2ObjectMapperBuilderCustomizer {
+
+    /**
+     * Customize the jacksonObjectMapperBuilder.
+     * @param jacksonObjectMapperBuilder the jacksonObjectMapperBuilder to customize
+     */
+    void customize(Jackson2ObjectMapperBuilder jacksonObjectMapperBuilder);
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/Jackson2ObjectMapperBuilderCustomizer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/Jackson2ObjectMapperBuilderCustomizer.java
@@ -21,7 +21,7 @@ import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 /**
  * Callback interface that can be implemented by beans wishing to further customize the
- * ${@link ObjectMapper} via ${@link Jackson2ObjectMapperBuilder} retaining its default
+ * {@link ObjectMapper} via {@link Jackson2ObjectMapperBuilder} retaining its default
  * auto-configuration.
  *
  * @author Grzegorz Poznachowski

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfigurationTests.java
@@ -72,6 +72,7 @@ import static org.mockito.Mockito.mock;
  * @author Marcel Overdijk
  * @author Sebastien Deleuze
  * @author Johannes Edmeier
+ * @author Grzegorz Poznachowski
  */
 public class JacksonAutoConfigurationTests {
 
@@ -420,6 +421,15 @@ public class JacksonAutoConfigurationTests {
 	}
 
 	@Test
+	public void additionalJacksonBuilderCustomization() throws Exception {
+		this.context.register(JacksonAutoConfiguration.class,
+				ObjectMapperBuilderCustomConfig.class);
+		this.context.refresh();
+		ObjectMapper mapper = this.context.getBean(ObjectMapper.class);
+		assertThat(mapper.getDateFormat()).isInstanceOf(MyDateFormat.class);
+	}
+
+	@Test
 	public void parameterNamesModuleIsAutoConfigured() {
 		assertParameterNamesModuleCreatorBinding(Mode.DEFAULT,
 				JacksonAutoConfiguration.class);
@@ -506,6 +516,21 @@ public class JacksonAutoConfigurationTests {
 		@Bean
 		public ParameterNamesModule parameterNamesModule() {
 			return new ParameterNamesModule(JsonCreator.Mode.DELEGATING);
+		}
+
+	}
+
+	@Configuration
+	protected static class ObjectMapperBuilderCustomConfig {
+
+		@Bean
+		public Jackson2ObjectMapperBuilderCustomizer customDateFormat() {
+			return new Jackson2ObjectMapperBuilderCustomizer() {
+				@Override
+				public void customize(Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder) {
+					jackson2ObjectMapperBuilder.dateFormat(new MyDateFormat());
+				}
+			};
 		}
 
 	}


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

Enables to customize Jackson2ObjectMapperBuilder retaining its default auto-configuration.
Fixes gh-5787