### PR TITLE
Set embedded test database as primary.

### DIFF
--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/orm/jpa/TestDatabaseAutoConfiguration.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/orm/jpa/TestDatabaseAutoConfiguration.java
@@ -109,7 +109,9 @@ public class TestDatabaseAutoConfiguration {
 		}
 
 		private BeanDefinition createEmbeddedBeanDefinition() {
-			return new RootBeanDefinition(EmbeddedDataSourceFactoryBean.class);
+			BeanDefinition beanDefinition = new RootBeanDefinition(EmbeddedDataSourceFactoryBean.class);
+			beanDefinition.setPrimary(true);
+			return beanDefinition;
 		}
 
 		private BeanDefinitionHolder getDataSourceBeanDefinition(

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/orm/jpa/AutoConfigureTestDatabaseWithMultipleDatasourcesIntegrationTests.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/orm/jpa/AutoConfigureTestDatabaseWithMultipleDatasourcesIntegrationTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.orm.jpa;
+
+import javax.sql.DataSource;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link AutoConfigureTestDatabase} when there are multiple datasources.
+ *
+ * @author Greg Potter
+ */
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@AutoConfigureTestDatabase
+public class AutoConfigureTestDatabaseWithMultipleDatasourcesIntegrationTests {
+
+	@Autowired
+	private TestEntityManager entities;
+
+	@Autowired
+	private ExampleRepository repository;
+
+	@Autowired
+	private DataSource dataSource;
+
+	@Test
+	public void testRepository() throws Exception {
+		this.entities.persist(new ExampleEntity("boot", "124"));
+		this.entities.flush();
+		ExampleEntity found = this.repository.findByReference("124");
+		assertThat(found.getName()).isEqualTo("boot");
+	}
+
+	@Test
+	public void replacesDefinedDataSourceWithExplicit() throws Exception {
+		// Look that the datasource is replaced with an H2 DB.
+		String product = this.dataSource.getConnection().getMetaData()
+				.getDatabaseProductName();
+		assertThat(product).startsWith("H2");
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	static class Config {
+
+		@Bean
+		@Primary
+		public DataSource dataSource() {
+			EmbeddedDatabaseBuilder builder = new EmbeddedDatabaseBuilder()
+					.setType(EmbeddedDatabaseType.HSQL);
+			return builder.build();
+		}
+
+		@Bean
+		public DataSource secondaryDataSource() {
+			EmbeddedDatabaseBuilder builder = new EmbeddedDatabaseBuilder()
+					.setType(EmbeddedDatabaseType.HSQL);
+			return builder.build();
+		}
+
+	}
+}


### PR DESCRIPTION
When there are multiple datasources present, make sure that the `AutoConfigureTestDatabase` annotation marks the embedded source as primary. Otherwise, it will still swap out the primary source but then the `HibernateJpaAutoConfiguration` won't be able to inject the `DataSource` because there will be 2 beans and neither of them will be marked as primary.
