### PR TITLE
Fix `QuartzAutoConfigurtion` failure with multiple `Executor` beans

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/quartz/QuartzAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/quartz/QuartzAutoConfiguration.java
@@ -81,7 +81,7 @@ public class QuartzAutoConfiguration {
 			ObjectProvider<Trigger[]> triggers, ApplicationContext applicationContext) {
 		this.properties = properties;
 		this.customizers = customizers.getIfAvailable();
-		this.taskExecutor = taskExecutor.getIfAvailable();
+		this.taskExecutor = taskExecutor.getIfUnique();
 		this.jobDetails = jobDetails.getIfAvailable();
 		this.calendars = calendars.getIfAvailable();
 		this.triggers = triggers.getIfAvailable();


### PR DESCRIPTION
`QuartzAutoConfigurtion` currently blows up if there are multiple `Executor` beans in the context due to use of `ObjectProvider#getIfAvailable`.

This PR changes the configuration to retrieve `Executor` bean using `ObjectProvider#getIfUnique` which won't fail in scenarios where there are multiple `Executor` beans with none marked as `@Primary`.

This resolves #9433.