### PR TITLE
server.connection-timeout configures main Tomcat connector instead

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -809,14 +809,19 @@ public class ServerProperties
 		}
 
 		private void customizeConnectionTimeout(
-				TomcatEmbeddedServletContainerFactory factory, int connectionTimeout) {
-			for (Connector connector : factory.getAdditionalTomcatConnectors()) {
-				if (connector.getProtocolHandler() instanceof AbstractProtocol) {
-					AbstractProtocol<?> handler = (AbstractProtocol<?>) connector
-							.getProtocolHandler();
-					handler.setConnectionTimeout(connectionTimeout);
+				TomcatEmbeddedServletContainerFactory factory, final int connectionTimeout) {
+			factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
+				@Override
+				public void customize(Connector connector) {
+
+					ProtocolHandler handler = connector.getProtocolHandler();
+					if (handler instanceof AbstractProtocol) {
+						AbstractProtocol protocol = (AbstractProtocol) handler;
+						protocol.setConnectionTimeout(connectionTimeout);
+					}
+
 				}
-			}
+			});
 		}
 
 		private void customizeRemoteIpValve(ServerProperties properties,

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -112,6 +112,14 @@ public class ServerPropertiesTests {
 	}
 
 	@Test
+	public void testConnectionTimeout() throws Exception {
+		Map<String, String> map = new HashMap<String, String>();
+		map.put("server.connection-timeout", "60000");
+		bindProperties(map);
+		assertThat(this.properties.getConnectionTimeout()).isEqualTo(60000);
+	}
+
+	@Test
 	public void testServletPathAsMapping() throws Exception {
 		RelaxedDataBinder binder = new RelaxedDataBinder(this.properties, "server");
 		binder.bind(new MutablePropertyValues(


### PR DESCRIPTION
Hello,

I discovered that `server.connection-timeout` has no effect for Tomcat's main connector and default value of 60000 is always used.
I observed this behavior with Spring Boot 1.4.
As far as I can see this happens because `org.springframework.boot.autoconfigure.web.ServerProperties.customizeConnectionTimeout` modifies only additional Tomcat connectors and keeping main one untouched.

There is also [Demo project](https://github.com/PostalBear/SpringConnectionTimeout) to illustrate this problem.

PS 
I hope this pull request would be helpful.
And thanks for great framework :)
