### PR TITLE
Make ConfigFileApplicationListener implement SmartApplicationListener

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
@@ -45,9 +45,9 @@ import org.springframework.boot.env.PropertySourceLoader;
 import org.springframework.boot.env.RandomValuePropertySource;
 import org.springframework.boot.logging.DeferredLog;
 import org.springframework.context.ApplicationEvent;
-import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ConfigurationClassPostProcessor;
+import org.springframework.context.event.SmartApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -58,6 +58,7 @@ import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.SpringFactoriesLoader;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
@@ -93,7 +94,7 @@ import org.springframework.util.StringUtils;
  * @author Madhura Bhave
  */
 public class ConfigFileApplicationListener implements EnvironmentPostProcessor,
-		ApplicationListener<ApplicationEvent>, Ordered {
+		SmartApplicationListener, Ordered {
 
 	private static final String DEFAULT_PROPERTIES = "defaultProperties";
 
@@ -230,6 +231,17 @@ public class ConfigFileApplicationListener implements EnvironmentPostProcessor,
 	public void setSearchNames(String names) {
 		Assert.hasLength(names, "Names must not be empty");
 		this.names = names;
+	}
+
+	@Override
+	public boolean supportsEventType(Class<? extends ApplicationEvent> aClass) {
+		return ApplicationEnvironmentPreparedEvent.class.isAssignableFrom(aClass) ||
+				ApplicationPreparedEvent.class.isAssignableFrom(aClass);
+	}
+
+	@Override
+	public boolean supportsSourceType(@Nullable Class<?> aClass) {
+		return true;
 	}
 
 	/**

--- a/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
@@ -234,9 +234,9 @@ public class ConfigFileApplicationListener implements EnvironmentPostProcessor,
 	}
 
 	@Override
-	public boolean supportsEventType(Class<? extends ApplicationEvent> aClass) {
-		return ApplicationEnvironmentPreparedEvent.class.isAssignableFrom(aClass) ||
-				ApplicationPreparedEvent.class.isAssignableFrom(aClass);
+	public boolean supportsEventType(Class<? extends ApplicationEvent> eventType) {
+		return ApplicationEnvironmentPreparedEvent.class.isAssignableFrom(eventType) ||
+				ApplicationPreparedEvent.class.isAssignableFrom(eventType);
 	}
 
 	@Override


### PR DESCRIPTION
This will prevent ConfigFileApplicationListener from unnecessary handling all application events.
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->