### PR TITLE
Add actuator endpoint to retrieve audit events

### DIFF
--- a/spring-boot-actuator-docs/src/main/asciidoc/index.adoc
+++ b/spring-boot-actuator-docs/src/main/asciidoc/index.adoc
@@ -20,6 +20,34 @@ include::{generated}/endpoints.adoc[]
 
 
 
+=== /auditevents
+This endpoint provides information about audit events registered by the application.
+Audit events can be filtered using the `after`, `principal` and `type` parameters as
+defined by `AuditEventRepository`.
+
+Example cURL request with `after` parameter:
+include::{generated}/auditevents/curl-request.adoc[]
+
+Example HTTP request with `after` parameter:
+include::{generated}/auditevents/http-request.adoc[]
+
+Example HTTP response:
+include::{generated}/auditevents/http-response.adoc[]
+
+Example cURL request with `principal` and `after` parameters:
+include::{generated}/auditevents/filter-by-principal/curl-request.adoc[]
+
+Example HTTP request with `principal` and `after` parameters:
+include::{generated}/auditevents/filter-by-principal/http-request.adoc[]
+
+Example cURL request with `principal`, `after` and `type` parameters:
+include::{generated}/auditevents/filter-by-principal-and-type/curl-request.adoc[]
+
+Example HTTP request with `principal`, `after` and `type` parameters:
+include::{generated}/auditevents/filter-by-principal-and-type/http-request.adoc[]
+
+
+
 === /logfile
 This endpoint (if available) contains the plain text logfile configured by the user
 using `logging.file` or `logging.path` (by default logs are only emitted on stdout

--- a/spring-boot-actuator-docs/src/restdoc/java/org/springframework/boot/actuate/hypermedia/EndpointDocumentation.java
+++ b/spring-boot-actuator-docs/src/restdoc/java/org/springframework/boot/actuate/hypermedia/EndpointDocumentation.java
@@ -76,7 +76,8 @@ public class EndpointDocumentation {
 	static final File LOG_FILE = new File("target/logs/spring.log");
 
 	private static final Set<String> SKIPPED = Collections.<String>unmodifiableSet(
-			new HashSet<String>(Arrays.asList("/docs", "/logfile", "/heapdump")));
+			new HashSet<String>(Arrays.asList("/docs", "/logfile", "/heapdump",
+					"/auditevents")));
 
 	@Autowired
 	private MvcEndpoints mvcEndpoints;
@@ -124,6 +125,33 @@ public class EndpointDocumentation {
 						.contentType(MediaType.APPLICATION_JSON)
 						.content("{\"configuredLevel\": \"DEBUG\"}"))
 				.andExpect(status().isOk()).andDo(document("set-logger"));
+	}
+
+	@Test
+	public void auditEvents() throws Exception {
+		this.mockMvc.perform(get("/auditevents")
+						.param("after", "2016-11-01T10:00:00+0000")
+						.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk()).andDo(document("auditevents"));
+	}
+
+	@Test
+	public void auditEventsByPrincipal() throws Exception {
+		this.mockMvc.perform(get("/auditevents").param("principal", "admin")
+						.param("after", "2016-11-01T10:00:00+0000")
+						.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andDo(document("auditevents/filter-by-principal"));
+	}
+
+	@Test
+	public void auditEventsByPrincipalAndType() throws Exception {
+		this.mockMvc.perform(get("/auditevents").param("principal", "admin")
+						.param("after", "2016-11-01T10:00:00+0000")
+						.param("type", "AUTHENTICATION_SUCCESS")
+						.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andDo(document("auditevents/filter-by-principal-and-type"));
 	}
 
 	@Test

--- a/spring-boot-actuator-docs/src/restdoc/java/org/springframework/boot/actuate/hypermedia/SpringBootHypermediaApplication.java
+++ b/spring-boot-actuator-docs/src/restdoc/java/org/springframework/boot/actuate/hypermedia/SpringBootHypermediaApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,18 @@
 
 package org.springframework.boot.actuate.hypermedia;
 
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+
 import groovy.text.GStringTemplateEngine;
 import groovy.text.TemplateEngine;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.audit.AuditEvent;
+import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.boot.actuate.endpoint.EnvironmentEndpoint;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
@@ -30,7 +38,10 @@ import org.springframework.context.annotation.Import;
 // Flyway must go first
 @SpringBootApplication
 @Import({ FlywayAutoConfiguration.class, LiquibaseAutoConfiguration.class })
-public class SpringBootHypermediaApplication {
+public class SpringBootHypermediaApplication implements CommandLineRunner {
+
+	@Autowired
+	private AuditEventRepository auditEventRepository;
 
 	@Bean
 	public TemplateEngine groovyTemplateEngine() {
@@ -44,6 +55,16 @@ public class SpringBootHypermediaApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(SpringBootHypermediaApplication.class, args);
+	}
+
+	@Override
+	public void run(String... args) throws Exception {
+		this.auditEventRepository.add(new AuditEvent(Date.from(Instant.parse(
+				"2016-11-01T11:00:00Z")), "user", "AUTHENTICATION_FAILURE",
+				Collections.emptyMap()));
+		this.auditEventRepository.add(new AuditEvent(Date.from(Instant.parse(
+				"2016-11-01T12:00:00Z")), "admin", "AUTHENTICATION_SUCCESS",
+				Collections.emptyMap()));
 	}
 
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/AuditEvent.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/AuditEvent.java
@@ -22,6 +22,11 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.util.Assert;
@@ -39,6 +44,7 @@ import org.springframework.util.Assert;
  * @author Dave Syer
  * @see AuditEventRepository
  */
+@JsonInclude(Include.NON_EMPTY)
 public class AuditEvent implements Serializable {
 
 	private final Date timestamp;
@@ -106,6 +112,7 @@ public class AuditEvent implements Serializable {
 	 * Returns the date/time that the even was logged.
 	 * @return the time stamp
 	 */
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssZ")
 	public Date getTimestamp() {
 		return this.timestamp;
 	}
@@ -130,6 +137,7 @@ public class AuditEvent implements Serializable {
 	 * Returns the event data.
 	 * @return the event data
 	 */
+	@JsonAnyGetter
 	public Map<String, Object> getData() {
 		return this.data;
 	}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointMBeanExportAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointMBeanExportAutoConfiguration.java
@@ -21,13 +21,17 @@ import javax.management.MBeanServer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.boot.actuate.autoconfigure.EndpointMBeanExportAutoConfiguration.JmxEnabledCondition;
+import org.springframework.boot.actuate.condition.ConditionalOnEnabledEndpoint;
 import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.actuate.endpoint.jmx.AuditEventsMBean;
 import org.springframework.boot.actuate.endpoint.jmx.EndpointMBeanExporter;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
@@ -81,6 +85,14 @@ public class EndpointMBeanExportAutoConfiguration {
 	@ConditionalOnMissingBean(MBeanServer.class)
 	public MBeanServer mbeanServer() {
 		return new JmxAutoConfiguration().mbeanServer();
+	}
+
+	@Bean
+	@ConditionalOnBean(AuditEventRepository.class)
+	@ConditionalOnEnabledEndpoint("auditevents")
+	public AuditEventsMBean abstractEndpointMBean(
+			AuditEventRepository auditEventRepository) {
+		return new AuditEventsMBean(this.objectMapper, auditEventRepository);
 	}
 
 	/**

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcManagementContextConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcManagementContextConfiguration.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.boot.actuate.condition.ConditionalOnEnabledEndpoint;
 import org.springframework.boot.actuate.endpoint.Endpoint;
 import org.springframework.boot.actuate.endpoint.EnvironmentEndpoint;
@@ -27,6 +28,7 @@ import org.springframework.boot.actuate.endpoint.HealthEndpoint;
 import org.springframework.boot.actuate.endpoint.LoggersEndpoint;
 import org.springframework.boot.actuate.endpoint.MetricsEndpoint;
 import org.springframework.boot.actuate.endpoint.ShutdownEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.AuditEventsMvcEndpoint;
 import org.springframework.boot.actuate.endpoint.mvc.EndpointHandlerMapping;
 import org.springframework.boot.actuate.endpoint.mvc.EndpointHandlerMappingCustomizer;
 import org.springframework.boot.actuate.endpoint.mvc.EnvironmentMvcEndpoint;
@@ -60,6 +62,7 @@ import org.springframework.web.cors.CorsConfiguration;
  *
  * @author Dave Syer
  * @author Ben Hale
+ * @author Vedran Pavic
  * @since 1.3.0
  */
 @ManagementContextConfiguration
@@ -178,6 +181,14 @@ public class EndpointWebMvcManagementContextConfiguration {
 	@ConditionalOnEnabledEndpoint(value = "shutdown", enabledByDefault = false)
 	public ShutdownMvcEndpoint shutdownMvcEndpoint(ShutdownEndpoint delegate) {
 		return new ShutdownMvcEndpoint(delegate);
+	}
+
+	@Bean
+	@ConditionalOnBean(AuditEventRepository.class)
+	@ConditionalOnEnabledEndpoint("auditevents")
+	public AuditEventsMvcEndpoint auditEventMvcEndpoint(
+			AuditEventRepository auditEventRepository) {
+		return new AuditEventsMvcEndpoint(auditEventRepository);
 	}
 
 	private boolean isHealthSecure() {

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/AbstractEndpointMBean.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/AbstractEndpointMBean.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.endpoint.jmx;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.actuate.endpoint.EndpointProperties;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+
+/**
+ * Abstract base class for JMX endpoint implementations without a backing
+ * {@link Endpoint}.
+ *
+ * @author Vedran Pavic
+ * @since 1.5.0
+ */
+public abstract class AbstractEndpointMBean extends EndpointMBeanSupport
+		implements EnvironmentAware {
+
+	private Environment environment;
+
+	/**
+	 * Enable the endpoint.
+	 */
+	private Boolean enabled;
+
+	/**
+	 * Mark if the endpoint exposes sensitive information.
+	 */
+	private Boolean sensitive;
+
+	private final boolean sensitiveDefault;
+
+	public AbstractEndpointMBean(ObjectMapper objectMapper, boolean sensitive) {
+		super(objectMapper);
+		this.sensitiveDefault = sensitive;
+	}
+
+	public AbstractEndpointMBean(ObjectMapper objectMapper, boolean sensitive,
+			boolean enabled) {
+		super(objectMapper);
+		this.sensitiveDefault = sensitive;
+		this.enabled = enabled;
+	}
+
+	@Override
+	public void setEnvironment(Environment environment) {
+		this.environment = environment;
+	}
+
+	protected final Environment getEnvironment() {
+		return this.environment;
+	}
+
+	public boolean isEnabled() {
+		return EndpointProperties.isEnabled(this.environment, this.enabled);
+	}
+
+	public void setEnabled(Boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	@Override
+	public boolean isSensitive() {
+		return EndpointProperties.isSensitive(this.environment, this.sensitive,
+				this.sensitiveDefault);
+	}
+
+	public void setSensitive(Boolean sensitive) {
+		this.sensitive = sensitive;
+	}
+
+	@Override
+	public String getEndpointClass() {
+		return null;
+	}
+
+}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/AuditEventsMBean.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/AuditEventsMBean.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.endpoint.jmx;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.boot.actuate.audit.AuditEvent;
+import org.springframework.boot.actuate.audit.AuditEventRepository;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.jmx.export.annotation.ManagedOperation;
+import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.util.Assert;
+
+/**
+ * Special JMX endpoint wrapper for {@link AuditEventRepository}.
+ *
+ * @author Vedran Pavic
+ * @since 1.5.0
+ */
+@ManagedResource
+@ConfigurationProperties(prefix = "endpoints.auditevents")
+public class AuditEventsMBean extends AbstractEndpointMBean {
+
+	private static final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+
+	private final AuditEventRepository auditEventRepository;
+
+	public AuditEventsMBean(ObjectMapper objectMapper,
+			AuditEventRepository auditEventRepository) {
+		super(objectMapper, true);
+		Assert.notNull(auditEventRepository, "AuditEventRepository must not be null");
+		this.auditEventRepository = auditEventRepository;
+	}
+
+	@ManagedOperation(description = "Retrieves a list of audit events meeting the given criteria")
+	public Object getData(String dateAfter) {
+		List<AuditEvent> auditEvents = this.auditEventRepository.find(
+				parseDate(dateAfter));
+		return convert(auditEvents);
+	}
+
+	@ManagedOperation(description = "Retrieves a list of audit events meeting the given criteria")
+	public Object getData(String dateAfter, String principal) {
+		List<AuditEvent> auditEvents = this.auditEventRepository.find(
+				principal, parseDate(dateAfter));
+		return convert(auditEvents);
+	}
+
+	@ManagedOperation(description = "Retrieves a list of audit events meeting the given criteria")
+	public Object getData(String principal, String dateAfter, String type) {
+		List<AuditEvent> auditEvents = this.auditEventRepository.find(
+				principal, parseDate(dateAfter), type);
+		return convert(auditEvents);
+	}
+
+	private Date parseDate(String date) {
+		try {
+			return dateFormat.parse(date);
+		}
+		catch (ParseException e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+
+}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBean.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBean.java
@@ -16,10 +16,6 @@
 
 package org.springframework.boot.actuate.endpoint.jmx;
 
-import java.util.List;
-import java.util.Map;
-
-import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.boot.actuate.endpoint.Endpoint;
@@ -33,17 +29,12 @@ import org.springframework.util.ClassUtils;
  *
  * @author Christian Dupuis
  * @author Andy Wilkinson
+ * @author Vedran Pavic
  */
 @ManagedResource
-public class EndpointMBean {
+public class EndpointMBean extends EndpointMBeanSupport {
 
 	private final Endpoint<?> endpoint;
-
-	private final ObjectMapper mapper;
-
-	private final JavaType listObject;
-
-	private final JavaType mapStringObject;
 
 	/**
 	 * Create a new {@link EndpointMBean} instance.
@@ -53,15 +44,10 @@ public class EndpointMBean {
 	 */
 	public EndpointMBean(String beanName, Endpoint<?> endpoint,
 			ObjectMapper objectMapper) {
+		super(objectMapper);
 		Assert.notNull(beanName, "BeanName must not be null");
 		Assert.notNull(endpoint, "Endpoint must not be null");
-		Assert.notNull(objectMapper, "ObjectMapper must not be null");
 		this.endpoint = endpoint;
-		this.mapper = objectMapper;
-		this.listObject = objectMapper.getTypeFactory()
-				.constructParametricType(List.class, Object.class);
-		this.mapStringObject = objectMapper.getTypeFactory()
-				.constructParametricType(Map.class, String.class, Object.class);
 	}
 
 	@ManagedAttribute(description = "Returns the class of the underlying endpoint")
@@ -76,19 +62,6 @@ public class EndpointMBean {
 
 	public Endpoint<?> getEndpoint() {
 		return this.endpoint;
-	}
-
-	protected Object convert(Object result) {
-		if (result == null) {
-			return null;
-		}
-		if (result instanceof String) {
-			return result;
-		}
-		if (result.getClass().isArray() || result instanceof List) {
-			return this.mapper.convertValue(result, this.listObject);
-		}
-		return this.mapper.convertValue(result, this.mapStringObject);
 	}
 
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBeanSupport.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBeanSupport.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.endpoint.jmx;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.jmx.export.annotation.ManagedAttribute;
+import org.springframework.util.Assert;
+
+/**
+ * Abstract base class for JMX endpoint implementations.
+ *
+ * @author Vedran Pavic
+ * @since 1.5.0
+ */
+public abstract class EndpointMBeanSupport {
+
+	private final ObjectMapper mapper;
+
+	private final JavaType listObject;
+
+	private final JavaType mapStringObject;
+
+	public EndpointMBeanSupport(ObjectMapper objectMapper) {
+		Assert.notNull(objectMapper, "ObjectMapper must not be null");
+		this.mapper = objectMapper;
+		this.listObject = objectMapper.getTypeFactory()
+				.constructParametricType(List.class, Object.class);
+		this.mapStringObject = objectMapper.getTypeFactory()
+				.constructParametricType(Map.class, String.class, Object.class);
+	}
+
+	@ManagedAttribute(description = "Indicates whether the underlying endpoint exposes sensitive information")
+	public abstract boolean isSensitive();
+
+	@ManagedAttribute(description = "Returns the class of the underlying endpoint")
+	public abstract String getEndpointClass();
+
+	protected Object convert(Object result) {
+		if (result == null) {
+			return null;
+		}
+		if (result instanceof String) {
+			return result;
+		}
+		if (result.getClass().isArray() || result instanceof List) {
+			return this.mapper.convertValue(result, this.listObject);
+		}
+		return this.mapper.convertValue(result, this.mapStringObject);
+	}
+
+}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/AbstractNamedMvcEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/AbstractNamedMvcEndpoint.java
@@ -26,7 +26,7 @@ import org.springframework.util.Assert;
  * @author Madhura Bhave
  * @since 1.5.0
  */
-public class AbstractNamedMvcEndpoint extends AbstractMvcEndpoint
+public abstract class AbstractNamedMvcEndpoint extends AbstractMvcEndpoint
 		implements NamedMvcEndpoint {
 
 	private final String name;

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/AuditEventsMvcEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/AuditEventsMvcEndpoint.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.endpoint.mvc;
+
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.boot.actuate.audit.AuditEvent;
+import org.springframework.boot.actuate.audit.AuditEventRepository;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * {@link MvcEndpoint} to expose {@link AuditEvent}s.
+ *
+ * @author Vedran Pavic
+ * @since 1.5.0
+ */
+@ConfigurationProperties(prefix = "endpoints.auditevents")
+public class AuditEventsMvcEndpoint extends AbstractNamedMvcEndpoint {
+
+	private final AuditEventRepository auditEventRepository;
+
+	public AuditEventsMvcEndpoint(AuditEventRepository auditEventRepository) {
+		super("auditevents", "/auditevents", true);
+		Assert.notNull(auditEventRepository, "AuditEventRepository must not be null");
+		this.auditEventRepository = auditEventRepository;
+	}
+
+	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE, params = { "after" })
+	@ResponseBody
+	public ResponseEntity<?> findByAfter(
+			@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssZ") Date after) {
+		if (!isEnabled()) {
+			return DISABLED_RESPONSE;
+		}
+		List<AuditEvent> auditEvents = this.auditEventRepository.find(after);
+		return ResponseEntity.ok(auditEvents);
+	}
+
+	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE,
+			params = { "principal", "after" })
+	@ResponseBody
+	public ResponseEntity<?> findByPrincipalAndAfter(@RequestParam String principal,
+			@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssZ") Date after) {
+		if (!isEnabled()) {
+			return DISABLED_RESPONSE;
+		}
+		List<AuditEvent> auditEvents = this.auditEventRepository.find(principal, after);
+		return ResponseEntity.ok(auditEvents);
+	}
+
+	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE,
+			params = { "principal", "after", "type" })
+	@ResponseBody
+	public ResponseEntity<?> findByPrincipalAndAfterAndType(@RequestParam String principal,
+			@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssZ") Date after,
+			@RequestParam String type) {
+		if (!isEnabled()) {
+			return DISABLED_RESPONSE;
+		}
+		List<AuditEvent> auditEvents = this.auditEventRepository.find(principal, after,
+				type);
+		return ResponseEntity.ok(auditEvents);
+	}
+
+}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/EndpointMvcIntegrationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/EndpointMvcIntegrationTests.java
@@ -101,7 +101,7 @@ public class EndpointMvcIntegrationTests {
 	@MinimalWebConfiguration
 	@Import({ ManagementServerPropertiesAutoConfiguration.class,
 			JacksonAutoConfiguration.class, EndpointAutoConfiguration.class,
-			EndpointWebMvcAutoConfiguration.class })
+			EndpointWebMvcAutoConfiguration.class, AuditAutoConfiguration.class })
 	@RestController
 	protected static class Application {
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/EndpointWebMvcAutoConfigurationTests.java
@@ -360,7 +360,7 @@ public class EndpointWebMvcAutoConfigurationTests {
 				EmbeddedServletContainerAutoConfiguration.class,
 				HttpMessageConvertersAutoConfiguration.class,
 				DispatcherServletAutoConfiguration.class, WebMvcAutoConfiguration.class,
-				EndpointWebMvcAutoConfiguration.class);
+				EndpointWebMvcAutoConfiguration.class, AuditAutoConfiguration.class);
 		this.applicationContext.refresh();
 		assertContent("/controller", ports.get().server, "controlleroutput");
 		assertContent("/test/endpoint", ports.get().server, "endpointoutput");
@@ -377,7 +377,7 @@ public class EndpointWebMvcAutoConfigurationTests {
 				EmbeddedServletContainerAutoConfiguration.class,
 				HttpMessageConvertersAutoConfiguration.class,
 				DispatcherServletAutoConfiguration.class, WebMvcAutoConfiguration.class,
-				EndpointWebMvcAutoConfiguration.class);
+				EndpointWebMvcAutoConfiguration.class, AuditAutoConfiguration.class);
 		this.applicationContext.refresh();
 		assertContent("/controller", ports.get().server, "controlleroutput");
 		ServerProperties serverProperties = this.applicationContext
@@ -436,9 +436,9 @@ public class EndpointWebMvcAutoConfigurationTests {
 				BaseConfiguration.class, ServerPortConfig.class,
 				EndpointWebMvcAutoConfiguration.class);
 		this.applicationContext.refresh();
-		// /health, /metrics, /loggers, /env, /actuator, /heapdump (/shutdown is disabled
-		// by default)
-		assertThat(this.applicationContext.getBeansOfType(MvcEndpoint.class)).hasSize(6);
+		// /health, /metrics, /loggers, /env, /actuator, /heapdump, /auditevents
+		// (/shutdown is disabled by default)
+		assertThat(this.applicationContext.getBeansOfType(MvcEndpoint.class)).hasSize(7);
 	}
 
 	@Test
@@ -730,7 +730,7 @@ public class EndpointWebMvcAutoConfigurationTests {
 			HttpMessageConvertersAutoConfiguration.class,
 			DispatcherServletAutoConfiguration.class, WebMvcAutoConfiguration.class,
 			ManagementServerPropertiesAutoConfiguration.class,
-			ServerPropertiesAutoConfiguration.class })
+			ServerPropertiesAutoConfiguration.class, AuditAutoConfiguration.class })
 	protected static class BaseConfiguration {
 
 	}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/HealthMvcEndpointAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/HealthMvcEndpointAutoConfigurationTests.java
@@ -84,7 +84,7 @@ public class HealthMvcEndpointAutoConfigurationTests {
 	@Configuration
 	@ImportAutoConfiguration({ SecurityAutoConfiguration.class,
 			JacksonAutoConfiguration.class, WebMvcAutoConfiguration.class,
-			HttpMessageConvertersAutoConfiguration.class,
+			HttpMessageConvertersAutoConfiguration.class, AuditAutoConfiguration.class,
 			ManagementServerPropertiesAutoConfiguration.class,
 			EndpointAutoConfiguration.class, EndpointWebMvcAutoConfiguration.class })
 	static class TestConfiguration {

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/ManagementWebSecurityAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/ManagementWebSecurityAutoConfigurationTests.java
@@ -91,7 +91,7 @@ public class ManagementWebSecurityAutoConfigurationTests {
 				HttpMessageConvertersAutoConfiguration.class,
 				EndpointAutoConfiguration.class, EndpointWebMvcAutoConfiguration.class,
 				ManagementServerPropertiesAutoConfiguration.class,
-				PropertyPlaceholderAutoConfiguration.class);
+				PropertyPlaceholderAutoConfiguration.class, AuditAutoConfiguration.class);
 		EnvironmentTestUtils.addEnvironment(this.context, "security.basic.enabled:false");
 		this.context.refresh();
 		assertThat(this.context.getBean(AuthenticationManagerBuilder.class)).isNotNull();
@@ -203,7 +203,7 @@ public class ManagementWebSecurityAutoConfigurationTests {
 				EndpointAutoConfiguration.class, EndpointWebMvcAutoConfiguration.class,
 				ManagementServerPropertiesAutoConfiguration.class,
 				WebMvcAutoConfiguration.class,
-				PropertyPlaceholderAutoConfiguration.class);
+				PropertyPlaceholderAutoConfiguration.class, AuditAutoConfiguration.class);
 		this.context.refresh();
 
 		Filter filter = this.context.getBean("springSecurityFilterChain", Filter.class);
@@ -265,7 +265,7 @@ public class ManagementWebSecurityAutoConfigurationTests {
 			JacksonAutoConfiguration.class, HttpMessageConvertersAutoConfiguration.class,
 			EndpointAutoConfiguration.class, EndpointWebMvcAutoConfiguration.class,
 			ManagementServerPropertiesAutoConfiguration.class,
-			PropertyPlaceholderAutoConfiguration.class,
+			PropertyPlaceholderAutoConfiguration.class, AuditAutoConfiguration.class,
 			FallbackWebSecurityAutoConfiguration.class })
 	static class WebConfiguration {
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/MinimalActuatorHypermediaApplication.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/MinimalActuatorHypermediaApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ import org.springframework.context.annotation.Configuration;
 		HttpMessageConvertersAutoConfiguration.class, WebMvcAutoConfiguration.class,
 		HypermediaAutoConfiguration.class, EndpointAutoConfiguration.class,
 		EndpointWebMvcAutoConfiguration.class, ErrorMvcAutoConfiguration.class,
-		PropertyPlaceholderAutoConfiguration.class })
+		PropertyPlaceholderAutoConfiguration.class, AuditAutoConfiguration.class })
 public @interface MinimalActuatorHypermediaApplication {
 
 }

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/MvcEndpointPathConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/MvcEndpointPathConfigurationTests.java
@@ -35,6 +35,7 @@ import org.springframework.boot.actuate.endpoint.LiquibaseEndpoint;
 import org.springframework.boot.actuate.endpoint.RequestMappingEndpoint;
 import org.springframework.boot.actuate.endpoint.ShutdownEndpoint;
 import org.springframework.boot.actuate.endpoint.TraceEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.AuditEventsMvcEndpoint;
 import org.springframework.boot.actuate.endpoint.mvc.DocsMvcEndpoint;
 import org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter;
 import org.springframework.boot.actuate.endpoint.mvc.EnvironmentMvcEndpoint;
@@ -85,6 +86,7 @@ public class MvcEndpointPathConfigurationTests {
 	@Parameters(name = "{0}")
 	public static Object[] parameters() {
 		return new Object[] { new Object[] { "actuator", HalJsonMvcEndpoint.class },
+				new Object[] { "auditevents", AuditEventsMvcEndpoint.class },
 				new Object[] { "autoconfig", AutoConfigurationReportEndpoint.class },
 				new Object[] { "beans", BeansEndpoint.class },
 				new Object[] { "configprops",
@@ -143,9 +145,8 @@ public class MvcEndpointPathConfigurationTests {
 	@ImportAutoConfiguration({ EndpointAutoConfiguration.class,
 			HttpMessageConvertersAutoConfiguration.class,
 			ManagementServerPropertiesAutoConfiguration.class,
-			ServerPropertiesAutoConfiguration.class,
-			EndpointWebMvcAutoConfiguration.class, JolokiaAutoConfiguration.class,
-			EndpointAutoConfiguration.class })
+			ServerPropertiesAutoConfiguration.class, AuditAutoConfiguration.class,
+			EndpointWebMvcAutoConfiguration.class, JolokiaAutoConfiguration.class })
 
 	protected static class TestConfiguration {
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/EnvironmentMvcEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/EnvironmentMvcEndpointTests.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.AuditAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.EndpointWebMvcAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.ManagementServerPropertiesAutoConfiguration;
 import org.springframework.boot.actuate.endpoint.EnvironmentEndpoint;
@@ -105,7 +106,7 @@ public class EnvironmentMvcEndpointTests {
 	@Configuration
 	@Import({ JacksonAutoConfiguration.class,
 			HttpMessageConvertersAutoConfiguration.class, WebMvcAutoConfiguration.class,
-			EndpointWebMvcAutoConfiguration.class,
+			EndpointWebMvcAutoConfiguration.class, AuditAutoConfiguration.class,
 			ManagementServerPropertiesAutoConfiguration.class })
 	public static class TestConfiguration {
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/HalBrowserMvcEndpointDisabledIntegrationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/HalBrowserMvcEndpointDisabledIntegrationTests.java
@@ -30,6 +30,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -84,7 +85,11 @@ public class HalBrowserMvcEndpointDisabledIntegrationTests {
 				continue;
 			}
 			path = path.length() > 0 ? path : "/";
-			this.mockMvc.perform(get(path).accept(MediaType.APPLICATION_JSON))
+			MockHttpServletRequestBuilder requestBuilder = get(path);
+			if (endpoint instanceof AuditEventsMvcEndpoint) {
+				requestBuilder.param("after", "2016-01-01T12:00:00+00:00");
+			}
+			this.mockMvc.perform(requestBuilder.accept(MediaType.APPLICATION_JSON))
 					.andExpect(status().isOk())
 					.andExpect(jsonPath("$._links").doesNotExist());
 		}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/HalBrowserMvcEndpointVanillaIntegrationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/HalBrowserMvcEndpointVanillaIntegrationTests.java
@@ -118,8 +118,8 @@ public class HalBrowserMvcEndpointVanillaIntegrationTests {
 
 	@Test
 	public void endpointsEachHaveSelf() throws Exception {
-		Set<String> collections = new HashSet<String>(
-				Arrays.asList("/trace", "/beans", "/dump", "/heapdump", "/loggers"));
+		Set<String> collections = new HashSet<String>(Arrays.asList("/trace", "/beans",
+				"/dump", "/heapdump", "/loggers", "/auditevents"));
 		for (MvcEndpoint endpoint : this.mvcEndpoints.getEndpoints()) {
 			String path = endpoint.getPath();
 			if (collections.contains(path)) {

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/HeapdumpMvcEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/HeapdumpMvcEndpointTests.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.AuditAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.EndpointWebMvcAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.ManagementServerPropertiesAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
@@ -106,7 +107,7 @@ public class HeapdumpMvcEndpointTests {
 		assertThat(uncompressed).isEqualTo("HEAPDUMP".getBytes());
 	}
 
-	@Import({ JacksonAutoConfiguration.class,
+	@Import({ JacksonAutoConfiguration.class, AuditAutoConfiguration.class,
 			HttpMessageConvertersAutoConfiguration.class,
 			EndpointWebMvcAutoConfiguration.class, WebMvcAutoConfiguration.class,
 			ManagementServerPropertiesAutoConfiguration.class })

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/InfoMvcEndpointWithNoInfoContributorsTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/InfoMvcEndpointWithNoInfoContributorsTests.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.AuditAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.EndpointWebMvcAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.ManagementServerPropertiesAutoConfiguration;
 import org.springframework.boot.actuate.endpoint.InfoEndpoint;
@@ -68,7 +69,7 @@ public class InfoMvcEndpointWithNoInfoContributorsTests {
 		this.mvc.perform(get("/info")).andExpect(status().isOk());
 	}
 
-	@Import({ JacksonAutoConfiguration.class,
+	@Import({ JacksonAutoConfiguration.class, AuditAutoConfiguration.class,
 			HttpMessageConvertersAutoConfiguration.class,
 			EndpointWebMvcAutoConfiguration.class, WebMvcAutoConfiguration.class,
 			ManagementServerPropertiesAutoConfiguration.class })

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/JolokiaMvcEndpointContextPathTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/JolokiaMvcEndpointContextPathTests.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.AuditAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.EndpointWebMvcAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.JolokiaAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.ManagementServerPropertiesAutoConfiguration;
@@ -83,7 +84,7 @@ public class JolokiaMvcEndpointContextPathTests {
 	@Configuration
 	@EnableConfigurationProperties
 	@EnableWebMvc
-	@Import({ JacksonAutoConfiguration.class,
+	@Import({ JacksonAutoConfiguration.class, AuditAutoConfiguration.class,
 			HttpMessageConvertersAutoConfiguration.class,
 			EndpointWebMvcAutoConfiguration.class, JolokiaAutoConfiguration.class,
 			ManagementServerPropertiesAutoConfiguration.class })

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/JolokiaMvcEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/JolokiaMvcEndpointTests.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.AuditAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.EndpointWebMvcAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.JolokiaAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.ManagementServerPropertiesAutoConfiguration;
@@ -102,7 +103,7 @@ public class JolokiaMvcEndpointTests {
 	@Configuration
 	@EnableConfigurationProperties
 	@EnableWebMvc
-	@Import({ JacksonAutoConfiguration.class,
+	@Import({ JacksonAutoConfiguration.class, AuditAutoConfiguration.class,
 			HttpMessageConvertersAutoConfiguration.class,
 			EndpointWebMvcAutoConfiguration.class, JolokiaAutoConfiguration.class,
 			ManagementServerPropertiesAutoConfiguration.class })

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/MetricsMvcEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/MetricsMvcEndpointTests.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.AuditAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.EndpointWebMvcAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.ManagementServerPropertiesAutoConfiguration;
 import org.springframework.boot.actuate.endpoint.MetricsEndpoint;
@@ -127,7 +128,7 @@ public class MetricsMvcEndpointTests {
 				.andExpect(content().string(containsString("1")));
 	}
 
-	@Import({ JacksonAutoConfiguration.class,
+	@Import({ JacksonAutoConfiguration.class, AuditAutoConfiguration.class,
 			HttpMessageConvertersAutoConfiguration.class,
 			EndpointWebMvcAutoConfiguration.class, WebMvcAutoConfiguration.class,
 			ManagementServerPropertiesAutoConfiguration.class })

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/MvcEndpointCorsIntegrationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/MvcEndpointCorsIntegrationTests.java
@@ -19,6 +19,7 @@ package org.springframework.boot.actuate.endpoint.mvc;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.boot.actuate.autoconfigure.AuditAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.EndpointWebMvcAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.JolokiaAutoConfiguration;
@@ -56,7 +57,7 @@ public class MvcEndpointCorsIntegrationTests {
 				HttpMessageConvertersAutoConfiguration.class,
 				EndpointAutoConfiguration.class, EndpointWebMvcAutoConfiguration.class,
 				ManagementServerPropertiesAutoConfiguration.class,
-				PropertyPlaceholderAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class, AuditAutoConfiguration.class,
 				JolokiaAutoConfiguration.class, WebMvcAutoConfiguration.class);
 	}
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/MvcEndpointIntegrationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/MvcEndpointIntegrationTests.java
@@ -19,6 +19,7 @@ package org.springframework.boot.actuate.endpoint.mvc;
 import org.junit.After;
 import org.junit.Test;
 
+import org.springframework.boot.actuate.autoconfigure.AuditAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.EndpointWebMvcAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.ManagementServerPropertiesAutoConfiguration;
@@ -223,7 +224,7 @@ public class MvcEndpointIntegrationTests {
 
 	@ImportAutoConfiguration({ JacksonAutoConfiguration.class,
 			HttpMessageConvertersAutoConfiguration.class, EndpointAutoConfiguration.class,
-			EndpointWebMvcAutoConfiguration.class,
+			EndpointWebMvcAutoConfiguration.class, AuditAutoConfiguration.class,
 			ManagementServerPropertiesAutoConfiguration.class,
 			PropertyPlaceholderAutoConfiguration.class, WebMvcAutoConfiguration.class })
 	static class DefaultConfiguration {
@@ -234,7 +235,8 @@ public class MvcEndpointIntegrationTests {
 			JacksonAutoConfiguration.class, HttpMessageConvertersAutoConfiguration.class,
 			EndpointAutoConfiguration.class, EndpointWebMvcAutoConfiguration.class,
 			ManagementServerPropertiesAutoConfiguration.class,
-			PropertyPlaceholderAutoConfiguration.class, WebMvcAutoConfiguration.class })
+			PropertyPlaceholderAutoConfiguration.class, WebMvcAutoConfiguration.class,
+			AuditAutoConfiguration.class })
 	static class SpringHateoasConfiguration {
 
 	}
@@ -242,7 +244,7 @@ public class MvcEndpointIntegrationTests {
 	@ImportAutoConfiguration({ HypermediaAutoConfiguration.class,
 			RepositoryRestMvcAutoConfiguration.class, JacksonAutoConfiguration.class,
 			HttpMessageConvertersAutoConfiguration.class, EndpointAutoConfiguration.class,
-			EndpointWebMvcAutoConfiguration.class,
+			EndpointWebMvcAutoConfiguration.class, AuditAutoConfiguration.class,
 			ManagementServerPropertiesAutoConfiguration.class,
 			PropertyPlaceholderAutoConfiguration.class, WebMvcAutoConfiguration.class })
 	static class SpringDataRestConfiguration {

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -949,6 +949,10 @@ content into your application; rather pick only the properties that you need.
 	endpoints.actuator.enabled=true # Enable the endpoint.
 	endpoints.actuator.path= # Endpoint URL path.
 	endpoints.actuator.sensitive=false # Enable security on the endpoint.
+	endpoints.auditevents.enabled= # Enable the endpoint.
+	endpoints.auditevents.id= # Endpoint identifier.
+	endpoints.auditevents.path= # Endpoint path.
+	endpoints.auditevents.sensitive= # Mark if the endpoint exposes sensitive information.
 	endpoints.autoconfig.enabled= # Enable the endpoint.
 	endpoints.autoconfig.id= # Endpoint identifier.
 	endpoints.autoconfig.path= # Endpoint path.

--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -73,6 +73,10 @@ The following technology agnostic endpoints are available:
 HATEOAS to be on the classpath.
 |true
 
+|`auditevents`
+|Exposes audit events information for the current application.
+|true
+
 |`autoconfig`
 |Displays an auto-configuration report showing all auto-configuration candidates and the
  reason why they '`were`' or '`were not`' applied.


### PR DESCRIPTION
This PR introduces `AuditEventsEndpoint` to retrieve audit events from `AuditEventRepository`. Both HTTP and JMX endpoints are available.

By default, the endpoint retrieves latest events as indicated by `endpoints.auditevents.default-max-age` configuration property, which itself defaults to 60 minutes. Endpoint also exposes `AuditEventRepository` operations to find audit events using custom criteria.

TODOs:
- [x] complete Actuator docs on this endpoint
