### PR TITLE
Improves metrics performance by not guarding map.get

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/buffer/BufferCounterService.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/buffer/BufferCounterService.java
@@ -58,8 +58,9 @@ public class BufferCounterService implements CounterService {
 	}
 
 	private String wrap(String metricName) {
-		if (this.names.containsKey(metricName)) {
-			return this.names.get(metricName);
+		String cached = this.names.get(metricName);
+		if (cached != null) {
+			return cached;
 		}
 		if (metricName.startsWith("counter") || metricName.startsWith("meter")) {
 			return metricName;

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/dropwizard/DropwizardMetricServices.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/dropwizard/DropwizardMetricServices.java
@@ -128,8 +128,9 @@ public class DropwizardMetricServices implements CounterService, GaugeService {
 	}
 
 	private String wrapName(String metricName, String prefix) {
-		if (this.names.containsKey(metricName)) {
-			return this.names.get(metricName);
+		String cached = this.names.get(metricName);
+		if (cached != null) {
+			return cached;
 		}
 		if (metricName.startsWith(prefix)) {
 			return metricName;

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/writer/DefaultCounterService.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/writer/DefaultCounterService.java
@@ -55,8 +55,9 @@ public class DefaultCounterService implements CounterService {
 	}
 
 	private String wrap(String metricName) {
-		if (this.names.containsKey(metricName)) {
-			return this.names.get(metricName);
+		String cached = this.names.get(metricName);
+		if (cached != null) {
+			return cached;
 		}
 		if (metricName.startsWith("counter.") || metricName.startsWith("meter.")) {
 			return metricName;


### PR DESCRIPTION
<!-- 
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
--> 

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [x] I have signed the CLA

ConcurrentHashMap implements `containsKey` with `get`. By removing a
redundant call to `containsKey`, we guarantee better performance in our
counter services.

The geek inside measured this with JMH, and found under 4 threads of
contention, throughput on this check was 40% higher in success case.

```
Benchmark                                  Mode  Cnt     Score     Error   Units
TestBenchmarks.containsKeyAndGet_success  thrpt   30   432.389 ±  20.616  ops/us
TestBenchmarks.get_success                thrpt   30   606.789 ±  10.848  ops/us
```