### PR TITLE
Add support for vendor specific Flyway migration locations

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
@@ -234,6 +234,18 @@ public class FlywayAutoConfigurationTests {
 				.isEqualTo(MigrationVersion.fromVersion("1"));
 	}
 
+	@Test
+	public void useVendorDirectory() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"flyway.locations:classpath:db/vendors/{vendor}");
+		registerAndRefresh(EmbeddedDataSourceConfiguration.class,
+				FlywayAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		Flyway flyway = this.context.getBean(Flyway.class);
+		assertThat(flyway.getLocations()).containsExactly(
+				"classpath:db/vendors/h2");
+	}
+
 	private void registerAndRefresh(Class<?>... annotatedClasses) {
 		this.context.register(annotatedClasses);
 		this.context.refresh();


### PR DESCRIPTION
This PR adds support for using vendor placeholder in `flyway.locations` configuration property value.

Resolves #6700 however without introducing additional configuration property, as originally discussed.
