### PR TITLE
Add auto-configuration support for Apache Geode as a caching provider.

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -357,6 +357,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-geode</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-jpa</artifactId>
 			<optional>true</optional>
 			<exclusions>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheConfigurations.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheConfigurations.java
@@ -27,6 +27,7 @@ import org.springframework.util.Assert;
  *
  * @author Phillip Webb
  * @author Eddú Meléndez
+ * @author John Blum
  */
 final class CacheConfigurations {
 
@@ -42,6 +43,7 @@ final class CacheConfigurations {
 		mappings.put(CacheType.COUCHBASE, CouchbaseCacheConfiguration.class);
 		mappings.put(CacheType.REDIS, RedisCacheConfiguration.class);
 		mappings.put(CacheType.CAFFEINE, CaffeineCacheConfiguration.class);
+		mappings.put(CacheType.GEODE, GeodeCacheConfiguration.class);
 		mappings.put(CacheType.SIMPLE, SimpleCacheConfiguration.class);
 		mappings.put(CacheType.NONE, NoOpCacheConfiguration.class);
 		MAPPINGS = Collections.unmodifiableMap(mappings);

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheType.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheType.java
@@ -22,6 +22,7 @@ package org.springframework.boot.autoconfigure.cache;
  * @author Stephane Nicoll
  * @author Phillip Webb
  * @author Eddú Meléndez
+ * @author John Blum
  * @since 1.3.0
  */
 public enum CacheType {
@@ -67,6 +68,11 @@ public enum CacheType {
 	CAFFEINE,
 
 	/**
+	 * Apache Geode backed caching.
+	 */
+	GEODE,
+
+	/**
 	 * Simple in-memory caching.
 	 */
 	SIMPLE,
@@ -74,6 +80,6 @@ public enum CacheType {
 	/**
 	 * No caching.
 	 */
-	NONE;
+	NONE
 
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/GeodeCacheConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/GeodeCacheConfiguration.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2011-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import java.util.HashSet;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.GemFireCache;
+import org.apache.geode.cache.client.ClientCache;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.gemfire.CacheFactoryBean;
+import org.springframework.data.gemfire.client.ClientCacheFactoryBean;
+import org.springframework.data.gemfire.support.GemfireCacheManager;
+
+/**
+ * GemFire cache configuration.
+ *
+ * @author John Blum
+ * @see org.apache.geode.cache.Cache
+ * @see org.apache.geode.cache.GemFireCache
+ * @see org.apache.geode.cache.client.ClientCache
+ * @see org.springframework.context.annotation.Bean
+ * @see org.springframework.context.annotation.Configuration
+ * @see org.springframework.data.gemfire.support.GemfireCacheManager
+ * @since 1.5.0
+ */
+@Configuration
+@ConditionalOnBean({ CacheFactoryBean.class, Cache.class,
+	ClientCacheFactoryBean.class, ClientCache.class })
+@ConditionalOnClass(GemfireCacheManager.class)
+@ConditionalOnMissingBean(CacheManager.class)
+@Conditional(CacheCondition.class)
+class GeodeCacheConfiguration {
+
+	private final CacheProperties cacheProperties;
+
+	private final CacheManagerCustomizers cacheManagerCustomizers;
+
+	GeodeCacheConfiguration(CacheProperties cacheProperties,
+			CacheManagerCustomizers cacheManagerCustomizers) {
+
+		this.cacheProperties = cacheProperties;
+		this.cacheManagerCustomizers = cacheManagerCustomizers;
+	}
+
+	@Bean
+	public GemfireCacheManager cacheManager(GemFireCache gemfireCache) {
+		GemfireCacheManager cacheManager = new GemfireCacheManager();
+
+		cacheManager.setCache(gemfireCache);
+		cacheManager.setCacheNames(new HashSet<String>(this.cacheProperties.getCacheNames()));
+
+		return this.cacheManagerCustomizers.customize(cacheManager);
+	}
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -73,6 +73,7 @@
 		<freemarker.version>2.3.25-incubating</freemarker.version>
 		<elasticsearch.version>2.4.1</elasticsearch.version>
 		<gemfire.version>8.2.0</gemfire.version>
+		<geode.version>1.0.0-incubating</geode.version>
 		<glassfish-el.version>3.0.0</glassfish-el.version>
 		<gradle.version>2.9</gradle.version>
 		<groovy.version>2.4.7</groovy.version>
@@ -147,6 +148,7 @@
 		<spring-amqp.version>1.6.4.BUILD-SNAPSHOT</spring-amqp.version>
 		<spring-cloud-connectors.version>1.2.3.RELEASE</spring-cloud-connectors.version>
 		<spring-batch.version>3.0.7.RELEASE</spring-batch.version>
+		<spring-data-geode.version>1.0.0.INCUBATING-RELEASE</spring-data-geode.version>
 		<spring-data-releasetrain.version>Ingalls-M1</spring-data-releasetrain.version>
 		<spring-hateoas.version>0.21.0.RELEASE</spring-hateoas.version>
 		<spring-integration.version>5.0.0.BUILD-SNAPSHOT</spring-integration.version>
@@ -1190,6 +1192,17 @@
 				<version>${derby.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.apache.geode</groupId>
+				<artifactId>geode-core</artifactId>
+				<version>${geode.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.apache.shiro</groupId>
+						<artifactId>shiro-core</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpasyncclient</artifactId>
 				<version>${httpasyncclient.version}</version>
@@ -2001,6 +2014,11 @@
 						<groupId>log4j</groupId>
 					</exclusion>
 				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.data</groupId>
+				<artifactId>spring-data-geode</artifactId>
+				<version>${spring-data-geode.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.data</groupId>

--- a/spring-boot-docs/src/main/asciidoc/index.adoc
+++ b/spring-boot-docs/src/main/asciidoc/index.adoc
@@ -43,6 +43,7 @@ Phillip Webb; Dave Syer; Josh Long; Stéphane Nicoll; Rob Winch; Andy Wilkinson;
 :spring-amqp-javadoc: http://docs.spring.io/spring-amqp/docs/current/api/org/springframework/amqp
 :spring-data-javadoc: http://docs.spring.io/spring-data/jpa/docs/current/api/org/springframework/data/jpa
 :spring-data-commons-javadoc: http://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data
+:spring-data-geode-reference: http://docs.spring.io/spring-data-gemfire/docs/current/reference/html
 :spring-data-mongo-javadoc: http://docs.spring.io/spring-data/mongodb/docs/current/api/org/springframework/data/mongodb
 :spring-data-rest-javadoc: http://docs.spring.io/spring-data/rest/docs/current/api/org/springframework/data/rest
 :gradle-userguide: http://www.gradle.org/docs/current/userguide
@@ -51,6 +52,7 @@ Phillip Webb; Dave Syer; Josh Long; Stéphane Nicoll; Rob Winch; Andy Wilkinson;
 :code-examples: ../java/org/springframework/boot
 :gradle-user-guide: https://docs.gradle.org/2.14.1/userguide
 :gradle-dsl: https://docs.gradle.org/2.14.1/dsl
+:apache-geode-user-docs: http://geode.docs.pivotal.io/
 // ======================================================================================
 
 include::documentation-overview.adoc[]

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -3737,7 +3737,7 @@ will replace the default.
 [[boot-features-caching]]
 == Caching
 The Spring Framework provides support for transparently adding caching to an application.
-At its core, the abstraction applies caching to methods, reducing thus the number of
+At its core, the abstraction applies caching to methods, thus reducing the number of
 executions based on the information available in the cache. The caching logic is applied
 transparently, without any interference to the invoker.
 
@@ -3765,7 +3765,7 @@ relevant annotation to its method:
 ----
 
 NOTE: You can either use the standard JSR-107 (JCache) annotations or Spring's own
-caching annotations transparently. We strongly advise you however to not mix and match
+caching annotations transparently. However, we strongly advise you to not mix and match
 them.
 
 TIP: It is also possible to {spring-reference}/#cache-annotations-put[update] or
@@ -3801,6 +3801,7 @@ providers (in this order):
 * <<boot-features-caching-provider-couchbase,Couchbase>>
 * <<boot-features-caching-provider-redis,Redis>>
 * <<boot-features-caching-provider-caffeine,Caffeine>>
+* <<boot-features-caching-provider-geode,Geode>>
 * <<boot-features-caching-provider-simple,Simple>>
 
 TIP: It is also possible to _force_ the cache provider to use via the `spring.cache.type`
@@ -4021,6 +4022,81 @@ going to be associated to _all_ caches managed by the cache manager, it must be 
 as `CacheLoader<Object, Object>`. Any other generic type will be ignored by the
 auto-configuration.
 
+
+[[boot-features-caching-provider-geode]]
+==== Geode
+When _Apache Geode_ is present and a Geode `Cache` or `ClientCache` bean has been
+properly configured, Spring Boot will auto-configure the `GemfireCacheManager`.
+
+By default, any configured Geode `Region` will function as a Spring cache. The only
+requirement is that the name of the cache identified in a caching annotation match
+the name of a configured Geode `Region`.  However, it is possible to identify specific
+`Regions` by name using the `spring.cache.cache-names` property that will purposefully
+function as Spring caches on startup.
+
+NOTE: Unlike some other stores, specifying the `spring.cache.cache-names` does not
+create the Geode `Region` in which application data will be cached.  You must explicitly
+configure and create the `Region` yourself using either Geode's native configuration
+meta-data or _Spring Data Geode_.
+
+To enable caching in your application with Geode as the provider, it is as simple as
+adding the _Spring Data Geode_ dependency to your application classpath and creating
+either a Geode peer `Cache` bean or `ClientCache` bean along with the `Regions` that
+will function as Spring caches in your application.
+
+[source,java,indent=0]
+----
+@Configuration
+public class PeerCacheGeodeConfiguration {
+
+  @Bean
+  public CacheFactoryBean gemfireCache() {
+    CacheFactoryBean gemfireCache = new CacheFactoryBean();
+    gemfireCache.setClose(true);
+    return gemfireCache;
+  }
+
+  @Bean
+  public PartitionedRegionFactoryBean computePiDecimal() {
+    PartitionedRegionFactoryBean regionFactory = new PartitionedRegionFactoryBean();
+    regionFactory.setCache(gemfireCache());
+    regionFactory.setClose(false);
+    return regionFactory;
+  }
+}
+----
+
+Or, if you are using Geode's client/server topology...
+
+[source,java,indent=0]
+----
+@Configuration
+public class ClientCacheGeodeConfiguration {
+
+  @Bean
+  public ClientCacheFactoryBean gemfireCache() {
+    ClientCacheFactoryBean gemfireCache = new ClientCacheFactoryBean();
+    gemfireCache.setClose(true);
+    gemfireCache.setServers(new ConnectionEndpoint("host", 40404));
+    return gemfireCache;
+  }
+
+  @Bean
+  public ClientRegionFactoryBean computePiDecimal() {
+    ClientRegionFactoryBean regionFactory = new ClientRegionFactoryBean();
+    regionFactory.setCache(gemfireCache());
+    regionFactory.setClose(false);
+    regionFactory.setShortcut(ClientRegionShortcut.PROXY);
+    return regionFactory;
+  }
+}
+----
+
+Refer to _Spring Data Geode's_ {spring-data-geode-reference}[Reference Guide] on how to
+configure _Apache Geode_ caches and `Regions` as well as for additional options on
+{spring-data-geode-reference}/#apis:spring-cache-abstraction[configuring] _Apache Geode_
+as a caching provider.  To learn more about _Apache Geode_ refer to the
+{apache-geode-user-docs}[user documentation].
 
 
 [[boot-features-caching-provider-simple]]

--- a/spring-boot-samples/spring-boot-sample-cache/README.adoc
+++ b/spring-boot-samples/spring-boot-sample-cache/README.adoc
@@ -10,6 +10,7 @@ abstraction is supported by many caching libraries, including:
 * `Couchbase`
 * `Redis`
 * `Caffeine`
+* `Geode`
 * Simple provider based on `ConcurrentHashMap`
 * Generic provider based on `org.springframework.Cache` bean definition(s)
 
@@ -63,6 +64,8 @@ used to configure the underlying `CacheManager`. Note that EhCache 3 uses a diff
 format and doesn't default to `ehcache.xml` anymore. Check
 http://www.ehcache.org/documentation/3.0/xml.html[the documentation] for more details.
 
+Run sample cache application using EhCache with `$mvn -P ehcache spring-boot:run`
+
 
 
 === Hazelcast
@@ -70,6 +73,8 @@ Both `com.hazelcast:hazelcast` and `com.hazelcast:hazelcast-spring` should be ad
 the project to enable support for Hazelcast.  Since there is a default `hazelcast.xml`
 configuration file at the root of the classpath, it is used to automatically configure
 the underlying `HazelcastInstance`.
+
+Run sample cache application using Hazelcast with `$mvn -P hazelcast spring-boot:run`
 
 
 
@@ -80,11 +85,15 @@ so if you don't specify anything it will bootstrap on a hardcoded default. You c
 the `spring.cache.infinispan.config` property to use the provided `infinispan.xml`
 configuration instead.
 
+Run sample cache application using Infinispan with `$mvn -P infinispan spring-boot:run`
+
 
 
 === Couchbase
 Add the `java-client` and `couchbase-spring-cache` dependencies and make sure that you
 have setup at least a `spring.couchbase.bootstrap-hosts` property.
+
+Start a Couchbase server, then run the sample cache application using Couchbase with `$mvn -P couchbase spring-boot:run`
 
 
 
@@ -92,9 +101,23 @@ have setup at least a `spring.couchbase.bootstrap-hosts` property.
 Add the `spring-boot-starter-data-redis` and make sure it is configured properly (by default,
 a redis instance with the default settings is expected on your local box).
 
+Start a Redis server, then run the sample cache application using Redis with `$mvn -P redis spring-boot:run`
+
 
 
 === Caffeine
 Simply add the `com.github.ben-manes.caffeine:caffeine` dependency to enable support
 for Caffeine. You can customize how caches are created in different ways, see
 `application.properties` for an example and the documentation for more details.
+
+Run sample cache application using Caffeine with `$mvn -P caffeine spring-boot:run`
+
+
+
+=== Geode
+Add the `spring-boot-starter-data-gemfire` dependency and make sure your Geode instance
+is configured properly. This involves creating an instance of either a Geode peer `Cache`
+or `ClientCache` depending on your topology preference and additionally creating
+and configuring Regions that will serve as the caches for your application.
+
+Run sample cache application using Geode with `$mvn -P geode spring-boot:run`

--- a/spring-boot-samples/spring-boot-sample-cache/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-cache/pom.xml
@@ -32,70 +32,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
-
-		<!-- JSR-107 API (uncomment to try the JCache support) -->
-		<!--
-		<dependency>
-			<groupId>javax.cache</groupId>
-			<artifactId>cache-api</artifactId>
-		</dependency>
-		-->
-
-		<!-- Additional cache providers (uncomment to try them) -->
-		<!--
-		<dependency>
-			<groupId>net.sf.ehcache</groupId>
-			<artifactId>ehcache</artifactId>
-		</dependency>
-		-->
-		<!--
-		<dependency>
-			<groupId>org.ehcache</groupId>
-			<artifactId>ehcache</artifactId>
-		</dependency>
-		-->
-		<!--
-		<dependency>
-			<groupId>com.hazelcast</groupId>
-			<artifactId>hazelcast</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.hazelcast</groupId>
-			<artifactId>hazelcast-spring</artifactId>
-		</dependency>
-		-->
-		<!--
-		<dependency>
-			<groupId>org.infinispan</groupId>
-			<artifactId>infinispan-spring4-embedded</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.infinispan</groupId>
-			<artifactId>infinispan-jcache</artifactId>
-		</dependency>
-		-->
-		<!--
-		<dependency>
-			<groupId>com.couchbase.client</groupId>
-			<artifactId>java-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.couchbase.client</groupId>
-			<artifactId>couchbase-spring-cache</artifactId>
-		</dependency>
-		-->
-		<!--
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-redis</artifactId>
-		</dependency>
-		-->
-		<!--
-		<dependency>
-			<groupId>com.github.ben-manes.caffeine</groupId>
-			<artifactId>caffeine</artifactId>
-		</dependency>
-		-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -110,4 +46,127 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<!-- JCache API (JSR-107 support) -->
+		<!-- Include with any of the caching providers below using, e.g. `$mvn -P jcache,hazelcast spring-boot:run` -->
+		<profile>
+			<id>jcache</id>
+			<dependencies>
+				<dependency>
+					<groupId>javax.cache</groupId>
+					<artifactId>cache-api</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- mvn -P caffeine spring-boot:run -->
+		<profile>
+			<id>caffeine</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.github.ben-manes.caffeine</groupId>
+					<artifactId>caffeine</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- Start Couchbase server, then... -->
+		<!-- mvn -P couchbase spring-boot:run -->
+		<profile>
+			<id>couchbase</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.couchbase.client</groupId>
+					<artifactId>java-client</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>com.couchbase.client</groupId>
+					<artifactId>couchbase-spring-cache</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- mvn -P ehcache spring-boot:run -->
+		<profile>
+			<id>ehcache</id>
+			<dependencies>
+				<dependency>
+					<groupId>net.sf.ehcache</groupId>
+					<artifactId>ehcache</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- Start a Ehcache server, then... -->
+		<!-- mvn -P org-ehcache spring-boot:run -->
+		<profile>
+			<id>org-ehcache</id>
+			<dependencies>
+				<dependency>
+					<groupId>org.ehcache</groupId>
+					<artifactId>ehcache</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- mvn -P geode spring-boot:run -->
+		<profile>
+			<id>geode</id>
+			<dependencies>
+				<!-- TODO change to the 'spring-boot-starter-data-geode' dependency when PR #5445 is merged -->
+				<dependency>
+					<groupId>org.springframework.data</groupId>
+					<artifactId>spring-data-geode</artifactId>
+				</dependency>
+			</dependencies>
+			<!-- Same as `mvn -P geode spring-boot:run -Drun.profiles=geode` -->
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<profiles>
+								<profile>geode</profile>
+							</profiles>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<!-- mvn -P hazelcast spring-boot:run -->
+		<profile>
+			<id>hazelcast</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.hazelcast</groupId>
+					<artifactId>hazelcast</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>com.hazelcast</groupId>
+					<artifactId>hazelcast-spring</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- mvn -P infinispan spring-boot:run -->
+		<profile>
+			<id>infinispan</id>
+			<dependencies>
+				<dependency>
+					<groupId>org.infinispan</groupId>
+					<artifactId>infinispan-spring4-embedded</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>org.infinispan</groupId>
+					<artifactId>infinispan-jcache</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- Start a Redis Server ($. <redis-install>/src/redis-server), then... -->
+		<!-- mvn -P redis spring-boot:run -->
+		<profile>
+			<id>redis</id>
+			<dependencies>
+				<dependency>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-data-redis</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 </project>

--- a/spring-boot-samples/spring-boot-sample-cache/src/main/java/sample/cache/config/GeodeConfiguration.java
+++ b/spring-boot-samples/spring-boot-sample-cache/src/main/java/sample/cache/config/GeodeConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2011-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.cache.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Spring {@link Configuration @Configuration} class to configure Geode as a caching provider.
+ * This {@link Configuration @Configuration} class is conditionally loaded based on
+ * whether Geode is on the classpath.
+ *
+ * @author John Blum
+ * @see org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+ * @see org.springframework.context.annotation.Configuration
+ * @see org.springframework.context.annotation.ImportResource
+ * @since 1.5.0
+ */
+@Configuration
+@ImportResource("geode.xml")
+@Profile("geode")
+@SuppressWarnings("unused")
+public class GeodeConfiguration {
+
+}

--- a/spring-boot-samples/spring-boot-sample-cache/src/main/resources/geode.xml
+++ b/spring-boot-samples/spring-boot-sample-cache/src/main/resources/geode.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:gfe="http://www.springframework.org/schema/geode"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
+">
+
+  <context:property-placeholder/>
+
+  <util:properties id="geodeProperties">
+    <prop key="name">SampleGeodeCacheApplication</prop>
+    <prop key="mcast-port">0</prop>
+    <prop key="log-level">${sample.cache.geode.log.level:config}</prop>
+  </util:properties>
+
+  <gfe:cache properties-ref="geodeProperties"/>
+
+  <gfe:local-region id="countries" persistent="false"/>
+
+</beans>


### PR DESCRIPTION
This PR enhances _Spring Boot's_ [Caching](http://docs.spring.io/spring-boot/docs/1.4.0.RELEASE/reference/htmlsingle/#boot-features-caching) `auto-configuration` feature to include support for _Apache Geode_ as a [caching provider](http://docs.spring.io/spring-boot/docs/1.4.0.RELEASE/reference/htmlsingle/#_supported_cache_providers).

The enhanced, auto-configuration Caching support in _Spring Boot_ uses _Spring Data Geode's_ `GemfireCacheManager` implementation to enable _Apache Geode_ as a provider in _Spring's_ Cache Abstraction.

Both _Spring Data Geode_ and _Apache Geode_ are **Open Source** and licensed under the ASL 2.0, and both are [freely available from Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cgeode).

NOTE: this PR **SHOULD NOT BE MERGED** until @philwebb and I discuss options for _Spring Boot's_ support of either _Pivotal GemFire_ or _Apache Geode_.
