### PR TITLE
Excludes SQL server transitive of azure-keyvault

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -696,6 +696,12 @@
 				<groupId>com.microsoft.sqlserver</groupId>
 				<artifactId>mssql-jdbc</artifactId>
 				<version>${mssql-jdbc.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>com.microsoft.azure</groupId>
+						<artifactId>azure-keyvault</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>com.querydsl</groupId>


### PR DESCRIPTION
When we use miscrosoft sql server as database in spring boot it also includes azure-keyvault as transitive dependency of mssql-jdbc maven dependency which is not used in most of the cases as azure-keyvalut is saperate usecase.

This PR removes azure-keyvalut which also bring many dependencies like jersey , httpclient, jackson jars which are not used in many cases.

We may need to add a note that if you want to use azure-keyvalut then add it manually to the project.
