### PR TITLE
Append contextPath to root URI in LocalHostUriTemplateHandler

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfigurationCustomFilterContextPathTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfigurationCustomFilterContextPathTests.java
@@ -64,7 +64,7 @@ public class JerseyAutoConfigurationCustomFilterContextPathTests {
 
 	@Test
 	public void contextLoads() {
-		ResponseEntity<String> entity = this.restTemplate.getForEntity("/app/rest/hello",
+		ResponseEntity<String> entity = this.restTemplate.getForEntity("/rest/hello",
 				String.class);
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
 	}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfigurationCustomServletContextPathTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfigurationCustomServletContextPathTests.java
@@ -64,7 +64,7 @@ public class JerseyAutoConfigurationCustomServletContextPathTests {
 
 	@Test
 	public void contextLoads() {
-		ResponseEntity<String> entity = this.restTemplate.getForEntity("/app/rest/hello",
+		ResponseEntity<String> entity = this.restTemplate.getForEntity("/rest/hello",
 				String.class);
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
 	}

--- a/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/LocalHostUriTemplateHandler.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/LocalHostUriTemplateHandler.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.test.web.client;
 
+import org.springframework.boot.bind.RelaxedPropertyResolver;
 import org.springframework.boot.web.client.RootUriTemplateHandler;
 import org.springframework.core.env.Environment;
 import org.springframework.util.Assert;
@@ -28,6 +29,7 @@ import org.springframework.web.util.UriTemplateHandler;
  *
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Eddú Meléndez
  * @since 1.4.0
  */
 public class LocalHostUriTemplateHandler extends RootUriTemplateHandler {
@@ -35,6 +37,8 @@ public class LocalHostUriTemplateHandler extends RootUriTemplateHandler {
 	private final Environment environment;
 
 	private final String scheme;
+
+	private RelaxedPropertyResolver contextPathResolver;
 
 	/**
 	 * Create a new {@code LocalHostUriTemplateHandler} that will generate {@code http}
@@ -58,12 +62,15 @@ public class LocalHostUriTemplateHandler extends RootUriTemplateHandler {
 		Assert.notNull(scheme, "Scheme must not be null");
 		this.environment = environment;
 		this.scheme = scheme;
+		this.contextPathResolver = new RelaxedPropertyResolver(environment,
+				"server.");
 	}
 
 	@Override
 	public String getRootUri() {
 		String port = this.environment.getProperty("local.server.port", "8080");
-		return this.scheme + "://localhost:" + port;
+		String contextPath = this.contextPathResolver.getProperty("context-path", "");
+		return this.scheme + "://localhost:" + port + contextPath;
 	}
 
 }

--- a/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/LocalHostUriTemplateHandlerTests.java
+++ b/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/LocalHostUriTemplateHandlerTests.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Eddú Meléndez
  */
 public class LocalHostUriTemplateHandlerTests {
 
@@ -72,6 +73,15 @@ public class LocalHostUriTemplateHandlerTests {
 		LocalHostUriTemplateHandler handler = new LocalHostUriTemplateHandler(environment,
 				"https");
 		assertThat(handler.getRootUri()).isEqualTo("https://localhost:8080");
+	}
+
+	@Test
+	public void getRootUriShouldUseContextPath() throws Exception {
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("server.contextPath", "/foo");
+		LocalHostUriTemplateHandler handler = new LocalHostUriTemplateHandler(
+				environment);
+		assertThat(handler.getRootUri()).isEqualTo("http://localhost:8080/foo");
 	}
 
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Previous to this commit, `server.context-path` property was not
considerate when TestRestTemplate perform an action. Now, context-path
is concatenated to the uri.

See gh-6904