### PR TITLE
Add Spring Data Web configuration properties

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/web/SpringDataWebProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/web/SpringDataWebProperties.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.web;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Spring Data Web.
+ *
+ * @author Vedran Pavic
+ * @since 2.0.0
+ */
+@ConfigurationProperties("spring.data.web")
+public class SpringDataWebProperties {
+
+	private final Pageable pageable = new Pageable();
+
+	private final Sort sort = new Sort();
+
+	public Pageable getPageable() {
+		return this.pageable;
+	}
+
+	public Sort getSort() {
+		return this.sort;
+	}
+
+	/**
+	 * Pageable properties.
+	 */
+	public static class Pageable {
+
+		/**
+		 * Page index parameter name.
+		 */
+		private String pageParameter = "page";
+
+		/**
+		 * Page size parameter name.
+		 */
+		private String sizeParameter = "size";
+
+		/**
+		 * Default page size.
+		 */
+		private int defaultPageSize = 20;
+
+		public String getPageParameter() {
+			return this.pageParameter;
+		}
+
+		public void setPageParameter(String pageParameter) {
+			this.pageParameter = pageParameter;
+		}
+
+		public String getSizeParameter() {
+			return this.sizeParameter;
+		}
+
+		public void setSizeParameter(String sizeParameter) {
+			this.sizeParameter = sizeParameter;
+		}
+
+		public int getDefaultPageSize() {
+			return this.defaultPageSize;
+		}
+
+		public void setDefaultPageSize(int defaultPageSize) {
+			this.defaultPageSize = defaultPageSize;
+		}
+	}
+
+	/**
+	 * Sort properties.
+	 */
+	public static class Sort {
+
+		/**
+		 * Sort parameter name.
+		 */
+		private String sortParameter = "sort";
+
+		public String getSortParameter() {
+			return this.sortParameter;
+		}
+
+		public void setSortParameter(String sortParameter) {
+			this.sortParameter = sortParameter;
+		}
+
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/web/SpringDataWebAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/web/SpringDataWebAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,14 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Test;
 
+import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.SortHandlerMethodArgumentResolver;
 import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link SpringDataWebAutoConfiguration}.
  *
  * @author Andy Wilkinson
+ * @author Vedran Pavic
  */
 public class SpringDataWebAutoConfigurationTests {
 
@@ -67,6 +72,41 @@ public class SpringDataWebAutoConfigurationTests {
 		Map<String, PageableHandlerMethodArgumentResolver> beans = this.context
 				.getBeansOfType(PageableHandlerMethodArgumentResolver.class);
 		assertThat(beans).isEmpty();
+	}
+
+	@Test
+	public void pageable() {
+		this.context = new AnnotationConfigWebApplicationContext();
+		TestPropertyValues
+				.of("spring.data.web.pageable.page-parameter=p",
+						"spring.data.web.pageable.size-parameter=s",
+						"spring.data.web.pageable.default-page-size=10")
+				.applyTo(this.context);
+		((AnnotationConfigWebApplicationContext) this.context)
+				.register(SpringDataWebAutoConfiguration.class);
+		this.context.refresh();
+		PageableHandlerMethodArgumentResolver argumentResolver = this.context
+				.getBean(PageableHandlerMethodArgumentResolver.class);
+		assertThat(ReflectionTestUtils.getField(argumentResolver, "pageParameterName"))
+				.isEqualTo("p");
+		assertThat(ReflectionTestUtils.getField(argumentResolver, "sizeParameterName"))
+				.isEqualTo("s");
+		assertThat(ReflectionTestUtils.getField(argumentResolver, "fallbackPageable"))
+				.isEqualTo(PageRequest.of(0, 10));
+	}
+
+	@Test
+	public void sort() {
+		this.context = new AnnotationConfigWebApplicationContext();
+		TestPropertyValues.of("spring.data.web.sort.sort-parameter=s")
+				.applyTo(this.context);
+		((AnnotationConfigWebApplicationContext) this.context)
+				.register(SpringDataWebAutoConfiguration.class);
+		this.context.refresh();
+		SortHandlerMethodArgumentResolver argumentResolver = this.context
+				.getBean(SortHandlerMethodArgumentResolver.class);
+		assertThat(ReflectionTestUtils.getField(argumentResolver, "sortParameter"))
+				.isEqualTo("s");
 	}
 
 }

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -652,6 +652,12 @@ content into your application; rather pick only the properties that you need.
 	spring.data.solr.repositories.enabled=true # Enable Solr repositories.
 	spring.data.solr.zk-host= # ZooKeeper host address in the form HOST:PORT.
 
+	# DATA WEB ({sc-spring-boot-autoconfigure}/data/web/SpringDataWebProperties.{sc-ext}[SpringDataWebProperties])
+	spring.data.web.pageable.default-page-size=20 # Default page size.
+	spring.data.web.pageable.page-parameter=page # Page index parameter name.
+	spring.data.web.pageable.size-parameter=size # Page size parameter name.
+	spring.data.web.sort.sort-parameter=sort # Sort parameter name.
+
 	# DATASOURCE ({sc-spring-boot-autoconfigure}/jdbc/DataSourceAutoConfiguration.{sc-ext}[DataSourceAutoConfiguration] & {sc-spring-boot-autoconfigure}/jdbc/DataSourceProperties.{sc-ext}[DataSourceProperties])
 	spring.datasource.continue-on-error=false # Do not stop if an error occurs while initializing the database.
 	spring.datasource.data= # Data (DML) script resource references.


### PR DESCRIPTION
This PR adds support for configuring Spring Data Web `PageableHandlerMethodArgumentResolver` and `SortHandlerMethodArgumentResolver` using configuration properties.

The exposed configuration properties are default page size, pageable index and size parameters names and sort parameter name.

This resolves #7775.