### PR TITLE
GH-2037: Auto-configure @IntegrationComponentScan

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.autoconfigure.integration;
 
+import java.util.Map;
+
 import javax.management.MBeanServer;
 
 import org.springframework.beans.BeansException;
@@ -23,6 +25,8 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -33,8 +37,14 @@ import org.springframework.boot.bind.RelaxedPropertyResolver;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.core.type.StandardAnnotationMetadata;
+import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.config.IntegrationComponentScanRegistrar;
+import org.springframework.integration.gateway.GatewayProxyFactoryBean;
 import org.springframework.integration.jmx.config.EnableIntegrationMBeanExport;
 import org.springframework.integration.monitor.IntegrationMBeanExporter;
 import org.springframework.integration.support.management.IntegrationManagementConfigurer;
@@ -109,6 +119,44 @@ public class IntegrationAutoConfiguration {
 				}
 			}
 			return exporter;
+		}
+
+	}
+
+	@Configuration
+	@ConditionalOnMissingBean(GatewayProxyFactoryBean.class)
+	@Import(AutoIntegrationComponentScanRegistrar.class)
+	protected static class IntegrationComponentScanAutoConfiguration {
+
+	}
+
+	private static class AutoIntegrationComponentScanRegistrar extends IntegrationComponentScanRegistrar {
+
+		@Override
+		public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata,
+				final BeanDefinitionRegistry registry) {
+			StandardAnnotationMetadata metadata =
+					new StandardAnnotationMetadata(IntegrationComponentScanConfiguration.class, true) {
+
+						@Override
+						public Map<String, Object> getAnnotationAttributes(String annotationName) {
+							Map<String, Object> annotationAttributes = super.getAnnotationAttributes(annotationName);
+							if (IntegrationComponentScan.class.getName().equals(annotationName)) {
+								BeanFactory beanFactory = (BeanFactory) registry;
+								if (AutoConfigurationPackages.has(beanFactory)) {
+									annotationAttributes.put("value", AutoConfigurationPackages.get(beanFactory));
+								}
+							}
+							return annotationAttributes;
+						}
+
+					};
+			super.registerBeanDefinitions(metadata, registry);
+		}
+
+		@IntegrationComponentScan
+		private class IntegrationComponentScanConfiguration {
+
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
@@ -30,6 +30,9 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.integration.annotation.IntegrationComponentScan;
+import org.springframework.integration.annotation.MessagingGateway;
+import org.springframework.integration.gateway.RequestReplyExchanger;
 import org.springframework.integration.support.channel.HeaderChannelRegistry;
 import org.springframework.jmx.export.MBeanExporter;
 import org.springframework.test.context.support.TestPropertySourceUtils;
@@ -60,24 +63,34 @@ public class IntegrationAutoConfigurationTests {
 	@Test
 	public void integrationIsAvailable() {
 		load();
-		assertThat(this.context.getBean(HeaderChannelRegistry.class)).isNotNull();
+		assertThat(this.context.getBean(TestGateway.class)).isNotNull();
+		assertThat(this.context.getBean(IntegrationAutoConfiguration.IntegrationComponentScanAutoConfiguration.class))
+				.isNotNull();
+	}
+
+	@Test
+	public void explicitIntegrationComponentScan() {
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(IntegrationComponentScanConfiguration.class,
+				JmxAutoConfiguration.class,
+				IntegrationAutoConfiguration.class);
+		this.context.refresh();
+		assertThat(this.context.getBean(TestGateway.class)).isNotNull();
+		assertThat(this.context.getBeansOfType(IntegrationAutoConfiguration.IntegrationComponentScanAutoConfiguration.class))
+				.isEmpty();
 	}
 
 	@Test
 	public void parentContext() {
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(JmxAutoConfiguration.class,
-				IntegrationAutoConfiguration.class);
-		this.context.refresh();
+		load();
 		AnnotationConfigApplicationContext parent = this.context;
 		this.context = new AnnotationConfigApplicationContext();
 		this.context.setParent(parent);
 		this.context.register(JmxAutoConfiguration.class,
 				IntegrationAutoConfiguration.class);
+		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context, "SPRING_JMX_DEFAULT_DOMAIN=org.foo");
 		this.context.refresh();
 		assertThat(this.context.getBean(HeaderChannelRegistry.class)).isNotNull();
-		((ConfigurableApplicationContext) this.context.getParent()).close();
-		this.context.close();
 	}
 
 	@Test
@@ -142,6 +155,17 @@ public class IntegrationAutoConfigurationTests {
 		public MBeanExporter myMBeanExporter() {
 			return mock(MBeanExporter.class);
 		}
+
+	}
+
+	@Configuration
+	@IntegrationComponentScan
+	static class IntegrationComponentScanConfiguration {
+
+	}
+
+	@MessagingGateway
+	public interface TestGateway extends RequestReplyExchanger {
 
 	}
 


### PR DESCRIPTION
Fixes GH-2037 (https://github.com/spring-projects/spring-boot/issues/2037)

Right now to scan `@MessagingGateway` interfaces we have to explicitly declare `@IntegrationComponentScan` alongside with the `@SpringBootApplication`

* Add `IntegrationComponentScanAutoConfiguration` conditional `@Configuration` to declare `@IntegrationComponentScan` with default properties and based on the `AutoConfigurationPackages.get(beanFactory)` as a package to scan.
The solution has been borrowed from the `JpaRepositoriesAutoConfiguration`

**Cherry-pick to master**