### PR TITLE
Validate Spring Batch database initializer configuration

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Stephane Nicoll
  * @author Eddú Meléndez
+ * @author Vedran Pavic
  * @since 1.2.0
  */
 @ConfigurationProperties("spring.batch")
@@ -69,7 +70,7 @@ public class BatchProperties {
 		return this.tablePrefix;
 	}
 
-	public static class Initializer {
+	public class Initializer {
 
 		/**
 		 * Create the required batch tables on startup if necessary.
@@ -77,7 +78,10 @@ public class BatchProperties {
 		private boolean enabled = true;
 
 		public boolean isEnabled() {
-			return this.enabled;
+			boolean isDefaultTablePrefix = BatchProperties.this.getTablePrefix() == null;
+			boolean isDefaultSchema = DEFAULT_SCHEMA_LOCATION.equals(
+					BatchProperties.this.getSchema());
+			return this.enabled && (isDefaultTablePrefix || !isDefaultSchema);
 		}
 
 		public void setEnabled(boolean enabled) {


### PR DESCRIPTION
This PR adds Spring Batch configuration validation that disables database initializer in case custom table prefix is configured with default schema.

Related: #6649