### PR TITLE
Nameless logger in /loggers when using log4j2

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/LoggersEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/LoggersEndpoint.java
@@ -26,6 +26,7 @@ import org.springframework.boot.logging.LogLevel;
 import org.springframework.boot.logging.LoggerConfiguration;
 import org.springframework.boot.logging.LoggingSystem;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link Endpoint} to expose a collection of {@link LoggerConfiguration}s.
@@ -60,13 +61,20 @@ public class LoggersEndpoint
 		Map<String, LoggerLevels> result = new LinkedHashMap<String, LoggerLevels>(
 				configurations.size());
 		for (LoggerConfiguration configuration : configurations) {
-			result.put(configuration.getName(), new LoggerLevels(configuration));
+			String name = configuration.getName();
+			if (!StringUtils.hasText(name)) {
+				name = "ROOT";
+			}
+			result.put(name, new LoggerLevels(configuration));
 		}
 		return result;
 	}
 
 	public LoggerLevels invoke(String name) {
 		Assert.notNull(name, "Name must not be null");
+		if (name.equalsIgnoreCase("root")) {
+			name = null;
+		}
 		LoggerConfiguration configuration = this.loggingSystem
 				.getLoggerConfiguration(name);
 		return (configuration == null ? null : new LoggerLevels(configuration));
@@ -74,6 +82,9 @@ public class LoggersEndpoint
 
 	public void setLogLevel(String name, LogLevel level) {
 		Assert.notNull(name, "Name must not be empty");
+		if (name.equalsIgnoreCase("root")) {
+			name = null;
+		}
 		this.loggingSystem.setLogLevel(name, level);
 	}
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/LoggersEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/LoggersEndpointTests.java
@@ -53,17 +53,29 @@ public class LoggersEndpointTests extends AbstractEndpointTests<LoggersEndpoint>
 		assertThat(levels.getEffectiveLevel()).isEqualTo("DEBUG");
 	}
 
+	@Test
+	public void invokeHandleEmptyLoggerName() {
+		given(getLoggingSystem().getLoggerConfigurations()).willReturn(Collections
+				.singletonList(new LoggerConfiguration("", null, LogLevel.INFO)));
+
+		LoggerLevels levels = getEndpointBean().invoke().get("ROOT");
+		assertThat(levels.getConfiguredLevel()).isNull();
+		assertThat(levels.getEffectiveLevel()).isEqualTo("INFO");
+	}
+
+	@Test
 	public void invokeWhenNameSpecifiedShouldReturnLevels() throws Exception {
-		given(getLoggingSystem().getLoggerConfiguration("ROOT"))
+		given(getLoggingSystem().getLoggerConfiguration(null))
 				.willReturn(new LoggerConfiguration("ROOT", null, LogLevel.DEBUG));
 		LoggerLevels levels = getEndpointBean().invoke("ROOT");
 		assertThat(levels.getConfiguredLevel()).isNull();
 		assertThat(levels.getEffectiveLevel()).isEqualTo("DEBUG");
 	}
 
+	@Test
 	public void setLogLevelShouldSetLevelOnLoggingSystem() throws Exception {
 		getEndpointBean().setLogLevel("ROOT", LogLevel.DEBUG);
-		verify(getLoggingSystem()).setLogLevel("ROOT", LogLevel.DEBUG);
+		verify(getLoggingSystem()).setLogLevel(null, LogLevel.DEBUG);
 	}
 
 	private LoggingSystem getLoggingSystem() {

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/LoggersMvcEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/LoggersMvcEndpointTests.java
@@ -102,7 +102,7 @@ public class LoggersMvcEndpointTests {
 
 	@Test
 	public void getLoggerShouldReturnLogLevels() throws Exception {
-		given(this.loggingSystem.getLoggerConfiguration("ROOT"))
+		given(this.loggingSystem.getLoggerConfiguration(null))
 				.willReturn(new LoggerConfiguration("ROOT", null, LogLevel.DEBUG));
 		this.mvc.perform(get("/loggers/ROOT")).andExpect(status().isOk())
 				.andExpect(content().string(equalTo(
@@ -125,7 +125,7 @@ public class LoggersMvcEndpointTests {
 	public void setLoggerShouldSetLogLevel() throws Exception {
 		this.mvc.perform(post("/loggers/ROOT").contentType(MediaType.APPLICATION_JSON)
 				.content("{\"configuredLevel\":\"DEBUG\"}")).andExpect(status().isOk());
-		verify(this.loggingSystem).setLogLevel("ROOT", LogLevel.DEBUG);
+		verify(this.loggingSystem).setLogLevel(null, LogLevel.DEBUG);
 	}
 
 	@Test


### PR DESCRIPTION
Log4j2 uses empty string as name of the root loggers. This turns out to
be a problem in the `LoggersMvcEndpoint` since setting the level of ""
results in a 405 - method not allowed.
So like in the `LoggingApplicationListener` we use "ROOT" as root
`loggername` for the `LoggersEndpoint` API and null when using the
`LoggingSystem`

fixes #7372