### PR TITLE
Update thymeleaf-layout-dialect.version to 2.0.3

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -1435,7 +1435,7 @@ for example:
 ----
 	<properties>
 		<thymeleaf.version>3.0.0.RELEASE</thymeleaf.version>
-		<thymeleaf-layout-dialect.version>2.0.0</thymeleaf-layout-dialect.version>
+		<thymeleaf-layout-dialect.version>2.0.3</thymeleaf-layout-dialect.version>
 	</dependency>
 ----
 


### PR DESCRIPTION
Version 2.0.0 had serval bugs which broke compatibility to older templates, so the guide should refer the fixed version instead