### PR TITLE
Set a default paths for fixed static version

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ResourceProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ResourceProperties.java
@@ -292,7 +292,7 @@ public class ResourceProperties implements ResourceLoaderAware {
 		/**
 		 * Comma-separated list of patterns to apply to the Version Strategy.
 		 */
-		private String[] paths;
+		private String[] paths = new String[] { "/**" };
 
 		/**
 		 * Version string to use for the Version Strategy.


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

I've set a default paths(`/**`) for allow as following settings:

* `src/main/resources/application.yml`

```yaml
spring:
  resources:
    chain:
      strategy:
        fixed:
          enabled: true
          version: 1.0.0
#        paths: /**
```

Currently, in this case, the `NullpointerException` occurred as follow:

```console
...
Caused by: java.lang.NullPointerException: null
	at java.util.Objects.requireNonNull(Objects.java:203) ~[na:1.8.0_66]
	at java.util.Arrays$ArrayList.<init>(Arrays.java:3813) ~[na:1.8.0_66]
	at java.util.Arrays.asList(Arrays.java:3800) ~[na:1.8.0_66]
	at org.springframework.web.servlet.resource.VersionResourceResolver.addFixedVersionStrategy(VersionResourceResolver.java:123) ~[spring-webmvc-4.3.0.BUILD-20160505.171705-382.jar:4.3.0.BUILD-SNAPSHOT]
	at org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration$ResourceChainResourceHandlerRegistrationCustomizer.getVersionResourceResolver(WebMvcAutoConfiguration.java:432) ~[spring-boot-autoconfigure-1.4.0.BUILD-SNAPSHOT.jar:1.4.0.BUILD-SNAPSHOT]
...
```


<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [x] I have signed the CLA

