### PR TITLE
Remove dependency management for `hibernate-entitymanager`

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -281,7 +281,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
+			<artifactId>hibernate-core</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -1680,17 +1680,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate</groupId>
-				<artifactId>hibernate-entitymanager</artifactId>
-				<version>${hibernate.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>xml-apis</groupId>
-						<artifactId>xml-apis</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-envers</artifactId>
 				<version>${hibernate.version}</version>
 			</dependency>

--- a/spring-boot-devtools/pom.xml
+++ b/spring-boot-devtools/pom.xml
@@ -51,7 +51,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
+			<artifactId>hibernate-core</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-boot-docs/pom.xml
+++ b/spring-boot-docs/pom.xml
@@ -440,7 +440,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
+			<artifactId>hibernate-core</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-boot-samples/spring-boot-sample-jpa/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-jpa/pom.xml
@@ -30,7 +30,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
+			<artifactId>hibernate-core</artifactId>
 		</dependency>
 		<!-- Runtime -->
 		<dependency>

--- a/spring-boot-starters/spring-boot-starter-data-jpa/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-data-jpa/pom.xml
@@ -43,18 +43,6 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
-			<exclusions>
-				<exclusion>
-					<artifactId>
-						jboss-transaction-api_1.2_spec
-					</artifactId>
-					<groupId>org.jboss.spec.javax.transaction</groupId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
 			<groupId>javax.transaction</groupId>
 			<artifactId>javax.transaction-api</artifactId>
 		</dependency>

--- a/spring-boot-test-autoconfigure/pom.xml
+++ b/spring-boot-test-autoconfigure/pom.xml
@@ -61,7 +61,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
+			<artifactId>hibernate-core</artifactId>
 			<exclusions>
 				<exclusion>
 					<groupId>org.jboss.spec.javax.transaction</groupId>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -161,7 +161,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
+			<artifactId>hibernate-core</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TldSkipPatterns.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TldSkipPatterns.java
@@ -86,7 +86,6 @@ final class TldSkipPatterns {
 		patterns.add("ehcache-core-*.jar");
 		patterns.add("hibernate-core-*.jar");
 		patterns.add("hibernate-commons-annotations-*.jar");
-		patterns.add("hibernate-entitymanager-*.jar");
 		patterns.add("hibernate-jpa-2.1-api-*.jar");
 		patterns.add("hibernate-validator-*.jar");
 		patterns.add("hsqldb-*.jar");


### PR DESCRIPTION
Since `hibernate-entitymanager` was merged into `hibernate-core` in Hibernate 5.2 (`hibernate-entitymanager` is empty artifact present only for backwards compatibility reasons and will be removed in Hibernate 6.0), and with Boot 2.0 supporting Hibernate 5.2 as minimum, dependency management for `hibernate-entitymanager` should be removed and `hibernate-core` should be used directly instead.