### PR TITLE
Handle particular case of Tomcat env var LOGGING_CONFIG

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/logging/LoggingApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/LoggingApplicationListener.java
@@ -315,11 +315,11 @@ public class LoggingApplicationListener implements GenericApplicationListener {
 
 	private boolean ignoreLogConfig(String logConfig) {
 		return !StringUtils.hasLength(logConfig)
-				|| isDefaultAzureLoggingConfig(logConfig);
+				|| isDefaultTomcatLoggingConfig(logConfig);
 	}
 
-	private boolean isDefaultAzureLoggingConfig(String candidate) {
-		return candidate.startsWith("-Djava.util.logging.config.file=") || candidate.equals("-Dnop");
+	private boolean isDefaultTomcatLoggingConfig(String candidate) {
+		return candidate.startsWith("-D");
 	}
 
 	private void initializeFinalLoggingLevels(ConfigurableEnvironment environment,

--- a/spring-boot/src/main/java/org/springframework/boot/logging/LoggingApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/LoggingApplicationListener.java
@@ -319,7 +319,7 @@ public class LoggingApplicationListener implements GenericApplicationListener {
 	}
 
 	private boolean isDefaultAzureLoggingConfig(String candidate) {
-		return candidate.startsWith("-Djava.util.logging.config.file=");
+		return candidate.startsWith("-Djava.util.logging.config.file=") || candidate.equals("-Dnop");
 	}
 
 	private void initializeFinalLoggingLevels(ConfigurableEnvironment environment,


### PR DESCRIPTION
Like explained in [this commit](https://github.com/spring-projects/spring-boot/commit/66d4a2a49e2b2a4f3730426a91111085f282ab0f), Tomcat's environment variable `LOGGING_CONFIG` can mistakenly be picked up by `LoggingApplicationListener` [here ](https://github.com/spring-projects/spring-boot/blob/1.4.x/spring-boot/src/main/java/org/springframework/boot/logging/LoggingApplicationListener.java#L297)(when it is actually looking for the spring environment variable `logging.config`). This PR addresses the fact that Tomcat's `LOGGING_CONFIG` variable can also be equal to "-Dnop" in some situations (if it doesn't not find a file at CATALINA_BASE\conf\logging.properties) like it can be seen [here](https://github.com/apache/tomcat/blob/72b287248851be491dcfba8e50850a6e39e16e19/bin/catalina.bat#L209).

A stackoverflow question describing the same issue can be found [here](http://stackoverflow.com/questions/40119640/tomcat8-startup-error-spring-boot-severe-error-deploying-web-application-di).

And here are the steps to reproduce the issue:
- Start a new Spring Boot project (from http://start.spring.io/ for example)
- Make the project create a deployable war on Tomcat (using http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#howto-create-a-deployable-war-file)
- In the folder of a fresh Tomcat 8.0, remove the file \conf\logging.properties
- Deploy the war on the tomcat. The deployment should crash with a FileNotFoundException (cf StackOverFlow link above).

This PR addresses a symptom (by ignoring logConfig when its value is "-Dnop") but the real problem is that `environment.getProperty(logging.config)` evaluates to the same as `environment.getProperty("LOGGING.CONFIG")` and the same as `environment.getProperty("LOGGING_CONFIG")`, which is strange to say the least.