### PR TITLE
Fix warnings about inconvertible types

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/LayoutsTests.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/LayoutsTests.java
@@ -55,7 +55,7 @@ public class LayoutsTests {
 
 	@Test
 	public void unknownFile() throws Exception {
-		this.thrown.equals(IllegalStateException.class);
+		this.thrown.expect(IllegalStateException.class);
 		this.thrown.expectMessage("Unable to deduce layout for 'test.txt'");
 		Layouts.forFile(new File("test.txt"));
 	}

--- a/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/data/RandomAccessDataFileTests.java
+++ b/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/data/RandomAccessDataFileTests.java
@@ -87,28 +87,28 @@ public class RandomAccessDataFileTests {
 	@Test
 	public void fileNotNull() throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.equals("File must not be null");
+		this.thrown.expectMessage("File must not be null");
 		new RandomAccessDataFile(null);
 	}
 
 	@Test
 	public void fileExists() throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.equals("File must exist");
+		this.thrown.expectMessage("File must exist");
 		new RandomAccessDataFile(new File("/does/not/exist"));
 	}
 
 	@Test
 	public void fileNotNullWithConcurrentReads() throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.equals("File must not be null");
+		this.thrown.expectMessage("File must not be null");
 		new RandomAccessDataFile(null, 1);
 	}
 
 	@Test
 	public void fileExistsWithConcurrentReads() throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.equals("File must exist");
+		this.thrown.expectMessage("File must exist");
 		new RandomAccessDataFile(new File("/does/not/exist"), 1);
 	}
 


### PR DESCRIPTION
Hey,

just noticed those two files where equals() is used with not matching types.

Cheers,
Christoph