### PR TITLE
Update production-ready-features.adoc

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -1378,7 +1378,7 @@ writes a PID file. Example:
 [indent=0]
 ----
 	org.springframework.context.ApplicationListener=\
-	org.springframework.boot.actuate.system.ApplicationPidFileWriter,
+	org.springframework.boot.actuate.system.ApplicationPidFileWriter,\
 	org.springframework.boot.actuate.system.EmbeddedServerPortFileWriter
 ----
 


### PR DESCRIPTION
Fix broke source code snippet:
Replace line break with missing line fold "\\\n" to continue the property value