### PR TITLE
Configure UserTypeResolver for Cassandra User-defined type support

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfiguration.java
@@ -45,6 +45,8 @@ import org.springframework.data.cassandra.core.CassandraAdminOperations;
 import org.springframework.data.cassandra.core.CassandraTemplate;
 import org.springframework.data.cassandra.mapping.BasicCassandraMappingContext;
 import org.springframework.data.cassandra.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.mapping.SimpleUserTypeResolver;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Spring Data's Cassandra support.
@@ -88,6 +90,10 @@ public class CassandraDataAutoConfiguration {
 		}
 		if (!packages.isEmpty()) {
 			context.setInitialEntitySet(CassandraEntityClassScanner.scan(packages));
+		}
+		if (StringUtils.hasText(this.properties.getKeyspaceName())) {
+			context.setUserTypeResolver(new SimpleUserTypeResolver(this.cluster,
+					this.properties.getKeyspaceName()));
 		}
 		return context;
 	}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfigurationTests.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfigurati
 import org.springframework.boot.autoconfigure.cassandra.CassandraAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.cassandra.city.City;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -33,6 +34,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.data.cassandra.core.CassandraTemplate;
 import org.springframework.data.cassandra.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.mapping.SimpleUserTypeResolver;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,6 +44,7 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link CassandraDataAutoConfiguration}
  *
  * @author Eddú Meléndez
+ * @author Mark Paluch
  */
 public class CassandraDataAutoConfigurationTests {
 
@@ -57,6 +60,8 @@ public class CassandraDataAutoConfigurationTests {
 	@Test
 	public void templateExists() {
 		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.data.cassandra.keyspaceName:boot_test");
 		this.context.register(TestExcludeConfiguration.class, TestConfiguration.class,
 				PropertyPlaceholderAutoConfiguration.class,
 				CassandraAutoConfiguration.class, CassandraDataAutoConfiguration.class);
@@ -69,6 +74,8 @@ public class CassandraDataAutoConfigurationTests {
 	@SuppressWarnings("unchecked")
 	public void entityScanShouldSetInitialEntitySet() throws Exception {
 		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.data.cassandra.keyspaceName:boot_test");
 		this.context.register(TestConfiguration.class, EntityScanConfig.class,
 				PropertyPlaceholderAutoConfiguration.class,
 				CassandraAutoConfiguration.class, CassandraDataAutoConfiguration.class);
@@ -78,6 +85,21 @@ public class CassandraDataAutoConfigurationTests {
 		Set<Class<?>> initialEntitySet = (Set<Class<?>>) ReflectionTestUtils
 				.getField(mappingContext, "initialEntitySet");
 		assertThat(initialEntitySet).containsOnly(City.class);
+	}
+
+	@Test
+	public void userTypeResolverShouldBeSet() throws Exception {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.data.cassandra.keyspaceName:boot_test");
+		this.context.register(TestConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class,
+				CassandraAutoConfiguration.class, CassandraDataAutoConfiguration.class);
+		this.context.refresh();
+		CassandraMappingContext mappingContext = this.context
+				.getBean(CassandraMappingContext.class);
+		assertThat(ReflectionTestUtils.getField(mappingContext, "userTypeResolver"))
+				.isInstanceOf(SimpleUserTypeResolver.class);
 	}
 
 	@Configuration


### PR DESCRIPTION
Configure `SimpleUserTypeResolver` in `BasicCassandraMappingContext` if a keyspace is set to resolve User-defined types.

----

User-defined type support will be available as of `Ingalls-RC1` and is already part of `Ingalls-BUILD-SNAPSHOT`.
