### PR TITLE
Add array support for spring.profiles.*

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -127,8 +127,8 @@ content into your application; rather pick only the properties that you need.
 	spring.pid.file= # Location of the PID file to write (if ApplicationPidFileWriter is used).
 
 	# PROFILES
-	spring.profiles.active= # Comma-separated list of <<howto-set-active-spring-profiles,active profiles>>.
-	spring.profiles.include= # Unconditionally activate the specified comma separated profiles.
+	spring.profiles.active= # Comma-separated list (or list if using YAML) of <<howto-set-active-spring-profiles,active profiles>>.
+	spring.profiles.include= # Unconditionally activate the specified comma separated profiles (or list of profiles if using YAML).
 
 	# SENDGRID ({sc-spring-boot-autoconfigure}/sendgrid/SendGridAutoConfiguration.{sc-ext}[SendGridAutoConfiguration])
 	spring.sendgrid.api-key= # SendGrid api key (alternative to username/password)

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -1173,7 +1173,9 @@ For example, when an application with following properties is run using the swit
 	my.property: fromyamlfile
 	---
 	spring.profiles: prod
-	spring.profiles.include: proddb,prodmq
+	spring.profiles.include:
+	  - proddb
+		- prodmq
 ----
 
 NOTE: Remember that the `spring.profiles` property can be defined in a YAML document

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -1174,8 +1174,8 @@ For example, when an application with following properties is run using the swit
 	---
 	spring.profiles: prod
 	spring.profiles.include:
-	  - proddb
-		- prodmq
+    - proddb
+    - prodmq
 ----
 
 NOTE: Remember that the `spring.profiles` property can be defined in a YAML document

--- a/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileApplicationListenerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileApplicationListenerTests.java
@@ -537,6 +537,14 @@ public class ConfigFileApplicationListenerTests {
 	}
 
 	@Test
+	public void yamlSetsMultiProfilesWhenListProvided() throws Exception {
+		this.initializer.setSearchNames("testsetmultiprofileslist");
+		this.initializer.postProcessEnvironment(this.environment, this.application);
+		assertThat(this.environment.getActiveProfiles()).containsExactly("dev",
+				"healthcheck");
+	}
+
+	@Test
 	public void yamlSetsMultiProfilesWithWhitespace() throws Exception {
 		this.initializer.setSearchNames("testsetmultiprofileswhitespace");
 		this.initializer.postProcessEnvironment(this.environment, this.application);

--- a/spring-boot/src/test/resources/testsetmultiprofileslist.yml
+++ b/spring-boot/src/test/resources/testsetmultiprofileslist.yml
@@ -1,0 +1,6 @@
+---
+spring:
+  profiles:
+    active:
+      - dev
+      - healthcheck


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

This change allows users to specify spring.profiles.active and spring.profiles.include as a list in a YAML file. It preserves support for a comma-separated string.
- Added code to parse list or string
- Added test to verify new functionality
- Adjusted documentation accordingly

Fixes gh-6995
