### PR TITLE
Added Artemis AMQP connector to BOM.

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -1167,6 +1167,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.activemq</groupId>
+				<artifactId>artemis-amqp-protocol</artifactId>
+				<version>${artemis.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.activemq</groupId>
 				<artifactId>artemis-jms-client</artifactId>
 				<version>${artemis.version}</version>
 			</dependency>


### PR DESCRIPTION
Hi,

Currently if you are importing Spring Boot BOM and would like to use AMQP with Artemis, you have to specify the same version of AMQP connector as defined in Spring BOM:

			<dependency>
				<groupId>org.apache.activemq</groupId>
				<artifactId>artemis-amqp-protocol</artifactId>
				<version>${the.same.version.of.artemis.as.spring.boot.uses}</version>
			</dependency>
			<dependency>
				<groupId>org.apache.activemq</groupId>
				<artifactId>artemis-jms-server</artifactId>
			</dependency>

It would be nice to have an AMQP protocol adapter jar defined in BOM, so I could skip the version for AMQP connector:

			<dependency>
				<groupId>org.apache.activemq</groupId>
				<artifactId>artemis-amqp-protocol</artifactId>
			</dependency>
			<dependency>
				<groupId>org.apache.activemq</groupId>
				<artifactId>artemis-jms-server</artifactId>
			</dependency>

Thanks!