### PR TITLE
Remove redundant toString() invocation

### DIFF
--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/archive/JarFileArchive.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/archive/JarFileArchive.java
@@ -219,7 +219,7 @@ public class JarFileArchive implements Archive {
 
 		@Override
 		public String getName() {
-			return this.jarEntry.getName().toString();
+			return this.jarEntry.getName();
 		}
 
 	}

--- a/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/archive/JarFileArchiveTests.java
+++ b/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/archive/JarFileArchiveTests.java
@@ -123,7 +123,7 @@ public class JarFileArchiveTests {
 	private Map<String, Archive.Entry> getEntriesMap(Archive archive) {
 		Map<String, Archive.Entry> entries = new HashMap<String, Archive.Entry>();
 		for (Archive.Entry entry : archive) {
-			entries.put(entry.getName().toString(), entry);
+			entries.put(entry.getName(), entry);
 		}
 		return entries;
 	}


### PR DESCRIPTION
Removes redundant toString invocation on String object in JarFileArchive and JarFileArchiveTests.