### PR TITLE
Spring boot server port range support

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/PortsRange.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/PortsRange.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.web;
+
+import java.util.StringTokenizer;
+
+import javax.validation.constraints.NotNull;
+
+import org.springframework.util.SocketUtils;
+
+/**
+ * Automatic port assignment with specific port range support.
+ * @author ishara
+ */
+public class PortsRange {
+
+	/**
+	 * Server HTTP port range. Ex 9000-9080
+	 * If single port specified, this also work
+	 */
+	private final String portRange;
+
+	public PortsRange(@NotNull String portRange) {
+		this.portRange = portRange;
+	}
+
+	public String getPortRangeString() {
+		return this.portRange;
+	}
+
+	public int getValidPort(int defaultPort) throws NumberFormatException {
+		int availablePort = defaultPort;
+		if (this.portRange == null) {
+			return availablePort;
+		}
+		StringTokenizer st = new StringTokenizer(this.portRange, ",");
+		while (st.hasMoreTokens()) {
+			String portToken = st.nextToken().trim();
+			int index = portToken.indexOf('-');
+			if (index == -1) {
+				availablePort = Integer.parseInt(portToken.trim());
+			}
+			else {
+				int startPort = Integer.parseInt(portToken.substring(0, index).trim());
+				int endPort = Integer.parseInt(portToken.substring(index + 1).trim());
+				if (endPort < startPort) {
+					throw new IllegalArgumentException("Start port [" + startPort
+							+ "] must be greater than end port [" + endPort + "]");
+				}
+				availablePort = SocketUtils.findAvailableTcpPort(startPort, endPort);
+			}
+		}
+		return availablePort;
+	}
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -60,6 +60,12 @@ public class ServerProperties {
 	private Integer port;
 
 	/**
+	 * Server HTTP port range. If port is set to 0 and portRange specified The port is
+	 * assign with port range value.
+	 */
+	private String portRange;
+
+	/**
 	 * Network address to which the server should bind to.
 	 */
 	private InetAddress address;
@@ -116,6 +122,14 @@ public class ServerProperties {
 
 	public void setPort(Integer port) {
 		this.port = port;
+	}
+
+	public String getPortRange() {
+		return this.portRange;
+	}
+
+	public void setPortRange(String portRange) {
+		this.portRange = portRange;
 	}
 
 	public InetAddress getAddress() {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/DefaultServletWebServerFactoryCustomizer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/DefaultServletWebServerFactoryCustomizer.java
@@ -42,6 +42,7 @@ import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
 
+import org.springframework.boot.autoconfigure.web.PortsRange;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.autoconfigure.web.ServerProperties.Session;
 import org.springframework.boot.cloud.CloudPlatform;
@@ -98,9 +99,17 @@ public class DefaultServletWebServerFactoryCustomizer
 
 	@Override
 	public void customize(ConfigurableServletWebServerFactory factory) {
+
 		if (this.serverProperties.getPort() != null) {
 			factory.setPort(this.serverProperties.getPort());
 		}
+
+		if (this.serverProperties.getPortRange() != null
+				&& this.serverProperties.getPort() == 0) {
+			PortsRange portsRange = new PortsRange(this.serverProperties.getPortRange());
+			factory.setPort(portsRange.getValidPort(this.serverProperties.getPort()));
+		}
+
 		if (this.serverProperties.getAddress() != null) {
 			factory.setAddress(this.serverProperties.getAddress());
 		}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/PortRangeTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/PortRangeTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.web;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author ishara
+ */
+public class PortRangeTests {
+
+	@Test
+	public void testPortRangeEmpty() throws Exception {
+		PortsRange portsRange = new PortsRange("");
+		assertThat(portsRange.getValidPort(0)).isEqualTo(0);
+	}
+
+	@Test
+	public void testPortRangeOnePort() throws Exception {
+		PortsRange portsRange = new PortsRange("9999");
+		assertThat(portsRange.getValidPort(0)).isEqualTo(9999);
+	}
+
+	@Test
+	public void testPortRangeRange() throws Exception {
+		PortsRange portsRange = new PortsRange("9000-9001");
+		assertThat(
+				portsRange.getValidPort(0) != 0 );
+	}
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/PortRangeTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/PortRangeTests.java
@@ -40,8 +40,7 @@ public class PortRangeTests {
 	@Test
 	public void testPortRangeRange() throws Exception {
 		PortsRange portsRange = new PortsRange("9000-9001");
-		assertThat(
-				portsRange.getValidPort(0) != 0 );
+		assertThat(portsRange.getValidPort(0) != 0);
 	}
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -59,6 +59,12 @@ public class ServerPropertiesTests {
 	}
 
 	@Test
+	public void testPortRangeBinding() throws Exception {
+		bind("server.port-range", "8000-9000");
+		assertThat(this.properties.getPortRange()).isEqualTo("8000-9000");
+	}
+
+	@Test
 	public void testServerHeaderDefault() throws Exception {
 		assertThat(this.properties.getServerHeader()).isNull();
 	}

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -177,6 +177,7 @@ content into your application; rather pick only the properties that you need.
 	server.jetty.max-http-post-size=0 # Maximum size in bytes of the HTTP post or put content.
 	server.jetty.selectors= # Number of selector threads to use.
 	server.port=8080 # Server HTTP port.
+	server.port-range= # If server.port value is 0 the port automatically pick with specific port range (Ex 9000-9050)
 	server.server-header= # Value to use for the Server response header (no header is sent if empty)
 	server.use-forward-headers= # If X-Forwarded-* headers should be applied to the HttpRequest.
 	server.servlet.context-parameters.*= # Servlet context init parameters


### PR DESCRIPTION
if `server.port` value is set to `0`, the server port will automatically assigned. 
If we need to restrict automatic port to specific  range value such as `8000`-`9000`, the new setting `server.port-range` feature added.  

Please check 
Thank you