### PR TITLE
Auto-configure HikariCP's Dropwizard metrics support

### DIFF
--- a/spring-boot-actuator/pom.xml
+++ b/spring-boot-actuator/pom.xml
@@ -265,6 +265,11 @@
 		</dependency>
 		<dependency>
 			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP-java6</artifactId>
 			<optional>true</optional>
 		</dependency>


### PR DESCRIPTION
Set the Dropwizard MetricRegistry to be used with the HikariDataSource bean, if both are present. This will register a variety of metrics[1] about the connection pool state.

[1] https://github.com/brettwooldridge/HikariCP/wiki/Dropwizard-Metrics

Resolves #2528

This will set the `MetricRegistry` regardless of whether it is a user-created or auto-configured `HikariDataSource` bean. I wasn't sure if this is the desired behavior or not. Would it be better to offer a property to toggle this behavior?

Also, logs like the following appear, and I'm not sure if they are something to be concerned about:

```
2016-12-06 23:12:45.452  INFO   --- [           main] trationDelegate$BeanPostProcessorChecker : Bean 'metricsDropwizardAutoConfiguration' of type [class org.springframework.boot.actuate.autoconfigure.MetricsDropwizardAutoConfiguration$$EnhancerBySpringCGLIB$$e731d9a6] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
2016-12-06 23:12:45.490  INFO   --- [           main] trationDelegate$BeanPostProcessorChecker : Bean 'metricRegistry' of type [class com.codahale.metrics.MetricRegistry] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
```