### PR TITLE
using getSingleton method in ResetMocksListener resolves gh-7270

### DIFF
--- a/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/ResetMocksTestExecutionListener.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/ResetMocksTestExecutionListener.java
@@ -65,7 +65,7 @@ public class ResetMocksTestExecutionListener extends AbstractTestExecutionListen
 		for (String name : names) {
 			BeanDefinition definition = beanFactory.getBeanDefinition(name);
 			if (definition.isSingleton() && instantiatedSingletons.contains(name)) {
-				Object bean = beanFactory.getBean(name);
+				Object bean = beanFactory.getSingleton(name);
 				if (reset.equals(MockReset.get(bean))) {
 					Mockito.reset(bean);
 				}


### PR DESCRIPTION
Frankly: I'm not sure what exactly is happening here, but I guess that if we're depending on singletons registered in the factory then we should stick to singletons - not beans.

This PR resolves this issue: https://github.com/spring-projects/spring-boot/issues/7270

I hope this helps,
Alek