### PR TITLE
Allow to configure Tomcat/Undertow rotate property

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -956,6 +956,7 @@ public class ServerProperties
 			valve.setPrefix(this.accesslog.getPrefix());
 			valve.setSuffix(this.accesslog.getSuffix());
 			valve.setRenameOnRotate(this.accesslog.isRenameOnRotate());
+			valve.setRotatable(this.accesslog.isRotatable());
 			factory.addEngineValves(valve);
 		}
 
@@ -1005,6 +1006,11 @@ public class ServerProperties
 			 */
 			private boolean renameOnRotate;
 
+			/**
+			 * Enable access log rotation.
+			 */
+			private boolean rotatable = true;
+
 			public boolean isEnabled() {
 				return this.enabled;
 			}
@@ -1053,6 +1059,13 @@ public class ServerProperties
 				this.renameOnRotate = renameOnRotate;
 			}
 
+			public boolean isRotatable() {
+				return this.rotatable;
+			}
+
+			public void setRotatable(boolean rotatable) {
+				this.rotatable = rotatable;
+			}
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -138,6 +138,7 @@ public class ServerPropertiesTests {
 		map.put("server.tomcat.accesslog.pattern", "%h %t '%r' %s %b");
 		map.put("server.tomcat.accesslog.prefix", "foo");
 		map.put("server.tomcat.accesslog.rename-on-rotate", "true");
+		map.put("server.tomcat.accesslog.rotatable", "false");
 		map.put("server.tomcat.accesslog.suffix", "-bar.log");
 		map.put("server.tomcat.protocol_header", "X-Forwarded-Protocol");
 		map.put("server.tomcat.remote_ip_header", "Remote-Ip");
@@ -148,6 +149,7 @@ public class ServerPropertiesTests {
 		assertThat(tomcat.getAccesslog().getPattern()).isEqualTo("%h %t '%r' %s %b");
 		assertThat(tomcat.getAccesslog().getPrefix()).isEqualTo("foo");
 		assertThat(tomcat.getAccesslog().isRenameOnRotate()).isTrue();
+		assertThat(tomcat.getAccesslog().isRotatable()).isFalse();
 		assertThat(tomcat.getAccesslog().getSuffix()).isEqualTo("-bar.log");
 		assertThat(tomcat.getRemoteIpHeader()).isEqualTo("Remote-Ip");
 		assertThat(tomcat.getProtocolHeader()).isEqualTo("X-Forwarded-Protocol");


### PR DESCRIPTION
Add a property to enable or disable tomcat access log rotation.