### PR TITLE
Remove @Autowired on constructor injection in docs

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -1154,7 +1154,6 @@ Here is a simple example that counts the number of times that a method is invoke
 
 [source,java,indent=0]
 ----
-	import org.springframework.beans.factory.annotation.Autowired;
 	import org.springframework.boot.actuate.metrics.CounterService;
 	import org.springframework.stereotype.Service;
 
@@ -1163,7 +1162,6 @@ Here is a simple example that counts the number of times that a method is invoke
 
 		private final CounterService counterService;
 
-		@Autowired
 		public MyService(CounterService counterService) {
 			this.counterService = counterService;
 		}

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -274,13 +274,11 @@ provides access to both the raw `String[]` arguments as well as parsed `option` 
 [source,java,indent=0]
 ----
 	import org.springframework.boot.*
-	import org.springframework.beans.factory.annotation.*
 	import org.springframework.stereotype.*
 
 	@Component
 	public class MyBean {
 
-		@Autowired
 		public MyBean(ApplicationArguments args) {
 			boolean debug = args.containsOption("debug");
 			List<String> files = args.getNonOptionArgs();
@@ -977,7 +975,6 @@ as any other bean.
 
 		private final FooProperties properties;
 
-		@Autowired
 		public MyService(FooProperties properties) {
 		    this.properties = properties;
 		}
@@ -2911,7 +2908,6 @@ you can `@Autowire` them directly into your own beans:
 
 [source,java,indent=0]
 ----
-	import org.springframework.beans.factory.annotation.Autowired;
 	import org.springframework.jdbc.core.JdbcTemplate;
 	import org.springframework.stereotype.Component;
 
@@ -2920,7 +2916,6 @@ you can `@Autowire` them directly into your own beans:
 
 		private final JdbcTemplate jdbcTemplate;
 
-		@Autowired
 		public MyBean(JdbcTemplate jdbcTemplate) {
 			this.jdbcTemplate = jdbcTemplate;
 		}
@@ -3196,7 +3191,6 @@ application `DataSource`. To use the `DSLContext` you can just `@Autowire` it:
 
 		private final DSLContext create;
 
-		@Autowired
 		public JooqExample(DSLContext dslContext) {
 			this.create = dslContext;
 		}
@@ -3289,7 +3283,6 @@ instance will attempt to connect to a Redis server using `localhost:6379`:
 
 		private StringRedisTemplate template;
 
-		@Autowired
 		public MyBean(StringRedisTemplate template) {
 			this.template = template;
 		}
@@ -3331,7 +3324,6 @@ server using the URL `mongodb://localhost/test`:
 
 		private final MongoDbFactory mongo;
 
-		@Autowired
 		public MyBean(MongoDbFactory mongo) {
 			this.mongo = mongo;
 		}
@@ -3387,7 +3379,6 @@ auto-configures a bean for you to simply inject:
 
 [source,java,indent=0]
 ----
-	import org.springframework.beans.factory.annotation.Autowired;
 	import org.springframework.data.mongodb.core.MongoTemplate;
 	import org.springframework.stereotype.Component;
 
@@ -3396,7 +3387,6 @@ auto-configures a bean for you to simply inject:
 
 		private final MongoTemplate mongoTemplate;
 
-		@Autowired
 		public MyBean(MongoTemplate mongoTemplate) {
 			this.mongoTemplate = mongoTemplate;
 		}
@@ -3487,7 +3477,6 @@ Neo4j server using `localhost:7474`:
 
 		private final Neo4jTemplate neo4jTemplate;
 
-		@Autowired
 		public MyBean(Neo4jTemplate neo4jTemplate) {
 			this.neo4jTemplate = neo4jTemplate;
 		}
@@ -3617,9 +3606,8 @@ bean. By default the instance will attempt to connect to a server using
 	@Component
 	public class MyBean {
 
-		private SolrClient solr;
+		private final SolrClient solr;
 
-		@Autowired
 		public MyBean(SolrClient solr) {
 			this.solr = solr;
 		}
@@ -3713,9 +3701,8 @@ Alternatively, you can switch to a remote server (i.e. a `TransportClient`) by s
 	@Component
 	public class MyBean {
 
-		private ElasticsearchTemplate template;
+		private final ElasticsearchTemplate template;
 
-		@Autowired
 		public MyBean(ElasticsearchTemplate template) {
 			this.template = template;
 		}
@@ -3775,9 +3762,8 @@ properties can be used to customize the connection. Generally you will provide
 	@Component
 	public class MyBean {
 
-		private CassandraTemplate template;
+		private final CassandraTemplate template;
 
-		@Autowired
 		public MyBean(CassandraTemplate template) {
 			this.template = template;
 		}
@@ -3868,7 +3854,6 @@ happens when you enable the couchbase support as explained above).
 
 		private final CouchbaseTemplate template;
 
-		@Autowired
 		public MyBean(CouchbaseTemplate template) {
 			this.template = template;
 		}
@@ -3961,7 +3946,6 @@ other Spring Bean.
 
 		private final LdapTemplate template;
 
-		@Autowired
 		public MyBean(LdapTemplate template) {
 			this.template = template;
 		}
@@ -4456,7 +4440,6 @@ beans:
 
 [source,java,indent=0]
 ----
-	import org.springframework.beans.factory.annotation.Autowired;
 	import org.springframework.jms.core.JmsTemplate;
 	import org.springframework.stereotype.Component;
 
@@ -4465,7 +4448,6 @@ beans:
 
 		private final JmsTemplate jmsTemplate;
 
-		@Autowired
 		public MyBean(JmsTemplate jmsTemplate) {
 			this.jmsTemplate = jmsTemplate;
 		}
@@ -4604,7 +4586,6 @@ directly into your own beans:
 ----
 	import org.springframework.amqp.core.AmqpAdmin;
 	import org.springframework.amqp.core.AmqpTemplate;
-	import org.springframework.beans.factory.annotation.Autowired;
 	import org.springframework.stereotype.Component;
 
 	@Component
@@ -4613,7 +4594,6 @@ directly into your own beans:
 		private final AmqpAdmin amqpAdmin;
 		private final AmqpTemplate amqpTemplate;
 
-		@Autowired
 		public MyBean(AmqpAdmin amqpAdmin, AmqpTemplate amqpTemplate) {
 			this.amqpAdmin = amqpAdmin;
 			this.amqpTemplate = amqpTemplate;
@@ -4752,7 +4732,6 @@ public class MyBean {
 
 	private final KafkaTemplate kafkaTemplate;
 
-	@Autowired
 	public MyBean(KafkaTemplate kafkaTemplate) {
 		this.kafkaTemplate = kafkaTemplate;
 	}

--- a/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
+++ b/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
@@ -572,8 +572,28 @@ required `RiskAssessor` bean.
 ----
 	package com.example.service;
 
+	import org.springframework.beans.factory.annotation.Autowired;
 	import org.springframework.stereotype.Service;
 
+	@Service
+	public class DatabaseAccountService implements AccountService {
+
+		private final RiskAssessor riskAssessor;
+
+		@Autowired
+		public DatabaseAccountService(RiskAssessor riskAssessor) {
+			this.riskAssessor = riskAssessor;
+		}
+
+		// ...
+
+	}
+----
+
+And if a bean has one constructor, you can omit the `@Autowired`.
+
+[source,java,indent=0]
+----
 	@Service
 	public class DatabaseAccountService implements AccountService {
 

--- a/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
+++ b/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
@@ -572,7 +572,6 @@ required `RiskAssessor` bean.
 ----
 	package com.example.service;
 
-	import org.springframework.beans.factory.annotation.Autowired;
 	import org.springframework.stereotype.Service;
 
 	@Service
@@ -580,7 +579,6 @@ required `RiskAssessor` bean.
 
 		private final RiskAssessor riskAssessor;
 
-		@Autowired
 		public DatabaseAccountService(RiskAssessor riskAssessor) {
 			this.riskAssessor = riskAssessor;
 		}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

I've polished reference document.
The Spring Boot 1.4+(Spring Boot 4.3+) can omit the `@Autowired` on constructor injection if it is define only one constructor.

Please review this.