### PR TITLE
Allow customization of AuditListener

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/listener/AbstractAuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/listener/AbstractAuditListener.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.audit.listener;
+
+import org.springframework.boot.actuate.audit.AuditEvent;
+import org.springframework.context.ApplicationListener;
+
+/**
+ * Abstract {@link ApplicationListener} to handle {@link AuditApplicationEvent}s.
+ *
+ * @author Vedran Pavic
+ * @since 1.4.0
+ */
+public abstract class AbstractAuditListener
+		implements ApplicationListener<AuditApplicationEvent> {
+
+	@Override
+	public void onApplicationEvent(AuditApplicationEvent event) {
+		handleAuditEvent(event.getAuditEvent());
+	}
+
+	protected abstract void handleAuditEvent(AuditEvent event);
+
+}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/listener/AuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/listener/AuditListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,18 @@ package org.springframework.boot.actuate.audit.listener;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
-import org.springframework.context.ApplicationListener;
 
 /**
- * {@link ApplicationListener} that listens for {@link AuditApplicationEvent}s and stores
- * them in a {@link AuditEventRepository}.
+ * The default {@link AbstractAuditListener} implementation. Listens for
+ * {@link AuditApplicationEvent}s and stores them in a {@link AuditEventRepository}.
  *
  * @author Dave Syer
  * @author Stephane Nicoll
+ * @author Vedran Pavic
  */
-public class AuditListener implements ApplicationListener<AuditApplicationEvent> {
+public class AuditListener extends AbstractAuditListener {
 
 	private static final Log logger = LogFactory.getLog(AuditListener.class);
 
@@ -40,11 +41,11 @@ public class AuditListener implements ApplicationListener<AuditApplicationEvent>
 	}
 
 	@Override
-	public void onApplicationEvent(AuditApplicationEvent event) {
+	protected void handleAuditEvent(AuditEvent event) {
 		if (logger.isDebugEnabled()) {
-			logger.debug(event.getAuditEvent());
+			logger.debug(event);
 		}
-		this.auditEventRepository.add(event.getAuditEvent());
+		this.auditEventRepository.add(event);
 	}
 
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/AuditAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/AuditAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.boot.actuate.audit.InMemoryAuditEventRepository;
+import org.springframework.boot.actuate.audit.listener.AbstractAuditListener;
 import org.springframework.boot.actuate.audit.listener.AuditListener;
 import org.springframework.boot.actuate.security.AbstractAuthenticationAuditListener;
 import org.springframework.boot.actuate.security.AbstractAuthorizationAuditListener;
@@ -48,6 +49,7 @@ public class AuditAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(AbstractAuditListener.class)
 	public AuditListener auditListener() throws Exception {
 		return new AuditListener(this.auditEventRepository);
 	}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/AuditAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/AuditAutoConfigurationTests.java
@@ -18,8 +18,10 @@ package org.springframework.boot.actuate.autoconfigure;
 
 import org.junit.Test;
 
+import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.boot.actuate.audit.InMemoryAuditEventRepository;
+import org.springframework.boot.actuate.audit.listener.AbstractAuditListener;
 import org.springframework.boot.actuate.security.AbstractAuthenticationAuditListener;
 import org.springframework.boot.actuate.security.AbstractAuthorizationAuditListener;
 import org.springframework.boot.actuate.security.AuthenticationAuditListener;
@@ -44,7 +46,7 @@ public class AuditAutoConfigurationTests {
 	private AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
 	@Test
-	public void testTraceConfiguration() throws Exception {
+	public void defaultConfiguration() throws Exception {
 		registerAndRefresh(AuditAutoConfiguration.class);
 		assertThat(this.context.getBean(AuditEventRepository.class)).isNotNull();
 		assertThat(this.context.getBean(AuthenticationAuditListener.class)).isNotNull();
@@ -52,7 +54,7 @@ public class AuditAutoConfigurationTests {
 	}
 
 	@Test
-	public void ownAutoRepository() throws Exception {
+	public void ownAuditEventRepository() throws Exception {
 		registerAndRefresh(CustomAuditEventRepositoryConfiguration.class,
 				AuditAutoConfiguration.class);
 		assertThat(this.context.getBean(AuditEventRepository.class))
@@ -73,6 +75,14 @@ public class AuditAutoConfigurationTests {
 				AuditAutoConfiguration.class);
 		assertThat(this.context.getBean(AbstractAuthorizationAuditListener.class))
 				.isInstanceOf(TestAuthorizationAuditListener.class);
+	}
+
+	@Test
+	public void ownAuditListener() throws Exception {
+		registerAndRefresh(CustomAuditListenerConfiguration.class,
+				AuditAutoConfiguration.class);
+		assertThat(this.context.getBean(AbstractAuditListener.class))
+				.isInstanceOf(TestAuditListener.class);
 	}
 
 	private void registerAndRefresh(Class<?>... annotatedClasses) {
@@ -135,6 +145,25 @@ public class AuditAutoConfigurationTests {
 
 		@Override
 		public void onApplicationEvent(AbstractAuthorizationEvent event) {
+		}
+
+	}
+
+	@Configuration
+	protected static class CustomAuditListenerConfiguration {
+
+		@Bean
+		public TestAuditListener testAuditListener() {
+			return new TestAuditListener();
+		}
+
+	}
+
+	protected static class TestAuditListener extends AbstractAuditListener {
+
+		@Override
+		protected void handleAuditEvent(AuditEvent event) {
+
 		}
 
 	}


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 
Introduce `AbstractAuditListener` so that users can extended it to replace the auto-configured default.

Currently it's not possible to customize the handling of ```AuditApplicationEvent``` since ```AuditListener``` is configured unconditionally.

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA