### PR TITLE
Expose idleEventInterval to RabbitProperties.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -504,6 +504,11 @@ public class RabbitProperties {
 		private Boolean defaultRequeueRejected;
 
 		/**
+		 * How often to publish idle container events.
+		 */
+		private Long idleEventInterval;
+
+		/**
 		 * Optional properties for a retry interceptor.
 		 */
 		@NestedConfigurationProperty
@@ -563,6 +568,14 @@ public class RabbitProperties {
 
 		public void setDefaultRequeueRejected(Boolean defaultRequeueRejected) {
 			this.defaultRequeueRejected = defaultRequeueRejected;
+		}
+
+		public Long getIdleEventInterval() {
+			return idleEventInterval;
+		}
+
+		public void setIdleEventInterval(Long idleEventInterval) {
+			this.idleEventInterval = idleEventInterval;
 		}
 
 		public ListenerRetry getRetry() {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/SimpleRabbitListenerContainerFactoryConfigurer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/SimpleRabbitListenerContainerFactoryConfigurer.java
@@ -90,6 +90,9 @@ public final class SimpleRabbitListenerContainerFactoryConfigurer {
 		if (listenerConfig.getDefaultRequeueRejected() != null) {
 			factory.setDefaultRequeueRejected(listenerConfig.getDefaultRequeueRejected());
 		}
+		if (listenerConfig.getIdleEventInterval() != null) {
+			factory.setIdleEventInterval(listenerConfig.getIdleEventInterval());
+		}
 		ListenerRetry retryConfig = listenerConfig.getRetry();
 		if (retryConfig.isEnabled()) {
 			RetryInterceptorBuilder<?> builder = (retryConfig.isStateless()

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -303,6 +303,7 @@ public class RabbitAutoConfigurationTests {
 				"spring.rabbitmq.listener.maxConcurrency:10",
 				"spring.rabbitmq.listener.prefetch:40",
 				"spring.rabbitmq.listener.defaultRequeueRejected:false",
+				"spring.rabbitmq.listener.idleEventInterval:5",
 				"spring.rabbitmq.listener.transactionSize:20");
 		SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory = this.context
 				.getBean("rabbitListenerContainerFactory",
@@ -319,6 +320,7 @@ public class RabbitAutoConfigurationTests {
 				.isSameAs(this.context.getBean("myMessageConverter"));
 		assertThat(dfa.getPropertyValue("defaultRequeueRejected"))
 				.isEqualTo(Boolean.FALSE);
+		assertThat(dfa.getPropertyValue("idleEventInterval")).isEqualTo(5L);
 		Advice[] adviceChain = (Advice[]) dfa.getPropertyValue("adviceChain");
 		assertThat(adviceChain).isNotNull();
 		assertThat(adviceChain.length).isEqualTo(1);


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Detecting idling listeners can be very handy and with this change idling time can be configured just by setting value for `spring.rabbitmq.listener.idle-event-interval` in `properties` or `yaml` file.