### PR TITLE
Adding support for nested config overrides

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -386,10 +386,12 @@ sensible overriding of values. Properties are considered in the following order:
 . A `RandomValuePropertySource` that only has properties in `+random.*+`.
 . <<boot-features-external-config-profile-specific-properties,Profile-specific
   application properties>> outside of your packaged jar
-  (`application-{profile}.properties` and YAML variants)
+  (`application-{profile}.properties` and YAML variants. Note: will be overridden by 
+  `\{profile}\application.properties` and YAML variants.)
 . <<boot-features-external-config-profile-specific-properties,Profile-specific
   application properties>> packaged inside your jar (`application-{profile}.properties`
-  and YAML variants)
+  and YAML variants. Note: will be overridden by `\{profile}\application.properties` 
+  and YAML variants.)
 . Application properties outside of your packaged jar (`application.properties` and YAML
   variants).
 . Application properties packaged inside your jar (`application.properties` and YAML

--- a/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
@@ -443,6 +443,7 @@ public class ConfigFileApplicationListener implements EnvironmentPostProcessor,
 										+ processedProfile + "." + ext, profile);
 							}
 						}
+						loadIntoGroup(group, location + profile + "/" + name + "." + ext, null);
 						// Sometimes people put "spring.profiles: dev" in
 						// application-dev.yml (gh-340). Arguably we should try and error
 						// out on that, but we can be kind and load it anyway.

--- a/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileApplicationListenerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileApplicationListenerTests.java
@@ -410,6 +410,19 @@ public class ConfigFileApplicationListenerTests {
 	}
 
 	@Test
+	public void profilesAddedToEnvironmentAndViaPropertyFromNestedFolder() throws Exception {
+		// External profile takes precedence over profile added via the environment
+		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.environment,
+				"spring.profiles.active=nested");
+		this.environment.addActiveProfile("dev");
+		this.initializer.postProcessEnvironment(this.environment, this.application);
+		assertThat(this.environment.getActiveProfiles()).contains("dev", "nested");
+		assertThat(this.environment.getProperty("my.property"))
+				.isEqualTo("fromnestedpropertiesfile");
+		validateProfilePrecedence(null, "dev", "nested");
+	}
+
+	@Test
 	public void profilesAddedToEnvironmentAndViaPropertyDuplicate() throws Exception {
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.environment,
 				"spring.profiles.active=dev,other");

--- a/spring-boot/src/test/resources/application-nested.properties
+++ b/spring-boot/src/test/resources/application-nested.properties
@@ -1,0 +1,1 @@
+my.property=fromNOTnestedpropertiesfile

--- a/spring-boot/src/test/resources/config/nested/application.properties
+++ b/spring-boot/src/test/resources/config/nested/application.properties
@@ -1,0 +1,1 @@
+my.property=fromnestedpropertiesfile


### PR DESCRIPTION
The main idea of this Pull request is described [here](http://stackoverflow.com/questions/38919090/spring-boot-environment-specific-properties-location). I didn't find anything to support this out of box.

In brief this is another property override to maintain following structure
`resources\config\{profile}\file.ext` which is currently supported only via `@PropertySources` annotation. 
Current template `resources\config\file-{profile}.ext` will be overridden by above if provided.
The default resolution behaviour is not changed.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
