### PR TITLE
GH-6183: Fix relaxed properties for SI JMX config

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -16,16 +16,30 @@
 
 package org.springframework.boot.autoconfigure.integration;
 
+import javax.management.MBeanServer;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
+import org.springframework.boot.bind.RelaxedPropertyResolver;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.env.Environment;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.jmx.config.EnableIntegrationMBeanExport;
 import org.springframework.integration.monitor.IntegrationMBeanExporter;
+import org.springframework.integration.support.management.IntegrationManagementConfigurer;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -50,8 +64,49 @@ public class IntegrationAutoConfiguration {
 	@ConditionalOnClass(EnableIntegrationMBeanExport.class)
 	@ConditionalOnMissingBean(value = IntegrationMBeanExporter.class, search = SearchStrategy.CURRENT)
 	@ConditionalOnProperty(prefix = "spring.jmx", name = "enabled", havingValue = "true", matchIfMissing = true)
-	@EnableIntegrationMBeanExport(defaultDomain = "${spring.jmx.default-domain:}", server = "${spring.jmx.server:mbeanServer}")
-	protected static class IntegrationJmxConfiguration {
+	protected static class IntegrationJmxConfiguration implements EnvironmentAware, BeanFactoryAware {
+
+		private BeanFactory beanFactory;
+
+		private RelaxedPropertyResolver propertyResolver;
+
+		@Autowired(required = false)
+		@Qualifier(IntegrationManagementConfigurer.MANAGEMENT_CONFIGURER_NAME)
+		private IntegrationManagementConfigurer configurer;
+
+		@Override
+		public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+			this.beanFactory = beanFactory;
+		}
+
+		@Override
+		public void setEnvironment(Environment environment) {
+			this.propertyResolver = new RelaxedPropertyResolver(environment, "spring.jmx.");
+		}
+
+		@Bean
+		@Primary
+		public IntegrationMBeanExporter integrationMbeanExporter() {
+			IntegrationMBeanExporter exporter = new IntegrationMBeanExporter();
+			String defaultDomain = this.propertyResolver.getProperty("default-domain");
+			if (StringUtils.hasLength(defaultDomain)) {
+				exporter.setDefaultDomain(defaultDomain);
+			}
+			String server = this.propertyResolver.getProperty("server", "mbeanServer");
+			if (StringUtils.hasLength(server)) {
+				exporter.setServer(this.beanFactory.getBean(server, MBeanServer.class));
+			}
+			if (this.configurer != null) {
+				if (this.configurer.getDefaultCountsEnabled() == null) {
+					this.configurer.setDefaultCountsEnabled(true);
+				}
+				if (this.configurer.getDefaultStatsEnabled() == null) {
+					this.configurer.setDefaultStatsEnabled(true);
+				}
+			}
+			return exporter;
+		}
+
 	}
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
@@ -92,7 +92,7 @@ public class IntegrationAutoConfigurationTests {
 
 	@Test
 	public void customizeJmxDomain() {
-		load("spring.jmx.default-domain=org.foo");
+		load("SPRING_JMX_DEFAULT_DOMAIN=org.foo");
 		MBeanServer mBeanServer = this.context.getBean(MBeanServer.class);
 		assertDomains(mBeanServer, true, "org.foo");
 		assertDomains(mBeanServer, false, "org.springframework.integration",


### PR DESCRIPTION
Fixes GH-6183 (https://github.com/spring-projects/spring-boot/issues/6183)

Since annotation based config like
```
@EnableIntegrationMBeanExport(defaultDomain = "${spring.jmx.default-domain:}")
```
is far away of `RelaxedPropertyResolver` in Spring Boot,
rework the `IntegrationJmxConfiguration` to configure required beans via raw JavaConfig

**Cherry-pick to 1.4**