### PR TITLE
update starter doc for add teiid spring boot starter link

### DIFF
--- a/spring-boot-starters/README.adoc
+++ b/spring-boot-starters/README.adoc
@@ -115,6 +115,9 @@ do as they were designed before this was clarified.
 | http://infinispan.org/[Infinispan]
 | https://github.com/infinispan/infinispan-spring-boot
 
+| http://teiid.org/[Teiid]
+| https://github.com/teiid/teiid-spring-boot
+
 | http://restfb.com/[RestFB] Messenger
 | https://github.com/marsbits/restfbmessenger
 


### PR DESCRIPTION
Base on Spring boot document [1] and another JBoss project infinispan [2], teiid developer has develop a Teiid Spring Boot Starter [3]. This PR is for **add a link to spring boot starter readme**.

[1] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-custom-starter
[2] https://github.com/infinispan/infinispan-spring-boot
[3] https://github.com/teiid/teiid-spring-boot