### PR TITLE
Update copyright header

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/index-docinfo.xml
+++ b/spring-boot-docs/src/main/asciidoc/index-docinfo.xml
@@ -1,7 +1,7 @@
 <productname>Spring Boot</productname>
 <releaseinfo>{spring-boot-version}</releaseinfo>
 <copyright>
-	<year>2013-2016</year>
+	<year>2013-2017</year>
 </copyright>
 <legalnotice>
 	<para>


### PR DESCRIPTION
Spring boot 1.5 is released yesterday. It contains 2016, it should be 2017

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->