### PR TITLE
Ensure web containers are stopped after close

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -205,9 +205,6 @@ public class JettyEmbeddedServletContainer implements EmbeddedWebServer {
 	@Override
 	public void stop() {
 		synchronized (this.monitor) {
-			if (!this.started) {
-				return;
-			}
 			this.started = false;
 			try {
 				this.server.stop();

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -279,9 +279,6 @@ public class TomcatEmbeddedServletContainer implements EmbeddedWebServer {
 	@Override
 	public void stop() throws EmbeddedWebServerException {
 		synchronized (this.monitor) {
-			if (!this.started) {
-				return;
-			}
 			try {
 				this.started = false;
 				try {

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactoryTests.java
@@ -143,6 +143,16 @@ public class JettyEmbeddedServletContainerFactoryTests
 				.isEmpty();
 	}
 
+	@Test
+	public void stopNoStart() throws Exception {
+		JettyEmbeddedServletContainerFactory factory = getFactory();
+		this.container = factory
+				.getEmbeddedServletContainer(exampleServletRegistration());
+		this.container.stop();
+		Server server = ((JettyEmbeddedServletContainer) this.container).getServer();
+		assertThat(server.isStopped()).isTrue();
+	}
+
 	@Override
 	protected void addConnector(final int port,
 			AbstractEmbeddedServletContainerFactory factory) {

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactoryTests.java
@@ -352,6 +352,16 @@ public class TomcatEmbeddedServletContainerFactoryTests
 				.doesNotContain("appears to have started a thread named [main]");
 	}
 
+	@Test
+	public void stopNoStart() throws Exception {
+		TomcatEmbeddedServletContainerFactory factory = getFactory();
+		this.container = factory
+				.getEmbeddedServletContainer(exampleServletRegistration());
+		this.container.stop();
+		Tomcat tomcat = ((TomcatEmbeddedServletContainer) this.container).getTomcat();
+		assertThat(tomcat.getServer().getState()).isSameAs(LifecycleState.DESTROYED);
+	}
+
 	@Override
 	protected void addConnector(int port,
 			AbstractEmbeddedServletContainerFactory factory) {


### PR DESCRIPTION
Closes #8224 

In fixing #8036, commit 0af53b3 was a bit over-zealous in preventing double-execution and prevented initialization done on object creation from being cleaned up for Tomcat and Jetty.  Undertow avoids the problem because it does not share similar initialization on creation.  This pull request removes the `started` check on stop() for Jetty and Tomcat because re-invoking stop() is safe, regardless, and stop() must execute to shutdown threads started on creation.  It also adds a test to prove that stopping without start is safe and that the servers are correctly stopped, even if not previously started.