### PR TITLE
Make Tomcat Access Log's fileDateFormat configurable via the environment

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -1006,6 +1006,7 @@ public class ServerProperties
 					this.accesslog.isRequestAttributesEnabled());
 			valve.setRotatable(this.accesslog.isRotate());
 			valve.setBuffered(this.accesslog.isBuffered());
+			valve.setFileDateFormat(this.accesslog.getFileDateFormat());
 			factory.addEngineValves(valve);
 		}
 
@@ -1070,6 +1071,11 @@ public class ServerProperties
 			 * Buffer output such that it is only flushed periodically.
 			 */
 			private boolean buffered = true;
+
+			/**
+			 * Customized date format in the access log file name.
+			 */
+			private String fileDateFormat = "yyyy-MM-dd";
 
 			public boolean isEnabled() {
 				return this.enabled;
@@ -1143,6 +1149,13 @@ public class ServerProperties
 				this.buffered = buffered;
 			}
 
+			public String getFileDateFormat() {
+				return fileDateFormat;
+			}
+
+			public void setFileDateFormat(String fileDateFormat) {
+				this.fileDateFormat = fileDateFormat;
+			}
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -161,6 +161,40 @@ public class ServerPropertiesTests {
 	}
 
 	@Test
+	public void tomcatAccessLogFileDateFormatByDefault() {
+		TomcatEmbeddedServletContainerFactory tomcatContainer = new TomcatEmbeddedServletContainerFactory();
+		Map<String, String> map = new HashMap<String, String>();
+		map.put("server.tomcat.accesslog.enabled", "true");
+		bindProperties(map);
+		this.properties.customize(tomcatContainer);
+		assertThat(((AccessLogValve) tomcatContainer.getEngineValves().iterator().next())
+				.getFileDateFormat()).isEqualTo("yyyy-MM-dd");
+	}
+
+	@Test
+	public void tomcatAccessLogFileDateFormatCanBeRedefined() {
+		TomcatEmbeddedServletContainerFactory tomcatContainer = new TomcatEmbeddedServletContainerFactory();
+		Map<String, String> map = new HashMap<String, String>();
+		map.put("server.tomcat.accesslog.enabled", "true");
+		map.put("server.tomcat.accesslog.file-date-format", "yyyy-MM-dd.HH");
+		bindProperties(map);
+		this.properties.customize(tomcatContainer);
+		assertThat(((AccessLogValve) tomcatContainer.getEngineValves().iterator().next())
+				.getFileDateFormat()).isEqualTo("yyyy-MM-dd.HH");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void tomcatAccessLogFileDateFormatWrongFormat() {
+		TomcatEmbeddedServletContainerFactory tomcatContainer = new TomcatEmbeddedServletContainerFactory();
+		Map<String, String> map = new HashMap<String, String>();
+		map.put("server.tomcat.accesslog.enabled", "true");
+		map.put("server.tomcat.accesslog.file-date-format",
+				"this-is-obviously-a-wrong-format");
+		bindProperties(map);
+		this.properties.customize(tomcatContainer);
+	}
+
+	@Test
 	public void tomcatAccessLogIsBufferedByDefault() {
 		TomcatEmbeddedServletContainerFactory tomcatContainer = new TomcatEmbeddedServletContainerFactory();
 		Map<String, String> map = new HashMap<String, String>();

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -196,6 +196,7 @@ content into your application; rather pick only the properties that you need.
 	server.tomcat.accesslog.buffered=true # Buffer output such that it is only flushed periodically.
 	server.tomcat.accesslog.directory=logs # Directory in which log files are created. Can be relative to the tomcat base dir or absolute.
 	server.tomcat.accesslog.enabled=false # Enable access log.
+	server.tomcat.accesslog.file-date-format=yyyy-MM-dd # Customized date format in the access log file name.
 	server.tomcat.accesslog.pattern=common # Format pattern for access logs.
 	server.tomcat.accesslog.prefix=access_log # Log file name prefix.
 	server.tomcat.accesslog.rename-on-rotate=false # Defer inclusion of the date stamp in the file name until rotate time.


### PR DESCRIPTION
Fixes gh-8396

Please see issue #8396 for details.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->