### PR TITLE
Adding new sample for a endless running application.

### DIFF
--- a/spring-boot-samples/spring-boot-sample-endless/build.gradle
+++ b/spring-boot-samples/spring-boot-sample-endless/build.gradle
@@ -1,0 +1,48 @@
+buildscript {
+	ext {
+		springBootVersion = '2.0.0.BUILD-SNAPSHOT'
+	}
+	repositories {
+		// NOTE: You should declare only repositories that you need here
+		mavenLocal()
+		mavenCentral()
+		maven { url "http://repo.spring.io/release" }
+		maven { url "http://repo.spring.io/milestone" }
+		maven { url "http://repo.spring.io/snapshot" }
+	}
+	dependencies {
+		classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+	}
+}
+
+apply plugin: 'java'
+apply plugin: 'eclipse'
+apply plugin: 'idea'
+apply plugin: 'org.springframework.boot'
+
+jar {
+	baseName = 'spring-boot-sample-endless'
+	version =  '0.0.0'
+}
+
+bootRun {
+  systemProperties = System.properties
+}
+
+repositories {
+	// NOTE: You should declare only repositories that you need here
+	mavenLocal()
+	mavenCentral()
+	maven { url "http://repo.spring.io/release" }
+	maven { url "http://repo.spring.io/milestone" }
+	maven { url "http://repo.spring.io/snapshot" }
+}
+
+dependencies {
+	compile("org.springframework.boot:spring-boot-starter")
+	testCompile("org.springframework.boot:spring-boot-starter-test")
+}
+
+task wrapper(type: Wrapper) {
+	gradleVersion = '1.6'
+}

--- a/spring-boot-samples/spring-boot-sample-endless/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-endless/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<!-- Your own application should inherit from spring-boot-starter-parent -->
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-samples</artifactId>
+		<version>2.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-sample-endless</artifactId>
+	<name>Spring Boot Sample Endless</name>
+	<description>A simple sample for a Spring Boot application which simply runs until the application is closed or interrupted.</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-samples/spring-boot-sample-endless/src/main/java/sample/endless/SampleEndlessApplication.java
+++ b/spring-boot-samples/spring-boot-sample-endless/src/main/java/sample/endless/SampleEndlessApplication.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.endless;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.annotation.PreDestroy;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.stereotype.Service;
+
+@SpringBootApplication
+public class SampleEndlessApplication {
+
+    // This simple example shows how a spring application can start and continuously does
+    // "something" until the application is stopped or interrupted.
+    // In this example a scheduled, non-blocking thread is logging.
+
+    private static final Logger LOG = LoggerFactory.getLogger(SampleEndlessApplication.class);
+
+    /**
+     * A waiting service to keep the application alive as long as no shutdown was initiated.
+     */
+    @Service
+    public class ShutdownService {
+
+        private final CountDownLatch countDownLatch;
+
+        public ShutdownService() {
+            this.countDownLatch = new CountDownLatch(1);
+        }
+
+        /**
+         * Will release the blocking {@link #await()}.
+         */
+        @PreDestroy
+        void countDown() {
+            this.countDownLatch.countDown();
+        }
+
+        /**
+         * This method is blocking until the application is shutting down.
+         *
+         * @throws InterruptedException if the waiting thread got interrupted
+         */
+        void await() throws InterruptedException {
+            this.countDownLatch.await();
+        }
+    }
+
+    public static void main(final String[] args) {
+        final ConfigurableApplicationContext ctx = SpringApplication.run(SampleEndlessApplication.class, args);
+
+        // keep the application from exiting the main thread, the running logic is non-blocking
+        try {
+            // If the shutdown (hook) is triggered, the Spring Application will close its context and all
+            // "@PreDestroy" methods will be called.
+            // Thus leading to the ShutdownService releasing the waiting thread and the application shuts down.
+            final ShutdownService shutdownService = ctx.getBean(ShutdownService.class);
+            shutdownService.await();
+
+            LOG.info("Application shutting down.");
+        } catch (final InterruptedException e) {
+            // The main thread was interrupted. Close the context gracefully.
+            LOG.info("Application thread interrupted. Shutting down.");
+            ctx.close();
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/spring-boot-samples/spring-boot-sample-endless/src/main/java/sample/endless/service/ScheduledPrinterService.java
+++ b/spring-boot-samples/spring-boot-sample-endless/src/main/java/sample/endless/service/ScheduledPrinterService.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.endless.service;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ScheduledPrinterService {
+
+    private final ScheduledExecutorService scheduledPrinter;
+
+    public ScheduledPrinterService() {
+        this.scheduledPrinter = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    @PostConstruct
+    public void startPrinting() {
+        // start the scheduled printer
+        final AtomicLong counter = new AtomicLong();
+        scheduledPrinter.scheduleWithFixedDelay(new Runnable() {
+            @Override
+            public void run() {
+                System.out.println("Hello World No. " + counter.incrementAndGet() + "!");
+            }
+        }, 0L, 1L, TimeUnit.SECONDS);
+    }
+
+    @PreDestroy
+    public void close() {
+        // closing the scheduled logger
+        scheduledPrinter.shutdown();
+    }
+}

--- a/spring-boot-samples/spring-boot-sample-endless/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-endless/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+name: Sven


### PR DESCRIPTION
There was a quite simple example for spring boot applications missing.

One application which starts and doesn't stop until the application is stopped. An endless running application in which non-blocking professional logic can run continuously.

This example contains a scheduler which simply prints a "Hello world!" every second.
In practice it could be a listener listening on a socket and delegates the incoming messages.
