### PR TITLE
Add support for "spring.kafka.listener.batch-listener" property 

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/ConcurrentKafkaListenerContainerFactoryConfigurer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/ConcurrentKafkaListenerContainerFactoryConfigurer.java
@@ -68,9 +68,7 @@ public class ConcurrentKafkaListenerContainerFactoryConfigurer {
 		if (container.getConcurrency() != null) {
 			listenerContainerFactory.setConcurrency(container.getConcurrency());
 		}
-		if (container.getBatchListener() != null) {
-			listenerContainerFactory.setBatchListener(container.getBatchListener());
-		}
+		listenerContainerFactory.setBatchListener(container.getBatchListener());
 	}
 
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/ConcurrentKafkaListenerContainerFactoryConfigurer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/ConcurrentKafkaListenerContainerFactoryConfigurer.java
@@ -68,6 +68,9 @@ public class ConcurrentKafkaListenerContainerFactoryConfigurer {
 		if (container.getConcurrency() != null) {
 			listenerContainerFactory.setConcurrency(container.getConcurrency());
 		}
+		if (container.getBatchListener() != null) {
+			listenerContainerFactory.setBatchListener(container.getBatchListener());
+		}
 	}
 
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
@@ -675,7 +675,7 @@ public class KafkaProperties {
 		/**
 		 * If true listener container factory will be configured to create batch listener.
 		 */
-		private Boolean batchListener;
+		private boolean batchListener;
 
 		public AckMode getAckMode() {
 			return this.ackMode;
@@ -717,11 +717,11 @@ public class KafkaProperties {
 			this.ackTime = ackTime;
 		}
 
-		public Boolean getBatchListener() {
+		public boolean getBatchListener() {
 			return this.batchListener;
 		}
 
-		public void setBatchListener(Boolean batchListener) {
+		public void setBatchListener(boolean batchListener) {
 			this.batchListener = batchListener;
 		}
 	}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
@@ -673,7 +673,7 @@ public class KafkaProperties {
 		private Long ackTime;
 
 		/**
-		 * True if this should be batch listener.
+		 * If true listener container factory will be configured to create batch listener.
 		 */
 		private Boolean batchListener;
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
@@ -672,6 +672,11 @@ public class KafkaProperties {
 		 */
 		private Long ackTime;
 
+		/**
+		 * True if this should be batch listener.
+		 */
+		private Boolean batchListener;
+
 		public AckMode getAckMode() {
 			return this.ackMode;
 		}
@@ -712,6 +717,13 @@ public class KafkaProperties {
 			this.ackTime = ackTime;
 		}
 
+		public Boolean getBatchListener() {
+			return batchListener;
+		}
+
+		public void setBatchListener(Boolean batchListener) {
+			this.batchListener = batchListener;
+		}
 	}
 
 	public static class Ssl {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
@@ -718,7 +718,7 @@ public class KafkaProperties {
 		}
 
 		public Boolean getBatchListener() {
-			return batchListener;
+			return this.batchListener;
 		}
 
 		public void setBatchListener(Boolean batchListener) {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfigurationTests.java
@@ -176,6 +176,7 @@ public class KafkaAutoConfigurationTests {
 				"spring.kafka.listener.ack-time=456",
 				"spring.kafka.listener.concurrency=3",
 				"spring.kafka.listener.poll-timeout=2000",
+				"spring.kafka.listener.batch-listener=true",
 				"spring.kafka.jaas.enabled=true", "spring.kafka.jaas.login-module=foo",
 				"spring.kafka.jaas.control-flag=REQUISITE",
 				"spring.kafka.jaas.options.useKeyTab=true");
@@ -198,6 +199,8 @@ public class KafkaAutoConfigurationTests {
 		assertThat(dfa.getPropertyValue("concurrency")).isEqualTo(3);
 		assertThat(dfa.getPropertyValue("containerProperties.pollTimeout"))
 				.isEqualTo(2000L);
+		assertThat(dfa.getPropertyValue("batchListener"))
+				.isEqualTo(true);
 		assertThat(this.context.getBeansOfType(KafkaJaasLoginModuleInitializer.class))
 				.hasSize(1);
 		KafkaJaasLoginModuleInitializer jaas = this.context

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -986,6 +986,7 @@ content into your application; rather pick only the properties that you need.
 	spring.kafka.listener.ack-time= # Time in milliseconds between offset commits when ackMode is "TIME" or "COUNT_TIME".
 	spring.kafka.listener.concurrency= # Number of threads to run in the listener containers.
 	spring.kafka.listener.poll-timeout= # Timeout in milliseconds to use when polling the consumer.
+	spring.kafka.listener.batch-listener= # If true listener container factory will be configured to create batch listeners.
 	spring.kafka.producer.acks= # Number of acknowledgments the producer requires the leader to have received before considering a request complete.
 	spring.kafka.producer.batch-size= # Number of records to batch before sending.
 	spring.kafka.producer.bootstrap-servers= # Comma-delimited list of host:port pairs to use for establishing the initial connection to the Kafka cluster.

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -986,7 +986,7 @@ content into your application; rather pick only the properties that you need.
 	spring.kafka.listener.ack-time= # Time in milliseconds between offset commits when ackMode is "TIME" or "COUNT_TIME".
 	spring.kafka.listener.concurrency= # Number of threads to run in the listener containers.
 	spring.kafka.listener.poll-timeout= # Timeout in milliseconds to use when polling the consumer.
-	spring.kafka.listener.batch-listener= # If true listener container factory will be configured to create batch listeners.
+	spring.kafka.listener.batch-listener= # If true listener container factory will be configured to create batch listener.
 	spring.kafka.producer.acks= # Number of acknowledgments the producer requires the leader to have received before considering a request complete.
 	spring.kafka.producer.batch-size= # Number of records to batch before sending.
 	spring.kafka.producer.bootstrap-servers= # Comma-delimited list of host:port pairs to use for establishing the initial connection to the Kafka cluster.


### PR DESCRIPTION
With this feature `ConcurrentKafkaListenerContainerFactoryConfigurer` is able to set batch listener option on `listenerContainerFactory` out of the box if so specified in kafka configuration properties option.

This enables me to write something like this which will work out of the box without any additional configuration (currently this is not the case and I need to create my own instance of `ConcurrentKafkaListenerContainerFactory`; overriding `CustomConcurrentKafkaListenerContainerFactoryConfigurer` is also not an option since it seems this class was not ment to be extended):
```
@SpringBootApplication
@EnableKafka
open class Application {
    val LOG = LoggerFactory.getLogger(this.javaClass.name)

    companion object {
        init {
            System.setProperty("spring.kafka.bootstrapServers", "kafka:9092");
            System.setProperty("spring.kafka.consumer.enableAutoCommit", "false");
            System.setProperty("spring.kafka.consumer.fetchMinSize", (10 * 1024 * 1024).toString());
            System.setProperty("spring.kafka.consumer.fetchMaxWait", 5000.toString());
            System.setProperty("spring.kafka.consumer.clientId", "mzagar-spring-kafka-test");
            System.setProperty("spring.kafka.consumer.groupId", "mzagar-spring-kafka-test");
            System.setProperty("spring.kafka.consumer.maxPollRecords", 5000.toString());
            System.setProperty("spring.kafka.listener.ackMode", MANUAL.name);
            System.setProperty("spring.kafka.listener.concurrency", "10");
            
            // without this I need to manually define ConcurrentKafkaListenerContainerFactory to set batchListener flag
            System.setProperty("spring.kafka.listener.batchListener", "true");
        }
    }

    @KafkaListener(id = "me", topics = arrayOf("my-topic"))
    fun listen(cr: List<ConsumerRecord<String,String>>, ack: Acknowledgment) {
        LOG.info(Thread.currentThread().name + " --> size=" + cr.size)
        ack.acknowledge()
    }
}

fun main(args: Array<String>) {
    SpringApplication.run(Application::class.java, *args)
}
```

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->