### PR TITLE
INIT INFO Required Start/Stop as embedded launch script properties

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/deployment.adoc
+++ b/spring-boot-docs/src/main/asciidoc/deployment.adoc
@@ -598,6 +598,12 @@ The following property substitutions are supported with the default script:
 |The `Provides` section of "`INIT INFO`". Defaults to `spring-boot-application` for Gradle
  and to `${project.artifactId}` for Maven.
 
+|`initInfoRequiredStart`
+|The `Required-Start` section of "`INIT INFO`". Defaults to `$remote_fs $syslog $network`.
+
+|`initInfoRequiredStop`
+|The `Required-Stop` section of "`INIT INFO`". Defaults to `$remote_fs $syslog $network`.
+
 |`initInfoShortDescription`
 |The `Short-Description` section of "`INIT INFO`". Defaults to `Spring Boot Application`
 for Gradle and to `${project.name}` for Maven.

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -11,8 +11,8 @@
 
 ### BEGIN INIT INFO
 # Provides:          {{initInfoProvides:spring-boot-application}}
-# Required-Start:    $remote_fs $syslog $network
-# Required-Stop:     $remote_fs $syslog $network
+# Required-Start:    {{initInfoRequiredStart:$remote_fs $syslog $network}}
+# Required-Stop:     {{initInfoRequiredStop:$remote_fs $syslog $network}}
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: {{initInfoShortDescription:Spring Boot Application}}

--- a/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/DefaultLaunchScriptTests.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/DefaultLaunchScriptTests.java
@@ -62,6 +62,16 @@ public class DefaultLaunchScriptTests {
 	}
 
 	@Test
+	public void initInfoRequiredStartCanBeReplaced() throws Exception {
+		assertThatPlaceholderCanBeReplaced("initInfoRequiredStart");
+	}
+
+	@Test
+	public void initInfoRequiredStopCanBeReplaced() throws Exception {
+		assertThatPlaceholderCanBeReplaced("initInfoRequiredStop");
+	}
+
+	@Test
 	public void initInfoShortDescriptionCanBeReplaced() throws Exception {
 		assertThatPlaceholderCanBeReplaced("initInfoShortDescription");
 	}


### PR DESCRIPTION
This PR exposes the `Required-Start` and `Require-Stop` lines in the launch script `INIT INFO` section as customizable embedded launch script properties.

This way one can express dependencies from other init services by simply changing the configuration in the build script.