### PR TITLE
Replace empty string concatenation with String.valueOf()

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/WebRequestTraceFilter.java
@@ -202,7 +202,7 @@ public class WebRequestTraceFilter extends OncePerRequestFilter implements Order
 
 	private void addTimeTaken(long startTime, long endTime, Map<String, Object> trace) {
 		long timeTaken = endTime - startTime;
-		add(trace, Include.TIME_TAKEN, "timeTaken", "" + timeTaken);
+		add(trace, Include.TIME_TAKEN, "timeTaken", String.valueOf(timeTaken));
 	}
 
 	@SuppressWarnings("unchecked")
@@ -222,7 +222,7 @@ public class WebRequestTraceFilter extends OncePerRequestFilter implements Order
 		if (!isIncluded(Include.COOKIES)) {
 			headers.remove("Set-Cookie");
 		}
-		headers.put("status", "" + response.getStatus());
+		headers.put("status", String.valueOf(response.getStatus()));
 		return headers;
 	}
 


### PR DESCRIPTION
Hey,

this PR replaces occurences with `"" + somePrimitive` with `String.valueOf(somePrimitive)`. Has a slight chance of being more efficient next to being more verbose.

Cheers,
Christoph