### PR TITLE
Fix aliases for database names in `JdbcSessionDatabaseInitializer`

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionDatabaseInitializer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionDatabaseInitializer.java
@@ -42,8 +42,9 @@ public class JdbcSessionDatabaseInitializer {
 
 	static {
 		Map<String, String> aliases = new HashMap<String, String>();
-		aliases.put("hsql", "hsqldb");
-		aliases.put("postgres", "postgresql");
+		aliases.put("apache derby", "derby");
+		aliases.put("hsql database engine", "hsqldb");
+		aliases.put("microsoft sql server", "sqlserver");
 		ALIASES = Collections.unmodifiableMap(aliases);
 	}
 


### PR DESCRIPTION
This resolves #6533.

Other than adding missing alias for SQL Server this PR also:

- adds missing alias for Derby
- fixes incorrect alias for HSQLDB
- removes redundant alias for PostgreSQL