### PR TITLE
Updating default Log4j2 dependency version to 2.8

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -126,7 +126,7 @@
 		<junit.version>4.12</junit.version>
 		<lettuce.version>5.0.0.Beta1</lettuce.version>
 		<liquibase.version>3.5.3</liquibase.version>
-		<log4j2.version>2.7</log4j2.version>
+		<log4j2.version>2.8</log4j2.version>
 		<logback.version>1.1.11</logback.version>
 		<lombok.version>1.16.14</lombok.version>
 		<mariadb.version>1.5.8</mariadb.version>


### PR DESCRIPTION
Fixes gh-8390

Updating the default Log4j2 dependency version to 2.8

First contribution, all feedback and comments very welcome!