### PR TITLE
Fix "spring war" to copy resources to WEB-INF/classes

### DIFF
--- a/spring-boot-cli/src/it/java/org/springframework/boot/cli/WarCommandIT.java
+++ b/spring-boot-cli/src/it/java/org/springframework/boot/cli/WarCommandIT.java
@@ -27,9 +27,6 @@ import java.io.File;
 import java.util.zip.ZipFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Integration test for {@link WarCommand}.
@@ -49,18 +46,18 @@ public class WarCommandIT {
 		Invocation invocation = this.cli.invoke("war", war.getAbsolutePath(),
 				"war.groovy");
 		invocation.await();
-		assertTrue(war.exists());
+		assertThat(war.exists()).isTrue();
 		Process process = new JavaExecutable()
 				.processBuilder("-jar", war.getAbsolutePath(), "--server.port=" + port)
 				.start();
 		invocation = new Invocation(process);
 		invocation.await();
-		assertThat(invocation.getOutput(), containsString("onStart error"));
-		assertThat(invocation.getOutput(), containsString("Tomcat started"));
-		assertThat(invocation.getOutput(),
-				containsString("/WEB-INF/lib-provided/tomcat-embed-core"));
-		assertThat(invocation.getOutput(),
-				containsString("/WEB-INF/lib-provided/tomcat-embed-core"));
+		assertThat(invocation.getOutput()).contains("onStart error");
+		assertThat(invocation.getOutput()).contains("Tomcat started");
+		assertThat(invocation.getOutput())
+				.contains("/WEB-INF/lib-provided/tomcat-embed-core");
+		assertThat(invocation.getOutput())
+				.contains("/WEB-INF/lib-provided/tomcat-embed-core");
 		process.destroy();
 	}
 
@@ -70,7 +67,7 @@ public class WarCommandIT {
 		Invocation invocation = this.cli.invoke("war", war.getAbsolutePath(),
 				"war.groovy");
 		invocation.await();
-		assertTrue(war.exists());
+		assertThat(war.exists()).isTrue();
 
 		ZipFile warFile = new ZipFile(war.getAbsolutePath());
 		try {

--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/archive/ArchiveCommand.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/archive/ArchiveCommand.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.cli.command.archive;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -73,6 +72,7 @@ import org.springframework.util.Assert;
  * @author Andy Wilkinson
  * @author Phillip Webb
  * @author Andrey Stolyarov
+ * @author Henri Kerola
  */
 abstract class ArchiveCommand extends OptionParsingCommand {
 
@@ -93,7 +93,7 @@ abstract class ArchiveCommand extends OptionParsingCommand {
 
 		private final String type;
 
-		private final Layout layout;
+		protected final Layout layout;
 
 		private OptionSpec<String> includeOption;
 
@@ -278,12 +278,14 @@ abstract class ArchiveCommand extends OptionParsingCommand {
 					libraries.add(new Library(entry.getFile(), LibraryScope.COMPILE));
 				}
 				else {
-					writer.writeEntry(entry.getName(),
-							new FileInputStream(entry.getFile()));
+					writeClasspathEntry(writer, entry);
 				}
 			}
 			return libraries;
 		}
+
+		protected abstract void writeClasspathEntry(JarWriter writer,
+				MatchedResource entry) throws IOException;
 
 		protected abstract LibraryScope getLibraryScope(File file);
 

--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/archive/JarCommand.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/archive/JarCommand.java
@@ -17,8 +17,11 @@
 package org.springframework.boot.cli.command.archive;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 
 import org.springframework.boot.cli.command.Command;
+import org.springframework.boot.loader.tools.JarWriter;
 import org.springframework.boot.loader.tools.Layouts;
 import org.springframework.boot.loader.tools.LibraryScope;
 
@@ -27,6 +30,7 @@ import org.springframework.boot.loader.tools.LibraryScope;
  *
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Henri Kerola
  */
 public class JarCommand extends ArchiveCommand {
 
@@ -44,6 +48,13 @@ public class JarCommand extends ArchiveCommand {
 		@Override
 		protected LibraryScope getLibraryScope(File file) {
 			return LibraryScope.COMPILE;
+		}
+
+		@Override
+		protected void writeClasspathEntry(JarWriter writer,
+				ResourceMatcher.MatchedResource entry) throws IOException {
+			writer.writeEntry(entry.getName(),
+					new FileInputStream(entry.getFile()));
 		}
 
 	}

--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/archive/WarCommand.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/archive/WarCommand.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.cli.command.archive;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 
 import org.springframework.boot.cli.command.Command;
@@ -29,6 +30,7 @@ import org.springframework.boot.loader.tools.LibraryScope;
  *
  * @author Andrey Stolyarov
  * @author Phillip Webb
+ * @author Henri Kerola
  * @since 1.3.0
  */
 public class WarCommand extends ArchiveCommand {
@@ -61,6 +63,12 @@ public class WarCommand extends ArchiveCommand {
 			super.addCliClasses(writer);
 		}
 
+		@Override
+		protected void writeClasspathEntry(JarWriter writer,
+				ResourceMatcher.MatchedResource entry) throws IOException {
+			writer.writeEntry(this.layout.getClassesLocation() + entry.getName(),
+					new FileInputStream(entry.getFile()));
+		}
 	}
 
 }


### PR DESCRIPTION
Fixes `spring war` to copy resources to war's `WEB-INF/classes` instead of `/`.

Another way to fix this issue would have been to introduce a method `getResourcesLocation()` to `org.springframework.boot.loader.tools.Layout` use that in `ArchiveCommand`. But I wasn't sure if you want to go with that approach. Fixes issue #6351.


<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA
