### PR TITLE
Support early JDBC connection pool creation

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
@@ -73,6 +73,13 @@ public class DataSourceAutoConfiguration {
 		return new DataSourceInitializer();
 	}
 
+	@Bean
+	@Conditional(PooledDataSourceCondition.class)
+	@ConditionalOnProperty(prefix = "spring.datasource", name = "early-pool-creation", havingValue = "true", matchIfMissing = true)
+	public PooledDataSourceBeanPostProcessor tomcatJdbcPooledDataSourceBeanPostProcessor() {
+		return new PooledDataSourceBeanPostProcessor();
+	}
+
 	/**
 	 * Determines if the {@code dataSource} being used by Spring was created from
 	 * {@link EmbeddedDataSourceConfiguration}.

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/PooledDataSourceBeanPostProcessor.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/PooledDataSourceBeanPostProcessor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jdbc;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+/**
+ * {@link BeanPostProcessor} for JDBC pooled {@link DataSource}.
+ *
+ * @author Johnny Lim
+ */
+public class PooledDataSourceBeanPostProcessor implements BeanPostProcessor {
+
+	@Override
+	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+		if (bean instanceof DataSource) {
+			DataSource dataSource = (DataSource) bean;
+			Connection connection = null;
+			try {
+				// Trigger JDBC connection pool creation.
+				connection = dataSource.getConnection();
+			}
+			catch (SQLException ex) {
+				throw new IllegalStateException(ex);
+			}
+			finally {
+				if (connection != null) {
+					try {
+						// Return the connection to the pool.
+						connection.close();
+					}
+					catch (SQLException ex) {
+						// Ignored
+					}
+				}
+			}
+		}
+		return bean;
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/CustomHibernateJpaAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/CustomHibernateJpaAutoConfigurationTests.java
@@ -56,7 +56,8 @@ public class CustomHibernateJpaAutoConfigurationTests {
 		EnvironmentTestUtils.addEnvironment(this.context,
 				"spring.datasource.driverClassName:com.mysql.jdbc.Driver",
 				"spring.datasource.url:jdbc:mysql://localhost/nonexistent",
-				"spring.datasource.initialize:false", "spring.jpa.database:MYSQL");
+				"spring.datasource.initialize:false", "spring.jpa.database:MYSQL",
+				"spring.datasource.early-pool-creation=false");
 		this.context.register(TestConfiguration.class, DataSourceAutoConfiguration.class,
 				PropertyPlaceholderAutoConfiguration.class,
 				HibernateJpaAutoConfiguration.class);

--- a/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/AbstractDevToolsDataSourceAutoConfigurationTests.java
+++ b/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/AbstractDevToolsDataSourceAutoConfigurationTests.java
@@ -102,7 +102,8 @@ public abstract class AbstractDevToolsDataSourceAutoConfigurationTests {
 		context.register(DevToolsDataSourceAutoConfiguration.class);
 		if (driverClassName != null) {
 			EnvironmentTestUtils.addEnvironment(context,
-					"spring.datasource.driver-class-name:" + driverClassName);
+					"spring.datasource.driver-class-name:" + driverClassName,
+					"spring.datasource.early-pool-creation=false");
 		}
 		context.refresh();
 		return context;

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -601,6 +601,7 @@ content into your application; rather pick only the properties that you need.
 	spring.datasource.data-password= # Password of the database to execute DML scripts (if different).
 	spring.datasource.dbcp2.*= # Commons DBCP2 specific settings
 	spring.datasource.driver-class-name= # Fully qualified name of the JDBC driver. Auto-detected based on the URL by default.
+	spring.datasource.early-pool-creation=true # Enable early JDBC connection pool creation.
 	spring.datasource.generate-unique-name=false # Generate a random datasource name.
 	spring.datasource.hikari.*= # Hikari specific settings
 	spring.datasource.initialize=true # Populate the database using 'data.sql'.


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR replaces #7310 which is closed mistakenly.

Original PR was only for Tomcat JDBC connection pool but this one is updated to support all three JDBC connection pools now.

See #7255 