### PR TITLE
Use git.commit.id.abbrev if present

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/info/GitProperties.java
+++ b/spring-boot/src/main/java/org/springframework/boot/info/GitProperties.java
@@ -54,6 +54,11 @@ public class GitProperties extends InfoProperties {
 	 * @return the short commit id
 	 */
 	public String getShortCommitId() {
+		String idAbbrev = get("commit.id.abbrev");
+		if (idAbbrev != null) {
+			return idAbbrev;
+		}
+
 		String id = getCommitId();
 		if (id == null) {
 			return null;

--- a/spring-boot/src/test/java/org/springframework/boot/info/GitPropertiesTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/info/GitPropertiesTests.java
@@ -32,7 +32,7 @@ public class GitPropertiesTests {
 	@Test
 	public void basicInfo() {
 		GitProperties properties = new GitProperties(
-				createProperties("master", "abcdefghijklmno", "1457527123"));
+				createProperties("master", "abcdefghijklmno", "abcdefg", "1457527123"));
 		assertThat(properties.getBranch()).isEqualTo("master");
 		assertThat(properties.getCommitId()).isEqualTo("abcdefghijklmno");
 		assertThat(properties.getShortCommitId()).isEqualTo("abcdefg");
@@ -50,7 +50,7 @@ public class GitPropertiesTests {
 	@Test
 	public void coerceEpochSecond() {
 		GitProperties properties = new GitProperties(
-				createProperties("master", "abcdefg", "1457527123"));
+				createProperties("master", "abcdefg", null, "1457527123"));
 		assertThat(properties.getCommitTime()).isNotNull();
 		assertThat(properties.get("commit.time")).isEqualTo("1457527123000");
 		assertThat(properties.getCommitTime().getTime()).isEqualTo(1457527123000L);
@@ -59,7 +59,7 @@ public class GitPropertiesTests {
 	@Test
 	public void coerceDateString() {
 		GitProperties properties = new GitProperties(
-				createProperties("master", "abcdefg", "2016-03-04T14:36:33+0100"));
+				createProperties("master", "abcdefg", null, "2016-03-04T14:36:33+0100"));
 		assertThat(properties.getCommitTime()).isNotNull();
 		assertThat(properties.get("commit.time")).isEqualTo("1457098593000");
 		assertThat(properties.getCommitTime().getTime()).isEqualTo(1457098593000L);
@@ -68,24 +68,43 @@ public class GitPropertiesTests {
 	@Test
 	public void coerceUnsupportedFormat() {
 		GitProperties properties = new GitProperties(
-				createProperties("master", "abcdefg", "2016-03-04 15:22:24"));
+				createProperties("master", "abcdefg", null, "2016-03-04 15:22:24"));
 		assertThat(properties.getCommitTime()).isNull();
 		assertThat(properties.get("commit.time")).isEqualTo("2016-03-04 15:22:24");
 	}
 
 	@Test
-	public void shortenCommitId() {
+	public void shortenCommitIdShorterThan7() {
 		GitProperties properties = new GitProperties(
-				createProperties("master", "abc", "1457527123"));
+				createProperties("master", "abc", null, "1457527123"));
 		assertThat(properties.getCommitId()).isEqualTo("abc");
 		assertThat(properties.getShortCommitId()).isEqualTo("abc");
 	}
 
+	@Test
+	public void shortenCommitIdLongerThan7() {
+		GitProperties properties = new GitProperties(
+				createProperties("master", "abcdefghijklmno", null, "1457527123"));
+		assertThat(properties.getCommitId()).isEqualTo("abcdefghijklmno");
+		assertThat(properties.getShortCommitId()).isEqualTo("abcdefg");
+	}
+
+	@Test
+	public void shortCommitIdCustomLength() {
+		GitProperties properties = new GitProperties(
+				createProperties("master", "abcdefghijklmno", "abcdefgh", "1457527123"));
+		assertThat(properties.getCommitId()).isEqualTo("abcdefghijklmno");
+		assertThat(properties.getShortCommitId()).isEqualTo("abcdefgh");
+	}
+
 	private static Properties createProperties(String branch, String commitId,
-			String commitTime) {
+			String commitIdAbbrev, String commitTime) {
 		Properties properties = new Properties();
 		properties.put("branch", branch);
 		properties.put("commit.id", commitId);
+		if (commitIdAbbrev != null) {
+			properties.put("commit.id.abbrev", commitIdAbbrev);
+		}
 		properties.put("commit.time", commitTime);
 		return properties;
 	}


### PR DESCRIPTION
Currently `GitProperties` always shortens the property `git.commit.id` to an hardcoded length of 7.

However, both the Maven plugin `git-commit-id-plugin` and the Gradle plugin `gradle-git-properties` are now providing the property `git.commit.id.abbrev` along with the propery `git.commit.id`.

Moreover, the Maven plugin allows to customize the length of the abbreviated commit ID with the configuration `abbrevLength`. The Gradle plugin doesn't allow (yet) to configure this length.

Closes gh-8773