### PR TITLE
Tidy up some parts of the OAuth2 autoconfiguration

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2RestOperationsConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2RestOperationsConfiguration.java
@@ -43,10 +43,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.DefaultOAuth2ClientContext;
-import org.springframework.security.oauth2.client.OAuth2ClientContext;
-import org.springframework.security.oauth2.client.OAuth2RestTemplate;
 import org.springframework.security.oauth2.client.filter.OAuth2ClientContextFilter;
-import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
 import org.springframework.security.oauth2.client.token.AccessTokenRequest;
 import org.springframework.security.oauth2.client.token.DefaultAccessTokenRequest;
 import org.springframework.security.oauth2.client.token.grant.client.ClientCredentialsResourceDetails;
@@ -68,15 +65,6 @@ import org.springframework.util.StringUtils;
 @ConditionalOnClass(EnableOAuth2Client.class)
 @Conditional(OAuth2ClientIdCondition.class)
 public class OAuth2RestOperationsConfiguration {
-
-	@Bean
-	@Primary
-	public OAuth2RestTemplate oauth2RestTemplate(OAuth2ClientContext oauth2ClientContext,
-			OAuth2ProtectedResourceDetails details) {
-		OAuth2RestTemplate template = new OAuth2RestTemplate(details,
-				oauth2ClientContext);
-		return template;
-	}
 
 	@Configuration
 	@ConditionalOnNotWebApplication

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfiguration.java
@@ -25,7 +25,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -113,7 +112,9 @@ public class ResourceServerTokenServicesConfiguration {
 			this.oauth2ClientContext = oauth2ClientContextProvider.getIfAvailable();
 		}
 
-		@Bean(name = "userInfoRestTemplate")
+		@Bean
+		@UserInfo
+		// TODO: make this conditional on there not being another one provided by user
 		public OAuth2RestTemplate userInfoRestTemplate() {
 			OAuth2RestTemplate template = getTemplate(
 					this.details == null ? DEFAULT_RESOURCE_DETAILS : this.details);
@@ -179,7 +180,7 @@ public class ResourceServerTokenServicesConfiguration {
 
 			public SocialTokenServicesConfiguration(ResourceServerProperties sso,
 					ObjectProvider<OAuth2ConnectionFactory<?>> connectionFactoryProvider,
-					@Qualifier("userInfoRestTemplate") ObjectProvider<OAuth2RestOperations> restTemplateProvider,
+					@UserInfo ObjectProvider<OAuth2RestOperations> restTemplateProvider,
 					ObjectProvider<AuthoritiesExtractor> authoritiesExtractorProvider) {
 				this.sso = sso;
 				this.connectionFactory = connectionFactoryProvider.getIfAvailable();
@@ -223,7 +224,7 @@ public class ResourceServerTokenServicesConfiguration {
 			private final AuthoritiesExtractor authoritiesExtractor;
 
 			public UserInfoTokenServicesConfiguration(ResourceServerProperties sso,
-					@Qualifier("userInfoRestTemplate") ObjectProvider<OAuth2RestOperations> restTemplateProvider,
+					@UserInfo ObjectProvider<OAuth2RestOperations> restTemplateProvider,
 					ObjectProvider<AuthoritiesExtractor> authoritiesExtractorProvider) {
 				this.sso = sso;
 				this.restTemplate = restTemplateProvider.getIfAvailable();

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/UserInfo.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/UserInfo.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.security.oauth2.resource;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+/**
+ * Qualifier annotation for beans that relate to user info for authentication purposes.
+ *
+ * @author Dave Syer
+ */
+@Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Qualifier
+public @interface UserInfo {
+
+}

--- a/spring-boot-samples/spring-boot-sample-web-secure-github/src/main/java/sample/web/secure/github/SampleGithubSecureApplication.java
+++ b/spring-boot-samples/spring-boot-sample-web-secure-github/src/main/java/sample/web/secure/github/SampleGithubSecureApplication.java
@@ -19,6 +19,9 @@ package sample.web.secure.github;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 @SpringBootApplication
@@ -27,6 +30,12 @@ public class SampleGithubSecureApplication extends WebMvcConfigurerAdapter {
 
 	public static void main(String[] args) throws Exception {
 		SpringApplication.run(SampleGithubSecureApplication.class, args);
+	}
+
+	@Bean
+	@Primary
+	public RestTemplate myRestTemplate() {
+		return new RestTemplate();
 	}
 
 }

--- a/spring-boot-samples/spring-boot-sample-web-secure-github/src/test/java/sample/web/secure/github/SampleGithubApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-web-secure-github/src/test/java/sample/web/secure/github/SampleGithubApplicationTests.java
@@ -16,11 +16,13 @@
 
 package sample.web.secure.github;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.net.URI;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -29,8 +31,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * Basic integration tests for GitHub SSO application.
@@ -45,6 +46,14 @@ public class SampleGithubApplicationTests {
 
 	@LocalServerPort
 	private int port;
+
+	@Autowired
+	private RestTemplate restTemplate;
+	
+	@Test
+	public void restTemplateInjectable() throws Exception {
+		assertThat(restTemplate).isNotNull();
+	}
 
 	@Test
 	public void everythingIsSecuredByDefault() throws Exception {


### PR DESCRIPTION
* Removes the OAuth2RestTemplate bean (user should define their own)
* Adds @UserInfo qualifier for the template that is needed by the
UserInfoTokenServices

Still for discussion:

* How to prevent the user app blowing up when they need to autowire
a RestTemplate and spring-boot-test wants to add a one as well (the
github sample in this change shows that you can create a @Primary one
to work around that)
* Do we need to further abstract the user info rest template. Most of
the time the user won't care about it and it doesn't need to be a
@Bean. Perhaps it could be provided by a @Bean that has an explicit
factory contract?