### PR TITLE
Update documentation on Actuator hypermedia support

### DIFF
--- a/spring-boot-actuator-docs/pom.xml
+++ b/spring-boot-actuator-docs/pom.xml
@@ -45,6 +45,11 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.jayway.jsonpath</groupId>
+			<artifactId>json-path</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>provided</scope>
@@ -81,6 +86,10 @@
 		<dependency>
 			<groupId>org.springframework.hateoas</groupId>
 			<artifactId>spring-hateoas</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.plugin</groupId>
+			<artifactId>spring-plugin-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.restdocs</groupId>

--- a/spring-boot-actuator-docs/src/main/asciidoc/index.adoc
+++ b/spring-boot-actuator-docs/src/main/asciidoc/index.adoc
@@ -58,7 +58,7 @@ HAL browser is not active).
 
 == Hypermedia Support
 If https://projects.spring.io/spring-hateoas[Spring HATEOAS] is enabled  (i.e. if it is
-on the classpath by default) then the Actuator endpoint responses are enhanced with
+on the classpath by default) and `endpoints.hypermedia.enabled` is set to `true` then the Actuator endpoint responses are enhanced with
 hypermedia in the form of "links". The default media type for responses is
 http://stateless.co/hal_specification.html[HAL], resulting in each resource having an
 extra property called "_links". You can change the media type to another one supported by

--- a/spring-boot-actuator-docs/src/restdoc/java/org/springframework/boot/actuate/hypermedia/HypermediaEndpointDocumentation.java
+++ b/spring-boot-actuator-docs/src/restdoc/java/org/springframework/boot/actuate/hypermedia/HypermediaEndpointDocumentation.java
@@ -33,12 +33,13 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = SpringBootHypermediaApplication.class, loader = SpringBootContextLoader.class)
 @WebAppConfiguration
-@TestPropertySource(properties = "spring.jackson.serialization.indent_output=true")
+@TestPropertySource(properties = { "spring.jackson.serialization.indent_output=true", "endpoints.hypermedia.enabled=true" })
 @DirtiesContext
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs("target/generated-snippets")
@@ -56,7 +57,9 @@ public class HypermediaEndpointDocumentation {
 	@Test
 	public void metrics() throws Exception {
 		this.mockMvc.perform(get("/metrics").accept(MediaType.APPLICATION_JSON))
-				.andExpect(status().isOk()).andDo(document("metrics/hypermedia"));
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$._links.self.href").value("http://localhost:8080/metrics"))
+				.andDo(document("metrics/hypermedia"));
 	}
 
 	@Test

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -902,6 +902,7 @@ content into your application; rather pick only the properties that you need.
 	# ENDPOINTS ({sc-spring-boot-actuator}/endpoint/AbstractEndpoint.{sc-ext}[AbstractEndpoint] subclasses)
 	endpoints.enabled=true # Enable endpoints.
 	endpoints.sensitive= # Default endpoint sensitive setting.
+	endpoints.hypermedia.enabled=false # Enable hypermedia support for endpoints.
 	endpoints.actuator.enabled=true # Enable the endpoint.
 	endpoints.actuator.path= # Endpoint URL path.
 	endpoints.actuator.sensitive=false # Enable security on the endpoint.

--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -205,7 +205,7 @@ For example, to mark _all_ endpoints as sensitive except `info`:
 === Hypermedia for actuator MVC endpoints
 If http://projects.spring.io/spring-hateoas[Spring HATEOAS] is on the classpath (e.g.
 through the `spring-boot-starter-hateoas` or if you are using
-http://projects.spring.io/spring-data-rest[Spring Data REST]) then the HTTP endpoints
+http://projects.spring.io/spring-data-rest[Spring Data REST]) and `endpoints.hypermedia.enabled` is set to `true` then the HTTP endpoints
 from the Actuator are enhanced with hypermedia links, and a "`discovery page`" is added
 with links to all the endpoints. The "`discovery page`" is available on `/actuator` by
 default. It is implemented as an endpoint, allowing properties to be used to configure


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Spring Boot Actuator hypermedia support has been disabled by default via c7c685f65fcf5cfa4219060a71ad6f654c187a96, but its documentation wasn't updated.

This PR updates the documentation related to the change.