### PR TITLE
Remove unchecked casts from GsonJsonParser and JacksonJsonParser

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/json/GsonJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/GsonJsonParser.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 
 /**
  * Thin wrapper to adapt {@link Gson} to a {@link JsonParser}.
@@ -35,24 +36,24 @@ public class GsonJsonParser implements JsonParser {
 	private Gson gson = new GsonBuilder().create();
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public Map<String, Object> parseMap(String json) {
 		if (json != null) {
 			json = json.trim();
 			if (json.startsWith("{")) {
-				return this.gson.fromJson(json, Map.class);
+				TypeToken<Map<String, Object>> type = new TypeToken<Map<String, Object>>() { };
+				return this.gson.fromJson(json, type.getType());
 			}
 		}
 		throw new IllegalArgumentException("Cannot parse JSON");
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public List<Object> parseList(String json) {
 		if (json != null) {
 			json = json.trim();
 			if (json.startsWith("[")) {
-				return this.gson.fromJson(json, List.class);
+				TypeToken<List<Object>> type = new TypeToken<List<Object>>() { };
+				return this.gson.fromJson(json, type.getType());
 			}
 		}
 		throw new IllegalArgumentException("Cannot parse JSON");

--- a/spring-boot/src/main/java/org/springframework/boot/json/JacksonJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/JacksonJsonParser.java
@@ -19,6 +19,7 @@ package org.springframework.boot.json;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -30,10 +31,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class JacksonJsonParser implements JsonParser {
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public Map<String, Object> parseMap(String json) {
 		try {
-			return new ObjectMapper().readValue(json, Map.class);
+			TypeReference<Map<String, Object>> type = new TypeReference<Map<String, Object>>() { };
+			return new ObjectMapper().readValue(json, type);
 		}
 		catch (Exception ex) {
 			throw new IllegalArgumentException("Cannot parse JSON", ex);
@@ -41,10 +42,10 @@ public class JacksonJsonParser implements JsonParser {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public List<Object> parseList(String json) {
 		try {
-			return new ObjectMapper().readValue(json, List.class);
+			TypeReference<List<Object>> type = new TypeReference<List<Object>>() { };
+			return new ObjectMapper().readValue(json, type);
 		}
 		catch (Exception ex) {
 			throw new IllegalArgumentException("Cannot parse JSON", ex);


### PR DESCRIPTION
This pull request removes the implicit unchecked casts and the need for `@SuppressWarnings("unchecked")` in [JacksonJsonParser](https://github.com/spring-projects/spring-boot/blob/master/spring-boot/src/main/java/org/springframework/boot/json/JacksonJsonParser.java) and [GsonJsonParser](https://github.com/spring-projects/spring-boot/blob/master/spring-boot/src/main/java/org/springframework/boot/json/GsonJsonParser.java).
- [x] I have signed the CLA

