### PR TITLE
Inclusing of Hazelcast in starters and samples

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -149,6 +149,7 @@
 		<spring-amqp.version>2.0.0.BUILD-SNAPSHOT</spring-amqp.version>
 		<spring-cloud-connectors.version>1.2.3.RELEASE</spring-cloud-connectors.version>
 		<spring-batch.version>3.0.7.RELEASE</spring-batch.version>
+		<spring-data-hazelcast.version>1.0</spring-data-hazelcast.version>
 		<spring-data-releasetrain.version>Ingalls-BUILD-SNAPSHOT</spring-data-releasetrain.version>
 		<spring-hateoas.version>0.21.0.RELEASE</spring-hateoas.version>
 		<spring-integration.version>5.0.0.BUILD-SNAPSHOT</spring-integration.version>
@@ -330,6 +331,11 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-data-gemfire</artifactId>
+				<version>2.0.0.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-data-hazelcast</artifactId>
 				<version>2.0.0.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
@@ -734,6 +740,22 @@
 				<groupId>com.hazelcast</groupId>
 				<artifactId>hazelcast-spring</artifactId>
 				<version>${hazelcast.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.hazelcast</groupId>
+				<artifactId>spring-data-hazelcast</artifactId>
+				<version>${spring-data-hazelcast.version}</version>
+				<exclusions>
+					<!-- Avoid dependency clash until spring-data-hazelcast is in spring-data release train -->
+					<exclusion>
+						<groupId>org.springframework.data</groupId>
+						<artifactId>spring-data-commons</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.springframework.data</groupId>
+						<artifactId>spring-data-keyvalue</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>com.jayway.jsonpath</groupId>

--- a/spring-boot-samples/pom.xml
+++ b/spring-boot-samples/pom.xml
@@ -36,6 +36,7 @@
 		<module>spring-boot-sample-data-couchbase</module>
 		<module>spring-boot-sample-data-elasticsearch</module>
 		<module>spring-boot-sample-data-gemfire</module>
+		<module>spring-boot-sample-data-hazelcast</module>
 		<module>spring-boot-sample-data-jpa</module>
 		<module>spring-boot-sample-data-mongodb</module>
 		<module>spring-boot-sample-data-neo4j</module>

--- a/spring-boot-samples/spring-boot-sample-data-hazelcast/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-data-hazelcast/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-samples</artifactId>
+		<version>2.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>spring-boot-sample-data-hazelcast</artifactId>
+	<name>Spring Boot Data Hazelcast Sample</name>
+	<description>Sample for using Hazelcast IMDG and Spring Data Hazelcast</description>
+
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-hazelcast</artifactId>
+		</dependency>
+		<dependency>
+			<!-- Can be removed once spring-data-hazelcast in spring data release train -->
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-keyvalue</artifactId>
+		</dependency>
+		
+		<!-- TEST scope -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-samples/spring-boot-sample-data-hazelcast/src/main/java/sample/data/hazelcast/Main.java
+++ b/spring-boot-samples/spring-boot-sample-data-hazelcast/src/main/java/sample/data/hazelcast/Main.java
@@ -1,0 +1,69 @@
+package sample.data.hazelcast;
+
+import java.util.Random;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.hazelcast.repository.config.EnableHazelcastRepositories;
+import org.springframework.util.Assert;
+
+import sample.data.hazelcast.domain.Zodiac;
+import sample.data.hazelcast.service.ZodiacService;
+
+/**
+ * <P>A main class to find the star sign for a random longitude.
+ * </P>
+ * <P>Run this from the command line with:
+ * <P>
+ * <UL>
+ * <LI>{@code java -jar target/spring-boot-sample-data-hazelcast-*.jar}</LI>
+ * </UL>
+ * <P>or</P>
+ * <UL>
+ * <LI>{@code mvn spring-boot:run}</LI>
+ * </UL>
+ * <P>As part of this a standalone Hazelcast instance is started, and this
+ * will log various messages. You can ignore the warning.
+ * "{@code No join method is enabled! Starting standalone.}"
+ * </P>
+ * 
+ * @author Neil Stevenson
+ */
+@SpringBootApplication
+@EnableHazelcastRepositories
+public class Main implements CommandLineRunner {
+
+	public static void main(String[] args) {
+		SpringApplication.run(Main.class, args);
+		System.exit(0);
+	}
+
+	@Autowired
+	private ZodiacService zodiacService;
+	
+	/**
+	 * <P>Look up the start sign for a random degee in the Sky,
+	 * from 0 to 359 (as 360 degrees).
+	 * </P>
+	 * 
+	 * @param Not used
+	 */
+	@Override
+	public void run(String... args) throws Exception {
+
+		int longitude = new Random().nextInt(360);
+		
+		Zodiac zodiac = this.zodiacService.findByLongitude(longitude);
+
+		Assert.notNull(zodiac, Zodiac.class.getSimpleName());
+		
+		System.out.println("***************************************************************************************************");
+		System.out.println("***************************************************************************************************");
+		System.out.println("Starsign for " + longitude + " is " + zodiac);
+		System.out.println("***************************************************************************************************");
+		System.out.println("***************************************************************************************************");
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-data-hazelcast/src/main/java/sample/data/hazelcast/config/ZodiacConfig.java
+++ b/spring-boot-samples/spring-boot-sample-data-hazelcast/src/main/java/sample/data/hazelcast/config/ZodiacConfig.java
@@ -1,0 +1,73 @@
+package sample.data.hazelcast.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.hazelcast.HazelcastKeyValueAdapter;
+import org.springframework.data.keyvalue.core.KeyValueTemplate;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+
+/**
+ * <P>Spring configuration to use {@link www.hazelcast.org Hazelcast} as
+ * the storage layer for Key-Value repositories.
+ * </P>
+ * <P>Hazelcast provides a storage structure called an {@link com.hazelcast.core.IMap IMap}
+ * that extends {@link java.util.Map}. So, you can do {@code put(key,value)} and {@code get(key)}
+ * and all the other map operations without knowing about Hazelcast.
+ * </P>
+ * <P>Hazelcast is normally set-up so that the "<I>server</I>" storage process forms a cluster
+ * with other such Hazelcast processes, and automatically stripes the map content across the
+ * group. Eg. with 5 processes each might hold 1/5th of the content. This is abstracted away
+ * from the caller, so you can keep doing {@code put(key,value)} and {@code get(key)} without
+ * knowing if the data is actually stored on the current process or one of the others in the
+ * group. You can then store more in the group than any one process can cope with.
+ * <P>
+ * <P>To make testing simple, networking is disabled so that process can't find any others,
+ * and so forms a cluster of 1.
+ * </P>
+ * <P><B>PLUS</B>
+ * </P>We then wrap everything up as a Spring Data {@code @Repository}, so then we can
+ * do CRUD and query operations, further hiding that it's Hazelcast underneath, and
+ * making everything be usable following standard Spring mechanisms such as
+ * {@code save(value)} and {@code findOne(key)}.
+ * </P>
+ * 
+ * @author Neil Stevenson
+ */
+@Configuration
+public class ZodiacConfig {
+	
+	/**
+	 * <P>Create a Hazelcast server for storing the Zodiac data, rather than
+	 * let Spring Boot auto-configure do so.
+	 * </P>
+	 * <P>Turn off default network, and don't turn on any other kinds. Without
+	 * networking, this instance will be standalone.
+	 * </P>
+	 * 
+	 * @return A standalone Hazelcast server
+	 */
+    @Bean
+    public HazelcastInstance hazelcastInstance() {
+            Config config = new Config();
+            
+            config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+            
+            return Hazelcast.newHazelcastInstance(config);
+    }
+	
+	/**
+	 * <P>Use Hazelcast as the implementation class for Key-Value operations.
+	 * </P>
+	 * 
+	 * @param hazelcastInstance Created above
+	 * @return Template for Key-Value operations
+	 */
+    @Bean
+    public KeyValueTemplate keyValueTemplate(HazelcastInstance hazelcastInstance) {
+            return new KeyValueTemplate(new HazelcastKeyValueAdapter(hazelcastInstance));
+    }
+
+}

--- a/spring-boot-samples/spring-boot-sample-data-hazelcast/src/main/java/sample/data/hazelcast/config/ZodiacData.java
+++ b/spring-boot-samples/spring-boot-sample-data-hazelcast/src/main/java/sample/data/hazelcast/config/ZodiacData.java
@@ -1,0 +1,64 @@
+package sample.data.hazelcast.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import sample.data.hazelcast.domain.Zodiac;
+import sample.data.hazelcast.repository.ZodiacRepository;
+
+/**
+ * <P>Load the Zodiac data. Use a {@link CommandLineRunner} with a low {@link Order}
+ * to ensure data loaded before we might need to use it.
+ * </P>
+ * 
+ * @author Neil Stevenson
+ *
+ * @see <A HREF="https://en.wikipedia.org/wiki/Astrological_sign">Astrological Sign</A>
+ */
+@Order(value=0)
+@Component
+public class ZodiacData implements CommandLineRunner {
+	
+	@Autowired
+	private ZodiacRepository zodiacRepository;
+
+	/**
+	 * <P>Inject data via a {@code @Repository} rather than directly into
+	 * a Hazelcast {@link com.hazelcast.core.IMap IMap}.
+	 * 
+	 * @param Not used
+	 */
+	@Override
+	public void run(String... args) throws Exception {
+		
+		for (int i=0 ; i < data.length ; i++) {
+			Zodiac zodiac = new Zodiac();
+			
+			zodiac.setId(i);
+			zodiac.setDescription(data[i][1].toString());
+			zodiac.setLongitude(i*30);
+			zodiac.setName(data[i][0].toString());
+			
+			this.zodiacRepository.save(zodiac);
+		}
+		
+	}
+	
+	private Object[][] data = new Object[][] {
+		{ "Aries", 	"The Ram"},
+		{ "Taurus", "The Bull"},
+		{ "Gemini", "The Twins"},
+		{ "Cancer", "The Crab"},
+		{ "Leo", "The Lion"},
+		{ "Virgo", "The Maiden"},
+		{ "Libra", "The Scales"},
+		{ "Scorpio", "The Scorpion"},
+		{ "Sagittarius", "The Archer"},
+		{ "Capricorn", "The Mountain Sea-goat"},
+		{ "Aquarius", "The Water-bearer"},
+		{ "Pisces", "The Fish"},
+	};
+	
+}

--- a/spring-boot-samples/spring-boot-sample-data-hazelcast/src/main/java/sample/data/hazelcast/domain/Zodiac.java
+++ b/spring-boot-samples/spring-boot-sample-data-hazelcast/src/main/java/sample/data/hazelcast/domain/Zodiac.java
@@ -1,0 +1,30 @@
+package sample.data.hazelcast.domain;
+
+import java.io.Serializable;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.keyvalue.annotation.KeySpace;
+
+import lombok.Data;
+
+/**
+ * <P>A domain object represent a sign of the Zodiac.
+ * </P>
+ * 
+ * @author Neil Stevenson
+ * 
+ * @see <A HREF="https://en.wikipedia.org/wiki/Astrological_sign">Astrological Sign</A>
+ */
+@SuppressWarnings("serial")
+@Data
+@KeySpace
+public class Zodiac implements Serializable {
+
+	@Id
+	private int 	id;
+	
+	private String	name;
+	private String  description;
+	private int     longitude;
+	
+}

--- a/spring-boot-samples/spring-boot-sample-data-hazelcast/src/main/java/sample/data/hazelcast/repository/ZodiacRepository.java
+++ b/spring-boot-samples/spring-boot-sample-data-hazelcast/src/main/java/sample/data/hazelcast/repository/ZodiacRepository.java
@@ -1,0 +1,19 @@
+package sample.data.hazelcast.repository;
+
+import org.springframework.data.hazelcast.repository.HazelcastRepository;
+
+import sample.data.hazelcast.domain.Zodiac;
+
+/**
+ * <P>A repository object to access the Zodiac domain objects.
+ * </P>
+ * <P>Extend this with a method to find "{@code longitude <= x < longitude}",
+ * Spring will deduce the implementation.
+ * </P>
+ * 
+ * @author Neil Stevenson
+ */
+public interface ZodiacRepository extends HazelcastRepository<Zodiac, Integer> {
+	
+	public Zodiac findByLongitudeGreaterThanAndLongitudeLessThanEqual(int lower, int upper);
+}

--- a/spring-boot-samples/spring-boot-sample-data-hazelcast/src/main/java/sample/data/hazelcast/service/ZodiacService.java
+++ b/spring-boot-samples/spring-boot-sample-data-hazelcast/src/main/java/sample/data/hazelcast/service/ZodiacService.java
@@ -1,0 +1,36 @@
+package sample.data.hazelcast.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import sample.data.hazelcast.domain.Zodiac;
+import sample.data.hazelcast.repository.ZodiacRepository;
+
+/**
+ * <P>A Spring {@code @Service} object, to avoid exposing the {@code @Repository}
+ * to any calling modules.
+ * </P>
+ * 
+ * @author Neil Stevenson
+ */
+@Service
+public class ZodiacService {
+
+	@Autowired
+	private ZodiacRepository zodiacRepository;
+
+	/**
+	 * <P>Take the provided repository and use a query to find the Zodiac sign,
+	 * exploiting the fact that each sign has exact 30 of 360 degrees.
+	 * </P>
+	 * 
+	 * @param longitude Assumed to be in range 0-359
+	 * @return One sign of the Zodiac
+	 */
+	public Zodiac findByLongitude(final int longitude) {
+		int lower = longitude - 30;
+		int upper = longitude;
+		return this.zodiacRepository.findByLongitudeGreaterThanAndLongitudeLessThanEqual(lower, upper);
+	}
+	
+}

--- a/spring-boot-samples/spring-boot-sample-data-hazelcast/src/test/java/sample/data/hazelcast/repository/ZodiacRepositoryTests.java
+++ b/spring-boot-samples/spring-boot-sample-data-hazelcast/src/test/java/sample/data/hazelcast/repository/ZodiacRepositoryTests.java
@@ -1,0 +1,87 @@
+package sample.data.hazelcast.repository;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.hazelcast.repository.config.EnableHazelcastRepositories;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.hazelcast.core.HazelcastInstance;
+
+import sample.data.hazelcast.config.ZodiacConfig;
+import sample.data.hazelcast.config.ZodiacData;
+import sample.data.hazelcast.domain.Zodiac;
+
+/**
+ * <P>Test the Hazelcast repository.
+ * </P>
+ * 
+ * @author Neil Stevenson
+ */
+@EnableHazelcastRepositories
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes={ZodiacConfig.class, ZodiacData.class})
+public class ZodiacRepositoryTests {
+	
+	@Autowired
+	private HazelcastInstance hazelcastInstance;
+	@Autowired
+	private ZodiacRepository zodiacRepository;
+	
+	/**
+	 * <P>Test that Hazelcast has an {@link com.hazelcast.core.IMap IMap}
+	 * for the {@link Zodiac} data.
+	 * </P>
+	 */
+	@Test
+	public void imap_exists_and_not_empty() {
+		String mapName = Zodiac.class.getCanonicalName();
+		
+		Map<?, ?> map = (Map<?, ?>) this.hazelcastInstance.getMap(mapName);
+		
+		assertThat(map, not(nullValue()));
+		assertThat(map.size(), equalTo(12));
+	}
+	
+	/**
+	 * <P>Test a value that isn't first or last.
+	 * </P>
+	 */
+	@Test
+	public void scorpio() {
+		Zodiac zodiac = this.zodiacRepository.findOne(7);
+		
+		assertThat(zodiac, not(nullValue()));
+		assertThat("Id", zodiac.getId(), equalTo(7));
+		assertThat("Longitude", zodiac.getLongitude(), equalTo(210));
+		assertThat("Name", zodiac.getName(), equalTo("Scorpio"));
+		assertThat("Description", zodiac.getDescription(), equalTo("The Scorpion"));
+	}
+	
+	/**
+	 * <P>Test all star signs present exactly once.
+	 * </P>
+	 */
+	@Test
+	public void all_signs() {
+		Set<Integer> keys = new TreeSet<>();
+
+		Iterator<Zodiac> iterator = this.zodiacRepository.findAll().iterator();
+		
+		while (iterator.hasNext()) {
+			keys.add(iterator.next().getId());
+		}
+		
+		assertThat("12 unique", keys.size(), equalTo(12));
+		assertThat("12 in total", this.zodiacRepository.count(), equalTo(12L));
+	}
+}

--- a/spring-boot-samples/spring-boot-sample-data-hazelcast/src/test/java/sample/data/hazelcast/service/ZodiacServiceTests.java
+++ b/spring-boot-samples/spring-boot-sample-data-hazelcast/src/test/java/sample/data/hazelcast/service/ZodiacServiceTests.java
@@ -1,0 +1,73 @@
+package sample.data.hazelcast.service;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.hazelcast.repository.config.EnableHazelcastRepositories;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import sample.data.hazelcast.config.ZodiacConfig;
+import sample.data.hazelcast.config.ZodiacData;
+import sample.data.hazelcast.domain.Zodiac;
+import sample.data.hazelcast.repository.ZodiacRepository;
+
+/**
+ * <P>{@code @Service} not {@code @Repository} tests, so business
+ * logic tests.
+ * </P>
+ * 
+ * @author Neil Stevenson
+ */
+@EnableHazelcastRepositories(basePackageClasses=ZodiacRepository.class)
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes={ZodiacConfig.class, ZodiacData.class, ZodiacService.class})
+public class ZodiacServiceTests {
+
+	@Autowired
+	private ZodiacService zodiacService;
+	
+	/** <P>Scorpio runs from 210 to 239.
+	 * </P>
+	 */
+	@Test
+	public void scorpio_lower_bound_inclusive() {
+		int longitude = 210;
+		
+		Zodiac zodiac = this.zodiacService.findByLongitude(longitude);
+		
+		assertThat(zodiac, not(nullValue()));
+		assertThat(zodiac.getName(), equalTo("Scorpio"));
+	}
+
+	/** <P>Scorpio runs from 210 to 239.
+	 * </P>
+	 */
+	@Test
+	public void scorpio_mid_range() {
+		int longitude = 239;
+		
+		Zodiac zodiac = this.zodiacService.findByLongitude(longitude);
+		
+		assertThat(zodiac, not(nullValue()));
+		assertThat(zodiac.getName(), equalTo("Scorpio"));
+	}
+
+	/** <P>Scorpio runs from 210 to 239.
+	 * </P>
+	 */
+	@Test
+	public void scorpio_upper_bound_exclusive() {
+		int longitude = 240;
+		
+		Zodiac zodiac = this.zodiacService.findByLongitude(longitude);
+		
+		assertThat(zodiac, not(nullValue()));
+		assertThat(zodiac.getName(), not(equalTo("Scorpio")));
+		assertThat(zodiac.getName(), equalTo("Sagittarius"));
+	}
+
+}

--- a/spring-boot-starters/pom.xml
+++ b/spring-boot-starters/pom.xml
@@ -32,6 +32,7 @@
 		<module>spring-boot-starter-data-couchbase</module>
 		<module>spring-boot-starter-data-elasticsearch</module>
 		<module>spring-boot-starter-data-gemfire</module>
+		<module>spring-boot-starter-data-hazelcast</module>
 		<module>spring-boot-starter-data-jpa</module>
 		<module>spring-boot-starter-data-mongodb</module>
 		<module>spring-boot-starter-data-neo4j</module>

--- a/spring-boot-starters/spring-boot-starter-data-hazelcast/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-data-hazelcast/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starters</artifactId>
+		<version>2.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>spring-boot-starter-data-hazelcast</artifactId>
+	<name>Spring Boot Data Hazelcast Starter</name>
+	<description>Starter for using Hazelcast IMDG and Spring Data Hazelcast</description>
+	
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	
+	<dependencies>
+		<dependency>
+			<groupId>com.hazelcast</groupId>
+			<artifactId>spring-data-hazelcast</artifactId>	
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-boot-starters/spring-boot-starter-data-hazelcast/src/main/resources/META-INF/spring.provides
+++ b/spring-boot-starters/spring-boot-starter-data-hazelcast/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: spring-data-hazelcast


### PR DESCRIPTION
Hazelcast already has Spring Boot support.

This augments this with a `spring-boot-starter-data-hazelcast`
and a `spring-boot-sample-data-hazelcast` demonstrating the use of this.