### PR TITLE
Use trust store of SSL store provider to set trust store in JettyEmbeddedServletContainerFactory

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactory.java
@@ -259,7 +259,7 @@ public class JettyEmbeddedServletContainerFactory
 		if (getSslStoreProvider() != null) {
 			try {
 				factory.setKeyStore(getSslStoreProvider().getKeyStore());
-				factory.setTrustStore(getSslStoreProvider().getKeyStore());
+				factory.setTrustStore(getSslStoreProvider().getTrustStore());
 			}
 			catch (Exception ex) {
 				throw new IllegalStateException("Unable to set SSL store", ex);


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 
It looks accidentally used key store instead of trust store.
<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA