### PR TITLE
Fix statsd metrics collection for metric names with ":"

### DIFF
--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/statsd/StatsdMetricWriterTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/statsd/StatsdMetricWriterTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link StatsdMetricWriter}.
  *
  * @author Dave Syer
+ * @author Odín del Río
  */
 public class StatsdMetricWriterTests {
 
@@ -95,6 +96,20 @@ public class StatsdMetricWriterTests {
 		this.writer.set(new Metric<>("gauge.foo", 3L));
 		this.server.waitForMessage();
 		assertThat(this.server.messagesReceived().get(0)).isEqualTo("my.gauge.foo:3|g");
+	}
+
+	@Test
+	public void incrementMetricWithInvalidCharsInName() throws Exception {
+		this.writer.increment(new Delta<>("counter.fo:o", 3L));
+		this.server.waitForMessage();
+		assertThat(this.server.messagesReceived().get(0)).isEqualTo("me.counter.foo:3|c");
+	}
+
+	@Test
+	public void setMetricWithInvalidCharsInName() throws Exception {
+		this.writer.set(new Metric<>("gauge.f:o:o", 3L));
+		this.server.waitForMessage();
+		assertThat(this.server.messagesReceived().get(0)).isEqualTo("me.gauge.foo:3|g");
 	}
 
 	private static final class DummyStatsDServer implements Runnable {


### PR DESCRIPTION
Statsd server is ignoring malformed metrics. This change introduces a basic sanitizing to metric names for avoid losing those metrics.

#### Why is this needed at this level?
Because current statsd clients for JAVA are not dealing with this... I proposed the change to that clients but I did not get an answer ([here](https://github.com/tim-group/java-statsd-client/issues/46) and [here](https://github.com/DataDog/java-dogstatsd-client/issues/27))

#### Is Spring Boot producing metric names with ":"?
Yes, if you are using hystrix you will get metrics like this one:

```json
 "gauge.servo.hystrix.hystrixcommand.https://mydomain.com.myfeignservice#getsomething(string).rollingcountshortcircuited": 0.0,
```

This kind of metrics are simply ignored by statsd servers.

#### Do you need a workaround?
For those that need this fixed right now, you can override the bean definition:

```java
  @Bean
  @ExportMetricWriter
  @ConditionalOnMissingBean
  @ConditionalOnProperty(prefix = "spring.metrics.export.statsd", name = "host")
  public StatsdMetricWriter statsdMetricWriter(MetricExportProperties properties) {
    MetricExportProperties.Statsd statsdProperties = properties.getStatsd();
    return new StatsdMetricWriter(statsdProperties.getPrefix(), statsdProperties.getHost(), statsdProperties.getPort()) {
      @Override
      public void increment(Delta<?> delta) {
        super.increment(new Delta<Number>(sanitizeMetricName(delta.getName()), delta.getValue(), delta.getTimestamp()));
      }

      @Override
      public void set(Metric<?> metric) {
        super.set(new Metric<Number>(sanitizeMetricName(metric.getName()), metric.getValue(), metric.getTimestamp()));
      }

      private String sanitizeMetricName(String name) {
        return name.replace(":", "");
      }
    };
  }
```