### PR TITLE
Added logFilename and pidFilename to EmbeddedLaunchScriptProperties

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/deployment.adoc
+++ b/spring-boot-docs/src/main/asciidoc/deployment.adoc
@@ -617,8 +617,14 @@ for Gradle and to `${project.name}` for Maven.
 |`logFolder`
 |The default value for `LOG_FOLDER`. Only valid for an `init.d` service.
 
+|`logFilename`
+|The default value for `LOG_FILENAME`. Only valid for an `init.d` service.
+
 |`pidFolder`
 |The default value for `PID_FOLDER`. Only valid for an `init.d` service.
+
+|`pidFilename`
+|The default value for the name of the pid file in `PID_FOLDER`. Only valid for an `init.d` service.
 
 |`useStartStopDaemon`
 |If the `start-stop-daemon` command, when it's available, should be used to control the

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -71,8 +71,7 @@ if [[ -z "$identity" ]]; then
 fi
 
 # Initialize log file name if not provided by the config file
-[[ -z "$LOG_FILENAME" ]] && LOG_FILENAME="${identity}.log"
-
+[[ -z "$LOG_FILENAME" ]] && LOG_FILENAME="{{logFilename:${identity}.log}}"
 
 # ANSI Colors
 echoRed() { echo $'\e[0;31m'"$1"$'\e[0m'; }
@@ -114,7 +113,7 @@ if [[ "$identity" == "$init_script" ]] || [[ "$identity" == "$APP_NAME" ]]; then
   PID_FOLDER="$PID_FOLDER/${identity}"
   pid_subfolder=$PID_FOLDER
 fi
-pid_file="$PID_FOLDER/${identity}.pid"
+pid_file="$PID_FOLDER/{{pidFilename:${identity}.pid}}"
 log_file="$LOG_FOLDER/$LOG_FILENAME"
 
 # Determine the user to run as if we are root

--- a/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/DefaultLaunchScriptTests.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/DefaultLaunchScriptTests.java
@@ -47,6 +47,16 @@ public class DefaultLaunchScriptTests {
 	}
 
 	@Test
+	public void logFilenameCanBeReplaced() throws Exception {
+		assertThatPlaceholderCanBeReplaced("logFilename");
+	}
+
+	@Test
+	public void pidFilenameCanBeReplaced() throws Exception {
+		assertThatPlaceholderCanBeReplaced("pidFilename");
+	}
+
+	@Test
 	public void initInfoProvidesCanBeReplaced() throws Exception {
 		assertThatPlaceholderCanBeReplaced("initInfoProvides");
 	}


### PR DESCRIPTION
#7140 I added logFilename and pidFilename to the EmbeddedLaunchScriptProperties to make the full qualified names of these file configurable.

`${identity}` is set as the default name to ensure backwards compatibility.
