### PR TITLE
Update Thymeleaf 3 docs and sample to use 2.1.1 of the layout dialect

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -1435,7 +1435,7 @@ By default, `spring-boot-starter-thymeleaf` uses Thymeleaf 2.1. If you are using
 ----
 	<properties>
 		<thymeleaf.version>3.0.2.RELEASE</thymeleaf.version>
-		<thymeleaf-layout-dialect.version>2.0.4</thymeleaf-layout-dialect.version>
+		<thymeleaf-layout-dialect.version>2.1.1</thymeleaf-layout-dialect.version>
 	</properties>
 ----
 

--- a/spring-boot-samples/spring-boot-sample-web-thymeleaf3/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-web-thymeleaf3/pom.xml
@@ -18,7 +18,7 @@
 	<properties>
 		<main.basedir>${basedir}/../..</main.basedir>
 		<thymeleaf.version>3.0.2.RELEASE</thymeleaf.version>
-		<thymeleaf-layout-dialect.version>2.0.4</thymeleaf-layout-dialect.version>
+		<thymeleaf-layout-dialect.version>2.1.1</thymeleaf-layout-dialect.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/spring-boot-samples/spring-boot-sample-web-thymeleaf3/src/main/resources/templates/layout.html
+++ b/spring-boot-samples/spring-boot-sample-web-thymeleaf3/src/main/resources/templates/layout.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-	xmlns:layout="http://www.ultraq.net.nz/web/thymeleaf/layout">
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
 <head>
 <title>Layout</title>
 <link rel="stylesheet" th:href="@{/css/bootstrap.min.css}"

--- a/spring-boot-samples/spring-boot-sample-web-thymeleaf3/src/main/resources/templates/messages/form.html
+++ b/spring-boot-samples/spring-boot-sample-web-thymeleaf3/src/main/resources/templates/messages/form.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-	xmlns:layout="http://www.ultraq.net.nz/web/thymeleaf/layout"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
 	layout:decorate="layout">
 <head>
 <title>Messages : Create</title>

--- a/spring-boot-samples/spring-boot-sample-web-thymeleaf3/src/main/resources/templates/messages/list.html
+++ b/spring-boot-samples/spring-boot-sample-web-thymeleaf3/src/main/resources/templates/messages/list.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-	xmlns:layout="http://www.ultraq.net.nz/web/thymeleaf/layout"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
 	layout:decorate="layout">
 <head>
 <title>Messages : View all</title>

--- a/spring-boot-samples/spring-boot-sample-web-thymeleaf3/src/main/resources/templates/messages/view.html
+++ b/spring-boot-samples/spring-boot-sample-web-thymeleaf3/src/main/resources/templates/messages/view.html
@@ -1,5 +1,5 @@
 <html xmlns:th="http://www.thymeleaf.org"
-	xmlns:layout="http://www.ultraq.net.nz/web/thymeleaf/layout"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
 	layout:decorate="layout">
 <head>
 <title>Messages : View</title>


### PR DESCRIPTION
I've recently updated the layout dialect with a big performance increase in it, and I think it'd be good to get the Thymeleaf 3 docs and sample to use that version over the previous ones.

This PR updates the "How To" section for Thymeleaf 3, as well as the Thymeleaf 3 sample project, to use this new version.  I also noticed that the sample HTML files mention a very old XML namespace that hasn't been in use for over 2 years now, so I thought to update those too.

This PR contains no "creative expression", so I believe constitutes an obvious fix.
