### PR TITLE
Improve performance of RelaxedNames

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/bind/RelaxedNames.java
+++ b/spring-boot/src/main/java/org/springframework/boot/bind/RelaxedNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ public final class RelaxedNames implements Iterable<String> {
 
 			@Override
 			public String apply(String value) {
-				return value.toLowerCase();
+				return value.isEmpty() ? value : value.toLowerCase();
 			}
 
 		},
@@ -100,7 +100,7 @@ public final class RelaxedNames implements Iterable<String> {
 
 			@Override
 			public String apply(String value) {
-				return value.toUpperCase();
+				return value.isEmpty() ? value : value.toUpperCase();
 			}
 
 		};
@@ -127,7 +127,7 @@ public final class RelaxedNames implements Iterable<String> {
 
 			@Override
 			public String apply(String value) {
-				return value.replace("-", "_");
+				return value.indexOf('-') != -1 ? value.replace("-", "_") : value;
 			}
 
 		},
@@ -136,7 +136,7 @@ public final class RelaxedNames implements Iterable<String> {
 
 			@Override
 			public String apply(String value) {
-				return value.replace("_", ".");
+				return value.indexOf('_') != -1 ? value.replace("_", ".") : value;
 			}
 
 		},
@@ -145,7 +145,7 @@ public final class RelaxedNames implements Iterable<String> {
 
 			@Override
 			public String apply(String value) {
-				return value.replace(".", "_");
+				return value.indexOf('.') != -1 ? value.replace(".", "_") : value;
 			}
 
 		},
@@ -154,7 +154,14 @@ public final class RelaxedNames implements Iterable<String> {
 
 			@Override
 			public String apply(String value) {
+				if (value.isEmpty()) {
+					return value;
+				}
 				Matcher matcher = CAMEL_CASE_PATTERN.matcher(value);
+				if (!matcher.find()) {
+					return value;
+				}
+				matcher = matcher.reset();
 				StringBuffer result = new StringBuffer();
 				while (matcher.find()) {
 					matcher.appendReplacement(result, matcher.group(1) + '_'
@@ -170,7 +177,14 @@ public final class RelaxedNames implements Iterable<String> {
 
 			@Override
 			public String apply(String value) {
+				if (value.isEmpty()) {
+					return value;
+				}
 				Matcher matcher = CAMEL_CASE_PATTERN.matcher(value);
+				if (!matcher.find()) {
+					return value;
+				}
+				matcher = matcher.reset();
 				StringBuffer result = new StringBuffer();
 				while (matcher.find()) {
 					matcher.appendReplacement(result, matcher.group(1) + '-'
@@ -206,7 +220,7 @@ public final class RelaxedNames implements Iterable<String> {
 
 		private static String separatedToCamelCase(String value,
 				boolean caseInsensitive) {
-			if (value.length() == 0) {
+			if (value.isEmpty()) {
 				return value;
 			}
 			StringBuilder builder = new StringBuilder();
@@ -233,7 +247,7 @@ public final class RelaxedNames implements Iterable<String> {
 	 * @return the relaxed names
 	 */
 	public static RelaxedNames forCamelCase(String name) {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		for (char c : name.toCharArray()) {
 			result.append(Character.isUpperCase(c) && result.length() > 0
 					&& result.charAt(result.length() - 1) != '-'


### PR DESCRIPTION
Hey,

despite the future plans to make RelaxedNames less relaxed, I stumpled upon some possible improvements that could be made in the meanwhile. The improvements made are mostly checks if something needs to be done in the variation/manipulation steps and therefore avoid allocations or rather costly regex checks.

### Empty String
##### (which seems to be a valid case given the code and that it's invoked quite often at startup with an empty string)
| Benchmark | Mode | Cnt | Score | Error | Units | 
| ----------- | ----------- | ----------- | ----------: | ----------: | ----------- |
| MyBenchmark.testNew | thrpt | 20 | 1906571,457 | ± 81029,421 | ops/s |
| MyBenchmark.testOld | thrpt | 20 | 392830,663 | ± 12464,055 | ops/s |

### spring.resource
| Benchmark | Mode | Cnt | Score | Error | Units | 
| ----------- | ----------- | ----------- | ----------: | ----------: | ----------- |
| MyBenchmark.testNew | thrpt | 20 | 140275,489 | ± 2741,235 | ops/s |
| MyBenchmark.testOld | thrpt | 20 | 113407,368 | ± 2269,253 | ops/s |

### spring.http.converters.preferred-json-mapper
| Benchmark | Mode | Cnt | Score | Error | Units | 
| ----------- | ----------- | ----------- | ----------: | ----------: | ----------- |
| MyBenchmark.testNew | thrpt | 20 | 57100,211 | ± 1365,889 | ops/s |
| MyBenchmark.testOld | thrpt | 20 | 51699,904 | ±  914,171 | ops/s |

Cheers,
Christoph