### PR TITLE
Add a missing 'io.spring.dependency-management' in doc

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-boot-docs/src/main/asciidoc/getting-started.adoc
@@ -224,6 +224,7 @@ ifeval::["{spring-boot-repo}" != "release"]
 
 	apply plugin: 'java'
 	apply plugin: 'org.springframework.boot'
+	apply plugin: 'io.spring.dependency-management'
 
 endif::[]
 	jar {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR adds a missing `apply plugin: 'io.spring.dependency-management'` to the sample `build.gradle` in the reference document.