### PR TITLE
Fix Narayana recovery manager's too early start

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/transaction/jta/NarayanaJtaConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/transaction/jta/NarayanaJtaConfiguration.java
@@ -22,6 +22,7 @@ import javax.jms.Message;
 import javax.transaction.TransactionManager;
 import javax.transaction.UserTransaction;
 
+import com.arjuna.ats.arjuna.recovery.RecoveryManager;
 import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
 import org.jboss.tm.XAResourceRecoveryRegistry;
 
@@ -114,6 +115,7 @@ public class NarayanaJtaConfiguration {
 	@Bean
 	@DependsOn("narayanaConfiguration")
 	public RecoveryManagerService narayanaRecoveryManagerService() {
+		RecoveryManager.delayRecoveryManagerThread();
 		return new RecoveryManagerService();
 	}
 


### PR DESCRIPTION
A fix to make sure that Narayana recovery manager doesn't start until application is ready.