### PR TITLE
Add option to configure logging filters

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -43,6 +43,8 @@ content into your application. Rather, pick only the properties that you need.
 	logging.file= # Log file name. For instance, `myapp.log`
 	logging.file.max-history= # Maximum of archive log files to keep. Only supported with the default logback setup.
 	logging.file.max-size= # Maximum log file size. Only supported with the default logback setup.
+	logging.filters.console= # Comma-separated list of filter classes to apply to console appender. Only supported with the default logback setup.
+	logging.filters.file= # Comma-separated list of filter classes to apply to file appender. Only supported with the default logback setup.
 	logging.level.*= # Log levels severity mapping. For instance, `logging.level.org.springframework=DEBUG`
 	logging.path= # Location of the log file. For instance, `/var/log`
 	logging.pattern.console= # Appender pattern for output to the console. Supported only with the default Logback setup.

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -86,6 +86,18 @@
       "defaultValue": 0
     },
     {
+      "name": "logging.filter.console",
+      "type": "java.lang.String[]",
+      "description": "Comma-separated list of filter classes to apply to console appender. Only supported with the default logback setup.",
+      "sourceType": "org.springframework.boot.logging.LoggingApplicationListener"
+    },
+    {
+      "name": "logging.filter.file",
+      "type": "java.lang.String[]",
+      "description": "Comma-separated list of filter classes to apply to file appender. Only supported with the default logback setup.",
+      "sourceType": "org.springframework.boot.logging.LoggingApplicationListener"
+    },
+    {
       "name": "logging.level",
       "type": "java.util.Map<java.lang.String,java.lang.String>",
       "description": "Log levels severity mapping. For instance, 'logging.level.org.springframework=DEBUG'",


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

This PR introduces `logging.filters.console` and `logging.filters.file` properties which allow applying logging filters for default console and file appenders.

This is in particular very useful in scenarios where file appender is enabled and users would like to have different things end up in console and file log.

This is related to #4357. Even though that issue was declined, the changes from this PR offer more flexibility and are IMO worth considering.
