### PR TITLE
error-prone introduced

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: java
 jdk:
   - oraclejdk8
-services:
-  - mongodb
-  - redis
-sudo: false
 install: true
-before_script:
-- ./mvnw install -q -U -DskipTests=true -Dmaven.test.redirectTestOutputToFile=true || true
-- ./mvnw install -q -U -DskipTests=true -Dmaven.test.redirectTestOutputToFile=true
-script: ./mvnw install -q -nsu -Dmaven.test.redirectTestOutputToFile=true -P '!integration'
+sudo: false
+script: ./mvnw -q clean package -DskipTests -Ddisable.checks -Perror-prone

--- a/spring-boot-parent/pom.xml
+++ b/spring-boot-parent/pom.xml
@@ -720,5 +720,37 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>error-prone</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<version>3.3</version>
+						<configuration>
+							<compilerId>javac-with-errorprone</compilerId>
+							<forceJavacCompilerUse>true</forceJavacCompilerUse>
+							<source>8</source>
+							<target>8</target>
+						</configuration>
+						<dependencies>
+							<dependency>
+								<groupId>org.codehaus.plexus</groupId>
+								<artifactId>plexus-compiler-javac-errorprone</artifactId>
+								<version>2.5</version>
+							</dependency>
+							<dependency>
+								<groupId>com.google.errorprone</groupId>
+								<artifactId>error_prone_core</artifactId>
+								<version>2.0.9</version>
+							</dependency>
+						</dependencies>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+
 	</profiles>
 </project>


### PR DESCRIPTION
https://github.com/google/error-prone is basically a javac-fork with greatly increased number of compile-time errors. Errors it caught are usually really errors. This PR adds maven profile with error-prone configured. I run it with
````
./mvnw clean package -DskipTests -Ddisable.checks -Perror-prone,default
````
And it gave me 3 errors that I fixed in this PR as well. 
Using System.identityHashCode() for array is equivalent of array.hashCode() that was there previously but may be not desired.

I will be great to introduce such build to CI, but I have not figured out how to do it easily - travis is not the main CI for spring-boot, right?

- [X] I have signed the CLA

