### PR TITLE
[Caffeine auto-config] Allow CacheLoader with specific generic types

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CaffeineCacheConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CaffeineCacheConfiguration.java
@@ -53,13 +53,13 @@ class CaffeineCacheConfiguration {
 
 	private final CaffeineSpec caffeineSpec;
 
-	private final CacheLoader<Object, Object> cacheLoader;
+	private final CacheLoader cacheLoader;
 
 	CaffeineCacheConfiguration(CacheProperties cacheProperties,
 			CacheManagerCustomizers customizers,
 			ObjectProvider<Caffeine<Object, Object>> caffeineProvider,
 			ObjectProvider<CaffeineSpec> caffeineSpecProvider,
-			ObjectProvider<CacheLoader<Object, Object>> cacheLoaderProvider) {
+			ObjectProvider<CacheLoader> cacheLoaderProvider) {
 		this.cacheProperties = cacheProperties;
 		this.customizers = customizers;
 		this.caffeine = caffeineProvider.getIfAvailable();


### PR DESCRIPTION
I came across this while trying out the new Caffeine caching auto-configuration. After reading the Spring Boot [documentation on Caffeine caching](https://docs.spring.io/spring-boot/docs/1.4.0.RELEASE/reference/html/boot-features-caching.html#boot-features-caching-provider-caffeine), I was surprised that my provided `CacheLoader<String, List<String>>` bean was not being used by the auto-configuration. If this is the intended behavior, then this pull request can be closed, but I think the documentation could be a bit more clear.

The UT added here fails without the main code changes. Similar to the UT, I wanted to use the Caffeine auto-configuration but provide a `CacheLoader` to be used, like the following in a `@Configuration` class:

```java
@Bean
public CacheLoader<String, List<String>> cacheLoader(SlowService service) {
	return service::getNames;
}
```