### PR TITLE
Fixes configuration properties output for actuator #3269

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/ConfigurationPropertiesReportEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/ConfigurationPropertiesReportEndpoint.java
@@ -337,8 +337,9 @@ public class ConfigurationPropertiesReportEndpoint
 			// that its a nested class used solely for binding to config props, so it
 			// should be kosher. This filter is not used if there is JSON metadata for
 			// the property, so it's mainly for user-defined beans.
-			return (setter != null) || ClassUtils.getPackageName(parentType)
-					.equals(ClassUtils.getPackageName(type));
+			return (setter != null)
+					|| ClassUtils.getPackageName(parentType).equals(ClassUtils.getPackageName(type))
+					|| ClassUtils.getPackageName(type).equals("java.util");
 		}
 
 		private AnnotatedMethod findSetter(BeanDescription beanDesc,
@@ -355,5 +356,4 @@ public class ConfigurationPropertiesReportEndpoint
 		}
 
 	}
-
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/ConfigurationPropertiesReportEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/ConfigurationPropertiesReportEndpoint.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -330,7 +331,7 @@ public class ConfigurationPropertiesReportEndpoint
 
 		private boolean isReadable(BeanDescription beanDesc, BeanPropertyWriter writer) {
 			Class<?> parentType = beanDesc.getType().getRawClass();
-			Class<?> type = writer.getType().getRawClass();
+			JavaType type = writer.getType();
 			AnnotatedMethod setter = findSetter(beanDesc, writer);
 			// If there's a setter, we assume it's OK to report on the value,
 			// similarly, if there's no setter but the package names match, we assume
@@ -338,8 +339,9 @@ public class ConfigurationPropertiesReportEndpoint
 			// should be kosher. This filter is not used if there is JSON metadata for
 			// the property, so it's mainly for user-defined beans.
 			return (setter != null)
-					|| ClassUtils.getPackageName(parentType).equals(ClassUtils.getPackageName(type))
-					|| ClassUtils.getPackageName(type).equals("java.util");
+					|| ClassUtils.getPackageName(parentType).equals(ClassUtils.getPackageName(type.getRawClass()))
+					|| type.isMapLikeType()
+					|| type.isCollectionLikeType();
 		}
 
 		private AnnotatedMethod findSetter(BeanDescription beanDesc,

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/ConfigurationPropertiesReportEndpointSerializationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/ConfigurationPropertiesReportEndpointSerializationTests.java
@@ -215,7 +215,10 @@ public class ConfigurationPropertiesReportEndpointSerializationTests {
 		Map<String, Object> propertiesMap = (Map<String, Object>) nestedProperties
 				.get("properties");
 		assertThat(propertiesMap).isNotNull();
-		assertThat(propertiesMap).hasSize(2);
+		assertThat(propertiesMap).hasSize(4);
+		String summary = (String) propertiesMap
+				.get("summary");
+		assertThat(summary).isNull();
 		Map<String, Object> map = (Map<String, Object>) propertiesMap
 				.get("map");
 		assertThat(map).isNotNull();
@@ -436,7 +439,7 @@ public class ConfigurationPropertiesReportEndpointSerializationTests {
 
 	}
 
-	public static class OnlyGetterProperties {
+	public static class OnlyGetterProperties extends Foo {
 		private Map<String, Boolean> map = new HashMap<>();
 		private List<String> list = new ArrayList<>();
 

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/ConfigurationPropertiesReportEndpointSerializationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/ConfigurationPropertiesReportEndpointSerializationTests.java
@@ -17,6 +17,8 @@
 package org.springframework.boot.actuate.endpoint;
 
 import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -195,6 +197,37 @@ public class ConfigurationPropertiesReportEndpointSerializationTests {
 		assertThat(map.get("address")).isEqualTo("192.168.1.10");
 	}
 
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testOutputAllOnlyGetterProperties() throws Exception {
+		this.context.register(OnlyGetterPropertiesConfig.class);
+		EnvironmentTestUtils.addEnvironment(this.context, "foo.map.entryOne:true",
+				"foo.list[0]:abc");
+		this.context.refresh();
+		ConfigurationPropertiesReportEndpoint report = this.context
+				.getBean(ConfigurationPropertiesReportEndpoint.class);
+		Map<String, Object> properties = report.invoke();
+		Map<String, Object> nestedProperties = (Map<String, Object>) properties
+				.get("foo");
+		assertThat(nestedProperties).isNotNull();
+		System.err.println(nestedProperties);
+		assertThat(nestedProperties.get("prefix")).isEqualTo("foo");
+		Map<String, Object> propertiesMap = (Map<String, Object>) nestedProperties
+				.get("properties");
+		assertThat(propertiesMap).isNotNull();
+		assertThat(propertiesMap).hasSize(2);
+		Map<String, Object> map = (Map<String, Object>) propertiesMap
+				.get("map");
+		assertThat(map).isNotNull();
+		assertThat(map).hasSize(1);
+		assertThat(map.get("entryOne")).isEqualTo(true);
+		List<String> list = (List<String>) propertiesMap
+				.get("list");
+		assertThat(list).isNotNull();
+		assertThat(list).hasSize(1);
+		assertThat(list.get(0)).isEqualTo("abc");
+	}
+
 	@Configuration
 	@EnableConfigurationProperties
 	public static class Base {
@@ -288,6 +321,16 @@ public class ConfigurationPropertiesReportEndpointSerializationTests {
 			return new Addressed();
 		}
 
+	}
+
+	@Configuration
+	@Import(Base.class)
+	public static class OnlyGetterPropertiesConfig {
+		@Bean
+		@ConfigurationProperties(prefix = "foo")
+		public OnlyGetterProperties foo() {
+			return new OnlyGetterProperties();
+		}
 	}
 
 	public static class Foo {
@@ -391,6 +434,19 @@ public class ConfigurationPropertiesReportEndpointSerializationTests {
 			this.address = address;
 		}
 
+	}
+
+	public static class OnlyGetterProperties {
+		private Map<String, Boolean> map = new HashMap<>();
+		private List<String> list = new ArrayList<>();
+
+		public Map<String, Boolean> getMap() {
+			return this.map;
+		}
+
+		public List<String> getList() {
+			return this.list;
+		}
 	}
 
 }


### PR DESCRIPTION
Adds the ability to output configuration properties that are of Map/Collection and only have getters to the /configprops endpoint in actuator. 

Since we can set Maps/Collections without setters, by adding the check for `java.util` we include setterless Map/Collection properties with the original logic of only pulling properties with setters or nested properties

Another possible solution would be to remove the `GenericSerializerModifier` class. By removing the `GenericSerializerModifier` the configprops serialization should then just use the default jackson serialization, which would output any getter methods.

Reference: https://github.com/spring-projects/spring-boot/issues/3269