### PR TITLE
Remove HSQLDB dependency from Batch Starter

### DIFF
--- a/spring-boot-samples/spring-boot-sample-batch/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-batch/pom.xml
@@ -24,6 +24,10 @@
 			<artifactId>spring-boot-starter-batch</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.hsqldb</groupId>
+			<artifactId>hsqldb</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/spring-boot-starters/spring-boot-starter-batch/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-batch/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>spring-boot-starter-batch</artifactId>
 	<name>Spring Boot Batch Starter</name>
-	<description>Starter for using Spring Batch, including HSQLDB in-memory database</description>
+	<description>Starter for using Spring Batch</description>
 	<url>http://projects.spring.io/spring-boot/</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
@@ -23,12 +23,8 @@
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.hsqldb</groupId>
-			<artifactId>hsqldb</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-jdbc</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.batch</groupId>

--- a/spring-boot-starters/spring-boot-starter-batch/src/main/resources/META-INF/spring.provides
+++ b/spring-boot-starters/spring-boot-starter-batch/src/main/resources/META-INF/spring.provides
@@ -1,1 +1,1 @@
-provides: spring-batch
+provides: spring-batch-core


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 
This commit removes HSQLDB dependency from Batch Starter as most apps that use Spring Batch will prefer to use a RDBMS of their choice to store batch metadata.

Additionally, explicit ```spring-jdbc``` dependency has been replaced with JDBC Starter dependency.

This is somewhat similar issue to the #5528 but perhaps even more obtrusive. 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA
