### PR TITLE
Exclude commons-logging from spring-session

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -2196,6 +2196,12 @@
 				<groupId>org.springframework.session</groupId>
 				<artifactId>spring-session</artifactId>
 				<version>${spring-session.version}</version>
+				<exclusions>
+					<exclusion>
+						<artifactId>commons-logging</artifactId>
+						<groupId>commons-logging</groupId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.session</groupId>


### PR DESCRIPTION
spring-session includes commons-logging and it should be excluded by default for all spring-boot applications.

Let me know if this should be back ported to other versions. Example: 1.4.X and 1.5.X