### PR TITLE
Make toc as sidepanel in htmlsingle docs

### DIFF
--- a/spring-boot-docs/src/main/docbook/css/manual-singlepage.css
+++ b/spring-boot-docs/src/main/docbook/css/manual-singlepage.css
@@ -1,6 +1,51 @@
 @IMPORT url("manual.css");
 
-body {
-	background: url("../images/background.png") no-repeat center top;
+div.toc {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 25%;
+    height: 100%;
+    overflow-y: auto;
+    background: white;
+}
+
+div.book {
+    margin-left: 30%;
+    background: url("../images/background.png") no-repeat center top;
+}
+
+div.toc {
+    line-height: 1;
+}
+
+dd {
+    margin: 0;
+}
+
+dl, dt {
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-left: 10px;
+}
+
+div.toc .part {
+    font-size: 20px;
+    font-weight: bold;
+    margin: 5px 0 5px 0;
+    display: block;
+}
+
+div.toc .chapter, div.toc .appendix {
+    font-size: 15px;
+    font-weight: bold;
+    margin: 5px 0 5px 0;
+    display: block;
+}
+
+div.toc .section {
+    font-weight: normal;
+    font-size: 15px;
+    margin: 5px 0 0 0;
 }
 


### PR DESCRIPTION
This small css change adds toc as sidepanel in htmlsingle mode

![image](https://cloud.githubusercontent.com/assets/1964214/20247201/16803304-a9d7-11e6-9bcf-12ef3162b9ae.png)

Fixes #1667

Online version can be viewed at http://spring-boot-htmlsingle.surge.sh/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spring-projects/spring-boot/7377)
<!-- Reviewable:end -->
