### PR TITLE
Add `LoggersEndpointMBean`

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBeanExporter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBeanExporter.java
@@ -35,6 +35,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.actuate.endpoint.LoggersEndpoint;
 import org.springframework.boot.actuate.endpoint.ShutdownEndpoint;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -58,6 +59,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Christian Dupuis
  * @author Andy Wilkinson
+ * @author Vedran Pavic
  */
 public class EndpointMBeanExporter extends MBeanExporter
 		implements SmartLifecycle, ApplicationContextAware {
@@ -190,6 +192,9 @@ public class EndpointMBeanExporter extends MBeanExporter
 	protected EndpointMBean getEndpointMBean(String beanName, Endpoint<?> endpoint) {
 		if (endpoint instanceof ShutdownEndpoint) {
 			return new ShutdownEndpointMBean(beanName, endpoint, this.objectMapper);
+		}
+		if (endpoint instanceof LoggersEndpoint) {
+			return new LoggersEndpointMBean(beanName, endpoint, this.objectMapper);
 		}
 		return new DataEndpointMBean(beanName, endpoint, this.objectMapper);
 	}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/LoggersEndpointMBean.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/LoggersEndpointMBean.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.endpoint.jmx;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.actuate.endpoint.LoggersEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoint;
+import org.springframework.boot.logging.LogLevel;
+import org.springframework.jmx.export.annotation.ManagedAttribute;
+import org.springframework.jmx.export.annotation.ManagedOperation;
+
+/**
+ * Adapter to expose {@link LoggersEndpoint} as an {@link MvcEndpoint}.
+ *
+ * @author Vedran Pavic
+ * @since 1.5.0
+ */
+public class LoggersEndpointMBean extends EndpointMBean {
+
+	public LoggersEndpointMBean(String beanName, Endpoint<?> endpoint,
+			ObjectMapper objectMapper) {
+		super(beanName, endpoint, objectMapper);
+	}
+
+	@ManagedAttribute(description = "Get levels for all known loggers")
+	public Object getLoggers() {
+		return convert(getEndpoint().invoke());
+	}
+
+	@ManagedOperation(description = "Get level for a given logger")
+	public Object getLogger(String loggerName) {
+		return convert(getEndpoint().invoke(loggerName));
+	}
+
+	@ManagedOperation(description = "Set log level for a given logger")
+	public void setLogLevel(String loggerName, String logLevel) {
+		getEndpoint().setLogLevel(loggerName, LogLevel.valueOf(logLevel));
+	}
+
+	@Override
+	public LoggersEndpoint getEndpoint() {
+		return (LoggersEndpoint) super.getEndpoint();
+	}
+
+}


### PR DESCRIPTION
This PR adds dedicated JMX Endpoint for newly introduced `LoggersEndpoint`, in order to expose all operations supported by underlying endpoint over JMX.

Related to #5321, #7086.
