### PR TITLE
update jsf libraries supported by jsf-spring-boot-starter version 1.5.1 at README.adoc

### DIFF
--- a/spring-boot-starters/README.adoc
+++ b/spring-boot-starters/README.adoc
@@ -94,7 +94,7 @@ do as they were designed before this was clarified.
 | http://resteasy.jboss.org/[RESTEasy]
 | https://github.com/paypal/resteasy-spring-boot
 
-| JSF (https://javaserverfaces.java.net/[Mojarra], http://primefaces.org/[Prime Faces] and http://omnifaces.org/[OmniFaces])
+| JSF (http://primefaces.org/[PrimeFaces], http://primefaces-extensions.github.io/[PrimeFaces Extensions], http://omnifaces.org/[OmniFaces], https://javaserverfaces.java.net/[Mojarra] and http://myfaces.apache.org[MyFaces])
 | https://github.com/persapiens/jsf-spring-boot-starter
 
 |===


### PR DESCRIPTION
This pull request wants to update documentation about jsf-spring-boot-starter at README.adoc

Current supported libraries are [PrimeFaces](http://primefaces.org/), [PrimeFaces Extensions](http://primefaces-extensions.github.io/), [OmniFaces](http://omnifaces.org/), [Mojarra](https://javaserverfaces.java.net/) and [MyFaces](http://myfaces.apache.org).

- [X] I have signed the CLA

