### PR TITLE
Polish Spring Session auto-configuration

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HazelcastSessionConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HazelcastSessionConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.boot.autoconfigure.session;
 
 import com.hazelcast.core.HazelcastInstance;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Conditional;
@@ -40,11 +39,11 @@ import org.springframework.session.hazelcast.config.annotation.web.http.Hazelcas
 class HazelcastSessionConfiguration {
 
 	@Configuration
-	public static class SpringBootHazelcastHttpSessionConfiguration
+	protected static class SpringBootHazelcastHttpSessionConfiguration
 			extends HazelcastHttpSessionConfiguration {
 
-		@Autowired
-		public void customize(SessionProperties sessionProperties) {
+		protected SpringBootHazelcastHttpSessionConfiguration(
+				SessionProperties sessionProperties) {
 			Integer timeout = sessionProperties.getTimeout();
 			if (timeout != null) {
 				setMaxInactiveIntervalInSeconds(timeout);

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.boot.autoconfigure.session;
 
 import javax.sql.DataSource;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -53,11 +52,11 @@ class JdbcSessionConfiguration {
 	}
 
 	@Configuration
-	public static class SpringBootJdbcHttpSessionConfiguration
+	protected static class SpringBootJdbcHttpSessionConfiguration
 			extends JdbcHttpSessionConfiguration {
 
-		@Autowired
-		public void customize(SessionProperties sessionProperties) {
+		protected SpringBootJdbcHttpSessionConfiguration(
+				SessionProperties sessionProperties) {
 			Integer timeout = sessionProperties.getTimeout();
 			if (timeout != null) {
 				setMaxInactiveIntervalInSeconds(timeout);

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/MongoSessionConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/MongoSessionConfiguration.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.autoconfigure.session;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Conditional;
@@ -38,11 +37,11 @@ import org.springframework.session.data.mongo.config.annotation.web.http.MongoHt
 class MongoSessionConfiguration {
 
 	@Configuration
-	public static class SpringBootMongoHttpSessionConfiguration
+	static class SpringBootMongoHttpSessionConfiguration
 			extends MongoHttpSessionConfiguration {
 
-		@Autowired
-		public void customize(SessionProperties sessionProperties) {
+		protected SpringBootMongoHttpSessionConfiguration(
+				SessionProperties sessionProperties) {
 			Integer timeout = sessionProperties.getTimeout();
 			if (timeout != null) {
 				setMaxInactiveIntervalInSeconds(timeout);

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionConfiguration.java
@@ -21,7 +21,6 @@ import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Conditional;
@@ -49,13 +48,13 @@ class RedisSessionConfiguration {
 			.getLogger(RedisSessionConfiguration.class);
 
 	@Configuration
-	public static class SpringBootRedisHttpSessionConfiguration
+	protected static class SpringBootRedisHttpSessionConfiguration
 			extends RedisHttpSessionConfiguration {
 
 		private SessionProperties sessionProperties;
 
-		@Autowired
-		public void customize(SessionProperties sessionProperties) {
+		protected SpringBootRedisHttpSessionConfiguration(
+				SessionProperties sessionProperties) {
 			this.sessionProperties = sessionProperties;
 			Integer timeout = this.sessionProperties.getTimeout();
 			if (timeout != null) {


### PR DESCRIPTION
This PR replaces random `@Autowired` methods in Boot's subclasses of Session's configuration classes with constructor injection, therefore removing the need for `@Autowired`. In addition, configuration classes have been made `protected` to be consistent with most other equivalent inner `@Configuration` classes.