### PR TITLE
Remove an unnecessary constructor in DefaultErrorViewResolver

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/DefaultErrorViewResolver.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/DefaultErrorViewResolver.java
@@ -26,7 +26,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.boot.autoconfigure.template.TemplateAvailabilityProvider;
 import org.springframework.boot.autoconfigure.template.TemplateAvailabilityProviders;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.Ordered;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
@@ -94,14 +93,6 @@ public class DefaultErrorViewResolver implements ErrorViewResolver, Ordered {
 			TemplateAvailabilityProviders templateAvailabilityProviders) {
 		Assert.notNull(applicationContext, "ApplicationContext must not be null");
 		Assert.notNull(resourceProperties, "ResourceProperties must not be null");
-		this.applicationContext = applicationContext;
-		this.resourceProperties = resourceProperties;
-		this.templateAvailabilityProviders = templateAvailabilityProviders;
-	}
-
-	DefaultErrorViewResolver(AnnotationConfigApplicationContext applicationContext,
-			ResourceProperties resourceProperties,
-			TemplateAvailabilityProviders templateAvailabilityProviders) {
 		this.applicationContext = applicationContext;
 		this.resourceProperties = resourceProperties;
 		this.templateAvailabilityProviders = templateAvailabilityProviders;


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 
The constructor is used only in a test and can be replace with `DefaultErrorViewResolver(ApplicationContext applicationContext, ResourceProperties resourceProperties, TemplateAvailabilityProviders templateAvailabilityProviders)`, so I guess it has been added accidentally.

This PR simply removes it.
<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

