### PR TITLE
Fixes gh-5434

### DIFF
--- a/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessor.java
+++ b/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessor.java
@@ -20,7 +20,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -192,21 +191,12 @@ public class ConfigurationMetadataAnnotationProcessor extends AbstractProcessor 
 
 	private void processTypeElement(String prefix, TypeElement element,
 			ExecutableElement source) {
-		TypeElementMembers members = new TypeElementMembers(this.processingEnv, element);
-		Map<String, Object> fieldValues = getFieldValues(element);
+		TypeElementMembers members = new TypeElementMembers(this.processingEnv, this.fieldValuesParser, element);
+		Map<String, Object> fieldValues = members.getFieldValues();
 		processSimpleTypes(prefix, element, source, members, fieldValues);
 		processSimpleLombokTypes(prefix, element, source, members, fieldValues);
 		processNestedTypes(prefix, element, source, members);
 		processNestedLombokTypes(prefix, element, source, members);
-	}
-
-	private Map<String, Object> getFieldValues(TypeElement element) {
-		try {
-			return this.fieldValuesParser.getFieldValues(element);
-		}
-		catch (Exception ex) {
-			return Collections.emptyMap();
-		}
 	}
 
 	private void processSimpleTypes(String prefix, TypeElement element,

--- a/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -47,6 +47,7 @@ import org.springframework.boot.configurationsample.method.EmptyTypeMethodConfig
 import org.springframework.boot.configurationsample.method.InvalidMethodConfig;
 import org.springframework.boot.configurationsample.method.MethodAndClassConfig;
 import org.springframework.boot.configurationsample.method.SimpleMethodConfig;
+import org.springframework.boot.configurationsample.simple.ClassWithNestedProperties;
 import org.springframework.boot.configurationsample.simple.DeprecatedSingleProperty;
 import org.springframework.boot.configurationsample.simple.HierarchicalProperties;
 import org.springframework.boot.configurationsample.simple.NotAnnotated;
@@ -765,6 +766,17 @@ public class ConfigurationMetadataAnnotationProcessorTests {
 		finally {
 			writer.close();
 		}
+	}
+
+	@Test
+	public void nestedClassChildProperties() throws Exception {
+		ConfigurationMetadata metadata = compile(ClassWithNestedProperties.class);
+		assertThat(metadata).has(Metadata.withGroup("nestedChildProps")
+				.fromSource(ClassWithNestedProperties.NestedChildClass.class));
+		assertThat(metadata).has(Metadata.withProperty("nestedChildProps.child-class-property", Integer.class)
+				.fromSource(ClassWithNestedProperties.NestedChildClass.class).withDefaultValue(20));
+		assertThat(metadata).has(Metadata.withProperty("nestedChildProps.parent-class-property", Integer.class)
+				.fromSource(ClassWithNestedProperties.NestedChildClass.class).withDefaultValue(10));
 	}
 
 	private static class AdditionalMetadata {

--- a/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/ClassWithNestedProperties.java
+++ b/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/ClassWithNestedProperties.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.configurationsample.simple;
+
+import org.springframework.boot.configurationsample.ConfigurationProperties;
+
+/**
+ * Class with nested configuration properties.
+ *
+ * @author Hrishikesh Joshi
+ */
+public class ClassWithNestedProperties {
+
+	public static class NestedParentClass {
+
+		private int parentClassProperty = 10;
+
+		public int getParentClassProperty() {
+			return this.parentClassProperty;
+		}
+
+		public void setParentClassProperty(int parentClassProperty) {
+			this.parentClassProperty = parentClassProperty;
+		}
+	}
+
+	@ConfigurationProperties(prefix = "nestedChildProps")
+	public static class NestedChildClass extends NestedParentClass {
+
+		private int childClassProperty = 20;
+
+		public int getChildClassProperty() {
+			return this.childClassProperty;
+		}
+
+		public void setChildClassProperty(int childClassProperty) {
+			this.childClassProperty = childClassProperty;
+		}
+	}
+}


### PR DESCRIPTION
Fixes gh-5434 - while populating the fieldValues, the ClassTree returns members from the passed TypeElement, but not from its parent type.
- Moved the getFieldValues method to TypeElementMembers class and recursively fetched the members of the passed type element instance and its super types to get the field values.