### PR TITLE
set password for redis configurations

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionConfiguration.java
@@ -79,6 +79,9 @@ abstract class RedisConnectionConfiguration {
 			RedisSentinelConfiguration config = new RedisSentinelConfiguration();
 			config.master(sentinelProperties.getMaster());
 			config.setSentinels(createSentinels(sentinelProperties));
+			if (properties.getPassword() != null) {
+				config.setPassword(RedisPassword.of(properties.getPassword()));
+			}
 			return config;
 		}
 		return null;
@@ -100,6 +103,9 @@ abstract class RedisConnectionConfiguration {
 				clusterProperties.getNodes());
 		if (clusterProperties.getMaxRedirects() != null) {
 			config.setMaxRedirects(clusterProperties.getMaxRedirects());
+		}
+		if (properties.getPassword() != null) {
+			config.setPassword(RedisPassword.of(properties.getPassword()));
 		}
 		return config;
 	}


### PR DESCRIPTION
**Set password for RedisSentinelConfiguration and RedisClusterConfiguration.**

_Since 2.0, configure the password using RedisStandaloneConfiguration, RedisSentinelConfiguration or RedisClusterConfiguration as described in the documentation._ 

In 2.0.0.M2,however,only RedisStandaloneConfiguration set the password property.
The test is as follows:
1. application.yml
```
spring:
  redis:
    cluster:
      nodes: ******
    password: ******
```
2. AppApplicationTests.kt
```
@RunWith(SpringRunner::class)
@SpringBootTest
class AppApplicationTests {
    @Autowired
    lateinit var stringRedisTemplate: StringRedisTemplate

    @Test
    fun contextLoads() {
        val valueOperations = stringRedisTemplate.opsForValue()
        valueOperations.set("foo", "bar")
        then(valueOperations.get("foo")).isEqualTo("bar")
    }
}
```

3. error

>  i.l.c.c.topology.ClusterTopologyRefresh  : Cannot retrieve partition view from RedisURI [host='******', port=****], error: java.util.concurrent.ExecutionException: io.lettuce.core.RedisCommandExecutionException: NOAUTH Authentication required.

While it's OK in version 2.0.0.M1. I have to declare a bean in AppApplicationTests then it works.

4. declare redisClusterConfiguration bean.
```
@RunWith(SpringRunner::class)
@SpringBootTest
class AppApplicationTests {
    @Autowired
    lateinit var stringRedisTemplate: StringRedisTemplate

    @TestConfiguration
    class Config {
        @Bean
        fun redisClusterConfiguration(redisProperties: RedisProperties) =
                RedisClusterConfiguration(redisProperties.cluster.nodes).apply {
                    redisProperties.cluster.maxRedirects?.let { maxRedirects = it }
                    redisProperties.password?.let { password = RedisPassword.of(it) }
                }
    }

    @Test
    fun contextLoads() {
        val valueOperations = stringRedisTemplate.opsForValue()
        valueOperations.set("foo", "bar")
        then(valueOperations.get("foo")).isEqualTo("bar")
    }

}
```

So it will be better without having to declare the bean.


