### PR TITLE
Nested class with multiple conditions is not evaluated in a standard way by AnyNestedCondition

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/AnyNestedConditionTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/AnyNestedConditionTests.java
@@ -92,6 +92,7 @@ public class AnyNestedConditionTests {
 
 		}
 
+		@ConditionalOnExpression("true")
 		@ConditionalOnProperty("b")
 		static class HasPropertyB {
 


### PR DESCRIPTION
If there are multiple conditions on one of the nested classes they are ORed when they should be ANDed. Anyone relying on the current behaviour would only have to split the conditions across multiple classes to fix it.

N.B. this PR is just a failing test for now.