### PR TITLE
fix(expansion): allow expansion in *.yml and *.yaml

### DIFF
--- a/spring-boot-starters/spring-boot-starter-parent/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-parent/pom.xml
@@ -47,6 +47,7 @@
 				<filtering>true</filtering>
 				<includes>
 					<include>**/application*.yml</include>
+					<include>**/application*.yaml</include>
 					<include>**/application*.properties</include>
 				</includes>
 			</resource>
@@ -54,6 +55,7 @@
 				<directory>${basedir}/src/main/resources</directory>
 				<excludes>
 					<exclude>**/application*.yml</exclude>
+					<exclude>**/application*.yaml</exclude>
 					<exclude>**/application*.properties</exclude>
 				</excludes>
 			</resource>


### PR DESCRIPTION
Spring boot handle *.yml and *.yaml file the same way to configure the app, but the expansion system (with `@` delimiter) uses only resources define by spring-boot-starters-parent. 
In that case, if you use expansion in a `application.yaml` file, the system will throw an error (see this [commit](https://github.com/davinkevin/yamlandexpansion/commit/cfd1422861e36be11eee89c44505e4b295b836cb)) due to error in yaml format. This modification should allow to use expansion in *.yml and *.yaml.

I've made a simple project to describe this problem : https://github.com/davinkevin/yamlandexpansion  
I haven't open an issue, instead I directly do a PR.