### PR TITLE
Spring Boot auto configure support for Google 

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/social/GoogleConfigurerAdapter
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/social/GoogleConfigurerAdapter
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hello;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.social.SocialAutoConfigurerAdapter;
+import org.springframework.boot.autoconfigure.social.SocialWebAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.social.config.annotation.EnableSocial;
+import org.springframework.social.config.annotation.SocialConfigurerAdapter;
+import org.springframework.social.connect.Connection;
+import org.springframework.social.connect.ConnectionFactory;
+import org.springframework.social.connect.ConnectionRepository;
+import org.springframework.social.connect.web.GenericConnectionStatusView;
+import org.springframework.social.google.api.Google;
+import org.springframework.social.google.connect.GoogleConnectionFactory;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Spring Social
+ * connectivity with Google.
+ *
+ * @author Abhishek Galoda
+ * @since 1.1.0
+ */
+@Configuration
+@ConditionalOnClass({ SocialConfigurerAdapter.class, GoogleConnectionFactory.class })
+@ConditionalOnProperty(prefix = "spring.social.google", name = "app-id")
+@AutoConfigureBefore(SocialWebAutoConfiguration.class)
+@AutoConfigureAfter(WebMvcAutoConfiguration.class)
+public class GoogleAutoConfiguration {
+
+	@Configuration
+	@EnableSocial
+	@EnableConfigurationProperties(GoogleProperties.class)
+	@ConditionalOnWebApplication
+	protected static class GoogleConfigurerAdapter extends SocialAutoConfigurerAdapter {
+
+		private final GoogleProperties properties;
+
+		protected GoogleConfigurerAdapter(GoogleProperties properties) {
+			this.properties = properties;
+		}
+
+		@Bean
+		@ConditionalOnMissingBean(Google.class)
+		@Scope(value = "request", proxyMode = ScopedProxyMode.INTERFACES)
+		public Google google(ConnectionRepository repository) {
+			Connection<Google> connection = repository.findPrimaryConnection(Google.class);
+			return connection != null ? connection.getApi() : null;
+		}
+
+		@Bean(name = { "connect/googleConnect", "connect/googleConnected" })
+		@ConditionalOnProperty(prefix = "spring.social", name = "auto-connection-views")
+		public GenericConnectionStatusView googleConnectView() {
+			return new GenericConnectionStatusView("google", "Google");
+		}
+
+		@Override
+		protected ConnectionFactory<?> createConnectionFactory() {
+			return new GoogleConnectionFactory(this.properties.getAppId(), this.properties.getAppSecret());
+		}
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/social/GoogleConfigurerAdapter
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/social/GoogleConfigurerAdapter
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package hello;
+package org.springframework.boot.autoconfigure.social;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/social/GoogleProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/social/GoogleProperties.java
@@ -1,0 +1,11 @@
+package org.springframework.boot.autoconfigure.social;
+
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.social.google")
+
+public class GoogleProperties extends SocialProperties{
+
+	
+}


### PR DESCRIPTION
I was using Social Login for  Google Facebook and LinkedIn, though spring boot autoconfigure support is available for FaceBook, LinkedIn and Twitter it is missing for Google. 

I have added 2 classes GoogleProperties and GoogleAutoConfiguration which will provide the autoconfigure support for Google also.