### PR TITLE
Fix `RedisSessionConfiguration` conditions

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -38,10 +39,12 @@ import org.springframework.session.data.redis.config.annotation.web.http.RedisHt
  * @author Tommy Ludwig
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @author Vedran Pavic
  */
 @Configuration
+@ConditionalOnClass(RedisTemplate.class)
 @ConditionalOnMissingBean(SessionRepository.class)
-@ConditionalOnBean({ RedisTemplate.class, RedisConnectionFactory.class })
+@ConditionalOnBean(RedisConnectionFactory.class)
 @Conditional(SessionCondition.class)
 class RedisSessionConfiguration {
 


### PR DESCRIPTION
`RedisSessionConfiguration` is currently conditional on `RedisTemplate` bean which shouldn't be a requirement since Spring Session's `RedisHttpSessionConfiguration` itself creates `RedisTemplate` bean named `sessionRedisTemplate` for use with `RedisOperationsSessionRepository`.

This situation prevents Boot from auto-configuring Spring Session when user provides `LettuceConnectionFactory` bean - since `RedisAutoConfiguration` is conditional on presence of Jedis, Boot won't configure `RedisTemplate` bean and in turn, `RedisSessionConfiguration` conditions won't match either. Such setup should be perfectly valid.

The correct approach would be to make `RedisSessionConfiguration` conditional only on `RedisConnectionFactory` bean and presence of `RedisTemplate` on classpath - analogous to `JdbcSessionConfiguration` where conditions are `@ConditionalOnClass(JdbcTemplate.class)` and `@ConditionalOnBean(DataSource.class)`.