### PR TITLE
Fix NoClassDefFoundError when Mockito is missing

### DIFF
--- a/spring-boot-samples/pom.xml
+++ b/spring-boot-samples/pom.xml
@@ -82,6 +82,7 @@
 		<module>spring-boot-sample-session-redis</module>
 		<module>spring-boot-sample-simple</module>
 		<module>spring-boot-sample-test</module>
+		<module>spring-boot-sample-test-nomockito</module>
 		<module>spring-boot-sample-testng</module>
 		<module>spring-boot-sample-tomcat</module>
 		<module>spring-boot-sample-tomcat-jsp</module>

--- a/spring-boot-samples/spring-boot-sample-test-nomockito/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-test-nomockito/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<!-- Your own application should inherit from spring-boot-starter-parent -->
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-samples</artifactId>
+		<version>1.4.2.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-sample-test-nomockito</artifactId>
+	<name>Spring Boot Test Sample No Mockito</name>
+	<description>Spring Boot Test Sample No Mockito</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-samples/spring-boot-sample-test-nomockito/src/main/java/sample/testnomockito/SampleTestNoMockitoApplication.java
+++ b/spring-boot-samples/spring-boot-sample-test-nomockito/src/main/java/sample/testnomockito/SampleTestNoMockitoApplication.java
@@ -1,0 +1,15 @@
+package sample.testnomockito;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SampleTestNoMockitoApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SampleTestNoMockitoApplication.class);
+    }
+
+}
+
+

--- a/spring-boot-samples/spring-boot-sample-test-nomockito/src/test/java/sample/testnomockito/SampleTestNoMockitoApplicationTest.java
+++ b/spring-boot-samples/spring-boot-sample-test-nomockito/src/test/java/sample/testnomockito/SampleTestNoMockitoApplicationTest.java
@@ -1,0 +1,23 @@
+package sample.testnomockito;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@RunWith(SpringRunner.class)
+public class SampleTestNoMockitoApplicationTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void contextLoads() throws Exception {
+        assertThat(this.context).isNotNull();
+    }
+
+}

--- a/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockReset.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockReset.java
@@ -26,6 +26,7 @@ import org.mockito.listeners.MethodInvocationReport;
 import org.mockito.mock.MockCreationSettings;
 
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 
 /**
  * Reset strategy used on a mock bean. Usually applied to a mock via the
@@ -52,8 +53,6 @@ public enum MockReset {
 	 * Don't reset the mock.
 	 */
 	NONE;
-
-	private static final MockUtil util = new MockUtil();
 
 	/**
 	 * Create {@link MockSettings settings} to be used with mocks where reset should occur
@@ -105,12 +104,15 @@ public enum MockReset {
 	@SuppressWarnings("rawtypes")
 	static MockReset get(Object mock) {
 		MockReset reset = MockReset.NONE;
-		if (util.isMock(mock)) {
-			MockCreationSettings settings = util.getMockSettings(mock);
-			List listeners = settings.getInvocationListeners();
-			for (Object listener : listeners) {
-				if (listener instanceof ResetInvocationListener) {
-					reset = ((ResetInvocationListener) listener).getReset();
+		if(ClassUtils.isPresent("org.mockito.internal.util.MockUtil", null)) {
+			MockUtil mockUtil = new MockUtil();
+			if (mockUtil.isMock(mock)) {
+				MockCreationSettings settings = mockUtil.getMockSettings(mock);
+				List listeners = settings.getInvocationListeners();
+				for (Object listener : listeners) {
+					if (listener instanceof ResetInvocationListener) {
+						reset = ((ResetInvocationListener) listener).getReset();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Update MockReset class to check for the presence of the MockUtil class
before attempting to use it.

Fixes gh-7065