### PR TITLE
Add AutoConfiguration for ConversionService

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/conversion/ConversionServiceAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/conversion/ConversionServiceAutoConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.conversion;
+
+import java.util.HashSet;
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ConversionServiceFactoryBean;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.converter.Converter;
+
+/**
+ * Autoconfiguration for {@link ConversionService}. Automatically locates and adds
+ * any {@link Converter} beans registered in the Spring context into a
+ * {@link org.springframework.core.convert.support.DefaultConversionService}
+ *
+ * @author Mark Douglass
+ * @author Rob Hill
+ * @see ConversionServiceFactoryBean
+ */
+@Configuration
+public class ConversionServiceAutoConfiguration {
+
+	@Bean
+	@ConditionalOnBean(Converter.class)
+	@ConditionalOnMissingBean(ConversionService.class)
+	public ConversionServiceFactoryBean conversionService(List<Converter> converterList) {
+		ConversionServiceFactoryBean conversionServiceFactoryBean = new ConversionServiceFactoryBean();
+		conversionServiceFactoryBean.setConverters(new HashSet<Converter>(converterList));
+		return conversionServiceFactoryBean;
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/conversion/package-info.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/conversion/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Spring Converter Service.
+ */
+package org.springframework.boot.autoconfigure.conversion;

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/conversion/ConversionServiceAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/conversion/ConversionServiceAutoConfigurationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.conversion;
+
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.DefaultConversionService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConversionServiceAutoConfiguration}.
+ *
+ * @author Mark Douglass
+ * @author Rob Hill
+ */
+public class ConversionServiceAutoConfigurationTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void tearDown() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void createsDefaultConversionService() {
+		this.context = new AnnotationConfigApplicationContext();
+		Class<?>[] configs = {ConversionServiceAutoConfiguration.class};
+		this.context.register(configs);
+		ExampleConverter1 converter1 = new ExampleConverter1();
+		this.context.getBeanFactory().registerSingleton("converter1", converter1);
+		ExampleConverter2 converter2 = new ExampleConverter2();
+		this.context.getBeanFactory().registerSingleton("converter2", converter2);
+		this.context.refresh();
+
+		ConversionService service = this.context.getBean(ConversionService.class);
+		assertThat(service.canConvert(Properties.class, Integer.class)).isTrue();
+		assertThat(service.canConvert(Integer.class, Properties.class)).isTrue();
+	}
+
+	@Test
+	public void ignoresConversionServiceWithoutConverters() {
+		this.context = new AnnotationConfigApplicationContext();
+		Class<?>[] configs = {ConversionServiceAutoConfiguration.class};
+		this.context.register(configs);
+		this.context.refresh();
+
+		this.thrown.expect(NoSuchBeanDefinitionException.class);
+		this.context.getBean(ConversionService.class);
+	}
+
+	@Test
+	public void wontReregisterConversionService() {
+		this.context = new AnnotationConfigApplicationContext();
+		Class<?>[] configs = {ConversionServiceAutoConfiguration.class};
+		this.context.register(configs);
+		ExampleConverter1 converter1 = new ExampleConverter1();
+		this.context.getBeanFactory().registerSingleton("converter1", converter1);
+		ExampleConverter2 converter2 = new ExampleConverter2();
+		this.context.getBeanFactory().registerSingleton("converter2", converter2);
+
+		this.context.getBeanFactory().registerSingleton("conversionService", new DefaultConversionService());
+		this.context.refresh();
+
+		ConversionService service = this.context.getBean(ConversionService.class);
+		assertThat(service.canConvert(Properties.class, Integer.class)).isFalse();
+		assertThat(service.canConvert(Integer.class, Properties.class)).isFalse();
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/conversion/ExampleConverter1.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/conversion/ExampleConverter1.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.conversion;
+
+import java.util.Properties;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+/**
+ * Examples for {@link ConversionServiceAutoConfigurationTest}.
+ *
+ * @author Mark Douglass
+ * @author Rob Hill
+ */
+@Component
+public class ExampleConverter1 implements Converter<Properties, Integer> {
+
+	@Override
+	public Integer convert(Properties properties) {
+		return null;
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/conversion/ExampleConverter2.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/conversion/ExampleConverter2.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.conversion;
+
+import java.util.Properties;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+/**
+ * Examples for {@link ConversionServiceAutoConfigurationTest}.
+ *
+ * @author Mark Douglass
+ * @author Rob Hill
+ */
+@Component
+public class ExampleConverter2 implements Converter<Integer, Properties> {
+
+	@Override
+	public Properties convert(Integer integer) {
+		return null;
+	}
+
+}


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

Provide a ConversionService populated with default Spring Converters
and any custom converters registered in the Spring Context.

Does not create a ConversionService if there are no converters
registered with the context.

Does not create a new ConversionService if there is already one
registered with the context.

Fixes #758
