### PR TITLE
Log an error if health indicator throws an exception

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/AbstractHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/AbstractHealthIndicator.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.actuate.health;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.boot.actuate.health.Health.Builder;
 
 /**
@@ -31,6 +34,8 @@ import org.springframework.boot.actuate.health.Health.Builder;
  */
 public abstract class AbstractHealthIndicator implements HealthIndicator {
 
+	private final Log logger = LogFactory.getLog(getClass());
+
 	@Override
 	public final Health health() {
 		Health.Builder builder = new Health.Builder();
@@ -38,6 +43,7 @@ public abstract class AbstractHealthIndicator implements HealthIndicator {
 			doHealthCheck(builder);
 		}
 		catch (Exception ex) {
+			this.logger.warn("Health check failed", ex);
 			builder.down(ex);
 		}
 		return builder.build();


### PR DESCRIPTION
When running an application on Kubernetes its probes use /health endpoint to check if application is ready and alive. In case if JMS connection is not available, probes fail and pod is killed and restarted. However, the error message is simply that 'readiness/liveliness probe has failed'. Because JMS health indicator doesn't print any logging about failure, it's hard to figure out why did the probe fail.