### PR TITLE
Consistent property prefixes for Spring Session MongoDB and Spring Data MongoDB

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/MongoSessionProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/MongoSessionProperties.java
@@ -24,7 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Andy Wilkinson
  * @since 2.0.0
  */
-@ConfigurationProperties(prefix = "spring.session.mongo")
+@ConfigurationProperties(prefix = "spring.session.mongodb")
 public class MongoSessionProperties {
 
 	/**

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionStoreMappings.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionStoreMappings.java
@@ -35,7 +35,7 @@ final class SessionStoreMappings {
 	static {
 		Map<StoreType, Class<?>> mappings = new HashMap<>();
 		mappings.put(StoreType.REDIS, RedisSessionConfiguration.class);
-		mappings.put(StoreType.MONGO, MongoSessionConfiguration.class);
+		mappings.put(StoreType.MONGODB, MongoSessionConfiguration.class);
 		mappings.put(StoreType.JDBC, JdbcSessionConfiguration.class);
 		mappings.put(StoreType.HAZELCAST, HazelcastSessionConfiguration.class);
 		mappings.put(StoreType.NONE, NoOpSessionConfiguration.class);

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/StoreType.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/StoreType.java
@@ -32,9 +32,9 @@ public enum StoreType {
 	REDIS,
 
 	/**
-	 * Mongo backed sessions.
+	 * MongoDB backed sessions.
 	 */
-	MONGO,
+	MONGODB,
 
 	/**
 	 * JDBC backed sessions.

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationMongoTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationMongoTests.java
@@ -47,7 +47,7 @@ public class SessionAutoConfigurationMongoTests
 
 	@Test
 	public void defaultConfig() {
-		this.contextRunner.withPropertyValues("spring.session.store-type=mongo")
+		this.contextRunner.withPropertyValues("spring.session.store-type=mongodb")
 				.withConfiguration(AutoConfigurations.of(
 						EmbeddedMongoAutoConfiguration.class,
 						MongoAutoConfiguration.class, MongoDataAutoConfiguration.class))
@@ -73,8 +73,8 @@ public class SessionAutoConfigurationMongoTests
 				.withConfiguration(AutoConfigurations.of(
 						EmbeddedMongoAutoConfiguration.class,
 						MongoAutoConfiguration.class, MongoDataAutoConfiguration.class))
-				.withPropertyValues("spring.session.store-type=mongo",
-						"spring.session.mongo.collection-name=foo")
+				.withPropertyValues("spring.session.store-type=mongodb",
+						"spring.session.mongodb.collection-name=foo")
 				.run(validateSpringSessionUsesMongo("foo"));
 	}
 

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -427,8 +427,8 @@ content into your application; rather pick only the properties that you need.
 	spring.session.jdbc.schema=classpath:org/springframework/session/jdbc/schema-@@platform@@.sql # Path to the SQL file to use to initialize the database schema.
 	spring.session.jdbc.table-name=SPRING_SESSION # Name of database table used to store sessions.
 
-	# SPRING SESSION MONGO ({sc-spring-boot-autoconfigure}/session/MonogoSessionProperties.{sc-ext}[MongoSessionProperties])
-	spring.session.mongo.collection-name=sessions # Collection name used to store sessions.
+	# SPRING SESSION MONGODB ({sc-spring-boot-autoconfigure}/session/MongoSessionProperties.{sc-ext}[MongoSessionProperties])
+	spring.session.mongodb.collection-name=sessions # Collection name used to store sessions.
 
 	# SPRING SESSION REDIS ({sc-spring-boot-autoconfigure}/session/RedisSessionProperties.{sc-ext}[RedisSessionProperties])
 	spring.session.redis.flush-mode=on-save # Sessions flush mode.


### PR DESCRIPTION
This resolves #9552.

Changes are mostly a revert of 33dd9d6 adopted with ones from #9554. There are however a few other changes:

- new dependency management version `spring-session-mongodb.version` which is currently set to `2.0.0.BUILD-SNAPSHOT` ([next milestone](https://repo.spring.io/libs-milestone/org/springframework/session/spring-session-data-mongodb/) should be `2.0.0.M2`)
- MongoDB related configuration properties are renamed to `mongodb` to be consistent with naming (module was previously named `spring-session-data-mongo`, now is `spring-session-data-mongodb`)
- MongoDB related tests are moved to `SessionAutoConfigurationMongoTests`

Depending on release date of Spring Session MongoDB `2.0.0.M2` this could be targeted at Boot's `2.0.0.M3` (#9552 is currently targeted at `2.0.0.M4`).

/cc @rwinch @gregturn