### PR TITLE
Include netty-handler as transient dependency of cassandra-driver-dse

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -596,10 +596,6 @@
 						<groupId>com.google.guava</groupId>
 						<artifactId>guava</artifactId>
 					</exclusion>
-					<exclusion>
-						<groupId>io.netty</groupId>
-						<artifactId>netty-handler</artifactId>
-					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Includes `netty-handler` as transient dependency of `cassandra-driver-dse` to fix #6616.