### PR TITLE
CouchbaseHealthIndicator shows Couchbase 'UP' when Couchbase is down or Couchbase has connectivity issue

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CouchbaseHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CouchbaseHealthIndicator.java
@@ -18,18 +18,20 @@ package org.springframework.boot.actuate.health;
 
 import java.util.List;
 
+import com.couchbase.client.java.bucket.BucketInfo;
 import com.couchbase.client.java.util.features.Version;
 
 import org.springframework.data.couchbase.core.CouchbaseOperations;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
+
 /**
  * {@link HealthIndicator} for Couchbase.
  *
- * @author Eddú Meléndez, kriskrishna
+ * @author  Kris Krishna
  * @since 1.4.0
- */
+**/
 public class CouchbaseHealthIndicator extends AbstractHealthIndicator {
 
 	private CouchbaseOperations couchbaseOperations;
@@ -41,10 +43,16 @@ public class CouchbaseHealthIndicator extends AbstractHealthIndicator {
 
 	@Override
 	protected void doHealthCheck(Health.Builder builder) throws Exception {
-		List<Version> versions = this.couchbaseOperations.getCouchbaseClusterInfo()
-				.getAllVersions();
-		builder.up().withDetail("versions",
-				StringUtils.collectionToCommaDelimitedString(versions));
+		try {
+			List<Version> versions = this.couchbaseOperations.getCouchbaseClusterInfo().getAllVersions();
+			BucketInfo bucketInfo = this.couchbaseOperations.getCouchbaseBucket().bucketManager().info();
+			builder.up().withDetail("versions", StringUtils.collectionToCommaDelimitedString(versions));
+			builder.up().withDetail("NodeInfo", StringUtils.collectionToCommaDelimitedString(bucketInfo.nodeList()));
+			builder.up().withDetail("NodeCount", (bucketInfo.nodeCount()));
+		}
+		catch (Exception ex) {
+			builder.down(ex);
+		}
 	}
 
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CouchbaseHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CouchbaseHealthIndicator.java
@@ -27,7 +27,7 @@ import org.springframework.util.StringUtils;
 /**
  * {@link HealthIndicator} for Couchbase.
  *
- * @author Eddú Meléndez
+ * @author Eddú Meléndez, kriskrishna
  * @since 1.4.0
  */
 public class CouchbaseHealthIndicator extends AbstractHealthIndicator {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
CouchbaseHealthIndicator shows Couchbase 'UP' when Couchbase is down or Couchbase has connectivity issue. This is a fix following the same methodology for CassandraHealthIndicator. This fix is tested for all scenarios.