### PR TITLE
Remove a duplicate application property for server.connection-timeout

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -167,7 +167,6 @@ content into your application; rather pick only the properties that you need.
 	server.server-header= # Value to use for the Server response header (no header is sent if empty)
 	server.servlet-path=/ # Path of the main dispatcher servlet.
 	server.use-forward-headers= # If X-Forwarded-* headers should be applied to the HttpRequest.
-	server.connectionTimeout=-1 # The number of milliseconds connectors will wait for another HTTP request before closing the connection.
 	server.session.cookie.comment= # Comment for the session cookie.
 	server.session.cookie.domain= # Domain for the session cookie.
 	server.session.cookie.http-only= # "HttpOnly" flag for the session cookie.


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 
`server.connectionTimeout` is a duplicate of `server.connection-timeout` and having a wrong default value.
<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA