### PR TITLE
Introduced protected getBannerText method to allow customization on banner text

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/ResourceBanner.java
+++ b/spring-boot/src/main/java/org/springframework/boot/ResourceBanner.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.boot;
 
 import java.io.PrintStream;
@@ -23,10 +22,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.boot.ansi.AnsiPropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MapPropertySource;
@@ -46,99 +43,102 @@ import org.springframework.util.StreamUtils;
  */
 public class ResourceBanner implements Banner {
 
-	private static final Log logger = LogFactory.getLog(ResourceBanner.class);
+    private static final Log logger = LogFactory.getLog(ResourceBanner.class);
 
-	private Resource resource;
+    private Resource resource;
 
-	public ResourceBanner(Resource resource) {
-		Assert.notNull(resource, "Resource must not be null");
-		Assert.isTrue(resource.exists(), "Resource must exist");
-		this.resource = resource;
-	}
+    public ResourceBanner(Resource resource) {
+        Assert.notNull(resource, "Resource must not be null");
+        Assert.isTrue(resource.exists(), "Resource must exist");
+        this.resource = resource;
+    }
 
-	@Override
-	public void printBanner(Environment environment, Class<?> sourceClass,
-			PrintStream out) {
-		try {
-			String banner = StreamUtils.copyToString(this.resource.getInputStream(),
-					environment.getProperty("banner.charset", Charset.class,
-							Charset.forName("UTF-8")));
+    @Override
+    public void printBanner(Environment environment, Class<?> sourceClass,
+            PrintStream out) {
+        try {
+            String banner = getBannerText(environment);
 
-			for (PropertyResolver resolver : getPropertyResolvers(environment,
-					sourceClass)) {
-				banner = resolver.resolvePlaceholders(banner);
-			}
-			out.println(banner);
-		}
-		catch (Exception ex) {
-			logger.warn("Banner not printable: " + this.resource + " (" + ex.getClass()
-					+ ": '" + ex.getMessage() + "')", ex);
-		}
-	}
+            for (PropertyResolver resolver : getPropertyResolvers(environment,
+                    sourceClass)) {
+                banner = resolver.resolvePlaceholders(banner);
+            }
+            out.println(banner);
+        } catch (Exception ex) {
+            logger.warn("Banner not printable: " + this.resource + " (" + ex.getClass()
+                    + ": '" + ex.getMessage() + "')", ex);
+        }
+    }
 
-	protected List<PropertyResolver> getPropertyResolvers(Environment environment,
-			Class<?> sourceClass) {
-		List<PropertyResolver> resolvers = new ArrayList<>();
-		resolvers.add(environment);
-		resolvers.add(getVersionResolver(sourceClass));
-		resolvers.add(getAnsiResolver());
-		resolvers.add(getTitleResolver(sourceClass));
-		return resolvers;
-	}
+    protected String getBannerText(Environment environment) throws Exception {
+        return StreamUtils.copyToString(this.resource.getInputStream(),
+                environment.getProperty("banner.charset", Charset.class,
+                        Charset.forName("UTF-8")));
+    }
 
-	private PropertyResolver getVersionResolver(Class<?> sourceClass) {
-		MutablePropertySources propertySources = new MutablePropertySources();
-		propertySources
-				.addLast(new MapPropertySource("version", getVersionsMap(sourceClass)));
-		return new PropertySourcesPropertyResolver(propertySources);
-	}
+    protected List<PropertyResolver> getPropertyResolvers(Environment environment,
+            Class<?> sourceClass) {
+        List<PropertyResolver> resolvers = new ArrayList<>();
+        resolvers.add(environment);
+        resolvers.add(getVersionResolver(sourceClass));
+        resolvers.add(getAnsiResolver());
+        resolvers.add(getTitleResolver(sourceClass));
+        return resolvers;
+    }
 
-	private Map<String, Object> getVersionsMap(Class<?> sourceClass) {
-		String appVersion = getApplicationVersion(sourceClass);
-		String bootVersion = getBootVersion();
-		Map<String, Object> versions = new HashMap<>();
-		versions.put("application.version", getVersionString(appVersion, false));
-		versions.put("spring-boot.version", getVersionString(bootVersion, false));
-		versions.put("application.formatted-version", getVersionString(appVersion, true));
-		versions.put("spring-boot.formatted-version",
-				getVersionString(bootVersion, true));
-		return versions;
-	}
+    private PropertyResolver getVersionResolver(Class<?> sourceClass) {
+        MutablePropertySources propertySources = new MutablePropertySources();
+        propertySources
+                .addLast(new MapPropertySource("version", getVersionsMap(sourceClass)));
+        return new PropertySourcesPropertyResolver(propertySources);
+    }
 
-	protected String getApplicationVersion(Class<?> sourceClass) {
-		Package sourcePackage = (sourceClass == null ? null : sourceClass.getPackage());
-		return (sourcePackage == null ? null : sourcePackage.getImplementationVersion());
-	}
+    private Map<String, Object> getVersionsMap(Class<?> sourceClass) {
+        String appVersion = getApplicationVersion(sourceClass);
+        String bootVersion = getBootVersion();
+        Map<String, Object> versions = new HashMap<>();
+        versions.put("application.version", getVersionString(appVersion, false));
+        versions.put("spring-boot.version", getVersionString(bootVersion, false));
+        versions.put("application.formatted-version", getVersionString(appVersion, true));
+        versions.put("spring-boot.formatted-version",
+                getVersionString(bootVersion, true));
+        return versions;
+    }
 
-	protected String getBootVersion() {
-		return SpringBootVersion.getVersion();
-	}
+    protected String getApplicationVersion(Class<?> sourceClass) {
+        Package sourcePackage = (sourceClass == null ? null : sourceClass.getPackage());
+        return (sourcePackage == null ? null : sourcePackage.getImplementationVersion());
+    }
 
-	private String getVersionString(String version, boolean format) {
-		if (version == null) {
-			return "";
-		}
-		return (format ? " (v" + version + ")" : version);
-	}
+    protected String getBootVersion() {
+        return SpringBootVersion.getVersion();
+    }
 
-	private PropertyResolver getAnsiResolver() {
-		MutablePropertySources sources = new MutablePropertySources();
-		sources.addFirst(new AnsiPropertySource("ansi", true));
-		return new PropertySourcesPropertyResolver(sources);
-	}
+    private String getVersionString(String version, boolean format) {
+        if (version == null) {
+            return "";
+        }
+        return (format ? " (v" + version + ")" : version);
+    }
 
-	private PropertyResolver getTitleResolver(Class<?> sourceClass) {
-		MutablePropertySources sources = new MutablePropertySources();
-		String applicationTitle = getApplicationTitle(sourceClass);
-		Map<String, Object> titleMap = Collections.<String, Object>singletonMap(
-				"application.title", (applicationTitle == null ? "" : applicationTitle));
-		sources.addFirst(new MapPropertySource("title", titleMap));
-		return new PropertySourcesPropertyResolver(sources);
-	}
+    private PropertyResolver getAnsiResolver() {
+        MutablePropertySources sources = new MutablePropertySources();
+        sources.addFirst(new AnsiPropertySource("ansi", true));
+        return new PropertySourcesPropertyResolver(sources);
+    }
 
-	protected String getApplicationTitle(Class<?> sourceClass) {
-		Package sourcePackage = (sourceClass == null ? null : sourceClass.getPackage());
-		return (sourcePackage == null ? null : sourcePackage.getImplementationTitle());
-	}
+    private PropertyResolver getTitleResolver(Class<?> sourceClass) {
+        MutablePropertySources sources = new MutablePropertySources();
+        String applicationTitle = getApplicationTitle(sourceClass);
+        Map<String, Object> titleMap = Collections.<String, Object>singletonMap(
+                "application.title", (applicationTitle == null ? "" : applicationTitle));
+        sources.addFirst(new MapPropertySource("title", titleMap));
+        return new PropertySourcesPropertyResolver(sources);
+    }
+
+    protected String getApplicationTitle(Class<?> sourceClass) {
+        Package sourcePackage = (sourceClass == null ? null : sourceClass.getPackage());
+        return (sourcePackage == null ? null : sourcePackage.getImplementationTitle());
+    }
 
 }

--- a/spring-boot/src/main/java/org/springframework/boot/ResourceBanner.java
+++ b/spring-boot/src/main/java/org/springframework/boot/ResourceBanner.java
@@ -74,12 +74,12 @@ public class ResourceBanner implements Banner {
 		}
 	}
 
-        protected String getBannerText(Environment environment) throws Exception {
-                return StreamUtils.copyToString(this.resource.getInputStream(),
-                        environment.getProperty("banner.charset", Charset.class,
-                                Charset.forName("UTF-8")));
-        }
-        
+	protected String getBannerText(Environment environment) throws Exception {
+		return StreamUtils.copyToString(this.resource.getInputStream(),
+			environment.getProperty("banner.charset", Charset.class,
+				Charset.forName("UTF-8")));
+	}
+
 	protected List<PropertyResolver> getPropertyResolvers(Environment environment,
 			Class<?> sourceClass) {
 		List<PropertyResolver> resolvers = new ArrayList<>();

--- a/spring-boot/src/main/java/org/springframework/boot/ResourceBanner.java
+++ b/spring-boot/src/main/java/org/springframework/boot/ResourceBanner.java
@@ -23,8 +23,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.boot.ansi.AnsiPropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MapPropertySource;
@@ -73,9 +75,9 @@ public class ResourceBanner implements Banner {
 	}
 
         protected String getBannerText(Environment environment) throws Exception {
-            return StreamUtils.copyToString(this.resource.getInputStream(),
-                    environment.getProperty("banner.charset", Charset.class,
-                            Charset.forName("UTF-8")));
+                return StreamUtils.copyToString(this.resource.getInputStream(),
+                        environment.getProperty("banner.charset", Charset.class,
+                                Charset.forName("UTF-8")));
         }
         
 	protected List<PropertyResolver> getPropertyResolvers(Environment environment,


### PR DESCRIPTION
Referring to the starter in the following project [sshd-shell-spring-boot](https://github.com/anand1st/sshd-shell-spring-boot). When a user logs in with SSH, the text in banner file is displayed as per spring boot settings. However, with SSH, a `\n` should be followed by `\r` as to display the banner correctly. Introducing the getBannerText method allows for a developer to customise banner text where string containing `\n` can be replaced by `\n\r` by just overriding this method.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->