### PR TITLE
Add @ConfigurationPropertyValue annotation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -904,6 +904,9 @@ your application, as shown in the following example:
 
 		private InetAddress remoteAddress;
 
+		@ConfigurationPropertyValue(fallback="acmeCorp.companyName")
+		private String companyName;
+
 		private final Security security = new Security();
 
 		public boolean isEnabled() { ... }
@@ -913,6 +916,10 @@ your application, as shown in the following example:
 		public InetAddress getRemoteAddress() { ... }
 
 		public void setRemoteAddress(InetAddress remoteAddress) { ... }
+
+		public String getCompanyName() { ... }
+
+		public void setCompanyName(String companyName) { ... }
 
 		public Security getSecurity() { ... }
 
@@ -944,6 +951,8 @@ The preceding POJO defines the following properties:
 
 * `acme.enabled`, `false` by default.
 * `acme.remote-address`, with a type that can be coerced from `String`.
+* `acme.companyName`, with a `String` value that is read from the property `acmeCorp.companyName` if
+  `acme.companyName` has not been set
 * `acme.security.username`, with a nested "security" object whose name is determined by
 the name of the property. In particular, the return type is not used at all there and
 could have been `SecurityProperties`.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertyValue.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertyValue.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.context.properties;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to be used on accessor methods or fields when the class is annotated with
+ * {@link ConfigurationProperties}. It allows to specify additional metadata for a single
+ * property.
+ * <p>
+ * Annotating a method that is not a getter or setter in the sense of the JavaBeans spec
+ * will cause an exception.
+ *
+ * @author Tom Hombergs
+ * @since 2.0.0
+ * @see ConfigurationProperties
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ConfigurationPropertyValue {
+
+	/**
+	 * Name of the property whose value to use if the property with the name of the
+	 * annotated field itself is not defined.
+	 * <p>
+	 * The fallback property name has to be specified including potential prefixes defined
+	 * in {@link ConfigurationProperties} annotations.
+	 *
+	 * @return the name of the fallback property
+	 */
+	String fallback() default "";
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertyValueBindingException.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertyValueBindingException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.context.properties;
+
+import org.springframework.util.ClassUtils;
+
+/**
+ * Exception thrown when a {@code @ConfigurationPropertyValue} annotation on a field or
+ * method conflicts with another annotation.
+ *
+ * @author Tom Hombergs
+ * @since 2.0.0
+ */
+public final class ConfigurationPropertyValueBindingException extends RuntimeException {
+
+	private ConfigurationPropertyValueBindingException(String message) {
+		super(message);
+	}
+
+	public static ConfigurationPropertyValueBindingException invalidUseOnMethod(
+			Class<?> targetClass, String methodName, String reason) {
+		return new ConfigurationPropertyValueBindingException(String.format(
+				"Invalid use of annotation %s on method '%s' of class '%s': %s",
+				ClassUtils.getShortName(ConfigurationPropertyValue.class), methodName,
+				targetClass.getName(), reason));
+	}
+
+	public static ConfigurationPropertyValueBindingException invalidUseOnField(
+			Class<?> targetClass, String fieldName, String reason) {
+		return new ConfigurationPropertyValueBindingException(String.format(
+				"Invalid use of annotation %s on field '%s' of class '%s': %s",
+				ClassUtils.getShortName(ConfigurationPropertyValue.class), fieldName,
+				targetClass.getName(), reason));
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertyValueReader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertyValueReader.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.context.properties;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Utility class that reads
+ * {@link org.springframework.boot.context.properties.ConfigurationPropertyValue}
+ * annotations from getters and fields of a bean and provides methods to access the
+ * metadata contained in the annotations.
+ *
+ * @author Tom Hombergs
+ * @since 2.0.0
+ * @see org.springframework.boot.context.properties.ConfigurationPropertyValue
+ */
+public class ConfigurationPropertyValueReader {
+
+	private Map<ConfigurationPropertyName, ConfigurationPropertyValue> annotations = new HashMap<>();
+
+	public ConfigurationPropertyValueReader(Object bean, String prefix) {
+		this.annotations = findAnnotations(bean, prefix);
+	}
+
+	/**
+	 * Returns a map that maps configuration property names to their fallback properties.
+	 * If this map does not contain a value for a certain configuration property, it means
+	 * that there is no fallback specified for this property.
+	 *
+	 * @return a map of configuration property names to their fallback property names.
+	 */
+	public Map<ConfigurationPropertyName, ConfigurationPropertyName> getPropertyFallbacks() {
+		return this.annotations.entrySet().stream()
+				.filter(entry -> !StringUtils.isEmpty(entry.getValue().fallback()))
+				.collect(Collectors.toMap(Map.Entry::getKey,
+						entry -> ConfigurationPropertyName
+								.of(entry.getValue().fallback())));
+	}
+
+	/**
+	 * Walks through the methods and fields of the specified bean to extract
+	 * {@link ConfigurationPropertyValue} annotations. A field can be annotated either by
+	 * directly annotating the field or by annotating the corresponding getter or setter
+	 * method. This method will throw a {@link BeanCreationException} if multiple
+	 * annotations are found for the same field.
+	 *
+	 * @param bean the bean whose annotations to retrieve.
+	 * @param prefix the prefix of the superordinate {@link ConfigurationProperties}
+	 * annotation. May be null.
+	 * @return a map that maps configuration property names to the annotations that were
+	 * found for them.
+	 * @throws ConfigurationPropertyValueBindingException if multiple
+	 * {@link ConfigurationPropertyValue} annotations have been found for the same field.
+	 */
+	private Map<ConfigurationPropertyName, ConfigurationPropertyValue> findAnnotations(
+			Object bean, String prefix) {
+		Map<ConfigurationPropertyName, ConfigurationPropertyValue> fieldAnnotations = new HashMap<>();
+		ReflectionUtils.doWithMethods(bean.getClass(), method -> {
+			ConfigurationPropertyValue annotation = AnnotationUtils.findAnnotation(method,
+					ConfigurationPropertyValue.class);
+			if (annotation != null) {
+				PropertyDescriptor propertyDescriptor = findPropertyDescriptorOrFail(
+						method);
+				ConfigurationPropertyName name = getConfigurationPropertyName(prefix,
+						propertyDescriptor.getName());
+				if (fieldAnnotations.containsKey(name)) {
+					throw ConfigurationPropertyValueBindingException.invalidUseOnMethod(
+							bean.getClass(), method.getName(),
+							"You may either annotate a field, a getter or a setter but not two of these.");
+				}
+				fieldAnnotations.put(name, annotation);
+			}
+		});
+
+		ReflectionUtils.doWithFields(bean.getClass(), field -> {
+			ConfigurationPropertyValue annotation = AnnotationUtils.findAnnotation(field,
+					ConfigurationPropertyValue.class);
+			if (annotation != null) {
+				ConfigurationPropertyName name = getConfigurationPropertyName(prefix,
+						field.getName());
+				if (fieldAnnotations.containsKey(name)) {
+					throw ConfigurationPropertyValueBindingException.invalidUseOnField(
+							bean.getClass(), field.getName(),
+							"You may either annotate a field, a getter or a setter but not two of these.");
+				}
+				fieldAnnotations.put(name, annotation);
+			}
+		});
+		return fieldAnnotations;
+	}
+
+	private PropertyDescriptor findPropertyDescriptorOrFail(Method method) {
+		PropertyDescriptor propertyDescriptor = BeanUtils.findPropertyForMethod(method);
+		if (propertyDescriptor == null) {
+			throw ConfigurationPropertyValueBindingException.invalidUseOnMethod(
+					method.getDeclaringClass(), method.getName(),
+					"This annotation may only be used on getter and setter methods or fields.");
+		}
+		return propertyDescriptor;
+	}
+
+	private ConfigurationPropertyName getConfigurationPropertyName(String prefix,
+			String fieldName) {
+		if (StringUtils.isEmpty(prefix)) {
+			return ConfigurationPropertyName.of(fieldName);
+		}
+		else {
+			return ConfigurationPropertyName.of(prefix + "." + fieldName);
+		}
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/AbstractBindHandler.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/AbstractBindHandler.java
@@ -70,4 +70,9 @@ public abstract class AbstractBindHandler implements BindHandler {
 		this.parent.onFinish(name, target, context, result);
 	}
 
+	@Override
+	public Object onNull(ConfigurationPropertyName name, Bindable<?> target,
+			BindContext context) {
+		return this.parent.onNull(name, target, context);
+	}
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/BindHandler.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/BindHandler.java
@@ -89,4 +89,16 @@ public interface BindHandler {
 			BindContext context, Object result) throws Exception {
 	}
 
+	/**
+	 * Called when binding resolves to null.
+	 * @param name the name of the element being bound
+	 * @param target the item being bound
+	 * @param context the bind context
+	 * @return the actual result that should be used instead of the null value.
+	 */
+	default Object onNull(ConfigurationPropertyName name, Bindable<?> target,
+			BindContext context) {
+		return null;
+	}
+
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java
@@ -210,6 +210,9 @@ public class Binder {
 			result = handler.onSuccess(name, target, context, result);
 			result = convert(result, target);
 		}
+		else {
+			result = handler.onNull(name, target, context);
+		}
 		handler.onFinish(name, target, context, result);
 		return convert(result, target);
 	}
@@ -235,11 +238,8 @@ public class Binder {
 
 	private <T> Object bindObject(ConfigurationPropertyName name, Bindable<T> target,
 			BindHandler handler, Context context, boolean allowRecursiveBinding)
-					throws Exception {
+			throws Exception {
 		ConfigurationProperty property = findProperty(name, context);
-		if (property == null && containsNoDescendantOf(context.streamSources(), name)) {
-			return null;
-		}
 		AggregateBinder<?> aggregateBinder = getAggregateBinder(target, context);
 		if (aggregateBinder != null) {
 			return bindAggregate(name, target, handler, context, aggregateBinder);
@@ -306,8 +306,7 @@ public class Binder {
 
 	private Object bindBean(ConfigurationPropertyName name, Bindable<?> target,
 			BindHandler handler, Context context, boolean allowRecursiveBinding) {
-		if (containsNoDescendantOf(context.streamSources(), name)
-				|| isUnbindableBean(name, target, context)) {
+		if (isUnbindableBean(name, target, context)) {
 			return null;
 		}
 		BeanPropertyBinder propertyBinder = (propertyName, propertyTarget) -> bind(
@@ -336,12 +335,6 @@ public class Binder {
 		}
 		String packageName = ClassUtils.getPackageName(resolved);
 		return packageName.startsWith("java.");
-	}
-
-	private boolean containsNoDescendantOf(Stream<ConfigurationPropertySource> sources,
-			ConfigurationPropertyName name) {
-		return sources.allMatch(
-				(s) -> s.containsDescendantOf(name) == ConfigurationPropertyState.ABSENT);
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/handler/FallbackBindHandler.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/handler/FallbackBindHandler.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.context.properties.bind.handler;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.springframework.boot.context.properties.bind.AbstractBindHandler;
+import org.springframework.boot.context.properties.bind.BindContext;
+import org.springframework.boot.context.properties.bind.BindHandler;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.source.ConfigurationProperty;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+
+/**
+ * {@link BindHandler} that falls back on a default value when a property could not be
+ * bound (i.e. resolved to null).
+ *
+ * @author Tom Hombergs
+ * @since 2.0.0
+ */
+public class FallbackBindHandler extends AbstractBindHandler {
+
+	private final Map<ConfigurationPropertyName, ConfigurationPropertyName> fallbacks;
+
+	public FallbackBindHandler(
+			Map<ConfigurationPropertyName, ConfigurationPropertyName> fallbacks) {
+		this.fallbacks = fallbacks;
+	}
+
+	@Override
+	public Object onNull(ConfigurationPropertyName name, Bindable<?> target,
+			BindContext context) {
+		ConfigurationPropertyName fallbackPropertyName = this.fallbacks.get(name);
+		if (fallbackPropertyName != null) {
+			ConfigurationProperty fallbackProperty = findProperty(fallbackPropertyName,
+					context.streamSources());
+			if (fallbackProperty != null && fallbackProperty.getValue() != null) {
+				return fallbackProperty.getValue();
+			}
+		}
+		return super.onNull(name, target, context);
+	}
+
+	private ConfigurationProperty findProperty(ConfigurationPropertyName name,
+			Stream<ConfigurationPropertySource> sources) {
+		return sources.map((source) -> source.getConfigurationProperty(name))
+				.filter(Objects::nonNull).findFirst().orElse(null);
+	}
+}


### PR DESCRIPTION
Adds the `@ConfigurationPropertyValue `annotation as proposed in issue #7986. Fixes issue #7986 if merged.

The annotation supports defining a fallback property to bind if the original property is not available and defining a default value which is bound if the fallback property also fails (or is not defined).

Changes are covered with unit tests and I added a short example of the annotation to the feature docs.

Looking forward to feedback :). 

