### PR TITLE
Allow lowercase on logger change endpoint for MVC

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/LoggersMvcEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/LoggersMvcEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  * Adapter to expose {@link LoggersEndpoint} as an {@link MvcEndpoint}.
  *
  * @author Ben Hale
+ * @author Kazuki Shimizu
  * @since 1.5.0
  */
 @ConfigurationProperties(prefix = "endpoints.loggers")
@@ -71,7 +72,7 @@ public class LoggersMvcEndpoint extends EndpointMvcAdapter {
 			return getDisabledResponse();
 		}
 		String level = configuration.get("configuredLevel");
-		this.delegate.setLogLevel(name, level == null ? null : LogLevel.valueOf(level));
+		this.delegate.setLogLevel(name, level == null ? null : LogLevel.valueOf(level.toUpperCase()));
 		return HttpEntity.EMPTY;
 	}
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/LoggersMvcEndpointTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/LoggersMvcEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Ben Hale
  * @author Phillip Webb
+ * @author Kazuki Shimizu
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -131,7 +132,7 @@ public class LoggersMvcEndpointTests {
 	@Test
 	public void setLoggerShouldSetLogLevel() throws Exception {
 		this.mvc.perform(post("/loggers/ROOT").contentType(MediaType.APPLICATION_JSON)
-				.content("{\"configuredLevel\":\"DEBUG\"}")).andExpect(status().isOk());
+				.content("{\"configuredLevel\":\"debug\"}")).andExpect(status().isOk());
 		verify(this.loggingSystem).setLogLevel("ROOT", LogLevel.DEBUG);
 	}
 


### PR DESCRIPTION
I've fixed to allow lowercase on logger change endpoint(`POST /loggers/{name}`) for Spring MVC.
Currently, `IllegalArgumentException` occur if contains lowercase into log level.

e.g.)
```json
{
    "configuredLevel": "debug"
}
```

Please review this.
