### PR TITLE
Add auto-configuration support for Hazelcast client

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -77,6 +77,11 @@
 		</dependency>
 		<dependency>
 			<groupId>com.hazelcast</groupId>
+			<artifactId>hazelcast-client</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.hazelcast</groupId>
 			<artifactId>hazelcast-spring</artifactId>
 			<optional>true</optional>
 		</dependency>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,15 @@
 
 package org.springframework.boot.autoconfigure.hazelcast;
 
-import java.io.IOException;
-
-import com.hazelcast.config.Config;
-import com.hazelcast.core.Hazelcast;
+import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.core.HazelcastInstance;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.Resource;
+import org.springframework.context.annotation.Import;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Hazelcast. Creates a
@@ -38,57 +32,27 @@ import org.springframework.core.io.Resource;
  * configuration file is found in the environment.
  *
  * @author Stephane Nicoll
+ * @author Vedran Pavic
  * @since 1.3.0
  * @see HazelcastConfigResourceCondition
  */
 @Configuration
 @ConditionalOnClass(HazelcastInstance.class)
-@ConditionalOnMissingBean(HazelcastInstance.class)
 @EnableConfigurationProperties(HazelcastProperties.class)
 public class HazelcastAutoConfiguration {
 
 	@Configuration
-	@ConditionalOnMissingBean(Config.class)
-	@Conditional(ConfigAvailableCondition.class)
-	static class HazelcastConfigFileConfiguration {
-
-		private final HazelcastProperties hazelcastProperties;
-
-		HazelcastConfigFileConfiguration(HazelcastProperties hazelcastProperties) {
-			this.hazelcastProperties = hazelcastProperties;
-		}
-
-		@Bean
-		public HazelcastInstance hazelcastInstance() throws IOException {
-			Resource config = this.hazelcastProperties.resolveConfigLocation();
-			if (config != null) {
-				return new HazelcastInstanceFactory(config).getHazelcastInstance();
-			}
-			return Hazelcast.newHazelcastInstance();
-		}
+	@ConditionalOnMissingBean(HazelcastInstance.class)
+	@Import(HazelcastServerConfiguration.class)
+	static class ServerConfiguration {
 
 	}
 
 	@Configuration
-	@ConditionalOnSingleCandidate(Config.class)
-	static class HazelcastConfigConfiguration {
-
-		@Bean
-		public HazelcastInstance hazelcastInstance(Config config) {
-			return new HazelcastInstanceFactory(config).getHazelcastInstance();
-		}
-
-	}
-
-	/**
-	 * {@link HazelcastConfigResourceCondition} that checks if the
-	 * {@code spring.hazelcast.config} configuration key is defined.
-	 */
-	static class ConfigAvailableCondition extends HazelcastConfigResourceCondition {
-
-		ConfigAvailableCondition() {
-			super("spring.hazelcast", "config");
-		}
+	@ConditionalOnClass(HazelcastClient.class)
+	@ConditionalOnMissingBean(HazelcastInstance.class)
+	@Import(HazelcastClientConfiguration.class)
+	static class ClientConfiguration {
 
 	}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.hazelcast;
+
+import java.io.IOException;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.core.HazelcastInstance;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+
+/**
+ * Configuration for Hazelcast client.
+ *
+ * @author Vedran Pavic
+ * @since 2.0.0
+ */
+class HazelcastClientConfiguration {
+
+	static final String CONFIG_SYSTEM_PROPERTY = "hazelcast.client.config";
+
+	@Configuration
+	@ConditionalOnMissingBean(ClientConfig.class)
+	@Conditional(ConfigAvailableCondition.class)
+	static class HazelcastClientConfigFileConfiguration {
+
+		@Bean
+		public HazelcastInstance hazelcastInstance(HazelcastProperties properties)
+				throws IOException {
+			Resource config = properties.resolveConfigLocation();
+			if (config != null) {
+				return HazelcastInstanceFactory.createHazelcastClient(config);
+			}
+			return HazelcastClient.newHazelcastClient();
+		}
+
+	}
+
+	@Configuration
+	@ConditionalOnSingleCandidate(ClientConfig.class)
+	static class HazelcastClientConfigConfiguration {
+
+		@Bean
+		public HazelcastInstance hazelcastInstance(ClientConfig config) {
+			return HazelcastInstanceFactory.createHazelcastClient(config);
+		}
+
+	}
+
+	/**
+	 * {@link HazelcastConfigResourceCondition} that checks if the
+	 * {@code spring.hazelcast.config} configuration key is defined.
+	 */
+	static class ConfigAvailableCondition extends HazelcastConfigResourceCondition {
+
+		ConfigAvailableCondition() {
+			super(CONFIG_SYSTEM_PROPERTY, "file:./hazelcast-client.xml",
+					"classpath:/hazelcast-client.xml");
+		}
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastConfigResourceCondition.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastConfigResourceCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.springframework.boot.autoconfigure.condition.ResourceCondition;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.Assert;
 
 /**
  * {@link SpringBootCondition} used to check if the Hazelcast configuration is available.
@@ -28,23 +29,26 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
  * property referring to the resource to use has been set.
  *
  * @author Stephane Nicoll
+ * @author Vedran Pavic
  * @since 1.3.0
  */
 public abstract class HazelcastConfigResourceCondition extends ResourceCondition {
 
-	static final String CONFIG_SYSTEM_PROPERTY = "hazelcast.config";
+	private final String configSystemProperty;
 
-	protected HazelcastConfigResourceCondition(String prefix, String propertyName) {
-		super("Hazelcast", prefix, propertyName, "file:./hazelcast.xml",
-				"classpath:/hazelcast.xml");
+	protected HazelcastConfigResourceCondition(String configSystemProperty,
+			String... resourceLocations) {
+		super("Hazelcast", "spring.hazelcast", "config", resourceLocations);
+		Assert.notNull(configSystemProperty, "ConfigSystemProperty must not be null");
+		this.configSystemProperty = configSystemProperty;
 	}
 
 	@Override
 	protected ConditionOutcome getResourceOutcome(ConditionContext context,
 			AnnotatedTypeMetadata metadata) {
-		if (System.getProperty(CONFIG_SYSTEM_PROPERTY) != null) {
+		if (System.getProperty(this.configSystemProperty) != null) {
 			return ConditionOutcome.match(startConditionMessage()
-					.because("System property '" + CONFIG_SYSTEM_PROPERTY + "' is set."));
+					.because("System property '" + this.configSystemProperty + "' is set."));
 		}
 		return super.getResourceOutcome(context, metadata);
 	}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastServerConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastServerConfiguration.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.hazelcast;
+
+import java.io.IOException;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+
+/**
+ * Configuration for Hazelcast server.
+ *
+ * @author Stephane Nicoll
+ * @author Vedran Pavic
+ * @since 2.0.0
+ */
+class HazelcastServerConfiguration {
+
+	static final String CONFIG_SYSTEM_PROPERTY = "hazelcast.config";
+
+	@Configuration
+	@ConditionalOnMissingBean(Config.class)
+	@Conditional(ConfigAvailableCondition.class)
+	static class HazelcastServerConfigFileConfiguration {
+
+		@Bean
+		public HazelcastInstance hazelcastInstance(HazelcastProperties properties)
+				throws IOException {
+			Resource config = properties.resolveConfigLocation();
+			if (config != null) {
+				return HazelcastInstanceFactory.createHazelcastInstance(config);
+			}
+			return Hazelcast.newHazelcastInstance();
+		}
+
+	}
+
+	@Configuration
+	@ConditionalOnSingleCandidate(Config.class)
+	static class HazelcastServerConfigConfiguration {
+
+		@Bean
+		public HazelcastInstance hazelcastInstance(Config config) {
+			return HazelcastInstanceFactory.createHazelcastInstance(config);
+		}
+
+	}
+
+	/**
+	 * {@link HazelcastConfigResourceCondition} that checks if the
+	 * {@code spring.hazelcast.config} configuration key is defined.
+	 */
+	static class ConfigAvailableCondition extends HazelcastConfigResourceCondition {
+
+		ConfigAvailableCondition() {
+			super(CONFIG_SYSTEM_PROPERTY, "file:./hazelcast.xml",
+					"classpath:/hazelcast.xml");
+		}
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
@@ -49,12 +49,15 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.cache.support.MockCachingProvider;
 import org.springframework.boot.autoconfigure.hazelcast.HazelcastAutoConfiguration;
+import org.springframework.boot.junit.runner.classpath.ClassPathExclusions;
+import org.springframework.boot.junit.runner.classpath.ModifiedClassPathRunner;
 import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -91,6 +94,8 @@ import static org.mockito.Mockito.verify;
  * @author Stephane Nicoll
  * @author Eddú Meléndez
  */
+@RunWith(ModifiedClassPathRunner.class)
+@ClassPathExclusions("hazelcast-client-*.jar")
 public class CacheAutoConfigurationTests {
 
 	@Rule

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationServerTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationServerTests.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.hazelcast;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.QueueConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.junit.runner.classpath.ClassPathExclusions;
+import org.springframework.boot.junit.runner.classpath.ModifiedClassPathRunner;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link HazelcastAutoConfiguration}.
+ *
+ * @author Stephane Nicoll
+ */
+@RunWith(ModifiedClassPathRunner.class)
+@ClassPathExclusions("hazelcast-client-*.jar")
+public class HazelcastAutoConfigurationServerTests {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void closeContext() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void defaultConfigFile() throws IOException {
+		load(); // hazelcast.xml present in root classpath
+		HazelcastInstance hazelcastInstance = this.context
+				.getBean(HazelcastInstance.class);
+		assertThat(hazelcastInstance.getConfig().getConfigurationUrl())
+				.isEqualTo(new ClassPathResource("hazelcast.xml").getURL());
+	}
+
+	@Test
+	public void systemProperty() throws IOException {
+		System.setProperty(HazelcastServerConfiguration.CONFIG_SYSTEM_PROPERTY,
+				"classpath:org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.xml");
+		try {
+			load();
+			HazelcastInstance hazelcastInstance = this.context
+					.getBean(HazelcastInstance.class);
+			Map<String, QueueConfig> queueConfigs = hazelcastInstance.getConfig()
+					.getQueueConfigs();
+			assertThat(queueConfigs).hasSize(1).containsKey("foobar");
+		}
+		finally {
+			System.clearProperty(HazelcastServerConfiguration.CONFIG_SYSTEM_PROPERTY);
+		}
+	}
+
+	@Test
+	public void explicitConfigFile() throws IOException {
+		load("spring.hazelcast.config=org/springframework/boot/autoconfigure/hazelcast/"
+				+ "hazelcast-specific.xml");
+		HazelcastInstance hazelcastInstance = this.context
+				.getBean(HazelcastInstance.class);
+		assertThat(hazelcastInstance.getConfig().getConfigurationFile()).isEqualTo(
+				new ClassPathResource("org/springframework/boot/autoconfigure/hazelcast"
+						+ "/hazelcast-specific.xml").getFile());
+	}
+
+	@Test
+	public void explicitConfigUrl() throws IOException {
+		load("spring.hazelcast.config=hazelcast-default.xml");
+		HazelcastInstance hazelcastInstance = this.context
+				.getBean(HazelcastInstance.class);
+		assertThat(hazelcastInstance.getConfig().getConfigurationUrl())
+				.isEqualTo(new ClassPathResource("hazelcast-default.xml").getURL());
+	}
+
+	@Test
+	public void unknownConfigFile() {
+		this.thrown.expect(BeanCreationException.class);
+		this.thrown.expectMessage("foo/bar/unknown.xml");
+		load("spring.hazelcast.config=foo/bar/unknown.xml");
+	}
+
+	@Test
+	public void configInstanceWithName() {
+		Config config = new Config("my-test-instance");
+		HazelcastInstance existingHazelcastInstance = Hazelcast
+				.newHazelcastInstance(config);
+		try {
+			load(HazelcastConfigWithName.class,
+					"spring.hazelcast.config=this-is-ignored.xml");
+			HazelcastInstance hazelcastInstance = this.context
+					.getBean(HazelcastInstance.class);
+			assertThat(hazelcastInstance.getConfig().getInstanceName())
+					.isEqualTo("my-test-instance");
+			// Should reuse any existing instance by default.
+			assertThat(hazelcastInstance).isEqualTo(existingHazelcastInstance);
+		}
+		finally {
+			existingHazelcastInstance.shutdown();
+		}
+	}
+
+	@Test
+	public void configInstanceWithoutName() {
+		load(HazelcastConfigNoName.class, "spring.hazelcast.config=this-is-ignored.xml");
+		HazelcastInstance hazelcastInstance = this.context
+				.getBean(HazelcastInstance.class);
+		Map<String, QueueConfig> queueConfigs = hazelcastInstance.getConfig()
+				.getQueueConfigs();
+		assertThat(queueConfigs).hasSize(1).containsKey("another-queue");
+	}
+
+	private void load(String... environment) {
+		load(null, environment);
+	}
+
+	private void load(Class<?> config, String... environment) {
+		AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(applicationContext, environment);
+		if (config != null) {
+			applicationContext.register(config);
+		}
+		applicationContext.register(HazelcastAutoConfiguration.class);
+		applicationContext.refresh();
+		this.context = applicationContext;
+	}
+
+	@Configuration
+	static class HazelcastConfigWithName {
+
+		@Bean
+		public Config myHazelcastConfig() {
+			return new Config("my-test-instance");
+		}
+
+	}
+
+	@Configuration
+	static class HazelcastConfigNoName {
+
+		@Bean
+		public Config anotherHazelcastConfig() {
+			Config config = new Config();
+			config.addQueueConfig(new QueueConfig("another-queue"));
+			return config;
+		}
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-client-specific.xml
+++ b/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-client-specific.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.8.xsd">
+
+</hazelcast-client>


### PR DESCRIPTION
As discussed in #4918, this is a WIP effort on auto-configuration support for Hazelcast client.
Most of the parts should be covered by this PR, however the tricky part is auto-config prioritization between server and client modes and I'm not quite sure how to approach that (`HazelcastClientAutoConfigurationTests` are failing).

Hazelcast itself of course prefers client if both are available (see [`HazelcastCachingProvider` constructor](https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java#L80-L100) as an example) - this is why `CacheAutoConfigurationTests` required setting up `hazelcast.jcache.provider.type` once `hazelcast-client` was available on the classpath.

/cc @snicoll @neilstevenson