### PR TITLE
Remove `if` in MockitoPostProcessor.registerSpies()

### DIFF
--- a/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -242,13 +242,11 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 
 	private void registerSpies(SpyDefinition spyDefinition, Field field,
 			String[] existingBeans) {
-		if (field != null) {
-			Assert.state(field == null || existingBeans.length == 1,
-					"Unable to register spy bean "
-							+ spyDefinition.getClassToSpy().getName()
-							+ " expected a single existing bean to replace but found "
-							+ new TreeSet<String>(Arrays.asList(existingBeans)));
-		}
+		Assert.state(field == null || existingBeans.length == 1,
+				"Unable to register spy bean "
+						+ spyDefinition.getClassToSpy().getName()
+						+ " expected a single existing bean to replace but found "
+						+ new TreeSet<String>(Arrays.asList(existingBeans)));
 		for (String beanName : existingBeans) {
 			registerSpy(spyDefinition, field, beanName);
 		}


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 
This PR simply removes `if` in `MockitoPostProcessor.registerSpies()` because the `Assert.state()` already implies the `if` condition.
<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

