### PR TITLE
Redis configuration with URL

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
@@ -16,10 +16,14 @@
 
 package org.springframework.boot.autoconfigure.data.redis;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPoolConfig;
@@ -55,12 +59,14 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @author Marco Aust
  */
 @Configuration
 @ConditionalOnClass({ JedisConnection.class, RedisOperations.class, Jedis.class })
 @EnableConfigurationProperties(RedisProperties.class)
 public class RedisAutoConfiguration {
 
+	private static final Log logger = LogFactory.getLog(RedisAutoConfiguration.class);
 	/**
 	 * Redis connection configuration.
 	 */
@@ -91,10 +97,23 @@ public class RedisAutoConfiguration {
 
 		protected final JedisConnectionFactory applyProperties(
 				JedisConnectionFactory factory) {
-			factory.setHostName(this.properties.getHost());
-			factory.setPort(this.properties.getPort());
-			if (this.properties.getPassword() != null) {
-				factory.setPassword(this.properties.getPassword());
+			if (StringUtils.hasText(this.properties.getUrl())) {
+				try {
+					URI redisURI = new URI(this.properties.getUrl());
+					factory.setHostName(redisURI.getHost());
+					factory.setPort(redisURI.getPort());
+					if (redisURI.getUserInfo() != null) {
+						factory.setPassword(redisURI.getUserInfo().split(":", 2)[1]);
+					}
+				} catch (URISyntaxException e) {
+					logger.error("Incorrect spring.redis.url", e);
+				}
+			} else {
+				factory.setHostName(this.properties.getHost());
+				factory.setPort(this.properties.getPort());
+				if (this.properties.getPassword() != null) {
+					factory.setPassword(this.properties.getPassword());
+				}
 			}
 			factory.setDatabase(this.properties.getDatabase());
 			if (this.properties.getTimeout() > 0) {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
@@ -99,6 +99,9 @@ public class RedisAutoConfiguration {
 		protected final JedisConnectionFactory applyProperties(
 				JedisConnectionFactory factory) {
 			if (StringUtils.hasText(this.properties.getUrl())) {
+				if (this.properties.getUrl().startsWith("rediss://")) {
+					factory.setUseSsl(true);
+				}
 				try {
 					URI redisURI = new URI(this.properties.getUrl());
 					factory.setHostName(redisURI.getHost());
@@ -117,6 +120,9 @@ public class RedisAutoConfiguration {
 				if (this.properties.getPassword() != null) {
 					factory.setPassword(this.properties.getPassword());
 				}
+			}
+			if (this.properties.isSsl()) {
+				factory.setUseSsl(true);
 			}
 			factory.setDatabase(this.properties.getDatabase());
 			if (this.properties.getTimeout() > 0) {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
@@ -67,6 +67,7 @@ import org.springframework.util.StringUtils;
 public class RedisAutoConfiguration {
 
 	private static final Log logger = LogFactory.getLog(RedisAutoConfiguration.class);
+
 	/**
 	 * Redis connection configuration.
 	 */

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
@@ -106,10 +106,12 @@ public class RedisAutoConfiguration {
 					if (redisURI.getUserInfo() != null) {
 						factory.setPassword(redisURI.getUserInfo().split(":", 2)[1]);
 					}
-				} catch (URISyntaxException e) {
+				}
+				catch (URISyntaxException e) {
 					logger.error("Incorrect spring.redis.url", e);
 				}
-			} else {
+			}
+			else {
 				factory.setHostName(this.properties.getHost());
 				factory.setPort(this.properties.getPort());
 				if (this.properties.getPassword() != null) {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -75,9 +75,13 @@ public class RedisProperties {
 		this.database = database;
 	}
 
-	public String getUrl() { return this.url; }
+	public String getUrl() {
+		return this.url;
+	}
 
-	public void setUrl(String url) { this.url = url; }
+	public void setUrl(String url) {
+		this.url = url;
+	}
 
 	public String getHost() {
 		return this.host;

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -57,6 +57,11 @@ public class RedisProperties {
 	private int port = 6379;
 
 	/**
+	 * Enable SSL.
+	 */
+	private boolean ssl;
+
+	/**
 	 * Connection timeout in milliseconds.
 	 */
 	private int timeout;
@@ -105,6 +110,14 @@ public class RedisProperties {
 
 	public void setPort(int port) {
 		this.port = port;
+	}
+
+	public boolean isSsl() {
+		return this.ssl;
+	}
+
+	public void setSsl(boolean ssl) {
+		this.ssl = ssl;
 	}
 
 	public void setTimeout(int timeout) {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -26,6 +26,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Dave Syer
  * @author Christoph Strobl
  * @author Eddú Meléndez
+ * @author Marco Aust
  */
 @ConfigurationProperties(prefix = "spring.redis")
 public class RedisProperties {
@@ -34,6 +35,11 @@ public class RedisProperties {
 	 * Database index used by the connection factory.
 	 */
 	private int database = 0;
+
+	/**
+	 * Redis url, which will overrule host, port and password if set.
+	 */
+	private String url;
 
 	/**
 	 * Redis server host.
@@ -68,6 +74,10 @@ public class RedisProperties {
 	public void setDatabase(int database) {
 		this.database = database;
 	}
+
+	public String getUrl() { return this.url; }
+
+	public void setUrl(String url) { this.url = url; }
 
 	public String getHost() {
 		return this.host;

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -77,7 +77,8 @@ public class RedisAutoConfigurationTests {
 
 	@Test
 	public void testOverrideURLRedisConfiguration() throws Exception {
-		load("spring.redis.host:foo", "spring.redis.password:xyz", "spring.redis.port:1000",
+		load("spring.redis.host:foo", "spring.redis.password:xyz",
+				"spring.redis.port:1000",
 				"spring.redis.url:redis://user:password@example:33");
 		assertThat(this.context.getBean(JedisConnectionFactory.class).getHostName())
 				.isEqualTo("example");

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -79,6 +79,7 @@ public class RedisAutoConfigurationTests {
 	public void testOverrideURLRedisConfiguration() throws Exception {
 		load("spring.redis.host:foo", "spring.redis.password:xyz",
 				"spring.redis.port:1000",
+				"spring.redis.ssl:true",
 				"spring.redis.url:redis://user:password@example:33");
 		assertThat(this.context.getBean(JedisConnectionFactory.class).getHostName())
 				.isEqualTo("example");
@@ -86,6 +87,8 @@ public class RedisAutoConfigurationTests {
 				.isEqualTo(33);
 		assertThat(this.context.getBean(JedisConnectionFactory.class).getPassword())
 				.isEqualTo("password");
+		assertThat(this.context.getBean(JedisConnectionFactory.class).isUseSsl())
+				.isEqualTo(true);
 	}
 
 	@Test

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -76,6 +76,18 @@ public class RedisAutoConfigurationTests {
 	}
 
 	@Test
+	public void testOverrideURLRedisConfiguration() throws Exception {
+		load("spring.redis.host:foo", "spring.redis.password:xyz", "spring.redis.port:1000",
+				"spring.redis.url:redis://user:password@example:33");
+		assertThat(this.context.getBean(JedisConnectionFactory.class).getHostName())
+				.isEqualTo("example");
+		assertThat(this.context.getBean(JedisConnectionFactory.class).getPort())
+				.isEqualTo(33);
+		assertThat(this.context.getBean(JedisConnectionFactory.class).getPassword())
+				.isEqualTo("password");
+	}
+
+	@Test
 	public void testRedisConfigurationWithPool() throws Exception {
 		load("spring.redis.host:foo", "spring.redis.pool.max-idle:1");
 		assertThat(this.context.getBean(JedisConnectionFactory.class).getHostName())

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -787,7 +787,7 @@ content into your application; rather pick only the properties that you need.
 	spring.redis.cluster.max-redirects= # Maximum number of redirects to follow when executing commands across the cluster.
 	spring.redis.cluster.nodes= # Comma-separated list of "host:port" pairs to bootstrap from.
 	spring.redis.database=0 # Database index used by the connection factory.
-	spring.redis.url=redis://x:password@example.com:6379 # Connection URL, will override host, port and password (user will be ignored)
+	spring.redis.url=redis://x:password@example.com:6379 # Connection URL, will override host, port and password (user will be ignored), e.g. redis://user:password@localhost:6379
 	spring.redis.host=localhost # Redis server host.
 	spring.redis.password= # Login password of the redis server.
 	spring.redis.pool.max-active=8 # Max number of connections that can be allocated by the pool at a given time. Use a negative value for no limit.

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -787,6 +787,7 @@ content into your application; rather pick only the properties that you need.
 	spring.redis.cluster.max-redirects= # Maximum number of redirects to follow when executing commands across the cluster.
 	spring.redis.cluster.nodes= # Comma-separated list of "host:port" pairs to bootstrap from.
 	spring.redis.database=0 # Database index used by the connection factory.
+	spring.redis.url=redis://x:password@example.com:6379 # Connection URL, will override host, port and password (user will be ignored)
 	spring.redis.host=localhost # Redis server host.
 	spring.redis.password= # Login password of the redis server.
 	spring.redis.pool.max-active=8 # Max number of connections that can be allocated by the pool at a given time. Use a negative value for no limit.

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -787,9 +787,10 @@ content into your application; rather pick only the properties that you need.
 	spring.redis.cluster.max-redirects= # Maximum number of redirects to follow when executing commands across the cluster.
 	spring.redis.cluster.nodes= # Comma-separated list of "host:port" pairs to bootstrap from.
 	spring.redis.database=0 # Database index used by the connection factory.
-	spring.redis.url=redis://user:password@example.com:6379 # Connection URL, will override host, port and password (user will be ignored)
+	spring.redis.url= # Connection URL, will override host, port and password (user will be ignored), e.g. redis://user:password@example.com:6379
 	spring.redis.host=localhost # Redis server host.
 	spring.redis.password= # Login password of the redis server.
+	spring.redis.ssl=false # Enable SSL support.
 	spring.redis.pool.max-active=8 # Max number of connections that can be allocated by the pool at a given time. Use a negative value for no limit.
 	spring.redis.pool.max-idle=8 # Max number of "idle" connections in the pool. Use a negative value to indicate an unlimited number of idle connections.
 	spring.redis.pool.max-wait=-1 # Maximum amount of time (in milliseconds) a connection allocation should block before throwing an exception when the pool is exhausted. Use a negative value to block indefinitely.


### PR DESCRIPTION
As some platforms provide Redis configuration through environment variables as URL (e.g. redis://redistogo:44ec0bc04dd4a5afe77a649acee7a8f3@drum.redistogo.com:9092/ on Heroku) it would be nice to be able to configure it without manually creating an JedisConnectionFactory similar to spring.datasource.url.

So I introduced: spring.redis.url which will parse the URL and create the JedisConnectionFactory.

As of the current implementation spring.redis.url would overrule spring.redis.host, spring.redis.port and spring.redis.password. But this would be open for discussion.

Note: There is only a password for Redis and no user, therefore the user in the URL will be ignored.