### PR TITLE
sanitize by default a key containing `uri` or `url`.

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
@@ -36,7 +36,8 @@ class Sanitizer {
 	private Pattern[] keysToSanitize;
 
 	Sanitizer() {
-		this("password", "secret", "key", "token", ".*credentials.*", "vcap_services");
+		this("password", "secret", "key", "token", ".*credentials.*", "vcap_services",
+				"uri", "url");
 	}
 
 	Sanitizer(String... keysToSanitize) {

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/SanitizerTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/SanitizerTests.java
@@ -38,6 +38,12 @@ public class SanitizerTests {
 		assertThat(sanitizer.sanitize("somekey", "secret")).isEqualTo("******");
 		assertThat(sanitizer.sanitize("token", "secret")).isEqualTo("******");
 		assertThat(sanitizer.sanitize("sometoken", "secret")).isEqualTo("******");
+		assertThat(sanitizer.sanitize("cloud.services.mysql.connection.uri",
+				"jdbc:mysql://mysql.example.com/ad_52e8338d0dd5336?user=bd06cab2b844bb&password=8626a3a4"))
+						.isEqualTo("******");
+		assertThat(sanitizer.sanitize("cloud.services.mysql.connection.jdbcurl",
+				"jdbc:mysql://mysql.example.com/ad_52e8338d0dd5336?user=bd06cab2b844bb&password=8626a3a4"))
+						.isEqualTo("******");
 		assertThat(sanitizer.sanitize("find", "secret")).isEqualTo("secret");
 	}
 


### PR DESCRIPTION
Spring Boot apps in Cloud foundry often expose credentials as the property whose key ends with `url` or `uri` as follows:

![image](https://cloud.githubusercontent.com/assets/106908/18476810/6b1f5ff8-7a06-11e6-860c-54bb1a7641e4.png)

I hope those are hidden by default.
