### PR TITLE
Added embedded Redis support

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -438,6 +438,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>de.flapdoodle.embed</groupId>
+			<artifactId>de.flapdoodle.embed.redis</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.boot.autoconfigure.data.redis.RedisProperties.Sentine
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisNode;
@@ -84,15 +85,15 @@ public class RedisAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(RedisConnectionFactory.class)
-		public JedisConnectionFactory redisConnectionFactory()
+		public JedisConnectionFactory redisConnectionFactory(Environment environment)
 				throws UnknownHostException {
-			return applyProperties(createJedisConnectionFactory());
+			return applyProperties(createJedisConnectionFactory(), environment);
 		}
 
 		protected final JedisConnectionFactory applyProperties(
-				JedisConnectionFactory factory) {
+				JedisConnectionFactory factory, Environment environment) {
 			factory.setHostName(this.properties.getHost());
-			factory.setPort(this.properties.getPort());
+			factory.setPort(this.properties.determinePort(environment));
 			if (this.properties.getPassword() != null) {
 				factory.setPassword(this.properties.getPassword());
 			}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.data.redis;
 import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.env.Environment;
 
 /**
  * Configuration properties for Redis.
@@ -29,6 +30,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties(prefix = "spring.redis")
 public class RedisProperties {
+
+	/**
+	 * Default port used when the configured port is {@code null}.
+	 */
+	public static final int DEFAULT_PORT = 6379;
 
 	/**
 	 * Database index used by the connection factory.
@@ -48,7 +54,7 @@ public class RedisProperties {
 	/**
 	 * Redis server port.
 	 */
-	private int port = 6379;
+	private Integer port = null;
 
 	/**
 	 * Connection timeout in milliseconds.
@@ -85,11 +91,11 @@ public class RedisProperties {
 		this.password = password;
 	}
 
-	public int getPort() {
+	public Integer getPort() {
 		return this.port;
 	}
 
-	public void setPort(int port) {
+	public void setPort(Integer port) {
 		this.port = port;
 	}
 
@@ -123,6 +129,24 @@ public class RedisProperties {
 
 	public void setCluster(Cluster cluster) {
 		this.cluster = cluster;
+	}
+
+	public int determinePort(Environment environment) {
+		if (this.port == null) {
+			return DEFAULT_PORT;
+		}
+		if (this.port == 0) {
+			if (environment != null) {
+				String localPort = environment.getProperty("local.redis.port");
+				if (localPort != null) {
+					return Integer.valueOf(localPort);
+				}
+			}
+			throw new IllegalStateException(
+					"spring.redis.port=0 and no local redis port configuration "
+							+ "is available");
+		}
+		return this.port;
 	}
 
 	/**
@@ -256,4 +280,5 @@ public class RedisProperties {
 		}
 
 	}
+
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/embedded/EmbeddedRedisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/embedded/EmbeddedRedisAutoConfiguration.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.redis.embedded;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+
+import de.flapdoodle.embed.process.config.IRuntimeConfig;
+import de.flapdoodle.embed.process.config.io.ProcessOutput;
+import de.flapdoodle.embed.process.distribution.IVersion;
+import de.flapdoodle.embed.process.io.Processors;
+import de.flapdoodle.embed.process.io.Slf4jLevel;
+import de.flapdoodle.embed.process.io.progress.Slf4jProgressListener;
+import de.flapdoodle.embed.process.runtime.Network;
+import de.flapdoodle.embed.process.store.ArtifactStoreBuilder;
+import de.flapdoodle.embed.redis.Command;
+import de.flapdoodle.embed.redis.RedisDExecutable;
+import de.flapdoodle.embed.redis.RedisDStarter;
+import de.flapdoodle.embed.redis.config.AbstractRedisConfig;
+import de.flapdoodle.embed.redis.config.DownloadConfigBuilder;
+import de.flapdoodle.embed.redis.config.ExtractedArtifactStoreBuilder;
+import de.flapdoodle.embed.redis.config.RedisDConfig;
+import de.flapdoodle.embed.redis.config.RuntimeConfigBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+import org.springframework.util.Assert;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Embedded Redis.
+ *
+ * @author Alexey Zhokhov
+ * @since 1.4.0
+ */
+@Configuration
+@ConditionalOnClass({ Jedis.class, RedisDStarter.class })
+@EnableConfigurationProperties({ RedisProperties.class, EmbeddedRedisProperties.class })
+@AutoConfigureBefore(RedisAutoConfiguration.class)
+public class EmbeddedRedisAutoConfiguration {
+
+	private static final byte[] IP4_LOOPBACK_ADDRESS = { 127, 0, 0, 1 };
+
+	private static final byte[] IP6_LOOPBACK_ADDRESS = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 1 };
+
+	private final RedisProperties properties;
+
+	private final EmbeddedRedisProperties embeddedProperties;
+
+	private final ApplicationContext context;
+
+	private final IRuntimeConfig runtimeConfig;
+
+	public EmbeddedRedisAutoConfiguration(RedisProperties properties,
+			EmbeddedRedisProperties embeddedProperties, ApplicationContext context,
+			IRuntimeConfig runtimeConfig) {
+		this.properties = properties;
+		this.embeddedProperties = embeddedProperties;
+		this.context = context;
+		this.runtimeConfig = runtimeConfig;
+	}
+
+	@Bean(initMethod = "start", destroyMethod = "stop")
+	@ConditionalOnMissingBean
+	public RedisDExecutable embeddedRedisServer(RedisDConfig redisdConfig)
+			throws IOException {
+		if (getPort() == 0) {
+			publishPortInfo(redisdConfig.net().getPort());
+		}
+		RedisDStarter redisdStarter = getRedisdStarter(this.runtimeConfig);
+		return redisdStarter.prepare(redisdConfig);
+	}
+
+	private RedisDStarter getRedisdStarter(IRuntimeConfig runtimeConfig) {
+		if (runtimeConfig == null) {
+			return RedisDStarter.getDefaultInstance();
+		}
+		return RedisDStarter.getInstance(runtimeConfig);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public RedisDConfig embeddedRedisConfiguration() throws IOException {
+		IVersion featureAwareVersion = new ToStringFriendlyFeatureAwareVersion(
+				this.embeddedProperties.getVersion());
+
+		AbstractRedisConfig.Net port = null;
+		if (getPort() > 0) {
+			port = new AbstractRedisConfig.Net(getPort());
+		}
+		else {
+			// get free server port
+			port = new AbstractRedisConfig.Net();
+		}
+
+		AbstractRedisConfig.Storage storage = null;
+		if (this.embeddedProperties.getStorage() != null) {
+			storage = new AbstractRedisConfig.Storage(
+					this.embeddedProperties.getStorage().getDatabaseDir(), null, null);
+		}
+		else {
+			storage = new AbstractRedisConfig.Storage();
+		}
+
+		return new RedisDConfig(featureAwareVersion, port, storage,
+				new AbstractRedisConfig.Timeout());
+	}
+
+	private int getPort() {
+		if (this.properties.getPort() == null) {
+			return RedisProperties.DEFAULT_PORT;
+		}
+		return this.properties.getPort();
+	}
+
+	private InetAddress getHost() throws UnknownHostException {
+		if (this.properties.getHost() == null) {
+			return InetAddress.getByAddress(Network.localhostIsIPv6()
+					? IP6_LOOPBACK_ADDRESS : IP4_LOOPBACK_ADDRESS);
+		}
+		return InetAddress.getByName(this.properties.getHost());
+	}
+
+	private void publishPortInfo(int port) {
+		setPortProperty(this.context, port);
+	}
+
+	private void setPortProperty(ApplicationContext currentContext, int port) {
+		if (currentContext instanceof ConfigurableApplicationContext) {
+			MutablePropertySources sources = ((ConfigurableApplicationContext) currentContext)
+					.getEnvironment().getPropertySources();
+			getRedisPorts(sources).put("local.redis.port", port);
+		}
+		if (currentContext.getParent() != null) {
+			setPortProperty(currentContext.getParent(), port);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> getRedisPorts(MutablePropertySources sources) {
+		PropertySource<?> propertySource = sources.get("redis.ports");
+		if (propertySource == null) {
+			propertySource = new MapPropertySource("redis.ports",
+					new HashMap<String, Object>());
+			sources.addFirst(propertySource);
+		}
+		return (Map<String, Object>) propertySource.getSource();
+	}
+
+	@Configuration
+	@ConditionalOnClass(Logger.class)
+	@ConditionalOnMissingBean(IRuntimeConfig.class)
+	static class RuntimeConfigConfiguration {
+
+		@Bean
+		public IRuntimeConfig embeddedRedisRuntimeConfig() {
+			Logger logger = LoggerFactory
+					.getLogger(getClass().getPackage().getName() + ".EmbeddedRedis");
+			ProcessOutput processOutput = new ProcessOutput(
+					Processors.logTo(logger, Slf4jLevel.INFO),
+					Processors.logTo(logger, Slf4jLevel.ERROR), Processors.named(
+							"[console>]", Processors.logTo(logger, Slf4jLevel.DEBUG)));
+			return new RuntimeConfigBuilder().defaultsWithLogger(Command.RedisD, logger)
+					.processOutput(processOutput).artifactStore(getArtifactStore(logger))
+					.build();
+		}
+
+		private ArtifactStoreBuilder getArtifactStore(Logger logger) {
+			return new ExtractedArtifactStoreBuilder().defaults(Command.RedisD)
+					.download(new DownloadConfigBuilder()
+							.defaultsForCommand(Command.RedisD)
+							.progressListener(new Slf4jProgressListener(logger)).build());
+		}
+
+	}
+
+	/**
+	 * A workaround for the lack of a {@code toString} implementation on
+	 * {@code GenericFeatureAwareVersion}.
+	 */
+	private final static class ToStringFriendlyFeatureAwareVersion implements IVersion {
+
+		private final String version;
+
+		private ToStringFriendlyFeatureAwareVersion(String version) {
+			Assert.notNull(version, "version must not be null");
+			this.version = version;
+		}
+
+		@Override
+		public String asInDownloadPath() {
+			return this.version;
+		}
+
+		@Override
+		public String toString() {
+			return this.version;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + this.version.hashCode();
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() == obj.getClass()) {
+				ToStringFriendlyFeatureAwareVersion other = (ToStringFriendlyFeatureAwareVersion) obj;
+				boolean equals = true;
+				equals &= this.version.equals(other.version);
+				return equals;
+			}
+			return super.equals(obj);
+		}
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/embedded/EmbeddedRedisProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/embedded/EmbeddedRedisProperties.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.redis.embedded;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Embedded Redis.
+ *
+ * @author Alexey Zhokhov
+ * @since 1.4.0
+ */
+@ConfigurationProperties(prefix = "spring.redis.embedded")
+public class EmbeddedRedisProperties {
+
+	/**
+	 * Version of Redis to use.
+	 */
+	private String version = "3.2.1";
+
+	private final Storage storage = new Storage();
+
+	public String getVersion() {
+		return this.version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	public Storage getStorage() {
+		return this.storage;
+	}
+
+	public static class Storage {
+
+		/**
+		 * Directory used for data storage.
+		 */
+		private String databaseDir;
+
+		public String getDatabaseDir() {
+			return this.databaseDir;
+		}
+
+		public void setDatabaseDir(String databaseDir) {
+			this.databaseDir = databaseDir;
+		}
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/embedded/package-info.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/embedded/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Spring Data Redis (Embedded).
+ */
+package org.springframework.boot.autoconfigure.data.redis.embedded;

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -36,6 +36,7 @@ org.springframework.boot.autoconfigure.data.neo4j.Neo4jRepositoriesAutoConfigura
 org.springframework.boot.autoconfigure.data.solr.SolrRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration,\
+org.springframework.boot.autoconfigure.data.redis.embedded.EmbeddedRedisAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration,\
 org.springframework.boot.autoconfigure.elasticsearch.jest.JestAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/embedded/EmbeddedRedisAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/embedded/EmbeddedRedisAutoConfigurationTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.redis.embedded;
+
+import java.io.File;
+import java.net.UnknownHostException;
+
+import org.junit.After;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.util.FileSystemUtils;
+import org.springframework.util.SocketUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link EmbeddedRedisAutoConfiguration}.
+ *
+ * @author Alexey Zhokhov
+ */
+public class EmbeddedRedisAutoConfigurationTests {
+
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void close() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void defaultVersion() {
+		assertVersionConfiguration(null, "3.2.1");
+	}
+
+	@Test
+	public void randomlyAllocatedPortIsAvailableWhenCreatingRedisClient() {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.redis.port=0");
+		this.context.register(EmbeddedRedisAutoConfiguration.class,
+				JedisClientConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		assertThat(this.context.getBean(Jedis.class).getClient().getPort())
+				.isEqualTo(Integer.valueOf(
+						this.context.getEnvironment().getProperty("local.redis.port")));
+	}
+
+	@Test
+	public void portIsAvailableInParentContext() {
+		ConfigurableApplicationContext parent = new AnnotationConfigApplicationContext();
+		parent.refresh();
+		try {
+			this.context = new AnnotationConfigApplicationContext();
+			this.context.setParent(parent);
+			EnvironmentTestUtils.addEnvironment(this.context, "spring.redis.port=0");
+			this.context.register(EmbeddedRedisAutoConfiguration.class,
+					JedisClientConfiguration.class,
+					PropertyPlaceholderAutoConfiguration.class);
+			this.context.refresh();
+			assertThat(parent.getEnvironment().getProperty("local.redis.port"))
+					.isNotNull();
+		}
+		finally {
+			parent.close();
+		}
+	}
+
+	@Test
+	public void redisWritesToCustomDatabaseDir() {
+		File customDatabaseDir = new File("target/custom-redis-database-dir");
+		FileSystemUtils.deleteRecursively(customDatabaseDir);
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context, "spring.redis.port=0",
+				"spring.redis.embedded.storage.databaseDir="
+						+ customDatabaseDir.getPath());
+		this.context.register(EmbeddedRedisAutoConfiguration.class,
+				JedisClientConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		assertThat(customDatabaseDir).isDirectory();
+	}
+
+	private void assertVersionConfiguration(String configuredVersion,
+			String expectedVersion) {
+		this.context = new AnnotationConfigApplicationContext();
+		int redisPort = SocketUtils.findAvailableTcpPort();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.redis.port=" + redisPort);
+		if (configuredVersion != null) {
+			EnvironmentTestUtils.addEnvironment(this.context,
+					"spring.redis.embedded.version=" + configuredVersion);
+		}
+		this.context.register(RedisAutoConfiguration.class,
+				EmbeddedRedisAutoConfiguration.class);
+		this.context.refresh();
+		RedisTemplate<String, String> redis = (RedisTemplate<String, String>) this.context
+				.getBean("redisTemplate");
+		String redisVersion = redis.execute(new RedisCallback<String>() {
+			@Override
+			public String doInRedis(RedisConnection redisConnection)
+					throws DataAccessException {
+				return redisConnection.info("server").getProperty("redis_version");
+			}
+		});
+		assertThat(redisVersion).isEqualTo(expectedVersion);
+	}
+
+	@Configuration
+	static class JedisClientConfiguration {
+
+		@Bean
+		public Jedis jedis(@Value("${local.redis.port}") int port)
+				throws UnknownHostException {
+			return new Jedis("localhost", port);
+		}
+
+	}
+
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -71,6 +71,7 @@
 		<ehcache.version>2.10.2.2.21</ehcache.version>
 		<ehcache3.version>3.1.1</ehcache3.version>
 		<embedded-mongo.version>1.50.5</embedded-mongo.version>
+		<embedded-redis.version>1.11.5-SNAPSHOT</embedded-redis.version>
 		<flyway.version>3.2.1</flyway.version>
 		<freemarker.version>2.3.24-incubating</freemarker.version>
 		<elasticsearch.version>2.3.3</elasticsearch.version>
@@ -853,6 +854,11 @@
 				<groupId>de.flapdoodle.embed</groupId>
 				<artifactId>de.flapdoodle.embed.mongo</artifactId>
 				<version>${embedded-mongo.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.flapdoodle.embed</groupId>
+				<artifactId>de.flapdoodle.embed.redis</artifactId>
+				<version>${embedded-redis.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>dom4j</groupId>

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -3106,6 +3106,23 @@ pooled connection factory by default.
 
 
 
+[[boot-features-redis-embedded]]
+==== Embedded Redis
+Spring Boot offers auto-configuration for
+https://github.com/flapdoodle-oss/de.flapdoodle.embed.redis[Embedded Redis]. To use
+it in your Spring Boot application add a dependency on
+`de.flapdoodle.embed:de.flapdoodle.embed.redis`.
+
+The port that Redis will listen on can be configured using the `spring.redis.port`
+property. To use a randomly allocated free port use a value of zero. The `RedisTemplate`
+created by `RedisAutoConfiguration` will be automatically configured to use the randomly
+allocated port.
+
+If you have SLF4J on the classpath, output produced by Redis will be automatically routed
+to a logger named `org.springframework.boot.autoconfigure.redis.embedded.EmbeddedRedis`.
+
+
+
 [[boot-features-mongodb]]
 === MongoDB
 http://www.mongodb.com/[MongoDB] is an open-source NoSQL document database that uses a

--- a/spring-boot-samples/pom.xml
+++ b/spring-boot-samples/pom.xml
@@ -40,6 +40,7 @@
 		<module>spring-boot-sample-data-mongodb</module>
 		<module>spring-boot-sample-data-neo4j</module>
 		<module>spring-boot-sample-data-redis</module>
+		<module>spring-boot-sample-data-redis-embedded</module>
 		<module>spring-boot-sample-data-rest</module>
 		<module>spring-boot-sample-data-solr</module>
 		<module>spring-boot-sample-devtools</module>

--- a/spring-boot-samples/spring-boot-sample-data-redis-embedded/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-data-redis-embedded/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <!-- Your own application should inherit from spring-boot-starter-parent -->
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-samples</artifactId>
+        <version>1.4.0.BUILD-SNAPSHOT</version>
+    </parent>
+    <artifactId>spring-boot-sample-data-redis-embedded</artifactId>
+    <name>Spring Boot Data Redis Embedded Sample</name>
+    <description>Spring Boot Data Redis Embedded Sample</description>
+    <url>http://projects.spring.io/spring-boot/</url>
+    <organization>
+        <name>Pivotal Software, Inc.</name>
+        <url>http://www.spring.io</url>
+    </organization>
+    <properties>
+        <main.basedir>${basedir}/../..</main.basedir>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.redis</artifactId>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>production</id>
+            <dependencies>
+                <!-- This sample is a test for the autoconfig when commons-pool is *absent*.
+                    In production it would be useful to enable pooling by using this dependency. -->
+                <dependency>
+                    <groupId>commons-pool</groupId>
+                    <artifactId>commons-pool</artifactId>
+                    <type>pom.lastUpdated</type>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-boot-samples/spring-boot-sample-data-redis-embedded/src/main/java/sample/data/redis/embedded/SampleRedisEmbeddedApplication.java
+++ b/spring-boot-samples/spring-boot-sample-data-redis-embedded/src/main/java/sample/data/redis/embedded/SampleRedisEmbeddedApplication.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.data.redis.embedded;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@SpringBootApplication
+public class SampleRedisEmbeddedApplication implements CommandLineRunner {
+
+	@Autowired
+	private StringRedisTemplate template;
+
+	@Override
+	public void run(String... args) throws Exception {
+		ValueOperations<String, String> ops = this.template.opsForValue();
+		String key = "spring.boot.redis.test";
+		if (!this.template.hasKey(key)) {
+			ops.set(key, "foo");
+		}
+		System.out.println("Found key " + key + ", value=" + ops.get(key));
+	}
+
+	public static void main(String[] args) throws Exception {
+		// Close the context so it doesn't stay awake listening for redis
+		SpringApplication.run(SampleRedisEmbeddedApplication.class, args).close();
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-data-redis-embedded/src/test/java/sample/data/redis/embedded/SampleRedisEmbeddedApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-data-redis-embedded/src/test/java/sample/data/redis/embedded/SampleRedisEmbeddedApplicationTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.data.redis.embedded;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.data.redis.RedisConnectionFailureException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SampleRedisEmbeddedApplication}.
+ *
+ * @author Dave Syer
+ */
+public class SampleRedisEmbeddedApplicationTests {
+
+	@Rule
+	public OutputCapture outputCapture = new OutputCapture();
+
+	@Test
+	public void testDefaultSettings() throws Exception {
+		try {
+			SampleRedisEmbeddedApplication.main(new String[0]);
+		}
+		catch (Exception ex) {
+			if (!redisServerRunning(ex)) {
+				return;
+			}
+		}
+		String output = this.outputCapture.toString();
+		assertThat(output).contains("Found key spring.boot.redis.test");
+	}
+
+	private boolean redisServerRunning(Throwable ex) {
+		System.out.println(ex.getMessage());
+		if (ex instanceof RedisConnectionFailureException) {
+			return false;
+		}
+		return (ex.getCause() == null || redisServerRunning(ex.getCause()));
+	}
+
+}


### PR DESCRIPTION
Hello!

I've added auto-configuration for Embedded Redis. Spring Boot already have Embedded MongoDB support, and I think it will be better if Redis also will be out-of-box.

This PR depends on latest `de.flapdoodle.embed.redis` snapshot, I have upgraded it to use latest Redis (3.2.1) on three platforms (Linux, macOS, Windows), https://github.com/flapdoodle-oss/de.flapdoodle.embed.redis/pull/8

This commit included auto-configuration, unit tests and sample application.

Best regards,
  Alexey Zhokhov.
