### PR TITLE
Removes unused thymeleaf-layout-dialect dependency

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -181,7 +181,6 @@
 		<thymeleaf.version>3.0.3.RELEASE</thymeleaf.version>
 		<thymeleaf-spring5.version>3.0.3.M1</thymeleaf-spring5.version>
 		<thymeleaf-extras-springsecurity4.version>3.0.1.RELEASE</thymeleaf-extras-springsecurity4.version>
-		<thymeleaf-layout-dialect.version>2.1.2</thymeleaf-layout-dialect.version>
 		<thymeleaf-extras-data-attribute.version>2.0.1</thymeleaf-extras-data-attribute.version>
 		<thymeleaf-extras-java8time.version>3.0.0.RELEASE</thymeleaf-extras-java8time.version>
 		<tomcat.version>8.5.11</tomcat.version>
@@ -996,11 +995,6 @@
 				<groupId>net.sourceforge.nekohtml</groupId>
 				<artifactId>nekohtml</artifactId>
 				<version>${nekohtml.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>nz.net.ultraq.thymeleaf</groupId>
-				<artifactId>thymeleaf-layout-dialect</artifactId>
-				<version>${thymeleaf-layout-dialect.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.activemq</groupId>


### PR DESCRIPTION
As part of https://github.com/spring-projects/spring-boot/issues/7557 thymeleaf-layout-dialect is removed from spring-boot-starter-thymeleaf therefore this dependency is not supported by spring-boot hence removing this

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->