### PR TITLE
CRaSH Web connector support

### DIFF
--- a/spring-boot-actuator/README.adoc
+++ b/spring-boot-actuator/README.adoc
@@ -3,7 +3,7 @@
 Spring Boot Actuator includes a number of additional features to help you monitor and
 manage your application when it's pushed to production. You can choose to manage and
 monitor your application using HTTP endpoints, with JMX or even by remote shell (SSH or
-Telnet).  Auditing, health and metrics gathering can be automatically applied to your
+Telnet or Websocket).  Auditing, health and metrics gathering can be automatically applied to your
 application. The
 http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready[user guide]
 covers the features in more detail.

--- a/spring-boot-actuator/pom.xml
+++ b/spring-boot-actuator/pom.xml
@@ -244,6 +244,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.crashub</groupId>
+			<artifactId>crash.connectors.web</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.jolokia</groupId>
 			<artifactId>jolokia-core</artifactId>
 			<optional>true</optional>
@@ -315,11 +320,6 @@
 		<dependency>
 			<groupId>org.crashub</groupId>
 			<artifactId>crash.connectors.telnet</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.crashub</groupId>
-			<artifactId>crash.connectors.web</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-actuator/pom.xml
+++ b/spring-boot-actuator/pom.xml
@@ -318,6 +318,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.crashub</groupId>
+			<artifactId>crash.connectors.web</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
 			<scope>test</scope>
@@ -346,6 +351,10 @@
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-websocket</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/CrshAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/CrshAutoConfiguration.java
@@ -38,9 +38,11 @@ import org.crsh.plugin.PluginDiscovery;
 import org.crsh.plugin.PluginLifeCycle;
 import org.crsh.plugin.PropertyDescriptor;
 import org.crsh.plugin.ServiceLoaderDiscovery;
+import org.crsh.plugin.WebPluginLifeCycle;
 import org.crsh.vfs.FS;
 import org.crsh.vfs.spi.AbstractFSDriver;
 import org.crsh.vfs.spi.FSDriver;
+import org.crsh.web.servlet.CRaSHConnector;
 
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -78,12 +80,14 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for embedding an extensible shell
  * into a Spring Boot enabled application. By default a SSH daemon is started on port
  * 2000. If the CRaSH Telnet plugin is available on the classpath, Telnet daemon will be
- * launched on port 5000.
+ * launched on port 5000. If the CRaSH Web plugin is available on the classpath, Web
+ * daemon will be launched.
  * <p>
  * The default shell authentication method uses a username and password combination. If no
  * configuration is provided the default username is 'user' and the password will be
@@ -163,6 +167,29 @@ public class CrshAutoConfiguration {
 			return new SimpleAuthenticationProperties();
 		}
 
+	}
+
+	@Configuration
+	static class CrshWebPlugin {
+
+		@Bean
+		@ConditionalOnProperty(name = "crash.web.enabled", havingValue = "true")
+		public WebPluginLifeCycle webPluginLifeCycle() {
+			return new WebPluginLifeCycle();
+		}
+
+		@Bean
+		@ConditionalOnProperty(name = "crash.web.enabled", havingValue = "true")
+		public CRaSHConnector cRaSHWebConnector() {
+			return new CRaSHConnector();
+		}
+
+		@Bean
+		@ConditionalOnProperty(name = "crash.web.enabled", havingValue = "true")
+		@ConditionalOnMissingBean(ServerEndpointExporter.class)
+		public ServerEndpointExporter serverEndpointExporter() {
+			return new ServerEndpointExporter();
+		}
 	}
 
 	/**

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/CrshAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/CrshAutoConfiguration.java
@@ -180,6 +180,7 @@ public class CrshAutoConfiguration {
 
 		@Bean
 		@ConditionalOnProperty(name = "management.shell.web.enabled", havingValue = "true")
+		@ConditionalOnClass(CRaSHConnector.class)
 		public CRaSHConnector cRaSHWebConnector() {
 			return new CRaSHConnector();
 		}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/CrshAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/CrshAutoConfiguration.java
@@ -173,19 +173,19 @@ public class CrshAutoConfiguration {
 	static class CrshWebPlugin {
 
 		@Bean
-		@ConditionalOnProperty(name = "crash.web.enabled", havingValue = "true")
+		@ConditionalOnProperty(name = "management.shell.web.enabled", havingValue = "true")
 		public WebPluginLifeCycle webPluginLifeCycle() {
 			return new WebPluginLifeCycle();
 		}
 
 		@Bean
-		@ConditionalOnProperty(name = "crash.web.enabled", havingValue = "true")
+		@ConditionalOnProperty(name = "management.shell.web.enabled", havingValue = "true")
 		public CRaSHConnector cRaSHWebConnector() {
 			return new CRaSHConnector();
 		}
 
 		@Bean
-		@ConditionalOnProperty(name = "crash.web.enabled", havingValue = "true")
+		@ConditionalOnProperty(name = "management.shell.web.enabled", havingValue = "true")
 		@ConditionalOnMissingBean(ServerEndpointExporter.class)
 		public ServerEndpointExporter serverEndpointExporter() {
 			return new ServerEndpointExporter();

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ShellProperties.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ShellProperties.java
@@ -349,7 +349,8 @@ public class ShellProperties {
 		 * Enable CRaSH telnet support. Enabled by default if the TelnetPlugin is
 		 * available.
 		 */
-		private boolean enabled = false;
+		private boolean enabled = ClassUtils.isPresent("org.crsh.telnet.TelnetPlugin",
+				ClassUtils.getDefaultClassLoader());
 
 		/**
 		 * Telnet port.
@@ -391,8 +392,7 @@ public class ShellProperties {
 		 * Enable CRaSH websocket support. Enabled by default if the WebPlugin is
 		 * available.
 		 */
-		private boolean enabled = ClassUtils.isPresent("org.crsh.web.servlet.WebPlugin",
-				ClassUtils.getDefaultClassLoader());
+		private boolean enabled = false;
 
 		public void setEnabled(boolean enabled) {
 			this.enabled = enabled;

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ShellProperties.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ShellProperties.java
@@ -349,8 +349,7 @@ public class ShellProperties {
 		 * Enable CRaSH telnet support. Enabled by default if the TelnetPlugin is
 		 * available.
 		 */
-		private boolean enabled = ClassUtils.isPresent("org.crsh.telnet.TelnetPlugin",
-				ClassUtils.getDefaultClassLoader());
+		private boolean enabled = false;
 
 		/**
 		 * Telnet port.

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ShellProperties.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/ShellProperties.java
@@ -38,6 +38,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @author Alex Fainshtein
  */
 @ConfigurationProperties(prefix = ShellProperties.SHELL_PREFIX, ignoreUnknownFields = true)
 public class ShellProperties {
@@ -82,6 +83,8 @@ public class ShellProperties {
 	private final Ssh ssh = new Ssh();
 
 	private final Telnet telnet = new Telnet();
+
+	private final Web web = new Web();
 
 	public Auth getAuth() {
 		return this.auth;
@@ -143,6 +146,10 @@ public class ShellProperties {
 		return this.telnet;
 	}
 
+	public Web getWeb() {
+		return this.web;
+	}
+
 	/**
 	 * Return a properties file configured from these settings that can be applied to a
 	 * CRaSH shell instance.
@@ -152,6 +159,7 @@ public class ShellProperties {
 		Properties properties = new Properties();
 		this.ssh.applyToCrshShellConfig(properties);
 		this.telnet.applyToCrshShellConfig(properties);
+		this.web.applyToCrshShellConfig(properties);
 
 		for (CrshShellProperties shellProperties : this.additionalProperties) {
 			shellProperties.applyToCrshShellConfig(properties);
@@ -162,13 +170,16 @@ public class ShellProperties {
 					String.valueOf(this.commandRefreshInterval));
 		}
 
-		// special handling for disabling Ssh and Telnet support
+		// special handling for disabling Ssh, Telnet and Web support
 		List<String> dp = new ArrayList<String>(Arrays.asList(this.disabledPlugins));
 		if (!this.ssh.isEnabled()) {
 			dp.add("org.crsh.ssh.SSHPlugin");
 		}
 		if (!this.telnet.isEnabled()) {
 			dp.add("org.crsh.telnet.TelnetPlugin");
+		}
+		if (!this.web.isEnabled()) {
+			dp.add("org.crsh.web.servlet.WebPlugin");
 		}
 		this.disabledPlugins = dp.toArray(new String[dp.size()]);
 
@@ -368,6 +379,35 @@ public class ShellProperties {
 
 		public Integer getPort() {
 			return this.port;
+		}
+
+	}
+
+	/**
+	 * Web properties.
+	 */
+	public static class Web extends CrshShellProperties {
+
+		/**
+		 * Enable CRaSH websocket support. Enabled by default if the WebPlugin is
+		 * available.
+		 */
+		private boolean enabled = ClassUtils.isPresent("org.crsh.web.servlet.WebPlugin",
+				ClassUtils.getDefaultClassLoader());
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		@Override
+		protected void applyToCrshShellConfig(Properties config) {
+			if (this.enabled) {
+				config.put("crash.web.enabled", String.valueOf(this.enabled));
+			}
 		}
 
 	}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/CrshAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/CrshAutoConfigurationTests.java
@@ -66,6 +66,7 @@ import static org.hamcrest.CoreMatchers.isA;
  * @author Eddú Meléndez
  * @author Matt Benson
  * @author Stephane Nicoll
+ * @author Alex Fainshtein
  */
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class CrshAutoConfigurationTests {
@@ -137,6 +138,14 @@ public class CrshAutoConfigurationTests {
 				.isEqualTo("300000");
 		assertThat(lifeCycle.getConfig().getProperty("crash.ssh.idle_timeout"))
 				.isEqualTo("400000");
+	}
+
+	@Test
+	public void testWebConfiguration() {
+		load("management.shell.web.enabled=true");
+		PluginLifeCycle lifeCycle = this.context.getBean(PluginLifeCycle.class);
+		assertThat(lifeCycle.getConfig().getProperty("crash.web.enabled"))
+				.isEqualTo("true");
 	}
 
 	@Test

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/ShellPropertiesTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/ShellPropertiesTests.java
@@ -156,6 +156,29 @@ public class ShellPropertiesTests {
 	}
 
 	@Test
+	public void testBindingWeb() {
+		ShellProperties props = load(ShellProperties.class,
+				"management.shell.web.enabled=true");
+		Properties p = props.asCrshShellConfig();
+		assertThat(p.get("crash.web.enabled")).isEqualTo("true");
+	}
+
+	@Test
+	public void testBindingWebAutoloaded() {
+		ShellProperties props = load(ShellProperties.class);
+		Properties p = props.asCrshShellConfig();
+		assertThat(p.get("crash.web.enabled")).isEqualTo("true");
+	}
+
+	@Test
+	public void testBindingWebIgnored() {
+		ShellProperties props = load(ShellProperties.class,
+				"management.shell.web.enabled=false");
+		Properties p = props.asCrshShellConfig();
+		assertThat(p.get("crash.web.enabled")).isNull();
+	}
+
+	@Test
 	public void testBindingJaas() {
 		JaasAuthenticationProperties props = load(JaasAuthenticationProperties.class,
 				"management.shell.auth.jaas.domain=my-test-domain");

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/ShellPropertiesTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/ShellPropertiesTests.java
@@ -164,13 +164,6 @@ public class ShellPropertiesTests {
 	}
 
 	@Test
-	public void testBindingWebAutoloaded() {
-		ShellProperties props = load(ShellProperties.class);
-		Properties p = props.asCrshShellConfig();
-		assertThat(p.get("crash.web.enabled")).isEqualTo("true");
-	}
-
-	@Test
 	public void testBindingWebIgnored() {
 		ShellProperties props = load(ShellProperties.class,
 				"management.shell.web.enabled=false");

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -1498,6 +1498,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.crashub</groupId>
+				<artifactId>crash.connectors.web</artifactId>
+				<version>${crashub.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.crashub</groupId>
 				<artifactId>crash.embed.spring</artifactId>
 				<version>${crashub.version}</version>
 			</dependency>

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -1082,6 +1082,7 @@ content into your application; rather pick only the properties that you need.
 	management.shell.ssh.port=2000 # SSH port.
 	management.shell.telnet.enabled=false # Enable CRaSH telnet support. Enabled by default if the TelnetPlugin is  available.
 	management.shell.telnet.port=5000 # Telnet port.
+	management.shell.web.enabled=false # Enable CRaSH websocket support. Enabled by default if the WebPlugin is  available.
 
 	# TRACING ({sc-spring-boot-actuator}/trace/TraceProperties.{sc-ext}[TraceProperties])
 	management.trace.include=request-headers,response-headers,cookies,errors # Items to be included in the trace.

--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -805,8 +805,8 @@ If you are using Jolokia but you don't want Spring Boot to configure it, simply 
 [[production-ready-remote-shell]]
 == Monitoring and management using a remote shell
 Spring Boot supports an integrated Java shell called '`CRaSH`'. You can use CRaSH to
-`ssh` or `telnet` into your running application. To enable remote shell support, add
-the following dependency to your project:
+`ssh` or `telnet` or `websocket` into your running application. To enable remote shell
+support, add the following dependency to your project:
 
 [source,xml,indent=0]
 ----
@@ -818,6 +818,9 @@ the following dependency to your project:
 
 TIP: If you want to also enable telnet access you will additionally need a dependency
 on `org.crsh:crsh.shell.telnet`.
+
+TIP: If you want to also enable websocket access you will additionally need a dependency
+on `org.crsh:crsh.shell.web`.
 
 NOTE: CRaSH requires to run with a JDK as it compiles commands on the fly. If a basic
 `help` command fails, you are probably running with a JRE.

--- a/spring-boot-samples/spring-boot-sample-actuator/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-actuator/pom.xml
@@ -48,10 +48,14 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-<!--		<dependency>
+		<dependency>
 			<groupId>org.crashub</groupId>
-			<artifactId>crash.connectors.telnet</artifactId>
+			<artifactId>crash.connectors.web</artifactId>
 			<exclusions>
+				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>servlet-api</artifactId>
+				</exclusion>
 				<exclusion>
 					<groupId>log4j</groupId>
 					<artifactId>log4j</artifactId>
@@ -61,7 +65,11 @@
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency> -->
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-websocket</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-boot-samples/spring-boot-sample-actuator/src/main/java/sample/actuator/SampleActuatorApplication.java
+++ b/spring-boot-samples/spring-boot-sample-actuator/src/main/java/sample/actuator/SampleActuatorApplication.java
@@ -32,5 +32,4 @@ public class SampleActuatorApplication implements HealthIndicator {
 	public static void main(String[] args) throws Exception {
 		SpringApplication.run(SampleActuatorApplication.class, args);
 	}
-
 }

--- a/spring-boot-samples/spring-boot-sample-actuator/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-actuator/src/main/resources/application.properties
@@ -6,6 +6,7 @@ management.shell.ssh.enabled=true
 management.shell.ssh.port=2222
 #management.shell.telnet.enabled=false
 #management.shell.telnet.port=1111
+management.shell.web.enabled=true
 management.shell.auth.type=spring
 #management.shell.auth.type=key
 #management.shell.auth.key.path=${user.home}/test/id_rsa.pub.pem

--- a/spring-boot-starters/spring-boot-starter-remote-shell/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-remote-shell/pom.xml
@@ -62,6 +62,25 @@
 		</dependency>
 		<dependency>
 			<groupId>org.crashub</groupId>
+			<artifactId>crash.connectors.web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>servlet-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.crashub</groupId>
 			<artifactId>crash.embed.spring</artifactId>
 			<exclusions>
 				<exclusion>


### PR DESCRIPTION
This is my first pull request to an oss, so please be gentle :)

added web connector to CRaSH auto config
added web connector to shell properties
added crash web connector to actuator sample app

Will resolves #6233 

Still have one issue needed to resolve:
`WebPluginLifeCycle` bean which is needed for `CRaSHConnector` implements `ServletContextListener` and calls `getClassLoader` while `contextInitialized` runs.
This generates the following exception:

```
java.lang.UnsupportedOperationException: Section 4.4 of the Servlet 3.0 specification does not permit this method to be called from a ServletContextListener that was not defined in web.xml, a web-fragment.xml file nor annotated with @WebListener
	at org.apache.catalina.core.StandardContext$NoPluggabilityServletContext.getClassLoader(StandardContext.java:6694)
	at org.crsh.plugin.WebPluginLifeCycle.contextInitialized(WebPluginLifeCycle.java:101)
	at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4714)
	at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5178)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:152)
	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1403)
	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1393)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

Not sure how to tackle this, will appreciate some assistance.