### PR TITLE
Refactoring for IntAutoConfigurationScanRegistrar

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationScanRegistrar.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationScanRegistrar.java
@@ -16,9 +16,8 @@
 
 package org.springframework.boot.autoconfigure.integration;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.Collection;
+import java.util.Collections;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -36,6 +35,8 @@ import org.springframework.integration.config.IntegrationComponentScanRegistrar;
  *
  * @author Artem Bilan
  * @author Phillip Webb
+ *
+ * @since 1.5
  */
 class IntegrationAutoConfigurationScanRegistrar extends IntegrationComponentScanRegistrar
 		implements BeanFactoryAware {
@@ -51,32 +52,16 @@ class IntegrationAutoConfigurationScanRegistrar extends IntegrationComponentScan
 	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata,
 			final BeanDefinitionRegistry registry) {
 		super.registerBeanDefinitions(
-				new IntegrationComponentScanConfigurationMetaData(this.beanFactory),
+				new StandardAnnotationMetadata(IntegrationComponentScanConfiguration.class, true),
 				registry);
 	}
 
-	private static class IntegrationComponentScanConfigurationMetaData
-			extends StandardAnnotationMetadata {
-
-		private final BeanFactory beanFactory;
-
-		IntegrationComponentScanConfigurationMetaData(BeanFactory beanFactory) {
-			super(IntegrationComponentScanConfiguration.class, true);
-			this.beanFactory = beanFactory;
-		}
-
-		@Override
-		public Map<String, Object> getAnnotationAttributes(String annotationName) {
-			Map<String, Object> attributes = super.getAnnotationAttributes(
-					annotationName);
-			if (IntegrationComponentScan.class.getName().equals(annotationName)
-					&& AutoConfigurationPackages.has(this.beanFactory)) {
-				List<String> packages = AutoConfigurationPackages.get(this.beanFactory);
-				attributes = new LinkedHashMap<String, Object>(attributes);
-				attributes.put("value", packages.toArray(new String[packages.size()]));
-			}
-			return attributes;
-		}
+	@Override
+	protected Collection<String> getBasePackages(AnnotationMetadata importingClassMetadata,
+			BeanDefinitionRegistry registry) {
+		return AutoConfigurationPackages.has(this.beanFactory)
+				? AutoConfigurationPackages.get(this.beanFactory)
+				: Collections.emptyList();
 	}
 
 	@IntegrationComponentScan


### PR DESCRIPTION
To avoid the mocking code for the `StandardAnnotationMetadata` override  `IntegrationComponentScanRegistrar.getBasePackages()` to return `AutoConfigurationPackages.get(this.beanFactory)`

See https://github.com/spring-projects/spring-integration/issues/2007