### PR TITLE
Replace org.json with json-simple

### DIFF
--- a/spring-boot-tools/spring-boot-configuration-metadata/pom.xml
+++ b/spring-boot-tools/spring-boot-configuration-metadata/pom.xml
@@ -18,10 +18,9 @@
 		<main.basedir>${basedir}/../..</main.basedir>
 	</properties>
 	<dependencies>
-		<!-- Compile (should stick to the bare minimum) -->
 		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
+			<groupId>com.googlecode.json-simple</groupId>
+			<artifactId>json-simple</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-tools/spring-boot-configuration-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataRepositoryJsonBuilder.java
+++ b/spring-boot-tools/spring-boot-configuration-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataRepositoryJsonBuilder.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.json.JSONException;
+import org.json.simple.parser.ParseException;
 
 /**
  * Load a {@link ConfigurationMetadataRepository} from the content of arbitrary
@@ -98,8 +98,7 @@ public final class ConfigurationMetadataRepositoryJsonBuilder {
 		return result;
 	}
 
-	private SimpleConfigurationMetadataRepository add(InputStream in, Charset charset)
-			throws IOException {
+	private SimpleConfigurationMetadataRepository add(InputStream in, Charset charset) {
 		try {
 			RawConfigurationMetadata metadata = this.reader.read(in, charset);
 			return create(metadata);
@@ -108,7 +107,7 @@ public final class ConfigurationMetadataRepositoryJsonBuilder {
 			throw new IllegalArgumentException(
 					"Failed to read configuration " + "metadata", ex);
 		}
-		catch (JSONException ex) {
+		catch (ParseException ex) {
 			throw new IllegalArgumentException(
 					"Invalid configuration " + "metadata document", ex);
 		}

--- a/spring-boot-tools/spring-boot-configuration-metadata/src/test/java/org/springframework/boot/configurationmetadata/JsonReaderTests.java
+++ b/spring-boot-tools/spring-boot-configuration-metadata/src/test/java/org/springframework/boot/configurationmetadata/JsonReaderTests.java
@@ -16,11 +16,9 @@
 
 package org.springframework.boot.configurationmetadata;
 
-import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
 
-import org.json.JSONException;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,20 +35,20 @@ public class JsonReaderTests extends AbstractConfigurationMetadataTests {
 	private final JsonReader reader = new JsonReader();
 
 	@Test
-	public void emptyMetadata() throws IOException {
+	public void emptyMetadata() throws Exception {
 		RawConfigurationMetadata rawMetadata = readFor("empty");
 		assertThat(rawMetadata.getSources()).isEmpty();
 		assertThat(rawMetadata.getItems()).isEmpty();
 	}
 
 	@Test
-	public void invalidMetadata() throws IOException {
-		this.thrown.expect(JSONException.class);
+	public void invalidMetadata() throws Exception {
+		this.thrown.expect(IllegalStateException.class);
 		readFor("invalid");
 	}
 
 	@Test
-	public void emptyGroupName() throws IOException {
+	public void emptyGroupName() throws Exception {
 		RawConfigurationMetadata rawMetadata = readFor("empty-groups");
 		List<ConfigurationMetadataItem> items = rawMetadata.getItems();
 		assertThat(items).hasSize(2);
@@ -62,7 +60,7 @@ public class JsonReaderTests extends AbstractConfigurationMetadataTests {
 	}
 
 	@Test
-	public void simpleMetadata() throws IOException {
+	public void simpleMetadata() throws Exception {
 		RawConfigurationMetadata rawMetadata = readFor("foo");
 		List<ConfigurationMetadataSource> sources = rawMetadata.getSources();
 		assertThat(sources).hasSize(2);
@@ -92,7 +90,7 @@ public class JsonReaderTests extends AbstractConfigurationMetadataTests {
 		assertThat(hint.getId()).isEqualTo("spring.foo.counter");
 		assertThat(hint.getValueHints()).hasSize(1);
 		ValueHint valueHint = hint.getValueHints().get(0);
-		assertThat(valueHint.getValue()).isEqualTo(42);
+		assertThat(valueHint.getValue()).isEqualTo(42L);
 		assertThat(valueHint.getDescription()).isEqualTo(
 				"Because that's the answer to any question, choose it. \nReally.");
 		assertThat(valueHint.getShortDescription())
@@ -106,7 +104,7 @@ public class JsonReaderTests extends AbstractConfigurationMetadataTests {
 	}
 
 	@Test
-	public void metadataHints() throws IOException {
+	public void metadataHints() throws Exception {
 		RawConfigurationMetadata rawMetadata = readFor("bar");
 		List<ConfigurationMetadataHint> hints = rawMetadata.getHints();
 		assertThat(hints).hasSize(1);
@@ -133,7 +131,7 @@ public class JsonReaderTests extends AbstractConfigurationMetadataTests {
 	}
 
 	@Test
-	public void rootMetadata() throws IOException {
+	public void rootMetadata() throws Exception {
 		RawConfigurationMetadata rawMetadata = readFor("root");
 		List<ConfigurationMetadataSource> sources = rawMetadata.getSources();
 		assertThat(sources).isEmpty();
@@ -144,7 +142,7 @@ public class JsonReaderTests extends AbstractConfigurationMetadataTests {
 	}
 
 	@Test
-	public void deprecatedMetadata() throws IOException {
+	public void deprecatedMetadata() throws Exception {
 		RawConfigurationMetadata rawMetadata = readFor("deprecated");
 		List<ConfigurationMetadataItem> items = rawMetadata.getItems();
 		assertThat(items).hasSize(3);
@@ -171,8 +169,7 @@ public class JsonReaderTests extends AbstractConfigurationMetadataTests {
 		assertThat(item3.getDeprecation()).isEqualTo(null);
 	}
 
-	RawConfigurationMetadata readFor(String path) throws IOException {
+	private RawConfigurationMetadata readFor(String path) throws Exception {
 		return this.reader.read(getInputStreamFor(path), DEFAULT_CHARSET);
 	}
-
 }

--- a/spring-boot-tools/spring-boot-configuration-processor/pom.xml
+++ b/spring-boot-tools/spring-boot-configuration-processor/pom.xml
@@ -19,9 +19,13 @@
 	</properties>
 	<dependencies>
  		<!-- Compile (should stick to the bare minimum) -->
- 		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
+		<dependency>
+			<groupId>com.googlecode.json-simple</groupId>
+			<artifactId>json-simple</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-core</artifactId>
 		</dependency>
 		<!-- Test -->
 		<dependency>
@@ -30,8 +34,14 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-core</artifactId>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	<build>

--- a/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataStore.java
+++ b/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataStore.java
@@ -27,8 +27,7 @@ import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 
-import org.json.JSONException;
-
+import org.json.simple.parser.ParseException;
 import org.springframework.boot.configurationprocessor.metadata.ConfigurationMetadata;
 import org.springframework.boot.configurationprocessor.metadata.InvalidConfigurationMetadataException;
 import org.springframework.boot.configurationprocessor.metadata.JsonMarshaller;
@@ -87,7 +86,7 @@ public class MetadataStore {
 		catch (IOException ex) {
 			return null;
 		}
-		catch (JSONException ex) {
+		catch (ParseException ex) {
 			throw new InvalidConfigurationMetadataException(
 					"Invalid additional meta-data in '" + METADATA_PATH + "': "
 							+ ex.getMessage(),

--- a/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -68,7 +68,10 @@ import org.springframework.boot.configurationsample.specific.InvalidDoubleRegist
 import org.springframework.boot.configurationsample.specific.SimplePojo;
 import org.springframework.util.FileCopyUtils;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Tests for {@link ConfigurationMetadataAnnotationProcessor}.
@@ -87,10 +90,12 @@ public class ConfigurationMetadataAnnotationProcessorTests {
 	public ExpectedException thrown = ExpectedException.none();
 
 	private TestCompiler compiler;
+	private final ObjectMapper mapper = new ObjectMapper();
 
 	@Before
 	public void createCompiler() throws IOException {
 		this.compiler = new TestCompiler(this.temporaryFolder);
+		mapper.setSerializationInclusion(NON_NULL);
 	}
 
 	@Test
@@ -606,11 +611,11 @@ public class ConfigurationMetadataAnnotationProcessorTests {
 		property.put("type", "java.lang.String");
 		property.put("sourceType", AdditionalMetadata.class.getName());
 		JSONArray properties = new JSONArray();
-		properties.put(property);
+		properties.add(property);
 		JSONObject additionalMetadata = new JSONObject();
 		additionalMetadata.put("properties", properties);
 		FileWriter writer = new FileWriter(additionalMetadataFile);
-		additionalMetadata.write(writer);
+		additionalMetadata.writeJSONString(writer);
 		writer.flush();
 		ConfigurationMetadata metadata = compile(SimpleProperties.class);
 		assertThat(metadata).has(Metadata.withProperty("simple.comparator"));
@@ -692,7 +697,7 @@ public class ConfigurationMetadataAnnotationProcessorTests {
 		assertThat(metadata).has(Metadata.withProperty(prefix + ".description"));
 		assertThat(metadata).has(Metadata.withProperty(prefix + ".counter"));
 		assertThat(metadata).has(Metadata.withProperty(prefix + ".number")
-				.fromSource(source).withDefaultValue(0).withDeprecation(null, null));
+				.fromSource(source).withDefaultValue(0L).withDeprecation(null, null));
 		assertThat(metadata).has(Metadata.withProperty(prefix + ".items"));
 		assertThat(metadata).doesNotHave(Metadata.withProperty(prefix + ".ignored"));
 	}
@@ -739,7 +744,7 @@ public class ConfigurationMetadataAnnotationProcessorTests {
 				}
 				jsonObject.put("deprecation", deprecationJson);
 			}
-			propertiesArray.put(jsonObject);
+			propertiesArray.add(jsonObject);
 
 		}
 		JSONObject additionalMetadata = new JSONObject();
@@ -760,7 +765,7 @@ public class ConfigurationMetadataAnnotationProcessorTests {
 			throws IOException {
 		FileWriter writer = new FileWriter(metadataFile);
 		try {
-			metadata.write(writer);
+			mapper.writeValue(writer, metadata);
 		}
 		finally {
 			writer.close();

--- a/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/TestConfigurationMetadataAnnotationProcessor.java
+++ b/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/TestConfigurationMetadataAnnotationProcessor.java
@@ -24,6 +24,7 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 
+import org.json.simple.parser.ParseException;
 import org.springframework.boot.configurationprocessor.metadata.ConfigurationMetadata;
 import org.springframework.boot.configurationprocessor.metadata.JsonMarshaller;
 
@@ -84,7 +85,7 @@ public class TestConfigurationMetadataAnnotationProcessor
 			}
 			return this.metadata;
 		}
-		catch (IOException e) {
+		catch (IOException|ParseException e) {
 			throw new RuntimeException("Failed to read metadata from disk", e);
 		}
 	}

--- a/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/JsonMarshallerTests.java
+++ b/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/JsonMarshallerTests.java
@@ -18,7 +18,6 @@ package org.springframework.boot.configurationprocessor.metadata;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
@@ -38,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JsonMarshallerTests {
 
 	@Test
-	public void marshallAndUnmarshal() throws IOException {
+	public void marshallAndUnmarshal() throws Exception {
 		ConfigurationMetadata metadata = new ConfigurationMetadata();
 		metadata.add(ItemMetadata.newProperty("a", "b", StringBuffer.class.getName(),
 				InputStream.class.getName(), "sourceMethod", "desc", "x",
@@ -72,7 +71,7 @@ public class JsonMarshallerTests {
 				.fromSource(InputStream.class).withDescription("desc")
 				.withDefaultValue("x").withDeprecation("Deprecation comment", "b.c.d"));
 		assertThat(read).has(Metadata.withProperty("b.c.d"));
-		assertThat(read).has(Metadata.withProperty("c").withDefaultValue(123));
+		assertThat(read).has(Metadata.withProperty("c").withDefaultValue(123L));
 		assertThat(read).has(Metadata.withProperty("d").withDefaultValue(true));
 		assertThat(read).has(
 				Metadata.withProperty("e").withDefaultValue(new String[] { "y", "n" }));
@@ -81,9 +80,8 @@ public class JsonMarshallerTests {
 		assertThat(read).has(Metadata.withGroup("d"));
 		assertThat(read).has(Metadata.withHint("a.b"));
 		assertThat(read).has(
-				Metadata.withHint("c").withValue(0, 123, "hey").withValue(1, 456, null));
+				Metadata.withHint("c").withValue(0, 123L, "hey").withValue(1, 456L, null));
 		assertThat(read).has(Metadata.withHint("d").withProvider("first", "target", "foo")
 				.withProvider("second"));
 	}
-
 }


### PR DESCRIPTION
Replace `org.json` with `json-simple` due to licensing issues with `org.json`.

See #5929 gh-5929