### PR TITLE
Replace `WebMvcRegistrationsAdapter` with default methods

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcRegistrations.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcRegistrations.java
@@ -40,20 +40,26 @@ public interface WebMvcRegistrations {
 	 * processed by the MVC configuration.
 	 * @return the custom {@link RequestMappingHandlerMapping} instance
 	 */
-	RequestMappingHandlerMapping getRequestMappingHandlerMapping();
+	default RequestMappingHandlerMapping getRequestMappingHandlerMapping() {
+		return null;
+	}
 
 	/**
 	 * Return the custom {@link RequestMappingHandlerAdapter} that should be used and
 	 * processed by the MVC configuration.
 	 * @return the custom {@link RequestMappingHandlerAdapter} instance
 	 */
-	RequestMappingHandlerAdapter getRequestMappingHandlerAdapter();
+	default RequestMappingHandlerAdapter getRequestMappingHandlerAdapter() {
+		return null;
+	}
 
 	/**
 	 * Return the custom {@link ExceptionHandlerExceptionResolver} that should be used and
 	 * processed by the MVC configuration.
 	 * @return the custom {@link ExceptionHandlerExceptionResolver} instance
 	 */
-	ExceptionHandlerExceptionResolver getExceptionHandlerExceptionResolver();
+	default ExceptionHandlerExceptionResolver getExceptionHandlerExceptionResolver() {
+		return null;
+	}
 
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcRegistrationsAdapter.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcRegistrationsAdapter.java
@@ -16,32 +16,16 @@
 
 package org.springframework.boot.autoconfigure.web.servlet;
 
-import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
-
 /**
  * An implementation of {@link WebMvcRegistrations} with empty methods allowing
  * sub-classes to override only the methods they're interested in.
  *
  * @author Brian Clozel
  * @since 1.4.0
+ * @deprecated as of 2.0.0 {@link WebMvcRegistrations} has default methods (made possible
+ * by a Java 8 baseline) and can be implemented directly without the need for this adapter
  */
+@Deprecated
 public class WebMvcRegistrationsAdapter implements WebMvcRegistrations {
-
-	@Override
-	public RequestMappingHandlerMapping getRequestMappingHandlerMapping() {
-		return null;
-	}
-
-	@Override
-	public RequestMappingHandlerAdapter getRequestMappingHandlerAdapter() {
-		return null;
-	}
-
-	@Override
-	public ExceptionHandlerExceptionResolver getExceptionHandlerExceptionResolver() {
-		return null;
-	}
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
@@ -899,8 +899,8 @@ public class WebMvcAutoConfigurationTests {
 	static class CustomRequestMappingHandlerMapping {
 
 		@Bean
-		public WebMvcRegistrationsAdapter webMvcRegistrationsHandlerMapping() {
-			return new WebMvcRegistrationsAdapter() {
+		public WebMvcRegistrations webMvcRegistrationsHandlerMapping() {
+			return new WebMvcRegistrations() {
 
 				@Override
 				public RequestMappingHandlerMapping getRequestMappingHandlerMapping() {
@@ -921,8 +921,8 @@ public class WebMvcAutoConfigurationTests {
 	static class CustomRequestMappingHandlerAdapter {
 
 		@Bean
-		public WebMvcRegistrationsAdapter webMvcRegistrationsHandlerAdapter() {
-			return new WebMvcRegistrationsAdapter() {
+		public WebMvcRegistrations webMvcRegistrationsHandlerAdapter() {
+			return new WebMvcRegistrations() {
 
 				@Override
 				public RequestMappingHandlerAdapter getRequestMappingHandlerAdapter() {


### PR DESCRIPTION
This was largely inspired by changes to Spring MVC's `WebMvcConfigurer` in 5.0.