### PR TITLE
Default MongoMappingContext now uses default simple types.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoDataAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoDataAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.data.mongo;
 
 import java.net.UnknownHostException;
+import java.util.Collections;
 
 import com.mongodb.DB;
 import com.mongodb.Mongo;
@@ -24,7 +25,6 @@ import com.mongodb.MongoClient;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -103,23 +103,17 @@ public class MongoDataAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(MongoConverter.class)
 	public MappingMongoConverter mappingMongoConverter(MongoDbFactory factory,
-			MongoMappingContext context, BeanFactory beanFactory) {
+			MongoMappingContext context, BeanFactory beanFactory, CustomConversions conversions) {
 		DbRefResolver dbRefResolver = new DefaultDbRefResolver(factory);
 		MappingMongoConverter mappingConverter = new MappingMongoConverter(dbRefResolver,
 				context);
-		try {
-			mappingConverter
-					.setCustomConversions(beanFactory.getBean(CustomConversions.class));
-		}
-		catch (NoSuchBeanDefinitionException ex) {
-			// Ignore
-		}
+		mappingConverter.setCustomConversions(conversions);
 		return mappingConverter;
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
-	public MongoMappingContext mongoMappingContext(BeanFactory beanFactory)
+	public MongoMappingContext mongoMappingContext(BeanFactory beanFactory, CustomConversions conversions)
 			throws ClassNotFoundException {
 		MongoMappingContext context = new MongoMappingContext();
 		context.setInitialEntitySet(new EntityScanner(this.applicationContext)
@@ -129,6 +123,7 @@ public class MongoDataAutoConfiguration {
 			context.setFieldNamingStrategy(
 					(FieldNamingStrategy) BeanUtils.instantiate(strategyClass));
 		}
+		context.setSimpleTypeHolder(conversions.getSimpleTypeHolder());
 		return context;
 	}
 
@@ -139,6 +134,12 @@ public class MongoDataAutoConfiguration {
 		return new GridFsTemplate(
 				new GridFsMongoDbFactory(mongoDbFactory, this.properties),
 				mongoTemplate.getConverter());
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public CustomConversions customConversions() {
+		return new CustomConversions(Collections.emptyList());
 	}
 
 	/**

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/mongo/MongoDataAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/mongo/MongoDataAutoConfigurationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.autoconfigure.data.mongo;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Set;
 
@@ -44,6 +45,7 @@ import org.springframework.data.mapping.model.PropertyNameFieldNamingStrategy;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.CustomConversions;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.gridfs.GridFsTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -156,6 +158,19 @@ public class MongoDataAutoConfigurationTests {
 		assertThat(initialEntitySet).containsOnly(City.class, Country.class);
 	}
 
+	@Test
+	public void registersDefaultSimpleTypesWithMappingContext() {
+
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(MongoAutoConfiguration.class, MongoDataAutoConfiguration.class);
+		this.context.refresh();
+
+		MongoMappingContext context = this.context.getBean(MongoMappingContext.class);
+		MongoPersistentEntity<?> entity = context.getPersistentEntity(Sample.class);
+
+		assertThat(entity.getPersistentProperty("date").isEntity()).isFalse();
+	}
+
 	public void testFieldNamingStrategy(String strategy,
 			Class<? extends FieldNamingStrategy> expectedType) {
 		this.context = new AnnotationConfigApplicationContext();
@@ -205,4 +220,7 @@ public class MongoDataAutoConfigurationTests {
 
 	}
 
+	static class Sample {
+		LocalDateTime date;
+	}
 }


### PR DESCRIPTION
The `MongoMappingContext` that's set up by default now gets the `SimpleTypesHolder` instance set that's produced by a `CustomConversions` bean, which we in turn now default, too.

That's necessary as `CustomConversions` registers converters by inspecting the classpath (to automatically detect Java 8, JodaTime etc.) and by that rendering the types for which we find converters for as simple ones, i.e. non-entities.

Fixes #6881.