### PR TITLE
Support getting environment from other events.

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/system/ApplicationPidFileWriter.java
+++ b/spring-boot/src/main/java/org/springframework/boot/system/ApplicationPidFileWriter.java
@@ -30,6 +30,7 @@ import org.springframework.boot.ApplicationPid;
 import org.springframework.boot.bind.RelaxedPropertyResolver;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.boot.context.event.ApplicationPreparedEvent;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.event.SpringApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
@@ -49,7 +50,8 @@ import org.springframework.util.Assert;
  * <p>
  * Note: access to the Spring {@link Environment} is only possible when the
  * {@link #setTriggerEventType(Class) triggerEventType} is set to
- * {@link ApplicationEnvironmentPreparedEvent} or {@link ApplicationPreparedEvent}.
+ * {@link ApplicationEnvironmentPreparedEvent}, {@link ApplicationReadyEvent},
+ * or {@link ApplicationPreparedEvent}.
  *
  * @author Jakub Kubrynski
  * @author Dave Syer
@@ -229,6 +231,10 @@ public class ApplicationPidFileWriter
 			}
 			if (event instanceof ApplicationPreparedEvent) {
 				return ((ApplicationPreparedEvent) event).getApplicationContext()
+						.getEnvironment();
+			}
+			if (event instanceof ApplicationReadyEvent) {
+				return ((ApplicationReadyEvent) event).getApplicationContext()
 						.getEnvironment();
 			}
 			return null;

--- a/spring-boot/src/test/java/org/springframework/boot/system/ApplicationPidFileWriterTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/system/ApplicationPidFileWriterTests.java
@@ -29,6 +29,7 @@ import org.junit.rules.TemporaryFolder;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.boot.context.event.ApplicationPreparedEvent;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.event.ApplicationStartedEvent;
 import org.springframework.boot.context.event.SpringApplicationEvent;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -99,7 +100,7 @@ public class ApplicationPidFileWriterTests {
 	}
 
 	@Test
-	public void differentEventTypes() throws Exception {
+	public void tryEnvironmentPreparedEvent() throws Exception {
 		File file = this.temporaryFolder.newFile();
 		SpringApplicationEvent event = createEnvironmentPreparedEvent("spring.pid.file",
 				file.getAbsolutePath());
@@ -107,6 +108,19 @@ public class ApplicationPidFileWriterTests {
 		listener.onApplicationEvent(event);
 		assertThat(FileCopyUtils.copyToString(new FileReader(file))).isEmpty();
 		listener.setTriggerEventType(ApplicationEnvironmentPreparedEvent.class);
+		listener.onApplicationEvent(event);
+		assertThat(FileCopyUtils.copyToString(new FileReader(file))).isNotEmpty();
+	}
+
+	@Test
+	public void tryReadyEvent() throws Exception {
+		File file = this.temporaryFolder.newFile();
+		SpringApplicationEvent event = createReadyEvent("spring.pid.file",
+				file.getAbsolutePath());
+		ApplicationPidFileWriter listener = new ApplicationPidFileWriter();
+		listener.onApplicationEvent(event);
+		assertThat(FileCopyUtils.copyToString(new FileReader(file))).isEmpty();
+		listener.setTriggerEventType(ApplicationReadyEvent.class);
 		listener.onApplicationEvent(event);
 		assertThat(FileCopyUtils.copyToString(new FileReader(file))).isNotEmpty();
 	}
@@ -167,6 +181,16 @@ public class ApplicationPidFileWriterTests {
 				ConfigurableApplicationContext.class);
 		given(context.getEnvironment()).willReturn(environment);
 		return new ApplicationPreparedEvent(new SpringApplication(), new String[] {},
+				context);
+	}
+
+	private SpringApplicationEvent createReadyEvent(String propName,
+			String propValue) {
+		ConfigurableEnvironment environment = createEnvironment(propName, propValue);
+		ConfigurableApplicationContext context = mock(
+				ConfigurableApplicationContext.class);
+		given(context.getEnvironment()).willReturn(environment);
+		return new ApplicationReadyEvent(new SpringApplication(), new String[] {},
 				context);
 	}
 


### PR DESCRIPTION
PR for Issue: https://github.com/spring-projects/spring-boot/issues/7027

This PR supports using Environment properties from any event that provide a "getApplicationContext()" method.  It also changes existing functionality to log a warning if Environment properties are not used (would have been useful in my debugging of the issue).

After writing the code I realized that the Ready is probably the only other useful event that currently exists that someone might want to use that provides Environment properties.  If you'd prefer for me to change the PR to only add support for `Ready` and/or not log a warning let me know and I can update the PR to do that.
