### PR TITLE
Make @ConditionalOnProperty @Repeatable

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnProperties.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.condition;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Container annotation that aggregates several {@link ConditionalOnProperty} annotations.
+ *
+ * <p>Can be used natively, declaring several nested {@link ConditionalOnProperty} annotations.
+ * Can also be used in conjunction with Java 8's support for repeatable annotations,
+ * where {@link ConditionalOnProperty} can simply be declared several times on the same method,
+ * implicitly generating this container annotation.
+ *
+ * @author Michael J. Simons
+ * @since 1.4.3
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Documented
+public @interface ConditionalOnProperties {
+
+	ConditionalOnProperty[] value();
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnProperty.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnProperty.java
@@ -18,6 +18,7 @@ package org.springframework.boot.autoconfigure.condition;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -75,12 +76,14 @@ import org.springframework.core.env.Environment;
  * @author Maciej Walkowiak
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Michael J. Simons
  * @since 1.1.0
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Documented
 @Conditional(OnPropertyCondition.class)
+@Repeatable(ConditionalOnProperties.class)
 public @interface ConditionalOnProperty {
 
 	/**

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnPropertyTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnPropertyTests.java
@@ -82,7 +82,7 @@ public class ConditionalOnPropertyTests {
 	public void notAllPropertiesAreDefinedWithExpectedValues() {
 		load(MultiplePropertiesWithExplicitValuesRequiredConfiguration.class, "property1=value1",
 				"property2=foo");
-		assertThat(this.context.containsBean("foo")).isTrue();
+		assertThat(this.context.containsBean("foo")).isFalse();
 	}
 
 	@Test

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnPropertyTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnPropertyTests.java
@@ -42,6 +42,7 @@ import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
  * @author Stephane Nicoll
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Michael J. Simons
  */
 public class ConditionalOnPropertyTests {
 
@@ -68,6 +69,20 @@ public class ConditionalOnPropertyTests {
 	public void notAllPropertiesAreDefined() {
 		load(MultiplePropertiesRequiredConfiguration.class, "property1=value1");
 		assertThat(this.context.containsBean("foo")).isFalse();
+	}
+
+	@Test
+	public void allPropertiesAreDefinedWithExpectedValues() {
+		load(MultiplePropertiesWithExplicitValuesRequiredConfiguration.class, "property1=value1",
+				"property2=value2");
+		assertThat(this.context.containsBean("foo")).isTrue();
+	}
+
+	@Test
+	public void notAllPropertiesAreDefinedWithExpectedValues() {
+		load(MultiplePropertiesWithExplicitValuesRequiredConfiguration.class, "property1=value1",
+				"property2=foo");
+		assertThat(this.context.containsBean("foo")).isTrue();
 	}
 
 	@Test
@@ -280,6 +295,18 @@ public class ConditionalOnPropertyTests {
 	@Configuration
 	@ConditionalOnProperty(name = { "property1", "property2" })
 	protected static class MultiplePropertiesRequiredConfiguration {
+
+		@Bean
+		public String foo() {
+			return "foo";
+		}
+
+	}
+
+	@Configuration
+	@ConditionalOnProperty(name = "property1", havingValue = "value1")
+	@ConditionalOnProperty(name = "property2", havingValue = "value2")
+	protected static class MultiplePropertiesWithExplicitValuesRequiredConfiguration {
 
 		@Bean
 		public String foo() {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This implements #2541 by providing @ConditionalOnProperties as container for @ConditionalOnProperty and making it repeatable.

Feel free to use this PR however you like. It's based on the 2.0 branch.

I do understand that the ticket is still open for team discussion. I could understand if you are afraid of opening up to make all Conditional* repeatable, but I think also that it is really useful for ConditionalOnProperty, at least we have several use cases.

Thanks!
