### PR TITLE
Support original file name for config file 

### DIFF
--- a/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
+++ b/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
@@ -59,6 +59,7 @@ import static org.junit.Assume.assumeThat;
  * Integration tests for Spring Boot's launch script on OSs that use SysVinit.
  *
  * @author Andy Wilkinson
+ * @author Ali Shahbour
  */
 @RunWith(Parameterized.class)
 public class SysVinitLaunchScriptIT {

--- a/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
+++ b/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
@@ -194,7 +194,13 @@ public class SysVinitLaunchScriptIT {
 		doLaunch("launch-with-single-java-opt.sh");
 	}
 
-	@Test
+    @Test
+    public void launchWithDoubleLinkSingleJavaOpt() throws Exception {
+        doLaunch("launch-with-double-link-single-java-opt.sh");
+    }
+
+
+    @Test
 	public void launchWithMultipleJavaOpts() throws Exception {
 		doLaunch("launch-with-multiple-java-opts.sh");
 	}

--- a/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
+++ b/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
@@ -194,13 +194,13 @@ public class SysVinitLaunchScriptIT {
 		doLaunch("launch-with-single-java-opt.sh");
 	}
 
-    @Test
-    public void launchWithDoubleLinkSingleJavaOpt() throws Exception {
-        doLaunch("launch-with-double-link-single-java-opt.sh");
-    }
+	@Test
+	public void launchWithDoubleLinkSingleJavaOpt() throws Exception {
+		doLaunch("launch-with-double-link-single-java-opt.sh");
+	}
 
 
-    @Test
+	@Test
 	public void launchWithMultipleJavaOpts() throws Exception {
 		doLaunch("launch-with-multiple-java-opts.sh");
 	}

--- a/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-double-link-single-java-opt.sh
+++ b/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-double-link-single-java-opt.sh
@@ -1,0 +1,6 @@
+source ./test-functions.sh
+install_double_link_service
+echo 'JAVA_OPTS=-Dserver.port=8081' > /test-service/spring-boot-app.conf
+start_service
+await_app http://127.0.0.1:8081/
+curl -s http://127.0.0.1:8081/

--- a/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/test-functions.sh
+++ b/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/test-functions.sh
@@ -5,6 +5,14 @@ install_service() {
   ln -s /test-service/spring-boot-app.jar /etc/init.d/spring-boot-app
 }
 
+install_double_link_service() {
+  mkdir /test-service
+  mv /spring-boot-launch-script-tests-*.jar /test-service/
+  chmod +x /test-service/spring-boot-launch-script-tests-*.jar
+  ln -s /test-service/spring-boot-launch-script-tests-*.jar /test-service/spring-boot-app.jar
+  ln -s /test-service/spring-boot-app.jar /etc/init.d/spring-boot-app
+}
+
 start_service() {
   service spring-boot-app start $@
 }

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -31,9 +31,14 @@ WORKING_DIR="$(pwd)"
 # Follow symlinks to find the real jar and detect init.d script
 cd "$(dirname "$0")" || exit 1
 [[ -z "$jarfile" ]] && jarfile=$(pwd)/$(basename "$0")
-originalconfigfile="$(basename "${jarfile%.*}.conf")"
 while [[ -L "$jarfile" ]]; do
-  [[ "$jarfile" =~ init\.d ]] && init_script=$(basename "$jarfile")
+  if [[ "$jarfile" =~ init\.d ]]; then
+    init_script=$(basename "$jarfile")
+  else
+    # while looping check if their is any configuration file
+    configfile="${jarfile%.*}.conf"
+    [[ -r ${configfile} ]] && source "${configfile}"
+  fi
   jarfile=$(readlink "$jarfile")
   cd "$(dirname "$jarfile")" || exit 1
   jarfile=$(pwd)/$(basename "$jarfile")
@@ -46,10 +51,8 @@ configfile="$(basename "${jarfile%.*}.conf")"
 
 # Initialize CONF_FOLDER location defaulting to jarfolder
 [[ -z "$CONF_FOLDER" ]] && CONF_FOLDER="{{confFolder:${jarfolder}}}"
-
 # shellcheck source=/dev/null
-[[ -r "${CONF_FOLDER}/${originalconfigfile}" ]] && source "${CONF_FOLDER}/${originalconfigfile}"
-[[ ! -r "${CONF_FOLDER}/${originalconfigfile}" ]] && [[ -r "${CONF_FOLDER}/${configfile}" ]] && source "${CONF_FOLDER}/${configfile}"
+[[ -r "${CONF_FOLDER}/${configfile}" ]] && source "${CONF_FOLDER}/${configfile}"
 
 # Initialize PID/LOG locations if they weren't provided by the config file
 [[ -z "$PID_FOLDER" ]] && PID_FOLDER="{{pidFolder:/var/run}}"

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -31,6 +31,7 @@ WORKING_DIR="$(pwd)"
 # Follow symlinks to find the real jar and detect init.d script
 cd "$(dirname "$0")" || exit 1
 [[ -z "$jarfile" ]] && jarfile=$(pwd)/$(basename "$0")
+originalconfigfile="$(basename "${jarfile%.*}.conf")"
 while [[ -L "$jarfile" ]]; do
   [[ "$jarfile" =~ init\.d ]] && init_script=$(basename "$jarfile")
   jarfile=$(readlink "$jarfile")
@@ -47,7 +48,8 @@ configfile="$(basename "${jarfile%.*}.conf")"
 [[ -z "$CONF_FOLDER" ]] && CONF_FOLDER="{{confFolder:${jarfolder}}}"
 
 # shellcheck source=/dev/null
-[[ -r "${CONF_FOLDER}/${configfile}" ]] && source "${CONF_FOLDER}/${configfile}"
+[[ -r "${CONF_FOLDER}/${originalconfigfile}" ]] && source "${CONF_FOLDER}/${originalconfigfile}"
+[[ ! -r "${CONF_FOLDER}/${originalconfigfile}" ]] && [[ -r "${CONF_FOLDER}/${configfile}" ]] && source "${CONF_FOLDER}/${configfile}"
 
 # Initialize PID/LOG locations if they weren't provided by the config file
 [[ -z "$PID_FOLDER" ]] && PID_FOLDER="{{pidFolder:/var/run}}"


### PR DESCRIPTION
#Support original file name even if it is a symbolic link for [conf](https://docs.spring.io/spring-boot/docs/current/reference/html/deployment-install.html#deployment-script-customization-conf-file) file .  this is needed if systemd or init.d is pointing to a symbolic link file instead of the original fat jar [stackoverflow](http://stackoverflow.com/questions/43584510/conf-file-for-spring-boot-application).