### PR TITLE
Upgrade Spring Session to 1.3.0.RC1

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HazelcastSessionConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HazelcastSessionConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.session.hazelcast.config.annotation.web.http.Hazelcas
  * @author Tommy Ludwig
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @author Vedran Pavic
  */
 @Configuration
 @ConditionalOnMissingBean(SessionRepository.class)
@@ -49,7 +50,9 @@ class HazelcastSessionConfiguration {
 			if (timeout != null) {
 				setMaxInactiveIntervalInSeconds(timeout);
 			}
-			setSessionMapName(sessionProperties.getHazelcast().getMapName());
+			SessionProperties.Hazelcast hazelcast = sessionProperties.getHazelcast();
+			setSessionMapName(hazelcast.getMapName());
+			setHazelcastFlushMode(hazelcast.getFlushMode());
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionProperties.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.session.data.redis.RedisFlushMode;
+import org.springframework.session.hazelcast.HazelcastFlushMode;
 
 /**
  * Configuration properties for Spring Session.
@@ -92,12 +93,25 @@ public class SessionProperties {
 		 */
 		private String mapName = "spring:session:sessions";
 
+		/**
+		 * Flush mode for the Hazelcast sessions.
+		 */
+		private HazelcastFlushMode flushMode = HazelcastFlushMode.ON_SAVE;
+
 		public String getMapName() {
 			return this.mapName;
 		}
 
 		public void setMapName(String mapName) {
 			this.mapName = mapName;
+		}
+
+		public HazelcastFlushMode getFlushMode() {
+			return this.flushMode;
+		}
+
+		public void setFlushMode(HazelcastFlushMode flushMode) {
+			this.flushMode = flushMode;
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/AbstractSessionAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/AbstractSessionAutoConfigurationTests.java
@@ -47,9 +47,9 @@ public abstract class AbstractSessionAutoConfigurationTests {
 
 	protected <T extends SessionRepository<?>> T validateSessionRepository(
 			Class<T> type) {
-		SessionRepository<?> cacheManager = this.context.getBean(SessionRepository.class);
-		assertThat(cacheManager).as("Wrong session repository type").isInstanceOf(type);
-		return type.cast(cacheManager);
+		SessionRepository<?> repository = this.context.getBean(SessionRepository.class);
+		assertThat(repository).as("Wrong session repository type").isInstanceOf(type);
+		return type.cast(repository);
 	}
 
 	protected Integer getSessionTimeout(SessionRepository<?> sessionRepository) {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationHazelcastTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationHazelcastTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.session;
+
+import java.util.Collections;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import org.junit.Test;
+
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.hazelcast.HazelcastFlushMode;
+import org.springframework.session.hazelcast.HazelcastSessionRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Hazelcast specific tests for {@link SessionAutoConfiguration}.
+ *
+ * @author Vedran Pavic
+ */
+public class SessionAutoConfigurationHazelcastTests
+		extends AbstractSessionAutoConfigurationTests {
+
+	@Test
+	public void defaultConfig() {
+		load(Collections.<Class<?>>singletonList(HazelcastConfiguration.class),
+				"spring.session.store-type=hazelcast");
+		validateSessionRepository(HazelcastSessionRepository.class);
+		HazelcastInstance hazelcastInstance = this.context
+				.getBean(HazelcastInstance.class);
+		verify(hazelcastInstance, times(1)).getMap("spring:session:sessions");
+	}
+
+	@Test
+	public void customMapName() {
+		load(Collections.<Class<?>>singletonList(HazelcastConfiguration.class),
+				"spring.session.store-type=hazelcast",
+				"spring.session.hazelcast.map-name=foo:bar:biz");
+		validateSessionRepository(HazelcastSessionRepository.class);
+		HazelcastInstance hazelcastInstance = this.context
+				.getBean(HazelcastInstance.class);
+		verify(hazelcastInstance, times(1)).getMap("foo:bar:biz");
+	}
+
+	@Test
+	public void customFlushMode() {
+		load(Collections.<Class<?>>singletonList(HazelcastConfiguration.class),
+				"spring.session.store-type=hazelcast",
+				"spring.session.hazelcast.flush-mode=immediate");
+		HazelcastSessionRepository repository = validateSessionRepository(
+				HazelcastSessionRepository.class);
+		assertThat(new DirectFieldAccessor(repository).getPropertyValue(
+				"hazelcastFlushMode")).isEqualTo(HazelcastFlushMode.IMMEDIATE);
+	}
+
+	@Configuration
+	static class HazelcastConfiguration {
+
+		@Bean
+		@SuppressWarnings("unchecked")
+		public HazelcastInstance hazelcastInstance() {
+			IMap<Object, Object> map = mock(IMap.class);
+			HazelcastInstance mock = mock(HazelcastInstance.class);
+			given(mock.getMap("spring:session:sessions")).willReturn(map);
+			given(mock.getMap("foo:bar:biz")).willReturn(map);
+			return mock;
+		}
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
@@ -19,9 +19,6 @@ package org.springframework.boot.autoconfigure.session;
 import java.util.Arrays;
 import java.util.Collections;
 
-import com.hazelcast.core.Hazelcast;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -37,13 +34,8 @@ import org.springframework.session.ExpiringSession;
 import org.springframework.session.MapSessionRepository;
 import org.springframework.session.SessionRepository;
 import org.springframework.session.data.mongo.MongoOperationsSessionRepository;
-import org.springframework.session.hazelcast.HazelcastSessionRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link SessionAutoConfiguration}.
@@ -105,24 +97,7 @@ public class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurat
 	}
 
 	@Test
-	public void hazelcastSessionStore() {
-		load(Collections.<Class<?>>singletonList(HazelcastConfiguration.class),
-				"spring.session.store-type=hazelcast");
-		validateSessionRepository(HazelcastSessionRepository.class);
-	}
-
-	@Test
-	public void hazelcastSessionStoreWithCustomizations() {
-		load(Collections.<Class<?>>singletonList(HazelcastSpecificMap.class),
-				"spring.session.store-type=hazelcast",
-				"spring.session.hazelcast.map-name=foo:bar:biz");
-		validateSessionRepository(HazelcastSessionRepository.class);
-		HazelcastInstance hazelcastInstance = this.context
-				.getBean(HazelcastInstance.class);
-		verify(hazelcastInstance, times(1)).getMap("foo:bar:biz");
-	}
-
-	@Test
+	@SuppressWarnings("unchecked")
 	public void mongoSessionStore() {
 		load(Arrays.asList(EmbeddedMongoAutoConfiguration.class,
 				MongoAutoConfiguration.class, MongoDataAutoConfiguration.class),
@@ -131,6 +106,7 @@ public class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurat
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void mongoSessionStoreWithCustomizations() {
 		load(Arrays.asList(EmbeddedMongoAutoConfiguration.class,
 				MongoAutoConfiguration.class, MongoDataAutoConfiguration.class),
@@ -157,30 +133,6 @@ public class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurat
 		public SessionRepository<?> mySessionRepository() {
 			return new MapSessionRepository(
 					Collections.<String, ExpiringSession>emptyMap());
-		}
-
-	}
-
-	@Configuration
-	static class HazelcastConfiguration {
-
-		@Bean
-		public HazelcastInstance hazelcastInstance() {
-			return Hazelcast.newHazelcastInstance();
-		}
-
-	}
-
-	@Configuration
-	static class HazelcastSpecificMap {
-
-		@Bean
-		@SuppressWarnings("unchecked")
-		public HazelcastInstance hazelcastInstance() {
-			IMap<Object, Object> map = mock(IMap.class);
-			HazelcastInstance mock = mock(HazelcastInstance.class);
-			given(mock.getMap("foo:bar:biz")).willReturn(map);
-			return mock;
 		}
 
 	}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -165,7 +165,7 @@
 		<spring-security.version>4.2.0.RELEASE</spring-security.version>
 		<spring-security-jwt.version>1.0.5.RELEASE</spring-security-jwt.version>
 		<spring-security-oauth.version>2.0.12.RELEASE</spring-security-oauth.version>
-		<spring-session.version>1.3.0.M2</spring-session.version>
+		<spring-session.version>1.3.0.RC1</spring-session.version>
 		<spring-social.version>1.1.4.RELEASE</spring-social.version>
 		<spring-social-facebook.version>2.0.3.RELEASE</spring-social-facebook.version>
 		<spring-social-linkedin.version>1.0.2.RELEASE</spring-social-linkedin.version>
@@ -2222,11 +2222,6 @@
 			<dependency>
 				<groupId>org.springframework.session</groupId>
 				<artifactId>spring-session-data-gemfire</artifactId>
-				<version>${spring-session.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.session</groupId>
-				<artifactId>spring-session-data-geode</artifactId>
 				<version>${spring-session.version}</version>
 			</dependency>
 			<dependency>

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -375,6 +375,7 @@ content into your application; rather pick only the properties that you need.
 	spring.resources.static-locations=classpath:/META-INF/resources/,classpath:/resources/,classpath:/static/,classpath:/public/ # Locations of static resources.
 
 	# SPRING SESSION ({sc-spring-boot-autoconfigure}/session/SessionProperties.{sc-ext}[SessionProperties])
+	spring.session.hazelcast.flush-mode= # Flush mode for the Hazelcast sessions.
 	spring.session.hazelcast.map-name=spring:session:sessions # Name of the map used to store sessions.
 	spring.session.jdbc.initializer.enabled= # Create the required session tables on startup if necessary. Enabled automatically if the default table name is set or a custom schema is configured.
 	spring.session.jdbc.schema=classpath:org/springframework/session/jdbc/schema-@@platform@@.sql # Path to the SQL file to use to initialize the database schema.


### PR DESCRIPTION
Other than the usual version bump, this PR also:

- removes dependency management for reverted `spring-session-data-geode` module (see #7159, spring-projects/spring-session@06104c3)
- adds configuration support for Hazelcast flush mode (introduced in `1.3.0.RC1`, see spring-projects/spring-session#641)
- extracts Hazelcast specific tests into a separate test class