### PR TITLE
Enables cookie exclusion via TraceProperties.

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/TraceProperties.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/TraceProperties.java
@@ -50,10 +50,9 @@ public class TraceProperties {
 	private Set<Include> include = new HashSet<Include>(DEFAULT_INCLUDES);
 
 	/**
-	 * Whether {@literal Cookie} and {@literal Set-Cookie} should be excluded from
-	 * request/response headers. Defaults to {@code false}.
+	 * Items to be excluded from the trace.
 	 */
-	private Boolean excludeCookies = false;
+	private Set<Exclude> exclude = new HashSet<Exclude>();
 
 	public Set<Include> getInclude() {
 		return this.include;
@@ -63,12 +62,12 @@ public class TraceProperties {
 		this.include = include;
 	}
 
-	public Boolean getExcludeCookies() {
-		return this.excludeCookies;
+	public Set<Exclude> getExclude() {
+		return this.exclude;
 	}
 
-	public void setExcludeCookies(Boolean excludeCookies) {
-		this.excludeCookies = excludeCookies;
+	public void setExclude(Set<Exclude> exclude) {
+		this.exclude = exclude;
 	}
 
 	/**
@@ -140,6 +139,18 @@ public class TraceProperties {
 		 * Include the remote user.
 		 */
 		REMOTE_USER,
+
+	}
+
+	/**
+	 * Exclude options for tracing.
+	 */
+	public enum Exclude {
+
+		/**
+		 * Exclude Cookie from request and Set-Cookie from response headers.
+		 */
+		COOKIES,
 
 	}
 

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/TraceProperties.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/TraceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Wallace Wadge
  * @author Phillip Webb
+ * @author Venil Noronha
  * @since 1.3.0
  */
 @ConfigurationProperties(prefix = "management.trace")
@@ -48,12 +49,26 @@ public class TraceProperties {
 	 */
 	private Set<Include> include = new HashSet<Include>(DEFAULT_INCLUDES);
 
+	/**
+	 * Whether {@literal Cookie} and {@literal Set-Cookie} should be excluded from
+	 * request/response headers. Defaults to {@code false}.
+	 */
+	private Boolean excludeCookies = false;
+
 	public Set<Include> getInclude() {
 		return this.include;
 	}
 
 	public void setInclude(Set<Include> include) {
 		this.include = include;
+	}
+
+	public Boolean getExcludeCookies() {
+		return this.excludeCookies;
+	}
+
+	public void setExcludeCookies(Boolean excludeCookies) {
+		this.excludeCookies = excludeCookies;
 	}
 
 	/**

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/TraceProperties.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/TraceProperties.java
@@ -40,6 +40,7 @@ public class TraceProperties {
 		Set<Include> defaultIncludes = new LinkedHashSet<Include>();
 		defaultIncludes.add(Include.REQUEST_HEADERS);
 		defaultIncludes.add(Include.RESPONSE_HEADERS);
+		defaultIncludes.add(Include.COOKIES);
 		defaultIncludes.add(Include.ERRORS);
 		DEFAULT_INCLUDES = Collections.unmodifiableSet(defaultIncludes);
 	}
@@ -49,25 +50,12 @@ public class TraceProperties {
 	 */
 	private Set<Include> include = new HashSet<Include>(DEFAULT_INCLUDES);
 
-	/**
-	 * Items to be excluded from the trace.
-	 */
-	private Set<Exclude> exclude = new HashSet<Exclude>();
-
 	public Set<Include> getInclude() {
 		return this.include;
 	}
 
 	public void setInclude(Set<Include> include) {
 		this.include = include;
-	}
-
-	public Set<Exclude> getExclude() {
-		return this.exclude;
-	}
-
-	public void setExclude(Set<Exclude> exclude) {
-		this.exclude = exclude;
 	}
 
 	/**
@@ -84,6 +72,11 @@ public class TraceProperties {
 		 * Include response headers.
 		 */
 		RESPONSE_HEADERS,
+
+		/**
+		 * Include Cookie in request and Set-Cookie in response headers.
+		 */
+		COOKIES,
 
 		/**
 		 * Include errors (if any).
@@ -139,18 +132,6 @@ public class TraceProperties {
 		 * Include the remote user.
 		 */
 		REMOTE_USER,
-
-	}
-
-	/**
-	 * Exclude options for tracing.
-	 */
-	public enum Exclude {
-
-		/**
-		 * Exclude Cookie from request and Set-Cookie from response headers.
-		 */
-		COOKIES,
 
 	}
 

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.boot.actuate.trace.TraceProperties.Exclude;
 import org.springframework.boot.actuate.trace.TraceProperties.Include;
 import org.springframework.boot.autoconfigure.web.ErrorAttributes;

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
@@ -48,6 +48,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * @author Dave Syer
  * @author Wallace Wadge
  * @author Andy Wilkinson
+ * @author Venil Noronha
  */
 public class WebRequestTraceFilter extends OncePerRequestFilter implements Ordered {
 
@@ -122,7 +123,11 @@ public class WebRequestTraceFilter extends OncePerRequestFilter implements Order
 		trace.put("path", request.getRequestURI());
 		trace.put("headers", headers);
 		if (isIncluded(Include.REQUEST_HEADERS)) {
-			headers.put("request", getRequestHeaders(request));
+			Map<String, Object> requestHeaders = getRequestHeaders(request);
+			if (this.properties.getExcludeCookies()) {
+				requestHeaders.remove("Cookie");
+			}
+			headers.put("request", requestHeaders);
 		}
 		add(trace, Include.PATH_INFO, "pathInfo", request.getPathInfo());
 		add(trace, Include.PATH_TRANSLATED, "pathTranslated",
@@ -169,7 +174,11 @@ public class WebRequestTraceFilter extends OncePerRequestFilter implements Order
 	protected void enhanceTrace(Map<String, Object> trace, HttpServletResponse response) {
 		if (isIncluded(Include.RESPONSE_HEADERS)) {
 			Map<String, Object> headers = (Map<String, Object>) trace.get("headers");
-			headers.put("response", getResponseHeaders(response));
+			Map<String, String> responseHeaders = getResponseHeaders(response);
+			if (this.properties.getExcludeCookies()) {
+				responseHeaders.remove("Set-Cookie");
+			}
+			headers.put("response", responseHeaders);
 		}
 	}
 

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
@@ -35,7 +35,6 @@ import javax.servlet.http.HttpSession;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.springframework.boot.actuate.trace.TraceProperties.Exclude;
 import org.springframework.boot.actuate.trace.TraceProperties.Include;
 import org.springframework.boot.autoconfigure.web.ErrorAttributes;
 import org.springframework.core.Ordered;
@@ -125,7 +124,7 @@ public class WebRequestTraceFilter extends OncePerRequestFilter implements Order
 		trace.put("headers", headers);
 		if (isIncluded(Include.REQUEST_HEADERS)) {
 			Map<String, Object> requestHeaders = getRequestHeaders(request);
-			if (isExcluded(Exclude.COOKIES)) {
+			if (!isIncluded(Include.COOKIES)) {
 				requestHeaders.remove("Cookie");
 			}
 			headers.put("request", requestHeaders);
@@ -176,7 +175,7 @@ public class WebRequestTraceFilter extends OncePerRequestFilter implements Order
 		if (isIncluded(Include.RESPONSE_HEADERS)) {
 			Map<String, Object> headers = (Map<String, Object>) trace.get("headers");
 			Map<String, String> responseHeaders = getResponseHeaders(response);
-			if (isExcluded(Exclude.COOKIES)) {
+			if (!isIncluded(Include.COOKIES)) {
 				responseHeaders.remove("Set-Cookie");
 			}
 			headers.put("response", responseHeaders);
@@ -212,10 +211,6 @@ public class WebRequestTraceFilter extends OncePerRequestFilter implements Order
 
 	private boolean isIncluded(Include include) {
 		return this.properties.getInclude().contains(include);
-	}
-
-	private boolean isExcluded(Exclude exclude) {
-		return this.properties.getExclude().contains(exclude);
 	}
 
 	public void setErrorAttributes(ErrorAttributes errorAttributes) {

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
@@ -34,7 +34,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
+import org.springframework.boot.actuate.trace.TraceProperties.Exclude;
 import org.springframework.boot.actuate.trace.TraceProperties.Include;
 import org.springframework.boot.autoconfigure.web.ErrorAttributes;
 import org.springframework.core.Ordered;
@@ -124,7 +124,7 @@ public class WebRequestTraceFilter extends OncePerRequestFilter implements Order
 		trace.put("headers", headers);
 		if (isIncluded(Include.REQUEST_HEADERS)) {
 			Map<String, Object> requestHeaders = getRequestHeaders(request);
-			if (this.properties.getExcludeCookies()) {
+			if (isExcluded(Exclude.COOKIES)) {
 				requestHeaders.remove("Cookie");
 			}
 			headers.put("request", requestHeaders);
@@ -175,7 +175,7 @@ public class WebRequestTraceFilter extends OncePerRequestFilter implements Order
 		if (isIncluded(Include.RESPONSE_HEADERS)) {
 			Map<String, Object> headers = (Map<String, Object>) trace.get("headers");
 			Map<String, String> responseHeaders = getResponseHeaders(response);
-			if (this.properties.getExcludeCookies()) {
+			if (isExcluded(Exclude.COOKIES)) {
 				responseHeaders.remove("Set-Cookie");
 			}
 			headers.put("response", responseHeaders);
@@ -211,6 +211,10 @@ public class WebRequestTraceFilter extends OncePerRequestFilter implements Order
 
 	private boolean isIncluded(Include include) {
 		return this.properties.getInclude().contains(include);
+	}
+
+	private boolean isExcluded(Exclude exclude) {
+		return this.properties.getExclude().contains(exclude);
 	}
 
 	public void setErrorAttributes(ErrorAttributes errorAttributes) {

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/WebRequestTraceFilterTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/WebRequestTraceFilterTests.java
@@ -31,6 +31,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 
 import org.junit.Test;
+
 import org.springframework.boot.actuate.trace.TraceProperties.Exclude;
 import org.springframework.boot.actuate.trace.TraceProperties.Include;
 import org.springframework.boot.autoconfigure.web.DefaultErrorAttributes;

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/WebRequestTraceFilterTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/WebRequestTraceFilterTests.java
@@ -50,6 +50,7 @@ import static org.mockito.Mockito.verify;
  * @author Wallace Wadge
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Venil Noronha
  */
 public class WebRequestTraceFilterTests {
 
@@ -151,6 +152,35 @@ public class WebRequestTraceFilterTests {
 		Map<String, Object> info = this.repository.findAll().iterator().next().getInfo();
 		Map<String, Object> headers = (Map<String, Object>) info.get("headers");
 		assertThat(headers.get("response") == null).isTrue();
+	}
+
+	@Test
+	@SuppressWarnings({ "unchecked" })
+	public void filterDoesNotAddRequestCookiesWithCookiesExclude()
+			throws ServletException, IOException {
+		this.properties.setExcludeCookies(true);
+		MockHttpServletRequest request = spy(new MockHttpServletRequest("GET", "/foo"));
+		request.addHeader("Accept", "application/json");
+		request.addHeader("Cookie", "testCookie=testValue;");
+		Map<String, Object> map = (Map<String, Object>) this.filter.getTrace(request)
+				.get("headers");
+		assertThat(map.get("request").toString()).isEqualTo("{Accept=application/json}");
+	}
+
+	@Test
+	@SuppressWarnings({ "unchecked" })
+	public void filterDoesNotAddResponseCookiesWithCookiesExclude()
+			throws ServletException, IOException {
+		this.properties.setExcludeCookies(true);
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/foo");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		response.addHeader("Content-Type", "application/json");
+		response.addHeader("Set-Cookie", "testCookie=testValue;");
+		Map<String, Object> trace = this.filter.getTrace(request);
+		this.filter.enhanceTrace(trace, response);
+		Map<String, Object> map = (Map<String, Object>) trace.get("headers");
+		assertThat(map.get("response").toString())
+				.isEqualTo("{Content-Type=application/json, status=200}");
 	}
 
 	@Test

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/WebRequestTraceFilterTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/WebRequestTraceFilterTests.java
@@ -31,7 +31,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 
 import org.junit.Test;
-
+import org.springframework.boot.actuate.trace.TraceProperties.Exclude;
 import org.springframework.boot.actuate.trace.TraceProperties.Include;
 import org.springframework.boot.autoconfigure.web.DefaultErrorAttributes;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -158,7 +158,7 @@ public class WebRequestTraceFilterTests {
 	@SuppressWarnings({ "unchecked" })
 	public void filterDoesNotAddRequestCookiesWithCookiesExclude()
 			throws ServletException, IOException {
-		this.properties.setExcludeCookies(true);
+		this.properties.setExclude(Collections.singleton(Exclude.COOKIES));
 		MockHttpServletRequest request = spy(new MockHttpServletRequest("GET", "/foo"));
 		request.addHeader("Accept", "application/json");
 		request.addHeader("Cookie", "testCookie=testValue;");
@@ -171,7 +171,7 @@ public class WebRequestTraceFilterTests {
 	@SuppressWarnings({ "unchecked" })
 	public void filterDoesNotAddResponseCookiesWithCookiesExclude()
 			throws ServletException, IOException {
-		this.properties.setExcludeCookies(true);
+		this.properties.setExclude(Collections.singleton(Exclude.COOKIES));
 		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/foo");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		response.addHeader("Content-Type", "application/json");

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/WebRequestTraceFilterTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/WebRequestTraceFilterTests.java
@@ -32,7 +32,6 @@ import javax.servlet.http.Cookie;
 
 import org.junit.Test;
 
-import org.springframework.boot.actuate.trace.TraceProperties.Exclude;
 import org.springframework.boot.actuate.trace.TraceProperties.Include;
 import org.springframework.boot.autoconfigure.web.DefaultErrorAttributes;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -159,7 +158,7 @@ public class WebRequestTraceFilterTests {
 	@SuppressWarnings({ "unchecked" })
 	public void filterDoesNotAddRequestCookiesWithCookiesExclude()
 			throws ServletException, IOException {
-		this.properties.setExclude(Collections.singleton(Exclude.COOKIES));
+		this.properties.setInclude(Collections.singleton(Include.REQUEST_HEADERS));
 		MockHttpServletRequest request = spy(new MockHttpServletRequest("GET", "/foo"));
 		request.addHeader("Accept", "application/json");
 		request.addHeader("Cookie", "testCookie=testValue;");
@@ -172,7 +171,7 @@ public class WebRequestTraceFilterTests {
 	@SuppressWarnings({ "unchecked" })
 	public void filterDoesNotAddResponseCookiesWithCookiesExclude()
 			throws ServletException, IOException {
-		this.properties.setExclude(Collections.singleton(Exclude.COOKIES));
+		this.properties.setInclude(Collections.singleton(Include.RESPONSE_HEADERS));
 		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/foo");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		response.addHeader("Content-Type", "application/json");


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 
I've added a `excludeCookies` property to `TraceProperties`, which on setting `true` excludes `Cookie` and `Set-Cookie` from request/response headers. See #5982 for more info.

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

Please review and pull.

Thanks,
Venil Noronha