### PR TITLE
Ignore special variable related JVM output in CommandLineInvoker

### DIFF
--- a/spring-boot-cli/src/it/java/org/springframework/boot/cli/infrastructure/CommandLineInvoker.java
+++ b/spring-boot-cli/src/it/java/org/springframework/boot/cli/infrastructure/CommandLineInvoker.java
@@ -144,7 +144,9 @@ public final class CommandLineInvoker {
 			List<String> lines = new ArrayList<String>();
 			try {
 				while ((line = reader.readLine()) != null) {
-					lines.add(line);
+					if (!line.startsWith("Picked up ")) {
+						lines.add(line);
+					}
 				}
 			}
 			catch (IOException ex) {


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
JVM prints information about special variable, such as ```JAVA_TOOL_OPTIONS``` or ```_JAVA_OPTIONS``` to ```stderr```. For example:

> $ JAVA_TOOL_OPTIONS="-Dtest" java -version
> Picked up JAVA_TOOL_OPTIONS: -Dtest
> java version "1.8.0_91"
> Java(TM) SE Runtime Environment (build 1.8.0_91-b14)
> Java HotSpot(TM) 64-Bit Server VM (build 25.91-b14, mixed mode)

This breaks the ```CommandLineIT``` tests, since there's some unexpected ```stderr``` output.

I've added a simple check to ```CommandLineInvoker``` to ignore lines starting with "Picked up ".

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA