### PR TITLE
Fix doc about running native commands inside embedded shell

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-cli.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-cli.adoc
@@ -415,7 +415,7 @@ From inside the embedded shell you can run other commands directly:
 ----
 
 The embedded shell supports ANSI color output as well as `tab` completion. If you need
-to run a native command you can use the `$` prefix. Hitting `ctrl-c` will exit the
+to run a native command you can use the `!` prefix. Hitting `ctrl-c` will exit the
 embedded shell.
 
 


### PR DESCRIPTION
Fix a trivial typo in spring-boot-cli documentation.
Running native commands in the embedded shell requires the `!` prefix, code [speaks](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/shell/Shell.java#L210).