### PR TITLE
Fix an assertion in SkipPatternJarScanner

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/SkipPatternJarScanner.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/SkipPatternJarScanner.java
@@ -40,7 +40,7 @@ class SkipPatternJarScanner extends StandardJarScanner {
 
 	SkipPatternJarScanner(JarScanner jarScanner, Set<String> patterns) {
 		Assert.notNull(jarScanner, "JarScanner must not be null");
-		Assert.notNull(jarScanner, "Patterns must not be null");
+		Assert.notNull(patterns, "Patterns must not be null");
 		this.jarScanner = jarScanner;
 		StandardJarScanFilter filter = new StandardJarScanFilter();
 		filter.setTldSkip(StringUtils.collectionToCommaDelimitedString(patterns));


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR simply fixes an assertion for `patterns` in `SkipPatternJarScanner` constructor.