### PR TITLE
Include details in `AuditEvent` data in `AuthorizationAuditListener`

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthorizationAuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthorizationAuditListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,9 @@ public class AuthorizationAuditListener extends AbstractAuthorizationAuditListen
 		Map<String, Object> data = new HashMap<String, Object>();
 		data.put("type", event.getAccessDeniedException().getClass().getName());
 		data.put("message", event.getAccessDeniedException().getMessage());
+		if (event.getAuthentication().getDetails() != null) {
+			data.put("details", event.getAuthentication().getDetails());
+		}
 		publish(new AuditEvent(event.getAuthentication().getName(),
 				"AUTHORIZATION_FAILURE", data));
 	}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/security/AuthorizationAuditListenerTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/security/AuthorizationAuditListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,15 +20,20 @@ import java.util.Arrays;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
+import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.access.SecurityConfig;
+import org.springframework.security.access.event.AuthenticationCredentialsNotFoundEvent;
 import org.springframework.security.access.event.AuthorizationFailureEvent;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -49,12 +54,36 @@ public class AuthorizationAuditListenerTests {
 	}
 
 	@Test
-	public void testAuthenticationSuccess() {
+	public void testAuthenticationCredentialsNotFound() {
+		this.listener.onApplicationEvent(new AuthenticationCredentialsNotFoundEvent(this,
+				Arrays.<ConfigAttribute>asList(new SecurityConfig("USER")),
+				new AuthenticationCredentialsNotFoundException("Bad user")));
+		verify(this.publisher).publishEvent((ApplicationEvent) anyObject());
+	}
+
+	@Test
+	public void testAuthorizationFailure() {
 		this.listener.onApplicationEvent(new AuthorizationFailureEvent(this,
 				Arrays.<ConfigAttribute>asList(new SecurityConfig("USER")),
 				new UsernamePasswordAuthenticationToken("user", "password"),
 				new AccessDeniedException("Bad user")));
 		verify(this.publisher).publishEvent((ApplicationEvent) anyObject());
+	}
+
+	@Test
+	public void testDetailsAreIncludedInAuditEvent() throws Exception {
+		Object details = new Object();
+		UsernamePasswordAuthenticationToken authentication =
+				new UsernamePasswordAuthenticationToken("user", "password");
+		authentication.setDetails(details);
+		this.listener.onApplicationEvent(new AuthorizationFailureEvent(this,
+				Arrays.<ConfigAttribute>asList(new SecurityConfig("USER")),
+				authentication, new AccessDeniedException("Bad user")));
+		ArgumentCaptor<AuditApplicationEvent> auditApplicationEvent = ArgumentCaptor
+				.forClass(AuditApplicationEvent.class);
+		verify(this.publisher).publishEvent(auditApplicationEvent.capture());
+		assertThat(auditApplicationEvent.getValue().getAuditEvent().getData())
+				.containsEntry("details", details);
 	}
 
 }


### PR DESCRIPTION
This is analogous to the change proposed in #4819 and resolved in #4976.