### PR TITLE
Fix health endpoint visibility

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/HealthMvcEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/HealthMvcEndpoint.java
@@ -17,7 +17,10 @@
 package org.springframework.boot.actuate.endpoint.mvc;
 
 import java.security.Principal;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.boot.actuate.endpoint.HealthEndpoint;
@@ -35,6 +38,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -45,6 +49,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  * @author Dave Syer
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Eddú Meléndez
  * @since 1.1.0
  */
 @ConfigurationProperties(prefix = "endpoints.health")
@@ -184,11 +189,17 @@ public class HealthMvcEndpoint extends AbstractEndpointMvcAdapter<HealthEndpoint
 		}
 		if (isSpringSecurityAuthentication(principal)) {
 			Authentication authentication = (Authentication) principal;
-			String role = this.roleResolver.getProperty("role", "ROLE_ADMIN");
+			List<String> roles = Arrays.asList(StringUtils.trimArrayElements(StringUtils
+					.commaDelimitedListToStringArray(this.roleResolver.getProperty("roles"))));
+			if (roles.isEmpty()) {
+				roles = Collections.singletonList("ROLE_ADMIN");
+			}
 			for (GrantedAuthority authority : authentication.getAuthorities()) {
 				String name = authority.getAuthority();
-				if (role.equals(name) || ("ROLE_" + role).equals(name)) {
-					return true;
+				for (String role : roles) {
+					if (role.equals(name) || ("ROLE_" + role).equals(name)) {
+						return true;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Nowadays, health endpoint is partially visible to every role but completely visible
to users with ROLE_ADMIN. This is due to HealthMvcEndpoint is looking at key
`management.security.role` instead of `management.security.roles`.