### PR TITLE
Add debug logging for matching URLs in spring-devtools.properties

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/ChangeableUrls.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/ChangeableUrls.java
@@ -22,6 +22,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -29,6 +30,9 @@ import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.boot.devtools.settings.DevToolsSettings;
 import org.springframework.util.StringUtils;
@@ -41,6 +45,8 @@ import org.springframework.util.StringUtils;
  */
 final class ChangeableUrls implements Iterable<URL> {
 
+	private static final Log logger = LogFactory.getLog(ChangeableUrls.class);
+
 	private final List<URL> urls;
 
 	private ChangeableUrls(URL... urls) {
@@ -52,6 +58,11 @@ final class ChangeableUrls implements Iterable<URL> {
 				reloadableUrls.add(url);
 			}
 		}
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("Matching URLs for reloading : " + Arrays.toString(reloadableUrls.toArray()));
+		}
+
 		this.urls = Collections.unmodifiableList(reloadableUrls);
 	}
 

--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/settings/DevToolsSettings.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/settings/DevToolsSettings.java
@@ -18,11 +18,15 @@ package org.springframework.boot.devtools.settings;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.core.io.UrlResource;
 import org.springframework.core.io.support.PropertiesLoaderUtils;
@@ -39,6 +43,8 @@ public class DevToolsSettings {
 	 * The location to look for settings properties. Can be present in multiple JAR files.
 	 */
 	public static final String SETTINGS_RESOURCE_LOCATION = "META-INF/spring-devtools.properties";
+
+	private static final Log logger = LogFactory.getLog(DevToolsSettings.class);
 
 	private static DevToolsSettings settings;
 
@@ -85,6 +91,12 @@ public class DevToolsSettings {
 		return false;
 	}
 
+	private static void logMessage(String message) {
+		if (logger.isDebugEnabled()) {
+			logger.debug(message);
+		}
+	}
+
 	public static DevToolsSettings get() {
 		if (settings == null) {
 			settings = load();
@@ -105,6 +117,10 @@ public class DevToolsSettings {
 				settings.add(PropertiesLoaderUtils
 						.loadProperties(new UrlResource(urls.nextElement())));
 			}
+
+			logMessage("Included patterns for restart : " + Arrays.toString(settings.restartIncludePatterns.toArray()));
+			logMessage("Excluded patterns for restart : " + Arrays.toString(settings.restartExcludePatterns.toArray()));
+
 			return settings;
 		}
 		catch (Exception ex) {


### PR DESCRIPTION
When specifying jar files to include `/` exclude in the `spring-devtools.properties` file, it is not clear whether the property is being applied properly or not. A subtle mistake in the syntax of the a regex can mean that a property is not applied as expected. It is very difficult to figure out if this is the case.

Some debugging statements in `DevToolSettings` and `ChangeableUrls` would really, really help.

 ---
Adds debug logging in ChangeableUrls and DevToolsSettings for the included and excluded URL patterns and matching URLs.