### PR TITLE
Add SAP Hana Cloud Platform to CloudPlatforms.

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
+++ b/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
@@ -51,6 +51,17 @@ public enum CloudPlatform {
 			return environment.containsProperty("DYNO");
 		}
 
+	},
+
+	/**
+	 * SAP Hana Cloud platform.
+	 */
+	HCP {
+
+		@Override
+		public boolean isActive(Environment environment) {
+			return environment.containsProperty("HC_LANDSCAPE");
+		}
 	};
 
 	/**

--- a/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
@@ -71,4 +71,12 @@ public class CloudPlatformTests {
 		assertThat(platform.isActive(environment)).isTrue();
 	}
 
+	@Test
+	public void getActiveWhenHasHcLandscapeShouldReturnHcp() throws Exception {
+		Environment environment = new MockEnvironment().withProperty("HC_LANDSCAPE", "---");
+		CloudPlatform platform = CloudPlatform.getActive(environment);
+		assertThat(platform).isEqualTo(CloudPlatform.HCP);
+		assertThat(platform.isActive(environment)).isTrue();
+	}
+
 }


### PR DESCRIPTION
This adds SAP Hana Cloud Platform to Spring Boot's Cloud Platforms, to be able to distinguish the platform from others.
By that functionality like `@ConditionalOnCloudPlatform(CloudPlatfrom.HCP)` can be used.