### PR TITLE
Add Orika starter to the community list

### DIFF
--- a/spring-boot-starters/README.adoc
+++ b/spring-boot-starters/README.adoc
@@ -97,6 +97,9 @@ do as they were designed before this was clarified.
 | http://square.github.io/okhttp/[OkHttp]
 | https://github.com/freefair/okhttp-spring-boot
 
+| http://orika-mapper.github.io/orika-docs/[Orika]
+| https://github.com/akihyro/orika-spring-boot-starter
+
 | http://resteasy.jboss.org/[RESTEasy]
 | https://github.com/paypal/resteasy-spring-boot
 


### PR DESCRIPTION
This PR adds orika-spring-boot-starter to the list of community provided Spring Boot starters.