### PR TITLE
Produce Dropwizard timer metrics instead of gauges in MetricsFilter

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/MetricFilterProperties.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/MetricFilterProperties.java
@@ -42,10 +42,16 @@ public class MetricFilterProperties {
 	 */
 	private Set<MetricsFilterSubmission> counterSubmissions;
 
+	/**
+	 * Submissions that should be made to the timer.
+	 */
+	private Set<MetricsFilterSubmission> timerSubmissions;
+
 	public MetricFilterProperties() {
 		this.gaugeSubmissions = new HashSet<>(EnumSet.of(MetricsFilterSubmission.MERGED));
 		this.counterSubmissions = new HashSet<>(
 				EnumSet.of(MetricsFilterSubmission.MERGED));
+		this.timerSubmissions = new HashSet<>();
 	}
 
 	public Set<MetricsFilterSubmission> getGaugeSubmissions() {
@@ -64,12 +70,24 @@ public class MetricFilterProperties {
 		this.counterSubmissions = counterSubmissions;
 	}
 
+	public Set<MetricsFilterSubmission> getTimerSubmissions() {
+		return this.timerSubmissions;
+	}
+
+	public void setTimerSubmissions(Set<MetricsFilterSubmission> timerSubmissions) {
+		this.timerSubmissions = timerSubmissions;
+	}
+
 	boolean shouldSubmitToGauge(MetricsFilterSubmission submission) {
 		return shouldSubmit(this.gaugeSubmissions, submission);
 	}
 
 	boolean shouldSubmitToCounter(MetricsFilterSubmission submission) {
 		return shouldSubmit(this.counterSubmissions, submission);
+	}
+
+	boolean shouldSubmitToTimer(MetricsFilterSubmission submission) {
+		return shouldSubmit(this.timerSubmissions, submission);
 	}
 
 	private boolean shouldSubmit(Set<MetricsFilterSubmission> submissions,

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/MetricsFilter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/MetricsFilter.java
@@ -195,6 +195,9 @@ final class MetricsFilter extends OncePerRequestFilter {
 		if (this.properties.shouldSubmitToCounter(submission)) {
 			incrementCounter(getKey("status." + prefix + status + suffix));
 		}
+		if (this.properties.shouldSubmitToTimer(submission)) {
+			submitToGauge(getKey("timer.response." + prefix + suffix), time);
+		}
 	}
 
 	private String getKey(String string) {

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/MetricFilterAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/MetricFilterAutoConfigurationTests.java
@@ -67,6 +67,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -89,6 +90,7 @@ public class MetricFilterAutoConfigurationTests {
 				.containsExactly(MetricsFilterSubmission.MERGED);
 		assertThat(properties.getCounterSubmissions())
 				.containsExactly(MetricsFilterSubmission.MERGED);
+		assertThat(properties.getTimerSubmissions()).isEmpty();
 	}
 
 	@Test
@@ -405,6 +407,37 @@ public class MetricFilterAutoConfigurationTests {
 		filter.doFilter(request, response, chain);
 		verify(context.getBean(GaugeService.class), never()).submit(anyString(),
 				anyDouble());
+		verify(context.getBean(CounterService.class), never()).increment(anyString());
+		context.close();
+	}
+
+	@Test
+	public void recordsTimerMetricsIfConfigured() throws Exception {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		context.register(Config.class, MetricFilterAutoConfiguration.class);
+		TestPropertyValues.of("endpoints.metrics.filter.gauge-submissions=",
+				"endpoints.metrics.filter.counter-submissions=",
+				"endpoints.metrics.filter.timer-submissions=merged,per-http-method"
+		).applyTo(context);
+		context.refresh();
+		Filter filter = context.getBean(Filter.class);
+		final MockHttpServletRequest request = new MockHttpServletRequest("PUT",
+				"/test/path");
+		final MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain chain = mock(FilterChain.class);
+		willAnswer(new Answer<Object>() {
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				response.setStatus(200);
+				return null;
+			}
+		}).given(chain).doFilter(request, response);
+		filter.doFilter(request, response, chain);
+		verify(context.getBean(GaugeService.class)).submit(eq("timer.response.test.path"),
+				anyDouble());
+		verify(context.getBean(GaugeService.class)).submit(eq("timer.response.PUT.test.path"),
+				anyDouble());
+		verifyNoMoreInteractions(context.getBean(GaugeService.class));
 		verify(context.getBean(CounterService.class), never()).increment(anyString());
 		context.close();
 	}


### PR DESCRIPTION
Fixes #4405 in a general way (has nothing to do with DropWizard).
I think there's a strong case to be made that timers are way more appropriate than gauges for these kinds of metrics. Picking one value out of all the requests that are made within 10s (the default flush interval) is absolutely random for production systems.

I've only written one test, since the permutations would be quite a bunch.
I could imagine extracting a class that is responsible for submitting the metrics, which would ease testing, especially the need to test permutations - but maybe you're still fine with the way it is right now, so I didn' bother for now.