### PR TITLE
Add dependency management for `hazelcast-hibernate52`

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -79,7 +79,6 @@
 		<h2.version>1.4.193</h2.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<hazelcast.version>3.7.4</hazelcast.version>
-		<hazelcast-hibernate4.version>3.7.1</hazelcast-hibernate4.version>
 		<hazelcast-hibernate5.version>1.1.3</hazelcast-hibernate5.version>
 		<hibernate.version>5.2.5.Final</hibernate.version>
 		<hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
@@ -707,7 +706,7 @@
 			</dependency>
 			<dependency>
 				<groupId>com.hazelcast</groupId>
-				<artifactId>hazelcast-hibernate5</artifactId>
+				<artifactId>hazelcast-hibernate52</artifactId>
 				<version>${hazelcast-hibernate5.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Since `master` has moved to Hibernate 5.2 in 943262b, dependency management for `hazelcast-hibernate52` should be added.

This artifact originates from the same [repository](https://github.com/hazelcast/hazelcast-hibernate5) as `hazelcast-hibernate5` which is already included in Boot's dependency management so existing `hazelcast-hibernate5.version` can be reused:

> hazelcast-hibernate5 supports Java 6+, Hibernate 5.0.x, Hibernate 5.1.x and Hazelcast 3.7+
>
> hazelcast-hibernate52 supports Java 8, Hibernate 5.2.x and Hazelcast 3.7+

On a sidenote, if Boot 2.0 minimum supported version of Hibernate is indeed 5.2 as indicated by #7586 then perhaps this PR could be expanded to remove dependency management for `hazelcast-hibernate4` and `hazelcast-hibernate5`?