### PR TITLE
fix OptionalLiveReloadServer create bean

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -58,6 +58,7 @@ public class LocalDevToolsAutoConfiguration {
 	/**
 	 * Local LiveReload configuration.
 	 */
+	@Configuration
 	@ConditionalOnProperty(prefix = "spring.devtools.livereload", name = "enabled", matchIfMissing = true)
 	static class LiveReloadConfiguration {
 


### PR DESCRIPTION
The call of the method `optionalLiveReloadServer()` is realised in the method [`LocalDevToolsAutoConfiguration.onClassPathChanged(ClassPathChangedEvent)`](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java#L86) which implies the address to Bean, which is not really so. Every time a new instance of `OptionalLiveReloadServer` is created.

`OptionalLiveReloadServer` uses `@PostConstruct` annotation for the starting of `LiveReloadServer` while **this method is not executed during the direct call.** This brings to not executed `this.server = null`  [`OptionalLiveReloadServer:64`](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/OptionalLiveReloadServer.java#L64) as well.

This breaches the logic of realization of the method [`OptionalLiveReloadServer.triggerReload()`](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/OptionalLiveReloadServer.java#L73) which delegates the call to a not started server. 

P.S. Should I attach the youtube links with the demonstration of the problem in the debugger?
