### PR TITLE
get correct SQLExceptionTranslator

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqExceptionTranslator.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqExceptionTranslator.java
@@ -58,7 +58,7 @@ class JooqExceptionTranslator extends DefaultExecuteListener {
 	private SQLExceptionTranslator getTranslator(ExecuteContext context) {
 		SQLDialect dialect = context.configuration().dialect();
 		if (dialect != null) {
-			return new SQLErrorCodeSQLExceptionTranslator(dialect.name());
+			return new SQLErrorCodeSQLExceptionTranslator(dialect.thirdParty().springDbName());
 		}
 		return new SQLStateSQLExceptionTranslator();
 	}


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

E.g. for POSTGRES the translator was not initialized correctly, because in JOOQ the dialect is named SQLDialect.POSTGRES, but in sql-error-codes.xml (in spring-jdbc-4.2.5.RELEASE.jar) the bean is named "PostgreSQL". Therefore in getTranslator not the name, but the springDbName has to be used to match correctly.