### PR TITLE
Allow customization of MongoClientSettings.Builder

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoClientSettingsBuilderCustomizer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoClientSettingsBuilderCustomizer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.mongo;
+
+import com.mongodb.async.client.MongoClientSettings.Builder;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize the
+ * {@link com.mongodb.async.client.MongoClientSettings} via a {@link Builder
+ * MongoClientSettings.Builder} whilst retaining default auto-configuration.
+ *
+ * @author Mark Paluch
+ * @since 2.0.0
+ */
+@FunctionalInterface
+public interface MongoClientSettingsBuilderCustomizer {
+
+	/**
+	 * Customize the {@link Builder}.
+	 * @param clusterBuilder the builder to customize
+	 */
+	void customize(Builder clusterBuilder);
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoClientSettingsBuilderCustomizer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoClientSettingsBuilderCustomizer.java
@@ -31,8 +31,8 @@ public interface MongoClientSettingsBuilderCustomizer {
 
 	/**
 	 * Customize the {@link Builder}.
-	 * @param clusterBuilder the builder to customize
+	 * @param settingsBuilder the builder to customize
 	 */
-	void customize(Builder clusterBuilder);
+	void customize(Builder settingsBuilder);
 
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.autoconfigure.mongo;
 
+import java.util.List;
+
 import javax.annotation.PreDestroy;
 
 import com.mongodb.async.client.MongoClientSettings;
@@ -49,9 +51,11 @@ public class MongoReactiveAutoConfiguration {
 	private MongoClient mongo;
 
 	public MongoReactiveAutoConfiguration(MongoProperties properties,
-			ObjectProvider<MongoClientSettings> settings, Environment environment) {
+			ObjectProvider<MongoClientSettings> settings, Environment environment,
+			ObjectProvider<List<MongoClientSettingsBuilderCustomizer>> builderCustomizers) {
 		this.settings = settings.getIfAvailable();
-		this.factory = new ReactiveMongoClientFactory(properties, environment);
+		this.factory = new ReactiveMongoClientFactory(properties, environment,
+				builderCustomizers.getIfAvailable());
 	}
 
 	@PreDestroy

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactory.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactory.java
@@ -48,10 +48,13 @@ public class ReactiveMongoClientFactory {
 
 	private final Environment environment;
 
-	public ReactiveMongoClientFactory(MongoProperties properties,
-			Environment environment) {
+	private final List<MongoClientSettingsBuilderCustomizer> builderCustomizers;
+
+	public ReactiveMongoClientFactory(MongoProperties properties, Environment environment,
+			List<MongoClientSettingsBuilderCustomizer> builderCustomizers) {
 		this.properties = properties;
 		this.environment = environment;
+		this.builderCustomizers = builderCustomizers;
 	}
 
 	/**
@@ -149,7 +152,16 @@ public class ReactiveMongoClientFactory {
 		if (connectionString.getApplicationName() != null) {
 			builder.applicationName(connectionString.getApplicationName());
 		}
+		customize(builder);
 		return builder;
+	}
+
+	private void customize(MongoClientSettings.Builder builder) {
+		if (this.builderCustomizers != null) {
+			for (MongoClientSettingsBuilderCustomizer customizer : this.builderCustomizers) {
+				customizer.customize(builder);
+			}
+		}
 	}
 
 	private boolean hasCustomAddress() {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveAutoConfigurationTests.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.mongodb.ReadPreference;
 import com.mongodb.async.client.MongoClientSettings;
+import com.mongodb.async.client.MongoClientSettings.Builder;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.StreamFactory;
 import com.mongodb.connection.StreamFactoryFactory;
@@ -37,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link MongoReactiveAutoConfiguration}.
@@ -107,18 +109,18 @@ public class MongoReactiveAutoConfigurationTests {
 	}
 
 	@Test
-	public void createCustomize() {
+	public void customizerGetsInvoked() {
 		this.context = new AnnotationConfigApplicationContext();
-		TestPropertyValues.of("spring.data.mongodb.uri:mongodb://localhost/test")
-				.applyTo(this.context);
+		TestPropertyValues.of(
+				"spring.data.mongodb.uri:mongodb://localhost/test").applyTo(this.context);
 		this.context.register(PropertyPlaceholderAutoConfiguration.class,
 				MongoReactiveAutoConfiguration.class, MockCustomizerConfig.class);
 		this.context.refresh();
 		assertThat(this.context.getBeanNamesForType(MongoClient.class).length)
 				.isEqualTo(1);
-		assertThat(this.context
-				.getBeanNamesForType(MongoClientSettingsBuilderCustomizer.class).length)
-						.isEqualTo(1);
+		MongoClientSettingsBuilderCustomizer customizer = this.context
+				.getBean(MongoClientSettingsBuilderCustomizer.class);
+		verify(customizer).customize(any(Builder.class));
 	}
 
 	@Test

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactoryTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactoryTests.java
@@ -154,7 +154,7 @@ public class ReactiveMongoClientFactoryTests {
 
 	private MongoClient createMongoClient(MongoProperties properties,
 			Environment environment) {
-		return new ReactiveMongoClientFactory(properties, environment)
+		return new ReactiveMongoClientFactory(properties, environment, null)
 				.createMongoClient(null);
 	}
 


### PR DESCRIPTION
`MongoClientSettingsBuilderCustomizer` allows customization of `MongoClientSettings.Builder` while retaining default auto-configuration.