### PR TITLE
Adding responseTimeMs to actuator health indicators #9238

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeHealthIndicator.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.util.Assert;
+import org.springframework.util.StopWatch;
 
 /**
  * {@link HealthIndicator} that returns health indications from all registered delegates.
@@ -40,7 +41,7 @@ public class CompositeHealthIndicator implements HealthIndicator {
 	 * @param healthAggregator the health aggregator
 	 */
 	public CompositeHealthIndicator(HealthAggregator healthAggregator) {
-		this(healthAggregator, new LinkedHashMap<String, HealthIndicator>());
+		this(healthAggregator, new LinkedHashMap<>());
 	}
 
 	/**
@@ -63,11 +64,39 @@ public class CompositeHealthIndicator implements HealthIndicator {
 
 	@Override
 	public Health health() {
+		StopWatch stopWatch = new StopWatch();
+		stopWatch.start();
+
 		Map<String, Health> healths = new LinkedHashMap<>();
 		for (Map.Entry<String, HealthIndicator> entry : this.indicators.entrySet()) {
-			healths.put(entry.getKey(), entry.getValue().health());
+			healths.put(entry.getKey(), healthIndicatorWithResponseTime(entry.getValue()));
 		}
-		return this.healthAggregator.aggregate(healths);
+
+		Health aggregateHealths = this.healthAggregator.aggregate(healths);
+
+		stopWatch.stop();
+
+		return addResponseTimeMsToHealth(aggregateHealths, stopWatch);
 	}
 
+	private Health healthIndicatorWithResponseTime(HealthIndicator healthIndicator) {
+		StopWatch stopWatch = new StopWatch();
+		stopWatch.start();
+
+		Health health = healthIndicator.health();
+
+		stopWatch.stop();
+
+		return addResponseTimeMsToHealth(health, stopWatch);
+	}
+
+	private Health addResponseTimeMsToHealth(Health health, StopWatch stopWatch) {
+		if (health.getDetails().containsKey("responseTimeMs")) {
+			return health;
+		}
+
+		return new Health.Builder(health.getStatus(), health.getDetails())
+				.withDetail("responseTimeMs", stopWatch.getLastTaskTimeMillis())
+				.build();
+	}
 }

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeHealthIndicator.java
@@ -65,38 +65,40 @@ public class CompositeHealthIndicator implements HealthIndicator {
 	@Override
 	public Health health() {
 		StopWatch stopWatch = new StopWatch();
-		stopWatch.start();
+		stopWatch.setKeepTaskList(false);
 
 		Map<String, Health> healths = new LinkedHashMap<>();
+
 		for (Map.Entry<String, HealthIndicator> entry : this.indicators.entrySet()) {
-			healths.put(entry.getKey(), healthIndicatorWithResponseTime(entry.getValue()));
+			healths.put(entry.getKey(), healthIndicatorWithResponseTime(entry.getValue(), stopWatch));
 		}
+
+		stopWatch.start();
 
 		Health aggregateHealths = this.healthAggregator.aggregate(healths);
 
 		stopWatch.stop();
 
-		return addResponseTimeMsToHealth(aggregateHealths, stopWatch);
+		return addResponseTimeMsToHealth(aggregateHealths, stopWatch.getTotalTimeMillis());
 	}
 
-	private Health healthIndicatorWithResponseTime(HealthIndicator healthIndicator) {
-		StopWatch stopWatch = new StopWatch();
+	private Health healthIndicatorWithResponseTime(HealthIndicator healthIndicator, StopWatch stopWatch) {
 		stopWatch.start();
 
 		Health health = healthIndicator.health();
 
 		stopWatch.stop();
 
-		return addResponseTimeMsToHealth(health, stopWatch);
+		return addResponseTimeMsToHealth(health, stopWatch.getLastTaskTimeMillis());
 	}
 
-	private Health addResponseTimeMsToHealth(Health health, StopWatch stopWatch) {
+	private Health addResponseTimeMsToHealth(Health health, long responseTimeMs) {
 		if (health.getDetails().containsKey("responseTimeMs")) {
 			return health;
 		}
 
 		return new Health.Builder(health.getStatus(), health.getDetails())
-				.withDetail("responseTimeMs", stopWatch.getLastTaskTimeMillis())
+				.withDetail("responseTimeMs", responseTimeMs)
 				.build();
 	}
 }

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/HealthIndicatorAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/HealthIndicatorAutoConfigurationTests.java
@@ -244,7 +244,7 @@ public class HealthIndicatorAutoConfigurationTests {
 		HealthIndicator bean = beans.values().iterator().next();
 		assertThat(bean).isExactlyInstanceOf(CompositeHealthIndicator.class);
 		assertThat(bean.health().getDetails()).containsOnlyKeys("dataSource",
-				"testDataSource");
+				"testDataSource", "responseTimeMs");
 	}
 
 	@Test

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/NoSpringSecurityHealthMvcEndpointIntegrationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/NoSpringSecurityHealthMvcEndpointIntegrationTests.java
@@ -90,7 +90,7 @@ public class NoSpringSecurityHealthMvcEndpointIntegrationTests {
 		MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.context).build();
 		mockMvc.perform(get("/application/health")).andExpect(status().isOk())
 				.andExpect(content().string(containsString(
-						"\"status\":\"UP\",\"test\":{\"status\":\"UP\",\"hello\":\"world\"}")));
+						"\"status\":\"UP\",\"test\":{\"status\":\"UP\",\"hello\":\"world\",\"responseTimeMs\":1},\"responseTimeMs\":")));
 	}
 
 	private RequestPostProcessor getRequestPostProcessor() {
@@ -120,7 +120,9 @@ public class NoSpringSecurityHealthMvcEndpointIntegrationTests {
 
 				@Override
 				public Health health() {
-					return Health.up().withDetail("hello", "world").build();
+					return Health.up()
+							.withDetail("hello", "world")
+							.withDetail("responseTimeMs", 1).build();
 				}
 
 			};

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/CompositeHealthIndicatorTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/CompositeHealthIndicatorTests.java
@@ -52,11 +52,17 @@ public class CompositeHealthIndicatorTests {
 	public void setup() {
 		MockitoAnnotations.initMocks(this);
 		given(this.one.health())
-				.willReturn(new Health.Builder().unknown().withDetail("1", "1").build());
+				.willReturn(new Health.Builder().unknown()
+						.withDetail("1", "1")
+						.withDetail("responseTimeMs", 1L).build());
 		given(this.two.health())
-				.willReturn(new Health.Builder().unknown().withDetail("2", "2").build());
+				.willReturn(new Health.Builder().unknown()
+						.withDetail("2", "2")
+						.withDetail("responseTimeMs", 2L).build());
 		given(this.three.health())
-				.willReturn(new Health.Builder().unknown().withDetail("3", "3").build());
+				.willReturn(new Health.Builder().unknown()
+						.withDetail("3", "3")
+						.withDetail("responseTimeMs", 3L).build());
 
 		this.healthAggregator = new OrderedHealthAggregator();
 	}
@@ -69,11 +75,15 @@ public class CompositeHealthIndicatorTests {
 		CompositeHealthIndicator composite = new CompositeHealthIndicator(
 				this.healthAggregator, indicators);
 		Health result = composite.health();
-		assertThat(result.getDetails()).hasSize(2);
+		assertThat(result.getDetails()).hasSize(3);
 		assertThat(result.getDetails()).containsEntry("one",
-				new Health.Builder().unknown().withDetail("1", "1").build());
+				new Health.Builder().unknown()
+						.withDetail("1", "1")
+						.withDetail("responseTimeMs", 1L).build());
 		assertThat(result.getDetails()).containsEntry("two",
-				new Health.Builder().unknown().withDetail("2", "2").build());
+				new Health.Builder().unknown()
+						.withDetail("2", "2")
+						.withDetail("responseTimeMs", 2L).build());
 	}
 
 	@Test
@@ -85,13 +95,19 @@ public class CompositeHealthIndicatorTests {
 				this.healthAggregator, indicators);
 		composite.addHealthIndicator("three", this.three);
 		Health result = composite.health();
-		assertThat(result.getDetails()).hasSize(3);
+		assertThat(result.getDetails()).hasSize(4);
 		assertThat(result.getDetails()).containsEntry("one",
-				new Health.Builder().unknown().withDetail("1", "1").build());
+				new Health.Builder().unknown()
+						.withDetail("1", "1")
+						.withDetail("responseTimeMs", 1L).build());
 		assertThat(result.getDetails()).containsEntry("two",
-				new Health.Builder().unknown().withDetail("2", "2").build());
+				new Health.Builder().unknown()
+						.withDetail("2", "2")
+						.withDetail("responseTimeMs", 2L).build());
 		assertThat(result.getDetails()).containsEntry("three",
-				new Health.Builder().unknown().withDetail("3", "3").build());
+				new Health.Builder().unknown()
+						.withDetail("3", "3")
+						.withDetail("responseTimeMs", 3L).build());
 	}
 
 	@Test
@@ -101,11 +117,15 @@ public class CompositeHealthIndicatorTests {
 		composite.addHealthIndicator("one", this.one);
 		composite.addHealthIndicator("two", this.two);
 		Health result = composite.health();
-		assertThat(result.getDetails().size()).isEqualTo(2);
+		assertThat(result.getDetails().size()).isEqualTo(3);
 		assertThat(result.getDetails()).containsEntry("one",
-				new Health.Builder().unknown().withDetail("1", "1").build());
+				new Health.Builder().unknown()
+						.withDetail("1", "1")
+						.withDetail("responseTimeMs", 1L).build());
 		assertThat(result.getDetails()).containsEntry("two",
-				new Health.Builder().unknown().withDetail("2", "2").build());
+				new Health.Builder().unknown()
+						.withDetail("2", "2")
+						.withDetail("responseTimeMs", 2L).build());
 	}
 
 	@Test
@@ -121,9 +141,10 @@ public class CompositeHealthIndicatorTests {
 		Health result = composite.health();
 		ObjectMapper mapper = new ObjectMapper();
 		assertThat(mapper.writeValueAsString(result))
-				.isEqualTo("{\"status\":\"UNKNOWN\",\"db\":{\"status\":\"UNKNOWN\""
-						+ ",\"db1\":{\"status\":\"UNKNOWN\",\"1\":\"1\"},"
-						+ "\"db2\":{\"status\":\"UNKNOWN\",\"2\":\"2\"}}}");
+				.containsPattern("\\{\"status\":\"UNKNOWN\",\"db\":\\{\"status\":\"UNKNOWN\"," +
+						"\"db1\":\\{\"status\":\"UNKNOWN\",\"1\":\"1\",\"responseTimeMs\":\\d+\\}," +
+						"\"db2\":\\{\"status\":\"UNKNOWN\",\"2\":\"2\",\"responseTimeMs\":\\d+\\}," +
+						"\"responseTimeMs\":\\d+\\}");
 	}
 
 }


### PR DESCRIPTION
Adds responseTimeMs detail to all health indicators as well as the
aggregate for an overall response time.

Fixes gh-9238