### PR TITLE
Add a missing test for "Fix properties parsing for comment chars"

### DIFF
--- a/spring-boot/src/test/java/org/springframework/boot/env/OriginTrackedPropertiesLoaderTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/env/OriginTrackedPropertiesLoaderTests.java
@@ -112,6 +112,13 @@ public class OriginTrackedPropertiesLoaderTests {
 	}
 
 	@Test
+	public void getPropertyWithMultilineImmediateBang() {
+		OriginTrackedValue value = this.properties.get("test-multiline-immediate-bang");
+		assertThat(getValue(value)).isEqualTo("!foo");
+		assertThat(getLocation(value)).isEqualTo("39:1");
+	}
+
+	@Test
 	public void getPropertyWithCarriageReturn() throws Exception {
 		OriginTrackedValue value = this.properties.get("test-return-property");
 		assertThat(getValue(value)).isEqualTo("foo\rbar");


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
`test-multiline-immediate-bang` has been added to `test-properties.properties` in fe8fa2831a165195b29b26a7e9578098b0bb0021 but its test hasn't been added.

This PR simply adds its test.