### PR TITLE
Batch property to force DefaultLobHandler in JobRepositoryBean

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BasicBatchConfigurer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BasicBatchConfigurer.java
@@ -31,6 +31,7 @@ import org.springframework.batch.core.launch.support.SimpleJobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.lob.DefaultLobHandler;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -145,6 +146,9 @@ public class BasicBatchConfigurer implements BatchConfigurer {
 		String tablePrefix = this.properties.getTablePrefix();
 		if (StringUtils.hasText(tablePrefix)) {
 			factory.setTablePrefix(tablePrefix);
+		}
+		if (this.properties.isForceDefaultLobHandler()) {
+			factory.setLobHandler(new DefaultLobHandler());
 		}
 		factory.setTransactionManager(getTransactionManager());
 		factory.afterPropertiesSet();

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
@@ -42,6 +42,11 @@ public class BatchProperties {
 	 */
 	private String tablePrefix;
 
+	/**
+	 * Force use of DefaultLobHandler as the LobHandler of the JobRepositoryFactoryBean
+	 */
+	private boolean forceDefaultLobHandler = false;
+
 	private final Initializer initializer = new Initializer();
 
 	private final Job job = new Job();
@@ -68,6 +73,14 @@ public class BatchProperties {
 
 	public String getTablePrefix() {
 		return this.tablePrefix;
+	}
+
+	public boolean isForceDefaultLobHandler() {
+		return forceDefaultLobHandler;
+	}
+
+	public void setForceDefaultLobHandler(boolean forceDefaultLobHandler) {
+		this.forceDefaultLobHandler = forceDefaultLobHandler;
 	}
 
 	public class Initializer {


### PR DESCRIPTION
Introduces a property, `forceDefaultLobHandler`, in `BatchProperties` that forces the use of the `DefaultLobHandler` as the `LobHandler` of the `JobRepositoryFactoryBean`.  This prevents the use of the deprecated `OracleLobHandler` if set to `true` and even if the `databaseType` within the [JobRepositoryFactoryBean](https://github.com/spring-projects/spring-batch/blob/master/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBean.java#L187) is resolved as `Oracle`. The default value of the property is `false`, as to not alter the existing, default logic.