### PR TITLE
Close connection after use in LiquibaseEndpoint

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/LiquibaseEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/LiquibaseEndpoint.java
@@ -54,8 +54,13 @@ public class LiquibaseEndpoint extends AbstractEndpoint<List<Map<String, ?>>> {
 			DatabaseFactory factory = DatabaseFactory.getInstance();
 			DataSource dataSource = this.liquibase.getDataSource();
 			JdbcConnection connection = new JdbcConnection(dataSource.getConnection());
-			Database database = factory.findCorrectDatabaseImplementation(connection);
-			return service.queryDatabaseChangeLogTable(database);
+			try {
+				Database database = factory.findCorrectDatabaseImplementation(connection);
+				return service.queryDatabaseChangeLogTable(database);
+			}
+			finally {
+				connection.close();
+			}
 		}
 		catch (Exception ex) {
 			throw new IllegalStateException("Unable to get Liquibase changelog", ex);


### PR DESCRIPTION
Currently (1.3.x) the LiquibaseEndpoint doesn't close the database connection after using it. This PR fixes this.

- [X] I have signed the CLA