### PR TITLE
Fixed doc reference to an incorrect bootRun/javaexec task property

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -2722,15 +2722,15 @@ Check {spring-boot-maven-plugin-site}/examples/run-debug.html[this example] for 
 [[howto-remote-debug-gradle-run]]
 === Remote debug a Spring Boot application started with Gradle
 To attach a remote debugger to a Spring Boot application started with Gradle you can use
-the `applicationDefaultJvmArgs` in `build.gradle` or `--debug-jvm` command line option.
+the `jvmArgs` property of bootRun task OR `--debug-jvm` command line option.
 
 `build.gradle`:
 
 [source,groovy,indent=0,subs="verbatim,attributes"]
 ----
-	applicationDefaultJvmArgs = [
-	    "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
-	]
+  bootRun {
+      jvmArgs "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
+  }
 ----
 
 
@@ -2738,7 +2738,7 @@ Command line:
 
 [indent=0]
 ----
-	$ gradle run --debug-jvm
+	$ gradle bootRun --debug-jvm
 ----
 
 


### PR DESCRIPTION
This fixes an entry in the doc relating to debugging with the gradle plugin - the command line was referencing the application plugins `run` task instead of `bootRun` and the jvm arguments for an explicit debug can be more direct. I have not opened an issue as the change appears very minor.