### PR TITLE
Add InfluxDB exporter to Actuator

### DIFF
--- a/spring-boot-actuator/pom.xml
+++ b/spring-boot-actuator/pom.xml
@@ -47,6 +47,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.influxdb</groupId>
+			<artifactId>influxdb-java</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>io.searchbox</groupId>
 			<artifactId>jest</artifactId>
 			<optional>true</optional>

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/writer/InfluxDBMetricWriter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/writer/InfluxDBMetricWriter.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.metrics.writer;
+
+import java.util.concurrent.TimeUnit;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.Point;
+
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link GaugeWriter} that writes the metric updates to InfluxDB.
+ *
+ * @author Mateusz Klimaszewski
+ */
+public class InfluxDBMetricWriter implements GaugeWriter {
+
+	private static final String DEFAULT_DATABASE_NAME = "metrics";
+	private static final int DEFAULT_BATCH_ACTIONS = 500;
+	private static final int DEFAULT_FLUSH_DURATION = 30;
+
+	private final InfluxDB influxDB;
+	private final String databaseName;
+
+	private InfluxDBMetricWriter(Builder builder) {
+		this.influxDB = builder.influxDB;
+		this.databaseName = builder.databaseName;
+		this.influxDB.createDatabase(this.databaseName);
+		this.influxDB.enableBatch(builder.batchActions, builder.flushDuration,
+				builder.flushDurationTimeUnit);
+		this.influxDB.setLogLevel(builder.logLevel);
+	}
+
+	@Override
+	public void set(Metric<?> value) {
+		Point point = Point.measurement(value.getName())
+				.time(value.getTimestamp().getTime(), TimeUnit.MILLISECONDS)
+				.addField("value", value.getValue())
+				.build();
+		this.influxDB.write(this.databaseName, value.getName(), point);
+	}
+
+	/**
+	 * {@link InfluxDBMetricWriter} builder with possibility to change default arguments
+	 */
+	public static class Builder {
+		private final InfluxDB influxDB;
+		private String databaseName = DEFAULT_DATABASE_NAME;
+		private int batchActions = DEFAULT_BATCH_ACTIONS;
+		private int flushDuration = DEFAULT_FLUSH_DURATION;
+		private TimeUnit flushDurationTimeUnit = TimeUnit.SECONDS;
+		private InfluxDB.LogLevel logLevel = InfluxDB.LogLevel.BASIC;
+
+		public Builder(InfluxDB influxDB) {
+			Assert.notNull(influxDB, "InfluxDB must not be null");
+			this.influxDB = influxDB;
+		}
+
+		public Builder databaseName(String databaseName) {
+			this.databaseName = databaseName;
+			return this;
+		}
+
+		public Builder batchActions(int batchActions) {
+			this.batchActions = batchActions;
+			return this;
+		}
+
+		public Builder flushDuration(int flushDuration, TimeUnit flushDurationTimeUnit) {
+			this.flushDuration = flushDuration;
+			this.flushDurationTimeUnit = flushDurationTimeUnit;
+			return this;
+		}
+
+		public Builder logLevel(InfluxDB.LogLevel logLevel) {
+			this.logLevel = logLevel;
+			return this;
+		}
+
+		public InfluxDBMetricWriter build() {
+			return new InfluxDBMetricWriter(this);
+		}
+	}
+}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/writer/InfluxDBMetricWriterTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/writer/InfluxDBMetricWriterTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.metrics.writer;
+
+import java.util.concurrent.TimeUnit;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.Point;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.springframework.boot.actuate.metrics.Metric;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link InfluxDBMetricWriter}.
+ *
+ * @author Mateusz Klimaszewski
+ */
+public class InfluxDBMetricWriterTests {
+
+	private InfluxDB influxDB = mock(InfluxDB.class);
+	private InfluxDBMetricWriter influxDBMetricWriter;
+
+	@Test
+	public void builderNonDefaultOptions() {
+		this.influxDBMetricWriter = new InfluxDBMetricWriter.Builder(this.influxDB)
+				.databaseName("testDatabaseName")
+				.batchActions(2000)
+				.flushDuration(10, TimeUnit.MILLISECONDS)
+				.logLevel(InfluxDB.LogLevel.FULL)
+				.build();
+		ArgumentCaptor<String> databaseNameCaptor = ArgumentCaptor.forClass(
+				String.class);
+		ArgumentCaptor<Integer> bashActionsCaptor = ArgumentCaptor.forClass(
+				Integer.class);
+		ArgumentCaptor<Integer> flushDurationCaptor = ArgumentCaptor.forClass(
+				Integer.class);
+		ArgumentCaptor<TimeUnit> flushDurationTimeUnitCaptor = ArgumentCaptor.forClass(
+				TimeUnit.class);
+		ArgumentCaptor<InfluxDB.LogLevel> logLevelCaptor = ArgumentCaptor.forClass(
+				InfluxDB.LogLevel.class);
+		verify(this.influxDB).createDatabase(databaseNameCaptor.capture());
+		verify(this.influxDB).enableBatch(bashActionsCaptor.capture(),
+				flushDurationCaptor.capture(), flushDurationTimeUnitCaptor.capture());
+		verify(this.influxDB).setLogLevel(logLevelCaptor.capture());
+		assertThat("testDatabaseName").isEqualTo(databaseNameCaptor.getValue());
+		assertThat(2000).isEqualTo(bashActionsCaptor.getValue().intValue());
+		assertThat(10).isEqualTo(flushDurationCaptor.getValue().intValue());
+		assertThat(TimeUnit.MILLISECONDS).isEqualTo(flushDurationTimeUnitCaptor
+				.getValue());
+		assertThat(InfluxDB.LogLevel.FULL).isEqualTo(logLevelCaptor.getValue());
+	}
+
+	@Test
+	public void setMetric() {
+		this.influxDBMetricWriter = new InfluxDBMetricWriter.Builder(this.influxDB)
+				.build();
+		Metric<Number> metric = new Metric<Number>("testName", 1);
+		this.influxDBMetricWriter.set(metric);
+		verify(this.influxDB, times(1)).write(anyString(), eq(metric.getName()),
+				any(Point.class));
+	}
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -92,6 +92,7 @@
 		<httpclient.version>4.5.2</httpclient.version>
 		<httpcore.version>4.4.5</httpcore.version>
 		<infinispan.version>8.2.4.Final</infinispan.version>
+		<influx.version>2.4</influx.version>
 		<jackson.version>2.8.4</jackson.version>
 		<janino.version>2.7.8</janino.version>
 		<javassist.version>3.20.0-GA</javassist.version> <!-- Same as Hibernate -->
@@ -864,6 +865,11 @@
 				<groupId>io.projectreactor</groupId>
 				<artifactId>reactor-core</artifactId>
 				<version>${reactor.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.influxdb</groupId>
+				<artifactId>influxdb-java</artifactId>
+				<version>${influx.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.searchbox</groupId>


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Since 5688 issue wasn't done for a while, I decided to make my first contribution since I'm working on such configuration anyway.

Configurable implementation of gauge writer to export metrics into InfluxDB.

Fixes gh-5688