### PR TITLE
Use 'travis_wait' to prevent Travis CI from aborting builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ services:
 sudo: false
 install: true
 before_script:
-- ./mvnw install -q -U -DskipTests=true -Dmaven.test.redirectTestOutputToFile=true || true
-- ./mvnw install -q -U -DskipTests=true -Dmaven.test.redirectTestOutputToFile=true
+# Note that we're using '-q' here to suppress most build output since Travis has a limit
+# of 4MB of output and the build produces more than that. We're also using the 'travis_wait'
+# function to make sure Travis doesn't abort our build due to lack of output.
+- travis_wait ./mvnw install -q -U -DskipTests=true -Dmaven.test.redirectTestOutputToFile=true
 script: ./mvnw install -q -nsu -Dmaven.test.redirectTestOutputToFile=true -P '!integration'


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Builds use the `q` flag to suppress most output due to a limit of 4MB of logs
on Travis CI. However, Travis will also abort builds that don't generate any
output for 10 minutes. Thus we use the `travis_wait` function to make sure
builds aren't aborted for up to 20 minutes.

References:
* https://docs.travis-ci.com/user/common-build-problems/#My-builds-are-timing-out
* https://twitter.com/travisci/status/174904509754118144
* https://github.com/travis-ci/travis-ci/issues/1382

Fixes gh-6621