### PR TITLE
Reduce memory footprint of AsciiBytes.hashCode(int hash, String string)

### DIFF
--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/AsciiBytes.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/AsciiBytes.java
@@ -224,9 +224,8 @@ final class AsciiBytes {
 	}
 
 	public static int hashCode(int hash, String string) {
-		char[] chars = string.toCharArray();
-		for (int i = 0; i < chars.length; i++) {
-			hash = 31 * hash + chars[i];
+		for (int i = 0; i < string.length(); i++) {
+			hash = 31 * hash + string.charAt(i);
 		}
 		return hash;
 	}


### PR DESCRIPTION
Hey,

just noticed a small improvement when building hash codes with AsciiBytes.hashCode(int hash, String string). There is an unnecessary invocation of String.toCharArray() which copies the backing array of the string. Because we're just iterating over the chars here we could simply use String.charAt().

Benchmark | Mode | Cnt | Score | Error | Units
------------ | ------------- | ------------ | ------------- | ------------ | -------------
MyBenchmark.testNew | thrpt | 20 | 30120816,951 | ±  155853,632 | ops/s
MyBenchmark.testOld | thrpt | 20 | 22063573,907 | ± 2329741,929 | ops/s

Cheers,
Christoph

Fixes #7850 