### PR TITLE
In properties files comments can only come at the start of a line

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/env/OriginTrackedPropertiesLoader.java
+++ b/spring-boot/src/main/java/org/springframework/boot/env/OriginTrackedPropertiesLoader.java
@@ -164,7 +164,6 @@ class OriginTrackedPropertiesLoader {
 			this.character = this.reader.read();
 			this.columnNumber++;
 			skipLeadingWhitespace();
-			skipComment();
 			if (this.character == '\\') {
 				this.escaped = true;
 				readEscaped();
@@ -181,6 +180,7 @@ class OriginTrackedPropertiesLoader {
 					this.character = this.reader.read();
 					this.columnNumber++;
 				}
+				skipComment();
 			}
 		}
 

--- a/spring-boot/src/test/java/org/springframework/boot/env/OriginTrackedPropertiesLoaderTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/env/OriginTrackedPropertiesLoaderTests.java
@@ -98,6 +98,13 @@ public class OriginTrackedPropertiesLoaderTests {
 	}
 
 	@Test
+	public void getPropertyWithBang() throws Exception {
+		OriginTrackedValue value = this.properties.get("test-bang-property");
+		assertThat(getValue(value)).isEqualTo("foo!");
+		assertThat(getLocation(value)).isEqualTo("34:20");
+	}
+
+	@Test
 	public void getPropertyWithCarriageReturn() throws Exception {
 		OriginTrackedValue value = this.properties.get("test-return-property");
 		assertThat(getValue(value)).isEqualTo("foo\rbar");

--- a/spring-boot/src/test/resources/org/springframework/boot/env/test-properties.properties
+++ b/spring-boot/src/test/resources/org/springframework/boot/env/test-properties.properties
@@ -31,3 +31,5 @@ language[pascal]=Lame
 test-multiline-immediate=\
 foo
 !commented-two=bang\
+test-bang-property=foo!
+another=bar


### PR DESCRIPTION
This "!" is part of a property value not a comment:

foo=bar!
bar=spam

Before this fix the value of foo was parsed as "barbar=spam"