### PR TITLE
DropwizardMetricServices checks the wrong metric if it fails to register

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/dropwizard/DropwizardMetricServices.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/dropwizard/DropwizardMetricServices.java
@@ -148,7 +148,7 @@ public class DropwizardMetricServices implements CounterService, GaugeService {
 		}
 		catch (IllegalArgumentException ex) {
 			Metric added = this.registry.getMetrics().get(name);
-			registrar.checkExisting(metric);
+			registrar.checkExisting(added);
 			return (T) added;
 		}
 	}


### PR DESCRIPTION
should check the added one, and not the metric var, it will throw exception under concurrent