### PR TITLE
Remove unused parameters in String.format()

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/diagnostics/analyzer/NoSuchBeanDefinitionFailureAnalyzerTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/diagnostics/analyzer/NoSuchBeanDefinitionFailureAnalyzerTests.java
@@ -184,15 +184,14 @@ public class NoSuchBeanDefinitionFailureAnalyzerTests {
 	private void assertBeanMethodDisabled(FailureAnalysis analysis, String description,
 			Class<?> target, String methodName) {
 		String expected = String.format("Bean method '%s' in '%s' not loaded because",
-				methodName, ClassUtils.getShortName(target), description);
+				methodName, ClassUtils.getShortName(target));
 		assertThat(analysis.getDescription()).contains(expected);
 		assertThat(analysis.getDescription()).contains(description);
 	}
 
 	private void assertClassDisabled(FailureAnalysis analysis, String description,
 			String methodName) {
-		String expected = String.format("Bean method '%s' not loaded because", methodName,
-				description);
+		String expected = String.format("Bean method '%s' not loaded because", methodName);
 		assertThat(analysis.getDescription()).contains(expected);
 		assertThat(analysis.getDescription()).contains(description);
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR simply removes unused parameters in `String.format()`.