### PR TITLE
Remove `@Primary` from `IntegrationMBeanExporter`

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -33,7 +33,6 @@ import org.springframework.boot.bind.RelaxedPropertyResolver;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.jmx.config.EnableIntegrationMBeanExport;
@@ -87,7 +86,6 @@ public class IntegrationAutoConfiguration {
 		}
 
 		@Bean
-		@Primary
 		public IntegrationMBeanExporter integrationMbeanExporter() {
 			IntegrationMBeanExporter exporter = new IntegrationMBeanExporter();
 			String defaultDomain = this.propertyResolver.getProperty("default-domain");

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/admin/SpringApplicationAdminJmxAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/admin/SpringApplicationAdminJmxAutoConfigurationTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.autoconfigure.admin;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
 import java.lang.management.ManagementFactory;
 
 import javax.management.InstanceNotFoundException;
@@ -30,6 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.DispatcherServletAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
@@ -39,9 +43,6 @@ import org.springframework.boot.context.embedded.EmbeddedWebApplicationContext;
 import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link SpringApplicationAdminJmxAutoConfiguration}.
@@ -119,6 +120,7 @@ public class SpringApplicationAdminJmxAutoConfigurationTests {
 						ServerPropertiesAutoConfiguration.class,
 						DispatcherServletAutoConfiguration.class,
 						JmxAutoConfiguration.class,
+						IntegrationAutoConfiguration.class,
 						SpringApplicationAdminJmxAutoConfiguration.class)
 				.run("--" + ENABLE_ADMIN_PROP, "--server.port=0");
 		assertThat(this.context).isInstanceOf(EmbeddedWebApplicationContext.class);
@@ -152,6 +154,7 @@ public class SpringApplicationAdminJmxAutoConfigurationTests {
 		AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils.addEnvironment(applicationContext, environment);
 		applicationContext.register(JmxAutoConfiguration.class,
+				IntegrationAutoConfiguration.class,
 				SpringApplicationAdminJmxAutoConfiguration.class);
 		applicationContext.refresh();
 		this.context = applicationContext;


### PR DESCRIPTION
After reworking `IntegrationAutoConfiguration` JMX from annotation based to the direct `@Bean` usage,
the `@Primary` annotation has been added to the `IntegrationMBeanExporter` by mistake.
That causes the ` more than one 'primary' bean found among candidates` problem for the `SpringApplicationAdminJmxAutoConfiguration` injections.

* Remove `@Primary` from `IntegrationMBeanExporter` `@Bean`
* Modify `SpringApplicationAdminJmxAutoConfigurationTests` test to include `IntegrationAutoConfiguration`
to be sure that we have only one `@Primary` for `MBeanExporter` in the `JmxAutoConfiguration`

**Cherry-pick to 1.3.x**