### PR TITLE
Fix incorrect usage of Assert.notNull()

### DIFF
--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/CacheStatisticsAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/CacheStatisticsAutoConfigurationTests.java
@@ -199,7 +199,7 @@ public class CacheStatisticsAutoConfigurationTests {
 
 	private Cache getCache(String cacheName) {
 		Cache cache = this.cacheManager.getCache(cacheName);
-		Assert.notNull("No cache with name '" + cacheName + "' found.");
+		Assert.notNull(cache, "No cache with name '" + cacheName + "' found.");
 		return cache;
 	}
 


### PR DESCRIPTION
The message was actually used as the 'object to check' argument.
This fixes it by using the right 'object to check'.

- [x] I have signed the CLA

