### PR TITLE
Allow fail-fast of the key-uri lookup

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfiguration.java
@@ -68,7 +68,6 @@ import org.springframework.social.connect.support.OAuth2ConnectionFactory;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
-import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 /**


### PR DESCRIPTION
Since the public key should be retrieved from a highly available authorisation server, it makes no sense to leave the resource server in an unusable state when something does go wrong.

Please see https://github.com/spring-projects/spring-security-oauth/issues/734