### PR TITLE
Update `DevToolsProperties` to exclude `META-INF/build-info.properties` file

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
@@ -60,7 +60,7 @@ public class DevToolsProperties {
 
 		private static final String DEFAULT_RESTART_EXCLUDES = "META-INF/maven/**,"
 				+ "META-INF/resources/**,resources/**,static/**,public/**,templates/**,"
-				+ "**/*Test.class,**/*Tests.class,git.properties";
+				+ "**/*Test.class,**/*Tests.class,git.properties,META-INF/build-info.properties";
 
 		private static final long DEFAULT_RESTART_POLL_INTERVAL = 1000;
 

--- a/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/DevToolsPropertiesTests.java
+++ b/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/DevToolsPropertiesTests.java
@@ -38,7 +38,7 @@ public class DevToolsPropertiesTests {
 				arrayContaining("META-INF/maven/**", "META-INF/resources/**",
 						"resources/**", "static/**", "public/**", "templates/**",
 						"**/*Test.class", "**/*Tests.class", "git.properties", "foo/**",
-						"bar/**"));
+						"bar/**", "META-INF/build-info.properties"));
 	}
 
 	@Test


### PR DESCRIPTION
Prior to this commit any application configured to write `META-INF/build-properties`
could trigger unexpected application restarts. The problem is particularly
prevalent when using Eclipse M2E in combination with Maven's
`spring-boot-maven-plugin` `build-info` goal and Gradle's `springBoot` `buildInfo()`.

This situation is very similar to #3938 and I fixed it in the same way.