### PR TITLE
Allow configuration of JMS session transactions

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/DefaultJmsListenerContainerFactoryConfigurer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/DefaultJmsListenerContainerFactoryConfigurer.java
@@ -87,11 +87,14 @@ public final class DefaultJmsListenerContainerFactoryConfigurer {
 		Assert.notNull(connectionFactory, "ConnectionFactory must not be null");
 		factory.setConnectionFactory(connectionFactory);
 		factory.setPubSubDomain(this.jmsProperties.isPubSubDomain());
-		if (this.transactionManager != null) {
-			factory.setTransactionManager(this.transactionManager);
-		}
-		else {
-			factory.setSessionTransacted(true);
+		if (this.jmsProperties.getSessionTransacted() == null) {
+			if (this.transactionManager != null) {
+				factory.setTransactionManager(this.transactionManager);
+			} else {
+				factory.setSessionTransacted(true);
+			}
+		} else {
+			factory.setSessionTransacted(this.jmsProperties.getSessionTransacted());
 		}
 		if (this.destinationResolver != null) {
 			factory.setDestinationResolver(this.destinationResolver);

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsProperties.java
@@ -39,6 +39,11 @@ public class JmsProperties {
 	 */
 	private String jndiName;
 
+	/**
+	 * Set the transaction mode that is used when creating a JMS {@link javax.jms.Session}.
+	 */
+	private Boolean sessionTransacted;
+
 	private final Listener listener = new Listener();
 
 	public boolean isPubSubDomain() {
@@ -55,6 +60,14 @@ public class JmsProperties {
 
 	public void setJndiName(String jndiName) {
 		this.jndiName = jndiName;
+	}
+
+	public Boolean getSessionTransacted() {
+		return this.sessionTransacted;
+	}
+
+	public void setSessionTransacted(Boolean sessionTransacted) {
+		this.sessionTransacted = sessionTransacted;
 	}
 
 	public Listener getListener() {

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -877,6 +877,7 @@ content into your application; rather pick only the properties that you need.
 	spring.jms.listener.concurrency= # Minimum number of concurrent consumers.
 	spring.jms.listener.max-concurrency= # Maximum number of concurrent consumers.
 	spring.jms.pub-sub-domain=false # Specify if the default destination type is topic.
+	spring.jms.session-transacted= # Set the transaction mode that is used when creating a JMS Session. By default, sessions are transacted.
 
 	# RABBIT ({sc-spring-boot-autoconfigure}/amqp/RabbitProperties.{sc-ext}[RabbitProperties])
 	spring.rabbitmq.addresses= # Comma-separated list of addresses to which the client should connect.


### PR DESCRIPTION
Add a `spring.jms.session-transacted` property to enable or disable session transactions.

Some JMS implements, such as https://github.com/awslabs/amazon-sqs-java-messaging-lib don't support session transactions (see https://github.com/awslabs/amazon-sqs-java-messaging-lib/issues/5 ). So providing an easy way of disabling them makes using such providers much easier.

This change would also be relevant to https://github.com/spring-cloud/spring-cloud-aws/issues/186