### PR TITLE
Fix usage of @ImportResource for migrating classic applications

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -2944,7 +2944,7 @@ replacing those elements from the `web.xml` as follows:
   container as if it was a `<servlet/>` and `<servlet-mapping/>` in `web.xml`.
 * A `@Bean` of type `Filter` or `FilterRegistrationBean` behaves similarly (like a
   `<filter/>` and `<filter-mapping/>`.
-* An `ApplicationContext` in an XML file can be added to an `@Import` in your
+* An `ApplicationContext` in an XML file can be added through an `@ImportResource` in your
   `Application`. Or simple cases where annotation configuration is heavily used already
   can be recreated in a few lines as `@Bean` definitions.
 


### PR DESCRIPTION
`@ImportResource` is used for importing XML-configuration, not `@Import`. In case you don't mean something completely different, I think that the wording proposed is better.