### PR TITLE
Set Lettuce shutdown timeout properly

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
@@ -85,8 +85,16 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 
 	private LettuceConnectionFactory createLettuceConnectionFactory(
 			ClientResources clientResources) {
-		return new LettuceConnectionFactory(applyProperties(createLettucePool(),
-				this.properties.getLettuce().getPool(), clientResources));
+		return applyProperties(
+				new LettuceConnectionFactory(applyProperties(createLettucePool(),
+						this.properties.getLettuce().getPool(), clientResources)));
+	}
+
+	private LettuceConnectionFactory applyProperties(
+			LettuceConnectionFactory connectionFactory) {
+		connectionFactory
+				.setShutdownTimeout(this.properties.getLettuce().getShutdownTimeout());
+		return connectionFactory;
 	}
 
 	private DefaultLettucePool createLettucePool() {
@@ -173,7 +181,7 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 			RedisProperties.Lettuce lettuce = this.properties.getLettuce();
 			if (lettuce.getShutdownTimeout() >= 0) {
 				builder.shutdownTimeout(Duration
-						.ofSeconds(this.properties.getLettuce().getShutdownTimeout()));
+						.ofMillis(this.properties.getLettuce().getShutdownTimeout()));
 			}
 		}
 		return builder;

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -316,7 +316,7 @@ public class RedisProperties {
 		/**
 		 * Shutdown timeout in milliseconds.
 		 */
-		private int shutdownTimeout = 2000;
+		private int shutdownTimeout = 100;
 
 		/**
 		 * Lettuce pool configuration.

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -72,13 +72,15 @@ public class RedisAutoConfigurationTests {
 
 	@Test
 	public void testOverrideRedisConfiguration() {
-		load("spring.redis.host:foo", "spring.redis.database:1");
+		load("spring.redis.host:foo", "spring.redis.database:1",
+				"spring.redis.lettuce.shutdown-timeout:100");
 		LettuceConnectionFactory cf = this.context
 				.getBean(LettuceConnectionFactory.class);
 		assertThat(cf.getHostName()).isEqualTo("foo");
 		assertThat(cf.getDatabase()).isEqualTo(1);
 		assertThat(cf.getPassword()).isNull();
 		assertThat(cf.isUseSsl()).isFalse();
+		assertThat(cf.getShutdownTimeout()).isEqualTo(100);
 	}
 
 	@Test
@@ -118,9 +120,11 @@ public class RedisAutoConfigurationTests {
 		load("spring.redis.host:foo", "spring.redis.lettuce.pool.min-idle:1",
 				"spring.redis.lettuce.pool.max-idle:4",
 				"spring.redis.lettuce.pool.max-active:16",
-				"spring.redis.lettuce.pool.max-wait:2000");
+				"spring.redis.lettuce.pool.max-wait:2000",
+				"spring.redis.lettuce.shutdown-timeout:100");
 		LettuceConnectionFactory cf = this.context
 				.getBean(LettuceConnectionFactory.class);
+		assertThat(cf.getShutdownTimeout()).isEqualTo(100);
 		assertThat(getDefaultLettucePool(cf).getHostName()).isEqualTo("foo");
 		assertThat(getDefaultLettucePool(cf).getPoolConfig().getMinIdle()).isEqualTo(1);
 		assertThat(getDefaultLettucePool(cf).getPoolConfig().getMaxIdle()).isEqualTo(4);


### PR DESCRIPTION
We now properly set the Lettuce client shutdown for unpooled and pooled configuration and reduce the default to 100ms.

Reducing the default to 100ms is a good compromise to retain a quiet time in for parallel execution and optimize for default, single-threaded execution (such as test execution or regular application shutdown). The shutdown timeout can be adjusted to fit specific application needs.