### PR TITLE
Remove @JsonAnyGetter from AuditEvent

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/AuditEvent.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/AuditEvent.java
@@ -22,7 +22,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -137,7 +136,6 @@ public class AuditEvent implements Serializable {
 	 * Returns the event data.
 	 * @return the event data
 	 */
-	@JsonAnyGetter
 	public Map<String, Object> getData() {
 		return this.data;
 	}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/audit/AuditEventTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/audit/AuditEventTests.java
@@ -18,9 +18,12 @@ package org.springframework.boot.actuate.audit;
 
 import java.util.Collections;
 
+import org.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,6 +75,16 @@ public class AuditEventTests {
 		this.thrown.expect(IllegalArgumentException.class);
 		this.thrown.expectMessage("Type must not be null");
 		new AuditEvent("phil", null, Collections.singletonMap("a", (Object) "b"));
+	}
+
+	@Test
+	public void jsonFormat() throws Exception {
+		AuditEvent event = new AuditEvent("johannes", "UNKNOWN", Collections.singletonMap("type", (Object) "BadCredentials"));
+
+		String json = Jackson2ObjectMapperBuilder.json().build().writeValueAsString(event);
+		JSONObject jsonObject = new JSONObject(json);
+
+		assertThat(jsonObject.getString("type")).isEqualTo("UNKNOWN");
 	}
 
 }


### PR DESCRIPTION
In case the data for the audit event contains an entry with the key
"type" the member `type` from the AuditEvent is overlayed when rendering
this object as json. Hence the @JsonAnyGetter annotation should be
removed from the data member of AuditEvent.

The `AuditEventListener` for example stores `AuditEvent`s with `type = AUTHENTICATION_FAILURE` and `data = { "type": "org.springframework.security.authentication.BadCredentialsException" ...}`

which results in the following json (note the `AUTHENTICATION_FAILURE` is entirely missing):

```json
{
  "timestamp": "2017-01-15T14:11:31+0000",
  "principal": "admin",
  "type": "org.springframework.security.authentication.BadCredentialsException",
  "details": {
    "remoteAddress": "0:0:0:0:0:0:0:1",
    "sessionId": null
  },
  "message": "Bad credentials"
}
```