### PR TITLE
Validate Spring Session database initializer configuration

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionProperties.java
@@ -107,6 +107,8 @@ public class SessionProperties {
 		private static final String DEFAULT_SCHEMA_LOCATION = "classpath:org/springframework/"
 				+ "session/jdbc/schema-@@platform@@.sql";
 
+		private static final String DEFAULT_TABLE_NAME = "SPRING_SESSION";
+
 		/**
 		 * Path to the SQL file to use to initialize the database schema.
 		 */
@@ -115,7 +117,7 @@ public class SessionProperties {
 		/**
 		 * Name of database table used to store sessions.
 		 */
-		private String tableName = "SPRING_SESSION";
+		private String tableName = DEFAULT_TABLE_NAME;
 
 		private final Initializer initializer = new Initializer();
 
@@ -139,7 +141,7 @@ public class SessionProperties {
 			return this.initializer;
 		}
 
-		public static class Initializer {
+		public class Initializer {
 
 			/**
 			 * Create the required session tables on startup if necessary.
@@ -147,7 +149,11 @@ public class SessionProperties {
 			private boolean enabled = true;
 
 			public boolean isEnabled() {
-				return this.enabled;
+				boolean isDefaultTableName = DEFAULT_TABLE_NAME.equals(
+						Jdbc.this.getTableName());
+				boolean isDefaultSchema = DEFAULT_SCHEMA_LOCATION.equals(
+						Jdbc.this.getSchema());
+				return this.enabled && (isDefaultTableName || !isDefaultSchema);
 			}
 
 			public void setEnabled(boolean enabled) {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationJdbcTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationJdbcTests.java
@@ -52,6 +52,8 @@ public class SessionAutoConfigurationJdbcTests
 				JdbcOperationsSessionRepository.class);
 		assertThat(new DirectFieldAccessor(repository).getPropertyValue("tableName"))
 				.isEqualTo("SPRING_SESSION");
+		assertThat(this.context.getBean(SessionProperties.class)
+				.getJdbc().getInitializer().isEnabled()).isTrue();
 		assertThat(this.context.getBean(JdbcOperations.class)
 				.queryForList("select * from SPRING_SESSION")).isEmpty();
 	}
@@ -66,6 +68,8 @@ public class SessionAutoConfigurationJdbcTests
 				JdbcOperationsSessionRepository.class);
 		assertThat(new DirectFieldAccessor(repository).getPropertyValue("tableName"))
 				.isEqualTo("SPRING_SESSION");
+		assertThat(this.context.getBean(SessionProperties.class)
+				.getJdbc().getInitializer().isEnabled()).isFalse();
 		this.thrown.expect(BadSqlGrammarException.class);
 		assertThat(this.context.getBean(JdbcOperations.class)
 				.queryForList("select * from SPRING_SESSION")).isEmpty();
@@ -82,8 +86,27 @@ public class SessionAutoConfigurationJdbcTests
 				JdbcOperationsSessionRepository.class);
 		assertThat(new DirectFieldAccessor(repository).getPropertyValue("tableName"))
 				.isEqualTo("FOO_BAR");
+		assertThat(this.context.getBean(SessionProperties.class)
+				.getJdbc().getInitializer().isEnabled()).isTrue();
 		assertThat(this.context.getBean(JdbcOperations.class)
 				.queryForList("select * from FOO_BAR")).isEmpty();
+	}
+
+	@Test
+	public void customTableNameWithDefaultSchemaDisablesInitializer() {
+		load(Arrays.asList(EmbeddedDataSourceConfiguration.class,
+				DataSourceTransactionManagerAutoConfiguration.class),
+				"spring.session.store-type=jdbc",
+				"spring.session.jdbc.table-name=FOO_BAR");
+		JdbcOperationsSessionRepository repository = validateSessionRepository(
+				JdbcOperationsSessionRepository.class);
+		assertThat(new DirectFieldAccessor(repository).getPropertyValue("tableName"))
+				.isEqualTo("FOO_BAR");
+		assertThat(this.context.getBean(SessionProperties.class)
+				.getJdbc().getInitializer().isEnabled()).isFalse();
+		this.thrown.expect(BadSqlGrammarException.class);
+		assertThat(this.context.getBean(JdbcOperations.class)
+				.queryForList("select * from SPRING_SESSION")).isEmpty();
 	}
 
 }


### PR DESCRIPTION
This PR adds Spring Session JDBC configuration validation that disables database initializer in case custom table name is configured with default schema.

Currently, it is possible to set custom table name but leave default schema configuration property. This will either result in an error in runtime since expected table (with custom name) won't be found, or, if user has set up the correct table by some other means, with created unused table.

In both cases the correct approach would be to fail fast and indicate invalid configuration.