### PR TITLE
Disable resource chain cache when DevTools is enabled

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsPropertyDefaultsPostProcessor.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsPropertyDefaultsPostProcessor.java
@@ -54,6 +54,7 @@ public class DevToolsPropertyDefaultsPostProcessor implements EnvironmentPostPro
 		properties.put("server.session.persistent", "true");
 		properties.put("spring.h2.console.enabled", "true");
 		properties.put("spring.resources.cache-period", "0");
+		properties.put("spring.resources.chain.cache", "false");
 		properties.put("spring.template.provider.cache", "false");
 		properties.put("spring.mvc.log-resolved-exception", "true");
 		PROPERTIES = Collections.unmodifiableMap(properties);


### PR DESCRIPTION
If the resource chain is used, such as by using the `spring.resources.chain.strategy.content.enabled` property, resource chain caching can prevent the developer from seeing changes made to resources, so that caching should be disabled when DevTools is enabled.