### PR TITLE
Added support for HotSwapAgent (http://hotswapagent.org/) to spring-boot-devtools

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/AgentReloader.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/AgentReloader.java
@@ -36,6 +36,7 @@ public abstract class AgentReloader {
 		Set<String> agentClasses = new LinkedHashSet<String>();
 		agentClasses.add("org.zeroturnaround.javarebel.Integration");
 		agentClasses.add("org.zeroturnaround.javarebel.ReloaderFactory");
+		agentClasses.add("org.hotswap.agent.HotswapAgent"); // relevant for http://hotswapagent.org/ (https://github.com/HotswapProjects/HotswapAgent)
 		AGENT_CLASSES = Collections.unmodifiableSet(agentClasses);
 	}
 


### PR DESCRIPTION
HotSwapAgent is an open source competition to JRebel. This commit adds class "org.hotswap.agent.HotswapAgent" to the list of known Java agent based class reloaders. This causes same behavior as when JRebel is used: a full restart is NOT triggered when any class changes, however LiveReload event is still triggered, which is exactly what we want to have.

Tested with spring boot devtools 1.5.2 and a current version of HotSwapAgent (DCEVM light patch 8u112 (build 8) + Hotswap Agent 1.1.0-SNAPSHOT) both on Windows and Linux and it works beautifully.