### PR TITLE
Add Membrane Spring Boot Starter

### DIFF
--- a/spring-boot-starters/README.adoc
+++ b/spring-boot-starters/README.adoc
@@ -121,4 +121,10 @@ do as they were designed before this was clarified.
 | http://square.github.io/okhttp/[OkHttp]
 | https://github.com/freefair/okhttp-spring-boot
 
+| Charon reverse proxy
+| https://github.com/mkopylec/charon-spring-boot-starter
+
+| https://github.com/membrane/service-proxy[Membrane Service Proxy]
+| https://github.com/helpermethod/membrane-spring-boot-starter
+
 |===

--- a/spring-boot-starters/README.adoc
+++ b/spring-boot-starters/README.adoc
@@ -121,9 +121,6 @@ do as they were designed before this was clarified.
 | http://square.github.io/okhttp/[OkHttp]
 | https://github.com/freefair/okhttp-spring-boot
 
-| Charon reverse proxy
-| https://github.com/mkopylec/charon-spring-boot-starter
-
 | https://github.com/membrane/service-proxy[Membrane Service Proxy]
 | https://github.com/helpermethod/membrane-spring-boot-starter
 


### PR DESCRIPTION
This PR adds membrane-spring-boot-starter to the list of community provided Spring Boot starters.

