### PR TITLE
gh-8508: Fix bug to set server.tomcat.max-http-post-size to -1 ("off")

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -834,7 +834,7 @@ public class ServerProperties
 			if (maxHttpHeaderSize > 0) {
 				customizeMaxHttpHeaderSize(factory, maxHttpHeaderSize);
 			}
-			if (this.maxHttpPostSize > 0) {
+			if (this.maxHttpPostSize != 0) {
 				customizeMaxHttpPostSize(factory, this.maxHttpPostSize);
 			}
 			if (this.accesslog.enabled) {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -574,6 +574,23 @@ public class ServerPropertiesTests {
 		}
 	}
 
+    @Test
+    public void customDisableTomcatMaxHttpPostSize() {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("server.tomcat.max-http-post-size", "-1");
+        bindProperties(map);
+        TomcatEmbeddedServletContainerFactory container = new TomcatEmbeddedServletContainerFactory(0);
+        this.properties.customize(container);
+        TomcatEmbeddedServletContainer embeddedContainer = (TomcatEmbeddedServletContainer) container.getEmbeddedServletContainer();
+        embeddedContainer.start();
+        try {
+            assertThat(embeddedContainer.getTomcat().getConnector().getMaxPostSize()).isEqualTo(-1);
+        }
+        finally {
+            embeddedContainer.stop();
+        }
+    }
+
 	@Test
 	@Deprecated
 	public void customTomcatMaxHttpPostSizeWithDeprecatedProperty() {


### PR DESCRIPTION
gh-8508:  Fix bug to set server.tomcat.max-http-post-size to -1 ("off") 
- Fix bug by checking maxHttPostSize != 0
- Provide unit test in customDisableTomcatMaxHttpPostSize()

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->