### PR TITLE
Support @ConditionalOnSingleCandidate on auto configuration of JdbcTemplate and DataSourceTransactionManager #6448

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
@@ -47,10 +47,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.type.AnnotatedTypeMetadata;
-import org.springframework.jdbc.core.JdbcOperations;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
 /**
@@ -59,6 +55,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
  * @author Dave Syer
  * @author Phillip Webb
  * @author Stephane Nicoll
+ * @author Kazuki Shimizu
  */
 @Configuration
 @ConditionalOnClass({ DataSource.class, EmbeddedDatabaseType.class })
@@ -106,29 +103,6 @@ public class DataSourceAutoConfiguration {
 			DataSourceConfiguration.Dbcp.class, DataSourceConfiguration.Dbcp2.class })
 	protected static class PooledDataSourceConfiguration {
 
-	}
-
-	@Configuration
-	@Conditional(DataSourceAutoConfiguration.DataSourceAvailableCondition.class)
-	protected static class JdbcTemplateConfiguration {
-
-		private final DataSource dataSource;
-
-		public JdbcTemplateConfiguration(DataSource dataSource) {
-			this.dataSource = dataSource;
-		}
-
-		@Bean
-		@ConditionalOnMissingBean(JdbcOperations.class)
-		public JdbcTemplate jdbcTemplate() {
-			return new JdbcTemplate(this.dataSource);
-		}
-
-		@Bean
-		@ConditionalOnMissingBean(NamedParameterJdbcOperations.class)
-		public NamedParameterJdbcTemplate namedParameterJdbcTemplate() {
-			return new NamedParameterJdbcTemplate(this.dataSource);
-		}
 	}
 
 	@Configuration

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
@@ -20,9 +20,9 @@ import javax.sql.DataSource;
 
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -39,6 +39,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  * @author Dave Syer
  * @author Stephane Nicoll
  * @author Andy Wilkinson
+ * @author Kazuki Shimizu
  */
 @Configuration
 @ConditionalOnClass({ JdbcTemplate.class, PlatformTransactionManager.class })
@@ -46,7 +47,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 public class DataSourceTransactionManagerAutoConfiguration {
 
 	@Configuration
-	@ConditionalOnBean(DataSource.class)
+	@ConditionalOnSingleCandidate(DataSource.class)
 	static class DataSourceTransactionManagerConfiguration {
 
 		private final DataSource dataSource;

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateAutoConfiguration.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jdbc;
+
+import javax.sql.DataSource;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for {@link JdbcTemplate} and {@link NamedParameterJdbcTemplate}.
+ *
+ * @author Dave Syer
+ * @author Phillip Webb
+ * @author Stephane Nicoll
+ * @author Kazuki Shimizu
+ * @since 1.4.0
+ */
+@Configuration
+@ConditionalOnClass(DataSource.class)
+@ConditionalOnSingleCandidate(DataSource.class)
+@AutoConfigureAfter(DataSourceAutoConfiguration.class)
+public class JdbcTemplateAutoConfiguration {
+
+	private final DataSource dataSource;
+
+	JdbcTemplateAutoConfiguration(DataSource dataSource) {
+		this.dataSource = dataSource;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(JdbcOperations.class)
+	public JdbcTemplate jdbcTemplate() {
+		return new JdbcTemplate(this.dataSource);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(NamedParameterJdbcOperations.class)
+	public NamedParameterJdbcTemplate namedParameterJdbcTemplate() {
+		return new NamedParameterJdbcTemplate(this.dataSource);
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -51,6 +51,7 @@ org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration,\
 org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,\
 org.springframework.boot.autoconfigure.jdbc.JndiDataSourceAutoConfiguration,\
 org.springframework.boot.autoconfigure.jdbc.XADataSourceAutoConfiguration,\
+org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration,\
 org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration,\
 org.springframework.boot.autoconfigure.jms.JmsAutoConfiguration,\
 org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfigurationTests.java
@@ -42,8 +42,6 @@ import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -226,35 +224,6 @@ public class DataSourceAutoConfigurationTests {
 		this.context.refresh();
 		DataSource dataSource = this.context.getBean(DataSource.class);
 		assertThat(dataSource).isInstanceOf(BasicDataSource.class);
-	}
-
-	@Test
-	public void testJdbcTemplateExists() throws Exception {
-		this.context.register(DataSourceAutoConfiguration.class,
-				PropertyPlaceholderAutoConfiguration.class);
-		this.context.refresh();
-		JdbcTemplate jdbcTemplate = this.context.getBean(JdbcTemplate.class);
-		assertThat(jdbcTemplate).isNotNull();
-		assertThat(jdbcTemplate.getDataSource()).isNotNull();
-	}
-
-	@Test
-	public void testJdbcTemplateExistsWithCustomDataSource() throws Exception {
-		this.context.register(TestDataSourceConfiguration.class,
-				DataSourceAutoConfiguration.class,
-				PropertyPlaceholderAutoConfiguration.class);
-		this.context.refresh();
-		JdbcTemplate jdbcTemplate = this.context.getBean(JdbcTemplate.class);
-		assertThat(jdbcTemplate).isNotNull();
-		assertThat(jdbcTemplate.getDataSource() instanceof BasicDataSource).isTrue();
-	}
-
-	@Test
-	public void testNamedParameterJdbcTemplateExists() throws Exception {
-		this.context.register(DataSourceAutoConfiguration.class,
-				PropertyPlaceholderAutoConfiguration.class);
-		this.context.refresh();
-		assertThat(this.context.getBean(NamedParameterJdbcOperations.class)).isNotNull();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceInitializerTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceInitializerTests.java
@@ -28,7 +28,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.springframework.beans.factory.UnsatisfiedDependencyException;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -223,7 +223,7 @@ public class DataSourceInitializerTests {
 			fail("User does not exist");
 		}
 		catch (Exception ex) {
-			assertThat(ex).isInstanceOf(UnsatisfiedDependencyException.class);
+			assertThat(ex).isInstanceOf(BeanCreationException.class);
 		}
 	}
 
@@ -245,7 +245,7 @@ public class DataSourceInitializerTests {
 			fail("User does not exist");
 		}
 		catch (Exception ex) {
-			assertThat(ex).isInstanceOf(UnsatisfiedDependencyException.class);
+			assertThat(ex).isInstanceOf(BeanCreationException.class);
 		}
 	}
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateAutoConfigurationTests.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jdbc;
+
+import java.util.Random;
+
+import javax.sql.DataSource;
+
+import org.apache.commons.dbcp.BasicDataSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DataSourceAutoConfiguration}.
+ *
+ * @author Dave Syer
+ * @author Stephane Nicoll
+ * @author Kazuki Shimizu
+ * @since 1.4.0
+ */
+public class JdbcTemplateAutoConfigurationTests {
+
+	private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+	@Before
+	public void init() {
+		EmbeddedDatabaseConnection.override = null;
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.datasource.initialize:false",
+				"spring.datasource.url:jdbc:hsqldb:mem:testdb-" + new Random().nextInt());
+	}
+
+	@After
+	public void restore() {
+		EmbeddedDatabaseConnection.override = null;
+		this.context.close();
+	}
+
+	@Test
+	public void testJdbcTemplateExists() throws Exception {
+		this.context.register(DataSourceAutoConfiguration.class, JdbcTemplateAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		JdbcTemplate jdbcTemplate = this.context.getBean(JdbcTemplate.class);
+		assertThat(jdbcTemplate).isNotNull();
+		assertThat(jdbcTemplate.getDataSource()).isNotNull();
+	}
+
+	@Test
+	public void testJdbcTemplateExistsWithCustomDataSource() throws Exception {
+		this.context.register(TestDataSourceConfiguration.class,
+				DataSourceAutoConfiguration.class, JdbcTemplateAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		JdbcTemplate jdbcTemplate = this.context.getBean(JdbcTemplate.class);
+		assertThat(jdbcTemplate).isNotNull();
+		assertThat(jdbcTemplate.getDataSource() instanceof BasicDataSource).isTrue();
+	}
+
+	@Test
+	public void testNamedParameterJdbcTemplateExists() throws Exception {
+		this.context.register(DataSourceAutoConfiguration.class, JdbcTemplateAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		assertThat(this.context.getBean(NamedParameterJdbcOperations.class)).isNotNull();
+	}
+
+	@Test
+	public void testMultiDataSource() throws Exception {
+		this.context.register(TestMultiDataSourceConfiguration.class,
+				DataSourceAutoConfiguration.class, JdbcTemplateAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		assertThat(this.context.getBeansOfType(JdbcOperations.class)).isEmpty();
+		assertThat(this.context.getBeansOfType(NamedParameterJdbcOperations.class)).isEmpty();
+	}
+
+	@Test
+	public void testMultiDataSourceUsingPrimary() throws Exception {
+		this.context.register(TestMultiDataSourceUsingPrimaryConfiguration.class,
+				DataSourceAutoConfiguration.class, JdbcTemplateAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		assertThat(this.context.getBean(JdbcOperations.class)).isNotNull();
+		assertThat(this.context.getBean(NamedParameterJdbcOperations.class)).isNotNull();
+	}
+
+	@Test
+	public void testExistingCustomJdbcTemplate() throws Exception {
+		this.context.register(CustomConfiguration.class, DataSourceAutoConfiguration.class,
+				JdbcTemplateAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		assertThat(this.context.getBean(JdbcOperations.class))
+				.isEqualTo(this.context.getBean("customJdbcOperations"));
+	}
+
+	@Test
+	public void testExistingCustomNamedParameterJdbcTemplate() throws Exception {
+		this.context.register(CustomConfiguration.class, DataSourceAutoConfiguration.class,
+				JdbcTemplateAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		assertThat(this.context.getBean(NamedParameterJdbcOperations.class))
+				.isEqualTo(this.context.getBean("customNamedParameterJdbcOperations"));
+	}
+
+	@Configuration
+	static class CustomConfiguration {
+		@Bean
+		JdbcOperations customJdbcOperations(DataSource dataSource) {
+			return new JdbcTemplate(dataSource);
+		}
+		@Bean
+		NamedParameterJdbcOperations customNamedParameterJdbcOperations(DataSource dataSource) {
+			return new NamedParameterJdbcTemplate(dataSource);
+		}
+	}
+
+	@Configuration
+	static class TestDataSourceConfiguration {
+
+		private BasicDataSource pool;
+
+		@Bean
+		public DataSource dataSource() {
+			this.pool = new BasicDataSource();
+			this.pool.setDriverClassName("org.hsqldb.jdbcDriver");
+			this.pool.setUrl("jdbc:hsqldb:target/overridedb");
+			this.pool.setUsername("sa");
+			return this.pool;
+		}
+
+	}
+
+	@Configuration
+	static class TestMultiDataSourceConfiguration {
+
+		@Bean
+		public DataSource test1DataSource() {
+			BasicDataSource pool = new BasicDataSource();
+			pool.setDriverClassName("org.hsqldb.jdbcDriver");
+			pool.setUrl("jdbc:hsqldb:target/test1");
+			pool.setUsername("sa");
+			return pool;
+		}
+
+		@Bean
+		public DataSource test2DataSource() {
+			BasicDataSource pool = new BasicDataSource();
+			pool.setDriverClassName("org.hsqldb.jdbcDriver");
+			pool.setUrl("jdbc:hsqldb:target/test2");
+			pool.setUsername("sa");
+			return pool;
+		}
+
+	}
+
+	@Configuration
+	static class TestMultiDataSourceUsingPrimaryConfiguration {
+
+		@Bean
+		@Primary
+		public DataSource test1DataSource() {
+			BasicDataSource pool = new BasicDataSource();
+			pool.setDriverClassName("org.hsqldb.jdbcDriver");
+			pool.setUrl("jdbc:hsqldb:target/test1");
+			pool.setUsername("sa");
+			return pool;
+		}
+
+		@Bean
+		public DataSource test2DataSource() {
+			BasicDataSource pool = new BasicDataSource();
+			pool.setDriverClassName("org.hsqldb.jdbcDriver");
+			pool.setUrl("jdbc:hsqldb:target/test2");
+			pool.setUsername("sa");
+			return pool;
+		}
+
+	}
+
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

I've supported to ignore auto configuration of `JdbcTemplate` and `DataSourceTransactionManager` when detect multiple datasource. Please review #6448.
