### PR TITLE
Add short docs on using Google App Engine

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/deployment.adoc
+++ b/spring-boot-docs/src/main/asciidoc/deployment.adoc
@@ -439,8 +439,64 @@ Maven build to run the app.
 
 
 [[cloud-deployment-gae]]
-=== Google App Engine
-Google App Engine is tied to the Servlet 2.5 API, so you can't deploy a Spring Application
+=== Google Cloud
+
+Google Cloud has several options that could be used to launch Spring Boot applications. The
+easiest to get started with is probably App Engine, but you could also find ways to run
+Spring Boot in a container with Container Engine, or on a virtual machine using Compute Engine.
+
+To run in App Engine you can create a project in the UI first, which
+sets up a unique identifier for you and also HTTP routes. Add a Java
+app to the project and leave it empty, then use the
+https://cloud.google.com/sdk/downloads[Google Cloud SDK] to push your
+Spring Boot app into that slot from the command line or CI build.
+
+App Engine needs you to create an `app.yaml` file to describe the
+resources your app requires. Normally you put this in
+`src/min/appengine`, and it looks something like this:
+
+[source,yaml,indent=0]
+----
+service: default
+
+runtime: java
+env: flex
+
+runtime_config:
+  jdk: openjdk8
+
+handlers:
+- url: /.*
+  script: this field is required, but ignored
+
+manual_scaling:
+  instances: 1
+
+health_check:
+  enable_health_check: False
+
+env_variables:
+  ENCRYPT_KEY: your_encryption_key_here
+----
+
+You can deploy the app, for example, with a Maven plugin by simply
+adding the project ID to the build configuration:
+
+[source,xml,indent=0,subs="verbatim,quotes,attributes"]
+----
+			<plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>appengine-maven-plugin</artifactId>
+                <version>1.3.0</version>
+                <configuration>
+                    <project>myproject</project>
+                </configuration>
+            </plugin>
+----
+
+Then deploy with `mvn appengine:deploy` (if you need to authenticate first the build will fail).
+
+NOTE: Google App Engine Classic is tied to the Servlet 2.5 API, so you can't deploy a Spring Application
 there without some modifications. See the <<howto.adoc#howto-servlet-2-5, Servlet 2.5 section>>
 of this guide.
 


### PR DESCRIPTION
Now that Google actually supports arbitrary docker container
execution in app engine, we can provide some more guidance
on how to use it in the "deployment" section.