### PR TITLE
Fix JWT token URI derivation

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,7 +246,7 @@ public class ResourceServerProperties implements Validator, BeanFactoryAware {
 			if (ResourceServerProperties.this.tokenInfoUri != null
 					&& ResourceServerProperties.this.tokenInfoUri
 							.endsWith("/check_token")) {
-				return ResourceServerProperties.this.userInfoUri.replace("/check_token",
+				return ResourceServerProperties.this.tokenInfoUri.replace("/check_token",
 						"/token_key");
 			}
 			return null;

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerPropertiesTests.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link ResourceServerProperties}.
  *
  * @author Dave Syer
+ * @author Vedran Pavic
  */
 public class ResourceServerPropertiesTests {
 
@@ -45,9 +46,17 @@ public class ResourceServerPropertiesTests {
 	}
 
 	@Test
-	public void tokenKeyDerived() throws Exception {
+	public void tokenKeyDerivedFromUserInfoUri() throws Exception {
 		this.properties.setUserInfoUri("http://example.com/userinfo");
-		assertThat(this.properties.getJwt().getKeyUri()).isNotNull();
+		assertThat(this.properties.getJwt().getKeyUri())
+				.isEqualTo("http://example.com/token_key");
+	}
+
+	@Test
+	public void tokenKeyDerivedFromTokenInfoUri() throws Exception {
+		this.properties.setTokenInfoUri("http://example.com/check_token");
+		assertThat(this.properties.getJwt().getKeyUri())
+				.isEqualTo("http://example.com/token_key");
 	}
 
 }


### PR DESCRIPTION
This PR fixes bad JWT token URL derivation is scenario where derivation is done from `tokenInfoUri` (as demonstrated by new `tokenKeyDerivedFromTokenInfoUri` test).