### PR TITLE
Remove HikariCP-java6 dependency management

### DIFF
--- a/spring-boot-actuator/pom.xml
+++ b/spring-boot-actuator/pom.xml
@@ -256,7 +256,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.zaxxer</groupId>
-			<artifactId>HikariCP-java6</artifactId>
+			<artifactId>HikariCP</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -241,7 +241,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.zaxxer</groupId>
-			<artifactId>HikariCP-java6</artifactId>
+			<artifactId>HikariCP</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/HikariDriverConfigurationFailureAnalyzer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/HikariDriverConfigurationFailureAnalyzer.java
@@ -28,8 +28,8 @@ import org.springframework.boot.diagnostics.FailureAnalysis;
 class HikariDriverConfigurationFailureAnalyzer
 		extends AbstractFailureAnalyzer<IllegalStateException> {
 
-	private static final String EXPECTED_MESSAGE = "both driverClassName and "
-			+ "dataSourceClassName are specified, one or the other should be used";
+	private static final String EXPECTED_MESSAGE = "cannot use driverClassName and "
+			+ "dataSourceClassName together.";
 
 	@Override
 	protected FailureAnalysis analyze(Throwable rootFailure,

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -87,7 +87,6 @@
 		<hibernate.version>5.2.5.Final</hibernate.version>
 		<hibernate-validator.version>5.3.4.Final</hibernate-validator.version>
 		<hikaricp.version>2.5.1</hikaricp.version>
-		<hikaricp-java6.version>2.3.13</hikaricp-java6.version>
 		<hsqldb.version>2.3.3</hsqldb.version>
 		<htmlunit.version>2.21</htmlunit.version>
 		<httpasyncclient.version>4.1.2</httpasyncclient.version>
@@ -742,11 +741,6 @@
 				<groupId>com.zaxxer</groupId>
 				<artifactId>HikariCP</artifactId>
 				<version>${hikaricp.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.zaxxer</groupId>
-				<artifactId>HikariCP-java6</artifactId>
-				<version>${hikaricp-java6.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-beanutils</groupId>


### PR DESCRIPTION
Dependency management for the `HikariCP-java6` dependency is no longer needed since Java 6 is no longer supported by Spring Boot.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->