### PR TITLE
Include mention of excluding tomcat-jdbc if needed

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -2484,6 +2484,7 @@ Here's the algorithm for choosing a specific implementation:
 
 If you use the `spring-boot-starter-jdbc` or `spring-boot-starter-data-jpa`
 '`starter POMs`' you will automatically get a dependency to `tomcat-jdbc`.
+If you choose to use HikariCP or Commons DBCP instead, you need to additionally exclude the dependency to `tomcat-jdbc`.
 
 NOTE: You can bypass that algorithm completely and specify the connection pool to use via
 the `spring.datasource.type` property. This is especially important if you are running


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [] I have signed the CLA

In relation to #5863 and [this comment](https://github.com/spring-projects/spring-boot/issues/5863#issuecomment-216889673), this is a draft edit to include a mention about explicitly excluding `tomcat-jdbc` dependency so that the algorithm mentioned below:

```
...

* We prefer the Tomcat pooling `DataSource` for its performance and concurrency, so if
  that is available we always choose it.
* If HikariCP is available we will use it.
* If Commons DBCP is available we will use it, but we don't recommend it in production.
* Lastly, if Commons DBCP2 is available we will use it.

...
```

will actually work as described when including `spring-boot-starter-jdbc` or `spring-boot-starter-data-jpa`.