### PR TITLE
Fix #7380 ErrorPageFilter logging customization

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/web/support/ErrorPageFilter.java
+++ b/spring-boot/src/main/java/org/springframework/boot/web/support/ErrorPageFilter.java
@@ -185,7 +185,7 @@ public class ErrorPageFilter implements Filter, ErrorPageRegistry {
 		request.getRequestDispatcher(path).forward(request, response);
 	}
 
-	private String getDescription(HttpServletRequest request) {
+	protected String getDescription(HttpServletRequest request) {
 		return "[" + request.getServletPath()
 				+ (request.getPathInfo() == null ? "" : request.getPathInfo()) + "]";
 	}


### PR DESCRIPTION
Make `ErrorPageFilter#getDescription` protected instead of private to be
able to customize the details for the request logged in case of error
(currently, only request path is logged).