### PR TITLE
Remove environment null check in LdapProperties

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapProperties.java
@@ -108,7 +108,6 @@ public class LdapProperties {
 	}
 
 	private int determinePort(Environment environment) {
-		Assert.state(environment != null, "No local LDAP port configured");
 		String localPort = environment.getProperty("local.ldap.port");
 		if (localPort != null) {
 			return Integer.valueOf(localPort);


### PR DESCRIPTION
It looks it can't be null unless I missed anything.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->