### PR TITLE
Allow configuration to specify randomly generated database name

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -189,7 +189,7 @@ public class DataSourceProperties
 	}
 
 	public boolean isGenerateName() {
-		return generateName;
+		return this.generateName;
 	}
 
 	public void setGenerateName(boolean generateName) {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -58,6 +58,11 @@ public class DataSourceProperties
 	private String name = "testdb";
 
 	/**
+	 * If <code>true</code> the database name is randomly generated.
+	 */
+	private boolean generateName = false;
+
+	/**
 	 * Fully qualified name of the connection pool implementation to use. By default, it
 	 * is auto-detected from the classpath.
 	 */
@@ -181,6 +186,14 @@ public class DataSourceProperties
 
 	public void setName(String name) {
 		this.name = name;
+	}
+
+	public boolean isGenerateName() {
+		return generateName;
+	}
+
+	public void setGenerateName(boolean generateName) {
+		this.generateName = generateName;
 	}
 
 	public Class<? extends DataSource> getType() {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/EmbeddedDataSourceConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/EmbeddedDataSourceConfiguration.java
@@ -57,7 +57,8 @@ public class EmbeddedDataSourceConfiguration implements BeanClassLoaderAware {
 				.setType(EmbeddedDatabaseConnection.get(this.classLoader).getType());
 		if (this.properties.isGenerateName()) {
 			builder.generateUniqueName(true);
-		} else {
+		}
+		else {
 			builder.setName(this.properties.getName());
 		}
 		this.database = builder.build();

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/EmbeddedDataSourceConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/EmbeddedDataSourceConfiguration.java
@@ -55,7 +55,12 @@ public class EmbeddedDataSourceConfiguration implements BeanClassLoaderAware {
 	public EmbeddedDatabase dataSource() {
 		EmbeddedDatabaseBuilder builder = new EmbeddedDatabaseBuilder()
 				.setType(EmbeddedDatabaseConnection.get(this.classLoader).getType());
-		this.database = builder.setName(this.properties.getName()).build();
+		if (this.properties.isGenerateName()) {
+			builder.generateUniqueName(true);
+		} else {
+			builder.setName(this.properties.getName());
+		}
+		this.database = builder.build();
 		return this.database;
 	}
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/EmbeddedDataSourceConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/EmbeddedDataSourceConfigurationTests.java
@@ -20,6 +20,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Properties;
+
 import javax.sql.DataSource;
 
 import org.junit.Test;
@@ -65,9 +66,14 @@ public class EmbeddedDataSourceConfigurationTests {
 		Connection connection = dataSource.getConnection();
 		try {
 			ResultSet catalogs = connection.getMetaData().getCatalogs();
-			catalogs.next();
-			return catalogs.getString(1);
-		} finally {
+			if (catalogs.next()) {
+				return catalogs.getString(1);
+			}
+			else {
+				throw new IllegalStateException("Unable to get database name");
+			}
+		}
+		finally {
 			connection.close();
 		}
 	}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/EmbeddedDataSourceConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/EmbeddedDataSourceConfigurationTests.java
@@ -16,11 +16,16 @@
 
 package org.springframework.boot.autoconfigure.jdbc;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Properties;
 import javax.sql.DataSource;
 
 import org.junit.Test;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.PropertiesPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,6 +45,31 @@ public class EmbeddedDataSourceConfigurationTests {
 		this.context.refresh();
 		assertThat(this.context.getBean(DataSource.class)).isNotNull();
 		this.context.close();
+	}
+
+	@Test
+	public void generatesUniqueDatabaseName() throws Exception {
+		Properties myProps = new Properties();
+		myProps.setProperty("spring.datasource.generate-name", "true");
+
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(EmbeddedDataSourceConfiguration.class);
+		this.context.getEnvironment().getPropertySources().addFirst(new PropertiesPropertySource("whatever", myProps));
+		this.context.refresh();
+		DataSource dataSource = this.context.getBean(DataSource.class);
+		assertThat(getDatabaseName(dataSource)).isNotEqualToIgnoringCase("testdb");
+		this.context.close();
+	}
+
+	private String getDatabaseName(DataSource dataSource) throws SQLException {
+		Connection connection = dataSource.getConnection();
+		try {
+			ResultSet catalogs = connection.getMetaData().getCatalogs();
+			catalogs.next();
+			return catalogs.getString(1);
+		} finally {
+			connection.close();
+		}
 	}
 
 }


### PR DESCRIPTION
Currently (it seems to me) the only way to have an embedded test database use a random name is to completely override the `dataSource` bean or to use XML configuration with`<embedded-database generate-name="true"/>`. 
This PR makes it possible to do so by using `spring.datasource.generate-name = true` in properties or yaml config.

This is useful when running tests with multiple application context configurations as all cached contexts will try to destroy their `dataSource` bean which by default are all pointing to the same in-memory H2 database. 
The first will successfully shut down the embedded database and any subsequent ones will throw exceptions.
This does not cause the tests to fail but does produce a large stacktrace.