### PR TITLE
upgrade to latest version of gradle plugin

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -2466,7 +2466,7 @@ https://plugins.gradle.org/plugin/com.gorylenko.gradle-git-properties[`gradle-gi
 [source,groovy,indent=0]
 ----
 	plugins {
-		id "com.gorylenko.gradle-git-properties" version "1.4.6"
+		id "com.gorylenko.gradle-git-properties" version "1.4.17"
 	}
 ----
 


### PR DESCRIPTION
Upgrades to latest version of gradle plugin https://plugins.gradle.org/plugin/com.gorylenko.gradle-git-properties, so that users will use latest version and get all features from gradle plugin same as maven plugin.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->