### PR TITLE
document trace endpoint defaults to 100

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -125,7 +125,7 @@ authenticated).
 |true
 
 |`trace`
-|Displays trace information (by default the last few HTTP requests).
+|Displays trace information (by default the last 100 HTTP requests).
 |true
 |===
 
@@ -1408,7 +1408,7 @@ use that directly, or you can simply publish `AuditApplicationEvent` via the Spr
 [[production-ready-tracing]]
 == Tracing
 Tracing is automatically enabled for all HTTP requests. You can view the `trace` endpoint
-and obtain basic information about the last few requests:
+and obtain basic information about the last 100 requests:
 
 [source,json,indent=0]
 ----


### PR DESCRIPTION
In section `Custom tracing`, it already documented that default `TraceRepository` will store last 100 events.
But there are two places still documented as `last few` so change it to 100.

Fix #6839 

- [x] I have signed the CLA