### PR TITLE
Add Mono and Flux REST endpoints to spring-boot-samples/spring-boot-s…

### DIFF
--- a/spring-boot-samples/spring-boot-sample-webflux/src/main/java/sample/webflux/WelcomeController.java
+++ b/spring-boot-samples/spring-boot-sample-webflux/src/main/java/sample/webflux/WelcomeController.java
@@ -18,6 +18,11 @@ package sample.webflux;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSource;
+import reactor.core.publisher.Mono;
+
+import java.util.stream.Stream;
 
 @RestController
 public class WelcomeController {
@@ -27,4 +32,16 @@ public class WelcomeController {
 		return "Hello World";
 	}
 
+	@GetMapping("/mono")
+	public Mono<String> mono() {
+		return Mono.just("mono");
+	}
+
+	@GetMapping("/flux")
+	public Flux<String> flux() {
+		return FluxSource.fromStream(
+				Stream.of("one", "two", "three", "two", "one")
+						.map("flux-"::concat))
+				.distinct();
+	}
 }

--- a/spring-boot-samples/spring-boot-sample-webflux/src/test/java/sample/webflux/SampleWebFluxApplicationIntegrationTests.java
+++ b/spring-boot-samples/spring-boot-sample-webflux/src/test/java/sample/webflux/SampleWebFluxApplicationIntegrationTests.java
@@ -18,13 +18,15 @@ package sample.webflux;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Basic integration tests for WebFlux application.
@@ -47,4 +49,21 @@ public class SampleWebFluxApplicationIntegrationTests {
 				.expectBody(String.class).value().isEqualTo("Hello World");
 	}
 
+	@Test
+	public void testMono() throws Exception {
+		this.webClient
+				.get().uri("/mono")
+				.exchange()
+				.expectBody(String.class).value().isEqualTo("mono");
+	}
+
+	@Test
+	public void testFlux() throws Exception {
+		this.webClient
+				.get().uri("/flux")
+				.exchange()
+				.expectBody(String.class).value().isEqualTo(
+						Stream.of("flux-one", "flux-two", "flux-three")
+								.collect(Collectors.joining()));
+	}
 }


### PR DESCRIPTION
Hello, I've just added few reactor-like REST-endpoints to make spring-boot-sample-webflux project more helpful for developers who wants see usage of it in action in regular spring REST-controllers

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->