### PR TITLE
Make stop wait time in the launch script configurable

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/deployment.adoc
+++ b/spring-boot-docs/src/main/asciidoc/deployment.adoc
@@ -620,6 +620,10 @@ for Gradle and to `${project.name}` for Maven.
 |`useStartStopDaemon`
 |If the `start-stop-daemon` command, when it's available, should be used to control the
  process. Defaults to `true`.
+
+|`stopWaitTime`
+|The default value for `STOP_WAIT_TIME`. Only valid for an `init.d` service.
+ Defaults to 60 seconds.
 |===
 
 
@@ -680,6 +684,10 @@ The following environment properties are supported with the default script:
 |`DEBUG`
 |if not empty will set the `-x` flag on the shell process, making it easy to see the logic
  in the script.
+
+|`STOP_WAIT_TIME`
+|The time in seconds to wait when stopping the application before forcing a shutdown
+ (`60` by default).
 |===
 
 NOTE: The `PID_FOLDER`, `LOG_FOLDER` and `LOG_FILENAME` variables are only valid for an

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -73,6 +73,8 @@ fi
 # Initialize log file name if not provided by the config file
 [[ -z "$LOG_FILENAME" ]] && LOG_FILENAME="${identity}.log"
 
+# Initialize stop wait time if not provided by the config file
+[[ -z "$STOP_WAIT_TIME" ]] && STOP_WAIT_TIME={{stopWaitTime:60}}
 
 # ANSI Colors
 echoRed() { echo $'\e[0;31m'"$1"$'\e[0m'; }
@@ -192,9 +194,9 @@ stop() {
 
 do_stop() {
   kill "$1" &> /dev/null || { echoRed "Unable to kill process $1"; return 1; }
-  for i in $(seq 1 60); do
+  for i in $(seq 1 $STOP_WAIT_TIME); do
     isRunning "$1" || { echoGreen "Stopped [$1]"; rm -f "$2"; return 0; }
-    [[ $i -eq 30 ]] && kill "$1" &> /dev/null
+    [[ $i -eq STOP_WAIT_TIME/2 ]] && kill "$1" &> /dev/null
     sleep 1
   done
   echoRed "Unable to kill process $1";

--- a/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/DefaultLaunchScriptTests.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/DefaultLaunchScriptTests.java
@@ -92,6 +92,11 @@ public class DefaultLaunchScriptTests {
 	}
 
 	@Test
+	public void stopWaitTimeCanBeReplaced() throws Exception {
+		assertThatPlaceholderCanBeReplaced("stopWaitTime");
+	}
+
+	@Test
 	public void defaultForUseStartStopDaemonIsTrue() throws Exception {
 		DefaultLaunchScript script = new DefaultLaunchScript(null, null);
 		String content = new String(script.toByteArray());
@@ -103,6 +108,13 @@ public class DefaultLaunchScriptTests {
 		DefaultLaunchScript script = new DefaultLaunchScript(null, null);
 		String content = new String(script.toByteArray());
 		assertThat(content).contains("MODE=\"auto\"");
+	}
+
+	@Test
+	public void defaultForStopWaitTimeIs60() throws Exception {
+		DefaultLaunchScript script = new DefaultLaunchScript(null, null);
+		String content = new String(script.toByteArray());
+		assertThat(content).contains("STOP_WAIT_TIME=60");
 	}
 
 	@Test


### PR DESCRIPTION
Create a parameter `STOP_WAIT_TIME` for the startup script
that configures the time in seconds to wait for a normal
shutdown. 

Because of #4941 we also send a shutdown half
way the countdown.

Fixes #7121
