### PR TITLE
Support uninstall a UrlStreamHandlerFactory

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfigurationServletContainerTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfigurationServletContainerTests.java
@@ -16,14 +16,19 @@
 
 package org.springframework.boot.autoconfigure.jersey;
 
+import java.net.URL;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
 import org.apache.catalina.Context;
 import org.apache.catalina.Wrapper;
+import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
 import org.apache.tomcat.util.buf.UDecoder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +48,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,6 +65,14 @@ public class JerseyAutoConfigurationServletContainerTests {
 
 	@ClassRule
 	public static OutputCapture output = new OutputCapture();
+
+	@BeforeClass
+	@AfterClass
+	public static void uninstallUrlStreamHandlerFactory() {
+		ReflectionTestUtils.setField(TomcatURLStreamHandlerFactory.class, "instance",
+				null);
+		ReflectionTestUtils.setField(URL.class, "factory", null);
+	}
 
 	@Test
 	public void existingJerseyServletIsAmended() {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/SecurityFilterAutoConfigurationEarlyInitializationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/SecurityFilterAutoConfigurationEarlyInitializationTests.java
@@ -17,12 +17,16 @@
 package org.springframework.boot.autoconfigure.security;
 
 import java.io.IOException;
+import java.net.URL;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +48,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -54,6 +59,14 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Phillip Webb
  */
 public class SecurityFilterAutoConfigurationEarlyInitializationTests {
+
+	@BeforeClass
+	@AfterClass
+	public static void uninstallUrlStreamHandlerFactory() {
+		ReflectionTestUtils.setField(TomcatURLStreamHandlerFactory.class, "instance",
+				null);
+		ReflectionTestUtils.setField(URL.class, "factory", null);
+	}
 
 	// gh-4154
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/OAuth2AutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/OAuth2AutoConfigurationTests.java
@@ -17,10 +17,14 @@
 package org.springframework.boot.autoconfigure.security.oauth2;
 
 import java.net.URI;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.springframework.aop.support.AopUtils;
@@ -112,6 +116,14 @@ public class OAuth2AutoConfigurationTests {
 	private static final Class<?> AUTHORIZATION_SERVER_CONFIG = OAuth2AuthorizationServerConfiguration.class;
 
 	private AnnotationConfigEmbeddedWebApplicationContext context;
+
+	@BeforeClass
+	@AfterClass
+	public static void uninstallUrlStreamHandlerFactory() {
+		ReflectionTestUtils.setField(TomcatURLStreamHandlerFactory.class, "instance",
+				null);
+		ReflectionTestUtils.setField(URL.class, "factory", null);
+	}
 
 	@Test
 	public void testDefaultConfiguration() {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/BasicErrorControllerIntegrationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/BasicErrorControllerIntegrationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.web;
 
 import java.net.URI;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -27,7 +28,10 @@ import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
 import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -47,6 +51,7 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -72,6 +77,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BasicErrorControllerIntegrationTests {
 
 	private ConfigurableApplicationContext context;
+
+	@BeforeClass
+	@AfterClass
+	public static void uninstallUrlStreamHandlerFactory() {
+		ReflectionTestUtils.setField(TomcatURLStreamHandlerFactory.class, "instance",
+				null);
+		ReflectionTestUtils.setField(URL.class, "factory", null);
+	}
 
 	@After
 	public void closeContext() {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/EmbeddedServletContainerServletContextListenerTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/EmbeddedServletContainerServletContextListenerTests.java
@@ -16,9 +16,14 @@
 
 package org.springframework.boot.autoconfigure.web;
 
+import java.net.URL;
+
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext;
@@ -30,6 +35,7 @@ import org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServle
 import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -42,6 +48,14 @@ import static org.mockito.Mockito.verify;
  * @author Andy Wilkinson
  */
 public class EmbeddedServletContainerServletContextListenerTests {
+
+	@BeforeClass
+	@AfterClass
+	public static void uninstallUrlStreamHandlerFactory() {
+		ReflectionTestUtils.setField(TomcatURLStreamHandlerFactory.class, "instance",
+				null);
+		ReflectionTestUtils.setField(URL.class, "factory", null);
+	}
 
 	@Test
 	public void registeredServletContextListenerBeanIsCalledByJetty() {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/MultipartAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/MultipartAutoConfigurationTests.java
@@ -17,10 +17,14 @@
 package org.springframework.boot.autoconfigure.web;
 
 import java.net.URI;
+import java.net.URL;
 
 import javax.servlet.MultipartConfigElement;
 
+import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
 import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -68,6 +72,14 @@ public class MultipartAutoConfigurationTests {
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
+
+	@BeforeClass
+	@AfterClass
+	public static void uninstallUrlStreamHandlerFactory() {
+		ReflectionTestUtils.setField(TomcatURLStreamHandlerFactory.class, "instance",
+				null);
+		ReflectionTestUtils.setField(URL.class, "factory", null);
+	}
 
 	@After
 	public void close() {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -18,6 +18,7 @@ package org.springframework.boot.autoconfigure.web;
 
 import java.io.File;
 import java.net.InetAddress;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -32,7 +33,10 @@ import javax.servlet.SessionTrackingMode;
 import org.apache.catalina.Context;
 import org.apache.catalina.Valve;
 import org.apache.catalina.valves.RemoteIpValve;
+import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -48,6 +52,7 @@ import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletCon
 import org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServletContainerFactory;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -75,6 +80,14 @@ public class ServerPropertiesTests {
 
 	@Captor
 	private ArgumentCaptor<ServletContextInitializer[]> initializersCaptor;
+
+	@BeforeClass
+	@AfterClass
+	public static void uninstallUrlStreamHandlerFactory() {
+		ReflectionTestUtils.setField(TomcatURLStreamHandlerFactory.class, "instance",
+				null);
+		ReflectionTestUtils.setField(URL.class, "factory", null);
+	}
 
 	@Before
 	public void setup() {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/websocket/WebSocketAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/websocket/WebSocketAutoConfigurationTests.java
@@ -16,10 +16,15 @@
 
 package org.springframework.boot.autoconfigure.websocket;
 
+import java.net.URL;
+
 import javax.websocket.server.ServerContainer;
 
+import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext;
@@ -29,6 +34,7 @@ import org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletConta
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,6 +46,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class WebSocketAutoConfigurationTests {
 
 	private AnnotationConfigEmbeddedWebApplicationContext context;
+
+	@BeforeClass
+	@AfterClass
+	public static void uninstallUrlStreamHandlerFactory() {
+		ReflectionTestUtils.setField(TomcatURLStreamHandlerFactory.class, "instance",
+				null);
+		ReflectionTestUtils.setField(URL.class, "factory", null);
+	}
 
 	@Before
 	public void createContext() {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Some tests of `spring-boot-autocinfigure` are failed on my Travis CI account(forked repository).

* https://travis-ci.org/kazuki43zoo/spring-boot/builds/164068580

```
...
Results :
Tests in error: 
  JerseyAutoConfigurationServletContainerTests.existingJerseyServletIsAmended » IllegalState
  SecurityFilterAutoConfigurationEarlyInitializationTests.testSecurityFilterDoesNotCauseEarlyInitialization:67 » ApplicationContext
  OAuth2AutoConfigurationTests.testAuthorizationServerOverride:235 » ApplicationContext
  OAuth2AutoConfigurationTests.testClassicSecurityAnnotationOverride:271 » ApplicationContext
  OAuth2AutoConfigurationTests.testClientIsNotResourceServer:182 » ApplicationContext
  OAuth2AutoConfigurationTests.testDefaultConfiguration:121 » ApplicationContext
  OAuth2AutoConfigurationTests.testDefaultPrePostSecurityAnnotations:253 » ApplicationContext
  OAuth2AutoConfigurationTests.testDisablingAuthorizationServer:208 » ApplicationContext
  OAuth2AutoConfigurationTests.testDisablingResourceServer:172 » ApplicationContext
  OAuth2AutoConfigurationTests.testEnvironmentalOverrides:155 » ApplicationContext
  OAuth2AutoConfigurationTests.testJsr250SecurityAnnotationOverride:289 » ApplicationContext
  OAuth2AutoConfigurationTests.testMethodSecurityBackingOff:307 » ApplicationContext
  OAuth2AutoConfigurationTests.testResourceServerOverride:220 » ApplicationContext
  BasicErrorControllerIntegrationTests.testBindingExceptionForMachineClient » IllegalState
  BasicErrorControllerIntegrationTests.testConventionTemplateMapping » IllegalState
  BasicErrorControllerIntegrationTests.testErrorForAnnotatedException » IllegalState
  BasicErrorControllerIntegrationTests.testErrorForAnnotatedNoReasonException » IllegalState
  BasicErrorControllerIntegrationTests.testErrorForMachineClient » IllegalState ...
  BasicErrorControllerIntegrationTests.testErrorForMachineClientAlwaysStacktrace » IllegalState
  BasicErrorControllerIntegrationTests.testErrorForMachineClientNoStacktrace » IllegalState
  BasicErrorControllerIntegrationTests.testErrorForMachineClientTraceParamStacktrace » IllegalState
  BasicErrorControllerIntegrationTests.testRequestBodyValidationForMachineClient » IllegalState
  EmbeddedServletContainerServletContextListenerTests.registeredServletContextListenerBeanIsCalledByTomcat:53->registeredServletContextListenerBeanIsCalled:86 » ApplicationContext
  EmbeddedServletContainerServletContextListenerTests.servletContextListenerBeanIsCalledByTomcat:68->servletContextListenerBeanIsCalled:77 » ApplicationContext
  MultipartAutoConfigurationTests.containerWithAutomatedMultipartTomcatConfiguration:139 » ApplicationContext
  MultipartAutoConfigurationTests.containerWithMultipartConfigDisabled:162->testContainerWithCustomMultipartConfigEnabledSetting:177 » ApplicationContext
  MultipartAutoConfigurationTests.containerWithMultipartConfigEnabled:167->testContainerWithCustomMultipartConfigEnabledSetting:177 » ApplicationContext
  MultipartAutoConfigurationTests.containerWithNoMultipartTomcatConfiguration:117 » ApplicationContext
  ServerPropertiesTests.customTomcatBackgroundProcessorDelay:376 » EmbeddedServletContainer
  ServerPropertiesTests.defaultTomcatBackgroundProcessorDelay:363 » EmbeddedServletContainer
  WebSocketAutoConfigurationTests.tomcatServerContainerIsAvailableFromTheServletContext:58->serverContainerIsAvailableFromTheServletContext:71 » ApplicationContext
  WebSocketMessagingAutoConfigurationTests.basicMessagingWithJsonResponse:101->performStompSubscription:146 » ApplicationContext
  WebSocketMessagingAutoConfigurationTests.basicMessagingWithStringResponse:108->performStompSubscription:146 » ApplicationContext
Tests run: 1349, Failures: 0, Errors: 33, Skipped: 4
...
```

Error occurred at the `URL#setURLStreamHandlerFactory` method.
```diff
    public static void setURLStreamHandlerFactory(URLStreamHandlerFactory fac) {
        synchronized (streamHandlerLock) {
            if (factory != null) {
+                throw new Error("factory already defined"); // ### Here
            }
            SecurityManager security = System.getSecurityManager();
            if (security != null) {
                security.checkSetFactory();
            }
            handlers.clear();
            factory = fac;
        }
    }
```

I've fix as uninstall a `UrlStreamHandlerFactory` instance before / after executing test. I've copied from the `AbstractEmbeddedServletContainerFactoryTests`'s implementation.

Please review.

* https://travis-ci.org/kazuki43zoo/spring-boot/builds/164209519
