### PR TITLE
Auto-detect jOOQ dialect

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  * {@link EnableAutoConfiguration Auto-configuration} for JOOQ.
  *
  * @author Andreas Ahlenstorf
+ * @author Michael Simons
  * @since 1.3.0
  */
 @Configuration
@@ -85,6 +86,8 @@ public class JooqAutoConfiguration {
 
 		private final ConnectionProvider connection;
 
+		private final DataSource dataSource;
+
 		private final TransactionProvider transactionProvider;
 
 		private final RecordMapperProvider recordMapperProvider;
@@ -99,6 +102,7 @@ public class JooqAutoConfiguration {
 
 		public DslContextConfiguration(JooqProperties properties,
 				ConnectionProvider connectionProvider,
+				DataSource dataSource,
 				ObjectProvider<TransactionProvider> transactionProvider,
 				ObjectProvider<RecordMapperProvider> recordMapperProvider,
 				ObjectProvider<Settings> settings,
@@ -107,6 +111,7 @@ public class JooqAutoConfiguration {
 				ObjectProvider<VisitListenerProvider[]> visitListenerProviders) {
 			this.properties = properties;
 			this.connection = connectionProvider;
+			this.dataSource = dataSource;
 			this.transactionProvider = transactionProvider.getIfAvailable();
 			this.recordMapperProvider = recordMapperProvider.getIfAvailable();
 			this.settings = settings.getIfAvailable();
@@ -124,9 +129,7 @@ public class JooqAutoConfiguration {
 		@ConditionalOnMissingBean(org.jooq.Configuration.class)
 		public DefaultConfiguration jooqConfiguration() {
 			DefaultConfiguration configuration = new DefaultConfiguration();
-			if (this.properties.getSqlDialect() != null) {
-				configuration.set(this.properties.getSqlDialect());
-			}
+			configuration.set(this.properties.determineSqlDialect(this.dataSource));
 			configuration.set(this.connection);
 			if (this.transactionProvider != null) {
 				configuration.set(this.transactionProvider);

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqProperties.java
@@ -34,8 +34,7 @@ public class JooqProperties {
 
 	/**
 	 * SQLDialect JOOQ used when communicating with the configured datasource, for
-	 * instance "POSTGRES". Please note the enum valus differ slightly from the ones
-	 * used by <code>spring.jpa</code>.
+	 * instance "POSTGRES".
 	 */
 	private SQLDialect sqlDialect;
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.autoconfigure.jooq;
 
+import javax.sql.DataSource;
+
 import org.jooq.SQLDialect;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -24,6 +26,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Configuration properties for the JOOQ database library.
  *
  * @author Andreas Ahlenstorf
+ * @author Michael Simons
  * @since 1.3.0
  */
 @ConfigurationProperties(prefix = "spring.jooq")
@@ -31,7 +34,8 @@ public class JooqProperties {
 
 	/**
 	 * SQLDialect JOOQ used when communicating with the configured datasource, for
-	 * instance "POSTGRES".
+	 * instance "POSTGRES". Please note the enum valus differ slightly from the ones
+	 * used by <code>spring.jpa</code>.
 	 */
 	private SQLDialect sqlDialect;
 
@@ -41,6 +45,19 @@ public class JooqProperties {
 
 	public void setSqlDialect(SQLDialect sqlDialect) {
 		this.sqlDialect = sqlDialect;
+	}
+
+	/**
+	 * Determine the {@link SQLDialect} to use based on this configuration and the primary
+	 * {@link DataSource}.
+	 * @param dataSource the auto-configured data source
+	 * @return {@code SQLDialect}
+	 */
+	public SQLDialect determineSqlDialect(DataSource dataSource) {
+		if (this.sqlDialect != null) {
+			return this.sqlDialect;
+		}
+		return SQLDialectLookup.getDialect(dataSource);
 	}
 
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/SQLDialectLookup.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/SQLDialectLookup.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jooq;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jooq.SQLDialect;
+
+import org.springframework.boot.jdbc.DatabaseDriver;
+import org.springframework.jdbc.support.JdbcUtils;
+import org.springframework.jdbc.support.MetaDataAccessException;
+
+/**
+ * Utility to lookup well known {@link SQLDialect SQLDialects} from a {@link DataSource}.
+ *
+ * Note: This lookup only supports the SQL dialects that the open source edition of jOOQ supports.
+ *
+ * @author Michael Simons
+ */
+final class SQLDialectLookup {
+
+	private static final Log logger = LogFactory.getLog(SQLDialectLookup.class);
+
+	private static final Map<DatabaseDriver, SQLDialect> LOOKUP;
+
+	static {
+		Map<DatabaseDriver, SQLDialect> map = new HashMap<>();
+		map.put(DatabaseDriver.DERBY, SQLDialect.DERBY);
+		map.put(DatabaseDriver.H2, SQLDialect.H2);
+		map.put(DatabaseDriver.HSQLDB, SQLDialect.HSQLDB);
+		map.put(DatabaseDriver.MARIADB, SQLDialect.MARIADB);
+		map.put(DatabaseDriver.MYSQL, SQLDialect.MYSQL);
+		map.put(DatabaseDriver.POSTGRESQL, SQLDialect.POSTGRES);
+		map.put(DatabaseDriver.SQLITE, SQLDialect.SQLITE);
+		LOOKUP = Collections.unmodifiableMap(map);
+	}
+
+	private SQLDialectLookup() {
+	}
+
+	/**
+	 * Return the most suitable {@link SQLDialect} for the given {@link DataSource}.
+	 * @param dataSource the source {@link DataSource}
+	 * @return the most suitable {@link SQLDialect}
+	 */
+	public static SQLDialect getDialect(DataSource dataSource) {
+		if (dataSource == null) {
+			return SQLDialect.DEFAULT;
+		}
+		try {
+			String url = (String) JdbcUtils.extractDatabaseMetaData(dataSource, "getURL");
+			DatabaseDriver driver = DatabaseDriver.fromJdbcUrl(url);
+			SQLDialect sQLDialect = LOOKUP.get(driver);
+			if (sQLDialect != null) {
+				return sQLDialect;
+			}
+		}
+		catch (MetaDataAccessException ex) {
+			logger.warn("Unable to determine jdbc url from datasource", ex);
+		}
+		return SQLDialect.DEFAULT;
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfigurationTests.java
@@ -69,7 +69,6 @@ public class JooqAutoConfigurationTests {
 	@Before
 	public void init() {
 		TestPropertyValues.of("spring.datasource.name:jooqtest").applyTo(this.context);
-		TestPropertyValues.of("spring.jooq.sql-dialect:H2").applyTo(this.context);
 	}
 
 	@After
@@ -121,7 +120,7 @@ public class JooqAutoConfigurationTests {
 				JooqAutoConfiguration.class);
 		this.context.getBean(PlatformTransactionManager.class);
 		DSLContext dsl = this.context.getBean(DSLContext.class);
-		assertThat(dsl.configuration().dialect()).isEqualTo(SQLDialect.H2);
+		assertThat(dsl.configuration().dialect()).isEqualTo(SQLDialect.HSQLDB);
 		dsl.execute("create table jooqtest_tx (name varchar(255) primary key);");
 		dsl.transaction(
 				new AssertFetch(dsl, "select count(*) as total from jooqtest_tx;", "0"));

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/SQLDialectLookupTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/SQLDialectLookupTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jooq;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+
+import javax.sql.DataSource;
+
+import org.jooq.SQLDialect;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link SQLDialectLookup}.
+ *
+ * @author Michael Simons
+ */
+public class SQLDialectLookupTests {
+
+	@Test
+	public void getDatabaseWhenDataSourceIsNullShouldReturnDefault() throws Exception {
+		assertThat(SQLDialectLookup.getDialect(null)).isEqualTo(SQLDialect.DEFAULT);
+	}
+
+	@Test
+	public void getDatabaseWhenDataSourceIsUnknownShouldReturnDefault() throws Exception {
+		testGetDatabase("jdbc:idontexist:", SQLDialect.DEFAULT);
+	}
+
+	@Test
+	public void getDatabaseWhenDerbyShouldReturnDerby() throws Exception {
+		testGetDatabase("jdbc:derby:", SQLDialect.DERBY);
+	}
+
+	@Test
+	public void getDatabaseWhenH2ShouldReturnH2() throws Exception {
+		testGetDatabase("jdbc:h2:", SQLDialect.H2);
+	}
+
+	@Test
+	public void getDatabaseWhenHsqldbShouldReturnHsqldb() throws Exception {
+		testGetDatabase("jdbc:hsqldb:", SQLDialect.HSQLDB);
+	}
+
+	@Test
+	public void getDatabaseWhenMysqlShouldReturnMysql() throws Exception {
+		testGetDatabase("jdbc:mysql:", SQLDialect.MYSQL);
+	}
+
+	@Test
+	public void getDatabaseWhenOracleShouldReturnOracle() throws Exception {
+		testGetDatabase("jdbc:oracle:", SQLDialect.DEFAULT);
+	}
+
+	@Test
+	public void getDatabaseWhenPostgresShouldReturnPostgres() throws Exception {
+		testGetDatabase("jdbc:postgresql:", SQLDialect.POSTGRES);
+	}
+
+	@Test
+	public void getDatabaseWhenSqlserverShouldReturnSqlserver() throws Exception {
+		testGetDatabase("jdbc:sqlserver:", SQLDialect.DEFAULT);
+	}
+
+	@Test
+	public void getDatabaseWhenDb2ShouldReturnDb2() throws Exception {
+		testGetDatabase("jdbc:db2:", SQLDialect.DEFAULT);
+	}
+
+	@Test
+	public void getDatabaseWhenInformixShouldReturnInformix() throws Exception {
+		testGetDatabase("jdbc:informix-sqli:", SQLDialect.DEFAULT);
+	}
+
+	private void testGetDatabase(String url, SQLDialect expected) throws Exception {
+		DataSource dataSource = mock(DataSource.class);
+		Connection connection = mock(Connection.class);
+		DatabaseMetaData metaData = mock(DatabaseMetaData.class);
+		given(dataSource.getConnection()).willReturn(connection);
+		given(connection.getMetaData()).willReturn(metaData);
+		given(metaData.getURL()).willReturn(url);
+		SQLDialect sQLDialect = SQLDialectLookup.getDialect(dataSource);
+		assertThat(sQLDialect).isEqualTo(expected);
+	}
+
+}

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -3214,13 +3214,23 @@ You can then use the `DSLContext` to construct your queries:
 
 
 ==== Customizing jOOQ
-You can customize the SQL dialect used by jOOQ by setting `spring.jooq.sql-dialect` in
-your `application.properties`. For example, to specify Postgres you would add:
+
+Spring Boot tries to determine the best SQL dialect for your datasource, but you can customize 
+the SQL dialect used by jOOQ by setting `spring.jooq.sql-dialect` in your `application.properties`. 
+
+Spring Boot cannot auto-configure dialects only supported by the commercial version of jOOQ. Those 
+have to be configured manually. For example, to specify Oracle you would add:
 
 [source,properties,indent=0]
 ----
-	spring.jooq.sql-dialect=Postgres
+	spring.jooq.sql-dialect=ORACLE12C
 ----
+
+Spring Boot uses `SQLDialect.DEFAULT` if it cannot determine the type of your database.
+
+NOTE: Be aware that the jOOQ SQL dialect doesn't use the same constants as the JPA
+configuration does. For example, jOOQ uses `POSTGRES` instead of `POSTGRESQL`. 
+If in doubt, have a look at the enum `org.jooq.SQLDialect`.
 
 More advanced customizations can be achieved by defining your own `@Bean` definitions
 which will be used when the jOOQ `Configuration` is created. You can define beans for

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -3216,21 +3216,19 @@ You can then use the `DSLContext` to construct your queries:
 ==== Customizing jOOQ
 
 Spring Boot tries to determine the best SQL dialect for your datasource, but you can customize 
-the SQL dialect used by jOOQ by setting `spring.jooq.sql-dialect` in your `application.properties`. 
+the dialect used by jOOQ by setting `spring.jooq.sql-dialect` in your `application.properties`. 
+Spring Boot uses `SQLDialect.DEFAULT` if it cannot determine the type of your database.
 
-Spring Boot cannot auto-configure dialects only supported by the commercial version of jOOQ. Those 
-have to be configured manually. For example, to specify Oracle you would add:
+Spring Boot can only auto-configure dialects supported by the open source version of jOOQ. Dialects 
+supported by the commercial edition only have to be configured manually. For example, to specify 
+Oracle you would add:
 
 [source,properties,indent=0]
 ----
 	spring.jooq.sql-dialect=ORACLE12C
 ----
 
-Spring Boot uses `SQLDialect.DEFAULT` if it cannot determine the type of your database.
-
-NOTE: Be aware that the jOOQ SQL dialect doesn't use the same constants as the JPA
-configuration does. For example, jOOQ uses `POSTGRES` instead of `POSTGRESQL`. 
-If in doubt, have a look at the enum `org.jooq.SQLDialect`.
+Refer to `org.jooq.SQLDialect` for all valid dialects.
 
 More advanced customizations can be achieved by defining your own `@Bean` definitions
 which will be used when the jOOQ `Configuration` is created. You can define beans for


### PR DESCRIPTION
This PR improves the auto configuration for jOOQ. It uses the same idea as auto configuration for `JPA` for determining the database platform.

It introduces a new class `SQLDialectLookup` that determines the dialect for databases supported by the open source edition of jOOQ.

This dialect or if not found `DEFAULT` as before is than used to configure the JOOQ Configuration.

I didn't have to change much in the test: The dialect has already been checked and there is also a test that sets the configuration property, so that case was already covered.

The PR also clarifies the documentation in regards of the dialects enum constants, which are not the same as used in JPA. Another idea would be "translating" `spring.datasource.platform` to jOOQs specific enums, but I'm not sure if that isn't too much heuristics.

This change here is required to make #9343 successfully build.