### PR TITLE
Simplify value check on failOnWriteError method

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/system/ApplicationPidFileWriter.java
+++ b/spring-boot/src/main/java/org/springframework/boot/system/ApplicationPidFileWriter.java
@@ -163,7 +163,7 @@ public class ApplicationPidFileWriter
 
 	private boolean failOnWriteError(SpringApplicationEvent event) {
 		String value = getProperty(event, FAIL_ON_WRITE_ERROR_PROPERTIES);
-		return (value == null ? false : Boolean.parseBoolean(value));
+		return (value != null && Boolean.parseBoolean(value));
 	}
 
 	private String getProperty(SpringApplicationEvent event, List<Property> candidates) {


### PR DESCRIPTION
I just simplified value check on failOnWriteError method. It becomes more readable than the original source code.