### PR TITLE
Use logical 'and' instead of bitwise 'and'

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/InMemoryAuditEventRepository.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/InMemoryAuditEventRepository.java
@@ -95,9 +95,9 @@ public class InMemoryAuditEventRepository implements AuditEventRepository {
 
 	private boolean isMatch(String principal, Date after, String type, AuditEvent event) {
 		boolean match = true;
-		match &= (principal == null || event.getPrincipal().equals(principal));
-		match &= (after == null || event.getTimestamp().compareTo(after) >= 0);
-		match &= (type == null || event.getType().equals(type));
+		match = match && (principal == null || event.getPrincipal().equals(principal));
+		match = match && (after == null || event.getTimestamp().compareTo(after) >= 0);
+		match = match && (type == null || event.getType().equals(type));
 		return match;
 	}
 

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/Metric.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/Metric.java
@@ -126,9 +126,9 @@ public class Metric<T extends Number> {
 		if (obj instanceof Metric) {
 			Metric<?> other = (Metric<?>) obj;
 			boolean rtn = true;
-			rtn &= ObjectUtils.nullSafeEquals(this.name, other.name);
-			rtn &= ObjectUtils.nullSafeEquals(this.timestamp, other.timestamp);
-			rtn &= ObjectUtils.nullSafeEquals(this.value, other.value);
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.name, other.name);
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.timestamp, other.timestamp);
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.value, other.value);
 			return rtn;
 		}
 		return super.equals(obj);

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
@@ -280,8 +280,8 @@ public class EmbeddedMongoAutoConfiguration {
 			if (getClass() == obj.getClass()) {
 				ToStringFriendlyFeatureAwareVersion other = (ToStringFriendlyFeatureAwareVersion) obj;
 				boolean equals = true;
-				equals &= this.features.equals(other.features);
-				equals &= this.version.equals(other.version);
+				equals = equals && this.features.equals(other.features);
+				equals = equals && this.version.equals(other.version);
 				return equals;
 			}
 			return super.equals(obj);

--- a/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/dependencies/Dependency.java
+++ b/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/dependencies/Dependency.java
@@ -125,10 +125,10 @@ public final class Dependency {
 		if (getClass() == obj.getClass()) {
 			Dependency other = (Dependency) obj;
 			boolean result = true;
-			result &= this.groupId.equals(other.groupId);
-			result &= this.artifactId.equals(other.artifactId);
-			result &= this.version.equals(other.version);
-			result &= this.exclusions.equals(other.exclusions);
+			result = result && this.groupId.equals(other.groupId);
+			result = result && this.artifactId.equals(other.artifactId);
+			result = result && this.version.equals(other.version);
+			result = result && this.exclusions.equals(other.exclusions);
 			return result;
 		}
 		return false;
@@ -187,8 +187,8 @@ public final class Dependency {
 			if (getClass() == obj.getClass()) {
 				Exclusion other = (Exclusion) obj;
 				boolean result = true;
-				result &= this.groupId.equals(other.groupId);
-				result &= this.artifactId.equals(other.artifactId);
+				result = result && this.groupId.equals(other.groupId);
+				result = result && this.artifactId.equals(other.artifactId);
 				return result;
 			}
 			return false;

--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSnapshot.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSnapshot.java
@@ -59,9 +59,9 @@ class FileSnapshot {
 		if (obj instanceof FileSnapshot) {
 			FileSnapshot other = (FileSnapshot) obj;
 			boolean equals = this.file.equals(other.file);
-			equals &= this.exists == other.exists;
-			equals &= this.length == other.length;
-			equals &= this.lastModified == other.lastModified;
+			equals = equals && this.exists == other.exists;
+			equals = equals && this.length == other.length;
+			equals = equals && this.lastModified == other.lastModified;
 			return equals;
 		}
 		return super.equals(obj);

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/filter/AnnotationCustomizableTypeExcludeFilter.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/filter/AnnotationCustomizableTypeExcludeFilter.java
@@ -142,17 +142,17 @@ public abstract class AnnotationCustomizableTypeExcludeFilter extends TypeExclud
 		}
 		AnnotationCustomizableTypeExcludeFilter other = (AnnotationCustomizableTypeExcludeFilter) obj;
 		boolean result = true;
-		result &= hasAnnotation() == other.hasAnnotation();
+		result = result && hasAnnotation() == other.hasAnnotation();
 		for (FilterType filterType : FilterType.values()) {
 			result &= ObjectUtils.nullSafeEquals(getFilters(filterType),
 					other.getFilters(filterType));
 		}
-		result &= isUseDefaultFilters() == other.isUseDefaultFilters();
-		result &= ObjectUtils.nullSafeEquals(getDefaultIncludes(),
+		result = result && isUseDefaultFilters() == other.isUseDefaultFilters();
+		result = result && ObjectUtils.nullSafeEquals(getDefaultIncludes(),
 				other.getDefaultIncludes());
-		result &= ObjectUtils.nullSafeEquals(getComponentIncludes(),
+		result = result && ObjectUtils.nullSafeEquals(getComponentIncludes(),
 				other.getComponentIncludes());
 		return result;
-	};
+	}
 
 }

--- a/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/Definition.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/Definition.java
@@ -97,11 +97,11 @@ abstract class Definition {
 		}
 		Definition other = (Definition) obj;
 		boolean result = true;
-		result &= ObjectUtils.nullSafeEquals(this.name, other.name);
-		result &= ObjectUtils.nullSafeEquals(this.reset, other.reset);
-		result &= ObjectUtils.nullSafeEquals(this.proxyTargetAware,
+		result = result && ObjectUtils.nullSafeEquals(this.name, other.name);
+		result = result && ObjectUtils.nullSafeEquals(this.reset, other.reset);
+		result = result && ObjectUtils.nullSafeEquals(this.proxyTargetAware,
 				other.proxyTargetAware);
-		result &= ObjectUtils.nullSafeEquals(this.qualifier, other.qualifier);
+		result = result && ObjectUtils.nullSafeEquals(this.qualifier, other.qualifier);
 		return result;
 	}
 

--- a/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
@@ -119,10 +119,10 @@ class MockDefinition extends Definition {
 		}
 		MockDefinition other = (MockDefinition) obj;
 		boolean result = super.equals(obj);
-		result &= ObjectUtils.nullSafeEquals(this.typeToMock, other.typeToMock);
-		result &= ObjectUtils.nullSafeEquals(this.extraInterfaces, other.extraInterfaces);
-		result &= ObjectUtils.nullSafeEquals(this.answer, other.answer);
-		result &= this.serializable == other.serializable;
+		result = result && ObjectUtils.nullSafeEquals(this.typeToMock, other.typeToMock);
+		result = result && ObjectUtils.nullSafeEquals(this.extraInterfaces, other.extraInterfaces);
+		result = result && ObjectUtils.nullSafeEquals(this.answer, other.answer);
+		result = result && this.serializable == other.serializable;
 		return result;
 	}
 

--- a/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyDefinition.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyDefinition.java
@@ -65,7 +65,7 @@ class SpyDefinition extends Definition {
 		}
 		SpyDefinition other = (SpyDefinition) obj;
 		boolean result = super.equals(obj);
-		result &= ObjectUtils.nullSafeEquals(this.typeToSpy, other.typeToSpy);
+		result = result && ObjectUtils.nullSafeEquals(this.typeToSpy, other.typeToSpy);
 		return result;
 	}
 

--- a/spring-boot/src/main/java/org/springframework/boot/logging/LoggerConfiguration.java
+++ b/spring-boot/src/main/java/org/springframework/boot/logging/LoggerConfiguration.java
@@ -99,10 +99,10 @@ public final class LoggerConfiguration {
 		if (obj instanceof LoggerConfiguration) {
 			LoggerConfiguration other = (LoggerConfiguration) obj;
 			boolean rtn = true;
-			rtn &= ObjectUtils.nullSafeEquals(this.name, other.name);
-			rtn &= ObjectUtils.nullSafeEquals(this.configuredLevel,
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.name, other.name);
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.configuredLevel,
 					other.configuredLevel);
-			rtn &= ObjectUtils.nullSafeEquals(this.effectiveLevel, other.effectiveLevel);
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.effectiveLevel, other.effectiveLevel);
 			return rtn;
 		}
 		return super.equals(obj);

--- a/spring-boot/src/main/java/org/springframework/boot/web/servlet/ErrorPage.java
+++ b/spring-boot/src/main/java/org/springframework/boot/web/servlet/ErrorPage.java
@@ -125,10 +125,10 @@ public class ErrorPage {
 		if (obj instanceof ErrorPage) {
 			ErrorPage other = (ErrorPage) obj;
 			boolean rtn = true;
-			rtn &= ObjectUtils.nullSafeEquals(getExceptionName(),
+			rtn = rtn && ObjectUtils.nullSafeEquals(getExceptionName(),
 					other.getExceptionName());
-			rtn &= ObjectUtils.nullSafeEquals(this.path, other.path);
-			rtn &= this.status == other.status;
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.path, other.path);
+			rtn = rtn && this.status == other.status;
 			return rtn;
 		}
 		return false;


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR simply replaces bitwise 'and' (`&`) with logical 'and' (`&&`) to take advantage of short-circuit evaluation.