### PR TITLE
Improve `UserInfoTokenServices` logging

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/UserInfoTokenServices.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/UserInfoTokenServices.java
@@ -123,7 +123,7 @@ public class UserInfoTokenServices implements ResourceServerTokenServices {
 
 	@SuppressWarnings({ "unchecked" })
 	private Map<String, Object> getMap(String path, String accessToken) {
-		this.logger.info("Getting user info from: " + path);
+		this.logger.debug("Getting user info from: " + path);
 		try {
 			OAuth2RestOperations restTemplate = this.restTemplate;
 			if (restTemplate == null) {
@@ -142,7 +142,7 @@ public class UserInfoTokenServices implements ResourceServerTokenServices {
 			return restTemplate.getForEntity(path, Map.class).getBody();
 		}
 		catch (Exception ex) {
-			this.logger.info("Could not fetch user details: " + ex.getClass() + ", "
+			this.logger.warn("Could not fetch user details: " + ex.getClass() + ", "
 					+ ex.getMessage());
 			return Collections.<String, Object>singletonMap("error",
 					"Could not fetch user details");


### PR DESCRIPTION
This PR improves logging in `UserInfoTokenServices` by:

- changing log level of message logged before userinfo endpoint call from `info` to `debug` - `info` causes too much noise in the logs especially with REST API calls
- changing log level of message logged when exception occurs on userinfo endpoint call from `info` to `warn`