### PR TITLE
Upgrade to Elasticsearch 2.3.3

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -73,7 +73,7 @@
 		<embedded-mongo.version>1.50.5</embedded-mongo.version>
 		<flyway.version>3.2.1</flyway.version>
 		<freemarker.version>2.3.23</freemarker.version>
-		<elasticsearch.version>2.2.2</elasticsearch.version>
+		<elasticsearch.version>2.3.3</elasticsearch.version>
 		<gemfire.version>8.2.0</gemfire.version>
 		<glassfish-el.version>3.0.0</glassfish-el.version>
 		<gradle.version>1.12</gradle.version>


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

Elasticsearch 2.3.3 is the latest available version:
https://www.elastic.co/guide/en/elasticsearch/reference/2.3/es-release-notes.html