### PR TITLE
Add Hibernate starter

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -378,6 +378,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-hibernate</artifactId>
+				<version>1.4.1.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-hornetq</artifactId>
 				<version>1.4.1.BUILD-SNAPSHOT</version>
 			</dependency>

--- a/spring-boot-starters/pom.xml
+++ b/spring-boot-starters/pom.xml
@@ -41,6 +41,7 @@
 		<module>spring-boot-starter-freemarker</module>
 		<module>spring-boot-starter-groovy-templates</module>
 		<module>spring-boot-starter-hateoas</module>
+		<module>spring-boot-starter-hibernate</module>
 		<module>spring-boot-starter-hornetq</module>
 		<module>spring-boot-starter-integration</module>
 		<module>spring-boot-starter-jdbc</module>

--- a/spring-boot-starters/spring-boot-starter-data-jpa/src/main/resources/META-INF/spring.provides
+++ b/spring-boot-starters/spring-boot-starter-data-jpa/src/main/resources/META-INF/spring.provides
@@ -1,1 +1,1 @@
-provides: spring-orm,hibernate-entity-manager,spring-data-jpa
+provides: spring-data-jpa

--- a/spring-boot-starters/spring-boot-starter-hibernate/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-hibernate/pom.xml
@@ -6,9 +6,9 @@
 		<artifactId>spring-boot-starters</artifactId>
 		<version>1.4.1.BUILD-SNAPSHOT</version>
 	</parent>
-	<artifactId>spring-boot-starter-data-jpa</artifactId>
-	<name>Spring Boot Data JPA Starter</name>
-	<description>Starter for using Spring Data JPA with Hibernate</description>
+	<artifactId>spring-boot-starter-hibernate</artifactId>
+	<name>Spring Boot Hibernate Starter</name>
+	<description>Starter for using Hibernate</description>
 	<url>http://projects.spring.io/spring-boot/</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
@@ -24,43 +24,39 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-hibernate</artifactId>
+			<artifactId>spring-boot-starter-aop</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.data</groupId>
-			<artifactId>spring-data-jpa</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-orm</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-core</artifactId>
 			<exclusions>
 				<exclusion>
-					<groupId>org.aspectj</groupId>
-					<artifactId>aspectjrt</artifactId>
+					<groupId>org.apache.geronimo.specs</groupId>
+					<artifactId>geronimo-jta_1.1_spec</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-aspects</artifactId>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-entitymanager</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.geronimo.specs</groupId>
+					<artifactId>geronimo-jta_1.1_spec</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>javax.transaction</groupId>
+			<artifactId>javax.transaction-api</artifactId>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.basepom.maven</groupId>
-				<artifactId>duplicate-finder-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>duplicate-dependencies</id>
-						<phase>validate</phase>
-						<goals>
-							<goal>check</goal>
-						</goals>
-						<configuration>
-							<ignoredResourcePatterns>
-								<ignoredResourcePattern>changelog.txt</ignoredResourcePattern>
-							</ignoredResourcePatterns>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/spring-boot-starters/spring-boot-starter-hibernate/src/main/resources/META-INF/spring.provides
+++ b/spring-boot-starters/spring-boot-starter-hibernate/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: spring-orm,hibernate-entity-manager


### PR DESCRIPTION
If one wants to use Hibernate/JPA for data access, but not with Spring Data JPA, there's no adequate starter to support such setup meaning the dependencies need to be declared manually.

This PR adds starter for Hibernate. In addition, the existing Spring Data JPA starter has been refactored to depend on newly introduced Hibernate starter.