### PR TITLE
Use Redis client configuration to configure connection factories.

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/JedisClientConfigurationBuilderCustomizer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/JedisClientConfigurationBuilderCustomizer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.redis;
+
+import org.springframework.data.redis.connection.jedis.JedisClientConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisClientConfigurationBuilder;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize the
+ * {@link JedisClientConfiguration} via a {@link JedisClientConfigurationBuilder
+ * JedisClientConfiguration.JedisClientConfigurationBuilder} whilst retaining default
+ * auto-configuration.
+ *
+ * @author Mark Paluch
+ * @since 2.0.0
+ */
+@FunctionalInterface
+public interface JedisClientConfigurationBuilderCustomizer {
+
+	/**
+	 * Customize the {@link JedisClientConfigurationBuilder}.
+	 * @param clientConfigurationBuilder the builder to customize
+	 */
+	void customize(JedisClientConfigurationBuilder clientConfigurationBuilder);
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceClientConfigurationBuilderCustomizer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceClientConfigurationBuilderCustomizer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.redis;
+
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize the
+ * {@link LettuceClientConfiguration} via a {@link LettuceClientConfigurationBuilder
+ * LettuceClientConfiguration.LettuceClientConfigurationBuilder} whilst retaining default
+ * auto-configuration.
+ *
+ * @author Mark Paluch
+ * @since 2.0.0
+ */
+@FunctionalInterface
+public interface LettuceClientConfigurationBuilderCustomizer {
+
+	/**
+	 * Customize the {@link LettuceClientConfigurationBuilder}.
+	 * @param clientConfigurationBuilder the builder to customize
+	 */
+	void customize(LettuceClientConfigurationBuilder clientConfigurationBuilder);
+
+}

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationJedisTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationJedisTests.java
@@ -28,6 +28,9 @@ import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.boot.testsupport.runner.classpath.ClassPathExclusions;
 import org.springframework.boot.testsupport.runner.classpath.ModifiedClassPathRunner;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisClientConfigurationBuilder;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.util.StringUtils;
 
@@ -60,6 +63,17 @@ public class RedisAutoConfigurationJedisTests {
 		assertThat(cf.getDatabase()).isEqualTo(1);
 		assertThat(cf.getPassword()).isNull();
 		assertThat(cf.isUseSsl()).isFalse();
+	}
+
+	@Test
+	public void testCustomizeRedisConfiguration() throws Exception {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.register(RedisAutoConfiguration.class);
+		ctx.register(CustomConfiguration.class);
+		ctx.refresh();
+
+		JedisConnectionFactory cf = ctx.getBean(JedisConnectionFactory.class);
+		assertThat(cf.isUseSsl()).isTrue();
 	}
 
 	@Test
@@ -170,6 +184,16 @@ public class RedisAutoConfigurationJedisTests {
 				}
 			}
 		}
+	}
+
+	@Configuration
+	static class CustomConfiguration {
+
+		@Bean
+		JedisClientConfigurationBuilderCustomizer customizer() {
+			return JedisClientConfigurationBuilder::useSsl;
+		}
+
 	}
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -28,7 +28,10 @@ import org.junit.Test;
 
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.lettuce.DefaultLettucePool;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -79,6 +82,17 @@ public class RedisAutoConfigurationTests {
 	}
 
 	@Test
+	public void testCustomizeRedisConfiguration() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.register(RedisAutoConfiguration.class);
+		ctx.register(CustomConfiguration.class);
+		ctx.refresh();
+
+		LettuceConnectionFactory cf = ctx.getBean(LettuceConnectionFactory.class);
+		assertThat(cf.isUseSsl()).isTrue();
+	}
+
+	@Test
 	public void testRedisUrlConfiguration() throws Exception {
 		load("spring.redis.host:foo",
 				"spring.redis.url:redis://user:password@example:33");
@@ -111,7 +125,6 @@ public class RedisAutoConfigurationTests {
 				"spring.redis.lettuce.pool.max-wait:2000");
 		LettuceConnectionFactory cf = this.context
 				.getBean(LettuceConnectionFactory.class);
-		assertThat(cf.getHostName()).isEqualTo("foo");
 		assertThat(getDefaultLettucePool(cf).getHostName()).isEqualTo("foo");
 		assertThat(getDefaultLettucePool(cf).getPoolConfig().getMinIdle()).isEqualTo(1);
 		assertThat(getDefaultLettucePool(cf).getPoolConfig().getMaxIdle()).isEqualTo(4);
@@ -195,6 +208,16 @@ public class RedisAutoConfigurationTests {
 		ctx.register(RedisAutoConfiguration.class);
 		ctx.refresh();
 		this.context = ctx;
+	}
+
+	@Configuration
+	static class CustomConfiguration {
+
+		@Bean
+		LettuceClientConfigurationBuilderCustomizer customizer() {
+			return LettuceClientConfigurationBuilder::useSsl;
+		}
+
 	}
 
 }


### PR DESCRIPTION
We now use `LettuceClientConfiguration` and `JedisClientConfiguration` to configure connection factories. Client-specific configuration can be customized by providing `LettuceClientConfigurationBuilderCustomizer` and `JedisClientConfigurationBuilderCustomizer` beans.