### PR TITLE
Update springloaded version to 1.2.6.RELEASE

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -2431,7 +2431,7 @@ Spring Boot plugin declaration, e.g.
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>springloaded</artifactId>
-				<version>1.2.0.RELEASE</version>
+				<version>1.2.6.RELEASE</version>
 			</dependency>
 		</dependencies>
 	</plugin>

--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -2457,7 +2457,7 @@ To configure IntelliJ IDEA correctly you can use the `idea` Gradle plugin:
 		repositories { jcenter() }
 		dependencies {
 			classpath "org.springframework.boot:spring-boot-gradle-plugin:{spring-boot-version}"
-			classpath 'org.springframework:springloaded:1.2.0.RELEASE'
+			classpath 'org.springframework:springloaded:1.2.6.RELEASE'
 		}
 	}
 


### PR DESCRIPTION
Just a quick improvement to make sure developers use the current version of springloaded.