### PR TITLE
disable trimStackTrace in surefire plugin

### DIFF
--- a/spring-boot-parent/pom.xml
+++ b/spring-boot-parent/pom.xml
@@ -570,6 +570,7 @@
 						<java.awt.headless>true</java.awt.headless>
 					</systemPropertyVariables>
 					<argLine>-Xmx1024m</argLine>
+					<trimStackTrace>false</trimStackTrace>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
In maven-surefire-plugin, the default value for `trimStackTrace` is true, so switch to false, then it will output full stack trace information

Fix #9428 