### PR TITLE
Upgrade GlassFish EL to 3.0.1-b08

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -77,7 +77,7 @@
 		<flyway.version>4.2.0</flyway.version>
 		<freemarker.version>2.3.26-incubating</freemarker.version>
 		<elasticsearch.version>2.4.5</elasticsearch.version>
-		<glassfish-el.version>3.0.0</glassfish-el.version>
+		<glassfish-el.version>3.0.1-b08</glassfish-el.version>
 		<groovy.version>2.4.11</groovy.version>
 		<gson.version>2.8.0</gson.version>
 		<h2.version>1.4.195</h2.version>


### PR DESCRIPTION
Upgrade GlassFish EL (Unified _Expression Language_ implementation) to latest version (3.0.1-b08).

To backport to branch 1.5.x if possible.