### PR TITLE
Spring boot docs - syntax fix

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -1436,7 +1436,7 @@ By default, `spring-boot-starter-thymeleaf` uses Thymeleaf 2.1. If you are using
 	<properties>
 		<thymeleaf.version>3.0.0.RELEASE</thymeleaf.version>
 		<thymeleaf-layout-dialect.version>2.0.3</thymeleaf-layout-dialect.version>
-	</dependency>
+	</properties>
 ----
 
 NOTE: if you are managing dependencies yourself, look at `spring-boot-dependencies` for


### PR DESCRIPTION
syntax fix the howto-use-thymeleaf-3 xml source