### PR TITLE
Allow injection of StatsDClient into StatsdMetricWriter

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/statsd/StatsdMetricWriter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/statsd/StatsdMetricWriter.java
@@ -19,6 +19,7 @@ package org.springframework.boot.actuate.metrics.statsd;
 import java.io.Closeable;
 
 import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.StatsDClient;
 import com.timgroup.statsd.StatsDClientErrorHandler;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -26,6 +27,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.boot.actuate.metrics.Metric;
 import org.springframework.boot.actuate.metrics.writer.Delta;
 import org.springframework.boot.actuate.metrics.writer.MetricWriter;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
@@ -43,7 +45,7 @@ public class StatsdMetricWriter implements MetricWriter, Closeable {
 
 	private static final Log logger = LogFactory.getLog(StatsdMetricWriter.class);
 
-	private final NonBlockingStatsDClient client;
+	private final StatsDClient client;
 
 	/**
 	 * Create a new writer instance with the given parameters.
@@ -61,12 +63,26 @@ public class StatsdMetricWriter implements MetricWriter, Closeable {
 	 * @param port the port for the statsd server
 	 */
 	public StatsdMetricWriter(String prefix, String host, int port) {
-		prefix = StringUtils.hasText(prefix) ? prefix : null;
-		while (prefix != null && prefix.endsWith(".")) {
-			prefix = prefix.substring(0, prefix.length() - 1);
+		this(new NonBlockingStatsDClient(trimPrefix(prefix), host, port,
+			new LoggingStatsdErrorHandler()));
+	}
+
+	/**
+	 * Create a new writer with the given client.
+	 * @param client StatsD client to write metrics with
+	 */
+	public StatsdMetricWriter(StatsDClient client) {
+		Assert.notNull(client);
+		this.client = client;
+	}
+
+	private static String trimPrefix(String prefix) {
+		String trimmedPrefix = StringUtils.hasText(prefix) ? prefix : null;
+		while (trimmedPrefix != null && trimmedPrefix.endsWith(".")) {
+			trimmedPrefix = trimmedPrefix.substring(0, trimmedPrefix.length() - 1);
 		}
-		this.client = new NonBlockingStatsDClient(prefix, host, port,
-				new LoggingStatsdErrorHandler());
+
+		return trimmedPrefix;
 	}
 
 	@Override


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

## Changes

Allow an instance of StatsDClient to be injected into the StatsdMetricWriter which is used for exporting metrics to a Statsd server. This new constructor allows the client to be injected but does not change the default behavior of the writer.

## Motivation

The existing `StatsdMetricWriter` creates a `StatsDClient` instance itself. This means it is not possible
to replace the default instance with a modified version. For example, there are some [forks](https://github.com/DataDog/java-dogstatsd-client) of the Statsd client that offer improved performance and buffering of metrics. Allowing the client instance to be injected into `StatsdMetricWriter` seemed to be the least invasive way to allow alternate implementations.

Thanks!