### PR TITLE
Enumerate supported audit event types

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthenticationAuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthenticationAuditListener.java
@@ -30,8 +30,24 @@ import org.springframework.util.ClassUtils;
  * Default implementation of {@link AbstractAuthenticationAuditListener}.
  *
  * @author Dave Syer
+ * @author Vedran Pavic
  */
 public class AuthenticationAuditListener extends AbstractAuthenticationAuditListener {
+
+	/**
+	 * Authentication success event type.
+	 */
+	public static final String AUTHENTICATION_SUCCESS = "AUTHENTICATION_SUCCESS";
+
+	/**
+	 * Authentication failure event type.
+	 */
+	public static final String AUTHENTICATION_FAILURE = "AUTHENTICATION_FAILURE";
+
+	/**
+	 * Authentication switch event type.
+	 */
+	public static final String AUTHENTICATION_SWITCH = "AUTHENTICATION_SWITCH";
 
 	private static final String WEB_LISTENER_CHECK_CLASS = "org.springframework.security.web.authentication.switchuser.AuthenticationSwitchUserEvent";
 
@@ -65,7 +81,7 @@ public class AuthenticationAuditListener extends AbstractAuthenticationAuditList
 			data.put("details", event.getAuthentication().getDetails());
 		}
 		publish(new AuditEvent(event.getAuthentication().getName(),
-				"AUTHENTICATION_FAILURE", data));
+				AUTHENTICATION_FAILURE, data));
 	}
 
 	private void onAuthenticationSuccessEvent(AuthenticationSuccessEvent event) {
@@ -74,7 +90,7 @@ public class AuthenticationAuditListener extends AbstractAuthenticationAuditList
 			data.put("details", event.getAuthentication().getDetails());
 		}
 		publish(new AuditEvent(event.getAuthentication().getName(),
-				"AUTHENTICATION_SUCCESS", data));
+				AUTHENTICATION_SUCCESS, data));
 	}
 
 	private static class WebAuditListener {
@@ -89,7 +105,7 @@ public class AuthenticationAuditListener extends AbstractAuthenticationAuditList
 				}
 				data.put("target", event.getTargetUser().getUsername());
 				listener.publish(new AuditEvent(event.getAuthentication().getName(),
-						"AUTHENTICATION_SWITCH", data));
+						AUTHENTICATION_SWITCH, data));
 			}
 
 		}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthorizationAuditListener.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/security/AuthorizationAuditListener.java
@@ -28,8 +28,14 @@ import org.springframework.security.access.event.AuthorizationFailureEvent;
  * Default implementation of {@link AbstractAuthorizationAuditListener}.
  *
  * @author Dave Syer
+ * @author Vedran Pavic
  */
 public class AuthorizationAuditListener extends AbstractAuthorizationAuditListener {
+
+	/**
+	 * Authorization failure event type.
+	 */
+	public static final String AUTHORIZATION_FAILURE = "AUTHORIZATION_FAILURE";
 
 	@Override
 	public void onApplicationEvent(AbstractAuthorizationEvent event) {
@@ -47,7 +53,8 @@ public class AuthorizationAuditListener extends AbstractAuthorizationAuditListen
 		Map<String, Object> data = new HashMap<String, Object>();
 		data.put("type", event.getCredentialsNotFoundException().getClass().getName());
 		data.put("message", event.getCredentialsNotFoundException().getMessage());
-		publish(new AuditEvent("<unknown>", "AUTHENTICATION_FAILURE", data));
+		publish(new AuditEvent("<unknown>",
+				AuthenticationAuditListener.AUTHENTICATION_FAILURE, data));
 	}
 
 	private void onAuthorizationFailureEvent(AuthorizationFailureEvent event) {
@@ -58,7 +65,7 @@ public class AuthorizationAuditListener extends AbstractAuthorizationAuditListen
 			data.put("details", event.getAuthentication().getDetails());
 		}
 		publish(new AuditEvent(event.getAuthentication().getName(),
-				"AUTHORIZATION_FAILURE", data));
+				AUTHORIZATION_FAILURE, data));
 	}
 
 }

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/security/AuthenticationAuditListenerTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/security/AuthenticationAuditListenerTests.java
@@ -57,7 +57,11 @@ public class AuthenticationAuditListenerTests {
 	public void testAuthenticationSuccess() {
 		this.listener.onApplicationEvent(new AuthenticationSuccessEvent(
 				new UsernamePasswordAuthenticationToken("user", "password")));
-		verify(this.publisher).publishEvent((ApplicationEvent) anyObject());
+		ArgumentCaptor<AuditApplicationEvent> argumentCaptor = ArgumentCaptor
+				.forClass(AuditApplicationEvent.class);
+		verify(this.publisher).publishEvent(argumentCaptor.capture());
+		assertThat(argumentCaptor.getValue().getAuditEvent().getType())
+				.isEqualTo(AuthenticationAuditListener.AUTHENTICATION_SUCCESS);
 	}
 
 	@Test
@@ -73,7 +77,11 @@ public class AuthenticationAuditListenerTests {
 		this.listener.onApplicationEvent(new AuthenticationFailureExpiredEvent(
 				new UsernamePasswordAuthenticationToken("user", "password"),
 				new BadCredentialsException("Bad user")));
-		verify(this.publisher).publishEvent((ApplicationEvent) anyObject());
+		ArgumentCaptor<AuditApplicationEvent> argumentCaptor = ArgumentCaptor
+				.forClass(AuditApplicationEvent.class);
+		verify(this.publisher).publishEvent(argumentCaptor.capture());
+		assertThat(argumentCaptor.getValue().getAuditEvent().getType())
+				.isEqualTo(AuthenticationAuditListener.AUTHENTICATION_FAILURE);
 	}
 
 	@Test
@@ -82,7 +90,11 @@ public class AuthenticationAuditListenerTests {
 				new UsernamePasswordAuthenticationToken("user", "password"),
 				new User("user", "password",
 						AuthorityUtils.commaSeparatedStringToAuthorityList("USER"))));
-		verify(this.publisher).publishEvent((ApplicationEvent) anyObject());
+		ArgumentCaptor<AuditApplicationEvent> argumentCaptor = ArgumentCaptor
+				.forClass(AuditApplicationEvent.class);
+		verify(this.publisher).publishEvent(argumentCaptor.capture());
+		assertThat(argumentCaptor.getValue().getAuditEvent().getType())
+				.isEqualTo(AuthenticationAuditListener.AUTHENTICATION_SWITCH);
 	}
 
 	@Test
@@ -93,10 +105,13 @@ public class AuthenticationAuditListenerTests {
 		authentication.setDetails(details);
 		this.listener.onApplicationEvent(new AuthenticationFailureExpiredEvent(
 				authentication, new BadCredentialsException("Bad user")));
-		ArgumentCaptor<AuditApplicationEvent> auditApplicationEvent = ArgumentCaptor
+		ArgumentCaptor<AuditApplicationEvent> argumentCaptor = ArgumentCaptor
 				.forClass(AuditApplicationEvent.class);
-		verify(this.publisher).publishEvent(auditApplicationEvent.capture());
-		assertThat(auditApplicationEvent.getValue().getAuditEvent().getData())
+		verify(this.publisher).publishEvent(argumentCaptor.capture());
+		AuditApplicationEvent event = argumentCaptor.getValue();
+		assertThat(event.getAuditEvent().getType())
+				.isEqualTo(AuthenticationAuditListener.AUTHENTICATION_FAILURE);
+		assertThat(event.getAuditEvent().getData())
 				.containsEntry("details", details);
 	}
 


### PR DESCRIPTION
The motivation behind this change:
- safe creation of audit events and avoided string duplication
- since `AuditEventRepository` allows retrieval of audit events by event type, it makes sense provide out-of-the-box supported event type values to the users
