### PR TITLE
Remove redundant toString() invocation

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/BasicErrorControllerIntegrationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/BasicErrorControllerIntegrationTests.java
@@ -182,7 +182,7 @@ public class BasicErrorControllerIntegrationTests {
 				.accept(MediaType.TEXT_HTML).build();
 		ResponseEntity<String> entity = new TestRestTemplate().exchange(request,
 				String.class);
-		String resp = entity.getBody().toString();
+		String resp = entity.getBody();
 		assertThat(resp).contains("We are out of storage");
 	}
 

--- a/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/archive/ExplodedArchiveTests.java
+++ b/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/archive/ExplodedArchiveTests.java
@@ -190,7 +190,7 @@ public class ExplodedArchiveTests {
 	private Map<String, Archive.Entry> getEntriesMap(Archive archive) {
 		Map<String, Archive.Entry> entries = new HashMap<String, Archive.Entry>();
 		for (Archive.Entry entry : archive) {
-			entries.put(entry.getName().toString(), entry);
+			entries.put(entry.getName(), entry);
 		}
 		return entries;
 	}


### PR DESCRIPTION
Fixes the two last redundant toString invocations