### PR TITLE
Guarantee stable ordering of metric names

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/reader/MetricRegistryMetricReader.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/reader/MetricRegistryMetricReader.java
@@ -19,10 +19,12 @@ package org.springframework.boot.actuate.metrics.reader;
 import java.beans.PropertyDescriptor;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.TimeUnit;
 
 import com.codahale.metrics.Counter;
@@ -61,7 +63,7 @@ public class MetricRegistryMetricReader implements MetricReader, MetricRegistryL
 
 	private final Object monitor = new Object();
 
-	private final Map<String, String> names = new ConcurrentHashMap<String, String>();
+	private final Map<String, String> names = new ConcurrentSkipListMap<String, String>();
 
 	private final MultiValueMap<String, String> reverse = new LinkedMultiValueMap<String, String>();
 
@@ -116,7 +118,7 @@ public class MetricRegistryMetricReader implements MetricReader, MetricRegistryL
 		return new Iterable<Metric<?>>() {
 			@Override
 			public Iterator<Metric<?>> iterator() {
-				Set<Metric<?>> metrics = new HashSet<Metric<?>>();
+				Set<Metric<?>> metrics = new LinkedHashSet<Metric<?>>();
 				for (String name : MetricRegistryMetricReader.this.names.keySet()) {
 					Metric<?> metric = findOne(name);
 					if (metric != null) {


### PR DESCRIPTION
As a follow-up on the rejected pull-request #6883, here is a version with identical semantics.

Adresses the problem reported in #3761, but with less overhead than my previous pull request.