### PR TITLE
Update server.context properties

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -148,8 +148,6 @@ content into your application; rather pick only the properties that you need.
 	server.compression.mime-types= # Comma-separated list of MIME types that should be compressed. For instance `text/html,text/css,application/json`
 	server.compression.min-response-size= # Minimum response size that is required for compression to be performed. For instance 2048
 	server.connection-timeout= # Time in milliseconds that connectors will wait for another HTTP request before closing the connection. When not set, the connector's container-specific default will be used. Use a value of -1 to indicate no (i.e. infinite) timeout.
-	server.context-parameters.*= # Servlet context init parameters. For instance `server.context-parameters.a=alpha`
-	server.context-path= # Context path of the application.
 	server.display-name=application # Display name of the application.
 	server.max-http-header-size=0 # Maximum size in bytes of the HTTP message header.
 	server.error.include-stacktrace=never # When to include a "stacktrace" attribute.
@@ -164,6 +162,8 @@ content into your application; rather pick only the properties that you need.
 	server.port=8080 # Server HTTP port.
 	server.server-header= # Value to use for the Server response header (no header is sent if empty)
 	server.servlet-path=/ # Path of the main dispatcher servlet.
+	server.servlet.context-parameters.*= # Servlet context init parameters. For instance `server.servlet.context-parameters.a=alpha`
+	server.servlet.context-path= # Context path of the application.
 	server.use-forward-headers= # If X-Forwarded-* headers should be applied to the HttpRequest.
 	server.session.cookie.comment= # Comment for the session cookie.
 	server.session.cookie.domain= # Domain for the session cookie.


### PR DESCRIPTION
The documentation is out of date for `server.context-path` and `server.context-parameters.*`  and should be updated to `server.servlet.context-path` and `server.servlet.context-parameters.*` respectively.