### PR TITLE
Fix invalid grammar of adoc in supported servlet containers

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-boot-docs/src/main/asciidoc/getting-started.adoc
@@ -46,7 +46,7 @@ Framework {spring-version} or above. Explicit build support is provided for Mave
 The following embedded servlet containers are supported out of the box:
 
 |===
-|Name |Servlet Version |
+|Name |Servlet Version
 
 |Tomcat 8.5
 |3.1


### PR DESCRIPTION
I've fixed gh-8684. Please review.