### PR TITLE
Update to Spring Secuirty 4.1.4.RELEASE on 1.4.x

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -158,7 +158,7 @@
 		<spring-plugin.version>1.2.0.RELEASE</spring-plugin.version>
 		<spring-restdocs.version>1.1.2.RELEASE</spring-restdocs.version>
 		<spring-retry.version>1.1.5.RELEASE</spring-retry.version>
-		<spring-security.version>4.1.3.RELEASE</spring-security.version>
+		<spring-security.version>4.1.4.RELEASE</spring-security.version>
 		<spring-security-jwt.version>1.0.5.RELEASE</spring-security-jwt.version>
 		<spring-security-oauth.version>2.0.12.RELEASE</spring-security-oauth.version>
 		<spring-session.version>1.2.2.RELEASE</spring-session.version>


### PR DESCRIPTION
The Spring Security 4.1.4.RELEASE has been released.
