### PR TITLE
Fix compatibility with Apache Kafka 0.10.1

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
@@ -43,6 +43,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Gary Russell
  * @author Stephane Nicoll
+ * @author Artem Bilan
  * @since 1.5.0
  */
 @ConfigurationProperties(prefix = "spring.kafka")
@@ -199,7 +200,7 @@ public class KafkaProperties {
 		 * Frequency in milliseconds that the consumer offsets are auto-committed to Kafka
 		 * if 'enable.auto.commit' true.
 		 */
-		private Long autoCommitInterval;
+		private Integer autoCommitInterval;
 
 		/**
 		 * What to do when there is no initial offset in Kafka or if the current offset
@@ -264,11 +265,11 @@ public class KafkaProperties {
 			return this.ssl;
 		}
 
-		public Long getAutoCommitInterval() {
+		public Integer getAutoCommitInterval() {
 			return this.autoCommitInterval;
 		}
 
-		public void setAutoCommitInterval(Long autoCommitInterval) {
+		public void setAutoCommitInterval(Integer autoCommitInterval) {
 			this.autoCommitInterval = autoCommitInterval;
 		}
 

--- a/spring-boot-docs/src/main/java/org/springframework/boot/kafka/KafkaSpecialProducerConsumerConfigExample.java
+++ b/spring-boot-docs/src/main/java/org/springframework/boot/kafka/KafkaSpecialProducerConsumerConfigExample.java
@@ -64,11 +64,11 @@ public class KafkaSpecialProducerConsumerConfigExample {
 		 */
 		@Bean
 		public ConsumerFactory<?, ?> kafkaConsumerFactory(KafkaProperties properties) {
-			Map<String, Object> consumererProperties = properties
+			Map<String, Object> consumerProperties = properties
 					.buildConsumerProperties();
-			consumererProperties.put(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG,
+			consumerProperties.put(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG,
 					MyConsumerMetricsReporter.class);
-			return new DefaultKafkaConsumerFactory<Object, Object>(consumererProperties);
+			return new DefaultKafkaConsumerFactory<Object, Object>(consumerProperties);
 		}
 
 	}


### PR DESCRIPTION
In the Apache Kafka `0.10.1` the type for the `ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG` has been changed from the `Long` to `Integer`.

* Fix `KafkaProperties.Consumer.autoCommitInterval` to `Integer` type.
 Having conversion logic in Kafka as
 ```
 case LONG:
                     if (value instanceof Integer)
                         return ((Integer) value).longValue();
                     if (value instanceof Long)
                         return (Long) value;
                     else if (value instanceof String)
                         return Long.parseLong(trimmed);
 ```
 we are compatible with both `0.10.0` and `0.10.1`
* Fix typo in the `KafkaSpecialProducerConsumerConfigExample`

**Cherry-pick to master**