### PR TITLE
Relax Logback loadConfiguration to allow missing resources without failing.

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -30,6 +30,7 @@ import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.classic.jul.LevelChangePropagator;
 import ch.qos.logback.classic.turbo.TurboFilter;
 import ch.qos.logback.classic.util.ContextInitializer;
+import ch.qos.logback.core.joran.action.PropertyAction;
 import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.spi.FilterReply;
 import ch.qos.logback.core.status.Status;
@@ -53,6 +54,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @author Dave Syer
  * @author Andy Wilkinson
+ * @author David Harrigan
  */
 public class LogbackLoggingSystem extends Slf4JLoggingSystem {
 
@@ -143,6 +145,10 @@ public class LogbackLoggingSystem extends Slf4JLoggingSystem {
 		StringBuilder errors = new StringBuilder();
 		for (Status status : statuses) {
 			if (status.getLevel() == Status.ERROR) {
+				if ((status.getOrigin() instanceof PropertyAction) 
+						&& (status.getMessage().indexOf("Could not find") >= 0)) {
+					continue;
+				}
 				errors.append(errors.length() > 0 ? String.format("%n") : "");
 				errors.append(status.toString());
 			}

--- a/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -145,7 +145,7 @@ public class LogbackLoggingSystem extends Slf4JLoggingSystem {
 		StringBuilder errors = new StringBuilder();
 		for (Status status : statuses) {
 			if (status.getLevel() == Status.ERROR) {
-				if ((status.getOrigin() instanceof PropertyAction) 
+				if ((status.getOrigin() instanceof PropertyAction)
 						&& (status.getMessage().indexOf("Could not find") >= 0)) {
 					continue;
 				}

--- a/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -132,12 +132,12 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		assertThat(output).endsWith("BOOTBOOT");
 		assertThat(new File(tmpDir() + "/tmp.log").exists()).isFalse();
 	}
-	
+
 	@Test
 	public void testWithResources() throws Exception {
 		this.loggingSystem.beforeInitialize();
-		this.loggingSystem.initialize(this.initializationContext, 
-				"classpath:logback-with-resources.xml", 
+		this.loggingSystem.initialize(this.initializationContext,
+				"classpath:logback-with-resources.xml",
 				getLogFile(tmpDir() + "/tmp.log", null));
 		this.logger.info("Hello world");
 		String output = this.output.toString().trim();

--- a/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -55,6 +55,7 @@ import static org.hamcrest.Matchers.not;
  * @author Dave Syer
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author David Harrigan
  */
 public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 
@@ -124,6 +125,19 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.loggingSystem.beforeInitialize();
 		this.loggingSystem.initialize(this.initializationContext,
 				"classpath:logback-nondefault.xml",
+				getLogFile(tmpDir() + "/tmp.log", null));
+		this.logger.info("Hello world");
+		String output = this.output.toString().trim();
+		assertThat(output).contains("Hello world").contains(tmpDir() + "/tmp.log");
+		assertThat(output).endsWith("BOOTBOOT");
+		assertThat(new File(tmpDir() + "/tmp.log").exists()).isFalse();
+	}
+	
+	@Test
+	public void testWithResources() throws Exception {
+		this.loggingSystem.beforeInitialize();
+		this.loggingSystem.initialize(this.initializationContext, 
+				"classpath:logback-with-resources.xml", 
 				getLogFile(tmpDir() + "/tmp.log", null));
 		this.logger.info("Hello world");
 		String output = this.output.toString().trim();

--- a/spring-boot/src/test/resources/logback-with-resources.xml
+++ b/spring-boot/src/test/resources/logback-with-resources.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <property resource="override.properties"/>
+    <property file="/foo/bar/override.properties"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_FILE} [%t] ${PID:-????} %c{1}: %m%n BOOTBOOT</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+    
+</configuration>


### PR DESCRIPTION
Hi,

A simple patch to fix issue #6000. 
- [X] I have signed the CLA

property resources to be ignored, without aborting with and ERROR.

Fixes #6000.
