### PR TITLE
HealthIndicator for Neo4j

### DIFF
--- a/spring-boot-actuator/pom.xml
+++ b/spring-boot-actuator/pom.xml
@@ -362,7 +362,7 @@
 		<dependency>
 		    <groupId>org.neo4j</groupId>
 		    <artifactId>neo4j-ogm-test</artifactId>
-		    <version>3.0.0-M02</version>
+		    <version>${neo4j-ogm.version}</version>
 		    <scope>test</scope>
 		</dependency>		
 	</dependencies>

--- a/spring-boot-actuator/pom.xml
+++ b/spring-boot-actuator/pom.xml
@@ -359,5 +359,11 @@
 			<artifactId>snakeyaml</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+		    <groupId>org.neo4j</groupId>
+		    <artifactId>neo4j-ogm-test</artifactId>
+		    <version>3.0.0-M02</version>
+		    <scope>test</scope>
+		</dependency>		
 	</dependencies>
 </project>

--- a/spring-boot-actuator/pom.xml
+++ b/spring-boot-actuator/pom.xml
@@ -359,11 +359,5 @@
 			<artifactId>snakeyaml</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-		    <groupId>org.neo4j</groupId>
-		    <artifactId>neo4j-ogm-test</artifactId>
-		    <version>${neo4j-ogm.version}</version>
-		    <scope>test</scope>
-		</dependency>		
 	</dependencies>
 </project>

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/HealthIndicatorAutoConfiguration.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/HealthIndicatorAutoConfiguration.java
@@ -26,6 +26,7 @@ import javax.sql.DataSource;
 import com.couchbase.client.java.Bucket;
 import com.datastax.driver.core.Cluster;
 import org.apache.solr.client.solrj.SolrClient;
+import org.neo4j.ogm.session.SessionFactory;
 
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.InitializingBean;
@@ -42,6 +43,7 @@ import org.springframework.boot.actuate.health.JmsHealthIndicator;
 import org.springframework.boot.actuate.health.LdapHealthIndicator;
 import org.springframework.boot.actuate.health.MailHealthIndicator;
 import org.springframework.boot.actuate.health.MongoHealthIndicator;
+import org.springframework.boot.actuate.health.Neo4jHealthIndicator;
 import org.springframework.boot.actuate.health.OrderedHealthAggregator;
 import org.springframework.boot.actuate.health.RabbitHealthIndicator;
 import org.springframework.boot.actuate.health.RedisHealthIndicator;
@@ -59,6 +61,7 @@ import org.springframework.boot.autoconfigure.data.couchbase.CouchbaseDataAutoCo
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.ldap.LdapDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.neo4j.Neo4jDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.autoconfigure.elasticsearch.jest.JestAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -91,6 +94,7 @@ import org.springframework.mail.javamail.JavaMailSenderImpl;
  * @author Phillip Webb
  * @author Tommy Ludwig
  * @author Eddú Meléndez
+ * @author Eric Spiegelberg
  * @since 1.1.0
  */
 @Configuration
@@ -102,7 +106,7 @@ import org.springframework.mail.javamail.JavaMailSenderImpl;
 		LdapDataAutoConfiguration.class, MailSenderAutoConfiguration.class,
 		MongoAutoConfiguration.class, MongoDataAutoConfiguration.class,
 		RabbitAutoConfiguration.class, RedisAutoConfiguration.class,
-		SolrAutoConfiguration.class })
+		SolrAutoConfiguration.class, Neo4jDataAutoConfiguration.class })
 @EnableConfigurationProperties({ HealthIndicatorProperties.class })
 @Import({
 		ElasticsearchHealthIndicatorConfiguration.ElasticsearchClientHealthIndicatorConfiguration.class,
@@ -253,6 +257,28 @@ public class HealthIndicatorAutoConfiguration {
 		@ConditionalOnMissingBean(name = "ldapHealthIndicator")
 		public HealthIndicator ldapHealthIndicator() {
 			return createHealthIndicator(this.ldapOperations);
+		}
+
+	}
+
+	@Configuration
+	@ConditionalOnClass(SessionFactory.class)
+	@ConditionalOnBean(SessionFactory.class)
+	@ConditionalOnEnabledHealthIndicator("neo4j")
+	public static class Neo4jHealthIndicatorConfiguration extends
+			CompositeHealthIndicatorConfiguration<Neo4jHealthIndicator, SessionFactory> {
+
+		private final Map<String, SessionFactory> sessionFactories;
+
+		public Neo4jHealthIndicatorConfiguration(
+				Map<String, SessionFactory> sessionFactories) {
+			this.sessionFactories = sessionFactories;
+		}
+
+		@Bean
+		@ConditionalOnMissingBean(name = "neo4jHealthIndicator")
+		public HealthIndicator neo4jHealthIndicator() {
+			return createHealthIndicator(this.sessionFactories);
 		}
 
 	}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Neo4jHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Neo4jHealthIndicator.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.actuate.health;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 
 import org.neo4j.ogm.model.Result;
@@ -36,8 +36,6 @@ public class Neo4jHealthIndicator extends AbstractHealthIndicator {
 
 	private SessionFactory sessionFactory;
 
-	private Map<String, Object> emptyParameters = new HashMap<>();
-
 	/**
 	 * The default Cypher statement.
 	 */
@@ -56,7 +54,7 @@ public class Neo4jHealthIndicator extends AbstractHealthIndicator {
 	protected void doHealthCheck(Health.Builder builder) throws Exception {
 		Session session = this.sessionFactory.openSession();
 
-		Result result = session.query(this.cypher, this.emptyParameters);
+		Result result = session.query(this.cypher, Collections.emptyMap());
 		Iterable<Map<String, Object>> results = result.queryResults();
 
 		builder.up().withDetail(NEO4J, results);

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Neo4jHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Neo4jHealthIndicator.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.health;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+
+import org.neo4j.ogm.model.Result;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.util.Assert;
+
+/**
+ * {@link HealthIndicator} that tests the status of a Neo4j by executing a Cypher
+ * statement.
+ *
+ * @author Eric Spiegelberg
+ */
+public class Neo4jHealthIndicator extends AbstractHealthIndicator {
+
+	/** The key used to store Cypher execution results within the Health.Builder. */
+	public static final String CYPHER_RESULTS = "cypherResults";
+
+	/** The default Cypher query. */
+	public static final String CYPHER_DEFUALT = "match (n) return count(n) as nodeCount";
+
+	private SessionFactory sessionFactory;
+
+	private Map<String, Object> emptyParameters = new HashMap<>();
+
+	/**
+	 * The default Cypher statement.
+	 */
+	@Value("${neo4jHealthIndicator.cypher}")
+	private String cypher = CYPHER_DEFUALT;
+
+	/**
+	 * Create a new {@link Neo4jHealthIndicator} instance.
+	 */
+	public Neo4jHealthIndicator() {
+	}
+
+	/**
+	 * Create a new {@link Neo4jHealthIndicator} using the specified
+	 * {@link SessionFactory}.
+	 * @param sessionFactory the SessionFactory
+	 */
+	public Neo4jHealthIndicator(SessionFactory sessionFactory) {
+		this.sessionFactory = sessionFactory;
+	}
+
+	/**
+	 * Create a new {@link Neo4jHealthIndicator} using the specified
+	 * {@link SessionFactory} and validation query.
+	 * @param sessionFactory the SessionFactory
+	 * @param cypher the validation cypher query to use
+	 */
+	public Neo4jHealthIndicator(SessionFactory sessionFactory, String cypher) {
+		this.cypher = cypher;
+		this.sessionFactory = sessionFactory;
+	}
+
+	/**
+	 * Ensure that the SessionFactory and Cypher validation query has been supplied.
+	 */
+	@PostConstruct
+	public void postConstruct() {
+		Assert.notNull(this.sessionFactory,
+				"SessionFactory for Neo4jHealthIndicator must not be null");
+
+		Assert.hasText(this.cypher, "The Cypher statement must be specified");
+	}
+
+	@Override
+	protected void doHealthCheck(Health.Builder builder) throws Exception {
+		Session session = this.sessionFactory.openSession();
+
+		Result result = session.query(this.cypher, this.emptyParameters);
+		Iterable<Map<String, Object>> results = result.queryResults();
+
+		builder.up().withDetail(CYPHER_RESULTS, results);
+	}
+
+	/**
+	 * Return the validation Cypher query or {@code null}.
+	 * @return The query or {@code null}.
+	 */
+	public String getCypher() {
+		return this.cypher;
+	}
+
+	/**
+	 * Set a specific validation Cypher query to use to validate a connection. If none is
+	 * set, the default query is used.
+	 * @param cypher The cypher query used to evaluate the status of Neo4j.
+	 */
+	public void setCypher(String cypher) {
+		this.cypher = cypher;
+	}
+
+	/**
+	 * Set the {@link SessionFactory} to use.
+	 * @param sessionFactory The SessionFactory.
+	 */
+	public void setSessionFactory(SessionFactory sessionFactory) {
+		this.sessionFactory = sessionFactory;
+	}
+
+}

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Neo4jHealthIndicator.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Neo4jHealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,9 @@ package org.springframework.boot.actuate.health;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
-
 import org.neo4j.ogm.model.Result;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.session.SessionFactory;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.util.Assert;
 
 /**
  * {@link HealthIndicator} that tests the status of a Neo4j by executing a Cypher
@@ -37,10 +32,7 @@ import org.springframework.util.Assert;
 public class Neo4jHealthIndicator extends AbstractHealthIndicator {
 
 	/** The key used to store Cypher execution results within the Health.Builder. */
-	public static final String CYPHER_RESULTS = "cypherResults";
-
-	/** The default Cypher query. */
-	public static final String CYPHER_DEFUALT = "match (n) return count(n) as nodeCount";
+	public static final String NEO4J = "neo4j";
 
 	private SessionFactory sessionFactory;
 
@@ -49,14 +41,7 @@ public class Neo4jHealthIndicator extends AbstractHealthIndicator {
 	/**
 	 * The default Cypher statement.
 	 */
-	@Value("${neo4jHealthIndicator.cypher}")
-	private String cypher = CYPHER_DEFUALT;
-
-	/**
-	 * Create a new {@link Neo4jHealthIndicator} instance.
-	 */
-	public Neo4jHealthIndicator() {
-	}
+	private String cypher = "match (n) return count(n) as nodeCount";
 
 	/**
 	 * Create a new {@link Neo4jHealthIndicator} using the specified
@@ -67,28 +52,6 @@ public class Neo4jHealthIndicator extends AbstractHealthIndicator {
 		this.sessionFactory = sessionFactory;
 	}
 
-	/**
-	 * Create a new {@link Neo4jHealthIndicator} using the specified
-	 * {@link SessionFactory} and validation query.
-	 * @param sessionFactory the SessionFactory
-	 * @param cypher the validation cypher query to use
-	 */
-	public Neo4jHealthIndicator(SessionFactory sessionFactory, String cypher) {
-		this.cypher = cypher;
-		this.sessionFactory = sessionFactory;
-	}
-
-	/**
-	 * Ensure that the SessionFactory and Cypher validation query has been supplied.
-	 */
-	@PostConstruct
-	public void postConstruct() {
-		Assert.notNull(this.sessionFactory,
-				"SessionFactory for Neo4jHealthIndicator must not be null");
-
-		Assert.hasText(this.cypher, "The Cypher statement must be specified");
-	}
-
 	@Override
 	protected void doHealthCheck(Health.Builder builder) throws Exception {
 		Session session = this.sessionFactory.openSession();
@@ -96,7 +59,7 @@ public class Neo4jHealthIndicator extends AbstractHealthIndicator {
 		Result result = session.query(this.cypher, this.emptyParameters);
 		Iterable<Map<String, Object>> results = result.queryResults();
 
-		builder.up().withDetail(CYPHER_RESULTS, results);
+		builder.up().withDetail(NEO4J, results);
 	}
 
 	/**
@@ -114,14 +77,6 @@ public class Neo4jHealthIndicator extends AbstractHealthIndicator {
 	 */
 	public void setCypher(String cypher) {
 		this.cypher = cypher;
-	}
-
-	/**
-	 * Set the {@link SessionFactory} to use.
-	 * @param sessionFactory The SessionFactory.
-	 */
-	public void setSessionFactory(SessionFactory sessionFactory) {
-		this.sessionFactory = sessionFactory;
 	}
 
 }

--- a/spring-boot-actuator/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-actuator/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -182,6 +182,12 @@
     "defaultValue": true
   },
   {
+    "name": "management.health.neo4j.enabled",
+    "type": "java.lang.Boolean",
+    "description": "Enable Neo4j health check.",
+    "defaultValue": true
+  },
+  {
     "name": "management.info.build.enabled",
     "type": "java.lang.Boolean",
     "description": "Enable build info.",

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/HealthIndicatorAutoConfigurationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/autoconfigure/HealthIndicatorAutoConfigurationTests.java
@@ -23,6 +23,7 @@ import javax.sql.DataSource;
 import io.searchbox.client.JestClient;
 import org.junit.After;
 import org.junit.Test;
+import org.neo4j.ogm.session.SessionFactory;
 
 import org.springframework.boot.actuate.health.ApplicationHealthIndicator;
 import org.springframework.boot.actuate.health.CassandraHealthIndicator;
@@ -46,7 +47,6 @@ import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
-import org.springframework.boot.autoconfigure.data.neo4j.Neo4jDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.autoconfigure.elasticsearch.jest.JestAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
@@ -67,7 +67,6 @@ import org.springframework.data.cassandra.core.CassandraOperations;
 import org.springframework.data.couchbase.core.CouchbaseOperations;
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 import org.springframework.ldap.core.LdapOperations;
-import org.neo4j.ogm.session.SessionFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -595,7 +594,7 @@ public class HealthIndicatorAutoConfigurationTests {
 		assertThat(beans.values().iterator().next().getClass())
 				.isEqualTo(Neo4jHealthIndicator.class);
 	}
-	
+
 	@Test
 	public void notNeo4jHealthIndicator() throws Exception {
 		TestPropertyValues.of("management.health.diskspace.enabled:false",
@@ -609,7 +608,7 @@ public class HealthIndicatorAutoConfigurationTests {
 		assertThat(beans.values().iterator().next().getClass())
 				.isEqualTo(ApplicationHealthIndicator.class);
 	}
-	
+
 	@Configuration
 	@EnableConfigurationProperties
 	protected static class DataSourceConfig {
@@ -698,7 +697,7 @@ public class HealthIndicatorAutoConfigurationTests {
 		public SessionFactory sessionFactory() {
 			return mock(SessionFactory.class);
 		}
-		
+
 	}
-	
+
 }

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/Neo4jHealthIndicatorTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/Neo4jHealthIndicatorTests.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.health;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.ogm.config.Configuration;
+import org.neo4j.ogm.model.Result;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.transaction.Transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link Neo4jHealthIndicator}.
+ *
+ * @author Eric Spiegelberg
+ */
+public class Neo4jHealthIndicatorTests {
+
+	public static final String NODE_COUNT = "nodeCount";
+	public static final String RELATIONSHIP_COUNT = "relationshipCount";
+
+	private SessionFactory sessionFactory;
+
+	@Before
+	public void before() {
+		Configuration configuration = new Configuration.Builder().build();
+		this.sessionFactory = new SessionFactory(configuration, "foo.bar");
+	}
+
+	@After
+	public void after() {
+		if (this.sessionFactory != null) {
+			this.sessionFactory.close();
+		}
+	}
+
+	@Test
+	public void defaultValidationQuery() {
+		Map<String, Object> parameters = new HashMap<>();
+		Neo4jHealthIndicator neo4jHealthIndicator = new Neo4jHealthIndicator(
+				this.sessionFactory);
+		Session session = this.sessionFactory.openSession();
+		Result result = session.query(Neo4jHealthIndicator.CYPHER_DEFUALT, parameters);
+		long nodeCount = (long) result.iterator().next().get("nodeCount");
+		Map<String, Object> expectedCypherDetails = new HashMap<>();
+		expectedCypherDetails.put(NODE_COUNT, nodeCount);
+		assertExpectedResults(neo4jHealthIndicator, Status.UP, expectedCypherDetails);
+	}
+
+	@Test
+	public void customValidationQuery() {
+		Map<String, Object> parameters = new HashMap<>();
+		String customValidationQuery = "MATCH (n)-[r]-() RETURN count(n) as nodeCount, count(distinct(r)) as relationshipCount";
+		Session session = this.sessionFactory.openSession();
+		Result result = session.query(customValidationQuery, parameters);
+		Iterator<Map<String, Object>> results = result.iterator();
+		Map<String, Object> r = results.next();
+		long nodeCount = (long) r.get("nodeCount");
+		Map<String, Object> expectedCypherDetails = new HashMap<>();
+		expectedCypherDetails.put(NODE_COUNT, nodeCount);
+		long relationshipCount = (long) r.get("relationshipCount");
+		expectedCypherDetails.put(RELATIONSHIP_COUNT, relationshipCount);
+		Neo4jHealthIndicator neo4jHealthIndicator = new Neo4jHealthIndicator(
+				this.sessionFactory);
+		neo4jHealthIndicator.setCypher(customValidationQuery);
+		assertExpectedResults(neo4jHealthIndicator, Status.UP, expectedCypherDetails);
+
+		// Create 2 nodes and 1 relationship
+		try (Transaction transaction = session.beginTransaction()) {
+			session.query(
+					"create (a:A { name: 'foo' })-[:CONNECTED]->(b:B {name : 'bar'})",
+					parameters);
+			transaction.commit();
+		}
+
+		expectedCypherDetails.put(NODE_COUNT, nodeCount + 2);
+		expectedCypherDetails.put(RELATIONSHIP_COUNT, relationshipCount + 1);
+		assertExpectedResults(neo4jHealthIndicator, Status.UP, expectedCypherDetails);
+	}
+
+	@Test
+	public void invalidCustomValidationQuery() {
+		String invalidCypher = "invalid cypher statement";
+		Neo4jHealthIndicator neo4jHealthIndicator = new Neo4jHealthIndicator(
+				this.sessionFactory);
+		neo4jHealthIndicator.setCypher(invalidCypher);
+		assertExpectedResults(neo4jHealthIndicator, Status.DOWN, null);
+
+		neo4jHealthIndicator = new Neo4jHealthIndicator(this.sessionFactory,
+				invalidCypher);
+		assertExpectedResults(neo4jHealthIndicator, Status.DOWN, null);
+	}
+
+	@Test
+	public void postConstruct_success() {
+		Neo4jHealthIndicator neo4jHealthIndicator = new Neo4jHealthIndicator();
+		neo4jHealthIndicator.setSessionFactory(this.sessionFactory);
+		String cypher = "this is the cypher";
+		neo4jHealthIndicator.setCypher(cypher);
+		neo4jHealthIndicator.postConstruct();
+		Assert.assertEquals(cypher, neo4jHealthIndicator.getCypher());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void postConstruct_null_session_factor() {
+		Neo4jHealthIndicator neo4jHealthIndicator = new Neo4jHealthIndicator();
+		neo4jHealthIndicator.postConstruct();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void postConstruct_null_cypher() {
+		Neo4jHealthIndicator neo4jHealthIndicator = new Neo4jHealthIndicator();
+		neo4jHealthIndicator.setSessionFactory(this.sessionFactory);
+		neo4jHealthIndicator.setCypher(null);
+		neo4jHealthIndicator.postConstruct();
+	}
+
+	protected void assertExpectedResults(Neo4jHealthIndicator neo4jHealthIndicator,
+			Status expectedStatus, Map<String, Object> expectedCypherDetails) {
+		Health health = neo4jHealthIndicator.health();
+		assertThat(health.getStatus()).isEqualTo(expectedStatus);
+
+		if (expectedCypherDetails == null) {
+			assertThat(health.getDetails().get(Neo4jHealthIndicator.CYPHER_RESULTS))
+					.isNull();
+		}
+		else {
+			Map<String, Object> details = health.getDetails();
+			assertThat(health.getDetails().get(Neo4jHealthIndicator.CYPHER_RESULTS))
+					.isNotNull();
+			@SuppressWarnings("unchecked")
+			List<Map<String, Object>> cypherDetails = (List<Map<String, Object>>) details
+					.get(Neo4jHealthIndicator.CYPHER_RESULTS);
+			assertThat(cypherDetails).containsOnly(expectedCypherDetails);
+		}
+	}
+
+}


### PR DESCRIPTION
Add a HealthIndicator, modeled after existing ones such as DataSourceHealthIndicator, but tailored for Neo4j. A default Cypher statement, which can be overridden, is executed as the health check.

Includes basic code coverage, which makes use of an embedded instance of Neo4j and required neo4j-ogm-test to be added as a pom.xml dependency (at test scope).
