### PR TITLE
Allow SslStoreProvider to provide only a KeyStore

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/SslStoreProviderUrlStreamHandlerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/SslStoreProviderUrlStreamHandlerFactory.java
@@ -66,9 +66,12 @@ class SslStoreProviderUrlStreamHandlerFactory implements URLStreamHandlerFactory
 											.getKeyStore());
 						}
 						if (TRUST_STORE_PATH.equals(url.getPath())) {
-							return new KeyStoreUrlConnection(url,
-									SslStoreProviderUrlStreamHandlerFactory.this.sslStoreProvider
-											.getTrustStore());
+							KeyStore trustStore = SslStoreProviderUrlStreamHandlerFactory.this.sslStoreProvider
+											.getTrustStore();
+							if(trustStore == null) {
+								return null
+							}
+							return new KeyStoreUrlConnection(url, trustStore);
 						}
 					}
 					catch (Exception ex) {


### PR DESCRIPTION
In this case, the truststore should be `null`

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->