### PR TITLE
Introduce @ConditionalOnMissingServletFilter

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnMissingServletFilter.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnMissingServletFilter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.condition;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Conditional;
+
+/**
+ * {@link Conditional} that only matches when the specified servlet filter types
+ * are not contained in the {@link org.springframework.beans.factory.BeanFactory},
+ * either registered directly as beans or registered with
+ * {@link org.springframework.boot.web.servlet.FilterRegistrationBean}.
+ * <p>
+ * The condition can only match the bean definitions that have been processed by the
+ * application context so far and, as such, it is strongly recommended to use this
+ * condition on auto-configuration classes only. If a candidate bean may be created by
+ * another auto-configuration, make sure that the one using this condition runs after.
+ *
+ * @author Brian Clozel
+ * @since 1.5.0
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Conditional(OnMissingServletFilterCondition.class)
+public @interface ConditionalOnMissingServletFilter {
+
+	/**
+	 * The class type of servlet filter bean that should be checked.
+	 * The condition matches when each class specified is missing in the
+	 * {@link org.springframework.context.ApplicationContext}.
+	 * @return the class types of beans to check
+	 */
+	Class<?>[] value();
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnMissingServletFilterCondition.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnMissingServletFilterCondition.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.condition;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.Filter;
+
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.ConfigurationCondition;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+/**
+ * {@link Condition} that checks for the absence of specific Servlet Filters.
+ * @author Brian Clozel
+ */
+@Order(Ordered.LOWEST_PRECEDENCE)
+class OnMissingServletFilterCondition extends SpringBootCondition implements ConfigurationCondition {
+
+	@Override
+	public ConfigurationPhase getConfigurationPhase() {
+		return ConfigurationPhase.REGISTER_BEAN;
+	}
+
+	@Override
+	public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		ConditionMessage matchMessage = ConditionMessage.empty();
+		if (metadata.isAnnotated(ConditionalOnMissingServletFilter.class.getName())) {
+			List<String> servletFilters = parseAnnotationForServletFilters(context, metadata);
+			Set<String> matching = getMatchingBeans(context, servletFilters);
+			if (matching.isEmpty()) {
+				return ConditionOutcome.match(ConditionMessage
+						.forCondition(ConditionalOnMissingServletFilter.class)
+						.didNotFind("any Servlet filter").atAll());
+			}
+			else {
+				return ConditionOutcome.noMatch(ConditionMessage
+						.forCondition(ConditionalOnMissingServletFilter.class)
+						.found("Servlet filter", "Servlet filters")
+						.items(ConditionMessage.Style.QUOTE, matching));
+			}
+		}
+		return ConditionOutcome.match(matchMessage);
+	}
+
+	private List<String> parseAnnotationForServletFilters(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		List<String> servletFilters = new ArrayList<String>();
+		String annotationType = ConditionalOnMissingServletFilter.class.getName();
+		List<Object> values = metadata
+				.getAllAnnotationAttributes(annotationType, true).get("value");
+		for (Object value : values) {
+			if (value instanceof String[]) {
+				Collections.addAll(servletFilters, (String[]) value);
+			}
+			else {
+				servletFilters.add((String) value);
+			}
+		}
+		return servletFilters;
+	}
+
+	private Set<String> getMatchingBeans(ConditionContext context, List<String> servletFilters) {
+		ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+		if (beanFactory == null) {
+			return Collections.emptySet();
+		}
+		Set<String> result = new LinkedHashSet<String>();
+		BeanTypeRegistry beanTypeRegistry = BeanTypeRegistry.get(context.getBeanFactory());
+		try {
+			Map<String, FilterRegistrationBean> filterRegistrations = findFilterRegistrationBeans(context);
+			for (String servletFilter : servletFilters) {
+				// checking for servlet filter beans
+				Class<?> filterType = ClassUtils.forName(servletFilter, context.getClassLoader());
+				Assert.state(ClassUtils.isAssignable(Filter.class, filterType),
+						"Type " + filterType.getName() + " is not a Servlet Filter");
+				result.addAll(beanTypeRegistry.getNamesForType(filterType));
+				// checking for servlet filter registrations
+				for (Map.Entry<String, FilterRegistrationBean> entry : filterRegistrations.entrySet()) {
+					FilterRegistrationBean registrationBean = entry.getValue();
+					if (ClassUtils.isAssignableValue(filterType, registrationBean.getFilter())) {
+						result.add(entry.getKey());
+					}
+				}
+			}
+		}
+		catch (Throwable e) {
+			return Collections.emptySet();
+		}
+		return result;
+	}
+
+	private Map<String, FilterRegistrationBean> findFilterRegistrationBeans(ConditionContext context) {
+		BeanTypeRegistry beanTypeRegistry = BeanTypeRegistry.get(context.getBeanFactory());
+		Map<String, FilterRegistrationBean> filterRegistrations = new HashMap<String, FilterRegistrationBean>();
+		for (String registrationName : beanTypeRegistry.getNamesForType(FilterRegistrationBean.class)) {
+			filterRegistrations.put(registrationName,
+					context.getBeanFactory().getBean(registrationName, FilterRegistrationBean.class));
+		}
+		return filterRegistrations;
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/freemarker/FreeMarkerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/freemarker/FreeMarkerAutoConfiguration.java
@@ -17,10 +17,12 @@
 package org.springframework.boot.autoconfigure.freemarker;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Properties;
 
 import javax.annotation.PostConstruct;
+import javax.servlet.DispatcherType;
 import javax.servlet.Servlet;
 
 import org.apache.commons.logging.Log;
@@ -31,6 +33,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingServletFilter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnNotWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
@@ -38,6 +41,7 @@ import org.springframework.boot.autoconfigure.template.TemplateLocation;
 import org.springframework.boot.autoconfigure.web.ConditionalOnEnabledResourceChain;
 import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -157,10 +161,13 @@ public class FreeMarkerAutoConfiguration {
 		}
 
 		@Bean
-		@ConditionalOnMissingBean
+		@ConditionalOnMissingServletFilter(ResourceUrlEncodingFilter.class)
 		@ConditionalOnEnabledResourceChain
-		public ResourceUrlEncodingFilter resourceUrlEncodingFilter() {
-			return new ResourceUrlEncodingFilter();
+		public FilterRegistrationBean resourceUrlEncodingFilter() {
+			FilterRegistrationBean registration = new FilterRegistrationBean();
+			registration.setFilter(new ResourceUrlEncodingFilter());
+			registration.setDispatcherTypes(EnumSet.allOf(DispatcherType.class));
+			return registration;
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfiguration.java
@@ -49,6 +49,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingServletFilter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
@@ -132,7 +133,7 @@ public class JerseyAutoConfiguration implements ServletContextAware {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean
+	@ConditionalOnMissingServletFilter(RequestContextFilter.class)
 	public FilterRegistrationBean requestContextFilter() {
 		FilterRegistrationBean registration = new FilterRegistrationBean();
 		registration.setFilter(new RequestContextFilter());
@@ -142,7 +143,7 @@ public class JerseyAutoConfiguration implements ServletContextAware {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(name = "jerseyFilterRegistration")
+	@ConditionalOnMissingServletFilter(ServletContainer.class)
 	@ConditionalOnProperty(prefix = "spring.jersey", name = "type", havingValue = "filter")
 	public FilterRegistrationBean jerseyFilterRegistration() {
 		FilterRegistrationBean registration = new FilterRegistrationBean();

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
@@ -18,7 +18,9 @@ package org.springframework.boot.autoconfigure.thymeleaf;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.EnumSet;
 
+import javax.servlet.DispatcherType;
 import javax.servlet.Servlet;
 
 import com.github.mxab.thymeleaf.extras.dataattribute.dialect.DataAttributeDialect;
@@ -40,10 +42,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnJava;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingServletFilter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.ConditionalOnEnabledResourceChain;
 import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -262,10 +266,13 @@ public class ThymeleafAutoConfiguration {
 	protected static class ThymeleafResourceHandlingConfig {
 
 		@Bean
-		@ConditionalOnMissingBean
+		@ConditionalOnMissingServletFilter(ResourceUrlEncodingFilter.class)
 		@ConditionalOnEnabledResourceChain
-		public ResourceUrlEncodingFilter resourceUrlEncodingFilter() {
-			return new ResourceUrlEncodingFilter();
+		public FilterRegistrationBean resourceUrlEncodingFilter() {
+			FilterRegistrationBean registration = new FilterRegistrationBean();
+			registration.setFilter(new ResourceUrlEncodingFilter());
+			registration.setDispatcherTypes(EnumSet.allOf(DispatcherType.class));
+			return registration;
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/HttpEncodingAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/HttpEncodingAutoConfiguration.java
@@ -18,7 +18,7 @@ package org.springframework.boot.autoconfigure.web;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingServletFilter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.HttpEncodingProperties.Type;
@@ -53,7 +53,7 @@ public class HttpEncodingAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(CharacterEncodingFilter.class)
+	@ConditionalOnMissingServletFilter(CharacterEncodingFilter.class)
 	public CharacterEncodingFilter characterEncodingFilter() {
 		CharacterEncodingFilter filter = new OrderedCharacterEncodingFilter();
 		filter.setEncoding(this.properties.getCharset().name());

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebMvcAutoConfiguration.java
@@ -40,6 +40,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingServletFilter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.ResourceProperties.Strategy;
@@ -126,13 +127,13 @@ public class WebMvcAutoConfiguration {
 	public static String DEFAULT_SUFFIX = "";
 
 	@Bean
-	@ConditionalOnMissingBean(HiddenHttpMethodFilter.class)
+	@ConditionalOnMissingServletFilter(HiddenHttpMethodFilter.class)
 	public OrderedHiddenHttpMethodFilter hiddenHttpMethodFilter() {
 		return new OrderedHiddenHttpMethodFilter();
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(HttpPutFormContentFilter.class)
+	@ConditionalOnMissingServletFilter(HttpPutFormContentFilter.class)
 	@ConditionalOnProperty(prefix = "spring.mvc.formcontent.putfilter", name = "enabled", matchIfMissing = true)
 	public OrderedHttpPutFormContentFilter httpPutFormContentFilter() {
 		return new OrderedHttpPutFormContentFilter();

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnMissingServletFilterTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnMissingServletFilterTests.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.condition;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConditionalOnMissingServletFilter}.
+ *
+ * @author Brian Clozel
+ */
+public class ConditionalOnMissingServletFilterTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+	@Test
+	public void testMissingFilter() {
+		this.context.register(TestSingleFilterConfiguration.class);
+		this.context.refresh();
+		assertThat(this.context.getBeansOfType(CustomServletFilter.class).isEmpty()).isTrue();
+		assertThat(this.context.getBean("foo")).isEqualTo("foo");
+	}
+
+	@Test
+	public void testExistingFilter() {
+		this.context.register(CustomServletFilterConfiguration.class, TestSingleFilterConfiguration.class);
+		this.context.refresh();
+		assertThat(this.context.getBeansOfType(CustomServletFilter.class))
+				.containsKey("customServletFilter").hasSize(1);
+		assertThat(this.context.containsBean("foo")).isFalse();
+	}
+
+	@Test
+	public void testExistingFilterRegistration() {
+		this.context.register(CustomFilterRegistrationConfiguration.class, TestSingleFilterConfiguration.class);
+		this.context.refresh();
+		assertThat(this.context.getBeansOfType(FilterRegistrationBean.class))
+				.containsKey("customServletFilterRegistration").hasSize(1);
+		assertThat(this.context.containsBean("foo")).isFalse();
+	}
+
+	@Test
+	public void testMultipleFiltersCondition() {
+		this.context.register(OtherServletFilterConfiguration.class, CustomFilterRegistrationConfiguration.class,
+				TestMultipleFiltersConfiguration.class);
+		this.context.refresh();
+		assertThat(this.context.getBeansOfType(OtherServletFilter.class))
+				.containsKey("otherServletFilter").hasSize(1);
+		assertThat(this.context.getBeansOfType(FilterRegistrationBean.class))
+				.containsKey("customServletFilterRegistration").hasSize(1);
+		assertThat(this.context.containsBean("foo")).isFalse();
+	}
+
+	@Configuration
+	protected static class CustomServletFilterConfiguration {
+
+		@Bean
+		public CustomServletFilter customServletFilter() {
+			return new CustomServletFilter();
+		}
+
+	}
+
+	@Configuration
+	protected static class OtherServletFilterConfiguration {
+
+		@Bean
+		public OtherServletFilter otherServletFilter() {
+			return new OtherServletFilter();
+		}
+
+	}
+
+	@Configuration
+	protected static class CustomFilterRegistrationConfiguration {
+
+		@Bean
+		public FilterRegistrationBean customServletFilterRegistration() {
+			FilterRegistrationBean filter = new FilterRegistrationBean();
+			filter.setFilter(new CustomServletFilter());
+			return filter;
+		}
+
+	}
+
+	@Configuration
+	protected static class TestSingleFilterConfiguration {
+
+		@Bean
+		@ConditionalOnMissingServletFilter(CustomServletFilter.class)
+		public String foo() {
+			return "foo";
+		}
+
+	}
+
+	@Configuration
+	protected static class TestMultipleFiltersConfiguration {
+
+		@Bean
+		@ConditionalOnMissingServletFilter({CustomServletFilter.class, OtherServletFilter.class})
+		public String foo() {
+			return "foo";
+		}
+
+	}
+
+	static class CustomServletFilter implements Filter {
+
+		@Override
+		public void init(FilterConfig filterConfig) throws ServletException {
+		}
+
+		@Override
+		public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+				throws IOException, ServletException {
+		}
+
+		@Override
+		public void destroy() {
+		}
+	}
+
+	static class OtherServletFilter implements Filter {
+
+		@Override
+		public void init(FilterConfig filterConfig) throws ServletException {
+		}
+
+		@Override
+		public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+				throws IOException, ServletException {
+		}
+
+		@Override
+		public void destroy() {
+		}
+	}
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfigurationTests.java
@@ -17,8 +17,12 @@
 package org.springframework.boot.autoconfigure.thymeleaf;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Locale;
+
+import javax.servlet.DispatcherType;
 
 import nz.net.ultraq.thymeleaf.LayoutDialect;
 import nz.net.ultraq.thymeleaf.decorators.strategies.GroupingStrategy;
@@ -36,6 +40,7 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.test.rule.OutputCapture;
 import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -43,6 +48,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.resource.ResourceUrlEncodingFilter;
@@ -233,7 +239,15 @@ public class ThymeleafAutoConfigurationTests {
 		EnvironmentTestUtils.addEnvironment(this.context,
 				"spring.resources.chain.enabled:true");
 		this.context.refresh();
-		assertThat(this.context.getBean(ResourceUrlEncodingFilter.class)).isNotNull();
+		FilterRegistrationBean registration = this.context.getBean("resourceUrlEncodingFilter",
+				FilterRegistrationBean.class);
+		assertThat(registration).isNotNull();
+		assertThat(registration.getFilter()).isInstanceOf(ResourceUrlEncodingFilter.class);
+		Field dispatcherTypesField = ReflectionUtils.findField(FilterRegistrationBean.class, "dispatcherTypes");
+		ReflectionUtils.makeAccessible(dispatcherTypesField);
+		EnumSet<DispatcherType> dispatcherTypes = (EnumSet<DispatcherType>) ReflectionUtils
+				.getField(dispatcherTypesField, registration);
+		assertThat(dispatcherTypes).containsAll(EnumSet.allOf(DispatcherType.class));
 	}
 
 	@Test


### PR DESCRIPTION
These commits introduce the `@ConditionalOnMissingServletFilter`
and make use of it to register `ResourceUrlEncodingFilter`
instances as `FilterRegistrationBean`s instead of beans.

This new conditional annotation is borrows a bit from the bean
conditions but also checks for `FilterRegistrationBean` and the
type of filter they're about to register.
This requires getting the actual bean, which is obviously less
efficient than the checks involved in bean conditions. I've
configured that condition to have a low precedence, but I'm
wondering if more checks/guards should be added here.

The second commit applies that new Condition to existing filters
and turns them into `FilterRegistrationBean` to finally achieve
the original goal: configure `ResourceUrlEncodingFilter`s for
all dispatcher types and make them available during error
dispatches, so as to properly render URLs in error pages.