### PR TITLE
Perform Validation on beforeCreate/beforeSave

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/rest/SpringBootRepositoryRestConfigurer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/rest/SpringBootRepositoryRestConfigurer.java
@@ -20,8 +20,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
+import org.springframework.data.rest.core.event.ValidatingRepositoryEventListener;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurerAdapter;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.validation.Validator;
 
 /**
  * A {@code RepositoryRestConfigurer} that applies configuration items from the
@@ -33,6 +35,8 @@ import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
  * @author Stephane Nicoll
  */
 class SpringBootRepositoryRestConfigurer extends RepositoryRestConfigurerAdapter {
+	@Autowired
+	private Validator validator;
 
 	@Autowired(required = false)
 	private Jackson2ObjectMapperBuilder objectMapperBuilder;
@@ -52,4 +56,9 @@ class SpringBootRepositoryRestConfigurer extends RepositoryRestConfigurerAdapter
 		}
 	}
 
+	@Override
+	public void configureValidatingRepositoryEventListener(ValidatingRepositoryEventListener validatingListener) {
+		validatingListener.addValidator("beforeCreate", validator);
+		validatingListener.addValidator("beforeSave", validator);
+	}
 }


### PR DESCRIPTION
Currently, validation errors manifest as unhandled javax.validation.ConstraintViolationException's and end up being returned as nondescript HTTP 500 errors.

Spring validation (which includes JSR-303) should be handled on beforeCreate/beforeSave so validation errors get handled by org.springframework.data.rest.webmvc.RepositoryRestExceptionHandler resulting in HTTP 400 errors with helpful descriptive bodies.

See https://jira.spring.io/browse/DATAREST-370 and https://jira.spring.io/browse/DATAREST-372