### PR TITLE
Add @JooqTest support

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -5765,6 +5765,41 @@ A list of the auto-configuration that is enabled by `@JdbcTest` can be
 
 
 
+[[boot-features-testing-spring-boot-applications-testing-autoconfigured-jooq-test]]
+==== Auto-configured jOOQ tests
+`@JooqTest` is similar to `@JdbcTest` but for jOOQ related tests. By default it
+will configure an in-memory embedded database and a `DSLContext`. Regular
+`@Component` beans will not be loaded into the `ApplicationContext`:
+
+[source,java,indent=0]
+----
+	import org.jooq.DSLContext;
+	import org.junit.Test;
+	import org.junit.runner.RunWith;
+	import org.springframework.boot.test.autoconfigure.jooq.JooqTest;
+	import org.springframework.test.context.junit4.SpringRunner;
+	
+	@RunWith(SpringRunner.class)
+	@JooqTest
+	public class ExampleNonTransactionalTests {
+		@Autowired
+		DSLContext create;
+	}
+----
+
+JOOQ tests are also transactional and rollback at the end of each test by default. 
+If that's not what you want, you can disable transaction management for a test or for 
+the whole as shown with 
+<<boot-features-testing-spring-boot-applications-testing-autoconfigured-jdbc-test,`@JdbcTest`>>
+
+If you prefer your test to run against a real database, you can use the
+`@AutoConfigureTestDatabase` annotation the same way as for `JdbcTest` or `DataJpaTest`.
+
+A list of the auto-configuration that is enabled by `@JooqTest` can be
+<<appendix-test-auto-configuration#test-auto-configuration,found in the appendix>>.
+
+
+
 [[boot-features-testing-spring-boot-applications-testing-autoconfigured-mongo-test]]
 ==== Auto-configured Data MongoDB tests
 `@DataMongoTest` can be used if you want to test MongoDB applications. By default, it will

--- a/spring-boot-test-autoconfigure/pom.xml
+++ b/spring-boot-test-autoconfigure/pom.xml
@@ -227,5 +227,10 @@
 			<artifactId>de.flapdoodle.embed.mongo</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.jooq</groupId>
+			<artifactId>jooq</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jooq/AutoConfigureJooq.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jooq/AutoConfigureJooq.java
@@ -30,7 +30,7 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
  * annotation directly.
  *
  * @author Michael Simons
- * @since 1.5.x
+ * @since 2.0.0
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jooq/AutoConfigureJooq.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jooq/AutoConfigureJooq.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.jooq;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+
+/**
+ * {@link ImportAutoConfiguration Auto-configuration imports} for typical jOOQ tests. Most
+ * tests should consider using {@link JooqTest @JooqTest} rather than using this
+ * annotation directly.
+ *
+ * @author Michael Simons
+ * @since 1.5.x
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ImportAutoConfiguration
+public @interface AutoConfigureJooq {
+
+}

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jooq/JooqTest.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jooq/JooqTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.jooq;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Annotation that can be used in combination with {@code @RunWith(SpringRunner.class)}
+ * for a typical jOOQ test. Can be used when a test focuses <strong>only</strong> on
+ * jOOQ-based components.
+ * <p>
+ * Using this annotation will disable full auto-configuration and instead apply only
+ * configuration relevant to jOOQ tests.
+ * <p>
+ * By default, tests annotated with {@code @JooqTest} will use an embedded in-memory
+ * database (replacing any explicit or usually auto-configured DataSource). Since
+ * jOOQ relies heavily on a Java-based schema that corresponds with the database schema,
+ * that is propably not what you want. The
+ * {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase} annotation can be used
+ * to override these settings.
+ *
+ * @author Michael Simons
+ * @since 1.5.x
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@BootstrapWith(SpringBootTestContextBootstrapper.class)
+@OverrideAutoConfiguration(enabled = false)
+@TypeExcludeFilters(JooqTypeExcludeFilter.class)
+@Transactional
+@AutoConfigureJooq
+@AutoConfigureTestDatabase
+@ImportAutoConfiguration
+public @interface JooqTest {
+	/**
+	 * Determines if default filtering should be used with
+	 * {@link SpringBootApplication @SpringBootApplication}. By default no beans are
+	 * included.
+	 * @see #includeFilters()
+	 * @see #excludeFilters()
+	 * @return if default filters should be used
+	 */
+	boolean useDefaultFilters() default true;
+
+	/**
+	 * A set of include filters which can be used to add otherwise filtered beans to the
+	 * application context.
+	 * @return include filters to apply
+	 */
+	Filter[] includeFilters() default {};
+
+	/**
+	 * A set of exclude filters which can be used to filter beans that would otherwise be
+	 * added to the application context.
+	 * @return exclude filters to apply
+	 */
+	Filter[] excludeFilters() default {};
+
+	/**
+	 * Auto-configuration exclusions that should be applied for this test.
+	 * @return auto-configuration exclusions to apply
+	 */
+	@AliasFor(annotation = ImportAutoConfiguration.class, attribute = "exclude")
+	Class<?>[] excludeAutoConfiguration() default {};
+}

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jooq/JooqTest.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jooq/JooqTest.java
@@ -50,7 +50,7 @@ import org.springframework.transaction.annotation.Transactional;
  * to override these settings.
  *
  * @author Michael Simons
- * @since 1.5.x
+ * @since 2.0.0
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jooq/JooqTypeExcludeFilter.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jooq/JooqTypeExcludeFilter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.jooq;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.springframework.boot.context.TypeExcludeFilter;
+import org.springframework.boot.test.autoconfigure.filter.AnnotationCustomizableTypeExcludeFilter;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+
+/**
+ * {@link TypeExcludeFilter} for {@link JooqTest @JooqTest}.
+ *
+ * @author Michael Simons
+ */
+class JooqTypeExcludeFilter extends AnnotationCustomizableTypeExcludeFilter {
+
+	private final JooqTest annotation;
+
+	JooqTypeExcludeFilter(Class<?> testClass) {
+		this.annotation = AnnotatedElementUtils.getMergedAnnotation(testClass,
+				JooqTest.class);
+	}
+
+	@Override
+	protected boolean hasAnnotation() {
+		return this.annotation != null;
+	}
+
+	@Override
+	protected Filter[] getFilters(final FilterType type) {
+		switch (type) {
+		case INCLUDE:
+			return this.annotation.includeFilters();
+		case EXCLUDE:
+			return this.annotation.excludeFilters();
+		default:
+			throw new IllegalStateException("Unsupported type " + type);
+		}
+	}
+
+	@Override
+	protected boolean isUseDefaultFilters() {
+		return this.annotation.useDefaultFilters();
+	}
+
+	@Override
+	protected Set<Class<?>> getDefaultIncludes() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	protected Set<Class<?>> getComponentIncludes() {
+		return Collections.emptySet();
+	}
+
+}

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jooq/package-info.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jooq/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for jOOQ tests.
+ */
+package org.springframework.boot.test.autoconfigure.jooq;

--- a/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -45,7 +45,7 @@ org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration,\
 org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration,\
 org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration
 
-# AutoConfigureJooqc auto-configuration imports
+# AutoConfigureJooq auto-configuration imports
 org.springframework.boot.test.autoconfigure.jooq.AutoConfigureJooq=\
 org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration,\
 org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,\

--- a/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -45,6 +45,15 @@ org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration,\
 org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration,\
 org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration
 
+# AutoConfigureJooqc auto-configuration imports
+org.springframework.boot.test.autoconfigure.jooq.AutoConfigureJooq=\
+org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration,\
+org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,\
+org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration,\
+org.springframework.boot.autoconfigure.jooq.JooqAutoConfiguration,\
+org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration,\
+org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration
+
 # AutoConfigureTestDatabase auto-configuration imports
 org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase=\
 org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration,\

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jooq/ExampleJooqApplication.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jooq/ExampleJooqApplication.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.jooq;
+
+import javax.sql.DataSource;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+
+/**
+ * Example {@link SpringBootApplication} used with {@link JooqTest} tests.
+ *
+ * @author Michael Simons
+ */
+@SpringBootApplication
+public class ExampleJooqApplication {
+
+	@Bean
+	public DataSource dataSource() {
+		EmbeddedDatabaseBuilder builder = new EmbeddedDatabaseBuilder()
+				.generateUniqueName(true).setType(EmbeddedDatabaseType.HSQL);
+		return builder.build();
+	}
+
+}

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jooq/JooqTestIntegrationTests.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jooq/JooqTestIntegrationTests.java
@@ -19,7 +19,6 @@ package org.springframework.boot.test.autoconfigure.jooq;
 import javax.sql.DataSource;
 
 import org.jooq.DSLContext;
-import org.jooq.SQLDialect;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -31,7 +30,6 @@ import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.orm.jpa.ExampleComponent;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,7 +41,6 @@ import static org.springframework.boot.test.autoconfigure.AutoConfigurationImpor
  */
 @RunWith(SpringRunner.class)
 @JooqTest
-@TestPropertySource(properties = "spring.jooq.sql-dialect = H2")
 public class JooqTestIntegrationTests {
 
 	@Rule
@@ -60,7 +57,6 @@ public class JooqTestIntegrationTests {
 
 	@Test
 	public void testDSLContext() {
-		assertThat(this.dsl.configuration().dialect()).isEqualTo(SQLDialect.H2);
 		assertThat(this.dsl.selectCount().from("INFORMATION_SCHEMA.TABLES").fetchOne(0, Integer.class)).isGreaterThan(0);
 	}
 

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jooq/JooqTestIntegrationTests.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jooq/JooqTestIntegrationTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.jooq;
+
+import javax.sql.DataSource;
+
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.orm.jpa.ExampleComponent;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.autoconfigure.AutoConfigurationImportedCondition.importedAutoConfiguration;
+
+/**
+ *
+ * @author Michael Simons
+ */
+@RunWith(SpringRunner.class)
+@JooqTest
+@TestPropertySource(properties = "spring.jooq.sql-dialect = H2")
+public class JooqTestIntegrationTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Autowired
+	private DSLContext dsl;
+
+	@Autowired
+	private DataSource dataSource;
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Test
+	public void testDSLContext() {
+		assertThat(this.dsl.configuration().dialect()).isEqualTo(SQLDialect.H2);
+		assertThat(this.dsl.selectCount().from("INFORMATION_SCHEMA.TABLES").fetchOne(0, Integer.class)).isGreaterThan(0);
+	}
+
+	@Test
+	public void replacesDefinedDataSourceWithEmbeddedDefault() throws Exception {
+		String product = this.dataSource.getConnection().getMetaData()
+				.getDatabaseProductName();
+		assertThat(product).isEqualTo("H2");
+	}
+
+	@Test
+	public void didNotInjectExampleComponent() throws Exception {
+		this.thrown.expect(NoSuchBeanDefinitionException.class);
+		this.applicationContext.getBean(ExampleComponent.class);
+	}
+
+	@Test
+	public void flywayAutoConfigurationWasImported() {
+		assertThat(this.applicationContext)
+				.has(importedAutoConfiguration(FlywayAutoConfiguration.class));
+	}
+
+	@Test
+	public void liquibaseAutoConfigurationWasImported() {
+		assertThat(this.applicationContext)
+				.has(importedAutoConfiguration(LiquibaseAutoConfiguration.class));
+	}
+}

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jooq/JooqTestIntegrationTests.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jooq/JooqTestIntegrationTests.java
@@ -19,6 +19,7 @@ package org.springframework.boot.test.autoconfigure.jooq;
 import javax.sql.DataSource;
 
 import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -65,6 +66,7 @@ public class JooqTestIntegrationTests {
 		String product = this.dataSource.getConnection().getMetaData()
 				.getDatabaseProductName();
 		assertThat(product).isEqualTo("H2");
+		assertThat(this.dsl.configuration().dialect()).isEqualTo(SQLDialect.H2);
 	}
 
 	@Test


### PR DESCRIPTION
This PR introduces the `@JooqTest` annotation.

See #8544.

If you think those slices are getting out of hand and this PR is closed, I'd understand it, but the annotation would be very useful as you meaningful testing of jOOQ generated queries is only possible in integration scenarios. I'd even thought if it would be a good idea not replacing the default database with that one here.