### PR TITLE
Clean javadoc harvested by the configuration meta-data annotation processor

### DIFF
--- a/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -571,6 +571,12 @@ public class ConfigurationMetadataAnnotationProcessorTests {
 		assertThat(metadata).has(
 				Metadata.withProperty("foo.counter").fromSource(FooProperties.class));
 		assertThat(metadata).has(
+				Metadata.withProperty("foo.counter").withDescription("A nice counter description.").fromSource(FooProperties.class));
+		assertThat(metadata).has(
+				Metadata.withProperty("foo.name")
+						.withDescription("A javadoc method that has some inlined reference to a java.util.List list and some more text on a new line with a hyperlink spring boot.")
+						.fromSource(FooProperties.class));
+		assertThat(metadata).has(
 				Metadata.withProperty("bar.counter").fromSource(BarProperties.class));
 		metadata = project.incrementalBuild(BarProperties.class);
 		assertThat(metadata).has(

--- a/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/incremental/FooProperties.java
+++ b/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/incremental/FooProperties.java
@@ -21,6 +21,12 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
 @ConfigurationProperties("foo")
 public class FooProperties {
 
+	/**
+	 * A javadoc method that has some inlined reference to a {@link java.util.List} list
+	 * and some more text on a new line with a hyperlink <a href="https://github.com/spring-projects/spring-boot">spring boot</a>.
+	 *
+	 * @see BarProperties for the bar
+	 */
 	private String name;
 
 	private String description;


### PR DESCRIPTION
The APT processor to clean javadoc from the fields so the generated JSon descriptor file does not contain invalid text. See ticket #6119 

