### PR TITLE
Remove unnecessary file deletion in HeapdumpMvcEndpoint

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/HeapdumpMvcEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/HeapdumpMvcEndpoint.java
@@ -56,7 +56,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  */
 @ConfigurationProperties("endpoints.heapdump")
 @HypermediaDisabled
-public class HeapdumpMvcEndpoint extends AbstractMvcEndpoint implements MvcEndpoint {
+public class HeapdumpMvcEndpoint extends AbstractMvcEndpoint {
 
 	private final long timeout;
 
@@ -116,10 +116,8 @@ public class HeapdumpMvcEndpoint extends AbstractMvcEndpoint implements MvcEndpo
 
 	private File createTempFile(boolean live) throws IOException {
 		String date = new SimpleDateFormat("yyyy-MM-dd-HH-mm").format(new Date());
-		File file = File.createTempFile("heapdump" + date + (live ? "-live" : ""),
+		return File.createTempFile("heapdump" + date + (live ? "-live" : ""),
 				".hprof");
-		file.delete();
-		return file;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

The removed file deletion in `HeapdumpMvcEndpoint` looks unnecessary unless I'm missing anything.

This PR also removes redundant `implements MvcEndpoint`.