### PR TITLE
Modify Log4j2 support to use public APIs

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystem.java
@@ -57,7 +57,7 @@ public abstract class LoggingSystem {
 	private static final Map<String, String> SYSTEMS;
 
 	static {
-		Map<String, String> systems = new LinkedHashMap<String, String>();
+		Map<String, String> systems = new LinkedHashMap<>();
 		systems.put("ch.qos.logback.core.Appender",
 				"org.springframework.boot.logging.logback.LogbackLoggingSystem");
 		systems.put("org.apache.logging.log4j.core.impl.Log4jContextFactory",
@@ -165,9 +165,10 @@ public abstract class LoggingSystem {
 
 	private static LoggingSystem get(ClassLoader classLoader, String loggingSystemClass) {
 		try {
-			Class<?> systemClass = ClassUtils.forName(loggingSystemClass, classLoader);
-			return (LoggingSystem) systemClass.getConstructor(ClassLoader.class)
-					.newInstance(classLoader);
+			Class<? extends LoggingSystem> systemClass = ClassUtils
+					.forName(loggingSystemClass, classLoader)
+					.asSubclass(LoggingSystem.class);
+			return systemClass.getConstructor(ClassLoader.class).newInstance(classLoader);
 		}
 		catch (Exception ex) {
 			throw new IllegalStateException(ex);

--- a/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -16,27 +16,20 @@
 
 package org.springframework.boot.logging.log4j2;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Marker;
-import org.apache.logging.log4j.core.Filter;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.filter.AbstractFilter;
-import org.apache.logging.log4j.message.Message;
 
 import org.springframework.boot.logging.LogFile;
 import org.springframework.boot.logging.LogLevel;
@@ -50,19 +43,20 @@ import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
 
 /**
- * {@link LoggingSystem} for <a href="http://logging.apache.org/log4j/2.x/">Log4j 2</a>.
+ * {@link LoggingSystem} for <a href="https://logging.apache.org/log4j/2.x/">Log4j 2</a>.
  *
  * @author Daniel Fullarton
  * @author Andy Wilkinson
  * @author Alexander Heusingfeld
  * @author Ben Hale
+ * @author Matt Sicker
  * @since 1.2.0
  */
 public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 
-	private static final String FILE_PROTOCOL = "file";
+	private static final Object EXTERNAL_CONTEXT = LoggingSystem.class.getName();
 
-	private static final LogLevels<Level> LEVELS = new LogLevels<Level>();
+	private static final LogLevels<Level> LEVELS = new LogLevels<>();
 
 	static {
 		LEVELS.map(LogLevel.TRACE, Level.TRACE);
@@ -74,32 +68,7 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 		LEVELS.map(LogLevel.OFF, Level.OFF);
 	}
 
-	private static final Filter FILTER = new AbstractFilter() {
-
-		@Override
-		public Result filter(LogEvent event) {
-			return Result.DENY;
-		}
-
-		@Override
-		public Result filter(Logger logger, Level level, Marker marker, Message msg,
-				Throwable t) {
-			return Result.DENY;
-		}
-
-		@Override
-		public Result filter(Logger logger, Level level, Marker marker, Object msg,
-				Throwable t) {
-			return Result.DENY;
-		}
-
-		@Override
-		public Result filter(Logger logger, Level level, Marker marker, String msg,
-				Object... params) {
-			return Result.DENY;
-		}
-
-	};
+	private final AtomicBoolean initialized = new AtomicBoolean(false);
 
 	public Log4J2LoggingSystem(ClassLoader classLoader) {
 		super(classLoader);
@@ -111,13 +80,14 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 	}
 
 	private String[] getCurrentlySupportedConfigLocations() {
-		List<String> supportedConfigLocations = new ArrayList<String>();
+		List<String> supportedConfigLocations = new ArrayList<>();
 		if (isClassAvailable("com.fasterxml.jackson.dataformat.yaml.YAMLParser")) {
 			Collections.addAll(supportedConfigLocations, "log4j2.yaml", "log4j2.yml");
 		}
 		if (isClassAvailable("com.fasterxml.jackson.databind.ObjectMapper")) {
 			Collections.addAll(supportedConfigLocations, "log4j2.json", "log4j2.jsn");
 		}
+		supportedConfigLocations.add("log4j2.properties");
 		supportedConfigLocations.add("log4j2.xml");
 		return supportedConfigLocations
 				.toArray(new String[supportedConfigLocations.size()]);
@@ -128,36 +98,18 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 	}
 
 	@Override
-	public void beforeInitialize() {
-		LoggerContext loggerContext = getLoggerContext();
-		if (isAlreadyInitialized(loggerContext)) {
-			return;
-		}
-		super.beforeInitialize();
-		loggerContext.getConfiguration().addFilter(FILTER);
-	}
-
-	@Override
 	public void initialize(LoggingInitializationContext initializationContext,
 			String configLocation, LogFile logFile) {
-		LoggerContext loggerContext = getLoggerContext();
-		if (isAlreadyInitialized(loggerContext)) {
-			return;
+		if (this.initialized.compareAndSet(false, true)) {
+			super.initialize(initializationContext, configLocation, logFile);
 		}
-		loggerContext.getConfiguration().removeFilter(FILTER);
-		super.initialize(initializationContext, configLocation, logFile);
-		markAsInitialized(loggerContext);
 	}
 
 	@Override
 	protected void loadDefaults(LoggingInitializationContext initializationContext,
 			LogFile logFile) {
-		if (logFile != null) {
-			loadConfiguration(getPackagedConfigFile("log4j2-file.xml"), logFile);
-		}
-		else {
-			loadConfiguration(getPackagedConfigFile("log4j2.xml"), logFile);
-		}
+		String fileName = "log4j2" + (logFile == null ? "" : "-file") + ".xml";
+		loadConfiguration(getPackagedConfigFile(fileName), logFile);
 	}
 
 	@Override
@@ -169,24 +121,27 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 
 	protected void loadConfiguration(String location, LogFile logFile) {
 		Assert.notNull(location, "Location must not be null");
+		URI uri;
 		try {
-			LoggerContext ctx = getLoggerContext();
-			URL url = ResourceUtils.getURL(location);
-			ConfigurationSource source = getConfigurationSource(url);
-			ctx.start(ConfigurationFactory.getInstance().getConfiguration(ctx, source));
+			uri = ResourceUtils.toURI(location);
 		}
 		catch (Exception ex) {
 			throw new IllegalStateException(
 					"Could not initialize Log4J2 logging from " + location, ex);
 		}
+		LoggerContext ctx = getLoggerContext(uri);
+		if (ctx == null || ctx.getConfiguration() instanceof DefaultConfiguration) {
+			// a DefaultConfiguration is returned in case there's an error with the
+			// provided config file, but in our case, we specifically wanted it to work
+			// and a simple error log message isn't enough
+			throw new IllegalStateException(
+					"Could not initialize Log4J2 logging from " + location);
+		}
 	}
 
-	private ConfigurationSource getConfigurationSource(URL url) throws IOException {
-		InputStream stream = url.openStream();
-		if (FILE_PROTOCOL.equals(url.getProtocol())) {
-			return new ConfigurationSource(stream, ResourceUtils.getFile(url));
-		}
-		return new ConfigurationSource(stream, url);
+	private LoggerContext getLoggerContext(URI uri) {
+		return (LoggerContext) LogManager
+				.getContext(getClassLoader(), false, EXTERNAL_CONTEXT, uri);
 	}
 
 	@Override
@@ -202,26 +157,15 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 	@Override
 	public void setLogLevel(String loggerName, LogLevel logLevel) {
 		Level level = LEVELS.convertSystemToNative(logLevel);
-		LoggerConfig loggerConfig = getLoggerConfig(loggerName);
-		if (loggerConfig == null) {
-			loggerConfig = new LoggerConfig(loggerName, level, true);
-			getLoggerContext().getConfiguration().addLogger(loggerName, loggerConfig);
-		}
-		else {
-			loggerConfig.setLevel(level);
-		}
-		getLoggerContext().updateLoggers();
+		Configurator.setLevel(loggerName, level);
 	}
 
 	@Override
 	public List<LoggerConfiguration> getLoggerConfigurations() {
-		List<LoggerConfiguration> result = new ArrayList<LoggerConfiguration>();
-		Configuration configuration = getLoggerContext().getConfiguration();
-		for (LoggerConfig loggerConfig : configuration.getLoggers().values()) {
-			result.add(convertLoggerConfiguration(loggerConfig));
-		}
-		Collections.sort(result, CONFIGURATION_COMPARATOR);
-		return result;
+		return getLoggerContext().getConfiguration().getLoggers().values().stream()
+				.map(this::convertLoggerConfiguration)
+				.sorted(CONFIGURATION_COMPARATOR)
+				.collect(Collectors.toList());
 	}
 
 	@Override
@@ -242,15 +186,10 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 	}
 
 	@Override
-	public Runnable getShutdownHandler() {
-		return new ShutdownHandler();
-	}
-
-	@Override
 	public void cleanUp() {
 		super.cleanUp();
-		LoggerContext loggerContext = getLoggerContext();
-		markAsUninitialized(loggerContext);
+		LogManager.shutdown();
+		this.initialized.set(false);
 	}
 
 	private LoggerConfig getLoggerConfig(String name) {
@@ -261,28 +200,8 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 	}
 
 	private LoggerContext getLoggerContext() {
-		return (LoggerContext) LogManager.getContext(false);
-	}
-
-	private boolean isAlreadyInitialized(LoggerContext loggerContext) {
-		return LoggingSystem.class.getName().equals(loggerContext.getExternalContext());
-	}
-
-	private void markAsInitialized(LoggerContext loggerContext) {
-		loggerContext.setExternalContext(LoggingSystem.class.getName());
-	}
-
-	private void markAsUninitialized(LoggerContext loggerContext) {
-		loggerContext.setExternalContext(null);
-	}
-
-	private final class ShutdownHandler implements Runnable {
-
-		@Override
-		public void run() {
-			getLoggerContext().stop();
-		}
-
+		return (LoggerContext) LogManager
+				.getContext(getClassLoader(), false, EXTERNAL_CONTEXT);
 	}
 
 }

--- a/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
@@ -32,6 +32,7 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -73,8 +74,12 @@ public class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 
 	@Before
 	public void setup() {
-		this.loggingSystem.cleanUp();
 		this.logger = LogManager.getLogger(getClass());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		this.loggingSystem.cleanUp();
 	}
 
 	@Test
@@ -220,7 +225,7 @@ public class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 	@Test
 	public void springConfigLocations() throws Exception {
 		String[] locations = getSpringConfigLocations(this.loggingSystem);
-		assertThat(locations).isEqualTo(new String[] { "log4j2-spring.xml" });
+		assertThat(locations).isEqualTo(new String[] { "log4j2-spring.properties", "log4j2-spring.xml" });
 	}
 
 	@Test
@@ -236,10 +241,11 @@ public class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	@Test
-	public void beforeInitializeFilterDisablesErrorLogging() throws Exception {
+	public void beforeInitializeWarningsAreDisabled() throws Exception {
 		this.loggingSystem.beforeInitialize();
-		assertThat(this.logger.isErrorEnabled()).isFalse();
+		assertThat(this.logger.isWarnEnabled()).isFalse();
 		this.loggingSystem.initialize(null, null, getLogFile(null, tmpDir()));
+		assertThat(this.logger.isWarnEnabled()).isTrue();
 	}
 
 	@Test
@@ -279,7 +285,7 @@ public class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		this.loggingSystem.cleanUp();
 		this.loggingSystem.beforeInitialize();
 		this.loggingSystem.initialize(null, null, null);
-		verify(listener, times(4)).propertyChange(any(PropertyChangeEvent.class));
+		verify(listener, times(3)).propertyChange(any(PropertyChangeEvent.class));
 	}
 
 	private static class TestLog4J2LoggingSystem extends Log4J2LoggingSystem {


### PR DESCRIPTION
There are several changes to mention here. First off, the drop
everything filter installed at startup has been removed; it's pointless.

Next, the properties file format has been explicitly added to the
supported file format list (a more portable version that supports all
runtime configuration formats would require using some internal
`log4j-core` APIs such as `PluginManager` and some currently protected
methods in `ConfigurationFactory`).

Initialization is marked with an `AtomicBoolean` rather than relying on an
external context in the `LoggerContext` so we can defer creation of the
`LoggerContext` until actual initialization.

The most important change here is that the `LoggerContext` is no longer
configured via `ConfigurationFactory` as that API changed in 2.7 and is
not necessarily considered a stable API from release to release.
Instead, that path has been rewritten to use `Configurator`, a much more
stable class from log4j-core.

Similarly, `setLogLevel()` has been rewritten to use `Configurator` instead
of modifying the underlying `LoggerConfig` objects (which are even more of
an internal API than `ConfigurationFactory`).

Finally, the shutdown hook has been replaced with a call to
`LogManager.shutdown()` in `cleanUp()` (which is called very close to exit
as it is thanks to which `ApplicationEvent` is listens for).

This fixes gh-7991.