### PR TITLE
Use supplier variant of Assert in RelaxedConversionService

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/bind/RelaxedConversionService.java
+++ b/spring-boot/src/main/java/org/springframework/boot/bind/RelaxedConversionService.java
@@ -105,7 +105,7 @@ class RelaxedConversionService implements ConversionService {
 			while (enumType != null && !enumType.isEnum()) {
 				enumType = enumType.getSuperclass();
 			}
-			Assert.notNull(enumType, "The target type " + targetType.getName()
+			Assert.notNull(enumType, () -> "The target type " + targetType.getName()
 					+ " does not refer to an enum");
 			return new StringToEnum(enumType);
 		}


### PR DESCRIPTION
Hey,

I've just noticed an Assert statement that could use the supplier variant of Assert.notNull() in order to avoid allocating the String in case it's not needed.

Cheers,
Christoph