### PR TITLE
Allow abstract serializers/deserializer in @JsonComponent

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
+++ b/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.jackson;
 
+import java.lang.reflect.Modifier;
 import java.util.Map;
 
 import javax.annotation.PostConstruct;
@@ -78,8 +79,9 @@ public class JsonComponentModule extends SimpleModule implements BeanFactoryAwar
 			addDeserializerWithDeducedType((JsonDeserializer<?>) bean);
 		}
 		for (Class<?> innerClass : bean.getClass().getDeclaredClasses()) {
-			if (JsonSerializer.class.isAssignableFrom(innerClass)
-					|| JsonDeserializer.class.isAssignableFrom(innerClass)) {
+			if (!Modifier.isAbstract(innerClass.getModifiers()) &&
+					(JsonSerializer.class.isAssignableFrom(innerClass)
+							|| JsonDeserializer.class.isAssignableFrom(innerClass))) {
 				try {
 					addJsonBean(innerClass.newInstance());
 				}

--- a/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
@@ -59,6 +59,15 @@ public class JsonComponentModuleTests {
 		context.close();
 	}
 
+	@Test
+	public void moduleShouldAllowInnerAbstractClasses() throws Exception {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+				JsonComponentModule.class, ComponentWithInnerAbstractClass.class);
+		JsonComponentModule module = context.getBean(JsonComponentModule.class);
+		assertSerialize(module);
+		context.close();
+	}
+
 	private void assertSerialize(Module module) throws Exception {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.registerModule(module);
@@ -85,4 +94,15 @@ public class JsonComponentModuleTests {
 
 	}
 
+	@JsonComponent
+	static class ComponentWithInnerAbstractClass {
+
+		private static abstract class AbstractSerializer extends NameAndAgeJsonComponent.Serializer {
+
+		}
+
+		static class ConcreteSerializer extends AbstractSerializer {
+
+		}
+	}
 }


### PR DESCRIPTION
A small enhancement to the `JsonComponentModule` to allow inner abstract `JsonSerializer`/`JsonDeserializer`s to share common logic (#9442)