### PR TITLE
Redis connection pool test configuration.  Fixes #8894

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
@@ -214,6 +214,10 @@ public class RedisAutoConfiguration {
 			config.setMaxIdle(props.getMaxIdle());
 			config.setMinIdle(props.getMinIdle());
 			config.setMaxWaitMillis(props.getMaxWait());
+			config.setTestOnCreate(props.isTestOnCreate());
+			config.setTestOnBorrow(props.isTestOnBorrow());
+			config.setTestOnReturn(props.isTestOnReturn());
+			config.setTestWhileIdle(props.isTestWhileIdle());
 			return config;
 		}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -182,6 +182,29 @@ public class RedisProperties {
 		 */
 		private int maxWait = -1;
 
+		/**
+		 * Whether a connection in the connection pool should be tested after creation.
+		 */
+		private boolean testOnCreate = false;
+
+		/**
+		 * Whether a connection in the connection pool should be tested when it is
+		 * borrowed from the pool.
+		 */
+		private boolean testOnBorrow = false;
+
+		/**
+		 * Whether a connection in the connection pool should be tested before it is
+		 * returned to the pool.
+		 */
+		private boolean testOnReturn = false;
+
+		/**
+		 * Whether a connection in the connection pool will be tested while it is
+		 * idle.
+		 */
+		private boolean testWhileIdle = false;
+
 		public int getMaxIdle() {
 			return this.maxIdle;
 		}
@@ -214,6 +237,37 @@ public class RedisProperties {
 			this.maxWait = maxWait;
 		}
 
+		public boolean isTestOnCreate() {
+			return this.testOnCreate;
+		}
+
+		public void setTestOnCreate(boolean testOnCreate) {
+			this.testOnCreate = testOnCreate;
+		}
+
+		public boolean isTestOnBorrow() {
+			return this.testOnBorrow;
+		}
+
+		public void setTestOnBorrow(boolean testOnBorrow) {
+			this.testOnBorrow = testOnBorrow;
+		}
+
+		public boolean isTestOnReturn() {
+			return this.testOnReturn;
+		}
+
+		public void setTestOnReturn(boolean testOnReturn) {
+			this.testOnReturn = testOnReturn;
+		}
+
+		public boolean isTestWhileIdle() {
+			return this.testWhileIdle;
+		}
+
+		public void setTestWhileIdle(boolean testWhileIdle) {
+			this.testWhileIdle = testWhileIdle;
+		}
 	}
 
 	/**

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -131,6 +131,18 @@ public class RedisAutoConfigurationTests {
 		}
 	}
 
+	@Test
+	public void testRedisConfigurationWithPoolConnectionTesting() {
+		load("spring.redis.pool.test-on-create:true",
+			"spring.redis.pool.test-on-borrow:true",
+			"spring.redis.pool.test-on-return:true",
+			"spring.redis.pool.test-while-idle:true");
+		assertThat(this.context.getBean(JedisConnectionFactory.class).getPoolConfig().getTestOnCreate());
+		assertThat(this.context.getBean(JedisConnectionFactory.class).getPoolConfig().getTestOnBorrow());
+		assertThat(this.context.getBean(JedisConnectionFactory.class).getPoolConfig().getTestOnReturn());
+		assertThat(this.context.getBean(JedisConnectionFactory.class).getPoolConfig().getTestWhileIdle());
+	}
+
 	private boolean isAtLeastOneNodeAvailable(List<String> nodes) {
 		for (String node : nodes) {
 			if (isAvailable(node)) {

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -824,6 +824,10 @@ content into your application; rather pick only the properties that you need.
 	spring.redis.pool.max-idle=8 # Max number of "idle" connections in the pool. Use a negative value to indicate an unlimited number of idle connections.
 	spring.redis.pool.max-wait=-1 # Maximum amount of time (in milliseconds) a connection allocation should block before throwing an exception when the pool is exhausted. Use a negative value to block indefinitely.
 	spring.redis.pool.min-idle=0 # Target for the minimum number of idle connections to maintain in the pool. This setting only has an effect if it is positive.
+	spring.redis.pool.test-on-create=false # Whether connections to Redis should be tested after creation.
+	spring.redis.pool.test-on-borrow=false # Whether connections to Redis should be tested before they are borrowed from the connection pool.
+	spring.redis.pool.test-on-return=false # Whether connections to Redis should be tested before they are returned to the connection pool.
+	spring.redis.pool.test-while-idle=false # Whether to test idle connections in the Redis connection pool.
 	spring.redis.port=6379 # Redis server port.
 	spring.redis.sentinel.master= # Name of Redis server.
 	spring.redis.sentinel.nodes= # Comma-separated list of host:port pairs.


### PR DESCRIPTION
Added four configuration parameters which control how Redis connections
in the connection pool are tested so they can be evicted if needed

See #8894