### PR TITLE
Upgrade Jetty to 9.2.17.v20160517

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -106,7 +106,7 @@
 		<jdom2.version>2.0.6</jdom2.version>
 		<jedis.version>2.8.1</jedis.version>
 		<jersey.version>2.22.2</jersey.version>
-		<jetty.version>9.2.16.v20160414</jetty.version>
+		<jetty.version>9.2.17.v20160517</jetty.version>
 		<jetty-jsp.version>2.2.0.v201112011158</jetty-jsp.version>
 		<jmustache.version>1.12</jmustache.version>
 		<jna.version>4.2.2</jna.version>


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

Jetty version 9.2.16.v20160414 has a bug preventing the use of HTTP proxies over HTTPS tunnels.

The bug is fixed in version 9.2.17.v20160517.

    1 jetty-9.2.17.v20160517 - 17 May 2016
    2  + 560 Jetty Client Proxy Authentication does not work with HTTP Proxy
    3    tunneling
    4  + 571 AbstractAuthentication.matchesURI() fails to match scheme

This MR fixes #6079.

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

