### PR TITLE
Use JDK hashCode() variants for primitives

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionOutcome.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionOutcome.java
@@ -124,7 +124,7 @@ public class ConditionOutcome {
 
 	@Override
 	public int hashCode() {
-		return ObjectUtils.hashCode(this.match) * 31
+		return Boolean.hashCode(this.match) * 31
 				+ ObjectUtils.nullSafeHashCode(this.message);
 	}
 

--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSnapshot.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSnapshot.java
@@ -70,9 +70,9 @@ class FileSnapshot {
 	@Override
 	public int hashCode() {
 		int hashCode = this.file.hashCode();
-		hashCode = 31 * hashCode + (this.exists ? 1231 : 1237);
-		hashCode = 31 * hashCode + (int) (this.length ^ (this.length >>> 32));
-		hashCode = 31 * hashCode + (int) (this.lastModified ^ (this.lastModified >>> 32));
+		hashCode = 31 * hashCode + Boolean.hashCode(this.exists);
+		hashCode = 31 * hashCode + Long.hashCode(this.length);
+		hashCode = 31 * hashCode + Long.hashCode(this.lastModified);
 		return hashCode;
 	}
 

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/filter/AnnotationCustomizableTypeExcludeFilter.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/filter/AnnotationCustomizableTypeExcludeFilter.java
@@ -121,12 +121,12 @@ public abstract class AnnotationCustomizableTypeExcludeFilter extends TypeExclud
 	public int hashCode() {
 		final int prime = 31;
 		int result = 0;
-		result = prime * result + ObjectUtils.hashCode(hasAnnotation());
+		result = prime * result + Boolean.hashCode(hasAnnotation());
 		for (FilterType filterType : FilterType.values()) {
 			result = prime * result
 					+ ObjectUtils.nullSafeHashCode(getFilters(filterType));
 		}
-		result = prime * result + ObjectUtils.hashCode(isUseDefaultFilters());
+		result = prime * result + Boolean.hashCode(isUseDefaultFilters());
 		result = prime * result + ObjectUtils.nullSafeHashCode(getDefaultIncludes());
 		result = prime * result + ObjectUtils.nullSafeHashCode(getComponentIncludes());
 		return result;

--- a/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
@@ -105,7 +105,7 @@ class MockDefinition extends Definition {
 		result = MULTIPLIER * result + ObjectUtils.nullSafeHashCode(this.typeToMock);
 		result = MULTIPLIER * result + ObjectUtils.nullSafeHashCode(this.extraInterfaces);
 		result = MULTIPLIER * result + ObjectUtils.nullSafeHashCode(this.answer);
-		result = MULTIPLIER * result + (this.serializable ? 1231 : 1237);
+		result = MULTIPLIER * result + Boolean.hashCode(this.serializable);
 		return result;
 	}
 


### PR DESCRIPTION
Hey,

while working on https://jira.spring.io/browse/SPR-15395 I noticed that Spring-Boot is creating some hash codes for primitives on its own as well. So this PR replaces those with calling Spring's ObjectUtils.hashCode() variants. Seemed more consistent than using the JDK ones, but I'd be happy to use them if you tell me to.

I hope you don't mind that I changed to ObjectUtils.nullSafeEquals/hashCode() in FileSnapshot for the one none-primitive field while being on this one.

This is a second PR ( #8766 ) as I screwed with the history in the first one. Sorry for that.

Cheers,
Christoph