### PR TITLE
Set Pivotal GemFire dependency version to 8.2.2

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -75,7 +75,7 @@
 		<flyway.version>3.2.1</flyway.version>
 		<freemarker.version>2.3.25-incubating</freemarker.version>
 		<elasticsearch.version>2.4.4</elasticsearch.version>
-		<gemfire.version>8.2.0</gemfire.version>
+		<gemfire.version>8.2.2</gemfire.version>
 		<glassfish-el.version>3.0.0</glassfish-el.version>
 		<gradle.version>2.9</gradle.version>
 		<groovy.version>2.4.7</groovy.version>


### PR DESCRIPTION
Fixes gh-8201

While I only changed the _Pivotal GemFire_ dependency for this PR, there are other data stores that are out-of-sync with the _Spring Data_ BOM and could potentially cause issues for the _Spring Data_ modules in question (for instance, when using the related starter).

Currently, _Spring Boot_ `1.5.x` is [based on](https://github.com/spring-projects/spring-boot/blob/1.5.x/spring-boot-dependencies/pom.xml#L157) the _Spring Data_ `Ingalls-RELEASE`.  When you refer to the [_Spring Data_ modules that are part of the SD _Ingalls_ Release Train](https://github.com/spring-projects/spring-data-build/blob/1.9.0.RELEASE/bom/pom.xml#L7), you find discrepancies between _Spring Boot's_ curated and harmonized data store versions and the versions actually required by the _Spring Data_ modules.

The following are the conflicts I found...

1. SD `Ingalls-RELEASE` [includes](https://github.com/spring-projects/spring-data-build/blob/1.9.0.RELEASE/bom/pom.xml#L45) SD _Couchbase_ `2.2.0.RELEASE`, which [depends on](https://github.com/spring-projects/spring-data-couchbase/blob/2.2.0.RELEASE/pom.xml#L24) `com.couchbase.client:java-client:2.2.8`.

However, _Spring Boot_ `1.5.x` [pulls in](https://github.com/spring-projects/spring-boot/blob/1.5.x/spring-boot-dependencies/pom.xml#L66) _Couchbase_ `2.3.7`!

2. SD `Ingalls-RELEASE` [includes](https://github.com/spring-projects/spring-data-build/blob/1.9.0.RELEASE/bom/pom.xml#L52) SD _Elasticsearch_ `2.1.0.RELEASE`, which [depends on](https://github.com/spring-projects/spring-data-elasticsearch/blob/2.1.0.RELEASE/pom.xml#L26) Elasticsearch `2.4.0`.

However, _Spring Boot_ `1.5.x` [pulls in](https://github.com/spring-projects/spring-boot/blob/1.5.x/spring-boot-dependencies/pom.xml#L77) _Elasticsearch_ `2.4.4`.

In this case, SD _Elasticsearch_ should probably be upgraded to `2.4.4`.

3. SD `Ingalls-RELEASE` [includes](https://github.com/spring-projects/spring-data-build/blob/1.9.0.RELEASE/bom/pom.xml#L73) SG _MongoDB_ `1.10.0.RELEASE`, which [depends on](https://github.com/spring-projects/spring-data-mongodb/blob/1.10.0.RELEASE/pom.xml#L32) MongoDB, `mongo-java-driver` `2.14.3`.

However, _Spring Boot_ `1.5.x` [pulls in](https://github.com/spring-projects/spring-boot/blob/1.5.x/spring-boot-dependencies/pom.xml#L135) _MongoDB_ `3.4.1`!

4. SD `Ingalls-RELEASE` [includes](https://github.com/spring-projects/spring-data-build/blob/1.9.0.RELEASE/bom/pom.xml#L121) SD _Solr_ `2.1.0.RELEASE`, which [depends on](https://github.com/spring-projects/spring-data-solr/blob/master/pom.xml#L26) _Solr_ `5.5.0`.

However, Spring Boot `1.5.x` [pulls in](https://github.com/spring-projects/spring-boot/blob/1.5.x/spring-boot-dependencies/pom.xml#L151) Solr `5.5.3`.

Again, in this case, SD _Solr_ should probably be upgraded to `5.5.3`.
