### PR TITLE
use getUsableSpace instead of getFreeSpace in DiskSpaceHealthIndicator

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DiskSpaceHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DiskSpaceHealthIndicator.java
@@ -46,7 +46,7 @@ public class DiskSpaceHealthIndicator extends AbstractHealthIndicator {
 	@Override
 	protected void doHealthCheck(Health.Builder builder) throws Exception {
 		File path = this.properties.getPath();
-		long diskFreeInBytes = path.getFreeSpace();
+		long diskFreeInBytes = path.getUsableSpace();
 		if (diskFreeInBytes >= this.properties.getThreshold()) {
 			builder.up();
 		}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/DiskSpaceHealthIndicatorTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/DiskSpaceHealthIndicatorTests.java
@@ -56,7 +56,7 @@ public class DiskSpaceHealthIndicatorTests {
 
 	@Test
 	public void diskSpaceIsUp() throws Exception {
-		given(this.fileMock.getFreeSpace()).willReturn(THRESHOLD_BYTES + 10);
+		given(this.fileMock.getUsableSpace()).willReturn(THRESHOLD_BYTES + 10);
 		given(this.fileMock.getTotalSpace()).willReturn(THRESHOLD_BYTES * 10);
 		Health health = this.healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
@@ -67,7 +67,7 @@ public class DiskSpaceHealthIndicatorTests {
 
 	@Test
 	public void diskSpaceIsDown() throws Exception {
-		given(this.fileMock.getFreeSpace()).willReturn(THRESHOLD_BYTES - 10);
+		given(this.fileMock.getUsableSpace()).willReturn(THRESHOLD_BYTES - 10);
 		given(this.fileMock.getTotalSpace()).willReturn(THRESHOLD_BYTES * 10);
 		Health health = this.healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Fix #9540