### PR TITLE
Fix PoolingConnectionFactoryBean.createXAContext()

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/jta/bitronix/PoolingConnectionFactoryBean.java
+++ b/spring-boot/src/main/java/org/springframework/boot/jta/bitronix/PoolingConnectionFactoryBean.java
@@ -148,7 +148,7 @@ public class PoolingConnectionFactoryBean extends PoolingConnectionFactory
 
 		@Override
 		public XAJMSContext createXAContext(String username, String password) {
-			return this.createXAContext(username, password);
+			return this.connectionFactory.createXAContext(username, password);
 		}
 
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
It looks the `connectionFactory` reference is accidentally missing in `PoolingConnectionFactoryBean.createXAContext()` which causes invoking itself indefinitely.