### PR TITLE
Add WireMock Boot starter community contribution

### DIFF
--- a/spring-boot-starters/README.adoc
+++ b/spring-boot-starters/README.adoc
@@ -100,4 +100,7 @@ do as they were designed before this was clarified.
 | Charon reverse proxy
 | https://github.com/mkopylec/charon-spring-boot-starter
 
+| http://www.wiremock.org[WireMock] and Spring RESTDocs
+| https://github.com/ePages-de/restdocs-wiremock
+
 |===


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Spring RESTDocs WireMock Integration ...

is a RESTDocs plugin for auto-generating WireMock stubs as part of documenting your REST API with Spring REST Docs.
The basic idea is to use the requests and responses from the integration tests as stubs for testing your client's API contract. The mock templates can be packaged as jar files and be published into your company's artifact repository for this purpose.

The Boot starter simplifies the client-side to run the integration tests against the WireMock stubs.