### PR TITLE
Split up DispatcherServletConfiguration condition

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/EmbeddedServletContainerAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/EmbeddedServletContainerAutoConfigurationTests.java
@@ -217,7 +217,7 @@ public class EmbeddedServletContainerAutoConfigurationTests {
 			return new DispatcherServlet();
 		}
 
-		@Bean
+		@Bean(name = DispatcherServletAutoConfiguration.DEFAULT_DISPATCHER_SERVLET_REGISTRATION_BEAN_NAME)
 		public ServletRegistrationBean dispatcherRegistration() {
 			return new ServletRegistrationBean(dispatcherServlet(), "/app/*");
 		}


### PR DESCRIPTION
Prior to PR, defining a custom `DispatcherServlet` and/or a
`ServletRegistrationBean` with the default name would turn off
completely the `DispatcherServletAutoConfiguration`.

This commit splits this auto-configuration in two parts:

* first, a `DispatcherServlet` is automatically registered if no
instance is already defined with the default name
* then, a `ServletRegistrationBean` is registered is registered if a
`DispatcherServlet` instance exists with the default name *and* no
`ServletRegistrationBean` exists with the default name

This allows developers to register manually a `ServletRegistrationBean`
or a `DispatcherServlet` without having to redefine the whole
auto-configuration.

Note that this PR has some caveat compared to the previous behavior:
the condition for the `ServletRegistrationBean` auto-configuration
evolved as it's being switched off only if such a bean hasn't been
registered already with the default name.
See changes in `EmbeddedServletContainerAutoConfigurationTests`.