### PR TITLE
Fix ImportAutoConfigurationImportSelectorTests.determineImportsWhenUsingNonMetaWithClassesShouldBeSame()

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ImportAutoConfigurationImportSelectorTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ImportAutoConfigurationImportSelectorTests.java
@@ -157,7 +157,7 @@ public class ImportAutoConfigurationImportSelectorTests {
 		Set<Object> set1 = this.importSelector.determineImports(
 				getAnnotationMetadata(ImportAutoConfigurationWithItemsOne.class));
 		Set<Object> set2 = this.importSelector.determineImports(
-				getAnnotationMetadata(ImportAutoConfigurationWithItemsOne.class));
+				getAnnotationMetadata(ImportAutoConfigurationWithItemsTwo.class));
 		assertThat(set1).isEqualTo(set2);
 	}
 
@@ -269,7 +269,7 @@ public class ImportAutoConfigurationImportSelectorTests {
 	}
 
 	@ImportAutoConfiguration(classes = ThymeleafAutoConfiguration.class)
-	@UnrelatedOne
+	@UnrelatedTwo
 	static class ImportAutoConfigurationWithItemsTwo {
 
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
`ImportAutoConfigurationImportSelectorTests.determineImportsWhenUsingNonMetaWithClassesShouldBeSame()` references the wrong configuration class which also has the wrong annotation.

This PR fixes it.