### PR TITLE
Fixed: Order of the Dropwizard metrics exported via "/metrics" should be stable

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/reader/MetricRegistryMetricReader.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/reader/MetricRegistryMetricReader.java
@@ -19,9 +19,11 @@ package org.springframework.boot.actuate.metrics.reader;
 import java.beans.PropertyDescriptor;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -116,8 +118,8 @@ public class MetricRegistryMetricReader implements MetricReader, MetricRegistryL
 		return new Iterable<Metric<?>>() {
 			@Override
 			public Iterator<Metric<?>> iterator() {
-				Set<Metric<?>> metrics = new HashSet<Metric<?>>();
-				for (String name : MetricRegistryMetricReader.this.names.keySet()) {
+				Set<Metric<?>> metrics = new LinkedHashSet<Metric<?>>();
+				for (String name : new TreeSet<String>(MetricRegistryMetricReader.this.names.keySet())) {
 					Metric<?> metric = findOne(name);
 					if (metric != null) {
 						metrics.add(metric);


### PR DESCRIPTION
When using Dropwizard metrics, accessing them via the "/metrics" HTTP interface shuffles the order of the statistics on every refresh. By using a stable ordering, it is easier to see what changes between refreshes.

This patch is intended to make it easier to read the output as a human. I think the overhead of sorting the metrics should not be significant.

Please let me know if that patch makes sense for you. If that is the case, I could, of course, provide a unit test that checks the ordering, too.

---

Finally, here is a quite verbose example of the effect of the patch. It shows how the ordering is currently shuffled (without the patch). The output is directly taken from the exported "/metrics" HTTP endpoint.

Request 1 (without patch):

```
...
{

    "mem": 562216,
    "mem.free": 215501,
    "processors": 8,
    "instance.uptime": 231323,
    "uptime": 241583,
    "systemload.average": 2.09,
    "heap.committed": 484864,
    "heap.init": 256000,
    "heap.used": 269362,
    "heap": 3626496,
    "nonheap.committed": 78744,
    "nonheap.init": 2496,
    "nonheap.used": 77352,
    "nonheap": 0,
    "threads.peak": 59,
    "threads.daemon": 42,
    "threads.totalStarted": 111,
    "threads": 59,
    "classes": 9624,
    "classes.loaded": 9624,
    "classes.unloaded": 0,
    "gc.ps_scavenge.count": 7,
    "gc.ps_scavenge.time": 163,
    "gc.ps_marksweep.count": 2,
    "gc.ps_marksweep.time": 162,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.98thPercentile": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.successfulRequests": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.activeRequests": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.98thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.meanRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.98thPercentile": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.count": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.count": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.75thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.median": 0.0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.fiveMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.99thPercentile": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.stdDev": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.mean": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.successfulRequests": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.99thPercentile": 0,
    "com.mercateo.d3.differ.server.DifferEventProcessor.storedArticles": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.max": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.median": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.oneMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.stdDev": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.totalSizeInBytes": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.min": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.min": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.median": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.max": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.totalRequests": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.totalRequests": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.min": 0,
    "com.mercateo.d3.differ.server.DifferEventProcessor.deletedArticles": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.oneMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.75thPercentile": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.95thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.max": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.fifteenMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.activeRequests": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.meanRate": 0.0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.99thPercentile": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.stdDev": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.999thPercentile": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.mean": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.count": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.999thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.fifteenMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.fiveMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.mean": 0.0,
    "com.mercateo.d3.differ.server.DifferEventProcessor.unchangedArticles": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.95thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.95thPercentile": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.75thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.999thPercentile": 0,
    "httpsessions.max": -1,
    "httpsessions.active": 0

}
```

Request 2 (without patch):

```
{

    "mem": 562689,
    "mem.free": 204148,
    "processors": 8,
    "instance.uptime": 312859,
    "uptime": 323119,
    "systemload.average": 2.27,
    "heap.committed": 484864,
    "heap.init": 256000,
    "heap.used": 280715,
    "heap": 3626496,
    "nonheap.committed": 79384,
    "nonheap.init": 2496,
    "nonheap.used": 77828,
    "nonheap": 0,
    "threads.peak": 61,
    "threads.daemon": 43,
    "threads.totalStarted": 127,
    "threads": 60,
    "classes": 9624,
    "classes.loaded": 9624,
    "classes.unloaded": 0,
    "gc.ps_scavenge.count": 7,
    "gc.ps_scavenge.time": 163,
    "gc.ps_marksweep.count": 2,
    "gc.ps_marksweep.time": 162,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.successfulRequests": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.mean": 0.0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.activeRequests": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.activeRequests": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.75thPercentile": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.75thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.999thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.stdDev": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.stdDev": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.count": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.count": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.999thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.98thPercentile": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.successfulRequests": 0,
    "com.mercateo.d3.differ.server.DifferEventProcessor.deletedArticles": 0,
    "com.mercateo.d3.differ.server.DifferEventProcessor.unchangedArticles": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.meanRate": 0.0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.min": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.95thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.999thPercentile": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.mean": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.stdDev": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.totalRequests": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.fiveMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.fifteenMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.75thPercentile": 0.0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.max": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.median": 0.0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.99thPercentile": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.fifteenMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.95thPercentile": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.99thPercentile": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.mean": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.max": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.min": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.count": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.oneMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.99thPercentile": 0.0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.98thPercentile": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.fiveMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.min": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.meanRate": 0.0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.median": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.totalRequests": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.98thPercentile": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.max": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.95thPercentile": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.oneMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.DifferEventProcessor.storedArticles": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.totalSizeInBytes": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.median": 0,
    "httpsessions.max": -1,
    "httpsessions.active": 0

}
```

Requests (with patch):

```
{

    "mem": 540887,
    "mem.free": 258105,
    "processors": 8,
    "instance.uptime": 4952,
    "uptime": 15713,
    "systemload.average": 4.52,
    "heap.committed": 464384,
    "heap.init": 256000,
    "heap.used": 206278,
    "heap": 3626496,
    "nonheap.committed": 78424,
    "nonheap.init": 2496,
    "nonheap.used": 76503,
    "nonheap": 0,
    "threads.peak": 34,
    "threads.daemon": 19,
    "threads.totalStarted": 39,
    "threads": 34,
    "classes": 9624,
    "classes.loaded": 9624,
    "classes.unloaded": 0,
    "gc.ps_scavenge.count": 10,
    "gc.ps_scavenge.time": 255,
    "gc.ps_marksweep.count": 2,
    "gc.ps_marksweep.time": 176,
    "com.mercateo.d3.differ.server.DifferEventProcessor.deletedArticles": 0,
    "com.mercateo.d3.differ.server.DifferEventProcessor.storedArticles": 0,
    "com.mercateo.d3.differ.server.DifferEventProcessor.unchangedArticles": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.activeRequests": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.count": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.fifteenMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.fiveMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.meanRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.oneMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.75thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.95thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.98thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.999thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.99thPercentile": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.max": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.mean": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.median": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.min": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.requestsRate.snapshot.stdDev": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.count": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.75thPercentile": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.95thPercentile": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.98thPercentile": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.999thPercentile": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.99thPercentile": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.max": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.mean": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.median": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.min": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.sizeInBytesHistogram.snapshot.stdDev": 0.0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.successfulRequests": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.totalRequests": 0,
    "com.mercateo.d3.differ.server.grpc.CatalogRetrieverGrpcServiceAdapter.totalSizeInBytes": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.activeRequests": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.count": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.fifteenMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.fiveMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.meanRate": 0.0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.oneMinuteRate": 0.0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.75thPercentile": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.95thPercentile": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.98thPercentile": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.999thPercentile": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.99thPercentile": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.max": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.mean": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.median": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.min": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.requestDurationInMs.snapshot.stdDev": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.successfulRequests": 0,
    "com.mercateo.d3.differ.server.message.DifferEventListener.totalRequests": 0,
    "httpsessions.max": -1,
    "httpsessions.active": 0

}
```
