### PR TITLE
Broken compatibility with Mockito 2.0.47-beta+ in Spring Boot 1.4.0.M3

### DIFF
--- a/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.mockito.Answers;
 import org.mockito.MockSettings;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.util.Assert;
@@ -151,11 +152,21 @@ class MockDefinition extends Definition {
 		if (!this.extraInterfaces.isEmpty()) {
 			settings.extraInterfaces(this.extraInterfaces.toArray(new Class<?>[] {}));
 		}
-		settings.defaultAnswer(this.answer.get());
+		settings.defaultAnswer(getMockitoVersionIndependentDefaultAnswerForAnswer(this.answer));
 		if (this.serializable) {
 			settings.serializable();
 		}
 		return (T) Mockito.mock(this.classToMock, settings);
 	}
 
+	@SuppressWarnings({"UnnecessaryLocalVariable", "ConstantConditions"})
+	private Answer<?> getMockitoVersionIndependentDefaultAnswerForAnswer(Answers answer) {	//Issue #6320
+		Object answerAsObject = answer;
+		if (answerAsObject instanceof Answer) {	//Mockito 2.0.2-beta+
+			return (Answer) answerAsObject;
+		}
+		else {	//Mockito 1.x and <2.0.47-beta
+			return answer.get();	//TODO: once internally switched to mockito 2.x drop support for 1.x or handle it with reflection
+		}
+	}
 }


### PR DESCRIPTION
- [x] I have signed the CLA

This PR fixes incompatibility of 1.4.0.M3 (also snapshot 20160706) with Mockito 2.0.47-beta+ described in #6320.

Method get() on `Answers` is no longer [available](https://github.com/mockito/mockito/commit/da5e750957b494e7fa0548bf1286d67b8b0386d5) in 2.0.47-beta+.
Method get() is required only for Mockito 1.x and <2.0.2-beta. Starting with 2.0.0-beta an Answers enum [implements](https://github.com/mockito/mockito/commit/34f4436d988f04eaf7635b0497067ee8df7971a6) an Answer interface.

The implementation detects if `Answers` can be cast directly to `Answer` (new beta versions) and if not uses an old get() method. It should cover most of the Mockito versions. Ugly casts and warning suppression are required to make it compilable with Mockito 1.10.x.

Compatibility with 1.10.x is provided by current tests. Compatibility with recent Mockito 2.x has been tested manually (maybe there could be created a separated module to test compatibility with Mockito 2.x one day).

Fixes gh-6320.