### PR TITLE
Enable custom Reservoir in DropwizardMetricServices metrics

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/MetricsDropwizardAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/MetricsDropwizardAutoConfiguration.java
@@ -18,10 +18,12 @@ package org.springframework.boot.actuate.autoconfigure;
 
 import com.codahale.metrics.MetricRegistry;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.MetricReaderPublicMetrics;
 import org.springframework.boot.actuate.metrics.CounterService;
 import org.springframework.boot.actuate.metrics.GaugeService;
 import org.springframework.boot.actuate.metrics.dropwizard.DropwizardMetricServices;
+import org.springframework.boot.actuate.metrics.dropwizard.ReservoirFactory;
 import org.springframework.boot.actuate.metrics.reader.MetricRegistryMetricReader;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -41,6 +43,9 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureBefore(MetricRepositoryAutoConfiguration.class)
 public class MetricsDropwizardAutoConfiguration {
 
+	@Autowired(required = false)
+	private ReservoirFactory reservoirFactory;
+
 	@Bean
 	@ConditionalOnMissingBean
 	public MetricRegistry metricRegistry() {
@@ -52,7 +57,12 @@ public class MetricsDropwizardAutoConfiguration {
 			GaugeService.class })
 	public DropwizardMetricServices dropwizardMetricServices(
 			MetricRegistry metricRegistry) {
-		return new DropwizardMetricServices(metricRegistry);
+		if (this.reservoirFactory == null) {
+			return new DropwizardMetricServices(metricRegistry);
+		}
+		else {
+			return new DropwizardMetricServices(metricRegistry, this.reservoirFactory);
+		}
 	}
 
 	@Bean

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/dropwizard/ReservoirFactory.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/dropwizard/ReservoirFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.metrics.dropwizard;
+
+import com.codahale.metrics.Reservoir;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectFactory;
+
+/**
+ * A {@link Reservoir} factory to instantiate the Reservoir that will be set as default
+ * for the {@link DropwizardMetricServices}.
+ * The Reservoir instances can't be shared across {@link com.codahale.metrics.Metric}.
+ *
+ * @author Lucas Saldanha
+ */
+public abstract class ReservoirFactory implements ObjectFactory<Reservoir> {
+
+	protected abstract Reservoir defaultReservoir();
+
+	@Override
+	public Reservoir getObject() throws BeansException {
+		return defaultReservoir();
+	}
+}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/MetricsDropwizardAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/MetricsDropwizardAutoConfigurationTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure;
+
+import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.UniformReservoir;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.springframework.boot.actuate.metrics.dropwizard.DropwizardMetricServices;
+import org.springframework.boot.actuate.metrics.dropwizard.ReservoirFactory;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MetricsDropwizardAutoConfiguration}.
+ *
+ * @author Lucas Saldanha
+ */
+public class MetricsDropwizardAutoConfigurationTests {
+
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void after() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void dropwizardWithoutCustomReservoirConfigured() {
+		this.context = new AnnotationConfigApplicationContext(
+				MetricsDropwizardAutoConfiguration.class);
+
+		DropwizardMetricServices dropwizardMetricServices = this.context
+				.getBean(DropwizardMetricServices.class);
+
+		assertThat(ReflectionTestUtils.getField(dropwizardMetricServices, "reservoirFactory"))
+				.isNull();
+	}
+
+	@Test
+	public void dropwizardWithCustomReservoirConfigured() {
+		this.context = new AnnotationConfigApplicationContext(
+				MetricsDropwizardAutoConfiguration.class, Config.class);
+
+		DropwizardMetricServices dropwizardMetricServices = this.context
+				.getBean(DropwizardMetricServices.class);
+
+		assertThat(ReflectionTestUtils.getField(dropwizardMetricServices, "reservoirFactory"))
+				.isNotNull();
+	}
+
+	@Configuration
+	static class Config {
+
+		@Bean
+		public ReservoirFactory reservoirFactory() {
+			return new ReservoirFactory() {
+				@Override
+				protected Reservoir defaultReservoir() {
+					return new UniformReservoir();
+				}
+			};
+		}
+	}
+
+}


### PR DESCRIPTION
Uses the ReservoirFactory to customize the implementation of
the Reservoir that will be used when creating Timer and Histogram
in the DropwizardMetricServices.

Fixes #5199 
