### PR TITLE
Use the managed version for H2 in spring-boot-sample-actuator

### DIFF
--- a/spring-boot-samples/spring-boot-sample-actuator/build.gradle
+++ b/spring-boot-samples/spring-boot-sample-actuator/build.gradle
@@ -20,8 +20,6 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'spring-boot'
 
-ext['h2.version'] = '1.4.192'
-
 jar {
 	baseName = 'spring-boot-sample-actuator'
 }
@@ -47,7 +45,7 @@ dependencies {
 	compile("org.springframework.boot:spring-boot-starter-jdbc")
 	compile("org.springframework.boot:spring-boot-starter-security")
 	compile("org.springframework.boot:spring-boot-starter-web")
-	compile group:"com.h2database", name:"h2", version:property('h2.version')
+	compile("com.h2database:h2")
 
 	testCompile("org.springframework.boot:spring-boot-starter-test")
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

It looks accidentally added in https://github.com/spring-projects/spring-boot/commit/05ff4ed4e07349170e9ad4371bdf8687b82542ba .