### PR TITLE
Use ObjectUtils.hashCode() for primitives

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSnapshot.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSnapshot.java
@@ -19,6 +19,7 @@ package org.springframework.boot.devtools.filewatch;
 import java.io.File;
 
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 
 /**
  * A snapshot of a File at a given point in time.
@@ -58,7 +59,7 @@ class FileSnapshot {
 		}
 		if (obj instanceof FileSnapshot) {
 			FileSnapshot other = (FileSnapshot) obj;
-			boolean equals = this.file.equals(other.file);
+			boolean equals = ObjectUtils.nullSafeEquals(this.file, other.file);
 			equals = equals && this.exists == other.exists;
 			equals = equals && this.length == other.length;
 			equals = equals && this.lastModified == other.lastModified;
@@ -69,10 +70,10 @@ class FileSnapshot {
 
 	@Override
 	public int hashCode() {
-		int hashCode = this.file.hashCode();
-		hashCode = 31 * hashCode + (this.exists ? 1231 : 1237);
-		hashCode = 31 * hashCode + (int) (this.length ^ (this.length >>> 32));
-		hashCode = 31 * hashCode + (int) (this.lastModified ^ (this.lastModified >>> 32));
+		int hashCode = ObjectUtils.nullSafeHashCode(file);
+		hashCode = 31 * hashCode + ObjectUtils.hashCode(exists);
+		hashCode = 31 * hashCode + ObjectUtils.hashCode(length);
+		hashCode = 31 * hashCode + ObjectUtils.hashCode(lastModified);
 		return hashCode;
 	}
 

--- a/spring-boot-parent/pom.xml
+++ b/spring-boot-parent/pom.xml
@@ -505,7 +505,7 @@
 							<propertyExpansion>main.basedir=${main.basedir}</propertyExpansion>
 							<encoding>UTF-8</encoding>
 							<consoleOutput>true</consoleOutput>
-							<failsOnError>true</failsOnError>
+							<failOnViolation>true</failOnViolation>
 							<includeTestSourceDirectory>true</includeTestSourceDirectory>
 						</configuration>
 						<goals>

--- a/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
@@ -105,7 +105,7 @@ class MockDefinition extends Definition {
 		result = MULTIPLIER * result + ObjectUtils.nullSafeHashCode(this.typeToMock);
 		result = MULTIPLIER * result + ObjectUtils.nullSafeHashCode(this.extraInterfaces);
 		result = MULTIPLIER * result + ObjectUtils.nullSafeHashCode(this.answer);
-		result = MULTIPLIER * result + (this.serializable ? 1231 : 1237);
+		result = MULTIPLIER * result + ObjectUtils.hashCode(serializable);
 		return result;
 	}
 


### PR DESCRIPTION
Hey,

while working on https://jira.spring.io/browse/SPR-15395 I noticed that Spring-Boot is creating some hash codes for primitives on its own as well. So this PR replaces those with calling Spring's ObjectUtils.hashCode() variants. Seemed more consistent than using the JDK ones, but I'd be happy to use them if you tell me to.

I hope you don't mind that I changed to ObjectUtils.nullSafeEquals/hashCode() in FileSnapshot for the one none-primitive field while being on this one.

Cheers,
Christoph