### PR TITLE
Provide dependency management for querydsl

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -132,6 +132,7 @@
 		<nekohtml.version>1.9.22</nekohtml.version>
 		<neo4j-ogm.version>2.0.4</neo4j-ogm.version>
 		<postgresql.version>9.4.1209.jre7</postgresql.version>
+		<querydsl.version>4.1.3</querydsl.version>
 		<reactor.version>2.0.8.RELEASE</reactor.version>
 		<reactor-spring.version>2.0.7.RELEASE</reactor-spring.version>
 		<selenium.version>2.53.1</selenium.version>
@@ -767,6 +768,27 @@
 				<groupId>com.jayway.jsonpath</groupId>
 				<artifactId>json-path-assert</artifactId>
 				<version>${json-path.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.querydsl</groupId>
+				<artifactId>querydsl-collections</artifactId>
+				<version>${querydsl.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.querydsl</groupId>
+				<artifactId>querydsl-jpa</artifactId>
+				<version>${querydsl.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.querydsl</groupId>
+				<artifactId>querydsl-mongodb</artifactId>
+				<version>${querydsl.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.mongodb</groupId>
+						<artifactId>mongo-java-driver</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>com.samskivert</groupId>


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Querydsl is a third-party dependency in spring-data projects such as jpa
and mongodb. This commit provides such libraries in the dependency
management section to provide the right version to users.

See gh-6399