### PR TITLE
Upgrade to Groovy 2.4.10

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -79,7 +79,7 @@
 		<elasticsearch.version>2.4.4</elasticsearch.version>
 		<glassfish-el.version>3.0.0</glassfish-el.version>
 		<gradle.version>3.4</gradle.version>
-		<groovy.version>2.4.9</groovy.version>
+		<groovy.version>2.4.10</groovy.version>
 		<gson.version>2.8.0</gson.version>
 		<h2.version>1.4.193</h2.version>
 		<hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
Fixes few subtle Groovy issues
[Groovy 2.4.10 release notes](http://groovy-lang.org/changelogs/changelog-2.4.10.html)