### PR TITLE
Remove redundant tests

### DIFF
--- a/spring-boot-integration-tests/spring-boot-integration-tests-embedded-servlet-container/src/test/java/org/springframework/boot/context/embedded/EmbeddedServletContainerJarPackagingIntegrationTests.java
+++ b/spring-boot-integration-tests/spring-boot-integration-tests-embedded-servlet-container/src/test/java/org/springframework/boot/context/embedded/EmbeddedServletContainerJarPackagingIntegrationTests.java
@@ -54,13 +54,6 @@ public class EmbeddedServletContainerJarPackagingIntegrationTests
 	}
 
 	@Test
-	public void nestedMetaInfResourceIsAvailableViaServletContext() throws Exception {
-		ResponseEntity<String> entity = this.rest
-				.getForEntity("/nested-meta-inf-resource.txt", String.class);
-		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-	}
-
-	@Test
 	public void nestedJarIsNotAvailableViaHttp() throws Exception {
 		ResponseEntity<String> entity = this.rest
 				.getForEntity("/BOOT-INF/lib/resources-1.0.jar", String.class);

--- a/spring-boot-integration-tests/spring-boot-integration-tests-embedded-servlet-container/src/test/java/org/springframework/boot/context/embedded/EmbeddedServletContainerWarPackagingIntegrationTests.java
+++ b/spring-boot-integration-tests/spring-boot-integration-tests-embedded-servlet-container/src/test/java/org/springframework/boot/context/embedded/EmbeddedServletContainerWarPackagingIntegrationTests.java
@@ -54,13 +54,6 @@ public class EmbeddedServletContainerWarPackagingIntegrationTests
 	}
 
 	@Test
-	public void nestedMetaInfResourceIsAvailableViaServletContext() throws Exception {
-		ResponseEntity<String> entity = this.rest
-				.getForEntity("/nested-meta-inf-resource.txt", String.class);
-		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-	}
-
-	@Test
 	public void nestedJarIsNotAvailableViaHttp() throws Exception {
 		ResponseEntity<String> entity = this.rest
 				.getForEntity("/WEB-INF/lib/resources-1.0.jar", String.class);


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
They were added in b443b745fb21203d127caf88426547141e3ab724 but looking at the rest of the commit, it looks decided not to add tests on resource availability via servlet context.

This PR simply removes them.