### PR TITLE
set default credentials for rabbitmq

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -52,12 +52,12 @@ public class RabbitProperties {
 	/**
 	 * Login user to authenticate to the broker.
 	 */
-	private String username;
+	private String username = "guest";
 
 	/**
 	 * Login to authenticate against the broker.
 	 */
-	private String password;
+	private String password = "guest";
 
 	/**
 	 * SSL configuration.

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
@@ -134,8 +134,8 @@ public class RabbitPropertiesTests {
 	}
 
 	@Test
-	public void usernameDefaultsToNull() {
-		assertThat(this.properties.getUsername()).isNull();
+	public void usernameDefaultsToGuest() {
+		assertThat(this.properties.getUsername()).isEqualTo("guest");
 	}
 
 	@Test
@@ -166,8 +166,8 @@ public class RabbitPropertiesTests {
 	}
 
 	@Test
-	public void passwordDefaultsToNull() {
-		assertThat(this.properties.getPassword()).isNull();
+	public void passwordDefaultsToGuest() {
+		assertThat(this.properties.getPassword()).isEqualTo("guest");
 	}
 
 	@Test

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -897,7 +897,7 @@ content into your application; rather pick only the properties that you need.
 	spring.rabbitmq.listener.retry.multiplier=1.0 # A multiplier to apply to the previous delivery retry interval.
 	spring.rabbitmq.listener.retry.stateless=true # Whether or not retry is stateless or stateful.
 	spring.rabbitmq.listener.transaction-size= # Number of messages to be processed in a transaction. For best results it should be less than or equal to the prefetch count.
-	spring.rabbitmq.password= # Login to authenticate against the broker.
+	spring.rabbitmq.password=guest # Login to authenticate against the broker.
 	spring.rabbitmq.port=5672 # RabbitMQ port.
 	spring.rabbitmq.publisher-confirms=false # Enable publisher confirms.
 	spring.rabbitmq.publisher-returns=false # Enable publisher returns.
@@ -916,7 +916,7 @@ content into your application; rather pick only the properties that you need.
 	spring.rabbitmq.template.retry.max-attempts=3 # Maximum number of attempts to publish a message.
 	spring.rabbitmq.template.retry.max-interval=10000 # Maximum number of attempts to publish a message.
 	spring.rabbitmq.template.retry.multiplier=1.0 # A multiplier to apply to the previous publishing retry interval.
-	spring.rabbitmq.username= # Login user to authenticate to the broker.
+	spring.rabbitmq.username=guest # Login user to authenticate to the broker.
 	spring.rabbitmq.virtual-host= # Virtual host to use when connecting to the broker.
 
 


### PR DESCRIPTION
- [x] I  have signed the CLA

When connecting to RabbitMQ it is confusing with which username and password it is connecting since in the `RabbitProperties` the username and password do not have default value. Turns out the default's are used from the `ConnectionFactory` (RabbitMQ java client library)

Wouldn't it be better to set the `guest/guest` as defaults in the RabbitProperties (similar to `host` or `port`)?
