### PR TITLE
Prevent unnecessary debug log message creation at UserInfoTokenServices

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/UserInfoTokenServices.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/UserInfoTokenServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,9 @@ public class UserInfoTokenServices implements ResourceServerTokenServices {
 			throws AuthenticationException, InvalidTokenException {
 		Map<String, Object> map = getMap(this.userInfoEndpointUrl, accessToken);
 		if (map.containsKey("error")) {
-			this.logger.debug("userinfo returned error: " + map.get("error"));
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug("userinfo returned error: " + map.get("error"));
+			}
 			throw new InvalidTokenException(accessToken);
 		}
 		return extractAuthentication(map);
@@ -123,7 +125,9 @@ public class UserInfoTokenServices implements ResourceServerTokenServices {
 
 	@SuppressWarnings({ "unchecked" })
 	private Map<String, Object> getMap(String path, String accessToken) {
-		this.logger.debug("Getting user info from: " + path);
+		if (this.logger.isDebugEnabled()) {
+			this.logger.debug("Getting user info from: " + path);
+		}
 		try {
 			OAuth2RestOperations restTemplate = this.restTemplate;
 			if (restTemplate == null) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

I've added the `isDebugEnabled` on creating debug log message dynamically.

relates gh-7995