### PR TITLE
Add edge case docs of the value() attribute of ConditionalOnClass

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnClass.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnClass.java
@@ -36,9 +36,14 @@ import org.springframework.context.annotation.Conditional;
 public @interface ConditionalOnClass {
 
 	/**
+	 * <p>
 	 * The classes that must be present. Since this annotation parsed by loading class
 	 * bytecode it is safe to specify classes here that may ultimately not be on the
-	 * classpath.
+	 * classpath, only if this annotation is directly on the affected component and
+	 * <b>not</b> if this annotation is used as a composed, meta-annotation. If this
+	 * is used as a meta annotation and the given class is not available at runtime
+	 * then this {@link @Conditional} will effectively be ignored. In order to use
+	 * this annotation as a meta-annotation, only use the {@link #name} attribute.
 	 * @return the classes that must be present
 	 */
 	Class<?>[] value() default {};

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -6081,14 +6081,15 @@ code by annotating `@Configuration` classes or individual `@Bean` methods.
 ==== Class conditions
 The `@ConditionalOnClass` and `@ConditionalOnMissingClass` annotations allows
 configuration to be included based on the presence or absence of specific classes.
-If you are using this annotation directly on the class or method you are conditionally
+If you are using the `@ConditionalOnClass` annotation directly on the class you are conditionally
 registering, you can actually use the `value` attribute to refer to the real class,
 even though that class might not actually appear on the running application classpath.
-This is due to the fact that annotation metadata directly on a class or method is parsed
-using http://asm.ow2.org/[ASM] You can also use the `name` attribute if you prefer to
+This is due to the fact that annotation metadata directly on a class is parsed
+using http://asm.ow2.org/[ASM]. You can also use the `name` attribute if you prefer to
 specify the class name using a `String` value, which is required if you are using
 `@ConditionalOnClass` or `@ConditionalOnMissingClass` as apart of a meta-annotation to
-compose your own composed annotations.
+compose your own composed annotations or in an `@Bean` method as neither of these cases
+are handled by ASM.
 
 
 

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -6080,11 +6080,15 @@ code by annotating `@Configuration` classes or individual `@Bean` methods.
 [[boot-features-class-conditions]]
 ==== Class conditions
 The `@ConditionalOnClass` and `@ConditionalOnMissingClass` annotations allows
-configuration to be included based on the presence or absence of specific classes. Due to
-the fact that annotation metadata is parsed using http://asm.ow2.org/[ASM] you can
-actually use the `value` attribute to refer to the real class, even though that class
-might not actually appear on the running application classpath. You can also use the
-`name` attribute if you prefer to specify the class name using a `String` value.
+configuration to be included based on the presence or absence of specific classes.
+If you are using this annotation directly on the class or method you are conditionally
+registering, you can actually use the `value` attribute to refer to the real class,
+even though that class might not actually appear on the running application classpath.
+This is due to the fact that annotation metadata directly on a class or method is parsed
+using http://asm.ow2.org/[ASM] You can also use the `name` attribute if you prefer to
+specify the class name using a `String` value, which is required if you are using
+`@ConditionalOnClass` or `@ConditionalOnMissingClass` as apart of a meta-annotation to
+compose your own composed annotations.
 
 
 


### PR DESCRIPTION
When used as a meta-annotation the `value()` attribute of `@ConditionalOnClass` will fail silently resulting in the `@Conditional` nature of the annotation being ignored.

Here is an example that fails silently:

```java
@Target({ ElementType.TYPE, ElementType.METHOD })
@Retention(RetentionPolicy.RUNTIME)
@Documented
@ConditionalOnClass(ClassThatMayNotExistAtRuntime.class)
public @interface ConditionalOnOptionalComponent { }

@Component
@ConditionalOnOptionalComponent
public class SomeComponentToBeOptionallyRegistered {

}
```

On startup, `SomeComponentToBeOptionallyRegistered` will still be instantiated as a Spring component. The workaround is simple, simply add the `@ConditionalOnClass` directly to the component:

```java
@Component
@ConditionalOnClass(ClassThatMayNotExistAtRuntime.class)
public class SomeComponentToBeOptionallyRegistered {

}
```

The reason that the first example fails is because while the annotations directly on the component are read via bytecode reading, meta-annotations are read via Java reflection which results in class loading (specifically, loading the `ClassThatMayNotExistAtRuntime` class). The location in which this fails is in Spring Core's `AnnotationUtils.getAnnotations(AnnotatedElement annotatedElement)`. This uses `annotatedElement.getAnnotations()`, part of Java's reflection package, which triggers a load of the `ClassThatMayNotExistAtRuntime.class`, and then throws a `sun.reflect.annotation.TypeNotPresentExceptionProxy`. This ends up failing silently assuming that you do not have debug-logging enabled on this piece, specifically in `handleIntrospectionFailure()`.

This was verified against Spring core 4.3.6.RELEASE and Spring Boot 1.5.1.RELEASE.