### PR TITLE
Fix audit events related documentation

### DIFF
--- a/spring-boot-actuator/README.adoc
+++ b/spring-boot-actuator/README.adoc
@@ -43,7 +43,7 @@ For Gradle, use the declaration:
   delta (an increment or decrement). Metrics for all HTTP requests are automatically
   recorded, so if you hit the `metrics` endpoint should see a sensible response.
 * **Audit** Spring Boot Actuator has a flexible audit framework that will publish events
-  to an `AuditService`. Once Spring Security is in play it automatically publishes
+  to an `AuditEventRepository`. Once Spring Security is in play it automatically publishes
   authentication events by default. This can be very useful for reporting, and also to
   implement a lock-out policy based on authentication failures.
 * **Process Monitoring** In Spring Boot Actuator you can find `ApplicationPidFileWriter`

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -2710,7 +2710,8 @@ to the home page at "/" and keep the default for everything else:
 If the Actuator is also in use, you will find:
 
 * The management endpoints are secure even if the application endpoints are insecure.
-* Security events are transformed into `AuditEvents` and published to the `AuditService`.
+* Security events are transformed into `AuditEvent` instances and published to the
+`AuditEventRepository`.
 * The default user will have the `ADMIN` role as well as the `USER` role.
 
 The Actuator security features can be modified using external properties


### PR DESCRIPTION
This replaces documentation references to nonexistent `AuditService` and polishes the audit events related documentation.