### PR TITLE
Documentation hint about connection pool dependency for ActiveMQ

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -4338,10 +4338,10 @@ See
 {sc-spring-boot-autoconfigure}/jms/activemq/ActiveMQProperties.{sc-ext}[`ActiveMQProperties`]
 for more of the supported options.
 
+NOTE: If you are using `spring.activemq.pool.enabled=true` don't forget to add `org.apache.activemq:activemq-pool` to your application.
+
 By default, ActiveMQ creates a destination if it does not exist yet, so destinations are
 resolved against their provided names.
-
-
 
 [[boot-features-artemis]]
 ==== Artemis support

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -4343,6 +4343,8 @@ NOTE: If you are using pooled connections by setting `spring.activemq.pool.enabl
 By default, ActiveMQ creates a destination if it does not exist yet, so destinations are
 resolved against their provided names.
 
+
+
 [[boot-features-artemis]]
 ==== Artemis support
 Spring Boot can auto-configure a `ConnectionFactory` when it detects that Artemis is

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -4338,7 +4338,7 @@ See
 {sc-spring-boot-autoconfigure}/jms/activemq/ActiveMQProperties.{sc-ext}[`ActiveMQProperties`]
 for more of the supported options.
 
-NOTE: If you are using `spring.activemq.pool.enabled=true` don't forget to add `org.apache.activemq:activemq-pool` to your application.
+NOTE: If you are using pooled connections by setting `spring.activemq.pool.enabled=true` don't forget to add `org.apache.activemq:activemq-pool` to your application.
 
 By default, ActiveMQ creates a destination if it does not exist yet, so destinations are
 resolved against their provided names.


### PR DESCRIPTION
Despite pretty obvious it took me a while to figure out that this additional dependency was needed --> hint in documentation.