### PR TITLE
added sample usage of ActiveMQ Topic (use both Queue and Topic in same app)

### DIFF
--- a/spring-boot-samples/spring-boot-sample-activemq/src/main/java/sample/activemq/Consumer.java
+++ b/spring-boot-samples/spring-boot-sample-activemq/src/main/java/sample/activemq/Consumer.java
@@ -16,15 +16,103 @@
 
 package sample.activemq;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.jms.annotation.JmsListener;
 import org.springframework.stereotype.Component;
 
 @Component
 public class Consumer {
-
-	@JmsListener(destination = "sample.queue")
-	public void receiveQueue(String text) {
-		System.out.println(text);
+	
+	private static final Logger LOG = LoggerFactory.getLogger(Consumer.class);
+	
+	protected int countReceived_TestQueue1 = 0;
+	protected int countReceived_TestQueue1_withContainerFactory = 0;
+	protected int countReceived_TestTopic1 = 0;
+	protected int countReceived_TestTopic1_withContainerFactory = 0;
+	protected int countReceived_TestTopic1_explicit = 0;
+	
+	
+	@JmsListener(destination = "TestQueue1")
+	public void receiveQueue1(String text) {
+		countReceived_TestQueue1++;
+		doLog("TestQueue1", text);
 	}
 
+	/**
+	 * WARNING: looks ok, but does NOT receive any message !!
+	 * see receiveTopic1_withContainerFactory() instead
+	 * 
+	 * you "could" also change src/main/resources/application.properties 
+	 * <PRE>
+	 *    spring.jms.pub-sub-domain=true
+	 * </PRE>
+	 * ... in this case, this method would now correctly receive Topic messages, 
+	 *   but receiveQueue1() would STOP receiving Queue messages!!
+	 * @param text
+	 */
+	@JmsListener(destination = "TestTopic1")
+	public void receiveTopic1(String text) {
+		countReceived_TestTopic1++;
+		doLog("TestTopic1", text);
+	}
+
+	/**
+	 * Correction replacement for receiveTopic1()
+	 * see configuration bean definition in SampleActiveMQApplication:
+	 * <PRE>@Bean jmsListenerContainerTopic() { ... bean.setPubSubDomain(true); }<PRE>
+	 * @param text
+	 */
+	@JmsListener(destination = "TestTopic1", containerFactory="jmsListenerContainerTopic")
+	public void receiveTopic1_withContainerFactory(String text) {
+		countReceived_TestTopic1_withContainerFactory++;
+		doLog("TestTopic1 using jmsListenerContainerTopic", text);
+	}
+
+	/**
+	 * Queue message listener that also works... but will consume in round-robbing 1/2 messages, other messages are consumed by receiveQueue1()
+	 * (if starting another jvm process consuming events, then 1/4 messages only will be consumed in this method) 
+	 */
+	@JmsListener(destination = "TestQueue1", containerFactory="jmsListenerContainerQueue")
+	public void receiveQueue1_withContainerFactory(String text) {
+		countReceived_TestQueue1_withContainerFactory++;
+		doLog("TestQueue1 using jmsListenerContainerQueue", text);
+	}
+	
+	/**
+	 * WARNING: looks ok, but does NOT receive any message, even if springframework knows that the resolved destination is a Topic !!
+	 * see org.springframework.jms.config.AbstractJmsListenerContainerFactory line 181
+	 * @param text
+	 */
+	@JmsListener(destination = "topic://TestTopic1")
+	public void receiveTopic2(String text) {
+		countReceived_TestTopic1_explicit++;
+		doLog("topic://TestTopic1", text);
+	}
+	
+	protected void doLog(String from, String msg) {
+		LOG.info("**** RECEIVED MSG from " + from + " : " + msg);
+	}
+
+	public int getCountReceived_TestQueue1() {
+		return countReceived_TestQueue1;
+	}
+
+	public int getCountReceived_TestQueue1_withContainerFactory() {
+		return countReceived_TestQueue1_withContainerFactory;
+	}
+
+	public int getCountReceived_TestTopic1() {
+		return countReceived_TestTopic1;
+	}
+
+	public int getCountReceived_TestTopic1_withContainerFactory() {
+		return countReceived_TestTopic1_withContainerFactory;
+	}
+
+	public int getCountReceived_TestTopic1_explicit() {
+		return countReceived_TestTopic1_explicit;
+	}
+	
+	
 }

--- a/spring-boot-samples/spring-boot-sample-activemq/src/main/java/sample/activemq/Producer.java
+++ b/spring-boot-samples/spring-boot-sample-activemq/src/main/java/sample/activemq/Producer.java
@@ -17,29 +17,56 @@
 package sample.activemq;
 
 import javax.jms.Queue;
+import javax.jms.Topic;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.jms.core.JmsMessagingTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
 public class Producer implements CommandLineRunner {
-
+	
+	private static final Logger LOG = LoggerFactory.getLogger(Producer.class);
+	
 	@Autowired
 	private JmsMessagingTemplate jmsMessagingTemplate;
 
 	@Autowired
 	private Queue queue;
 
+	@Autowired
+	private Topic topic;
+
 	@Override
 	public void run(String... args) throws Exception {
 		send("Sample message");
-		System.out.println("Message was sent to the Queue");
+		repeatSend();
 	}
+
+	@Value("${sample.producer.sendRepeatCount:2}")
+	protected int sendRepeatCount = 2;
 
 	public void send(String msg) {
 		this.jmsMessagingTemplate.convertAndSend(this.queue, msg);
+		this.jmsMessagingTemplate.convertAndSend(this.topic, msg);
+		LOG.info("Message was sent to the Queue & Topic");
+	}
+	
+	public void repeatSend() {
+		for(int i = 0; i < sendRepeatCount; i++) {
+			try {
+				Thread.sleep(1000);
+			} catch (InterruptedException e) {
+			}
+			String evt = "msg " + i;
+			this.jmsMessagingTemplate.convertAndSend(this.queue, evt);
+			this.jmsMessagingTemplate.convertAndSend(this.topic, evt);
+			LOG.info("Message was sent to the Queue & Topic");
+		}
 	}
 
 }

--- a/spring-boot-samples/spring-boot-sample-activemq/src/main/java/sample/activemq/SampleActiveMQApplication.java
+++ b/spring-boot-samples/spring-boot-sample-activemq/src/main/java/sample/activemq/SampleActiveMQApplication.java
@@ -16,25 +16,61 @@
 
 package sample.activemq;
 
+import javax.jms.ConnectionFactory;
 import javax.jms.Queue;
+import javax.jms.Topic;
 
 import org.apache.activemq.command.ActiveMQQueue;
-
+import org.apache.activemq.command.ActiveMQTopic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.jms.annotation.EnableJms;
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
+import org.springframework.jms.config.JmsListenerContainerFactory;
 
 @SpringBootApplication
 @EnableJms
 public class SampleActiveMQApplication {
-
+	
+	private static final Logger LOG = LoggerFactory.getLogger(SampleActiveMQApplication.class);
+	
 	@Bean
-	public Queue queue() {
-		return new ActiveMQQueue("sample.queue");
+	public Queue testQueue1() {
+		return new ActiveMQQueue("TestQueue1");
 	}
 
+	@Bean
+	public Topic testTopic1() {
+		return new ActiveMQTopic("TestTopic1");
+	}
+	
+	@Autowired
+	protected ConnectionFactory activeMQConnectionFactory;
+
+	@Bean
+	public JmsListenerContainerFactory<?> jmsListenerContainerTopic() {
+		DefaultJmsListenerContainerFactory bean = new DefaultJmsListenerContainerFactory();
+		bean.setPubSubDomain(true);
+		bean.setConnectionFactory(activeMQConnectionFactory);
+		return bean;
+	}
+	
+	@Bean
+	public JmsListenerContainerFactory<?> jmsListenerContainerQueue() {
+		DefaultJmsListenerContainerFactory bean = new DefaultJmsListenerContainerFactory();
+		bean.setConnectionFactory(activeMQConnectionFactory);
+		return bean;
+	}
+	
 	public static void main(String[] args) {
+		LOG.trace("test log TRACE");
+		LOG.debug("test log DEBUG");
+		LOG.info("test log INFO");
+		
 		SpringApplication.run(SampleActiveMQApplication.class, args);
 	}
 

--- a/spring-boot-samples/spring-boot-sample-activemq/src/main/resources/application-inmemory.properties
+++ b/spring-boot-samples/spring-boot-sample-activemq/src/main/resources/application-inmemory.properties
@@ -1,0 +1,2 @@
+spring.activemq.in-memory=true
+spring.activemq.pool.enabled=false

--- a/spring-boot-samples/spring-boot-sample-activemq/src/main/resources/application-local-queues.properties
+++ b/spring-boot-samples/spring-boot-sample-activemq/src/main/resources/application-local-queues.properties
@@ -1,0 +1,12 @@
+#
+# sample configuration file, to connect to a local ActiveMQ server, and receive default messages from Queues
+#
+
+spring.activemq.brokerUrl=tcp://localhost:61616
+spring.activemq.user=admin
+spring.activemq.password=admin
+
+spring.activemq.pooled=true
+
+# default value "false" => received default messages from Queues only 
+# spring.jms.pub-sub-domain=false

--- a/spring-boot-samples/spring-boot-sample-activemq/src/main/resources/application-local-topics.properties
+++ b/spring-boot-samples/spring-boot-sample-activemq/src/main/resources/application-local-topics.properties
@@ -1,0 +1,12 @@
+#
+# sample configuration file, to connect to a local ActiveMQ server, and receive default messages from Topics
+#
+
+
+spring.activemq.brokerUrl=tcp://localhost:61616
+spring.activemq.user=admin
+spring.activemq.password=admin
+
+spring.activemq.pooled=true
+
+spring.jms.pub-sub-domain=true

--- a/spring-boot-samples/spring-boot-sample-activemq/src/main/resources/logback.xml
+++ b/spring-boot-samples/spring-boot-sample-activemq/src/main/resources/logback.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<layout class="ch.qos.logback.classic.PatternLayout">
+			<Pattern>%-5level %logger{36} - %msg%n</Pattern>
+		</layout>
+	</appender>
+
+	<appender name="file" class="ch.qos.logback.core.FileAppender">
+		<file>target/log.txt</file>
+		<layout class="ch.qos.logback.classic.PatternLayout">
+			<Pattern>%-5level %logger{36} - %msg%n</Pattern>
+		</layout>
+	</appender>
+	
+	<logger name="org.apache.activemq.ActiveMQSession" level="INFO"/>
+	<logger name="org.apache.activemq.transport.AbstractInactivityMonitor" level="INFO"/>
+	<logger name="org.springframework.jms.listener.DefaultMessageListenerContainer" level="INFO"/>
+	
+	<root level="INFO">
+		<!-- 
+		<appender-ref ref="STDOUT" />
+	    -->
+		<appender-ref ref="file" />
+	</root>
+
+</configuration>

--- a/spring-boot-samples/spring-boot-sample-activemq/src/test/java/sample/activemq/SampleActiveMqTests.java
+++ b/spring-boot-samples/spring-boot-sample-activemq/src/test/java/sample/activemq/SampleActiveMqTests.java
@@ -18,16 +18,13 @@ package sample.activemq;
 
 import javax.jms.JMSException;
 
-import org.junit.Rule;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration tests for demo application.
@@ -35,20 +32,31 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Eddú Meléndez
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest
+// @SpringBootTest
+@SpringApplicationConfiguration(SampleActiveMQApplication.class)
 public class SampleActiveMqTests {
-
-	@Rule
-	public OutputCapture outputCapture = new OutputCapture();
 
 	@Autowired
 	private Producer producer;
 
+	@Autowired
+	private Consumer consumer;
+
+	@Value("${sample.producer.sendRepeatCount:2}")
+	protected int sendRepeatCount = 2;
+	
 	@Test
 	public void sendSimpleMessage() throws InterruptedException, JMSException {
-		this.producer.send("Test message");
+		// this.producer.send("Test message"); // see messages already sent in main... or use @SpringBootTest ??
 		Thread.sleep(1000L);
-		assertThat(this.outputCapture.toString().contains("Test message")).isTrue();
+		
+		Assert.assertTrue(0 < consumer.getCountReceived_TestQueue1());
+		Assert.assertEquals(0, consumer.getCountReceived_TestTopic1()); // this receiver does not work!
+		Assert.assertTrue( 0 < consumer.getCountReceived_TestTopic1_withContainerFactory());
+		
+		Assert.assertEquals(1 + sendRepeatCount, (consumer.getCountReceived_TestQueue1() + consumer.getCountReceived_TestQueue1_withContainerFactory()));
+		Assert.assertEquals(1 + sendRepeatCount, consumer.getCountReceived_TestTopic1_withContainerFactory());
+		
 	}
 
 }


### PR DESCRIPTION
I found it non-intuitive to subscribe both to a Topic and a Queue in single spring-boot / springframework application.

The following code seems OK, but does not work
```
@Component 
public class MyJmsListener {
  @JmsListener(destination = "TestQueue1") 
  public void receiveQueueMsg(String msg) {}

  @JmsListener(destination = "TestTopic1") 
  public void receiveTopicMsg(String msg) {}
}

```

so I have enhanced the sample "spring-boot-samples/spring-boot-sample-activemq" to make it work
Basically, you have to be explicit to use a bean configuration "jmsListenerContainerTopic" ...

`@JmsListener(destination = "TestTopic1", containerFactory="jmsListenerContainerTopic")
`


- [x] I have signed the CLA
