### PR TITLE
Improve spring-boot-sample-cache UX by using Maven profiles

### DIFF
--- a/spring-boot-samples/spring-boot-sample-cache/README.adoc
+++ b/spring-boot-samples/spring-boot-sample-cache/README.adoc
@@ -64,6 +64,7 @@ used to configure the underlying `CacheManager`. Note that EhCache 3 uses a diff
 format and doesn't default to `ehcache.xml` anymore. Check
 http://www.ehcache.org/documentation/3.0/xml.html[the documentation] for more details.
 
+Run sample cache application using EhCache with `$mvn -P ehcache spring-boot:run`
 
 
 === Hazelcast
@@ -72,6 +73,7 @@ the project to enable support for Hazelcast.  Since there is a default `hazelcas
 configuration file at the root of the classpath, it is used to automatically configure
 the underlying `HazelcastInstance`.
 
+Run sample cache application using Hazelcast with `$mvn -P hazelcast spring-boot:run`
 
 
 === Infinispan
@@ -81,18 +83,21 @@ so if you don't specify anything it will bootstrap on a hardcoded default. You c
 the `spring.cache.infinispan.config` property to use the provided `infinispan.xml`
 configuration instead.
 
+Run sample cache application using Infinispan with `$mvn -P infinispan spring-boot:run`
 
 
 === Couchbase
 Add the `java-client` and `couchbase-spring-cache` dependencies and make sure that you
 have setup at least a `spring.couchbase.bootstrap-hosts` property.
 
+Start a Couchbase server, then run the sample cache application using Couchbase with `$mvn -P couchbase spring-boot:run`
 
 
 === Redis
 Add the `spring-boot-starter-data-redis` and make sure it is configured properly (by default,
 a redis instance with the default settings is expected on your local box).
 
+Start a Redis server, then run the sample cache application using Redis with `$mvn -P redis spring-boot:run`
 
 
 === Caffeine
@@ -100,6 +105,7 @@ Simply add the `com.github.ben-manes.caffeine:caffeine` dependency to enable sup
 for Caffeine. You can customize how caches are created in different ways, see
 `application.properties` for an example and the documentation for more details.
 
+Run sample cache application using Caffeine with `$mvn -P caffeine spring-boot:run`
 
 
 === Guava
@@ -107,3 +113,5 @@ Spring Boot does not provide any dependency management for _Guava_ so you'll hav
 the `com.google.guava:guava` dependency with a version. You can customize how caches are
 created in different ways, see `application.properties` for an example and the
 documentation for more details.
+
+Run sample cache application using Guava with `$mvn -P guava spring-boot:run`

--- a/spring-boot-samples/spring-boot-sample-cache/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-cache/pom.xml
@@ -33,78 +33,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
-
-		<!-- JSR-107 API (uncomment to try the JCache support) -->
-		<!--
-		<dependency>
-			<groupId>javax.cache</groupId>
-			<artifactId>cache-api</artifactId>
-		</dependency>
-		-->
-
-		<!-- Additional cache providers (uncomment to try them) -->
-		<!--
-		<dependency>
-			<groupId>net.sf.ehcache</groupId>
-			<artifactId>ehcache</artifactId>
-		</dependency>
-		-->
-		<!--
-		<dependency>
-			<groupId>org.ehcache</groupId>
-			<artifactId>ehcache</artifactId>
-		</dependency>
-		-->
-		<!--
-		<dependency>
-			<groupId>com.hazelcast</groupId>
-			<artifactId>hazelcast</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.hazelcast</groupId>
-			<artifactId>hazelcast-spring</artifactId>
-		</dependency>
-		-->
-		<!--
-		<dependency>
-			<groupId>org.infinispan</groupId>
-			<artifactId>infinispan-spring4-embedded</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.infinispan</groupId>
-			<artifactId>infinispan-jcache</artifactId>
-		</dependency>
-		-->
-		<!--
-		<dependency>
-			<groupId>com.couchbase.client</groupId>
-			<artifactId>java-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.couchbase.client</groupId>
-			<artifactId>couchbase-spring-cache</artifactId>
-		</dependency>
-		-->
-		<!--
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-redis</artifactId>
-		</dependency>
-		-->
-		<!--
-		<dependency>
-			<groupId>com.github.ben-manes.caffeine</groupId>
-			<artifactId>caffeine</artifactId>
-		</dependency>
-		-->
-		<!--
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>18.0</version>
-		</dependency>
-		-->
-
 		<!-- Test -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -120,4 +48,113 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<!-- JCache API (JSR-107 support) -->
+		<!-- Include with any of the caching providers below using, e.g. `$mvn -P jcache,hazelcast spring-boot:run` -->
+		<profile>
+			<id>jcache</id>
+			<dependencies>
+				<dependency>
+					<groupId>javax.cache</groupId>
+					<artifactId>cache-api</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- mvn -P caffeine spring-boot:run -->
+		<profile>
+			<id>caffeine</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.github.ben-manes.caffeine</groupId>
+					<artifactId>caffeine</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- Start Couchbase server, then... -->
+		<!-- mvn -P couchbase spring-boot:run -->
+		<profile>
+			<id>couchbase</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.couchbase.client</groupId>
+					<artifactId>java-client</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>com.couchbase.client</groupId>
+					<artifactId>couchbase-spring-cache</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- mvn -P ehcache spring-boot:run -->
+		<profile>
+			<id>ehcache</id>
+			<dependencies>
+				<dependency>
+					<groupId>net.sf.ehcache</groupId>
+					<artifactId>ehcache</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- Start a Ehcache server, then... -->
+		<!-- mvn -P org-ehcache spring-boot:run -->
+		<profile>
+			<id>org-ehcache</id>
+			<dependencies>
+				<dependency>
+					<groupId>org.ehcache</groupId>
+					<artifactId>ehcache</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- mvn -P guava spring-boot:run -->
+		<profile>
+			<id>guava</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+					<version>18.0</version>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- mvn -P hazelcast spring-boot:run -->
+		<profile>
+			<id>hazelcast</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.hazelcast</groupId>
+					<artifactId>hazelcast</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>com.hazelcast</groupId>
+					<artifactId>hazelcast-spring</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- mvn -P infinispan spring-boot:run -->
+		<profile>
+			<id>infinispan</id>
+			<dependencies>
+				<dependency>
+					<groupId>org.infinispan</groupId>
+					<artifactId>infinispan-spring4-embedded</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>org.infinispan</groupId>
+					<artifactId>infinispan-jcache</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<!-- Start a Redis Server ($. <redis-install>/src/redis-server), then... -->
+		<!-- mvn -P redis spring-boot:run -->
+		<profile>
+			<id>redis</id>
+			<dependencies>
+				<dependency>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-data-redis</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
Fixes gh-8202

The `spring-boot-sample-cache` UX improvements were part of my original PR #6967, which was to include _auto-configuration_ support for _Spring Data Geode_, and by extension, _Apache Geode_, as a "_caching provider_" in _Spring Boot_ applications using _Spring's_ Cache Abstraction.

Unfortunately, SDG/_Apache Geode_ never made into _Spring Boot's_ "_auto-configuration_" support as a "_caching provider_".

However, that does not mean we should not improve on the `sample cache` user experience by leveraging Maven Profiles over resorting to "comments"!

I have included the Maven Profile work I performed while working on PR #6967 (minus the SDG/_Apache Geode_ specific changes) in this PR.