### PR TITLE
Remove args.hash code based on #8680

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -546,7 +546,7 @@ public class SpringApplication {
 				PropertySource<?> source = sources.get(name);
 				CompositePropertySource composite = new CompositePropertySource(name);
 				composite.addPropertySource(new SimpleCommandLinePropertySource(
-						name + "-" + args.hashCode(), args));
+						name, args));
 				composite.addPropertySource(source);
 				sources.replace(name, composite);
 			}

--- a/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -545,8 +545,7 @@ public class SpringApplication {
 			if (sources.contains(name)) {
 				PropertySource<?> source = sources.get(name);
 				CompositePropertySource composite = new CompositePropertySource(name);
-				composite.addPropertySource(new SimpleCommandLinePropertySource(
-						name, args));
+				composite.addPropertySource(new SimpleCommandLinePropertySource(name, args));
 				composite.addPropertySource(source);
 				sources.replace(name, composite);
 			}


### PR DESCRIPTION
Removed args.hashCode() appending to the name parameter of SimpleCommandLinePropertySource when generating property source name, based on #8680 