### PR TITLE
Add a missing return

### DIFF
--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/orm/jpa/TestDatabaseAutoConfiguration.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/orm/jpa/TestDatabaseAutoConfiguration.java
@@ -118,6 +118,7 @@ public class TestDatabaseAutoConfiguration {
 			if (ObjectUtils.isEmpty(beanNames)) {
 				logger.warn("No DataSource beans found, "
 						+ "embedded version will not be used");
+				return null;
 			}
 			if (beanNames.length == 1) {
 				String beanName = beanNames[0];


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
It looks `return null;` is missing in `TestDatabaseAutoConfiguration.EmbeddedDataSourceBeanFactoryPostProcessor.getDataSourceBeanDefinition()`.