### PR TITLE
Modify to use standard mode and directory cache for Travis CI build speed up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ services:
   - mongodb
   - redis
   - cassandra
-sudo: false
+sudo: required
+cache:
+  directories:
+    - $HOME/.m2
 install: true
 before_script: travis_wait 45 ./mvnw install -q -U -DskipTests=true -Pfast -Dmaven.test.redirectTestOutputToFile=true
 script: ./mvnw install -q -nsu -Dmaven.test.redirectTestOutputToFile=true -P '!integration'


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Currently build time is about 35-40 minute. However PR's solution is about 20-25 minute + about 1 minute as start time. (actual time see https://travis-ci.org/kazuki43zoo/spring-boot/builds)
And standard mode has an advantage that it's used a latest JDK version(1.8.0_101 at the point of now). (Note: container based mode is used 1.8.0_31 at the point of now) 

Please consider to apply this PR.