### PR TITLE
#7865 Spring Batch : Fix PostgreSQL with defaultAutoCommit=false

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherCommandLineRunner.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherCommandLineRunner.java
@@ -50,6 +50,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.util.StringUtils;
 
@@ -81,6 +85,8 @@ public class JobLauncherCommandLineRunner
 
 	private ApplicationEventPublisher publisher;
 
+	private PlatformTransactionManager transactionManager;
+
 	public JobLauncherCommandLineRunner(JobLauncher jobLauncher,
 			JobExplorer jobExplorer) {
 		this.jobLauncher = jobLauncher;
@@ -109,6 +115,11 @@ public class JobLauncherCommandLineRunner
 	@Autowired(required = false)
 	public void setJobs(Collection<Job> jobs) {
 		this.jobs = jobs;
+	}
+
+	@Autowired(required = false)
+	public void setTransactionManager(PlatformTransactionManager transactionManager) {
+		this.transactionManager = transactionManager;
 	}
 
 	@Override
@@ -205,11 +216,25 @@ public class JobLauncherCommandLineRunner
 		}
 	}
 
-	protected void execute(Job job, JobParameters jobParameters)
+	protected void execute(final Job job, final JobParameters jobParameters)
 			throws JobExecutionAlreadyRunningException, JobRestartException,
 			JobInstanceAlreadyCompleteException, JobParametersInvalidException,
 			JobParametersNotFoundException {
-		JobParameters nextParameters = getNextJobParameters(job, jobParameters);
+
+		JobParameters nextParameters;
+		if (this.transactionManager != null) {
+			TransactionTemplate transactionTemplate = new TransactionTemplate(this.transactionManager);
+			nextParameters = transactionTemplate.execute(new TransactionCallback<JobParameters>() {
+				@Override
+				public JobParameters doInTransaction(TransactionStatus transactionStatus) {
+					return getNextJobParameters(job, jobParameters);
+				}
+			});
+		}
+		else {
+			nextParameters = getNextJobParameters(job, jobParameters);
+		}
+
 		if (nextParameters != null) {
 			JobExecution execution = this.jobLauncher.run(job, nextParameters);
 			if (this.publisher != null) {


### PR DESCRIPTION
Spring Boot 1.4.3 / JDK 8 / PostgreSQL Driver 9.4.1209

Using a Datasource (Tomcat JDBC in our case) configured with defaultAutoCommit=false leads to 

```
	java.lang.IllegalStateException: Failed to execute CommandLineRunner
		at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:803)
		at org.springframework.boot.SpringApplication.callRunners(SpringApplication.java:784)
		at org.springframework.boot.SpringApplication.afterRefresh(SpringApplication.java:771)
		at org.springframework.boot.SpringApplication.run(SpringApplication.java:316)
		at org.springframework.boot.SpringApplication.run(SpringApplication.java:1186)
		at org.springframework.boot.SpringApplication.run(SpringApplication.java:1175)
		at batchtest.TestBatch.main(TestBatch.java:24)
		at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.lang.reflect.Method.invoke(Method.java:498)
		at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
	Caused by: org.springframework.transaction.CannotCreateTransactionException: Could not open JDBC Connection for transaction; nested exception is org.postgresql.util.PSQLException: Cannot change transaction isolation level in the middle of a transaction.
		at org.springframework.jdbc.datasource.DataSourceTransactionManager.doBegin(DataSourceTransactionManager.java:245)
		at org.springframework.transaction.support.AbstractPlatformTransactionManager.getTransaction(AbstractPlatformTransactionManager.java:373)
		at org.springframework.transaction.interceptor.TransactionAspectSupport.createTransactionIfNecessary(TransactionAspectSupport.java:430)
		at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:276)
		at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96)
		at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
		at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213)
		at com.sun.proxy.$Proxy40.getLastJobExecution(Unknown Source)
		at org.springframework.batch.core.launch.support.SimpleJobLauncher.run(SimpleJobLauncher.java:98)
		at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.lang.reflect.Method.invoke(Method.java:498)
		at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:333)
		at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:190)
		at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157)
		at org.springframework.batch.core.configuration.annotation.SimpleBatchConfiguration$PassthruAdvice.invoke(SimpleBatchConfiguration.java:127)
		at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
		at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213)
		at com.sun.proxy.$Proxy42.run(Unknown Source)
		at org.springframework.boot.autoconfigure.batch.JobLauncherCommandLineRunner.execute(JobLauncherCommandLineRunner.java:216)
		at org.springframework.boot.autoconfigure.batch.JobLauncherCommandLineRunner.executeLocalJobs(JobLauncherCommandLineRunner.java:233)
		at org.springframework.boot.autoconfigure.batch.JobLauncherCommandLineRunner.launchJobFromProperties(JobLauncherCommandLineRunner.java:125)
		at org.springframework.boot.autoconfigure.batch.JobLauncherCommandLineRunner.run(JobLauncherCommandLineRunner.java:119)
		at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:800)
		... 11 common frames omitted
	Caused by: org.postgresql.util.PSQLException: Cannot change transaction isolation level in the middle of a transaction.
		at org.postgresql.jdbc.PgConnection.setTransactionIsolation(PgConnection.java:880)
		at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.lang.reflect.Method.invoke(Method.java:498)
		at org.apache.tomcat.jdbc.pool.ProxyConnection.invoke(ProxyConnection.java:126)
		at org.apache.tomcat.jdbc.pool.JdbcInterceptor.invoke(JdbcInterceptor.java:108)
		at org.apache.tomcat.jdbc.pool.DisposableConnectionFacade.invoke(DisposableConnectionFacade.java:81)
		at com.sun.proxy.$Proxy54.setTransactionIsolation(Unknown Source)
		at org.springframework.jdbc.datasource.DataSourceUtils.prepareConnectionForTransaction(DataSourceUtils.java:193)
		at org.springframework.jdbc.datasource.DataSourceTransactionManager.doBegin(DataSourceTransactionManager.java:214)
		... 35 common frames omitted
```
	
This error is caused by SQL requests being ran out of a transaction by `JobLauncherCommandLineRunner#getNextJobParameters()`.
PostgreSQL connection used are neither committed nor rollbacked and as such, are still considered "OPEN" by the PostgreSQL Driver. This connection is then returned to the pool.
The next request is made by Spring Batch using the same connection (the pool returned the same connection), but the transaction isolation needs to be changed due to the configuration defined in `AbstractJobRepositoryFactoryBean#initializeProxy()` configuration. This operation is forbidden by PostgreSQL since the connection is already open.

A very simple reproducer is available here : https://gist.github.com/gdarmont/0b796aa06b86c37d147a6cded8065e96
You only need a PostgreSQL DB.

---

This patch changes `JobLauncherCommandLineRunner` so it now wraps all DB call in transaction manager if available.

Fixes #7865

Hope this helps,
Guillaume