### PR TITLE
Reuse objects in JsonParser implementations

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/json/GsonJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/GsonJsonParser.java
@@ -33,6 +33,11 @@ import com.google.gson.reflect.TypeToken;
  */
 public class GsonJsonParser implements JsonParser {
 
+	private static final TypeToken<List<Object>> LIST_TYPE = new TypeToken<List<Object>>() {
+	};
+	private static final TypeToken<Map<String, Object>> MAP_TYPE = new TypeToken<Map<String, Object>>() {
+	};
+
 	private Gson gson = new GsonBuilder().create();
 
 	@Override
@@ -40,7 +45,7 @@ public class GsonJsonParser implements JsonParser {
 		if (json != null) {
 			json = json.trim();
 			if (json.startsWith("{")) {
-				return this.gson.fromJson(json, new MapTypeToken().getType());
+				return this.gson.fromJson(json, MAP_TYPE.getType());
 			}
 		}
 		throw new IllegalArgumentException("Cannot parse JSON");
@@ -51,16 +56,10 @@ public class GsonJsonParser implements JsonParser {
 		if (json != null) {
 			json = json.trim();
 			if (json.startsWith("[")) {
-				TypeToken<List<Object>> type = new TypeToken<List<Object>>() {
-				};
-				return this.gson.fromJson(json, type.getType());
+				return this.gson.fromJson(json, LIST_TYPE.getType());
 			}
 		}
 		throw new IllegalArgumentException("Cannot parse JSON");
-	}
-
-	private static final class MapTypeToken extends TypeToken<Map<String, Object>> {
-
 	}
 
 }

--- a/spring-boot/src/main/java/org/springframework/boot/json/JacksonJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/JacksonJsonParser.java
@@ -30,10 +30,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class JacksonJsonParser implements JsonParser {
 
+	private static final TypeReference<List<Object>> LIST_TYPE = new TypeReference<List<Object>>() {
+	};
+	private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<Map<String, Object>>() {
+	};
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
 	@Override
 	public Map<String, Object> parseMap(String json) {
 		try {
-			return new ObjectMapper().readValue(json, new MapTypeReference());
+			return this.objectMapper.readValue(json, MAP_TYPE);
 		}
 		catch (Exception ex) {
 			throw new IllegalArgumentException("Cannot parse JSON", ex);
@@ -43,17 +50,11 @@ public class JacksonJsonParser implements JsonParser {
 	@Override
 	public List<Object> parseList(String json) {
 		try {
-			TypeReference<List<Object>> type = new TypeReference<List<Object>>() {
-			};
-			return new ObjectMapper().readValue(json, type);
+			return this.objectMapper.readValue(json, LIST_TYPE);
 		}
 		catch (Exception ex) {
 			throw new IllegalArgumentException("Cannot parse JSON", ex);
 		}
 	}
-
-	private static class MapTypeReference extends TypeReference<Map<String, Object>> {
-
-	};
 
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 
Type-related objects and `ObjectMapper` look reusable, so this PR makes them be reused.
<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

