### PR TITLE
Update doc for add-application-context-header

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -1087,7 +1087,7 @@ content into your application; rather pick only the properties that you need.
 	jolokia.config.*= # See Jolokia manual
 
 	# MANAGEMENT HTTP SERVER ({sc-spring-boot-actuator}/autoconfigure/ManagementServerProperties.{sc-ext}[ManagementServerProperties])
-	management.add-application-context-header=true # Add the "X-Application-Context" HTTP header in each response.
+	management.add-application-context-header=false # Add the "X-Application-Context" HTTP header in each response.
 	management.address= # Network address that the management endpoints should bind to.
 	management.context-path= # Management endpoint context-path. For instance `/actuator`
 	management.cloudfoundry.enabled= # Enable extended Cloud Foundry actuator endpoints


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR simply updates documentation on the default value for `management.add-application-context-header` changed in 20f201b57a71ac06423ccc9e2ddabfa42265c18e .