### PR TITLE
Rework subtypes populating code algorithm

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/web/support/ErrorPageFilter.java
+++ b/spring-boot/src/main/java/org/springframework/boot/web/support/ErrorPageFilter.java
@@ -223,12 +223,12 @@ public class ErrorPageFilter implements Filter, ErrorPageRegistry {
 		if (this.subtypes.containsKey(type)) {
 			return this.exceptions.get(this.subtypes.get(type));
 		}
-		Class<?> subtype = type;
-		while (subtype != Object.class) {
-			subtype = subtype.getSuperclass();
-			if (this.exceptions.containsKey(subtype)) {
-				this.subtypes.put(subtype, type);
-				return this.exceptions.get(subtype);
+		Class<?> supertype = type;
+		while (supertype != Object.class) {
+			supertype = supertype.getSuperclass();
+			if (this.exceptions.containsKey(supertype)) {
+				this.subtypes.put(type, supertype);
+				return this.exceptions.get(supertype);
 			}
 		}
 		return this.global;


### PR DESCRIPTION
If I'm reading this correctly, `subtypes` contains mapping for exceptions that themselves doesn't have `error-path` mapped, but their super class has, therefore to skip checking inheritance chain each time, they have this shortcut mapping. But here, **_map is populated the other way around_**! This might be due to the naming glitch: local variable subtype should probably be named *super*type since it contains parent type. Then mapping would go like: map `type` to `supertype` - which is what is going on. Maybe map should also be named `supertypes`?