### PR TITLE
Add access to current trace to be abble to add some information of request execution

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/Trace.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/Trace.java
@@ -63,7 +63,7 @@ public final class Trace {
 		return ended;
 	}
 
-	void setEnded(Date ended) {
+	protected void setEnded(Date ended) {
 		this.ended = ended;
 	}
 

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/Trace.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/Trace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 
 package org.springframework.boot.actuate.trace;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.springframework.util.Assert;
+
 import java.util.Date;
 import java.util.Map;
-
-import org.springframework.util.Assert;
 
 /**
  * A value object representing a trace event: at a particular time with a simple (map)
@@ -27,22 +30,41 @@ import org.springframework.util.Assert;
  *
  * @author Dave Syer
  */
+@JsonInclude(Include.NON_NULL)
 public final class Trace {
 
-	private final Date timestamp;
+	private final String id;
+	private final Date started;
+	private Date ended;
 
 	private final Map<String, Object> info;
 
-	public Trace(Date timestamp, Map<String, Object> info) {
+	public Trace(String id, Date started, Map<String, Object> info) {
 		super();
-		Assert.notNull(timestamp, "Timestamp must not be null");
+		Assert.notNull(id, "Id must not be null");
+		Assert.notNull(started, "Timestamp must not be null");
 		Assert.notNull(info, "Info must not be null");
-		this.timestamp = timestamp;
+		this.id = id;
+		this.started = started;
 		this.info = info;
 	}
 
-	public Date getTimestamp() {
-		return this.timestamp;
+	public String getId() {
+		return id;
+	}
+
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssZ")
+	public Date getStarted() {
+		return this.started;
+	}
+
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssZ")
+	public Date getEnded() {
+		return ended;
+	}
+
+	void setEnded(Date ended) {
+		this.ended = ended;
 	}
 
 	public Map<String, Object> getInfo() {

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/TraceRepository.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/TraceRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,24 @@ public interface TraceRepository {
 	/**
 	 * Add a new {@link Trace} object at the current time.
 	 * @param traceInfo trace information
+	 * @throws IllegalStateException if trace associated with current thread
+	 * was not finished
 	 */
-	void add(Map<String, Object> traceInfo);
+	void add(String id, Map<String, Object> traceInfo);
 
+	/**
+	 * Returns started {@link Trace} associated with current thread.
+	 * @return trace
+	 * @throws IllegalStateException if any trace was not associated with current thread
+	 */
+	Trace current();
+
+	/**
+	 * Marks a {@link Trace} with trace identifier as finished and removes it
+	 * from the {@link #current()} holder.
+	 * @param id trace identifier
+	 * @throws IllegalStateException if any trace was not associated with current thread
+	 * or its identifier not match to the given
+	 */
+	void finish(String id);
 }

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/TraceEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/TraceEndpointTests.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.actuate.endpoint;
 
 import java.util.Collections;
-import java.util.UUID;
 
 import org.junit.Test;
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/TraceEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/TraceEndpointTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.actuate.endpoint;
 
 import java.util.Collections;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -43,6 +44,7 @@ public class TraceEndpointTests extends AbstractEndpointTests<TraceEndpoint> {
 	@Test
 	public void invoke() throws Exception {
 		Trace trace = getEndpointBean().invoke().get(0);
+		assertThat(trace.getId()).isEqualTo("trace-id");
 		assertThat(trace.getInfo().get("a")).isEqualTo("b");
 	}
 
@@ -53,7 +55,7 @@ public class TraceEndpointTests extends AbstractEndpointTests<TraceEndpoint> {
 		@Bean
 		public TraceEndpoint endpoint() {
 			TraceRepository repository = new InMemoryTraceRepository();
-			repository.add(Collections.<String, Object>singletonMap("a", "b"));
+			repository.add("trace-id", Collections.<String, Object>singletonMap("a", "b"));
 			return new TraceEndpoint(repository);
 		}
 	}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/InMemoryTraceRepositoryTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/InMemoryTraceRepositoryTests.java
@@ -18,7 +18,6 @@ package org.springframework.boot.actuate.trace;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 import org.junit.Test;
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/InMemoryTraceRepositoryTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/InMemoryTraceRepositoryTests.java
@@ -18,6 +18,7 @@ package org.springframework.boot.actuate.trace;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -35,26 +36,30 @@ public class InMemoryTraceRepositoryTests {
 	@Test
 	public void capacityLimited() {
 		this.repository.setCapacity(2);
-		this.repository.add(Collections.<String, Object>singletonMap("foo", "bar"));
-		this.repository.add(Collections.<String, Object>singletonMap("bar", "foo"));
-		this.repository.add(Collections.<String, Object>singletonMap("bar", "bar"));
+		this.repository.add("trace-1", Collections.<String, Object>singletonMap("foo", "bar"));
+		this.repository.add("trace-2", Collections.<String, Object>singletonMap("bar", "foo"));
+		this.repository.add("trace-3", Collections.<String, Object>singletonMap("bar", "bar"));
 		List<Trace> traces = this.repository.findAll();
 		assertThat(traces).hasSize(2);
 		assertThat(traces.get(0).getInfo().get("bar")).isEqualTo("bar");
+		assertThat(traces.get(0).getId()).isEqualTo("trace-3");
 		assertThat(traces.get(1).getInfo().get("bar")).isEqualTo("foo");
+		assertThat(traces.get(1).getId()).isEqualTo("trace-2");
 	}
 
 	@Test
 	public void reverseFalse() {
 		this.repository.setReverse(false);
 		this.repository.setCapacity(2);
-		this.repository.add(Collections.<String, Object>singletonMap("foo", "bar"));
-		this.repository.add(Collections.<String, Object>singletonMap("bar", "foo"));
-		this.repository.add(Collections.<String, Object>singletonMap("bar", "bar"));
+		this.repository.add("trace-1", Collections.<String, Object>singletonMap("foo", "bar"));
+		this.repository.add("trace-2", Collections.<String, Object>singletonMap("bar", "foo"));
+		this.repository.add("trace-3", Collections.<String, Object>singletonMap("bar", "bar"));
 		List<Trace> traces = this.repository.findAll();
 		assertThat(traces).hasSize(2);
 		assertThat(traces.get(1).getInfo().get("bar")).isEqualTo("bar");
+		assertThat(traces.get(1).getId()).isEqualTo("trace-3");
 		assertThat(traces.get(0).getInfo().get("bar")).isEqualTo("foo");
+		assertThat(traces.get(0).getId()).isEqualTo("trace-2");
 	}
 
 }


### PR DESCRIPTION
In our company we are saving some information (performed sqls, time spent on different request stages, etc.) inside of trace, so maybe it will be useful to someone else to have this abbility.

This PR adds unique identifier to each trace, adds trace information when request starts, which can be used if request stucks (maybe we should add status[executing, completed] to the trace info as well). For this reason I have replaced timestamp with two Date fields - started and ended. Also I've looked at https://github.com/spring-projects/spring-boot/pull/6579 and replaced timestamp with date pattern.
