### PR TITLE
Minor formatting fix in the log message

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/ChangeableUrls.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/ChangeableUrls.java
@@ -147,7 +147,7 @@ final class ChangeableUrls implements Iterable<URL> {
 					urls.add(referenced.toURI().toURL());
 				}
 				else {
-					System.err.println("Ignoring Class-Path entry " + entry + " found in"
+					System.err.println("Ignoring Class-Path entry " + entry + " found in "
 							+ jarFile.getName() + " as " + referenced
 							+ " does not exist");
 				}


### PR DESCRIPTION
This patch turns:

```
Ignoring Class-Path entry file:/... found in/Users/misagh/Workspace/...
```

Into

```
Ignoring Class-Path entry file:/... found in /Users/misagh/Workspace/...
```