### PR TITLE
Add TestNG support in TestTypeExcludeFilter

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -174,6 +174,7 @@
 		<sqlite-jdbc.version>3.8.11.2</sqlite-jdbc.version>
 		<statsd-client.version>3.1.0</statsd-client.version>
 		<sun-mail.version>${javax-mail.version}</sun-mail.version>
+		<testng.version>6.10</testng.version>
 		<thymeleaf.version>2.1.5.RELEASE</thymeleaf.version>
 		<thymeleaf-extras-springsecurity4.version>2.1.2.RELEASE</thymeleaf-extras-springsecurity4.version>
 		<thymeleaf-extras-conditionalcomments.version>2.1.2.RELEASE</thymeleaf-extras-conditionalcomments.version>
@@ -2342,6 +2343,11 @@
 				<groupId>org.xerial</groupId>
 				<artifactId>sqlite-jdbc</artifactId>
 				<version>${sqlite-jdbc.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.testng</groupId>
+				<artifactId>testng</artifactId>
+				<version>${testng.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.thymeleaf</groupId>

--- a/spring-boot-test/pom.xml
+++ b/spring-boot-test/pom.xml
@@ -154,6 +154,11 @@
 			<artifactId>spring-webmvc</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.testng</groupId>
+			<artifactId>testng</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-boot-test/src/main/java/org/springframework/boot/test/context/filter/TestTypeExcludeFilter.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/context/filter/TestTypeExcludeFilter.java
@@ -31,9 +31,9 @@ import org.springframework.core.type.classreading.MetadataReaderFactory;
  */
 class TestTypeExcludeFilter extends TypeExcludeFilter {
 
-	private static final String[] CLASS_ANNOTATIONS = { "org.junit.runner.RunWith" };
+	private static final String[] CLASS_ANNOTATIONS = { "org.junit.runner.RunWith", "org.testng.annotations.Test" };
 
-	private static final String[] METHOD_ANNOTATIONS = { "org.junit.Test" };
+	private static final String[] METHOD_ANNOTATIONS = { "org.junit.Test", "org.testng.annotations.Test" };
 
 	@Override
 	public boolean match(MetadataReader metadataReader,

--- a/spring-boot-test/src/test/java/org/springframework/boot/test/context/filter/AbstractTestNG.java
+++ b/spring-boot-test/src/test/java/org/springframework/boot/test/context/filter/AbstractTestNG.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.context.filter;
+
+import org.testng.annotations.Test;
+
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Abstract test with nest {@code @Configuration} and {@code @Test} used by
+ * {@link TestTypeExcludeFilter}.
+ *
+ * @author Eddú Meléndez
+ */
+@Test
+public abstract class AbstractTestNG {
+
+	@Configuration
+	static class Config {
+
+	}
+
+}

--- a/spring-boot-test/src/test/java/org/springframework/boot/test/context/filter/TestTypeExcludeFilterTests.java
+++ b/spring-boot-test/src/test/java/org/springframework/boot/test/context/filter/TestTypeExcludeFilterTests.java
@@ -70,6 +70,13 @@ public class TestTypeExcludeFilterTests {
 				this.metadataReaderFactory)).isFalse();
 	}
 
+	@Test
+	public void matchesNestedConfigurationClassWithoutTestngAnnotation()
+			throws Exception {
+		assertThat(this.filter.match(getMetadataReader(AbstractTestNG.Config.class),
+				this.metadataReaderFactory)).isTrue();
+	}
+
 	private MetadataReader getMetadataReader(Class<?> source) throws IOException {
 		return this.metadataReaderFactory.getMetadataReader(source.getName());
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Spring Framework has have support for testng for a long time. This
commit add checks for org.testng.annotations.Test annotation.

See gh-6901