### PR TITLE
Upgrade Hazelcast to 3.8

### DIFF
--- a/spring-boot-actuator/src/test/resources/cache/test-hazelcast.xml
+++ b/spring-boot-actuator/src/test/resources/cache/test-hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.8.xsd"
 		xmlns="http://www.hazelcast.com/schema/config"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/spring-boot-actuator/src/test/resources/hazelcast.xml
+++ b/spring-boot-actuator/src/test/resources/hazelcast.xml
@@ -1,5 +1,5 @@
 <hazelcast
-		xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
+		xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.8.xsd"
 		xmlns="http://www.hazelcast.com/schema/config"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/spring-boot-autoconfigure/src/test/resources/hazelcast.xml
+++ b/spring-boot-autoconfigure/src/test/resources/hazelcast.xml
@@ -1,5 +1,5 @@
 <hazelcast
-		xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
+		xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.8.xsd"
 		xmlns="http://www.hazelcast.com/schema/config"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.xml
+++ b/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.xml
@@ -1,4 +1,4 @@
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.8.xsd"
 		   xmlns="http://www.hazelcast.com/schema/config"
 		   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -83,8 +83,8 @@
 		<gson.version>2.8.0</gson.version>
 		<h2.version>1.4.194</h2.version>
 		<hamcrest.version>1.3</hamcrest.version>
-		<hazelcast.version>3.7.6</hazelcast.version>
-		<hazelcast-hibernate5.version>1.1.3</hazelcast-hibernate5.version>
+		<hazelcast.version>3.8</hazelcast.version>
+		<hazelcast-hibernate5.version>1.2</hazelcast-hibernate5.version>
 		<hibernate.version>5.2.9.Final</hibernate.version>
 		<hibernate-validator.version>5.4.1.Final</hibernate-validator.version>
 		<hikaricp.version>2.5.1</hikaricp.version>

--- a/spring-boot-samples/spring-boot-sample-cache/src/main/resources/hazelcast.xml
+++ b/spring-boot-samples/spring-boot-sample-cache/src/main/resources/hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.8.xsd"
 		   xmlns="http://www.hazelcast.com/schema/config"
 		   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 


### PR DESCRIPTION
Other than the Hazelcast version bump to 3.8, this PR also:

- upgrades `hazelcast-hibernate52` dependency to 1.2 which builds against Hazelcast 3.8
- updates test/sample Hazelcast XML configs schema