### PR TITLE
Add MongoClientFactoryBean as a ConditionalClass

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
@@ -63,6 +63,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
+import org.springframework.data.mongodb.core.MongoClientFactoryBean;
 import org.springframework.util.Assert;
 
 /**
@@ -199,7 +200,7 @@ public class EmbeddedMongoAutoConfiguration {
 	 * {@code embeddedMongoServer} bean.
 	 */
 	@Configuration
-	@ConditionalOnClass(MongoClient.class)
+	@ConditionalOnClass({MongoClient.class, MongoClientFactoryBean.class})
 	protected static class EmbeddedMongoDependencyConfiguration
 			extends MongoClientDependsOnBeanFactoryPostProcessor {
 


### PR DESCRIPTION
The class EmbeddedMongoAutoConfiguration.EmbeddedMongoDependencyConfiguration extends
MongoClientDependsOnBeanFactoryPostProcessor that uses MongoClientFactoryBean to ensure
that MongoClient beans depend on the embeddedMongoServer bean.

To prevent a MongoClientFactoryBean ClassNotFoundException, the MongoClientFactoryBean was
added to the ConditionalOnClass to prevent creating the Post Processort in case it is missing,
e.g. using the EmbeddedMongoAutoConfiguration without spring data mongo

- [X] I have signed the CLA
