### PR TITLE
Add schema validation options for embedded LDAP

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapAutoConfiguration.java
@@ -26,6 +26,7 @@ import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
 import com.unboundid.ldap.listener.InMemoryListenerConfig;
 import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.schema.Schema;
 import com.unboundid.ldif.LDIFReader;
 
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -55,6 +56,7 @@ import org.springframework.util.StringUtils;
  * {@link EnableAutoConfiguration Auto-configuration} for Embedded LDAP.
  *
  * @author Eddú Meléndez
+ * @author Mathieu Ouellet
  * @since 1.5.0
  */
 @Configuration
@@ -107,6 +109,22 @@ public class EmbeddedLdapAutoConfiguration {
 					this.embeddedProperties.getCredential().getUsername(),
 					this.embeddedProperties.getCredential().getPassword());
 		}
+
+		if (!this.embeddedProperties.getValidation().isEnabled()) {
+			config.setSchema(null);
+		}
+		else if (this.embeddedProperties.getValidation().getSchema() != null) {
+			Resource schemaLocation = this.embeddedProperties.getValidation().getSchema();
+			try {
+				config.setSchema(Schema.mergeSchemas(Schema.getDefaultStandardSchema(),
+						Schema.getSchema(schemaLocation.getFile())));
+			}
+			catch (Exception ex) {
+				throw new IllegalStateException(
+						"Unable to load schema " + schemaLocation.getDescription(), ex);
+			}
+		}
+
 		InMemoryListenerConfig listenerConfig = InMemoryListenerConfig
 				.createLDAPConfig("LDAP", this.embeddedProperties.getPort());
 		config.setListenerConfigs(listenerConfig);

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapAutoConfiguration.java
@@ -114,14 +114,13 @@ public class EmbeddedLdapAutoConfiguration {
 			config.setSchema(null);
 		}
 		else if (this.embeddedProperties.getValidation().getSchema() != null) {
-			Resource schemaLocation = this.embeddedProperties.getValidation().getSchema();
 			try {
 				config.setSchema(Schema.mergeSchemas(Schema.getDefaultStandardSchema(),
-						Schema.getSchema(schemaLocation.getFile())));
+						Schema.getSchema(
+								this.embeddedProperties.getValidation().getSchema())));
 			}
 			catch (Exception ex) {
-				throw new IllegalStateException(
-						"Unable to load schema " + schemaLocation.getDescription(), ex);
+				throw new IllegalStateException("Unable to load Schema", ex);
 			}
 		}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapProperties.java
@@ -17,11 +17,13 @@
 package org.springframework.boot.autoconfigure.ldap.embedded;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.Resource;
 
 /**
  * Configuration properties for Embedded LDAP.
  *
  * @author Eddú Meléndez
+ * @author Mathieu Ouellet
  * @since 1.5.0
  */
 @ConfigurationProperties(prefix = "spring.ldap.embedded")
@@ -46,6 +48,11 @@ public class EmbeddedLdapProperties {
 	 * Schema (LDIF) script resource reference.
 	 */
 	private String ldif = "classpath:schema.ldif";
+
+	/**
+	 * Schema validation
+	 */
+	private Validation validation = new Validation();
 
 	public int getPort() {
 		return this.port;
@@ -79,6 +86,10 @@ public class EmbeddedLdapProperties {
 		this.ldif = ldif;
 	}
 
+	public Validation getValidation() {
+		return this.validation;
+	}
+
 	static class Credential {
 
 		/**
@@ -105,6 +116,36 @@ public class EmbeddedLdapProperties {
 
 		public void setPassword(String password) {
 			this.password = password;
+		}
+
+	}
+
+	static class Validation {
+
+		/**
+		 * Enable LDAP schema validation
+		 */
+		private boolean enabled = true;
+
+		/**
+		 * Path to the custom schema file
+		 */
+		private Resource schema;
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public Resource getSchema() {
+			return this.schema;
+		}
+
+		public void setSchema(Resource schema) {
+			this.schema = schema;
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapProperties.java
@@ -120,7 +120,7 @@ public class EmbeddedLdapProperties {
 
 	}
 
-	static class Validation {
+	public static class Validation {
 
 		/**
 		 * Enable LDAP schema validation

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapProperties.java
@@ -130,7 +130,7 @@ public class EmbeddedLdapProperties {
 		/**
 		 * Path to the custom schema file
 		 */
-		private Resource schema;
+		private String schema;
 
 		public boolean isEnabled() {
 			return this.enabled;
@@ -140,11 +140,11 @@ public class EmbeddedLdapProperties {
 			this.enabled = enabled;
 		}
 
-		public Resource getSchema() {
+		public String getSchema() {
 			return this.schema;
 		}
 
-		public void setSchema(Resource schema) {
+		public void setSchema(String schema) {
 			this.schema = schema;
 		}
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapAutoConfigurationTests.java
@@ -131,6 +131,29 @@ public class EmbeddedLdapAutoConfigurationTests {
 		assertThat(ldapTemplate.list("ou=company1,c=Sweden,dc=spring,dc=org")).hasSize(4);
 	}
 
+	@Test
+	public void testDisableSchemaValidation() throws LDAPException {
+		load("spring.ldap.embedded.validation.enabled:false",
+				"spring.ldap.embedded.base-dn:dc=spring,dc=org");
+		InMemoryDirectoryServer server = this.context
+				.getBean(InMemoryDirectoryServer.class);
+		assertThat(server.getSchema()).isNull();
+	}
+
+	@Test
+	public void testCustomSchemaValidation() throws LDAPException {
+		load("spring.ldap.embedded.validation.schema:classpath:custom-schema.ldif",
+				"spring.ldap.embedded.ldif:classpath:custom-schema-sample.ldif",
+				"spring.ldap.embedded.base-dn:dc=spring,dc=org");
+		InMemoryDirectoryServer server = this.context
+				.getBean(InMemoryDirectoryServer.class);
+
+		assertThat(server.getSchema().getObjectClass("exampleAuxiliaryClass"))
+				.isNotNull();
+		assertThat(server.getSchema().getAttributeType("exampleAttributeName"))
+				.isNotNull();
+	}
+
 	private void load(String... properties) {
 		EnvironmentTestUtils.addEnvironment(this.context, properties);
 		this.context.register(EmbeddedLdapAutoConfiguration.class,

--- a/spring-boot-autoconfigure/src/test/resources/custom-schema-sample.ldif
+++ b/spring-boot-autoconfigure/src/test/resources/custom-schema-sample.ldif
@@ -1,0 +1,7 @@
+dn: dc=spring,dc=org
+objectclass: top
+objectclass: domain
+objectclass: extensibleObject
+objectClass: exampleAuxiliaryClass
+dc: spring
+exampleAttributeName: exampleAttributeName

--- a/spring-boot-autoconfigure/src/test/resources/custom-schema.ldif
+++ b/spring-boot-autoconfigure/src/test/resources/custom-schema.ldif
@@ -1,0 +1,17 @@
+dn: cn=schema
+attributeTypes: ( 1.3.6.1.4.1.32473.1.1.1
+  NAME 'exampleAttributeName'
+  DESC 'An example attribute type definition'
+  EQUALITY caseIgnoreMatch
+  ORDERING caseIgnoreOrderingMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE
+  X-ORIGIN 'Managing Schema Document' )
+objectClasses: ( 1.3.6.1.4.1.32473.1.2.2
+  NAME 'exampleAuxiliaryClass'
+  DESC 'An example auxiliary object class definition'
+  SUP top
+  AUXILIARY
+  MAY exampleAttributeName
+  X-ORIGIN 'Managing Schema Document' )


### PR DESCRIPTION
Unboundid uses a standard schema to validate LDIF files so importing one with a custom attribute type or object class fails.

This `spring.ldap.embedded.validation.enabled` property provides a way to deactivate the schema validation.

Alternatively, a custom schema file can be specified with the `spring.ldap.embedded.validation.schema` property. Such schema typically contains new or customized attribute types or object classes, so it's merged with the standard schema.

Fixes gh-8171



<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->