### PR TITLE
Provide dependency management for HikariCP-java7

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -89,6 +89,7 @@
 		<hibernate-validator.version>5.3.4.Final</hibernate-validator.version>
 		<hikaricp.version>2.5.1</hikaricp.version>
 		<hikaricp-java6.version>2.3.13</hikaricp-java6.version>
+		<hikaricp-java7.version>2.4.11</hikaricp-java7.version>
 		<hsqldb.version>2.3.3</hsqldb.version>
 		<htmlunit.version>2.21</htmlunit.version>
 		<httpasyncclient.version>4.1.2</httpasyncclient.version>
@@ -765,6 +766,11 @@
 				<groupId>com.zaxxer</groupId>
 				<artifactId>HikariCP-java6</artifactId>
 				<version>${hikaricp-java6.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.zaxxer</groupId>
+				<artifactId>HikariCP-java7</artifactId>
+				<version>${hikaricp-java7.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-beanutils</groupId>


### PR DESCRIPTION
Commit d996a1d5718a9534d1fb98f0db29bdbf655801f8 upgraded HikariCP to 2.5.1 however this version is Java 8 only and caused my build to fail. This pr provides the dependency management for the new maintenance lib that was created for Java 7.