### PR TITLE
Add JAVA_OPTS to launcher script.  Resolves #2797

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/deployment.adoc
+++ b/spring-boot-docs/src/main/asciidoc/deployment.adoc
@@ -700,6 +700,10 @@ for Gradle and to `${project.name}` for Maven.
 |`confFolder`
 |The default value for `CONF_FOLDER`. Defaults to the folder containing the jar.
 
+|`javaOpts`
+|The default value for `JAVA_OPTS`. Java options that should always be passed to the JVM regardless of environment.
+ These options will be appended by any set by the environment or the configuration file.  
+
 |`logFolder`
 |The default value for `LOG_FOLDER`. Only valid for an `init.d` service.
 

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -50,7 +50,7 @@ configfile="$(basename "${jarfile%.*}.conf")"
 [[ -r "${CONF_FOLDER}/${configfile}" ]] && source "${CONF_FOLDER}/${configfile}"
 
 # Append any JAVA_OPTS if specified
-JAVA_OPTS="$JAVA_OPTS {{javaOpts:}}"
+JAVA_OPTS="{{javaOpts:}} $JAVA_OPTS"
 
 # Initialize PID/LOG locations if they weren't provided by the config file
 [[ -z "$PID_FOLDER" ]] && PID_FOLDER="{{pidFolder:/var/run}}"

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -49,7 +49,7 @@ configfile="$(basename "${jarfile%.*}.conf")"
 # shellcheck source=/dev/null
 [[ -r "${CONF_FOLDER}/${configfile}" ]] && source "${CONF_FOLDER}/${configfile}"
 
-# Append any JAVA_OPTS if specified
+# Prepend any JAVA_OPTS if specified
 JAVA_OPTS="{{javaOpts:}} $JAVA_OPTS"
 
 # Initialize PID/LOG locations if they weren't provided by the config file

--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -49,6 +49,9 @@ configfile="$(basename "${jarfile%.*}.conf")"
 # shellcheck source=/dev/null
 [[ -r "${CONF_FOLDER}/${configfile}" ]] && source "${CONF_FOLDER}/${configfile}"
 
+# Append any JAVA_OPTS if specified
+JAVA_OPTS="$JAVA_OPTS {{javaOpts:}}"
+
 # Initialize PID/LOG locations if they weren't provided by the config file
 [[ -z "$PID_FOLDER" ]] && PID_FOLDER="{{pidFolder:/var/run}}"
 [[ -z "$LOG_FOLDER" ]] && LOG_FOLDER="{{logFolder:/var/log}}"

--- a/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/DefaultLaunchScriptTests.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/DefaultLaunchScriptTests.java
@@ -127,10 +127,22 @@ public class DefaultLaunchScriptTests {
 	}
 
 	@Test
+	public void javaOptsCanBeReplaced() throws Exception {
+		assertThatPlaceholderCanBeReplaced("javaOpts");
+	}
+
+	@Test
 	public void defaultForUseStartStopDaemonIsTrue() throws Exception {
 		DefaultLaunchScript script = new DefaultLaunchScript(null, null);
 		String content = new String(script.toByteArray());
 		assertThat(content).contains("USE_START_STOP_DAEMON=\"true\"");
+	}
+
+	@Test
+	public void defaultForJavaOptsIsBlank() throws Exception {
+		DefaultLaunchScript script = new DefaultLaunchScript(null, null);
+		String content = new String(script.toByteArray());
+		assertThat(content).contains("JAVA_OPTS=\"$JAVA_OPTS \"");
 	}
 
 	@Test
@@ -164,6 +176,15 @@ public class DefaultLaunchScriptTests {
 				createProperties("a:e", "b:o"));
 		String content = new String(script.toByteArray());
 		assertThat(content).isEqualTo("hello");
+	}
+
+	@Test
+	public void expandVariablesDefaultToBlank() throws Exception {
+		File file = this.temporaryFolder.newFile();
+		FileCopyUtils.copy("s{{p:}}{{r:}}ing".getBytes(), file);
+		DefaultLaunchScript script = new DefaultLaunchScript(file, null);
+		String content = new String(script.toByteArray());
+		assertThat(content).isEqualTo("sing");
 	}
 
 	@Test

--- a/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/DefaultLaunchScriptTests.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/DefaultLaunchScriptTests.java
@@ -142,7 +142,7 @@ public class DefaultLaunchScriptTests {
 	public void defaultForJavaOptsIsBlank() throws Exception {
 		DefaultLaunchScript script = new DefaultLaunchScript(null, null);
 		String content = new String(script.toByteArray());
-		assertThat(content).contains("JAVA_OPTS=\"$JAVA_OPTS \"");
+		assertThat(content).contains("JAVA_OPTS=\" $JAVA_OPTS\"");
 	}
 
 	@Test


### PR DESCRIPTION
Resolves #2797

When running Spring Boot as a Linux service, you can now instruct the spring-boot-maven plugin to include JAVA_OPTS in the launcher.script.  A new embeddedLaunchScriptProperties key called "javaOpts" has been created.  Any JVM options specified will be appended to any JAVA_OPTS set by other methods (e.g. environmental variable or .conf file).

This gives the flexibility to specify JAVA_OPTS that are universal across all environments, or in the case you already know the environment, all the JAVA_OPTS in your project.  The end result is the ability to have single artifact deployments even when JVM options are required.