### PR TITLE
Fix broken-initialization.factories

### DIFF
--- a/spring-boot/src/test/resources/failure-analyzers-tests/broken-initialization.factories
+++ b/spring-boot/src/test/resources/failure-analyzers-tests/broken-initialization.factories
@@ -1,4 +1,4 @@
 # Failure Analyzers
 org.springframework.boot.diagnostics.FailureAnalyzer=\
-org.springframework.boot.diagnostics.FailureAnalyzersTests$BrokenAnalysisFailureAnalyzer,\
+org.springframework.boot.diagnostics.FailureAnalyzersTests$BrokenInitializationFailureAnalyzer,\
 org.springframework.boot.diagnostics.FailureAnalyzersTests$BasicFailureAnalyzer


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR simply fixes a class name in `broken-initialization.factories` missed in bf642ff9db3f35d490cc1a5f7b413d01dc1a417b .