### PR TITLE
Allows Tomcat to support context docbase configuration, enable defaul…

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -142,6 +142,9 @@ public class ServerPropertiesTests {
 		map.put("server.tomcat.remote_ip_header", "Remote-Ip");
 		map.put("server.tomcat.internal_proxies", "10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
 		map.put("server.tomcat.background_processor_delay", "10");
+		map.put("server.tomcat.context.docbase", "/var/www");
+		map.put("server.tomcat.context.resources.linking.enabled", "true");
+		map.put("server.tomcat.servlets.defaultservlet.listing.enabled", "true");
 		bindProperties(map);
 		ServerProperties.Tomcat tomcat = this.properties.getTomcat();
 		assertThat(tomcat.getAccesslog().getPattern()).isEqualTo("%h %t '%r' %s %b");
@@ -153,6 +156,9 @@ public class ServerPropertiesTests {
 		assertThat(tomcat.getInternalProxies())
 				.isEqualTo("10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
 		assertThat(tomcat.getBackgroundProcessorDelay()).isEqualTo(10);
+		assertThat(tomcat.getContext().getDocbase().toString()).isEqualTo("/var/www");
+		assertThat(tomcat.getContext().getResources().getLinking().isEnabled()).isTrue();
+		assertThat(tomcat.getServlets().getDefaultservlet().getListing().isEnabled()).isTrue();
 	}
 
 	@Test

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -201,6 +201,9 @@ content into your application; rather pick only the properties that you need.
 	server.tomcat.accesslog.suffix=.log # Log file name suffix.
 	server.tomcat.background-processor-delay=30 # Delay in seconds between the invocation of backgroundProcess methods.
 	server.tomcat.basedir= # Tomcat base directory. If not specified a temporary directory will be used.
+	server.tomcat.context.docbase= # Tomcat docbase override. This allows for users to set static content external to the server.
+    server.tomcat.context.resources.linking.enabled=false # If the value of this flag is true, symlinks will be allowed inside the web application, pointing to resources outside the web application base path.
+    server.tomcat.servlets.defaultservlet.listing.enabled=false # controls if directory listings should be shown by the default servlet.
 	server.tomcat.internal-proxies=10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|\\
 			192\\.168\\.\\d{1,3}\\.\\d{1,3}|\\
 			169\\.254\\.\\d{1,3}\\.\\d{1,3}|\\

--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -640,7 +640,17 @@ Access logging for undertow can be configured in a similar fashion
 Logs are stored in a `logs` directory relative to the working directory of the
 application. This can be customized via `server.undertow.accesslog.directory`.
 
+[[howto-configure-external-context]]
+=== Configure External Static Content
+Tomcat can be configured to serve static external content, follow symlinks, and
+show directory listings.
 
+[source,properties,indent=0,subs="verbatim,quotes,attributes"]
+----
+	server.tomcat.context.docbase=/var/www
+    server.tomcat.context.resources.linking.enabled=true
+    server.tomcat.servlets.defaultservlet.listing.enabled=true
+----
 
 [[howto-use-behind-a-proxy-server]]
 [[howto-use-tomcat-behind-a-proxy-server]]

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractConfigurableEmbeddedServletContainer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractConfigurableEmbeddedServletContainer.java
@@ -230,6 +230,9 @@ public abstract class AbstractConfigurableEmbeddedServletContainer
 
 	@Override
 	public void setDocumentRoot(File documentRoot) {
+		if (documentRoot != null && !documentRoot.exists()) {
+			throw new IllegalStateException("document root must exist.");
+		}
 		this.documentRoot = documentRoot;
 	}
 


### PR DESCRIPTION
This allows for embedded Tomcat to support external doc bases for static content, enable such content to have symbolic links, and enable directory listings when a directory is requested.

These features are setup with application properties.

`# Tomcat docbase override. This allows for users to set static content external to the server.`
`server.tomcat.context.docbase=/var/www`

`# If the value of this flag is true, symlinks will be allowed inside the web application, pointing to resources outside the web application base path.`
`server.tomcat.context.resources.linking.enabled=false`

`# controls if directory listings should be shown by the default servlet.`
`server.tomcat.servlets.defaultservlet.listing.enabled=false`

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->