### PR TITLE
Adding a Tip about the trigger-file reload mechanism

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
+++ b/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
@@ -929,6 +929,8 @@ The trigger file could be updated manually, or via an IDE plugin.
 
 To use a trigger file use the `spring.devtools.restart.trigger-file` property.
 
+TIP: When you update the trigger file then application will be restarted only if there are any changes to reload.
+
 TIP: You might want to set `spring.devtools.restart.trigger-file` as a
 <<using-boot-devtools-globalsettings,global setting>> so that all your projects behave
 in the same way.


### PR DESCRIPTION
After reading **"Using a trigger file"** section, my assumption was whenever the **trigger-file** is changed then application will be restarted, which is not the case. 

So adding a tip to explicitly specify after **trigger-file** is changed then application will restart only if there are any changes to reload.