### PR TITLE
Update LogFileMvcEndpoint.java

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/LogFileMvcEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/LogFileMvcEndpoint.java
@@ -93,7 +93,7 @@ public class LogFileMvcEndpoint extends AbstractNamedMvcEndpoint {
 		}
 		LogFile logFile = LogFile.get(getEnvironment());
 		if (logFile == null) {
-			logger.debug("Missing 'logging.file' or 'logging.path' properties");
+			logger.warn ("Missing 'logging.file' or 'logging.path' properties and 'endpoints.logfile.externalFile' is set");
 			return null;
 		}
 		return new FileSystemResource(logFile.toString());


### PR DESCRIPTION
Using the property  `--endpoints.logfile.external-file` without loglevel debug it is hard to find. 
If I use the property `endpoints.logfile.external-file` I expect a logfile at the specified place.

