### PR TITLE
Fix default value for `spring.rabbitmq.connection-timeout`

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -856,7 +856,7 @@ content into your application; rather pick only the properties that you need.
 	spring.rabbitmq.cache.channel.size= # Number of channels to retain in the cache.
 	spring.rabbitmq.cache.connection.mode=CHANNEL # Connection factory cache mode.
 	spring.rabbitmq.cache.connection.size= # Number of connections to cache.
-	spring.rabbitmq.connection-timeout=0 # Connection timeout, in milliseconds; zero for infinite.
+	spring.rabbitmq.connection-timeout= # Connection timeout, in milliseconds; zero for infinite.
 	spring.rabbitmq.dynamic=true # Create an AmqpAdmin bean.
 	spring.rabbitmq.host=localhost # RabbitMQ host.
 	spring.rabbitmq.listener.acknowledge-mode= # Acknowledge mode of container.


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 
`spring.rabbitmq.connection-timeout` has no default value: https://github.com/spring-projects/spring-boot/blob/master/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java#L94

And when not having the `spring.rabbitmq.connection-timeout` property, the actual default value is 60,000 ms by `com.rabbitmq.client.ConnectionFactory`.

To align with others, this PR simply removes the default value.
<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

