### PR TITLE
Add dropwizard metrics annotation and reporters auto-configuration

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -646,6 +646,11 @@
 			<artifactId>narayana-jts-integration</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>com.ryantenney.metrics</groupId>
+			<artifactId>metrics-spring</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<!-- Annotation processing -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/metrics/dropwizard/annotation/DropwizardMetricsAnnotationsAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/metrics/dropwizard/annotation/DropwizardMetricsAnnotationsAutoConfiguration.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.metrics.dropwizard.annotation;
+
+import com.codahale.metrics.ConsoleReporter;
+import com.codahale.metrics.CsvReporter;
+import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Slf4jReporter;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.ryantenney.metrics.spring.config.annotation.EnableMetrics;
+import com.ryantenney.metrics.spring.config.annotation.MetricsConfigurer;
+import com.ryantenney.metrics.spring.config.annotation.MetricsConfigurerAdapter;
+
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Dropwizard application metrics library
+ * {@link MetricsConfigurerAdapter}.
+ * Configuration allows to use dropwizard http://metrics.ryantenney.com/annotations.
+ * Configuration activates only if one metrics reporter like {@link JmxReporter} configured.
+ *
+ * @author Sergey Kuptsov
+ */
+@Configuration
+@ConditionalOnClass(MetricsConfigurer.class)
+@ConditionalOnMissingBean(MetricsConfigurer.class)
+@EnableConfigurationProperties(DropwizardMetricsAnnotationsProperties.class)
+public class DropwizardMetricsAnnotationsAutoConfiguration {
+
+	private final DropwizardMetricsAnnotationsProperties properties;
+	private final ListableBeanFactory beanFactory;
+
+	public DropwizardMetricsAnnotationsAutoConfiguration(
+			DropwizardMetricsAnnotationsProperties properties,
+			ListableBeanFactory beanFactory) {
+		this.properties = properties;
+		this.beanFactory = beanFactory;
+	}
+
+	/**
+	 * Defines bean callback methods to customize the Java-based configuration
+	 * for Spring Metrics enabled via {@link EnableMetrics @EnableMetrics}.
+	 *
+	 * @return configured MetricsConfigurer.
+	 */
+	@Bean
+	public MetricsConfigurer metricsConfigurer() {
+		HealthCheckRegistry healthCheckRegistry = this.properties.isHealthCheck() ? new HealthCheckRegistry() : null;
+		String metricsRegistryBeanName = this.properties.getMetricsRegistryBeanName();
+		MetricRegistry metricRegistry = !StringUtils.isEmpty(metricsRegistryBeanName) ?
+				this.beanFactory.containsBean(metricsRegistryBeanName) ?
+						this.beanFactory.getBean(metricsRegistryBeanName, MetricRegistry.class)
+						: null
+				: null;
+
+		return new MetricsConfigurerAdapter() {
+			@Override
+			public MetricRegistry getMetricRegistry() {
+				return metricRegistry;
+			}
+
+			@Override
+			public HealthCheckRegistry getHealthCheckRegistry() {
+				return healthCheckRegistry;
+			}
+
+			@Override
+			public void configureReporters(MetricRegistry metricRegistry) {
+				DropwizardMetricsAnnotationsProperties.Reporter reporter = DropwizardMetricsAnnotationsAutoConfiguration.this.properties.getReporter();
+
+				if (reporter.getJmx().isEnabled()) {
+					registerReporter(JmxReporter
+							.forRegistry(metricRegistry)
+							.build())
+							.start();
+				}
+
+				if (reporter.getConsole().isEnabled()) {
+					registerReporter(ConsoleReporter
+							.forRegistry(metricRegistry)
+							.build())
+							.start(reporter.getConsole().getPeriodSec(),
+									reporter.getConsole().getTimeUnit());
+				}
+
+				if (reporter.getCsv().isEnabled()) {
+					registerReporter(CsvReporter
+							.forRegistry(metricRegistry)
+							.build(reporter.getCsv().getFile()))
+							.start(reporter.getConsole().getPeriodSec(),
+									reporter.getConsole().getTimeUnit());
+				}
+
+				if (reporter.getSlf4j().isEnabled()) {
+					registerReporter(Slf4jReporter
+							.forRegistry(metricRegistry)
+							.build())
+							.start(reporter.getConsole().getPeriodSec(),
+									reporter.getConsole().getTimeUnit());
+				}
+			}
+		};
+	}
+
+	@Configuration
+	@EnableMetrics(proxyTargetClass = true)
+	public static class EnableMetricsConfiguration {
+	}
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/metrics/dropwizard/annotation/DropwizardMetricsAnnotationsProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/metrics/dropwizard/annotation/DropwizardMetricsAnnotationsProperties.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.metrics.dropwizard.annotation;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Dropwizard application metrics reporter.
+ *
+ * @author Sergey Kuptsov
+ */
+@ConfigurationProperties(prefix = "spring.metrics.annotation")
+public class DropwizardMetricsAnnotationsProperties {
+
+	/**
+	 * If true creates a HealthCheckRegistry bean.
+	 */
+	private boolean healthCheck;
+
+	/**
+	 * If set tries to find and use given metricsRegistryBeanName bean as metrics registry
+	 * If not set or bean not found - used default metrics registry.
+	 */
+	private String metricsRegistryBeanName;
+
+	/**
+	 * Reporters definition.
+	 */
+	private final Reporter reporter = new Reporter();
+
+	public boolean isHealthCheck() {
+		return this.healthCheck;
+	}
+
+	public void setHealthCheck(boolean healthCheck) {
+		this.healthCheck = healthCheck;
+	}
+
+	public Reporter getReporter() {
+		return this.reporter;
+	}
+
+	public String getMetricsRegistryBeanName() {
+		return this.metricsRegistryBeanName;
+	}
+
+	public void setMetricsRegistryBeanName(String metricsRegistryBeanName) {
+		this.metricsRegistryBeanName = metricsRegistryBeanName;
+	}
+
+	public static class Reporter {
+		private Jmx jmx = new Jmx();
+		private Console console = new Console();
+		private Csv csv = new Csv();
+		private Slf4j slf4j = new Slf4j();
+
+		public Jmx getJmx() {
+			return this.jmx;
+		}
+
+		public void setJmx(Jmx jmx) {
+			this.jmx = jmx;
+		}
+
+		public Console getConsole() {
+			return this.console;
+		}
+
+		public void setConsole(Console console) {
+			this.console = console;
+		}
+
+		public Csv getCsv() {
+			return this.csv;
+		}
+
+		public void setCsv(Csv csv) {
+			this.csv = csv;
+		}
+
+		public Slf4j getSlf4j() {
+			return this.slf4j;
+		}
+
+		public void setSlf4j(Slf4j slf4j) {
+			this.slf4j = slf4j;
+		}
+
+		public static class Jmx extends BaseReporter {
+		}
+
+		public static class Console extends BaseScheduledReporter {
+		}
+
+		public static class Csv extends BaseScheduledReporter {
+			private File file;
+
+			public File getFile() {
+				return this.file;
+			}
+
+			public void setFile(File file) {
+				this.file = file;
+			}
+		}
+
+		public static class Slf4j extends BaseScheduledReporter {
+		}
+
+		public static class BaseScheduledReporter extends BaseReporter {
+			private int periodSec = 60;
+
+			public int getPeriodSec() {
+				return this.periodSec;
+			}
+
+			public void setPeriodSec(int periodSec) {
+				this.periodSec = periodSec;
+			}
+
+			public TimeUnit getTimeUnit() {
+				return TimeUnit.SECONDS;
+			}
+		}
+
+		public static abstract class BaseReporter {
+			private boolean enabled;
+
+			public boolean isEnabled() {
+				return this.enabled;
+			}
+
+			public void setEnabled(boolean enabled) {
+				this.enabled = enabled;
+			}
+		}
+	}
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/metrics/dropwizard/annotation/package-info.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/metrics/dropwizard/annotation/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Dropwizard metrics annotation.
+ */
+package org.springframework.boot.autoconfigure.metrics.dropwizard.annotation;

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -119,7 +119,8 @@ org.springframework.boot.autoconfigure.web.servlet.MultipartAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration,\
 org.springframework.boot.autoconfigure.websocket.WebSocketAutoConfiguration,\
 org.springframework.boot.autoconfigure.websocket.WebSocketMessagingAutoConfiguration,\
-org.springframework.boot.autoconfigure.webservices.WebServicesAutoConfiguration
+org.springframework.boot.autoconfigure.webservices.WebServicesAutoConfiguration,\
+org.springframework.boot.autoconfigure.metrics.dropwizard.annotation.DropwizardMetricsAnnotationsAutoConfiguration
 
 # Failure analyzers
 org.springframework.boot.diagnostics.FailureAnalyzer=\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/metrics/dropwizard/annotation/DropwizardMetricsAnnotationsAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/metrics/dropwizard/annotation/DropwizardMetricsAnnotationsAutoConfigurationTests.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.metrics.dropwizard.annotation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricRegistryListener;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.ryantenney.metrics.spring.config.annotation.MetricsConfigurer;
+import com.ryantenney.metrics.spring.config.annotation.MetricsConfigurerAdapter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DropwizardMetricsAnnotationsAutoConfiguration}.
+ *
+ * @author Sergey Kuptsov
+ */
+public class DropwizardMetricsAnnotationsAutoConfigurationTests {
+
+	private AnnotationConfigApplicationContext context;
+
+	@Before
+	public void setUp() {
+		this.context = new AnnotationConfigApplicationContext();
+	}
+
+	@After
+	public void tearDown() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void canEnableConfiguration() {
+		this.context.register(DropwizardMetricsAnnotationsAutoConfiguration.class);
+		this.context.refresh();
+		assertThat(this.context.getBeansOfType(MetricsConfigurer.class)).isNotEmpty();
+	}
+
+	@Test
+	public void configurationHealthCheckEmptyByDefault() {
+		this.context.register(MetricsConfigurerApplicationTestConfiguration.class);
+		this.context.register(DropwizardMetricsAnnotationsAutoConfiguration.class);
+		this.context.refresh();
+		assertThat(this.context.getBeansOfType(MetricsConfigurer.class)).hasSize(1);
+		MetricsConfigurer metricsConfigurer = this.context.getBean(MetricsConfigurer.class);
+		assertThat(metricsConfigurer.getHealthCheckRegistry() == null);
+	}
+
+	@Test
+	public void configurationHealthCheckEnabled() {
+		this.context.register(DropwizardMetricsAnnotationsAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.metrics.annotation.healthCheck:true");
+		this.context.refresh();
+
+		MetricsConfigurer metricsConfigurer = (MetricsConfigurer) this.context.getBean("metricsConfigurer");
+		assertThat(metricsConfigurer.getHealthCheckRegistry() != null);
+	}
+
+	@Test
+	public void configurationJmxReporterEnabled() {
+		this.context.register(TracingMetricRegistryConfiguration.class);
+		this.context.register(DropwizardMetricsAnnotationsAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.metrics.annotation.reporter.jmx.enabled:true");
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.metrics.annotation.metricsRegistryBeanName:tracingMetricRegistry");
+		this.context.refresh();
+
+		MetricsConfigurer metricsConfigurer = (MetricsConfigurer) this.context.getBean("metricsConfigurer");
+		MetricRegistry metricRegistry = metricsConfigurer.getMetricRegistry();
+
+		assertThat(metricRegistry instanceof TracingMetricRegistryConfiguration.TracingMetricRegistry);
+		@SuppressWarnings("ConstantConditions")
+		TracingMetricRegistryConfiguration.TracingMetricRegistry tracingMetricRegistry =
+				(TracingMetricRegistryConfiguration.TracingMetricRegistry) metricRegistry;
+
+		List<MetricRegistryListener> listeners = tracingMetricRegistry.listeners;
+		assertThat(listeners.size() == 1);
+		MetricRegistryListener metricRegistryListener = listeners.get(0);
+		assertThat(metricRegistryListener != null);
+		assertThat(metricRegistryListener instanceof JmxReporter);
+	}
+
+	@Test
+	public void configurationJmxReporterNotEnabledByDefault() {
+		this.context.register(TracingMetricRegistryConfiguration.class);
+		this.context.register(DropwizardMetricsAnnotationsAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.metrics.annotation.metricsRegistryBeanName:tracingMetricRegistry");
+		this.context.refresh();
+
+		MetricsConfigurer metricsConfigurer = (MetricsConfigurer) this.context.getBean("metricsConfigurer");
+		MetricRegistry metricRegistry = metricsConfigurer.getMetricRegistry();
+
+		assertThat(metricRegistry instanceof TracingMetricRegistryConfiguration.TracingMetricRegistry);
+		@SuppressWarnings("ConstantConditions")
+		TracingMetricRegistryConfiguration.TracingMetricRegistry tracingMetricRegistry =
+				(TracingMetricRegistryConfiguration.TracingMetricRegistry) metricRegistry;
+
+		List<MetricRegistryListener> listeners = tracingMetricRegistry.listeners;
+		assertThat(listeners.isEmpty());
+	}
+
+	@Test
+	public void configurationNotOverridesExisting() {
+		this.context.register(MetricsConfigurerApplicationTestConfiguration.class);
+		this.context.register(DropwizardMetricsAnnotationsAutoConfiguration.class);
+		this.context.refresh();
+		assertThat(this.context.getBeansOfType(MetricsConfigurer.class)).hasSize(1);
+		MetricsConfigurer metricsConfigurer = this.context.getBean(MetricsConfigurer.class);
+		assertThat(metricsConfigurer.getHealthCheckRegistry() != null);
+	}
+
+	@Configuration
+	protected static class MetricsConfigurerApplicationTestConfiguration {
+
+		@Bean
+		public MetricsConfigurer metricsConfigurer() {
+			return new MetricsConfigurerAdapter() {
+
+				@Override
+				public HealthCheckRegistry getHealthCheckRegistry() {
+					return new HealthCheckRegistry();
+				}
+			};
+		}
+	}
+
+	@Configuration
+	protected static class TracingMetricRegistryConfiguration {
+
+		@Bean(name = "tracingMetricRegistry")
+		public MetricRegistry metricRegistry() {
+			return new TracingMetricRegistry();
+		}
+
+		protected static class TracingMetricRegistry extends MetricRegistry {
+
+			public List<MetricRegistryListener> listeners = new ArrayList<>();
+
+			@Override
+			public void addListener(MetricRegistryListener listener) {
+				this.listeners.add(listener);
+			}
+		}
+	}
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -192,6 +192,7 @@
 		<webjars-locator.version>0.32-1</webjars-locator.version>
 		<wsdl4j.version>1.6.3</wsdl4j.version>
 		<xml-apis.version>1.4.01</xml-apis.version>
+		<dropwizard-metrics-spring.version>3.1.3</dropwizard-metrics-spring.version>
 		<!-- Plugin versions -->
 		<build-helper-maven-plugin.version>1.10</build-helper-maven-plugin.version>
 		<exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
@@ -2454,6 +2455,11 @@
 				<groupId>xml-apis</groupId>
 				<artifactId>xml-apis</artifactId>
 				<version>${xml-apis.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.ryantenney.metrics</groupId>
+				<artifactId>metrics-spring</artifactId>
+				<version>${dropwizard-metrics-spring.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
This allows to autoconfigure dropwizard metrics with annotations. 
To monitore your app you just need to add com.ryantenney.metrics:metrics-spring to classspath and start using com.codahale.metrics.annotation.
```
    @Timed(name = "dropwizard.metric.test", absolute = true)
    public void doWork() {
    }
```
Metrics are now will be collected.
To export them somewhere configure one of reporters in application configuration:
```
spring.metrics.annotation.reporter.jmx.enabled=true
spring.metrics.annotation.reporter.console.enabled=true
spring.metrics.annotation.reporter.console.periodSec=10
```
Now your metrics are exposed through jmx bean and printed to console output every 10 seconds.