### PR TITLE
Use family instead of name to check os system

### DIFF
--- a/spring-boot-tools/spring-boot-gradle-plugin/pom.xml
+++ b/spring-boot-tools/spring-boot-gradle-plugin/pom.xml
@@ -106,7 +106,7 @@
 			<id>windows</id>
 			<activation>
 				<os>
-					<name>windows</name>
+					<family>windows</family>
 				</os>
 			</activation>
 			<properties>


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
When I try to build source code in Windows 8.1 machine, it will throw a exception like "./gradlew is a not valid Win32 program". The root cause is in `spring-boot-gradle-plugin` project.

`name` is the name of the operating system, such like `Windows XP` or `Windows 8.1`.
I think we should use `family` to determine OS system.

More detail can find in here: http://maven.apache.org/enforcer/enforcer-rules/requireOS.html

