### PR TITLE
Adds maven install note for Windows

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-boot-docs/src/main/asciidoc/getting-started.adoc
@@ -99,7 +99,8 @@ installed you can follow the instructions at http://maven.apache.org.
 
 TIP: On many operating systems Maven can be installed via a package manager. If you're an
 OSX Homebrew user try `brew install maven`. Ubuntu users can run
-`sudo apt-get install maven`.
+`sudo apt-get install maven`. Windows users with Chocolatey can run `choco install maven`
+from an elevated prompt.
 
 Spring Boot dependencies use the `org.springframework.boot` `groupId`. Typically your
 Maven POM file will inherit from the `spring-boot-starter-parent` project and declare


### PR DESCRIPTION
See also: https://chocolatey.org/packages/maven

Chocolatey is a widely used software management system for Windows users. I've personally successfully used the Maven package with mentioned command.

I was tempted to include the chocolatey.org link in the docs too, but have not done so since this wasn't done for Homebrew or apt either.

Even though I guess this is an "Obvious Fix", I've still signed the contributors' agreement.