### PR TITLE
Document webjar-locator usage and if using JBoss

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -1709,8 +1709,16 @@ Spring Boot also supports advanced resource handling features provided by Spring
 allowing use cases such as cache busting static resources or using version agnostic URLs
 for Webjars.
 
-For example, the following configuration will configure a cache busting solution
-for all static resources, effectively adding a content hash in URLs, such as
+To use version agnostic URLs for Webjars, simply add the `webjars-locator` dependency.
+Then declare your Webjar, taking jQuery for example, as `"/webjars/jquery/dist/jquery.min.js"`
+which results in `"/webjars/jquery/x.y.z/dist/jquery.min.js"` where `x.y.z` is the Webjar
+version.
+
+NOTE: If you are using JBoss, you'll need to declare the `webjars-locator-jboss-vfs`
+dependency instead of the `webjars-locator`; otherwise all Webjars resolve as a `404`.
+
+To use cache bursting, the following configuration will configure a cache busting
+solution for all static resources, effectively adding a content hash in URLs, such as
 `<link href="/css/spring-2a2d595e6ed9a0b24f027f2b63b134d6.css"/>`:
 
 [source,properties,indent=0,subs="verbatim,quotes,attributes"]


### PR DESCRIPTION
Document version agnostic URLs for Webjars using the `webjars-locator`. Add a note if using JBoss, to use the `webjars-locator-jboss-vfs` instead.