### PR TITLE
Allow to inject a JdbcOperations into NamedParameterJdbcTemplate

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.boot.autoconfigure.jdbc;
 
 import javax.sql.DataSource;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -63,8 +64,14 @@ public class JdbcTemplateAutoConfiguration {
 	@Bean
 	@Primary
 	@ConditionalOnMissingBean(NamedParameterJdbcOperations.class)
-	public NamedParameterJdbcTemplate namedParameterJdbcTemplate() {
-		return new NamedParameterJdbcTemplate(this.dataSource);
+	public NamedParameterJdbcTemplate namedParameterJdbcTemplate(ObjectProvider<JdbcOperations> jdbcOperationsProvider) {
+		JdbcOperations jdbcOperations = jdbcOperationsProvider.getIfUnique();
+		if (jdbcOperations != null) {
+			return new NamedParameterJdbcTemplate(jdbcOperations);
+		}
+		else {
+			return new NamedParameterJdbcTemplate(this.dataSource);
+		}
 	}
 
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

I want to allow to inject a `JdbcOperation` into `NamedParameterJdbcTemplate` that create on auto configure. In this change, we can share configurations of `JdbcOperation` to `NamedParameterJdbcTemplate` that create on auto configure.

What do you think ?
