### PR TITLE
Fix ConfigurationPropertiesReportEndpoint.sanitize()

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/ConfigurationPropertiesReportEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/ConfigurationPropertiesReportEndpoint.java
@@ -109,7 +109,7 @@ public class ConfigurationPropertiesReportEndpoint
 			String beanName = entry.getKey();
 			Object bean = entry.getValue();
 			Map<String, Object> root = new HashMap<String, Object>();
-			String prefix = extractPrefix(context, beanFactoryMetaData, beanName, bean);
+			String prefix = extractPrefix(context, beanFactoryMetaData, beanName);
 			root.put("prefix", prefix);
 			root.put("properties", sanitize(prefix, safeSerialize(mapper, bean, prefix)));
 			result.put(beanName, root);
@@ -202,12 +202,10 @@ public class ConfigurationPropertiesReportEndpoint
 	 * @param context the application context
 	 * @param beanFactoryMetaData the bean factory meta-data
 	 * @param beanName the bean name
-	 * @param bean the bean
 	 * @return the prefix
 	 */
 	private String extractPrefix(ApplicationContext context,
-			ConfigurationBeanFactoryMetaData beanFactoryMetaData, String beanName,
-			Object bean) {
+			ConfigurationBeanFactoryMetaData beanFactoryMetaData, String beanName) {
 		ConfigurationProperties annotation = context.findAnnotationOnBean(beanName,
 				ConfigurationProperties.class);
 		if (beanFactoryMetaData != null) {
@@ -259,10 +257,9 @@ public class ConfigurationPropertiesReportEndpoint
 				sanitized.add(sanitize(prefix, (Map<String, Object>) item));
 			}
 			else if (item instanceof List) {
-				sanitize(prefix, (List<Object>) item);
+				sanitized.add(sanitize(prefix, (List<Object>) item));
 			}
 			else {
-				item = this.sanitizer.sanitize(prefix, item);
 				sanitized.add(this.sanitizer.sanitize(prefix, item));
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Adding to `sanitized ` has been missed in f27bb39af9d4fb5bbef07ef0e70f39281ceee758 .

This PR fixes it and also removes an unused parameter in `extractPrefix()` and a redundant invocation of `this.sanitizer.sanitize()`.