### PR TITLE
Improve `HashMapSessionConfiguration`

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HashMapSessionConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HashMapSessionConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.session.ExpiringSession;
 import org.springframework.session.MapSessionRepository;
 import org.springframework.session.SessionRepository;
 import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
@@ -30,6 +29,7 @@ import org.springframework.session.config.annotation.web.http.EnableSpringHttpSe
  *
  * @author Tommy Ludwig
  * @author Stephane Nicoll
+ * @author Vedran Pavic
  */
 @Configuration
 @EnableSpringHttpSession
@@ -38,8 +38,7 @@ import org.springframework.session.config.annotation.web.http.EnableSpringHttpSe
 class HashMapSessionConfiguration {
 
 	@Bean
-	public SessionRepository<ExpiringSession> sessionRepository(
-			SessionProperties properties) {
+	public MapSessionRepository sessionRepository(SessionProperties properties) {
 		MapSessionRepository repository = new MapSessionRepository();
 		Integer timeout = properties.getTimeout();
 		if (timeout != null) {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.session.ExpiringSession;
 import org.springframework.session.MapSessionRepository;
 import org.springframework.session.SessionRepository;
 import org.springframework.session.web.http.SessionRepositoryFilter;
@@ -66,7 +65,7 @@ public class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurat
 
 	@Test
 	public void backOffIfSessionRepositoryIsPresent() {
-		load(Collections.<Class<?>>singletonList(SessionRepositoryConfiguration.class),
+		load(Collections.singletonList(SessionRepositoryConfiguration.class),
 				"spring.session.store-type=redis");
 		MapSessionRepository repository = validateSessionRepository(
 				MapSessionRepository.class);
@@ -121,9 +120,8 @@ public class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurat
 	static class SessionRepositoryConfiguration {
 
 		@Bean
-		public SessionRepository<?> mySessionRepository() {
-			return new MapSessionRepository(
-					Collections.<String, ExpiringSession>emptyMap());
+		public MapSessionRepository mySessionRepository() {
+			return new MapSessionRepository(Collections.emptyMap());
 		}
 
 	}


### PR DESCRIPTION
This PR updates `MapSessionRepository` bean definition return type and applies equivalent change to `SessionAutoConfigurationTests`.

These changes also ensure compatibility with Spring Session 2.0 which will merge `ExpiringSession` API with `Session` API (see spring-projects/spring-session#682).

/cc @rwinch