### PR TITLE
updated readme with missing samples

### DIFF
--- a/spring-boot-samples/README.adoc
+++ b/spring-boot-samples/README.adoc
@@ -50,9 +50,6 @@ The following sample applications are provided:
 | link:spring-boot-sample-data-elasticsearch[spring-boot-sample-data-elasticsearch]
 | Stores data using Spring Data Elasticsearch
 
-| link:spring-boot-sample-data-gemfire[spring-boot-sample-data-gemfire]
-| Stores data using Spring Data GemFire
-
 | link:spring-boot-sample-data-jpa[spring-boot-sample-data-jpa]
 | Stores data using Spring Data JPA with Hibernate
 

--- a/spring-boot-samples/README.adoc
+++ b/spring-boot-samples/README.adoc
@@ -38,6 +38,9 @@ The following sample applications are provided:
 | link:spring-boot-sample-cache[spring-boot-sample-cache]
 | Web application that uses Spring's cache abstraction
 
+| link:spring-boot-sample-custom-layout[spring-boot-sample-custom-layout]
+| Creates custom Jar Layout
+
 | link:spring-boot-sample-data-cassandra[spring-boot-sample-data-cassandra]
 | Stores data using Spring Data Cassandra
 
@@ -52,6 +55,9 @@ The following sample applications are provided:
 
 | link:spring-boot-sample-data-jpa[spring-boot-sample-data-jpa]
 | Stores data using Spring Data JPA with Hibernate
+
+| link:spring-boot-sample-data-ldap[spring-boot-sample-data-ldap]
+| Stores data using Spring Data LDAP
 
 | link:spring-boot-sample-data-mongodb[spring-boot-sample-data-mongodb]
 | Stores data using Spring Data MongoDB
@@ -87,6 +93,9 @@ The following sample applications are provided:
 | Demonstrates Actuator's hypermedia support alongside Spring Data JPA and Spring Data
   REST
 
+| link:spring-boot-sample-hypermedia-ui-secure[spring-boot-sample-hypermedia-ui-secure]
+| Demonstrates Actuator's hypermedia support alongside a static secure web UI
+
 | link:spring-boot-sample-hypermedia-ui[spring-boot-sample-hypermedia-ui]
 | Demonstrates Actuator's hypermedia support alongside a static web UI
 
@@ -116,6 +125,9 @@ The following sample applications are provided:
 
 | link:spring-boot-sample-jetty92[spring-boot-sample-jetty92]
 | Embedded Jetty 9.2
+
+| link:spring-boot-sample-jetty93[spring-boot-sample-jetty93]
+| Embedded Jetty 9.3
 
 | link:spring-boot-sample-jooq[spring-boot-sample-jooq]
 | Stores data using jOOQ
@@ -162,6 +174,9 @@ The following sample applications are provided:
 | link:spring-boot-sample-secure[spring-boot-sample-secure]
 | Non-web application that uses Spring Security
 
+| link:spring-boot-sample-secure-oauth2-actuator[spring-boot-sample-secure-oauth2-actuator]
+| RESTful service secured using OAuth2 using Actuator 
+
 | link:spring-boot-sample-secure-oauth2[spring-boot-sample-secure-oauth2]
 | RESTful service secured using OAuth2
 
@@ -176,6 +191,9 @@ The following sample applications are provided:
 
 | link:spring-boot-sample-simple[spring-boot-sample-simple]
 | Simple command line application
+
+| link:spring-boot-sample-test-nomockito[spring-boot-sample-test-nomockito]
+| Demonstrates Spring Boot's testing capabilities without using Mockito
 
 | link:spring-boot-sample-test[spring-boot-sample-test]
 | Demonstrates Spring Boot's testing capabilities
@@ -246,6 +264,9 @@ The following sample applications are provided:
 | link:spring-boot-sample-web-static[spring-boot-sample-web-static]
 | Web application that serves static files
 
+| link:spring-boot-sample-web-thymeleaf3[spring-boot-sample-web-thymeleaf3]
+| Web application with a basic UI built using thymeleaf 3.x
+
 | link:spring-boot-sample-web-ui[spring-boot-sample-web-ui]
 | Web application with a basic UI built using Bootstrap and JQuery
 
@@ -254,6 +275,9 @@ The following sample applications are provided:
 
 | link:spring-boot-sample-websocket-jetty[spring-boot-sample-websocket-jetty]
 | WebSocket application that uses Jetty
+
+| link:spring-boot-sample-websocket-jetty93[spring-boot-sample-websocket-jetty93]
+| WebSocket application that uses Jetty 9.3
 
 | link:spring-boot-sample-websocket-tomcat[spring-boot-sample-websocket-tomcat]
 | WebSocket application that uses Tomcat


### PR DESCRIPTION
found some missing example modules from Readme and added them back.
also removed spring-boot-sample-data-gemfire entry which is not available as a sample.

The description might need some corrections. Please propose fixes if anything needed. thanks

This is how I found the missing ones:
```bash
ls -1  | grep spring-boot-sample  | sort | uniq  > available.list
cat README.adoc | grep link: | sed -e 's/\[/ /g'  | sed -e 's/:/ /g' | awk '{print ""$3;}' | sort | uniq  > documented.list
comm -3 available.list documented.list 
rm -f available.list documented.list 
```

output from above commands:
```bash
bash-3.2$ comm -3 available.list documented.list 
spring-boot-sample-custom-layout
	spring-boot-sample-data-gemfire
spring-boot-sample-data-ldap
spring-boot-sample-hypermedia-ui-secure
spring-boot-sample-jetty93
spring-boot-sample-secure-oauth2-actuator
spring-boot-sample-test-nomockito
spring-boot-sample-web-thymeleaf3
spring-boot-sample-websocket-jetty93
```