### PR TITLE
JUnit comes along with hamcrest-core as transitive dep that is not re…

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -981,6 +981,12 @@
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
 				<version>${junit.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.hamcrest</groupId>
+						<artifactId>hamcrest-core</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>mysql</groupId>


### PR DESCRIPTION
PR for discussion only!

"JUnit comes along with hamcrest-core that is not really necessary when using JUnit with other libraries like assertJ. Therefore exclude this dependency by default. The hamcrest libraries are already _defined_ in this module and need to be explicitly pulled by applications!"

 Has this already been discussed to exclude hamcrest in future releases?