### PR TITLE
Use String.replace() with single char if possible

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/HealthMvcEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/HealthMvcEndpoint.java
@@ -139,7 +139,7 @@ public class HealthMvcEndpoint extends AbstractEndpointMvcAdapter<HealthEndpoint
 	private HttpStatus getStatus(Health health) {
 		String code = health.getStatus().getCode();
 		if (code != null) {
-			code = code.toLowerCase().replace("_", "-");
+			code = code.toLowerCase().replace('_', '-');
 			for (String candidate : RelaxedNames.forCamelCase(code)) {
 				HttpStatus status = this.statusMapping.get(candidate);
 				if (status != null) {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheCondition.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheCondition.java
@@ -50,7 +50,7 @@ class CacheCondition extends SpringBootCondition {
 		}
 		CacheType cacheType = CacheConfigurations
 				.getType(((AnnotationMetadata) metadata).getClassName());
-		String value = resolver.getProperty("type").replace("-", "_").toUpperCase();
+		String value = resolver.getProperty("type").replace('-', '_').toUpperCase();
 		if (value.equals(cacheType.name())) {
 			return ConditionOutcome.match(message.because(value + " cache type"));
 		}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionCondition.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionCondition.java
@@ -45,7 +45,7 @@ class SessionCondition extends SpringBootCondition {
 			return ConditionOutcome.noMatch(
 					message.didNotFind("spring.session.store-type property").atAll());
 		}
-		String value = resolver.getProperty("store-type").replace("-", "_").toUpperCase();
+		String value = resolver.getProperty("store-type").replace('-', '_').toUpperCase();
 		if (value.equals(sessionStoreType.name())) {
 			return ConditionOutcome.match(message
 					.found("spring.session.store-type property").items(sessionStoreType));

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/DefaultErrorViewResolverTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/DefaultErrorViewResolverTests.java
@@ -212,7 +212,7 @@ public class DefaultErrorViewResolverTests {
 	private void setResourceLocation(String path) {
 		String packageName = getClass().getPackage().getName();
 		this.resourceProperties.setStaticLocations(new String[] {
-				"classpath:" + packageName.replace(".", "/") + path + "/" });
+				"classpath:" + packageName.replace('.', '/') + path + "/" });
 	}
 
 	private MockHttpServletResponse render(ModelAndView modelAndView) throws Exception {

--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/archive/ArchiveCommand.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/archive/ArchiveCommand.java
@@ -264,7 +264,7 @@ abstract class ArchiveCommand extends OptionParsingCommand {
 			if (classLoader == null) {
 				classLoader = Thread.currentThread().getContextClassLoader();
 			}
-			String name = sourceClass.replace(".", "/") + ".class";
+			String name = sourceClass.replace('.', '/') + ".class";
 			InputStream stream = classLoader.getResourceAsStream(name);
 			writer.writeEntry(this.layout.getClassesLocation() + name, stream);
 		}

--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/ExtendedGroovyClassLoader.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/ExtendedGroovyClassLoader.java
@@ -161,7 +161,7 @@ public class ExtendedGroovyClassLoader extends GroovyClassLoader {
 		protected Class<?> createClass(byte[] code, ClassNode classNode) {
 			Class<?> createdClass = super.createClass(code, classNode);
 			ExtendedGroovyClassLoader.this.classResources
-					.put(classNode.getName().replace(".", "/") + ".class", code);
+					.put(classNode.getName().replace('.', '/') + ".class", code);
 			return createdClass;
 		}
 

--- a/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/classloader/RestartClassLoaderTests.java
+++ b/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/classloader/RestartClassLoaderTests.java
@@ -52,7 +52,7 @@ public class RestartClassLoaderTests {
 	private static final String PACKAGE = RestartClassLoaderTests.class.getPackage()
 			.getName();
 
-	private static final String PACKAGE_PATH = PACKAGE.replace(".", "/");
+	private static final String PACKAGE_PATH = PACKAGE.replace('.', '/');
 
 	private static final Charset UTF_8 = Charset.forName("UTF-8");
 

--- a/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/settings/DevToolsSettingsTests.java
+++ b/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/settings/DevToolsSettingsTests.java
@@ -37,7 +37,7 @@ public class DevToolsSettingsTests {
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	private static final String ROOT = DevToolsSettingsTests.class.getPackage().getName()
-			.replace(".", "/") + "/";
+			.replace('.', '/') + "/";
 
 	@Test
 	public void includePatterns() throws Exception {

--- a/spring-boot-test-support/src/main/java/org/springframework/boot/junit/compiler/TestCompiler.java
+++ b/spring-boot-test-support/src/main/java/org/springframework/boot/junit/compiler/TestCompiler.java
@@ -99,7 +99,7 @@ public class TestCompiler {
 	}
 
 	public static String sourcePathFor(Class<?> type) {
-		return type.getName().replace(".", "/") + ".java";
+		return type.getName().replace('.', '/') + ".java";
 	}
 
 	protected File getSourceFolder() {

--- a/spring-boot-test/src/test/java/org/springframework/boot/test/testutil/AbstractConfigurationClassTests.java
+++ b/spring-boot-test/src/test/java/org/springframework/boot/test/testutil/AbstractConfigurationClassTests.java
@@ -65,7 +65,7 @@ public abstract class AbstractConfigurationClassTests {
 	private Set<AnnotationMetadata> findConfigurationClasses() throws IOException {
 		Set<AnnotationMetadata> configurationClasses = new HashSet<AnnotationMetadata>();
 		Resource[] resources = this.resolver.getResources("classpath*:"
-				+ getClass().getPackage().getName().replace(".", "/") + "/**/*.class");
+				+ getClass().getPackage().getName().replace('.', '/') + "/**/*.class");
 		for (Resource resource : resources) {
 			if (!isTestClass(resource)) {
 				MetadataReader metadataReader = new SimpleMetadataReaderFactory()

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/MainClassFinder.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/MainClassFinder.java
@@ -262,7 +262,7 @@ public abstract class MainClassFinder {
 	}
 
 	private static String convertToClassName(String name, String prefix) {
-		name = name.replace("/", ".");
+		name = name.replace('/', '.');
 		name = name.replace('\\', '.');
 		name = name.substring(0, name.length() - DOT_CLASS.length());
 		if (prefix != null) {

--- a/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/TestJarFile.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/TestJarFile.java
@@ -55,7 +55,7 @@ public class TestJarFile {
 		File file = getFilePath(filename);
 		file.getParentFile().mkdirs();
 		InputStream inputStream = getClass().getResourceAsStream(
-				"/" + classToCopy.getName().replace(".", "/") + ".class");
+				"/" + classToCopy.getName().replace('.', '/') + ".class");
 		copyToFile(inputStream, file);
 		if (time != null) {
 			file.setLastModified(time);

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/LaunchedURLClassLoader.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/LaunchedURLClassLoader.java
@@ -131,8 +131,8 @@ public class LaunchedURLClassLoader extends URLClassLoader {
 			AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
 				@Override
 				public Object run() throws ClassNotFoundException {
-					String packageEntryName = packageName.replace(".", "/") + "/";
-					String classEntryName = className.replace(".", "/") + ".class";
+					String packageEntryName = packageName.replace('.', '/') + "/";
+					String classEntryName = className.replace('.', '/') + ".class";
 					for (URL url : getURLs()) {
 						try {
 							URLConnection connection = url.openConnection();

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/PropertiesLauncher.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/PropertiesLauncher.java
@@ -359,7 +359,7 @@ public class PropertiesLauncher extends Launcher {
 
 	private String getProperty(String propertyKey, String manifestKey) throws Exception {
 		if (manifestKey == null) {
-			manifestKey = propertyKey.replace(".", "-");
+			manifestKey = propertyKey.replace('.', '-');
 			manifestKey = toCamelCase(manifestKey);
 		}
 		String property = SystemPropertyUtils.getProperty(propertyKey);

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/util/SystemPropertyUtils.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/util/SystemPropertyUtils.java
@@ -184,11 +184,11 @@ public abstract class SystemPropertyUtils {
 			}
 			if (propVal == null) {
 				// Try with underscores.
-				propVal = System.getenv(key.replace(".", "_"));
+				propVal = System.getenv(key.replace('.', '_'));
 			}
 			if (propVal == null) {
 				// Try uppercase with underscores as well.
-				propVal = System.getenv(key.toUpperCase().replace(".", "_"));
+				propVal = System.getenv(key.toUpperCase().replace('.', '_'));
 			}
 			if (propVal != null) {
 				return propVal;

--- a/spring-boot/src/main/java/org/springframework/boot/bind/RelaxedConversionService.java
+++ b/spring-boot/src/main/java/org/springframework/boot/bind/RelaxedConversionService.java
@@ -127,7 +127,7 @@ class RelaxedConversionService implements ConversionService {
 				source = source.trim();
 				for (T candidate : (Set<T>) EnumSet.allOf(this.enumType)) {
 					RelaxedNames names = new RelaxedNames(
-							candidate.name().replace("_", "-").toLowerCase());
+							candidate.name().replace('_', '-').toLowerCase());
 					for (String name : names) {
 						if (name.equals(source)) {
 							return candidate;

--- a/spring-boot/src/main/java/org/springframework/boot/bind/RelaxedNames.java
+++ b/spring-boot/src/main/java/org/springframework/boot/bind/RelaxedNames.java
@@ -127,7 +127,7 @@ public final class RelaxedNames implements Iterable<String> {
 
 			@Override
 			public String apply(String value) {
-				return value.indexOf('-') != -1 ? value.replace("-", "_") : value;
+				return value.indexOf('-') != -1 ? value.replace('-', '_') : value;
 			}
 
 		},
@@ -136,7 +136,7 @@ public final class RelaxedNames implements Iterable<String> {
 
 			@Override
 			public String apply(String value) {
-				return value.indexOf('_') != -1 ? value.replace("_", ".") : value;
+				return value.indexOf('_') != -1 ? value.replace('_', '.') : value;
 			}
 
 		},
@@ -145,7 +145,7 @@ public final class RelaxedNames implements Iterable<String> {
 
 			@Override
 			public String apply(String value) {
-				return value.indexOf('.') != -1 ? value.replace(".", "_") : value;
+				return value.indexOf('.') != -1 ? value.replace('.', '_') : value;
 			}
 
 		},

--- a/spring-boot/src/main/java/org/springframework/boot/logging/AbstractLoggingSystem.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/AbstractLoggingSystem.java
@@ -172,7 +172,7 @@ public abstract class AbstractLoggingSystem extends LoggingSystem {
 
 	protected final String getPackagedConfigFile(String fileName) {
 		String defaultPath = ClassUtils.getPackageName(getClass());
-		defaultPath = defaultPath.replace(".", "/");
+		defaultPath = defaultPath.replace('.', '/');
 		defaultPath = defaultPath + "/" + fileName;
 		defaultPath = "classpath:" + defaultPath;
 		return defaultPath;

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/XmlEmbeddedWebApplicationContextTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/XmlEmbeddedWebApplicationContextTests.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.verify;
 public class XmlEmbeddedWebApplicationContextTests {
 
 	private static final String PATH = XmlEmbeddedWebApplicationContextTests.class
-			.getPackage().getName().replace(".", "/") + "/";
+			.getPackage().getName().replace('.', '/') + "/";
 
 	private static final String FILE = "exampleEmbeddedWebApplicationConfiguration.xml";
 


### PR DESCRIPTION
Hey,

I noticed that there are quite a few places in the code that could avoid the additional regex overhead when replacing single characters.

In an isolated benchmark it shows the following results:

Benchmark | Mode | Cnt | Score | Error | Units
------------ | ------------ | ------------ | ------------: | ------------ | ------------
MyBenchmark.testNew | thrpt | 20 | 28807385,740 | ± 182204,067 | ops/s
MyBenchmark.testOld | thrpt | 20 |  2507257,210 | ± 108849,887 | ops/s

This should also give an additional boost when processing RelaxedNames, which I already worked on in #8002 but didn't notice this at the time. Sorry.
   
Cheers,
Christoph