### PR TITLE
Support externalized properties for spring transaction manager

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BasicBatchConfigurer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BasicBatchConfigurer.java
@@ -30,6 +30,7 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.support.SimpleJobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
+import org.springframework.boot.autoconfigure.transaction.TransactionProperties;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.stereotype.Component;
@@ -41,6 +42,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Dave Syer
  * @author Andy Wilkinson
+ * @author Kazuki Shimizu
  */
 @Component
 public class BasicBatchConfigurer implements BatchConfigurer {
@@ -48,6 +50,8 @@ public class BasicBatchConfigurer implements BatchConfigurer {
 	private static final Log logger = LogFactory.getLog(BasicBatchConfigurer.class);
 
 	private final BatchProperties properties;
+
+	private final TransactionProperties transactionProperties;
 
 	private final DataSource dataSource;
 
@@ -64,21 +68,24 @@ public class BasicBatchConfigurer implements BatchConfigurer {
 	/**
 	 * Create a new {@link BasicBatchConfigurer} instance.
 	 * @param properties the batch properties
+	 * @param transactionProperties the transaction properties
 	 * @param dataSource the underlying data source
 	 */
-	protected BasicBatchConfigurer(BatchProperties properties, DataSource dataSource) {
-		this(properties, dataSource, null);
+	protected BasicBatchConfigurer(BatchProperties properties, TransactionProperties transactionProperties, DataSource dataSource) {
+		this(properties, transactionProperties, dataSource, null);
 	}
 
 	/**
 	 * Create a new {@link BasicBatchConfigurer} instance.
 	 * @param properties the batch properties
+	 * @param transactionProperties the transaction properties
 	 * @param dataSource the underlying data source
 	 * @param entityManagerFactory the entity manager factory (or {@code null})
 	 */
-	protected BasicBatchConfigurer(BatchProperties properties, DataSource dataSource,
+	protected BasicBatchConfigurer(BatchProperties properties, TransactionProperties transactionProperties, DataSource dataSource,
 			EntityManagerFactory entityManagerFactory) {
 		this.properties = properties;
+		this.transactionProperties = transactionProperties;
 		this.entityManagerFactory = entityManagerFactory;
 		this.dataSource = dataSource;
 	}
@@ -152,10 +159,15 @@ public class BasicBatchConfigurer implements BatchConfigurer {
 	}
 
 	protected PlatformTransactionManager createTransactionManager() {
+		PlatformTransactionManager txManager;
 		if (this.entityManagerFactory != null) {
-			return new JpaTransactionManager(this.entityManagerFactory);
+			txManager = new JpaTransactionManager(this.entityManagerFactory);
 		}
-		return new DataSourceTransactionManager(this.dataSource);
+		else {
+			txManager = new DataSourceTransactionManager(this.dataSource);
+		}
+		this.transactionProperties.applyTo(txManager);
+		return txManager;
 	}
 
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScanPackages;
+import org.springframework.boot.autoconfigure.transaction.TransactionProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -46,12 +47,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
  * @author Josh Long
  * @author Vince Bickers
  * @author Stephane Nicoll
+ * @author Kazuki Shimizu
  * @since 1.4.0
  */
 @Configuration
-@ConditionalOnClass(SessionFactory.class)
+@ConditionalOnClass({SessionFactory.class, PlatformTransactionManager.class})
 @ConditionalOnMissingBean(SessionFactory.class)
-@EnableConfigurationProperties(Neo4jProperties.class)
+@EnableConfigurationProperties({Neo4jProperties.class, TransactionProperties.class})
 @SuppressWarnings("deprecation")
 public class Neo4jDataAutoConfiguration {
 
@@ -75,8 +77,11 @@ public class Neo4jDataAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(PlatformTransactionManager.class)
-	public Neo4jTransactionManager transactionManager(SessionFactory sessionFactory) {
-		return new Neo4jTransactionManager(sessionFactory);
+	public Neo4jTransactionManager transactionManager(SessionFactory sessionFactory,
+			TransactionProperties transactionProperties) {
+		Neo4jTransactionManager transactionManager = new Neo4jTransactionManager(sessionFactory);
+		transactionProperties.applyTo(transactionManager);
+		return transactionManager;
 	}
 
 	private String[] getPackagesToScan(ApplicationContext applicationContext) {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
@@ -23,6 +23,8 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
+import org.springframework.boot.autoconfigure.transaction.TransactionProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -39,6 +41,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  * @author Dave Syer
  * @author Stephane Nicoll
  * @author Andy Wilkinson
+ * @author Kazuki Shimizu
  */
 @Configuration
 @ConditionalOnClass({ JdbcTemplate.class, PlatformTransactionManager.class })
@@ -47,6 +50,7 @@ public class DataSourceTransactionManagerAutoConfiguration {
 
 	@Configuration
 	@ConditionalOnSingleCandidate(DataSource.class)
+	@EnableConfigurationProperties(TransactionProperties.class)
 	static class DataSourceTransactionManagerConfiguration {
 
 		private final DataSource dataSource;
@@ -57,8 +61,10 @@ public class DataSourceTransactionManagerAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(PlatformTransactionManager.class)
-		public DataSourceTransactionManager transactionManager() {
-			return new DataSourceTransactionManager(this.dataSource);
+		public DataSourceTransactionManager transactionManager(TransactionProperties transactionProperties) {
+			DataSourceTransactionManager transactionManager = new DataSourceTransactionManager(this.dataSource);
+			transactionProperties.applyTo(transactionManager);
+			return transactionManager;
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/JpaBaseConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/JpaBaseConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScanPackages;
+import org.springframework.boot.autoconfigure.transaction.TransactionProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
@@ -59,8 +60,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
  * @author Dave Syer
  * @author Oliver Gierke
  * @author Andy Wilkinson
+ * @author Kazuki Shimizu
  */
-@EnableConfigurationProperties(JpaProperties.class)
+@EnableConfigurationProperties({JpaProperties.class, TransactionProperties.class})
 @Import(DataSourceInitializedPublisher.Registrar.class)
 public abstract class JpaBaseConfiguration implements BeanFactoryAware {
 
@@ -81,8 +83,10 @@ public abstract class JpaBaseConfiguration implements BeanFactoryAware {
 
 	@Bean
 	@ConditionalOnMissingBean(PlatformTransactionManager.class)
-	public PlatformTransactionManager transactionManager() {
-		return new JpaTransactionManager();
+	public PlatformTransactionManager transactionManager(TransactionProperties transactionProperties) {
+		JpaTransactionManager transactionManager = new JpaTransactionManager();
+		transactionProperties.applyTo(transactionManager);
+		return transactionManager;
 	}
 
 	@Bean

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/transaction/TransactionProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/transaction/TransactionProperties.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.transaction;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.AbstractPlatformTransactionManager;
+
+/**
+ * External configuration properties for a {@link org.springframework.transaction.PlatformTransactionManager} created by
+ * Spring. All {@literal spring.transaction.} properties are also applied to the {@code PlatformTransactionManager}.
+ *
+ * @author Kazuki Shimizu
+ * @since 1.5.0
+ */
+@ConfigurationProperties(prefix = "spring.transaction")
+public class TransactionProperties {
+
+	/**
+	 * The default transaction timeout (sec).
+	 */
+	private Integer defaultTimeout;
+
+	/**
+	 * The indicating flag whether perform the rollback processing on commit failure (If perform rollback, set to the true).
+	 */
+	private Boolean rollbackOnCommitFailure;
+
+	public Integer getDefaultTimeout() {
+		return this.defaultTimeout;
+	}
+
+	public void setDefaultTimeout(Integer defaultTimeout) {
+		this.defaultTimeout = defaultTimeout;
+	}
+
+	public Boolean getRollbackOnCommitFailure() {
+		return this.rollbackOnCommitFailure;
+	}
+
+	public void setRollbackOnCommitFailure(Boolean rollbackOnCommitFailure) {
+		this.rollbackOnCommitFailure = rollbackOnCommitFailure;
+	}
+
+	/**
+	 * Apply all transaction custom properties to a specified {@link PlatformTransactionManager} instance.
+	 *
+	 * @param transactionManager the target transaction manager
+	 * @see AbstractPlatformTransactionManager#setDefaultTimeout(int)
+	 * @see AbstractPlatformTransactionManager#setRollbackOnCommitFailure(boolean)
+	 */
+	public void applyTo(PlatformTransactionManager transactionManager) {
+		if (transactionManager instanceof AbstractPlatformTransactionManager) {
+			AbstractPlatformTransactionManager abstractPlatformTransactionManager =
+					(AbstractPlatformTransactionManager) transactionManager;
+			if (this.defaultTimeout != null) {
+				abstractPlatformTransactionManager.setDefaultTimeout(this.defaultTimeout);
+			}
+			if (this.rollbackOnCommitFailure != null) {
+				abstractPlatformTransactionManager.setRollbackOnCommitFailure(this.rollbackOnCommitFailure);
+			}
+		}
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/transaction/jta/BitronixJtaConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/transaction/jta/BitronixJtaConfiguration.java
@@ -28,7 +28,9 @@ import bitronix.tm.jndi.BitronixContext;
 import org.springframework.boot.ApplicationHome;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.transaction.TransactionProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.jta.XAConnectionFactoryWrapper;
 import org.springframework.boot.jta.XADataSourceWrapper;
 import org.springframework.boot.jta.bitronix.BitronixDependentBeanFactoryPostProcessor;
@@ -46,17 +48,21 @@ import org.springframework.util.StringUtils;
  * @author Josh Long
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Kazuki Shimizu
  * @since 1.2.0
  */
 @Configuration
+@EnableConfigurationProperties({JtaProperties.class, TransactionProperties.class})
 @ConditionalOnClass({ JtaTransactionManager.class, BitronixContext.class })
 @ConditionalOnMissingBean(PlatformTransactionManager.class)
 class BitronixJtaConfiguration {
 
 	private final JtaProperties jtaProperties;
+	private final TransactionProperties transactionProperties;
 
-	BitronixJtaConfiguration(JtaProperties jtaProperties) {
+	BitronixJtaConfiguration(JtaProperties jtaProperties, TransactionProperties transactionProperties) {
 		this.jtaProperties = jtaProperties;
+		this.transactionProperties = transactionProperties;
 	}
 
 	@Bean
@@ -105,7 +111,9 @@ class BitronixJtaConfiguration {
 	@Bean
 	public JtaTransactionManager transactionManager(
 			TransactionManager transactionManager) {
-		return new JtaTransactionManager(transactionManager);
+		JtaTransactionManager jtaTransactionManager = new JtaTransactionManager(transactionManager);
+		this.transactionProperties.applyTo(jtaTransactionManager);
+		return jtaTransactionManager;
 	}
 
 	@ConditionalOnClass(Message.class)

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/transaction/jta/JndiJtaConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/transaction/jta/JndiJtaConfiguration.java
@@ -19,6 +19,8 @@ package org.springframework.boot.autoconfigure.transaction.jta;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnJndi;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.transaction.TransactionProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -30,6 +32,7 @@ import org.springframework.transaction.jta.JtaTransactionManager;
  *
  * @author Phillip Webb
  * @author Stephane Nicoll
+ * @author Kazuki Shimizu
  * @since 1.2.0
  */
 @Configuration
@@ -38,11 +41,20 @@ import org.springframework.transaction.jta.JtaTransactionManager;
 		"java:comp/TransactionManager", "java:appserver/TransactionManager",
 		"java:pm/TransactionManager", "java:/TransactionManager" })
 @ConditionalOnMissingBean(PlatformTransactionManager.class)
+@EnableConfigurationProperties(TransactionProperties.class)
 class JndiJtaConfiguration {
+
+	private final TransactionProperties transactionProperties;
+
+	JndiJtaConfiguration(TransactionProperties transactionProperties) {
+		this.transactionProperties = transactionProperties;
+	}
 
 	@Bean
 	public JtaTransactionManager transactionManager() {
-		return new JtaTransactionManagerFactoryBean().getObject();
+		JtaTransactionManager transactionManager = new JtaTransactionManagerFactoryBean().getObject();
+		this.transactionProperties.applyTo(transactionManager);
+		return transactionManager;
 	}
 
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/transaction/jta/NarayanaJtaConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/transaction/jta/NarayanaJtaConfiguration.java
@@ -28,6 +28,8 @@ import org.jboss.tm.XAResourceRecoveryRegistry;
 import org.springframework.boot.ApplicationHome;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.transaction.TransactionProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.jta.XAConnectionFactoryWrapper;
 import org.springframework.boot.jta.XADataSourceWrapper;
 import org.springframework.boot.jta.narayana.NarayanaBeanFactoryPostProcessor;
@@ -47,18 +49,22 @@ import org.springframework.util.StringUtils;
  * JTA Configuration for <a href="http://narayana.io/">Narayana</a>.
  *
  * @author Gytis Trikleris
+ * @author Kazuki Shimizu
  * @since 1.4.0
  */
 @Configuration
 @ConditionalOnClass({ JtaTransactionManager.class,
 		com.arjuna.ats.jta.UserTransaction.class, XAResourceRecoveryRegistry.class })
 @ConditionalOnMissingBean(PlatformTransactionManager.class)
+@EnableConfigurationProperties({JtaProperties.class, TransactionProperties.class})
 public class NarayanaJtaConfiguration {
 
 	private final JtaProperties jtaProperties;
+	private final TransactionProperties transactionProperties;
 
-	public NarayanaJtaConfiguration(JtaProperties jtaProperties) {
+	public NarayanaJtaConfiguration(JtaProperties jtaProperties, TransactionProperties transactionProperties) {
 		this.jtaProperties = jtaProperties;
+		this.transactionProperties = transactionProperties;
 	}
 
 	@Bean
@@ -116,7 +122,9 @@ public class NarayanaJtaConfiguration {
 	@Bean
 	public JtaTransactionManager transactionManager(UserTransaction userTransaction,
 			TransactionManager transactionManager) {
-		return new JtaTransactionManager(userTransaction, transactionManager);
+		JtaTransactionManager jtaTransactionManager = new JtaTransactionManager(userTransaction, transactionManager);
+		this.transactionProperties.applyTo(jtaTransactionManager);
+		return jtaTransactionManager;
 	}
 
 	@Bean

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfigurationTests.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.neo4j.mapping.Neo4jMappingContext;
 import org.springframework.data.neo4j.template.Neo4jOperations;
+import org.springframework.data.neo4j.transaction.Neo4jTransactionManager;
 import org.springframework.data.neo4j.web.support.OpenSessionInViewInterceptor;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
@@ -67,8 +68,19 @@ public class Neo4jDataAutoConfigurationTests {
 				.hasSize(1);
 		assertThat(this.context.getBeansOfType(SessionFactory.class)).hasSize(1);
 		assertThat(this.context.getBeansOfType(Neo4jOperations.class)).hasSize(1);
+		assertThat(this.context.getBeansOfType(Neo4jTransactionManager.class)).hasSize(1);
 		assertThat(this.context.getBeansOfType(OpenSessionInViewInterceptor.class))
 				.isEmpty();
+	}
+
+	@Test
+	public void customNeo4jTransactionManagerUsingProperties() {
+		load(null,
+				"spring.transaction.default-timeout=30",
+				"spring.transaction.rollback-on-commit-failure:true");
+		Neo4jTransactionManager transactionManager = this.context.getBean(Neo4jTransactionManager.class);
+		assertThat(transactionManager.getDefaultTimeout()).isEqualTo(30);
+		assertThat(transactionManager.isRollbackOnCommitFailure()).isTrue();
 	}
 
 	@Test

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfigurationTests.java
@@ -20,6 +20,7 @@ import javax.sql.DataSource;
 
 import org.junit.Test;
 
+import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -104,6 +105,19 @@ public class DataSourceTransactionManagerAutoConfigurationTests {
 		assertThat(this.context.getBean(DataSourceTransactionManager.class)).isNotNull();
 		assertThat(this.context.getBean(AbstractTransactionManagementConfiguration.class))
 				.isNotNull();
+	}
+
+	@Test
+	public void testCustomizeDataSourceTransactionManagerUsingProperties() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.transaction.default-timeout:30",
+				"spring.transaction.rollback-on-commit-failure:true");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				DataSourceTransactionManagerAutoConfiguration.class);
+		this.context.refresh();
+		DataSourceTransactionManager transactionManager = this.context.getBean(DataSourceTransactionManager.class);
+		assertThat(transactionManager.getDefaultTimeout()).isEqualTo(30);
+		assertThat(transactionManager.isRollbackOnCommitFailure()).isTrue();
 	}
 
 	@EnableTransactionManagement

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfigurationTests.java
@@ -38,6 +38,7 @@ import org.springframework.boot.autoconfigure.transaction.jta.JtaAutoConfigurati
 import org.springframework.boot.orm.jpa.hibernate.SpringJtaPlatform;
 import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -169,6 +170,18 @@ public class HibernateJpaAutoConfigurationTests
 				.getJpaPropertyMap();
 		assertThat((String) jpaPropertyMap.get("hibernate.transaction.jta.platform"))
 				.isEqualTo(TestJtaPlatform.class.getName());
+	}
+
+	@Test
+	public void testCustomJpaTransactionManagerUsingProperties() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.transaction.default-timeout:30",
+				"spring.transaction.rollback-on-commit-failure:true");
+		setupTestConfiguration();
+		this.context.refresh();
+		JpaTransactionManager transactionManager = context.getBean(JpaTransactionManager.class);
+		assertThat(transactionManager.getDefaultTimeout()).isEqualTo(30);
+		assertThat(transactionManager.isRollbackOnCommitFailure()).isTrue();
 	}
 
 	public static class TestJtaPlatform implements JtaPlatform {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/transaction/jta/JtaAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/transaction/jta/JtaAutoConfigurationTests.java
@@ -245,6 +245,32 @@ public class JtaAutoConfigurationTests {
 		assertThat(dataSource.getMaxPoolSize()).isEqualTo(10);
 	}
 
+	@Test
+	public void atomikosCustomizeJtaTransactionManagerUsingProperties() throws Exception {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.transaction.default-timeout:30",
+				"spring.transaction.rollback-on-commit-failure:true");
+		this.context.register(AtomikosJtaConfiguration.class);
+		this.context.refresh();
+		JtaTransactionManager transactionManager = this.context.getBean(JtaTransactionManager.class);
+		assertThat(transactionManager.getDefaultTimeout()).isEqualTo(30);
+		assertThat(transactionManager.isRollbackOnCommitFailure()).isTrue();
+	}
+
+	@Test
+	public void bitronixCustomizeJtaTransactionManagerUsingProperties() throws Exception {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.transaction.default-timeout:30",
+				"spring.transaction.rollback-on-commit-failure:true");
+		this.context.register(BitronixJtaConfiguration.class);
+		this.context.refresh();
+		JtaTransactionManager transactionManager = this.context.getBean(JtaTransactionManager.class);
+		assertThat(transactionManager.getDefaultTimeout()).isEqualTo(30);
+		assertThat(transactionManager.isRollbackOnCommitFailure()).isTrue();
+	}
+
 	@Configuration
 	@EnableConfigurationProperties(JtaProperties.class)
 	public static class JtaPropertiesConfiguration {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

I will submit a feature request that support externalized properties for spring transaction manager. In this request, following properties are supported.

* **defaultTimeout** (This setting is useful to prevent a long running transaction by default)
* **rollbackOnCommitFailure** (e.g. when it use on the Oracle, this setting should be set to the `true` because the Oracle perform implicit commit when close a connection)

e.g. )

```properties
spring.transaction.default-timeout=60
spring.transaction.rollback-on-commit-failure=true
```

What do you think about this request ?
