### PR TITLE
Update CouchbaseHealthIndicator.java

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CouchbaseHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CouchbaseHealthIndicator.java
@@ -28,6 +28,7 @@ import org.springframework.util.StringUtils;
  * {@link HealthIndicator} for Couchbase.
  *
  * @author Eddú Meléndez
+ * @author kriskrishna
  * @since 1.4.0
  */
 public class CouchbaseHealthIndicator extends AbstractHealthIndicator {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Health check from master branch doesn't show "Down" on /health endpoint, when couchbase is down or connectivity issue. Therefore I added followings on the lines of CassandraHealthIndicator. Its well tested.