### PR TITLE
Add support for CustomConversions in SDC

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.autoconfigure.data.cassandra;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.datastax.driver.core.Cluster;
@@ -40,6 +41,7 @@ import org.springframework.data.cassandra.config.CassandraEntityClassScanner;
 import org.springframework.data.cassandra.config.CassandraSessionFactoryBean;
 import org.springframework.data.cassandra.config.SchemaAction;
 import org.springframework.data.cassandra.convert.CassandraConverter;
+import org.springframework.data.cassandra.convert.CustomConversions;
 import org.springframework.data.cassandra.convert.MappingCassandraConverter;
 import org.springframework.data.cassandra.core.CassandraAdminOperations;
 import org.springframework.data.cassandra.core.CassandraTemplate;
@@ -81,7 +83,7 @@ public class CassandraDataAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public CassandraMappingContext cassandraMapping() throws ClassNotFoundException {
+	public CassandraMappingContext cassandraMapping(CustomConversions conversions) throws ClassNotFoundException {
 		BasicCassandraMappingContext context = new BasicCassandraMappingContext();
 		List<String> packages = EntityScanPackages.get(this.beanFactory)
 				.getPackageNames();
@@ -95,13 +97,17 @@ public class CassandraDataAutoConfiguration {
 			context.setUserTypeResolver(new SimpleUserTypeResolver(this.cluster,
 					this.properties.getKeyspaceName()));
 		}
+		context.setCustomConversions(conversions);
 		return context;
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
-	public CassandraConverter cassandraConverter(CassandraMappingContext mapping) {
-		return new MappingCassandraConverter(mapping);
+	public CassandraConverter cassandraConverter(CassandraMappingContext mapping,
+			CustomConversions conversions) {
+		MappingCassandraConverter converter = new MappingCassandraConverter(mapping);
+		converter.setCustomConversions(conversions);
+		return converter;
 	}
 
 	@Bean
@@ -123,6 +129,12 @@ public class CassandraDataAutoConfiguration {
 	public CassandraTemplate cassandraTemplate(Session session,
 			CassandraConverter converter) throws Exception {
 		return new CassandraTemplate(session, converter);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public CustomConversions cassandraCustomConversions() {
+		return new CustomConversions(Collections.emptyList());
 	}
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfigurationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.autoconfigure.data.cassandra;
 
+import java.util.Arrays;
 import java.util.Set;
 
 import com.datastax.driver.core.Session;
@@ -32,6 +33,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.cassandra.convert.CustomConversions;
 import org.springframework.data.cassandra.core.CassandraTemplate;
 import org.springframework.data.cassandra.mapping.CassandraMappingContext;
 import org.springframework.data.cassandra.mapping.SimpleUserTypeResolver;
@@ -102,6 +105,22 @@ public class CassandraDataAutoConfigurationTests {
 				.isInstanceOf(SimpleUserTypeResolver.class);
 	}
 
+	@Test
+	public void customConversions() {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.data.cassandra.keyspaceName:boot_test");
+		this.context.register(CustomConversionConfig.class,
+				TestConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class,
+				CassandraAutoConfiguration.class, CassandraDataAutoConfiguration.class);
+		this.context.refresh();
+		CassandraTemplate template = this.context.getBean(CassandraTemplate.class);
+		assertThat(template.getConverter().getConversionService().canConvert(Person.class,
+				String.class)).isTrue();
+
+	}
+
 	@Configuration
 	@ComponentScan(excludeFilters = @ComponentScan.Filter(classes = {
 			Session.class }, type = FilterType.ASSIGNABLE_TYPE))
@@ -122,6 +141,28 @@ public class CassandraDataAutoConfigurationTests {
 	@Configuration
 	@EntityScan("org.springframework.boot.autoconfigure.data.cassandra.city")
 	static class EntityScanConfig {
+
+	}
+
+	@Configuration
+	static class CustomConversionConfig {
+
+		@Bean
+		public CustomConversions cassandraCustomConversions() {
+			return new CustomConversions(Arrays.asList(new MyConverter()));
+		}
+
+	}
+
+	private static class MyConverter implements Converter<Person, String> {
+
+		@Override
+		public String convert(Person o) {
+			return null;
+		}
+	}
+
+	private static class Person {
 
 	}
 


### PR DESCRIPTION
This commit add the support for CustomConversions in
spring-data-cassandra. To customize, bean just need to be declared and
it will be auto-configured.

See gh-8411

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->