### PR TITLE
Expose all properties of AccessLogValve

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -21,6 +21,7 @@ import java.net.InetAddress;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -86,6 +87,7 @@ import org.springframework.util.StringUtils;
  * @author Eddú Meléndez
  * @author Quinten De Swaef
  * @author Venil Noronha
+ * @author Michael Hackner
  */
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = true)
 public class ServerProperties
@@ -876,6 +878,15 @@ public class ServerProperties
 			valve.setDirectory(this.accesslog.getDirectory());
 			valve.setPrefix(this.accesslog.getPrefix());
 			valve.setSuffix(this.accesslog.getSuffix());
+			valve.setFileDateFormat(this.accesslog.getFileDateFormat());
+			valve.setRotatable(this.accesslog.isRotatable());
+			valve.setRenameOnRotate(this.accesslog.isRenameOnRotate());
+			valve.setEncoding(this.accesslog.getEncoding());
+			valve.setLocale(this.accesslog.getLocale());
+			valve.setRequestAttributesEnabled(this.accesslog.isRequestAttributesEnabled());
+			valve.setConditionIf(this.accesslog.getConditionIf());
+			valve.setConditionUnless(this.accesslog.getConditionUnless());
+			valve.setBuffered(this.accesslog.isBuffered());
 			factory.addContextValves(valve);
 		}
 
@@ -906,6 +917,52 @@ public class ServerProperties
 			 * Log file name suffix.
 			 */
 			private String suffix = ".log";
+
+			/**
+			 * Date format to be appendend to log file name.
+			 */
+			private String fileDateFormat = ".yyyy-MM-dd";
+
+			/**
+			 * Flag to determine if log rotation should occur.
+			 */
+			private boolean rotatable = true;
+
+			/**
+			 * Defer appending timestamp until rotation.
+			 */
+			private boolean renameOnRotate = false;
+
+			/**
+			 * Character set used to write the log file. Defaults to system default.
+			 */
+			private String encoding = null;
+
+			/**
+			 * Locale used to format timestamps in access log lines. Defaults to Java
+			 * process default.
+			 */
+			private String locale = Locale.getDefault().toString();
+
+			/**
+			 * Check for overrides (e.g. X-Forwarded-For). See RemoteIpValve.
+			 */
+			private boolean requestAttributesEnabled = false;
+
+			/**
+			 * Request attribute that must be non-null to log a request.
+			 */
+			private String conditionIf = null;
+
+			/**
+			 * Request attribute that must be null to log a request.
+			 */
+			private String conditionUnless = null;
+
+			/**
+			 * Buffer logs instead of writing after each request.
+			 */
+			private boolean buffered = true;
 
 			public boolean isEnabled() {
 				return this.enabled;
@@ -945,6 +1002,78 @@ public class ServerProperties
 
 			public void setSuffix(String suffix) {
 				this.suffix = suffix;
+			}
+
+			public String getFileDateFormat() {
+				return this.fileDateFormat;
+			}
+
+			public void setFileDateFormat(String fileDateFormat) {
+				this.fileDateFormat = fileDateFormat;
+			}
+
+			public boolean isRotatable() {
+				return this.rotatable;
+			}
+
+			public void setRotatable(boolean rotatable) {
+				this.rotatable = rotatable;
+			}
+
+			public boolean isRenameOnRotate() {
+				return this.renameOnRotate;
+			}
+
+			public void setRenameOnRotate(boolean renameOnRotate) {
+				this.renameOnRotate = renameOnRotate;
+			}
+
+			public String getEncoding() {
+				return this.encoding;
+			}
+
+			public void setEncoding(String encoding) {
+				this.encoding = encoding;
+			}
+
+			public String getLocale() {
+				return this.locale;
+			}
+
+			public void setLocale(String locale) {
+				this.locale = locale;
+			}
+
+			public boolean isRequestAttributesEnabled() {
+				return this.requestAttributesEnabled;
+			}
+
+			public void setRequestAttributesEnabled(boolean requestAttributesEnabled) {
+				this.requestAttributesEnabled = requestAttributesEnabled;
+			}
+
+			public String getConditionIf() {
+				return this.conditionIf;
+			}
+
+			public void setConditionIf(String conditionIf) {
+				this.conditionIf = conditionIf;
+			}
+
+			public String getConditionUnless() {
+				return this.conditionUnless;
+			}
+
+			public void setConditionUnless(String conditionUnless) {
+				this.conditionUnless = conditionUnless;
+			}
+
+			public boolean isBuffered() {
+				return this.buffered;
+			}
+
+			public void setBuffered(boolean buffered) {
+				this.buffered = buffered;
 			}
 		}
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -134,6 +134,9 @@ public class ServerPropertiesTests {
 		map.put("server.tomcat.accesslog.pattern", "%h %t '%r' %s %b");
 		map.put("server.tomcat.accesslog.prefix", "foo");
 		map.put("server.tomcat.accesslog.suffix", "-bar.log");
+		map.put("server.tomcat.accesslog.fileDateFormat", "yyyy-MM-dd.HH");
+		map.put("server.tomcat.accesslog.rotatable", "false");
+		map.put("server.tomcat.accesslog.buffered", "false");
 		map.put("server.tomcat.protocol_header", "X-Forwarded-Protocol");
 		map.put("server.tomcat.remote_ip_header", "Remote-Ip");
 		map.put("server.tomcat.internal_proxies", "10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
@@ -142,6 +145,9 @@ public class ServerPropertiesTests {
 		assertThat(tomcat.getAccesslog().getPattern()).isEqualTo("%h %t '%r' %s %b");
 		assertThat(tomcat.getAccesslog().getPrefix()).isEqualTo("foo");
 		assertThat(tomcat.getAccesslog().getSuffix()).isEqualTo("-bar.log");
+		assertThat(tomcat.getAccesslog().getFileDateFormat()).isEqualTo("yyyy-MM-dd.HH");
+		assertThat(tomcat.getAccesslog().isRotatable()).isFalse();
+		assertThat(tomcat.getAccesslog().isBuffered()).isFalse();
 		assertThat(tomcat.getRemoteIpHeader()).isEqualTo("Remote-Ip");
 		assertThat(tomcat.getProtocolHeader()).isEqualTo("X-Forwarded-Protocol");
 		assertThat(tomcat.getInternalProxies())

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -197,6 +197,15 @@ content into your application; rather pick only the properties that you need.
 	server.tomcat.accesslog.pattern=common # Format pattern for access logs.
 	server.tomcat.accesslog.prefix=access_log # Log file name prefix.
 	server.tomcat.accesslog.suffix=.log # Log file name suffix.
+	server.tomcat.accesslog.fileDateFormat=.yyyy-MM-dd # Date format to be appendend to log file name.
+	server.tomcat.accesslog.rotatable=true # Flag to determine if log rotation should occur.
+	server.tomcat.accesslog.renameOnRotate=false # Defer appending timestamp until rotation.
+	server.tomcat.accesslog.encoding=null # Character set used to write the log file. Defaults to system default.
+	server.tomcat.accesslog.locale=en_US # Locale used to format timestamps in access log lines. Defaults to Java process default.
+	server.tomcat.accesslog.requestAttributesEnabled=false # Check for overrides (e.g. X-Forwarded-For). See RemoteIpValve.
+	server.tomcat.accesslog.conditionIf=null # Request attribute that must be non-null to log a request.
+	server.tomcat.accesslog.conditionUnless=null # Request attribute that must be null to log a request.
+	server.tomcat.accesslog.buffered=true # Buffer logs instead of writing after each request.
 	server.tomcat.background-processor-delay=30 # Delay in seconds between the invocation of backgroundProcess methods.
 	server.tomcat.basedir= # Tomcat base directory. If not specified a temporary directory will be used.
 	server.tomcat.internal-proxies=10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|\\


### PR DESCRIPTION
This commit allows all documented properties of the Tomcat AccessLogValve to be set via configuration, instead of just pattern, directory, prefix, and suffix.

- [x] I have signed the CLA