### PR TITLE
Add LiquibaseDataSource annotation

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -23,6 +23,7 @@ import javax.sql.DataSource;
 import liquibase.integration.spring.SpringLiquibase;
 import liquibase.servicelocator.ServiceLocator;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -50,6 +51,7 @@ import org.springframework.util.Assert;
  * @author Marcel Overdijk
  * @author Dave Syer
  * @author Phillip Webb
+ * @author Eddú Meléndez
  * @since 1.1.0
  */
 @Configuration
@@ -72,11 +74,15 @@ public class LiquibaseAutoConfiguration {
 
 		private final DataSource dataSource;
 
+		private final DataSource liquibaseDataSource;
+
 		public LiquibaseConfiguration(LiquibaseProperties properties,
-				ResourceLoader resourceLoader, DataSource dataSource) {
+				ResourceLoader resourceLoader, DataSource dataSource,
+				@LiquibaseDataSource ObjectProvider<DataSource> liquibaseDataSourceProvider) {
 			this.properties = properties;
 			this.resourceLoader = resourceLoader;
 			this.dataSource = dataSource;
+			this.liquibaseDataSource = liquibaseDataSourceProvider.getIfAvailable();
 		}
 
 		@PostConstruct
@@ -112,6 +118,9 @@ public class LiquibaseAutoConfiguration {
 		private DataSource getDataSource() {
 			if (this.properties.getUrl() == null) {
 				return this.dataSource;
+			}
+			else if (this.liquibaseDataSource != null) {
+				return this.liquibaseDataSource;
 			}
 			return DataSourceBuilder.create().url(this.properties.getUrl())
 					.username(this.properties.getUser())

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseDataSource.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseDataSource.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.liquibase;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+/**
+ * Qualifier annotation for a DataSource to be injected in to Liquibase. If used for a second
+ * data source, the other (main) one would normally be marked as {@code @Primary}.
+ *
+ * @author Eddú Meléndez
+ * @since 1.4.1
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE,
+		ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier
+public @interface LiquibaseDataSource {
+
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This commit allows to configure a special dataSource to be used by
Liquibase if is mark as `@LiquibaseDataSource`.

See gh-6604