### PR TITLE
Support multiple root contexts in `Restarter`

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/RestartApplicationListener.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/RestartApplicationListener.java
@@ -52,7 +52,7 @@ public class RestartApplicationListener
 				|| event instanceof ApplicationFailedEvent) {
 			Restarter.getInstance().finish();
 			if (event instanceof ApplicationFailedEvent) {
-				Restarter.getInstance().prepare(null);
+				Restarter.getInstance().remove(((ApplicationFailedEvent) event).getApplicationContext());
 			}
 		}
 	}

--- a/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/RestartApplicationListenerTests.java
+++ b/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/RestartApplicationListenerTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.devtools.restart;
 
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -64,8 +66,8 @@ public class RestartApplicationListenerTests {
 		assertThat(ReflectionTestUtils.getField(Restarter.getInstance(), "args"))
 				.isEqualTo(ARGS);
 		assertThat(Restarter.getInstance().isFinished()).isTrue();
-		assertThat(ReflectionTestUtils.getField(Restarter.getInstance(), "rootContext"))
-				.isNotNull();
+		assertThat((List<?>) ReflectionTestUtils.getField(Restarter.getInstance(),
+				"rootContexts")).isNotEmpty();
 	}
 
 	@Test
@@ -74,8 +76,8 @@ public class RestartApplicationListenerTests {
 		assertThat(ReflectionTestUtils.getField(Restarter.getInstance(), "args"))
 				.isEqualTo(ARGS);
 		assertThat(Restarter.getInstance().isFinished()).isTrue();
-		assertThat(ReflectionTestUtils.getField(Restarter.getInstance(), "rootContext"))
-				.isNull();
+		assertThat((List<?>) ReflectionTestUtils.getField(Restarter.getInstance(),
+				"rootContexts")).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #7335

The PR is made against the 1.4.x branch because I've been testing more exhaustively with Boot 1.4 apps. If it's OK, should be cherry-picked to master. 

Possibly additional tests are required. 