### PR TITLE
normalize path before compute hash in JarURLConnection

### DIFF
--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarURLConnection.java
@@ -27,9 +27,11 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.net.URLStreamHandler;
+import java.nio.file.Paths;
 import java.security.Permission;
 
 import org.springframework.boot.loader.data.RandomAccessData.ResourceAccess;
+import org.springframework.lang.UsesJava7;
 
 /**
  * {@link java.net.JarURLConnection} used to support {@link JarFile#getUrl()}.
@@ -252,6 +254,7 @@ final class JarURLConnection extends java.net.JarURLConnection {
 		return new JarURLConnection(url, jarFile, jarEntryName);
 	}
 
+	@UsesJava7
 	private static String extractFullSpec(URL url, String pathFromRoot) {
 		String file = url.getFile();
 		int separatorIndex = file.indexOf(SEPARATOR);
@@ -259,7 +262,7 @@ final class JarURLConnection extends java.net.JarURLConnection {
 			return "";
 		}
 		int specIndex = separatorIndex + SEPARATOR.length() + pathFromRoot.length();
-		return file.substring(specIndex);
+		return Paths.get(file.substring(specIndex)).normalize().toString();
 	}
 
 	private static JarURLConnection notFound() {

--- a/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarURLConnectionTests.java
+++ b/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarURLConnectionTests.java
@@ -126,6 +126,16 @@ public class JarURLConnectionTests {
 	}
 
 	@Test
+	public void connectionToEntryUsingRelativeUrlForRelativeEntryFromNestedJarFile()
+	throws Exception {
+		URL url = new URL("jar:file:" + getRelativePath() + "!/nested.jar!/./3.dat");
+		JarFile nested = this.jarFile
+			.getNestedJarFile(this.jarFile.getEntry("nested.jar"));
+		assertThat(JarURLConnection.get(url, nested).getInputStream())
+			.hasSameContentAs(new ByteArrayInputStream(new byte[] { 3 }));
+	}
+
+	@Test
 	public void connectionToEntryInNestedJarFromUrlThatUsesExistingUrlAsContext()
 			throws Exception {
 		URL url = new URL(new URL("jar", null, -1,


### PR DESCRIPTION
Dear,

We encounter an issue in one of our application that is using nested jar with xsd in it when migrating from 1.4.1.RELEASE to 1.4.2.RELEASE.
One xsd import another one in the same jar using a relative path like './foo/bar.xsd'.

# Problem
JarURLConnection send that relative path to JarEntry wich computes a hash with it and then it looks in its hash table to resolve it. 
The problem is that it cannot match because in its hash table, it computed the hash without './'

# Solution
IMHO, JarURLConnection should normalize the path before computing the hash.
This patch was tested with one of our project and it works.
