### PR TITLE
Documentation improvement for Cassandra Setup

### DIFF
--- a/spring-boot-samples/spring-boot-sample-data-cassandra/README.adoc
+++ b/spring-boot-samples/spring-boot-sample-data-cassandra/README.adoc
@@ -1,4 +1,10 @@
+= Spring Boot Sample Data Cassandra
 
+To run the project, need to run below cql commands on Cassandra.
 
+== Keyspace Creation in Cassandra
 CREATE KEYSPACE mykeyspace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
 
+== Table Creation in Cassandra
+
+Don't forget to run cql  link:src/test/resources/setup.cql[setup script] located in resources folder.


### PR DESCRIPTION
Since the documentation for Spring Boot Sample Data Cassandra lacks of details, It is a good idea to add how to setup Cassandra to run the sample project.