### PR TITLE
Support 'spring.jdbc.template.*' for customizing JdbcTemplate

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/JdbcProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/JdbcProperties.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jdbc;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for JDBC.
+ *
+ * @author Kazuki Shimizu
+ * @since 1.5.0
+ */
+@ConfigurationProperties(prefix = "spring.jdbc")
+public class JdbcProperties {
+
+	/**
+	 * Settings for JdbcTemplate.
+	 */
+	private final Template template = new Template();
+
+	public Template getTemplate() {
+		return this.template;
+	}
+
+	/**
+	 * {@link org.springframework.jdbc.core.JdbcTemplate} settings.
+	 */
+	public static class Template {
+
+		/**
+		 * Fetch size.
+		 * @see org.springframework.jdbc.core.JdbcTemplate#fetchSize
+		 */
+		private Integer fetchSize;
+
+		/**
+		 * Max row count.
+		 * @see org.springframework.jdbc.core.JdbcTemplate#maxRows
+		 */
+		private Integer maxRows;
+
+		/**
+		 * Query timeout in seconds.
+		 * @see org.springframework.jdbc.core.JdbcTemplate#queryTimeout
+		 */
+		private Integer queryTimeout;
+
+		public Integer getFetchSize() {
+			return this.fetchSize;
+		}
+
+		public void setFetchSize(Integer fetchSize) {
+			this.fetchSize = fetchSize;
+		}
+
+		public Integer getMaxRows() {
+			return this.maxRows;
+		}
+
+		public void setMaxRows(Integer maxRows) {
+			this.maxRows = maxRows;
+		}
+
+		public Integer getQueryTimeout() {
+			return this.queryTimeout;
+		}
+
+		public void setQueryTimeout(Integer queryTimeout) {
+			this.queryTimeout = queryTimeout;
+		}
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -45,11 +46,14 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 @ConditionalOnClass({ DataSource.class, JdbcTemplate.class })
 @ConditionalOnSingleCandidate(DataSource.class)
 @AutoConfigureAfter(DataSourceAutoConfiguration.class)
+@EnableConfigurationProperties(JdbcProperties.class)
 public class JdbcTemplateAutoConfiguration {
 
+	private final JdbcProperties properties;
 	private final DataSource dataSource;
 
-	public JdbcTemplateAutoConfiguration(DataSource dataSource) {
+	public JdbcTemplateAutoConfiguration(JdbcProperties properties, DataSource dataSource) {
+		this.properties = properties;
 		this.dataSource = dataSource;
 	}
 
@@ -57,7 +61,18 @@ public class JdbcTemplateAutoConfiguration {
 	@Primary
 	@ConditionalOnMissingBean(JdbcOperations.class)
 	public JdbcTemplate jdbcTemplate() {
-		return new JdbcTemplate(this.dataSource);
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(this.dataSource);
+		JdbcProperties.Template template = this.properties.getTemplate();
+		if (template.getFetchSize() != null) {
+			jdbcTemplate.setFetchSize(template.getFetchSize());
+		}
+		if (template.getQueryTimeout() != null) {
+			jdbcTemplate.setQueryTimeout(template.getQueryTimeout());
+		}
+		if (template.getMaxRows() != null) {
+			jdbcTemplate.setMaxRows(template.getMaxRows());
+		}
+		return jdbcTemplate;
 	}
 
 	@Bean

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,27 @@ public class JdbcTemplateAutoConfigurationTests {
 		JdbcTemplate jdbcTemplate = this.context.getBean(JdbcTemplate.class);
 		assertThat(jdbcTemplate).isNotNull();
 		assertThat(jdbcTemplate.getDataSource()).isNotNull();
+		assertThat(jdbcTemplate.getFetchSize()).isEqualTo(-1);
+		assertThat(jdbcTemplate.getQueryTimeout()).isEqualTo(-1);
+		assertThat(jdbcTemplate.getMaxRows()).isEqualTo(-1);
+	}
+
+	@Test
+	public void testJdbcTemplateWithCustomProperties() throws Exception {
+		EnvironmentTestUtils.addEnvironment(this.context,
+			"spring.jdbc.template.fetch-size:100",
+			"spring.jdbc.template.query-timeout:60",
+			"spring.jdbc.template.max-rows:1000");
+		this.context.register(DataSourceAutoConfiguration.class,
+			JdbcTemplateAutoConfiguration.class,
+			PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		JdbcTemplate jdbcTemplate = this.context.getBean(JdbcTemplate.class);
+		assertThat(jdbcTemplate).isNotNull();
+		assertThat(jdbcTemplate.getDataSource()).isNotNull();
+		assertThat(jdbcTemplate.getFetchSize()).isEqualTo(100);
+		assertThat(jdbcTemplate.getQueryTimeout()).isEqualTo(60);
+		assertThat(jdbcTemplate.getMaxRows()).isEqualTo(1000);
 	}
 
 	@Test


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

I want to support some useful properties for customizing a `JdbcTemplate` that creating on auto configure.

* `fetchSize`
* `queryTimeout`
* `maxRows`

What do you think ?
