### PR TITLE
Upgrade Hazelcast to 3.7.1

### DIFF
--- a/spring-boot-actuator/src/test/resources/cache/test-hazelcast.xml
+++ b/spring-boot-actuator/src/test/resources/cache/test-hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
 		xmlns="http://www.hazelcast.com/schema/config"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/spring-boot-actuator/src/test/resources/hazelcast.xml
+++ b/spring-boot-actuator/src/test/resources/hazelcast.xml
@@ -1,5 +1,5 @@
 <hazelcast
-		xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
+		xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
 		xmlns="http://www.hazelcast.com/schema/config"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/spring-boot-autoconfigure/src/test/resources/hazelcast.xml
+++ b/spring-boot-autoconfigure/src/test/resources/hazelcast.xml
@@ -1,5 +1,5 @@
 <hazelcast
-		xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
+		xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
 		xmlns="http://www.hazelcast.com/schema/config"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/cache/hazelcast-specific.xml
+++ b/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/cache/hazelcast-specific.xml
@@ -1,4 +1,4 @@
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
 		   xmlns="http://www.hazelcast.com/schema/config"
 		   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.xml
+++ b/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.xml
@@ -1,4 +1,4 @@
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
 		   xmlns="http://www.hazelcast.com/schema/config"
 		   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -81,7 +81,9 @@
 		<gson.version>2.7</gson.version>
 		<h2.version>1.4.192</h2.version>
 		<hamcrest.version>1.3</hamcrest.version>
-		<hazelcast.version>3.6.5</hazelcast.version>
+		<hazelcast.version>3.7.1</hazelcast.version>
+		<hazelcast-hibernate4.version>3.6.5</hazelcast-hibernate4.version>
+		<hazelcast-hibernate5.version>1.0.1</hazelcast-hibernate5.version>
 		<hibernate.version>5.0.11.Final</hibernate.version>
 		<hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
 		<hikaricp.version>2.4.7</hikaricp.version>
@@ -722,7 +724,12 @@
 			<dependency>
 				<groupId>com.hazelcast</groupId>
 				<artifactId>hazelcast-hibernate4</artifactId>
-				<version>${hazelcast.version}</version>
+				<version>${hazelcast-hibernate4.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.hazelcast</groupId>
+				<artifactId>hazelcast-hibernate5</artifactId>
+				<version>${hazelcast-hibernate5.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.hazelcast</groupId>

--- a/spring-boot-samples/spring-boot-sample-cache/src/main/resources/hazelcast.xml
+++ b/spring-boot-samples/spring-boot-sample-cache/src/main/resources/hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
 		   xmlns="http://www.hazelcast.com/schema/config"
 		   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 


### PR DESCRIPTION
Since Hazelcast 3.7, Hibernate integration modules have separate release lifecycle therefore version properties for [`hazelcast-hibernate4`](https://github.com/hazelcast/hazelcast-hibernate/blob/master/README.md#supported-hibernate-and-hazelcast-versions) and [`hazelcast-hibernate5`](https://github.com/hazelcast/hazelcast-hibernate5/blob/master/README.md) have been added.

Resolves #5101.