### PR TITLE
Rename AutoConfigurationJson to AutoConfigureJson

### DIFF
--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/AutoConfigureJson.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/AutoConfigureJson.java
@@ -39,6 +39,6 @@ import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @ImportAutoConfiguration({ GsonAutoConfiguration.class, JacksonAutoConfiguration.class })
-public @interface AutoConfigurationJson {
+public @interface AutoConfigureJson {
 
 }

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonTest.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonTest.java
@@ -39,7 +39,7 @@ import org.springframework.test.context.BootstrapWith;
  * serialization.
  * <p>
  * Using this annotation will disable full auto-configuration and instead apply only
- * configuration relevant to Json tests (i.e. {@code @JsonComponent}, Jackson
+ * configuration relevant to JSON tests (i.e. {@code @JsonComponent}, Jackson
  * {@code Module})
  * <p>
  * By default, tests annotated with {@code JsonTest} will also initialize
@@ -47,7 +47,7 @@ import org.springframework.test.context.BootstrapWith;
  * provided via the {@link AutoConfigureJsonTesters @AutoConfigureJsonTesters} annotation.
  *
  * @author Phillip Webb
- * @see AutoConfigurationJson
+ * @see AutoConfigureJson
  * @see AutoConfigureJsonTesters
  * @see AutoConfigureCache
  * @since 1.4.0
@@ -60,7 +60,7 @@ import org.springframework.test.context.BootstrapWith;
 @OverrideAutoConfiguration(enabled = false)
 @TypeExcludeFilters(JsonExcludeFilter.class)
 @AutoConfigureCache
-@AutoConfigurationJson
+@AutoConfigureJson
 @AutoConfigureJsonTesters
 public @interface JsonTest {
 


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 
`AutoConfigurationJson` looks intended to be `AutoConfigureJson` based on the description in https://github.com/spring-projects/spring-boot/commit/21bc166c95f8d7e49412644b51e9e79da2c62024.
<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

