### PR TITLE
Clear system property in SpringApplicationTests

### DIFF
--- a/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
@@ -130,21 +130,21 @@ public class SpringApplicationTests {
 
 	@After
 	public void reinstateHeadlessProperty() {
-		System.clearProperty("spring.main.banner-mode");
 		if (this.headlessProperty == null) {
 			System.clearProperty("java.awt.headless");
 		}
 		else {
 			System.setProperty("java.awt.headless", this.headlessProperty);
 		}
-
 	}
 
 	@After
-	public void close() {
+	public void cleanUp() {
 		if (this.context != null) {
 			this.context.close();
 		}
+		System.clearProperty("spring.main.banner-mode");
+		System.clearProperty(CachedIntrospectionResults.IGNORE_BEANINFO_PROPERTY_NAME);
 	}
 
 	@Test

--- a/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileApplicationListenerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileApplicationListenerTests.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.beans.CachedIntrospectionResults;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.context.config.ConfigFileApplicationListener.ConfigurationPropertySources;
@@ -98,14 +97,12 @@ public class ConfigFileApplicationListenerTests {
 	}
 
 	@After
-	public void cleanup() {
+	public void cleanUp() {
 		if (this.context != null) {
 			this.context.close();
 		}
 		System.clearProperty("the.property");
 		System.clearProperty("spring.config.location");
-		System.clearProperty("spring.main.banner-mode");
-		System.clearProperty(CachedIntrospectionResults.IGNORE_BEANINFO_PROPERTY_NAME);
 	}
 
 	@Test


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
`CachedIntrospectionResults.IGNORE_BEANINFO_PROPERTY_NAME` is set in `SpringApplicationTests` but not cleared. It was missed in a7f148091eb9acab2270fa6d510027d7a5510d88 .

This PR clears it and removes unnecessary clearing system properties in `ConfigFileApplicationListenerTests`.