### PR TITLE
Upgrade Spring Session to 1.3.0.M2

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
@@ -37,6 +37,7 @@ import org.springframework.session.ExpiringSession;
 import org.springframework.session.MapSessionRepository;
 import org.springframework.session.SessionRepository;
 import org.springframework.session.data.mongo.MongoOperationsSessionRepository;
+import org.springframework.session.hazelcast.HazelcastSessionRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -107,7 +108,7 @@ public class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurat
 	public void hazelcastSessionStore() {
 		load(Collections.<Class<?>>singletonList(HazelcastConfiguration.class),
 				"spring.session.store-type=hazelcast");
-		validateSessionRepository(MapSessionRepository.class);
+		validateSessionRepository(HazelcastSessionRepository.class);
 	}
 
 	@Test
@@ -115,7 +116,7 @@ public class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurat
 		load(Collections.<Class<?>>singletonList(HazelcastSpecificMap.class),
 				"spring.session.store-type=hazelcast",
 				"spring.session.hazelcast.map-name=foo:bar:biz");
-		validateSessionRepository(MapSessionRepository.class);
+		validateSessionRepository(HazelcastSessionRepository.class);
 		HazelcastInstance hazelcastInstance = this.context
 				.getBean(HazelcastInstance.class);
 		verify(hazelcastInstance, times(1)).getMap("foo:bar:biz");

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -160,7 +160,7 @@
 		<spring-security.version>4.1.3.RELEASE</spring-security.version>
 		<spring-security-jwt.version>1.0.5.RELEASE</spring-security-jwt.version>
 		<spring-security-oauth.version>2.0.11.RELEASE</spring-security-oauth.version>
-		<spring-session.version>1.2.2.RELEASE</spring-session.version>
+		<spring-session.version>1.3.0.M2</spring-session.version>
 		<spring-social.version>1.1.4.RELEASE</spring-social.version>
 		<spring-social-facebook.version>2.0.3.RELEASE</spring-social-facebook.version>
 		<spring-social-linkedin.version>1.0.2.RELEASE</spring-social-linkedin.version>
@@ -2256,6 +2256,11 @@
 			<dependency>
 				<groupId>org.springframework.session</groupId>
 				<artifactId>spring-session-data-mongo</artifactId>
+				<version>${spring-session.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.session</groupId>
+				<artifactId>spring-session-hazelcast</artifactId>
 				<version>${spring-session.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Other than the usual version bump, this PR adds dependency management for new `spring-session-hazelcast` module, and fixes Hazelcast related tests to expect the new `SessionRepository` implementation.