### PR TITLE
Adding AMQP 1.0 JMS feature using Qpid JMS as the client implementation

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -200,6 +200,17 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.qpid</groupId>
+			<artifactId>qpid-jms-client</artifactId>
+			<optional>true</optional>
+			<exclusions>
+				<exclusion>
+					<artifactId>geronimo-jms_2.0_spec</artifactId>
+					<groupId>org.apache.geronimo.specs</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-dbcp2</artifactId>
 			<optional>true</optional>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/amqp10/QpidJMSAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/amqp10/QpidJMSAutoConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms.amqp10;
+
+import javax.jms.ConnectionFactory;
+
+import org.apache.qpid.jms.JmsConnectionFactory;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.jms.JmsAutoConfiguration;
+import org.springframework.boot.autoconfigure.jms.JndiConnectionFactoryAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Auto Configuration class for Apache Qpid JMS.
+ *
+ * @author Timothy Bish
+ */
+@Configuration
+@AutoConfigureBefore(JmsAutoConfiguration.class)
+@AutoConfigureAfter({ JndiConnectionFactoryAutoConfiguration.class })
+@ConditionalOnClass({ ConnectionFactory.class, JmsConnectionFactory.class })
+@ConditionalOnMissingBean(ConnectionFactory.class)
+@EnableConfigurationProperties(QpidJMSProperties.class)
+@Import({ QpidJMSConnectionFactoryConfiguration.class })
+public class QpidJMSAutoConfiguration {
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/amqp10/QpidJMSConnectionFactoryConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/amqp10/QpidJMSConnectionFactoryConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms.amqp10;
+
+import javax.jms.ConnectionFactory;
+
+import org.apache.qpid.jms.JmsConnectionFactory;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Class that is responsible for creating and configuration the resulting Qpid JMS
+ * ConnectionFactory instance.
+ *
+ * @author Timothy Bish
+ */
+@Configuration
+@ConditionalOnMissingBean(ConnectionFactory.class)
+public class QpidJMSConnectionFactoryConfiguration {
+
+	@Bean
+	public JmsConnectionFactory jmsConnectionFactory(QpidJMSProperties properties) {
+		return new QpidJMSConnectionFactoryFactory(properties)
+				.createConnectionFactory(JmsConnectionFactory.class);
+	}
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/amqp10/QpidJMSConnectionFactoryFactory.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/amqp10/QpidJMSConnectionFactoryFactory.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms.amqp10;
+
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.apache.qpid.jms.policy.JmsDefaultDeserializationPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Factory of JmsConnectionFactory instances.
+ *
+ * @author Timothy Bish
+ */
+public class QpidJMSConnectionFactoryFactory {
+
+	private static final Logger LOG = LoggerFactory
+			.getLogger(QpidJMSConnectionFactoryFactory.class);
+
+	private static final String DEFAULT_REMOTE_URL = "amqp://localhost:5672";
+
+	private final QpidJMSProperties properties;
+
+	/**
+	 * Create a new factory instance with the given properties.
+	 *
+	 * @param properties the configuration properties to apply to newly created connections.
+	 */
+	public QpidJMSConnectionFactoryFactory(QpidJMSProperties properties) {
+		Assert.notNull(properties, "Properties must not be null");
+		this.properties = properties;
+	}
+
+	/**
+	 * Creates and returns a JmsConnectionFactory instance using the current configuration
+	 * to prepare the factory for use.
+	 *
+	 * @param factoryClass The type of JmsConnectionFactory to create.
+	 *
+	 * @return a newly created and configured JmsConnectionFactory instance.
+	 */
+	public JmsConnectionFactory createConnectionFactory(
+			Class<JmsConnectionFactory> factoryClass) {
+		try {
+			JmsConnectionFactory factory = new JmsConnectionFactory();
+
+			factory.setRemoteURI(getRemoteURI());
+
+			// Override the URI options with configuration values, but only if
+			// the value is actually set.
+
+			if (StringUtils.hasLength(this.properties.getUsername())) {
+				factory.setUsername(this.properties.getUsername());
+			}
+
+			if (StringUtils.hasLength(this.properties.getPassword())) {
+				factory.setPassword(this.properties.getPassword());
+			}
+
+			if (StringUtils.hasLength(this.properties.getClientId())) {
+				factory.setClientID(this.properties.getClientId());
+			}
+
+			if (this.properties.isReceiveLocalOnly() != null) {
+				factory.setReceiveLocalOnly(this.properties.isReceiveLocalOnly());
+			}
+
+			if (this.properties.isReceiveNoWaitLocalOnly() != null) {
+				factory.setReceiveNoWaitLocalOnly(this.properties.isReceiveNoWaitLocalOnly());
+			}
+
+			configureDeserializationPolicy(this.properties, factory);
+
+			return factory;
+		}
+		catch (Exception ex) {
+			LOG.error("Exception while createing Qpid JMS Connection Factory.", ex);
+			throw new IllegalStateException(
+					"Failed to create the Qpid JMS ConnectionFactory, "
+							+ "make sure the client Jar is on the Classpath.",
+					ex);
+		}
+	}
+
+	public String getRemoteURI() {
+		if (StringUtils.hasLength(this.properties.getRemoteURL())) {
+			return this.properties.getRemoteURL();
+		}
+		else {
+			return DEFAULT_REMOTE_URL;
+		}
+	}
+
+	private void configureDeserializationPolicy(QpidJMSProperties properties,
+			JmsConnectionFactory factory) {
+		JmsDefaultDeserializationPolicy deserializationPolicy = (JmsDefaultDeserializationPolicy) factory
+				.getDeserializationPolicy();
+
+		if (StringUtils.hasLength(properties.getDeserializationPolicy().getWhiteList())) {
+			deserializationPolicy
+					.setWhiteList(properties.getDeserializationPolicy().getWhiteList());
+		}
+
+		if (StringUtils.hasLength(properties.getDeserializationPolicy().getBlackList())) {
+			deserializationPolicy
+					.setBlackList(properties.getDeserializationPolicy().getBlackList());
+		}
+	}
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/amqp10/QpidJMSProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/amqp10/QpidJMSProperties.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms.amqp10;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Qpid JMS client.
+ *
+ * @author Timothy Bish
+ */
+@ConfigurationProperties(prefix = "spring.qpidjms")
+public class QpidJMSProperties {
+
+	private String remoteURL;
+	private String username;
+	private String password;
+	private String clientId;
+
+	private Boolean receiveLocalOnly;
+	private Boolean receiveNoWaitLocalOnly;
+
+	private final DeserializationPolicy deserializationPolicy = new DeserializationPolicy();
+
+	public String getRemoteURL() {
+		return this.remoteURL;
+	}
+
+	public void setRemoteURL(String remoteURL) {
+		this.remoteURL = remoteURL;
+	}
+
+	public String getUsername() {
+		return this.username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public String getPassword() {
+		return this.password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public String getClientId() {
+		return this.clientId;
+	}
+
+	public void setClientId(String clientId) {
+		this.clientId = clientId;
+	}
+
+	public Boolean isReceiveLocalOnly() {
+		return this.receiveLocalOnly;
+	}
+
+	public void setReceiveLocalOnly(Boolean receiveLocalOnly) {
+		this.receiveLocalOnly = receiveLocalOnly;
+	}
+
+	public Boolean isReceiveNoWaitLocalOnly() {
+		return this.receiveNoWaitLocalOnly;
+	}
+
+	public void setReceiveNoWaitLocalOnly(Boolean receiveNoWaitLocalOnly) {
+		this.receiveNoWaitLocalOnly = receiveNoWaitLocalOnly;
+	}
+
+	public DeserializationPolicy getDeserializationPolicy() {
+		return this.deserializationPolicy;
+	}
+
+	public static class DeserializationPolicy {
+
+		private String whiteList;
+		private String blackList;
+
+		public String getWhiteList() {
+			return this.whiteList;
+		}
+
+		public void setWhiteList(String whiteList) {
+			this.whiteList = whiteList;
+		}
+
+		public String getBlackList() {
+			return this.blackList;
+		}
+
+		public void setBlackList(String blackList) {
+			this.blackList = blackList;
+		}
+	}
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/amqp10/package-info.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/amqp10/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for an AMQP 1.0 JMS client using Qpid JMS.
+ *
+ * @author Timothy Bish
+ */
+package org.springframework.boot.autoconfigure.jms.amqp10;

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -75,6 +75,7 @@ org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration,\
 org.springframework.boot.autoconfigure.jms.JndiConnectionFactoryAutoConfiguration,\
 org.springframework.boot.autoconfigure.jms.activemq.ActiveMQAutoConfiguration,\
 org.springframework.boot.autoconfigure.jms.artemis.ArtemisAutoConfiguration,\
+org.springframework.boot.autoconfigure.jms.amqp10.QpidJMSAutoConfiguration,\
 org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration,\
 org.springframework.boot.autoconfigure.jersey.JerseyAutoConfiguration,\
 org.springframework.boot.autoconfigure.jooq.JooqAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/amqp10/QpidJMSAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/amqp10/QpidJMSAutoConfigurationTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms.amqp10;
+
+import javax.jms.ConnectionFactory;
+
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.junit.After;
+import org.junit.Test;
+
+import org.springframework.boot.autoconfigure.jms.JmsAutoConfiguration;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jms.core.JmsTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test that Qpid JMS Auto Configuration works.
+ *
+ * @author Timothy Bish
+ */
+public class QpidJMSAutoConfigurationTest {
+
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void tearDown() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void testDefaultsToLocalURI() {
+		load(EmptyConfiguration.class);
+
+		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
+		ConnectionFactory connectionFactory = this.context
+				.getBean(ConnectionFactory.class);
+
+		assertThat(connectionFactory instanceof JmsConnectionFactory).isTrue();
+
+		JmsConnectionFactory qpidJmsFactory = (JmsConnectionFactory) connectionFactory;
+
+		assertThat(jmsTemplate.getConnectionFactory()).isEqualTo(connectionFactory);
+		assertThat(qpidJmsFactory.getRemoteURI()).isEqualTo("amqp://localhost:5672");
+		assertThat(qpidJmsFactory.getUsername()).isNotNull();
+		assertThat(qpidJmsFactory.getPassword()).isNotNull();
+	}
+
+	@Test
+	public void testCustomConnectionFactorySettings() {
+		load(EmptyConfiguration.class, "spring.qpidjms.remoteURL=amqp://127.0.0.1:5672",
+				"spring.qpidjms.username=foo", "spring.qpidjms.password=bar");
+
+		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
+		JmsConnectionFactory connectionFactory = this.context
+				.getBean(JmsConnectionFactory.class);
+
+		assertThat(jmsTemplate.getConnectionFactory()).isEqualTo(connectionFactory);
+
+		assertThat(connectionFactory.getRemoteURI()).isEqualTo("amqp://127.0.0.1:5672");
+		assertThat(connectionFactory.getUsername()).isEqualTo("foo");
+		assertThat(connectionFactory.getPassword()).isEqualTo("bar");
+	}
+
+	@Test
+	public void testReceiveLocalOnlyOptionsAppliedFromEnv() {
+		load(EmptyConfiguration.class, "spring.qpidjms.receiveLocalOnly=true",
+				"spring.qpidjms.receiveNoWaitLocalOnly=true");
+
+		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
+		JmsConnectionFactory connectionFactory = this.context
+				.getBean(JmsConnectionFactory.class);
+
+		assertThat(jmsTemplate.getConnectionFactory()).isEqualTo(connectionFactory);
+
+		assertThat(connectionFactory.isReceiveLocalOnly()).isTrue();
+		assertThat(connectionFactory.isReceiveNoWaitLocalOnly()).isTrue();
+	}
+
+	@Test
+	public void testReceiveLocalOnlyOptionsAppliedFromEnvOverridesURI() {
+		load(EmptyConfiguration.class,
+				"spring.qpidjms.remoteURL=amqp://127.0.0.1:5672"
+						+ "?jms.receiveLocalOnly=false&jms.receiveNoWaitLocalOnly=false",
+				"spring.qpidjms.receiveLocalOnly=true",
+				"spring.qpidjms.receiveNoWaitLocalOnly=true");
+
+		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
+		JmsConnectionFactory connectionFactory = this.context
+				.getBean(JmsConnectionFactory.class);
+
+		assertThat(jmsTemplate.getConnectionFactory()).isEqualTo(connectionFactory);
+
+		assertThat(connectionFactory.isReceiveLocalOnly()).isTrue();
+		assertThat(connectionFactory.isReceiveNoWaitLocalOnly()).isTrue();
+	}
+
+	private void load(Class<?> config, String... environment) {
+		AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+		applicationContext.register(config);
+		applicationContext.register(QpidJMSAutoConfiguration.class,
+				JmsAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(applicationContext, environment);
+		applicationContext.refresh();
+		this.context = applicationContext;
+	}
+
+	@Configuration
+	static class EmptyConfiguration {
+	}
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/amqp10/QpidJMSPropertiesTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/amqp10/QpidJMSPropertiesTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms.amqp10;
+
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.apache.qpid.jms.policy.JmsDefaultDeserializationPolicy;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for Qpid JMS Properties object.
+ *
+ * @author Timothy Bish
+ */
+public class QpidJMSPropertiesTest {
+
+	private static final String DEFAULT_REMOTE_URI = "amqp://localhost:5672";
+
+	private final QpidJMSProperties properties = new QpidJMSProperties();
+
+	@Test
+	public void testDefaultURL() {
+		assertThat(new QpidJMSConnectionFactoryFactory(this.properties)
+				.getRemoteURI()).isEqualTo(DEFAULT_REMOTE_URI);
+	}
+
+	@Test
+	public void testWhiteListDefaultToEmpty() {
+		JmsConnectionFactory factory = new QpidJMSConnectionFactoryFactory(
+				this.properties).createConnectionFactory(JmsConnectionFactory.class);
+
+		JmsDefaultDeserializationPolicy policy = (JmsDefaultDeserializationPolicy) factory.getDeserializationPolicy();
+
+		assertThat(policy.getWhiteList().length()).isEqualTo(1);
+	}
+
+	@Test
+	public void testLocalOnlyReceiveOptions() {
+		this.properties.setReceiveLocalOnly(true);
+		this.properties.setReceiveNoWaitLocalOnly(true);
+
+		JmsConnectionFactory factory = new QpidJMSConnectionFactoryFactory(
+				this.properties).createConnectionFactory(JmsConnectionFactory.class);
+
+		assertThat(factory.isReceiveLocalOnly()).isTrue();
+		assertThat(factory.isReceiveNoWaitLocalOnly()).isTrue();
+	}
+
+	@Test
+	public void testBlackListDefaultToEmpty() {
+		JmsConnectionFactory factory = new QpidJMSConnectionFactoryFactory(
+				this.properties).createConnectionFactory(JmsConnectionFactory.class);
+
+		JmsDefaultDeserializationPolicy policy = (JmsDefaultDeserializationPolicy) factory.getDeserializationPolicy();
+
+		assertThat(policy.getBlackList().length()).isEqualTo(0);
+	}
+
+	@Test
+	public void testDeserializationPolicyValuesAreApplied() {
+		this.properties.getDeserializationPolicy().setWhiteList("org.apache.qpid.proton.*");
+		this.properties.getDeserializationPolicy().setBlackList("org.apache.activemq..*");
+
+		JmsConnectionFactory factory = new QpidJMSConnectionFactoryFactory(
+				this.properties).createConnectionFactory(JmsConnectionFactory.class);
+
+		JmsDefaultDeserializationPolicy policy = (JmsDefaultDeserializationPolicy) factory.getDeserializationPolicy();
+
+		assertThat(policy.getWhiteList()).isEqualTo("org.apache.qpid.proton.*");
+		assertThat(policy.getBlackList()).isEqualTo("org.apache.activemq..*");
+	}
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -138,6 +138,7 @@
 		<neo4j-ogm.version>3.0.0-M01</neo4j-ogm.version>
 		<netty.version>4.1.11.Final</netty.version>
 		<postgresql.version>42.1.1</postgresql.version>
+		<qpid-jms.version>0.23.0</qpid-jms.version>
 		<querydsl.version>4.1.4</querydsl.version>
 		<reactor-bom.version>Bismuth-M1</reactor-bom.version>
 		<rxjava.version>1.3.0</rxjava.version>
@@ -316,6 +317,11 @@
 				<artifactId>spring-boot-starter-amqp</artifactId>
 				<version>2.0.0.BUILD-SNAPSHOT</version>
 			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-amqp-1.0-jms</artifactId>
+				<version>2.0.0.BUILD-SNAPSHOT</version>
+			</dependency>			
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-aop</artifactId>
@@ -1250,6 +1256,11 @@
 				<version>${log4j2.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.qpid</groupId>
+				<artifactId>qpid-jms-client</artifactId>
+				<version>${qpid-jms.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.solr</groupId>

--- a/spring-boot-docs/pom.xml
+++ b/spring-boot-docs/pom.xml
@@ -299,6 +299,17 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.qpid</groupId>
+			<artifactId>qpid-jms-client</artifactId>
+			<optional>true</optional>
+			<exclusions>
+				<exclusion>
+					<artifactId>geronimo-jms_2.0_spec</artifactId>
+					<groupId>org.apache.geronimo.specs</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>		
+		<dependency>
 			<groupId>org.apache.activemq</groupId>
 			<artifactId>activemq-pool</artifactId>
 			<optional>true</optional>

--- a/spring-boot-samples/README.adoc
+++ b/spring-boot-samples/README.adoc
@@ -8,6 +8,9 @@ The following sample applications are provided:
 | link:spring-boot-sample-activemq[spring-boot-sample-activemq]
 | JMS consumer and producer using Apache ActiveMQ
 
+| link:spring-boot-sample-amqp-1.0-jms[spring-boot-sample-amqp-1.0-jms]
+| JMS consumer and producer using an AMQP 1.0 JMS client
+
 | link:spring-boot-sample-actuator[spring-boot-sample-actuator]
 | REST service with production-ready features
 

--- a/spring-boot-samples/pom.xml
+++ b/spring-boot-samples/pom.xml
@@ -28,6 +28,7 @@
 		<module>spring-boot-sample-actuator-noweb</module>
 		<module>spring-boot-sample-actuator-ui</module>
 		<module>spring-boot-sample-amqp</module>
+		<module>spring-boot-sample-amqp-1-0-jms</module>
 		<module>spring-boot-sample-aop</module>
 		<module>spring-boot-sample-atmosphere</module>
 		<module>spring-boot-sample-batch</module>

--- a/spring-boot-samples/spring-boot-sample-amqp-1-0-jms/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-amqp-1-0-jms/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<!-- Your own application should inherit from spring-boot-starter-parent -->
+		<artifactId>spring-boot-samples</artifactId>
+		<groupId>org.springframework.boot</groupId>
+		<version>2.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-sample-amqp-1-0-jms</artifactId>
+	<name>Spring Boot AMQP v1.0 over JMS Sample</name>
+	<description>Spring Boot AMQP v1.0 over JMS Sample</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<!-- Compile -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-amqp-1.0-jms</artifactId>
+		</dependency>
+		<!-- Test -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.activemq</groupId>
+			<artifactId>activemq-broker</artifactId>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>geronimo-jms_1.1_spec</artifactId>
+					<groupId>org.apache.geronimo.specs</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.activemq</groupId>
+			<artifactId>activemq-amqp</artifactId>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.qpid</groupId>
+					<artifactId>proton-j</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-samples/spring-boot-sample-amqp-1-0-jms/src/main/java/sample/amqp10/jms/AMQPConsumer.java
+++ b/spring-boot-samples/spring-boot-sample-amqp-1-0-jms/src/main/java/sample/amqp10/jms/AMQPConsumer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.amqp10.jms;
+
+import org.springframework.jms.annotation.JmsListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AMQPConsumer {
+
+	@JmsListener(destination = "sample.queue")
+	public void receiveQueue(String text) {
+		System.out.println("Received message with body:" + text);
+	}
+}

--- a/spring-boot-samples/spring-boot-sample-amqp-1-0-jms/src/main/java/sample/amqp10/jms/AMQPProducer.java
+++ b/spring-boot-samples/spring-boot-sample-amqp-1-0-jms/src/main/java/sample/amqp10/jms/AMQPProducer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.amqp10.jms;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.jms.core.JmsMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AMQPProducer implements CommandLineRunner {
+
+	@Autowired
+	private JmsMessagingTemplate jmsTemplate;
+
+	@Override
+	public void run(String... strings) throws Exception {
+		send("Sample message");
+		System.out.println("Message was sent to the Queue");
+	}
+
+	public void send(String msg) {
+		this.jmsTemplate.convertAndSend("sample.queue", msg);
+	}
+}

--- a/spring-boot-samples/spring-boot-sample-amqp-1-0-jms/src/main/java/sample/amqp10/jms/SampleAMQP10JMSApplication.java
+++ b/spring-boot-samples/spring-boot-sample-amqp-1-0-jms/src/main/java/sample/amqp10/jms/SampleAMQP10JMSApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.amqp10.jms;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.jms.annotation.EnableJms;
+
+/**
+ * Simple Hello World example that sends and receives a message using AMQP 1.0 mapped to
+ * JMS.
+ *
+ * @author Timothy Bish
+ */
+@SpringBootApplication
+@EnableJms
+public class SampleAMQP10JMSApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SampleAMQP10JMSApplication.class, args);
+	}
+}

--- a/spring-boot-samples/spring-boot-sample-amqp-1-0-jms/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-amqp-1-0-jms/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.qpidjms.remoteURL=amqp://127.0.0.1:5672

--- a/spring-boot-samples/spring-boot-sample-amqp-1-0-jms/src/test/java/sample/amqp10/jms/SampleAMQP10JMSTests.java
+++ b/spring-boot-samples/spring-boot-sample-amqp-1-0-jms/src/test/java/sample/amqp10/jms/SampleAMQP10JMSTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.amqp10.jms;
+
+import javax.jms.JMSException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import sample.amqp10.jms.AMQPProducer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for demo application of AMQP 1.0 JMS starter.
+ *
+ * @author Timothy Bish
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class SampleAMQP10JMSTests {
+
+	@Rule
+	public OutputCapture outputCapture = new OutputCapture();
+
+	@Autowired
+	private AMQPProducer producer;
+
+	@Test
+	public void sendSimpleMessage() throws InterruptedException, JMSException {
+		this.producer.send("Test message");
+		Thread.sleep(1000L);
+		assertThat(this.outputCapture.toString().contains("Test message")).isTrue();
+	}
+}

--- a/spring-boot-starters/pom.xml
+++ b/spring-boot-starters/pom.xml
@@ -23,6 +23,7 @@
 		<module>spring-boot-starter</module>
 		<module>spring-boot-starter-activemq</module>
 		<module>spring-boot-starter-amqp</module>
+		<module>spring-boot-starter-amqp-1.0-jms</module>
 		<module>spring-boot-starter-aop</module>
 		<module>spring-boot-starter-artemis</module>
 		<module>spring-boot-starter-batch</module>

--- a/spring-boot-starters/spring-boot-starter-amqp-1.0-jms/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-amqp-1.0-jms/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starters</artifactId>
+		<version>2.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-starter-amqp-1.0-jms</artifactId>
+	<name>Spring Boot AMQP 1.0 JMS Mapping Starter</name>
+	<description>Starter for JMS messaging using AMQP v1.0 via JMS Mappings</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-jms</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.qpid</groupId>
+			<artifactId>qpid-jms-client</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>geronimo-jms_2.0_spec</artifactId>
+					<groupId>org.apache.geronimo.specs</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>javax.jms</groupId>
+			<artifactId>javax.jms-api</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-boot-starters/spring-boot-starter-amqp-1.0-jms/src/main/resources/META-INF/spring.provides
+++ b/spring-boot-starters/spring-boot-starter-amqp-1.0-jms/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: qpid-jms-client,spring-jms


### PR DESCRIPTION
In order to allow quick ramp up of users wishing to perform messaging
activities against a broker or service that supports the ISO AMQP v1.0
standard the addition of a new set of modules that utilize the Qpid
JMS AMQP v1.0 client is made here.

Fixes gh-9313

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->