### PR TITLE
Fail tests with original exception when `ConditionEvaluationReport` cannot be generated

### DIFF
--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/SpringBootDependencyInjectionTestExecutionListener.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/SpringBootDependencyInjectionTestExecutionListener.java
@@ -51,7 +51,9 @@ public class SpringBootDependencyInjectionTestExecutionListener
 							.get(((ConfigurableApplicationContext) context).getBeanFactory());
 					System.err.println(new ConditionEvaluationReportMessage(report));
 				}
-			} catch (Exception ignore) {}
+			}
+			catch (Exception ignore) {
+			}
 			throw ex;
 		}
 	}

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/SpringBootDependencyInjectionTestExecutionListener.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/SpringBootDependencyInjectionTestExecutionListener.java
@@ -44,12 +44,14 @@ public class SpringBootDependencyInjectionTestExecutionListener
 			super.prepareTestInstance(testContext);
 		}
 		catch (Exception ex) {
-			ApplicationContext context = testContext.getApplicationContext();
-			if (context instanceof ConfigurableApplicationContext) {
-				ConditionEvaluationReport report = ConditionEvaluationReport
-						.get(((ConfigurableApplicationContext) context).getBeanFactory());
-				System.err.println(new ConditionEvaluationReportMessage(report));
-			}
+			try {
+				ApplicationContext context = testContext.getApplicationContext();
+				if (context instanceof ConfigurableApplicationContext) {
+					ConditionEvaluationReport report = ConditionEvaluationReport
+							.get(((ConfigurableApplicationContext) context).getBeanFactory());
+					System.err.println(new ConditionEvaluationReportMessage(report));
+				}
+			} catch (Exception ignore) {}
 			throw ex;
 		}
 	}


### PR DESCRIPTION
When application startup fails due to a bean configuration error, `SpringBootDependencyInjectionTestExecutionListener` attempts to get the `ApplicationContext` to build the `ConditionEvaluationReport`:

	Error starting ApplicationContext. To display the auto-configuration report re-run your application with 'debug' enabled.
	14:37:45.886 [main] ERROR o.s.b.SpringApplication - Application startup failed
	org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean

However, if that fails the test will fail with the failure from call to get the `ApplicationContext` which is likely different to the original failure, causing test results to show the incorrect failure:

	14:38:13.627 [main] ERROR o.s.t.c.TestContextManager - Caught exception while allowing TestExecutionListener [org.springframework.boot.test.autoconfigure.SpringBootDependencyInjectionTestExecutionListener@4dd02341] to prepare test instance
	java.lang.IllegalStateException: Failed to load ApplicationContext
		at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:124) ~[spring-test-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.springframework.test.context.support.DefaultTestContext.getApplicationContext(DefaultTestContext.java:83) ~[spring-test-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.springframework.boot.test.autoconfigure.SpringBootDependencyInjectionTestExecutionListener.prepareTestInstance(SpringBootDependencyInjectionTestExecutionListener.java:47) ~[spring-boot-test-autoconfigure-1.5.2.RELEASE.jar:1.5.2.RELEASE]
		at org.springframework.test.context.TestContextManager.prepareTestInstance(TestContextManager.java:230) [spring-test-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.createTest(SpringJUnit4ClassRunner.java:228) [spring-test-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.springframework.test.context.junit4.SpringJUnit4ClassRunner$1.runReflectiveCall(SpringJUnit4ClassRunner.java:287) [spring-test-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12) [junit-4.12.jar:4.12]
		at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.methodBlock(SpringJUnit4ClassRunner.java:289) [spring-test-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:247) [spring-test-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:94) [spring-test-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290) [junit-4.12.jar:4.12]
		at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71) [junit-4.12.jar:4.12]
		at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288) [junit-4.12.jar:4.12]
		at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58) [junit-4.12.jar:4.12]
		at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268) [junit-4.12.jar:4.12]
		at org.springframework.test.context.junit4.statements.RunBeforeTestClassCallbacks.evaluate(RunBeforeTestClassCallbacks.java:61) [spring-test-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.springframework.test.context.junit4.statements.RunAfterTestClassCallbacks.evaluate(RunAfterTestClassCallbacks.java:70) [spring-test-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.junit.runners.ParentRunner.run(ParentRunner.java:363) [junit-4.12.jar:4.12]
		at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.run(SpringJUnit4ClassRunner.java:191) [spring-test-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.junit.runner.JUnitCore.run(JUnitCore.java:137) [junit-4.12.jar:4.12]
		at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68) [junit-rt.jar:?]
		at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47) [junit-rt.jar:?]
		at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242) [junit-rt.jar:?]
		at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70) [junit-rt.jar:?]
	Caused by: java.lang.IllegalStateException: Not using expected bridge!!! class com.netflix.archaius.bridge.StaticAbstractConfiguration instead of class com.netflix.archaius.bridge.StaticAbstractConfiguration
		at com.netflix.archaius.bridge.StaticAbstractConfiguration.initialize(StaticAbstractConfiguration.java:51) ~[archaius2-archaius1-bridge-2.1.11.jar:0.7.0]
		at com.netflix.archaius.bridge.StaticBridgeInitializer.postProcessBeanFactory(StaticBridgeInitializer.java:13) ~[spring-boot-netflix-config-0.7.0.jar:0.7.0]
		at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:281) ~[spring-context-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:176) ~[spring-context-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.springframework.context.support.AbstractApplicationContext.invokeBeanFactoryPostProcessors(AbstractApplicationContext.java:686) ~[spring-context-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:524) ~[spring-context-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:737) ~[spring-boot-1.5.2.RELEASE.jar:1.5.2.RELEASE]
		at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:370) ~[spring-boot-1.5.2.RELEASE.jar:1.5.2.RELEASE]
		at org.springframework.boot.SpringApplication.run(SpringApplication.java:314) ~[spring-boot-1.5.2.RELEASE.jar:1.5.2.RELEASE]
		at org.springframework.boot.test.context.SpringBootContextLoader.loadContext(SpringBootContextLoader.java:120) ~[spring-boot-test-1.5.2.RELEASE.jar:1.5.2.RELEASE]
		at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContextInternal(DefaultCacheAwareContextLoaderDelegate.java:98) ~[spring-test-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:116) ~[spring-test-4.3.7.RELEASE.jar:4.3.7.RELEASE]
		... 23 more
