### PR TITLE
Quote $jarfile in -jar command.

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -133,7 +133,7 @@ else
     exit 1
 fi
 
-arguments=(-Dsun.misc.URLClassPath.disableJarChecking=true $JAVA_OPTS -jar $jarfile $RUN_ARGS "$@")
+arguments=(-Dsun.misc.URLClassPath.disableJarChecking=true $JAVA_OPTS -jar "$jarfile" $RUN_ARGS "$@")
 
 # Action functions
 start() {


### PR DESCRIPTION
If the pathname of fully executable contains any space characters, the launch script will failed to locate the jar file like:
`Error: Unable to access jarfile /Users/tang/My `

This patch fix this issue by quoting the jarfile when invoking java process.