### PR TITLE
Add Slice test annotation for Redis

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -74,7 +74,6 @@
 		<ehcache.version>2.10.4</ehcache.version>
 		<ehcache3.version>3.3.1</ehcache3.version>
 		<embedded-mongo.version>2.0.0</embedded-mongo.version>
-		<embedded-redis.version>0.6</embedded-redis.version>
 		<flyway.version>4.2.0</flyway.version>
 		<freemarker.version>2.3.26-incubating</freemarker.version>
 		<elasticsearch.version>2.4.5</elasticsearch.version>
@@ -637,11 +636,6 @@
 				<groupId>com.github.ben-manes.caffeine</groupId>
 				<artifactId>caffeine</artifactId>
 				<version>${caffeine.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.github.kstyrc</groupId>
-				<artifactId>embedded-redis</artifactId>
-				<version>${embedded-redis.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.mxab.thymeleaf.extras</groupId>

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -190,6 +190,7 @@
 		<webjars-locator.version>0.32-1</webjars-locator.version>
 		<wsdl4j.version>1.6.3</wsdl4j.version>
 		<xml-apis.version>1.4.01</xml-apis.version>
+		<embedded-redis.version>0.6</embedded-redis.version>
 		<!-- Plugin versions -->
 		<build-helper-maven-plugin.version>1.10</build-helper-maven-plugin.version>
 		<exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
@@ -2447,6 +2448,13 @@
 				<artifactId>xml-apis</artifactId>
 				<version>${xml-apis.version}</version>
 			</dependency>
+
+			<dependency>
+				<groupId>com.github.kstyrc</groupId>
+				<artifactId>embedded-redis</artifactId>
+				<version>${embedded-redis.version}</version>
+			</dependency>
+
 		</dependencies>
 	</dependencyManagement>
 	<build>

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -74,6 +74,7 @@
 		<ehcache.version>2.10.4</ehcache.version>
 		<ehcache3.version>3.3.1</ehcache3.version>
 		<embedded-mongo.version>2.0.0</embedded-mongo.version>
+		<embedded-redis.version>0.6</embedded-redis.version>
 		<flyway.version>4.2.0</flyway.version>
 		<freemarker.version>2.3.26-incubating</freemarker.version>
 		<elasticsearch.version>2.4.5</elasticsearch.version>
@@ -190,7 +191,6 @@
 		<webjars-locator.version>0.32-1</webjars-locator.version>
 		<wsdl4j.version>1.6.3</wsdl4j.version>
 		<xml-apis.version>1.4.01</xml-apis.version>
-		<embedded-redis.version>0.6</embedded-redis.version>
 		<!-- Plugin versions -->
 		<build-helper-maven-plugin.version>1.10</build-helper-maven-plugin.version>
 		<exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
@@ -637,6 +637,11 @@
 				<groupId>com.github.ben-manes.caffeine</groupId>
 				<artifactId>caffeine</artifactId>
 				<version>${caffeine.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.github.kstyrc</groupId>
+				<artifactId>embedded-redis</artifactId>
+				<version>${embedded-redis.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.mxab.thymeleaf.extras</groupId>
@@ -2448,13 +2453,6 @@
 				<artifactId>xml-apis</artifactId>
 				<version>${xml-apis.version}</version>
 			</dependency>
-
-			<dependency>
-				<groupId>com.github.kstyrc</groupId>
-				<artifactId>embedded-redis</artifactId>
-				<version>${embedded-redis.version}</version>
-			</dependency>
-
 		</dependencies>
 	</dependencyManagement>
 	<build>

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -5887,29 +5887,6 @@ A list of the auto-configuration that is enabled by `@DataNeo4jTest` can be
 	}
 ----
 
-Data Redis tests are transactional and rollback at the end of each test by default,
-see the {spring-reference}#testcontext-tx-enabling-transactions[relevant section] in the
-Spring Reference Documentation for more details. If that's not what you want, you can
-disable transaction management for a test or for the whole class as follows:
-
-[source,java,indent=0]
-----
-	import org.junit.Test;
-	import org.junit.runner.RunWith;
-	import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
-	import org.springframework.test.context.junit4.SpringRunner;
-	import org.springframework.transaction.annotation.Propagation;
-	import org.springframework.transaction.annotation.Transactional;
-
-	@RunWith(SpringRunner.class)
-	@DataRedisTest
-	@Transactional(propagation = Propagation.NOT_SUPPORTED)
-	public class ExampleNonTransactionalTests {
-
-	}
-----
-
-
 A list of the auto-configuration that is enabled by `@DataRedisTest` can be
 <<appendix-test-auto-configuration#test-auto-configuration,found in the appendix>>.
 

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -5865,6 +5865,53 @@ disable transaction management for a test or for the whole class as follows:
 A list of the auto-configuration that is enabled by `@DataNeo4jTest` can be
 <<appendix-test-auto-configuration#test-auto-configuration,found in the appendix>>.
 
+[[boot-features-testing-spring-boot-applications-testing-autoconfigured-redis-test]]
+==== Auto-configured Data Redis tests
+`@DataRedisTest` can be used if you want to test Redis applications.
+
+[source,java,indent=0]
+----
+	import org.junit.runner.RunWith;
+	import org.springframework.beans.factory.annotation.Autowired;
+	import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+	import org.springframework.test.context.junit4.SpringRunner;
+
+	@RunWith(SpringRunner.class)
+	@DataRedisTest
+	public class ExampleDataRedisTests {
+
+		@Autowired
+		private YourRepository repository;
+
+		//
+	}
+----
+
+Data Redis tests are transactional and rollback at the end of each test by default,
+see the {spring-reference}#testcontext-tx-enabling-transactions[relevant section] in the
+Spring Reference Documentation for more details. If that's not what you want, you can
+disable transaction management for a test or for the whole class as follows:
+
+[source,java,indent=0]
+----
+	import org.junit.Test;
+	import org.junit.runner.RunWith;
+	import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+	import org.springframework.test.context.junit4.SpringRunner;
+	import org.springframework.transaction.annotation.Propagation;
+	import org.springframework.transaction.annotation.Transactional;
+
+	@RunWith(SpringRunner.class)
+	@DataRedisTest
+	@Transactional(propagation = Propagation.NOT_SUPPORTED)
+	public class ExampleNonTransactionalTests {
+
+	}
+----
+
+
+A list of the auto-configuration that is enabled by `@DataRedisTest` can be
+<<appendix-test-auto-configuration#test-auto-configuration,found in the appendix>>.
 
 
 [[boot-features-testing-spring-boot-applications-testing-autoconfigured-ldap-test]]

--- a/spring-boot-test-autoconfigure/pom.xml
+++ b/spring-boot-test-autoconfigure/pom.xml
@@ -174,11 +174,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.kstyrc</groupId>
-			<artifactId>embedded-redis</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>test</scope>

--- a/spring-boot-test-autoconfigure/pom.xml
+++ b/spring-boot-test-autoconfigure/pom.xml
@@ -146,6 +146,25 @@
 			<artifactId>spring-security-test</artifactId>
 			<optional>true</optional>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-redis</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-pool2</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>redis.clients</groupId>
+			<artifactId>jedis</artifactId>
+			<optional>true</optional>
+		</dependency>
+
 		<!-- Test -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -227,5 +246,12 @@
 			<artifactId>de.flapdoodle.embed.mongo</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>com.github.kstyrc</groupId>
+			<artifactId>embedded-redis</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/spring-boot-test-autoconfigure/pom.xml
+++ b/spring-boot-test-autoconfigure/pom.xml
@@ -60,6 +60,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-pool2</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>
 			<exclusions>
@@ -146,19 +151,11 @@
 			<artifactId>spring-security-test</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-redis</artifactId>
 			<optional>true</optional>
 		</dependency>
-
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-pool2</artifactId>
-			<optional>true</optional>
-		</dependency>
-
 		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
@@ -174,6 +171,11 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.kstyrc</groupId>
+			<artifactId>embedded-redis</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -246,12 +248,5 @@
 			<artifactId>de.flapdoodle.embed.mongo</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-		<dependency>
-			<groupId>com.github.kstyrc</groupId>
-			<artifactId>embedded-redis</artifactId>
-			<scope>test</scope>
-		</dependency>
-
 	</dependencies>
 </project>

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/data/redis/AutoConfigureDataRedis.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/data/redis/AutoConfigureDataRedis.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.data.redis;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+
+/**
+ * {@link ImportAutoConfiguration Auto-configuration imports} for typical Data redis
+ * tests. Most tests should consider using {@link DataRedisTest @DataRedisTest} rather
+ * than using this annotation directly.
+ *
+ * @author Jayaram Pradhan
+ *
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ImportAutoConfiguration
+public @interface AutoConfigureDataRedis {
+
+}

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTest.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.data.redis;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
+import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
+import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.test.context.BootstrapWith;
+
+
+
+/**
+ * Annotation that can be used in combination with {@code @RunWith(SpringRunner.class)}
+ * for a typical Data Redis test. Can be used when a test focuses <strong>only</strong> on
+ * RedisDB components.
+ * <p>
+ * Using this annotation will disable full auto-configuration and instead apply only
+ * configuration relevant to RedisDB tests.
+ * <p>
+ *
+ * @author Jayaram Pradhan
+ *
+ */
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@BootstrapWith(SpringBootTestContextBootstrapper.class)
+@OverrideAutoConfiguration(enabled = false)
+@TypeExcludeFilters(DataRedisTypeExcludeFilter.class)
+@AutoConfigureCache
+@AutoConfigureDataRedis
+@ImportAutoConfiguration
+public @interface DataRedisTest {
+
+	/**
+	 * Determines if default filtering should be used with
+	 * {@link SpringBootApplication @SpringBootApplication}. By default no beans are
+	 * included.
+	 * @see #includeFilters()
+	 * @see #excludeFilters()
+	 * @return if default filters should be used
+	 */
+	boolean useDefaultFilters() default true;
+
+	/**
+	 * A set of include filters which can be used to add otherwise filtered beans to the
+	 * application context.
+	 * @return include filters to apply
+	 */
+	Filter[] includeFilters() default {};
+
+	/**
+	 * A set of exclude filters which can be used to filter beans that would otherwise be
+	 * added to the application context.
+	 * @return exclude filters to apply
+	 */
+	Filter[] excludeFilters() default {};
+
+	/**
+	 * Auto-configuration exclusions that should be applied for this test.
+	 * @return auto-configuration exclusions to apply
+	 */
+	@AliasFor(annotation = ImportAutoConfiguration.class, attribute = "exclude")
+	Class<?>[] excludeAutoConfiguration() default {};
+
+}

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTypeExcludeFilter.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTypeExcludeFilter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.data.redis;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.springframework.boot.context.TypeExcludeFilter;
+import org.springframework.boot.test.autoconfigure.filter.AnnotationCustomizableTypeExcludeFilter;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+
+
+
+/**
+ * {@link TypeExcludeFilter} for {@link DataRedisTest @DataRedisTest}.
+ *
+ * @author Jayaram Pradhan
+ */
+class DataRedisTypeExcludeFilter extends AnnotationCustomizableTypeExcludeFilter {
+
+	private final DataRedisTest annotation;
+
+	DataRedisTypeExcludeFilter(Class<?> testClass) {
+		this.annotation = AnnotatedElementUtils.getMergedAnnotation(testClass,
+				DataRedisTest.class);
+	}
+
+	@Override
+	protected boolean hasAnnotation() {
+		return this.annotation != null;
+	}
+
+	@Override
+	protected Filter[] getFilters(FilterType type) {
+		switch (type) {
+			case INCLUDE:
+				return this.annotation.includeFilters();
+			case EXCLUDE:
+				return this.annotation.excludeFilters();
+			default:
+				throw new IllegalStateException("Unsupported type " + type);
+		}
+	}
+
+	@Override
+	protected boolean isUseDefaultFilters() {
+		return this.annotation.useDefaultFilters();
+	}
+
+	@Override
+	protected Set<Class<?>> getDefaultIncludes() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	protected Set<Class<?>> getComponentIncludes() {
+		return Collections.emptySet();
+	}
+}

--- a/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -36,6 +36,12 @@ org.springframework.boot.autoconfigure.data.neo4j.Neo4jDataAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.neo4j.Neo4jRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration
 
+# AutoConfigureDataRedis auto-configuration imports
+org.springframework.boot.test.autoconfigure.data.redis.AutoConfigureDataRedis=\
+org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,\
+org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration,\
+org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration
+
 # AutoConfigureJdbc auto-configuration imports
 org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureJdbc=\
 org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration,\
@@ -128,9 +134,3 @@ org.springframework.boot.test.autoconfigure.restdocs.RestDocsTestExecutionListen
 org.springframework.boot.test.autoconfigure.web.client.MockRestServiceServerResetTestExecutionListener,\
 org.springframework.boot.test.autoconfigure.web.servlet.MockMvcPrintOnlyOnFailureTestExecutionListener,\
 org.springframework.boot.test.autoconfigure.web.servlet.WebDriverTestExecutionListener
-
-# AutoConfigureDataRedis auto-configuration imports
-org.springframework.boot.test.autoconfigure.data.redis.AutoConfigureDataRedis=\
-org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,\
-org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration,\
-org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration

--- a/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -128,3 +128,9 @@ org.springframework.boot.test.autoconfigure.restdocs.RestDocsTestExecutionListen
 org.springframework.boot.test.autoconfigure.web.client.MockRestServiceServerResetTestExecutionListener,\
 org.springframework.boot.test.autoconfigure.web.servlet.MockMvcPrintOnlyOnFailureTestExecutionListener,\
 org.springframework.boot.test.autoconfigure.web.servlet.WebDriverTestExecutionListener
+
+# AutoConfigureDataRedis auto-configuration imports
+org.springframework.boot.test.autoconfigure.data.redis.AutoConfigureDataRedis=\
+org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,\
+org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration,\
+org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestIntegrationTests.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestIntegrationTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.data.redis;
+
+import java.nio.charset.Charset;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import redis.embedded.RedisServer;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * Integration test for {@link DataRedisTest}.
+ *
+ * @author Jayaram Pradhan
+ */
+@RunWith(SpringRunner.class)
+@DataRedisTest
+public class DataRedisTestIntegrationTests {
+
+	@Autowired
+	private RedisOperations<Object, Object> operations;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Autowired
+	private ExampleRepository exampleRepository;
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	private static final Charset CHARSET = Charset.forName("UTF-8");
+
+	private static RedisServer redisServer;
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+		redisServer = new RedisServer(6379);
+		redisServer.start();
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		redisServer.stop();
+	}
+
+	@Test
+	public void testRepository() {
+		PersonHash personHash = new PersonHash();
+		personHash.setDescription("Look, new @DataRedisTest!");
+		assertThat(personHash.getId()).isNull();
+		PersonHash savedEntity = this.exampleRepository.save(personHash);
+		assertThat(savedEntity.getId()).isNotNull();
+		assertThat(this.operations.execute((RedisConnection connection) -> connection.exists(("persons:" + savedEntity.getId()).getBytes(CHARSET)))).isTrue();
+		this.exampleRepository.deleteAll();
+	}
+
+	@Test
+	public void didNotInjectExampleService() {
+		this.thrown.expect(NoSuchBeanDefinitionException.class);
+		this.applicationContext.getBean(ExampleService.class);
+	}
+
+}

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestIntegrationTests.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestIntegrationTests.java
@@ -18,13 +18,10 @@ package org.springframework.boot.test.autoconfigure.data.redis;
 
 import java.nio.charset.Charset;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import redis.embedded.RedisServer;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,19 +55,6 @@ public class DataRedisTestIntegrationTests {
 	private ApplicationContext applicationContext;
 
 	private static final Charset CHARSET = Charset.forName("UTF-8");
-
-	private static RedisServer redisServer;
-
-	@BeforeClass
-	public static void setUp() throws Exception {
-		redisServer = new RedisServer(6379);
-		redisServer.start();
-	}
-
-	@AfterClass
-	public static void tearDown() throws Exception {
-		redisServer.stop();
-	}
 
 	@Test
 	public void testRepository() {

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestWithIncludeFilterIntegrationTests.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestWithIncludeFilterIntegrationTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.data.redis;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import redis.embedded.RedisServer;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.stereotype.Service;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test with custom include filter for {@link DataRedisTest}.
+ *
+ * @author Jayaram Pradhan
+ */
+@RunWith(SpringRunner.class)
+@DataRedisTest(includeFilters = @Filter(Service.class))
+public class DataRedisTestWithIncludeFilterIntegrationTests {
+
+	@Autowired
+	private ExampleRepository exampleRepository;
+
+	@Autowired
+	private ExampleService service;
+
+	private static RedisServer redisServer;
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+		redisServer = new RedisServer(6379);
+		redisServer.start();
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		redisServer.stop();
+	}
+
+	@Test
+	public void testService() {
+		PersonHash personHash = new PersonHash();
+		personHash.setDescription("Look, new @DataRedisTest!");
+		assertThat(personHash.getId()).isNull();
+		PersonHash savedEntity = this.exampleRepository.save(personHash);
+		assertThat(this.service.hasRecord(savedEntity)).isTrue();
+		this.exampleRepository.deleteAll();
+	}
+
+}

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestWithIncludeFilterIntegrationTests.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestWithIncludeFilterIntegrationTests.java
@@ -16,11 +16,8 @@
 
 package org.springframework.boot.test.autoconfigure.data.redis;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import redis.embedded.RedisServer;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan.Filter;
@@ -43,19 +40,6 @@ public class DataRedisTestWithIncludeFilterIntegrationTests {
 
 	@Autowired
 	private ExampleService service;
-
-	private static RedisServer redisServer;
-
-	@BeforeClass
-	public static void setUp() throws Exception {
-		redisServer = new RedisServer(6379);
-		redisServer.start();
-	}
-
-	@AfterClass
-	public static void tearDown() throws Exception {
-		redisServer.stop();
-	}
 
 	@Test
 	public void testService() {

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/ExampleRedisApplication.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/ExampleRedisApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.data.redis;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Example {@link SpringBootApplication} used with {@link DataRedisTest} tests.
+ *
+ * @author Jayaram Pradhan
+ */
+@SpringBootApplication
+public class ExampleRedisApplication {
+
+}

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/ExampleRepository.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/ExampleRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.data.redis;
+
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * Example repository used with {@link DataRedisTest} tests.
+ *
+ * @author Jayaram Pradhan
+ */
+public interface ExampleRepository extends CrudRepository<PersonHash, String> {
+}

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/ExampleService.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/ExampleService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.data.redis;
+
+import java.nio.charset.Charset;
+
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.stereotype.Service;
+
+
+/**
+ * Example service used with {@link DataRedisTest} tests.
+ *
+ * @author Jayaram Pradhan
+ */
+@Service
+public class ExampleService {
+
+	private RedisOperations<Object, Object> operations;
+	private static final Charset CHARSET = Charset.forName("UTF-8");
+
+	public ExampleService(RedisOperations<Object, Object> operations) {
+		this.operations = operations;
+	}
+
+	public boolean hasRecord(PersonHash personHash) {
+		return this.operations.execute(
+				(RedisConnection connection) -> connection.exists(("persons:" + personHash.getId()).getBytes(CHARSET)));
+	}
+
+}

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/PersonHash.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/PersonHash.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.data.redis;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+/**
+ * Example graph used with {@link DataRedisTest} tests.
+ *
+ * @author Jayaram Pradhan
+ */
+@RedisHash("persons")
+public class PersonHash {
+
+	@Id
+	private String id;
+	private String description;
+
+	public String getId() {
+		return this.id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getDescription() {
+		return this.description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+}


### PR DESCRIPTION
This commit adds new annotation `@DataRedisTest` which provides test
infrastructure for redis.

fix for #8608 