### PR TITLE
Customize Data Couchbase customConversion/typeKey

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/couchbase/CouchbaseDataProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/couchbase/CouchbaseDataProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.data.couchbase;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.data.couchbase.core.convert.DefaultCouchbaseTypeMapper;
 import org.springframework.data.couchbase.core.query.Consistency;
 
 /**
@@ -39,6 +40,11 @@ public class CouchbaseDataProperties {
 	 */
 	private Consistency consistency = Consistency.READ_YOUR_OWN_WRITES;
 
+	/**
+	 * The name of the JSON attribute in which to store class information when marshalling entities (type key).
+	 */
+	private String typeKey = DefaultCouchbaseTypeMapper.DEFAULT_TYPE_KEY;
+
 	public boolean isAutoIndex() {
 		return this.autoIndex;
 	}
@@ -53,6 +59,14 @@ public class CouchbaseDataProperties {
 
 	public void setConsistency(Consistency consistency) {
 		this.consistency = consistency;
+	}
+
+	public String getTypeKey() {
+		return this.typeKey;
+	}
+
+	public void setTypeKey(String typeKey) {
+		this.typeKey = typeKey;
 	}
 
 }

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -551,6 +551,7 @@ content into your application; rather pick only the properties that you need.
 	spring.data.couchbase.auto-index=false # Automatically create views and indexes.
 	spring.data.couchbase.consistency=read-your-own-writes # Consistency to apply by default on generated queries.
 	spring.data.couchbase.repositories.enabled=true # Enable Couchbase repositories.
+	spring.data.couchbase.typeKey=_class # Attribute to use to store class information when marshalling to JSON.
 
 	# ELASTICSEARCH ({sc-spring-boot-autoconfigure}/elasticsearch/ElasticsearchProperties.{sc-ext}[ElasticsearchProperties])
 	spring.data.elasticsearch.cluster-name=elasticsearch # Elasticsearch cluster name.


### PR DESCRIPTION
This change allows to customize two elements of Spring Data Couchbase while
still relying on the Spring Boot autoconfiguration for the rest:

 - `typeKey`: the attribute under which Spring Data will store class info when
 marshalling to JSON, tunable as a Spring Boot property.
 - `customConversions`: the bean that contains Converters that will get
 registered with Spring Data Couchbase, tunable by taking a user-defined bean
 into account instead of always relying on the default one created inside the
 AbstractCouchbaseDataConfiguration.

Fixes gh-5979