### PR TITLE
Refactoring for Spring Integration Metrics

### DIFF
--- a/spring-boot-actuator/pom.xml
+++ b/spring-boot-actuator/pom.xml
@@ -195,11 +195,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-jmx</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-core</artifactId>
 			<optional>true</optional>
 		</dependency>
@@ -371,6 +366,11 @@
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-jmx</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/integration/SpringIntegrationMetricReaderNoJmxTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/integration/SpringIntegrationMetricReaderNoJmxTests.java
@@ -16,17 +16,18 @@
 
 package org.springframework.boot.actuate.metrics.integration;
 
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.actuate.autoconfigure.PublicMetricsAutoConfiguration;
+import org.springframework.boot.actuate.endpoint.MetricReaderPublicMetrics;
 import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
-import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.integration.support.management.IntegrationManagementConfigurer;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -35,30 +36,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for {@link SpringIntegrationMetricReader}.
  *
- * @author Dave Syer
  * @author Artem Bilan
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest("spring.jmx.enabled=true")
+@SpringBootTest("spring.jmx.enabled=false")
 @DirtiesContext
-public class SpringIntegrationMetricReaderTests {
+public class SpringIntegrationMetricReaderNoJmxTests {
 
 	@Autowired
-	private SpringIntegrationMetricReader reader;
+	@Qualifier("springIntegrationPublicMetrics")
+	private MetricReaderPublicMetrics integrationMetricReader;
 
 	@Test
 	public void test() {
-		assertThat(this.reader.count() > 0).isTrue();
+		assertThat(this.integrationMetricReader.metrics().size() > 0).isTrue();
 	}
 
 	@Configuration
-	@Import({ JmxAutoConfiguration.class, IntegrationAutoConfiguration.class })
+	@Import({IntegrationAutoConfiguration.class, PublicMetricsAutoConfiguration.class})
 	protected static class TestConfiguration {
-
-		@Bean
-		public SpringIntegrationMetricReader reader(IntegrationManagementConfigurer managementConfigurer) {
-			return new SpringIntegrationMetricReader(managementConfigurer);
-		}
 
 	}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -21,8 +21,6 @@ import javax.management.MBeanServer;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -35,6 +33,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.config.EnableIntegrationManagement;
 import org.springframework.integration.jmx.config.EnableIntegrationMBeanExport;
 import org.springframework.integration.monitor.IntegrationMBeanExporter;
 import org.springframework.integration.support.management.IntegrationManagementConfigurer;
@@ -67,16 +66,9 @@ public class IntegrationAutoConfiguration {
 	protected static class IntegrationJmxConfiguration
 			implements EnvironmentAware, BeanFactoryAware {
 
-		private final IntegrationManagementConfigurer configurer;
-
 		private BeanFactory beanFactory;
 
 		private RelaxedPropertyResolver propertyResolver;
-
-		protected IntegrationJmxConfiguration(
-				@Qualifier(IntegrationManagementConfigurer.MANAGEMENT_CONFIGURER_NAME) ObjectProvider<IntegrationManagementConfigurer> configurerProvider) {
-			this.configurer = configurerProvider.getIfAvailable();
-		}
 
 		@Override
 		public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
@@ -100,15 +92,23 @@ public class IntegrationAutoConfiguration {
 			if (StringUtils.hasLength(server)) {
 				exporter.setServer(this.beanFactory.getBean(server, MBeanServer.class));
 			}
-			if (this.configurer != null) {
-				if (this.configurer.getDefaultCountsEnabled() == null) {
-					this.configurer.setDefaultCountsEnabled(true);
-				}
-				if (this.configurer.getDefaultStatsEnabled() == null) {
-					this.configurer.setDefaultStatsEnabled(true);
-				}
-			}
 			return exporter;
+		}
+
+	}
+
+	@Configuration
+	@ConditionalOnClass({EnableIntegrationManagement.class, EnableIntegrationMBeanExport.class})
+	@ConditionalOnMissingBean(value = IntegrationManagementConfigurer.class,
+			name = IntegrationManagementConfigurer.MANAGEMENT_CONFIGURER_NAME,
+			search = SearchStrategy.CURRENT)
+	@ConditionalOnProperty(prefix = "spring.jmx", name = "enabled", havingValue = "true", matchIfMissing = true)
+	protected static class IntegrationManagementConfiguration {
+
+		@Configuration
+		@EnableIntegrationManagement(defaultCountsEnabled = "true", defaultStatsEnabled = "true")
+		protected static class EnableIntegrationManagementConfiguration {
+
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.integration.support.channel.HeaderChannelRegistry;
+import org.springframework.integration.support.management.IntegrationManagementConfigurer;
 import org.springframework.jmx.export.MBeanExporter;
 import org.springframework.test.context.support.TestPropertySourceUtils;
 
@@ -86,12 +87,14 @@ public class IntegrationAutoConfigurationTests {
 		MBeanServer mBeanServer = this.context.getBean(MBeanServer.class);
 		assertDomains(mBeanServer, true, "org.springframework.integration",
 				"org.springframework.integration.monitor");
+		assertThat(this.context.getBean(IntegrationManagementConfigurer.MANAGEMENT_CONFIGURER_NAME)).isNotNull();
 	}
 
 	@Test
 	public void disableJmxIntegration() {
 		load("spring.jmx.enabled=false");
 		assertThat(this.context.getBeansOfType(MBeanServer.class)).hasSize(0);
+		assertThat(this.context.getBeansOfType(IntegrationManagementConfigurer.class)).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-starters/spring-boot-starter-integration/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-integration/pom.xml
@@ -34,9 +34,5 @@
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-java-dsl</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-jmx</artifactId>
-		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-starters/spring-boot-starter-integration/src/main/resources/META-INF/spring.provides
+++ b/spring-boot-starters/spring-boot-starter-integration/src/main/resources/META-INF/spring.provides
@@ -1,1 +1,1 @@
-provides: spring-integration-core,spring-integration-java-dsl,spring-integration-jmx
+provides: spring-integration-core,spring-integration-java-dsl


### PR DESCRIPTION
Starting with Spring Integration `4.3.6` we don't need SI-JMX any more to enable `MessageChannel`, `MessageHandler` and `MessageSource` metrics

* Add `IntegrationManagementConfiguration` conditional auto-configuration to provide `@EnableIntegrationManagement` when JMX is `enabled` or there is no `IntegrationManagementConfigurer.MANAGEMENT_CONFIGURER_NAME` bean.
By default this bean doesn't exist and you explicitly should declare it (e.g. via `@EnableIntegrationManagement`) if you would like to collect metrics.
But at the same time Spring Integration enables it when JMX management is present.
That is a purpose of that new `IntegrationManagementConfiguration`
* Change `SpringIntegrationMetricReader` to read metrics from the `IntegrationManagementConfigurer`, not `IntegrationMBeanExporter`
* Change `PublicMetricsAutoConfiguration` to register `IntegrationManagementConfigurer.MANAGEMENT_CONFIGURER_NAME` bean if not present.
Since we are here in `actuator`, therefore we are interested in the metrics for SI as well
* Since we don't need JMX for the metrics any more, remove SI-JMX dependency from the `spring-boot-starter-integration`

**Cherry-pick to master**