### PR TITLE
Added independent SSL configuration for management server

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcChildContextConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcChildContextConfiguration.java
@@ -188,6 +188,9 @@ public class EndpointWebMvcChildContextConfiguration {
 			container.setContextPath("");
 			// and add the management-specific bits
 			container.setPort(this.managementServerProperties.getPort());
+			if (this.managementServerProperties.getSsl() != null) {
+				container.setSsl(this.managementServerProperties.getSsl());
+			}
 			container.setServerHeader(this.server.getServerHeader());
 			container.setAddress(this.managementServerProperties.getAddress());
 			container.addErrorPages(new ErrorPage(this.server.getError().getPath()));

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ManagementServerProperties.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ManagementServerProperties.java
@@ -25,7 +25,9 @@ import javax.validation.constraints.NotNull;
 import org.springframework.boot.autoconfigure.security.SecurityPrerequisite;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.context.embedded.Ssl;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
@@ -67,6 +69,9 @@ public class ManagementServerProperties implements SecurityPrerequisite {
 	 * Management endpoint HTTP port. Use the same port as the application by default.
 	 */
 	private Integer port;
+
+	@NestedConfigurationProperty
+	private Ssl ssl;
 
 	/**
 	 * Network address that the management endpoints should bind to.
@@ -110,6 +115,14 @@ public class ManagementServerProperties implements SecurityPrerequisite {
 	 */
 	public void setPort(Integer port) {
 		this.port = port;
+	}
+
+	public Ssl getSsl() {
+		return this.ssl;
+	}
+
+	public void setSsl(Ssl ssl) {
+		this.ssl = ssl;
 	}
 
 	public InetAddress getAddress() {

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcAutoConfigurationTests.java
@@ -181,6 +181,32 @@ public class EndpointWebMvcAutoConfigurationTests {
 	}
 
 	@Test
+	public void onDifferentPortManagementSslDisabled() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.applicationContext,
+				"management.ssl.enabled:false");
+		this.applicationContext.register(RootConfig.class, EndpointConfig.class,
+				DifferentPortConfig.class, BaseConfiguration.class,
+				EndpointWebMvcAutoConfiguration.class, ErrorMvcAutoConfiguration.class);
+		this.applicationContext.refresh();
+		assertContent("/controller", ports.get().server, "controlleroutput");
+		assertContent("/endpoint", ports.get().server, null);
+		assertContent("/controller", ports.get().management, null);
+		assertContent("/endpoint", ports.get().management, "endpointoutput");
+		assertContent("/error", ports.get().management, startsWith("{"));
+		ApplicationContext managementContext = this.applicationContext
+				.getBean(ManagementContextResolver.class).getApplicationContext();
+		List<?> interceptors = (List<?>) ReflectionTestUtils.getField(
+				managementContext.getBean(EndpointHandlerMapping.class), "interceptors");
+		assertThat(interceptors).hasSize(1);
+		ManagementServerProperties managementServerProperties = this.applicationContext
+				.getBean(ManagementServerProperties.class);
+		assertThat(managementServerProperties.getSsl()).isNotNull();
+		assertThat(managementServerProperties.getSsl().isEnabled()).isFalse();
+		this.applicationContext.close();
+		assertAllClosed();
+	}
+
+	@Test
 	public void onDifferentPortWithSpecificContainer() throws Exception {
 		this.applicationContext.register(SpecificContainerConfig.class, RootConfig.class,
 				DifferentPortConfig.class, EndpointConfig.class, BaseConfiguration.class,


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

More complete (IMHO) solution to #4881 (also should address #3509 and #4810)

This PR provides support for complete `management.ssl.*` configuration, identical to the `server.ssl.*` (uses the same internal implementation) to provide separate provisioning not only ports but also ability to disable `ssl` for management server, or, if needed, provide alternative certificates to main server and management server containers (when running on different ports).