### PR TITLE
Replace hashCode() on array with Arrays.hashCode()

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -542,7 +542,7 @@ public class SpringApplication {
 				PropertySource<?> source = sources.get(name);
 				CompositePropertySource composite = new CompositePropertySource(name);
 				composite.addPropertySource(new SimpleCommandLinePropertySource(
-						name + "-" + args.hashCode(), args));
+						name + "-" + Arrays.hashCode(args), args));
 				composite.addPropertySource(source);
 				sources.replace(name, composite);
 			}


### PR DESCRIPTION
Hey,

though I can't think of a need to have the same hashCode for the same arguments given in SpringApplication, it probably doesn't hurt ;-)

At least it gets rid of an IDEA warning.

Cheers,
Christoph