### PR TITLE
Add support to generate random management port

### DIFF
--- a/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTest.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ import org.springframework.web.context.WebApplicationContext;
  *
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Eddú Meléndez
  * @since 1.4.0
  * @see ContextConfiguration
  */
@@ -124,6 +125,13 @@ public @interface SpringBootTest {
 		 * {@link LocalServerPort} injected field on the test.
 		 */
 		RANDOM_PORT(true),
+
+		/**
+		 * Creates an {@link EmbeddedWebApplicationContext} and sets
+		 * {@code server.port=0} and {@code management.port=0} {@link Environment}
+		 * properties.
+		 */
+		RANDOM_SERVER_AND_MANAGEMENT_PORT(true),
 
 		/**
 		 * Creates an {@link EmbeddedWebApplicationContext} without defining any

--- a/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestContextBootstrapper.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestContextBootstrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Eddú Meléndez
  * @since 1.4.0
  * @see SpringBootTest
  * @see TestConfiguration
@@ -237,6 +238,10 @@ public class SpringBootTestContextBootstrapper extends DefaultTestContextBootstr
 		if (getWebEnvironment(testClass) == WebEnvironment.RANDOM_PORT) {
 			propertySourceProperties.add("server.port=0");
 		}
+		else if (getWebEnvironment(testClass) == WebEnvironment.RANDOM_SERVER_AND_MANAGEMENT_PORT) {
+			propertySourceProperties.add("server.port=0");
+			propertySourceProperties.add("management.port=0");
+		}
 	}
 
 	/**
@@ -267,7 +272,8 @@ public class SpringBootTestContextBootstrapper extends DefaultTestContextBootstr
 		SpringBootTest springBootTest = getAnnotation(testClass);
 		if (springBootTest != null
 				&& (springBootTest.webEnvironment() == WebEnvironment.DEFINED_PORT
-						|| springBootTest.webEnvironment() == WebEnvironment.RANDOM_PORT)
+						|| springBootTest.webEnvironment() == WebEnvironment.RANDOM_PORT
+						|| springBootTest.webEnvironment() == WebEnvironment.RANDOM_SERVER_AND_MANAGEMENT_PORT)
 				&& getAnnotation(WebAppConfiguration.class, testClass) != null) {
 			throw new IllegalStateException("@WebAppConfiguration should only be used "
 					+ "with @SpringBootTest when @SpringBootTest is configured with a "

--- a/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootTestWebEnvironmentRandomServerAndManagementPortTests.java
+++ b/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootTestWebEnvironmentRandomServerAndManagementPortTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.context;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.AbstractSpringBootTestEmbeddedWebEnvironmentTests.AbstractConfig;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SpringBootTest} configured with {@link WebEnvironment#RANDOM_SERVER_AND_MANAGEMENT_PORT}.
+ *
+ * @author Eddú Meléndez
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_SERVER_AND_MANAGEMENT_PORT)
+public class SpringBootTestWebEnvironmentRandomServerAndManagementPortTests {
+
+	@Autowired
+	private Environment environment;
+
+	@Test
+	public void validateServerAndManagementPorts() {
+		String serverPort = this.environment.getProperty("server.port");
+		String managementPort = this.environment.getProperty("management.port");
+		assertThat(serverPort).isEqualTo("0");
+		assertThat(managementPort).isEqualTo("0");
+	}
+
+	@Configuration
+	@EnableWebMvc
+	protected static class Config extends AbstractConfig {
+
+	}
+
+}


### PR DESCRIPTION
Previous to this commit, in order to provide a random port for
management key property should be explicitly provided. Now,
SpringBootTest annotation can do this if
WebEnvironment.RANDOM_SERVER_AND_MANAGEMENT_PORT is set.

```
@RunWith(SpringRunner.class)
@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_SERVER_AND_MANAGEMENT_PORT)
public classSpringBootApplicationTests {

}
```

See gh-4424

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->