### PR TITLE
Upgrade the versions maven plugin

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -217,7 +217,7 @@
 		<maven-source-plugin.version>3.0.1</maven-source-plugin.version>
 		<maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
 		<maven-war-plugin.version>2.6</maven-war-plugin.version>
-		<versions-maven-plugin.version>2.2</versions-maven-plugin.version>
+		<versions-maven-plugin.version>2.3</versions-maven-plugin.version>
 	</properties>
 	<prerequisites>
 		<maven>3.2.1</maven>


### PR DESCRIPTION
This is a pull request for the issue #8426

Version 2.2 throws a null pointer in some cases.
For more information, check this issue in the maven plugin github
repository:
mojohaus/versions-maven-plugin#51