### PR TITLE
Redis Metrics Exporter needs afterPropertiesSet()

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -1054,8 +1054,12 @@ Example:
 @Bean
 @ExportMetricWriter
 MetricWriter metricWriter(MetricExportProperties export) {
-	return new RedisMetricRepository(connectionFactory,
-      export.getRedis().getPrefix(), export.getRedis().getKey());
+	RedisMetricRepository redisMetricRepository = new RedisMetricRepository(
+		connectionFactory,
+		export.getRedis().getPrefix(),
+		export.getRedis().getKey());
+        redisMetricRepository.afterPropertiesSet();
+	return redisMetricRepository;
 }
 ----
 


### PR DESCRIPTION
On my system I get an NPE without this change.