### PR TITLE
Notify BuildContext of changed properties file

### DIFF
--- a/spring-boot-parent/pom.xml
+++ b/spring-boot-parent/pom.xml
@@ -158,6 +158,11 @@
 				<version>3.0.20</version>
 			</dependency>
 			<dependency>
+				<groupId>org.sonatype.plexus</groupId>
+				<artifactId>plexus-build-api</artifactId>
+				<version>0.0.7</version>
+			</dependency>
+			<dependency>
 				<groupId>org.eclipse.aether</groupId>
 				<artifactId>aether-api</artifactId>
 				<version>${aether.version}</version>

--- a/spring-boot-tools/spring-boot-maven-plugin/pom.xml
+++ b/spring-boot-tools/spring-boot-maven-plugin/pom.xml
@@ -170,6 +170,10 @@
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-utils</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.sonatype.plexus</groupId>
+			<artifactId>plexus-build-api</artifactId>
+		</dependency>
 		<!-- Optional -->
 		<dependency>
 			<groupId>org.apache.maven.plugins</groupId>

--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildInfoMojo.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildInfoMojo.java
@@ -22,10 +22,13 @@ import java.util.Map;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+
+import org.sonatype.plexus.build.incremental.BuildContext;
 
 import org.springframework.boot.loader.tools.BuildPropertiesWriter;
 import org.springframework.boot.loader.tools.BuildPropertiesWriter.NullAdditionalPropertyValueException;
@@ -60,6 +63,12 @@ public class BuildInfoMojo extends AbstractMojo {
 	@Parameter
 	private Map<String, String> additionalProperties;
 
+	/**
+	 * The Maven project.
+	 */
+	@Component
+	private BuildContext buildContext;
+
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		try {
@@ -67,6 +76,7 @@ public class BuildInfoMojo extends AbstractMojo {
 					.writeBuildProperties(new ProjectDetails(this.project.getGroupId(),
 							this.project.getArtifactId(), this.project.getVersion(),
 							this.project.getName(), this.additionalProperties));
+			this.buildContext.refresh(this.outputFile);
 		}
 		catch (NullAdditionalPropertyValueException ex) {
 			throw new MojoFailureException(


### PR DESCRIPTION
This ensures the compatibility of the maven plugin with m2e as described in the [documentation](http://www.eclipse.org/m2e/documentation/m2e-making-maven-plugins-compat.html#buildcontext).

Please advise me whether the commit messages are according to your standards. And I am not sure sure about whether to manage the dependency or not. I have opted for managed now.

See #7701 