### PR TITLE
Added configuration for disabling the actuator trace filter

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/TraceWebFilterAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/TraceWebFilterAutoConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.web.servlet.error.ErrorAttributes;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -42,6 +43,7 @@ import org.springframework.web.servlet.DispatcherServlet;
  */
 @ConditionalOnClass({ Servlet.class, DispatcherServlet.class, ServletRegistration.class })
 @AutoConfigureAfter(TraceRepositoryAutoConfiguration.class)
+@ConditionalOnProperty(name = "endpoints.trace.filter.enabled", matchIfMissing = true)
 @EnableConfigurationProperties(TraceProperties.class)
 @Configuration
 public class TraceWebFilterAutoConfiguration {

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/TraceWebFilterAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/TraceWebFilterAutoConfigurationTests.java
@@ -24,6 +24,7 @@ import org.springframework.boot.actuate.trace.TraceProperties;
 import org.springframework.boot.actuate.trace.TraceRepository;
 import org.springframework.boot.actuate.trace.WebRequestTraceFilter;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -55,6 +56,19 @@ public class TraceWebFilterAutoConfigurationTests {
 				TraceWebFilterAutoConfiguration.class);
 		WebRequestTraceFilter filter = context.getBean(WebRequestTraceFilter.class);
 		assertThat(filter).isInstanceOf(TestWebRequestTraceFilter.class);
+		context.close();
+	}
+
+	@Test
+	public void skipsFilterIfPropertyDisabled() throws Exception {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(context,
+				"endpoints.trace.filter.enabled:false");
+		context.register(PropertyPlaceholderAutoConfiguration.class,
+				TraceRepositoryAutoConfiguration.class,
+				TraceWebFilterAutoConfiguration.class);
+		context.refresh();
+		assertThat(context.getBeansOfType(WebRequestTraceFilter.class).size()).isEqualTo(0);
 		context.close();
 	}
 


### PR DESCRIPTION
Added configuration for disabling the actuator trace filter (`WebRequestTraceFilter`).  
This pattern already exists in `MetricFilterAutoConfiguration` but was missed in the `TraceWebFilterAutoConfiguration`. See Issue #8322 for more detail.  Note: we've observed a measured overhead in Grails applications due to the `WebRequestTraceFilter` being in place when including the actuator dependency.  Related: https://github.com/grails/grails-core/issues/640  

