### PR TITLE
Add Jsonb support

### DIFF
--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -729,6 +729,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>javax.json</groupId>
+			<artifactId>javax.json-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 			<scope>test</scope>

--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -280,11 +280,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>javax.json</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>io.undertow</groupId>
 			<artifactId>undertow-servlet</artifactId>
 			<optional>true</optional>
@@ -739,8 +734,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse</groupId>
-			<artifactId>yasson</artifactId>
+			<groupId>org.apache.johnzon</groupId>
+			<artifactId>johnzon-jsonb</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -121,6 +121,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>javax.json.bind</groupId>
+			<artifactId>javax.json.bind-api</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>io.searchbox</groupId>
 			<artifactId>jest</artifactId>
 			<optional>true</optional>
@@ -272,6 +277,11 @@
 		<dependency>
 			<groupId>org.eclipse.jetty.websocket</groupId>
 			<artifactId>javax-websocket-server-impl</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.json</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -726,6 +736,12 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse</groupId>
+			<artifactId>yasson</artifactId>
+			<version>${javax-jsonb.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -741,7 +741,6 @@
 		<dependency>
 			<groupId>org.eclipse</groupId>
 			<artifactId>yasson</artifactId>
-			<version>${javax-jsonb.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/HttpMessageConvertersAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/HttpMessageConvertersAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.autoconfigure.jsonb.JsonbAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -44,12 +45,15 @@ import org.springframework.http.converter.StringHttpMessageConverter;
  * @author Andy Wilkinson
  * @author Sebastien Deleuze
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  */
 @Configuration
 @ConditionalOnClass(HttpMessageConverter.class)
-@AutoConfigureAfter({ GsonAutoConfiguration.class, JacksonAutoConfiguration.class })
+@AutoConfigureAfter({ GsonAutoConfiguration.class, JacksonAutoConfiguration.class,
+		JsonbAutoConfiguration.class })
 @Import({ JacksonHttpMessageConvertersConfiguration.class,
-		GsonHttpMessageConvertersConfiguration.class })
+		GsonHttpMessageConvertersConfiguration.class,
+		JsonbHttpMessageConvertersConfiguration.class })
 public class HttpMessageConvertersAutoConfiguration {
 
 	static final String PREFERRED_MAPPER_PROPERTY = "spring.http.converters.preferred-json-mapper";

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/JsonbHttpMessageConvertersConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/JsonbHttpMessageConvertersConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.autoconfigure.http;
 
-import com.google.gson.Gson;
+import javax.json.bind.Jsonb;
 
 import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -27,56 +27,55 @@ import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.converter.json.GsonHttpMessageConverter;
+import org.springframework.http.converter.json.JsonbHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
 /**
- * Configuration for HTTP Message converters that use Gson.
+ * Configuration for HTTP Message converters that use JSON-B.
  *
- * @author Andy Wilkinson
  * @author Eddú Meléndez
- * @since 1.2.2
+ * @author 2.0.0
  */
 @Configuration
-@ConditionalOnClass(Gson.class)
-class GsonHttpMessageConvertersConfiguration {
+@ConditionalOnClass(Jsonb.class)
+class JsonbHttpMessageConvertersConfiguration {
 
 	@Configuration
-	@ConditionalOnBean(Gson.class)
-	@Conditional(PreferGsonOrMissingJacksonAndJsonbCondition.class)
-	protected static class GsonHttpMessageConverterConfiguration {
+	@ConditionalOnBean(Jsonb.class)
+	@Conditional(PreferJsonbOrMissingJacksonAndGsonCondition.class)
+	protected static class JsonbHttpMessageConverterConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		public GsonHttpMessageConverter gsonHttpMessageConverter(Gson gson) {
-			GsonHttpMessageConverter converter = new GsonHttpMessageConverter();
-			converter.setGson(gson);
+		public JsonbHttpMessageConverter jsonbHttpMessageConverter(Jsonb jsonb) {
+			JsonbHttpMessageConverter converter = new JsonbHttpMessageConverter();
+			converter.setJsonb(jsonb);
 			return converter;
 		}
 
 	}
 
-	private static class PreferGsonOrMissingJacksonAndJsonbCondition extends AnyNestedCondition {
+	private static class PreferJsonbOrMissingJacksonAndGsonCondition extends AnyNestedCondition {
 
-		PreferGsonOrMissingJacksonAndJsonbCondition() {
+		PreferJsonbOrMissingJacksonAndGsonCondition() {
 			super(ConfigurationPhase.REGISTER_BEAN);
 		}
 
-		@ConditionalOnProperty(name = HttpMessageConvertersAutoConfiguration.PREFERRED_MAPPER_PROPERTY, havingValue = "gson", matchIfMissing = false)
-		static class GsonPreferred {
+		@ConditionalOnProperty(name = HttpMessageConvertersAutoConfiguration.PREFERRED_MAPPER_PROPERTY, havingValue = "jsonb", matchIfMissing = false)
+		static class JsonbPreferred {
 
 		}
 
-		@Conditional(JacksonAndJsonbMissing.class)
-		static class JacksonJsonbMissing {
+		@Conditional(JacksonAndGsonMissing.class)
+		static class JacksonGsonMissing {
 
 		}
 
 	}
 
-	private static class JacksonAndJsonbMissing extends NoneNestedConditions {
+	private static class JacksonAndGsonMissing extends NoneNestedConditions {
 
-		JacksonAndJsonbMissing() {
+		JacksonAndGsonMissing() {
 			super(ConfigurationPhase.REGISTER_BEAN);
 		}
 
@@ -85,8 +84,8 @@ class GsonHttpMessageConvertersConfiguration {
 
 		}
 
-		@ConditionalOnProperty(name = HttpMessageConvertersAutoConfiguration.PREFERRED_MAPPER_PROPERTY, havingValue = "jsonb")
-		static class JsonbMissing {
+		@ConditionalOnProperty(name = HttpMessageConvertersAutoConfiguration.PREFERRED_MAPPER_PROPERTY, havingValue = "gson")
+		static class GsonMissing {
 
 		}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jsonb/JsonbAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jsonb/JsonbAutoConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jsonb;
+
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for JSON-B.
+ *
+ * @author Eddú Meléndez
+ * @since 2.0.0
+ */
+@Configuration
+@ConditionalOnClass(Jsonb.class)
+public class JsonbAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	public Jsonb jsonb() {
+		return JsonbBuilder.create();
+	}
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jsonb/package-info.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jsonb/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for JSON-B.
+ */
+package org.springframework.boot.autoconfigure.jsonb;

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -572,7 +572,6 @@
   },
   {
     "name": "spring.http.converters.preferred-json-mapper",
-    "defaultValue" : "jackson",
     "values": [
       {
         "value": "gson"

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -572,12 +572,16 @@
   },
   {
     "name": "spring.http.converters.preferred-json-mapper",
+    "defaultValue" : "jackson",
     "values": [
       {
         "value": "gson"
       },
       {
         "value": "jackson"
+      },
+      {
+        "value": "jsonb"
       }
     ],
     "providers": [

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -80,6 +80,7 @@ org.springframework.boot.autoconfigure.jms.artemis.ArtemisAutoConfiguration,\
 org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration,\
 org.springframework.boot.autoconfigure.jersey.JerseyAutoConfiguration,\
 org.springframework.boot.autoconfigure.jooq.JooqAutoConfiguration,\
+org.springframework.boot.autoconfigure.jsonb.JsonbAutoConfiguration,\
 org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration,\
 org.springframework.boot.autoconfigure.ldap.embedded.EmbeddedLdapAutoConfiguration,\
 org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jsonb/JsonbAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jsonb/JsonbAutoConfigurationTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jsonb;
+
+import javax.json.bind.Jsonb;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link JsonbAutoConfiguration}.
+ *
+ * @author Eddú Meléndez
+ */
+public class JsonbAutoConfigurationTests {
+
+	AnnotationConfigApplicationContext context;
+
+	@Before
+	public void setUp() {
+		this.context = new AnnotationConfigApplicationContext();
+	}
+
+	@After
+	public void tearDown() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void jsonbRegistration() {
+		this.context.register(JsonbAutoConfiguration.class);
+		this.context.refresh();
+		Jsonb jsonb = this.context.getBean(Jsonb.class);
+		assertThat(jsonb.toJson(new DataObject())).isEqualTo("{\"data\":\"hello\"}");
+	}
+
+	public class DataObject {
+
+		@SuppressWarnings("unused")
+		private String data = "hello";
+
+		public String getData() {
+			return this.data;
+		}
+
+		public void setData(String data) {
+			this.data = data;
+		}
+	}
+
+}

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -117,9 +117,9 @@
 		<jna.version>4.4.0</jna.version>
 		<joda-time.version>2.9.9</joda-time.version>
 		<jolokia.version>1.3.7</jolokia.version>
+		<johnzon-jsonb.version>1.1.2</johnzon-jsonb.version>
 		<jooq.version>3.9.4</jooq.version>
 		<jsonassert.version>1.5.0</jsonassert.version>
-		<javax.json-api.version>1.1</javax.json-api.version>
 		<javax-jsonb.version>1.0</javax-jsonb.version>
 		<json-path.version>2.4.0</json-path.version>
 		<jstl.version>1.2</jstl.version>
@@ -886,11 +886,6 @@
 				<version>${javax-jms.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.glassfish</groupId>
-				<artifactId>javax.json</artifactId>
-				<version>${javax.json-api.version}</version>
-			</dependency>
-			<dependency>
 				<groupId>javax.json.bind</groupId>
 				<artifactId>javax.json.bind-api</artifactId>
 				<version>${javax-jsonb.version}</version>
@@ -1251,6 +1246,11 @@
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpmime</artifactId>
 				<version>${httpclient.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.johnzon</groupId>
+				<artifactId>johnzon-jsonb</artifactId>
+				<version>${johnzon-jsonb.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
@@ -2453,11 +2453,6 @@
 				<groupId>org.yaml</groupId>
 				<artifactId>snakeyaml</artifactId>
 				<version>${snakeyaml.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse</groupId>
-				<artifactId>yasson</artifactId>
-				<version>${javax-jsonb.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>redis.clients</groupId>

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -120,6 +120,7 @@
 		<johnzon-jsonb.version>1.1.2</johnzon-jsonb.version>
 		<jooq.version>3.9.4</jooq.version>
 		<jsonassert.version>1.5.0</jsonassert.version>
+		<javax-json.version>1.1</javax-json.version>
 		<javax-jsonb.version>1.0</javax-jsonb.version>
 		<json-path.version>2.4.0</json-path.version>
 		<jstl.version>1.2</jstl.version>
@@ -884,6 +885,11 @@
 				<groupId>javax.jms</groupId>
 				<artifactId>javax.jms-api</artifactId>
 				<version>${javax-jms.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>javax.json</groupId>
+				<artifactId>javax.json-api</artifactId>
+				<version>${javax-json.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.json.bind</groupId>

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -2455,6 +2455,11 @@
 				<version>${snakeyaml.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.eclipse</groupId>
+				<artifactId>yasson</artifactId>
+				<version>${javax-jsonb.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>redis.clients</groupId>
 				<artifactId>jedis</artifactId>
 				<version>${jedis.version}</version>

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -119,6 +119,8 @@
 		<jolokia.version>1.3.7</jolokia.version>
 		<jooq.version>3.9.4</jooq.version>
 		<jsonassert.version>1.5.0</jsonassert.version>
+		<javax.json-api.version>1.1</javax.json-api.version>
+		<javax-jsonb.version>1.0</javax-jsonb.version>
 		<json-path.version>2.4.0</json-path.version>
 		<jstl.version>1.2</jstl.version>
 		<jtds.version>1.3.1</jtds.version>
@@ -882,6 +884,16 @@
 				<groupId>javax.jms</groupId>
 				<artifactId>javax.jms-api</artifactId>
 				<version>${javax-jms.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.glassfish</groupId>
+				<artifactId>javax.json</artifactId>
+				<version>${javax.json-api.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>javax.json.bind</groupId>
+				<artifactId>javax.json.bind-api</artifactId>
+				<version>${javax-jsonb.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.mail</groupId>

--- a/spring-boot-test-autoconfigure/pom.xml
+++ b/spring-boot-test-autoconfigure/pom.xml
@@ -65,11 +65,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>javax.json</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>
 			<exclusions>
@@ -219,8 +214,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse</groupId>
-			<artifactId>yasson</artifactId>
+			<groupId>org.apache.johnzon</groupId>
+			<artifactId>johnzon-jsonb</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-test-autoconfigure/pom.xml
+++ b/spring-boot-test-autoconfigure/pom.xml
@@ -30,6 +30,11 @@
 		</dependency>
 		<!-- Optional -->
 		<dependency>
+			<groupId>javax.json.bind</groupId>
+			<artifactId>javax.json.bind-api</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<optional>true</optional>
@@ -57,6 +62,11 @@
 		<dependency>
 			<groupId>net.sourceforge.htmlunit</groupId>
 			<artifactId>htmlunit</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.json</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -206,6 +216,12 @@
 		<dependency>
 			<groupId>org.jooq</groupId>
 			<artifactId>jooq</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse</groupId>
+			<artifactId>yasson</artifactId>
+			<version>${javax-jsonb.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-test-autoconfigure/pom.xml
+++ b/spring-boot-test-autoconfigure/pom.xml
@@ -189,6 +189,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>javax.json</groupId>
+			<artifactId>javax.json-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-pool2</artifactId>
 			<scope>test</scope>

--- a/spring-boot-test-autoconfigure/pom.xml
+++ b/spring-boot-test-autoconfigure/pom.xml
@@ -221,7 +221,6 @@
 		<dependency>
 			<groupId>org.eclipse</groupId>
 			<artifactId>yasson</artifactId>
-			<version>${javax-jsonb.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/AutoConfigureJsonTesters.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/AutoConfigureJsonTesters.java
@@ -28,6 +28,7 @@ import org.springframework.boot.test.autoconfigure.properties.PropertyMapping;
 import org.springframework.boot.test.json.BasicJsonTester;
 import org.springframework.boot.test.json.GsonTester;
 import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.boot.test.json.JsonbTester;
 
 /**
  * Annotation that can be applied to a test class to enable and configure
@@ -45,8 +46,8 @@ import org.springframework.boot.test.json.JacksonTester;
 public @interface AutoConfigureJsonTesters {
 
 	/**
-	 * If {@link BasicJsonTester}, {@link JacksonTester} and {@link GsonTester} beans
-	 * should be registered. Defaults to {@code true}
+	 * If {@link BasicJsonTester}, {@link JacksonTester}, {@link JsonbTester} and
+	 * {@link GsonTester} beans should be registered. Defaults to {@code true}
 	 * @return if tester support is enabled
 	 */
 	boolean enabled() default true;

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonTest.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonTest.java
@@ -31,6 +31,7 @@ import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
 import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
 import org.springframework.boot.test.json.GsonTester;
 import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.boot.test.json.JsonbTester;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.test.context.BootstrapWith;
@@ -45,8 +46,9 @@ import org.springframework.test.context.BootstrapWith;
  * {@code Module})
  * <p>
  * By default, tests annotated with {@code JsonTest} will also initialize
- * {@link JacksonTester} and {@link GsonTester} fields. More fine-grained control can be
- * provided via the {@link AutoConfigureJsonTesters @AutoConfigureJsonTesters} annotation.
+ * {@link JacksonTester}, {@link JsonbTester} and {@link GsonTester} fields. More
+ * fine-grained control can be provided via the {@link AutoConfigureJsonTesters @AutoConfigureJsonTesters}
+ * annotation.
  *
  * @author Phillip Webb
  * @see AutoConfigureJson

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonTestersAutoConfiguration.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonTestersAutoConfiguration.java
@@ -19,6 +19,8 @@ package org.springframework.boot.test.autoconfigure.json;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 
+import javax.json.bind.Jsonb;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 
@@ -33,10 +35,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.autoconfigure.jsonb.JsonbAutoConfiguration;
 import org.springframework.boot.test.json.AbstractJsonMarshalTester;
 import org.springframework.boot.test.json.BasicJsonTester;
 import org.springframework.boot.test.json.GsonTester;
 import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.boot.test.json.JsonbTester;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
@@ -48,13 +52,15 @@ import org.springframework.util.ReflectionUtils;
  * Auto-configuration for Json testers.
  *
  * @author Phillip Webb
+ * @author Eddú Meléndez
  * @see AutoConfigureJsonTesters
  * @since 1.4.0
  */
 @Configuration
 @ConditionalOnClass(name = "org.assertj.core.api.Assert")
 @ConditionalOnProperty("spring.test.jsontesters.enabled")
-@AutoConfigureAfter({ JacksonAutoConfiguration.class, GsonAutoConfiguration.class })
+@AutoConfigureAfter({ JacksonAutoConfiguration.class, GsonAutoConfiguration.class,
+		JsonbAutoConfiguration.class })
 public class JsonTestersAutoConfiguration {
 
 	@Bean
@@ -90,6 +96,18 @@ public class JsonTestersAutoConfiguration {
 		@ConditionalOnBean(Gson.class)
 		public FactoryBean<GsonTester<?>> gsonTesterFactoryBean(Gson gson) {
 			return new JsonTesterFactoryBean<>(GsonTester.class, gson);
+		}
+
+	}
+
+	@ConditionalOnClass(Jsonb.class)
+	private static class JsonbJsonTesterConfiguration {
+
+		@Bean
+		@Scope("prototype")
+		@ConditionalOnBean(Jsonb.class)
+		public FactoryBean<JsonbTester<?>> jsonbTesterFactoryBean(Jsonb jsonb) {
+			return new JsonTesterFactoryBean<>(JsonbTester.class, jsonb);
 		}
 
 	}

--- a/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -67,13 +67,15 @@ org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration
 # AutoConfigureJson auto-configuration imports
 org.springframework.boot.test.autoconfigure.json.AutoConfigureJson=\
 org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration,\
-org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
+org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration,\
+org.springframework.boot.autoconfigure.jsonb.JsonbAutoConfiguration
 
 # AutoConfigureJsonTesters auto-configuration imports
 org.springframework.boot.test.autoconfigure.json.AutoConfigureJsonTesters=\
 org.springframework.boot.test.autoconfigure.json.JsonTestersAutoConfiguration,\
 org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration,\
-org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
+org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration,\
+org.springframework.boot.autoconfigure.jsonb.JsonbAutoConfiguration
 
 # AutoConfigureWebClient auto-configuration imports
 org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient=\
@@ -111,6 +113,7 @@ org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration,\
 org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration,\
 org.springframework.boot.autoconfigure.http.codec.CodecsAutoConfiguration,\
 org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration,\
+org.springframework.boot.autoconfigure.jsonb.JsonbAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration
 
@@ -123,6 +126,7 @@ org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration,\
 org.springframework.boot.autoconfigure.hateoas.HypermediaAutoConfiguration,\
 org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration,\
 org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration,\
+org.springframework.boot.autoconfigure.jsonb.JsonbAutoConfiguration.\
 org.springframework.boot.autoconfigure.mustache.MustacheAutoConfiguration,\
 org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration,\
 org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration,\

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/json/JsonTestIntegrationTests.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/json/JsonTestIntegrationTests.java
@@ -28,6 +28,7 @@ import org.springframework.boot.test.json.BasicJsonTester;
 import org.springframework.boot.test.json.GsonTester;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.boot.test.json.JsonContent;
+import org.springframework.boot.test.json.JsonbTester;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -38,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Eddú Meléndez
  */
 @RunWith(SpringRunner.class)
 @JsonTest
@@ -58,6 +60,9 @@ public class JsonTestIntegrationTests {
 
 	@Autowired
 	private GsonTester<ExampleBasicObject> gsonJson;
+
+	@Autowired
+	private JsonbTester<ExampleBasicObject> jsonbJson;
 
 	@Test
 	public void basicJson() throws Exception {
@@ -82,6 +87,13 @@ public class JsonTestIntegrationTests {
 		ExampleBasicObject object = new ExampleBasicObject();
 		object.setValue("spring");
 		assertThat(this.gsonJson.write(object)).isEqualToJson("example.json");
+	}
+
+	@Test
+	public void jsonb() throws Exception {
+		ExampleBasicObject object = new ExampleBasicObject();
+		object.setValue("spring");
+		assertThat(this.jsonbJson.write(object)).isEqualToJson("example.json");
 	}
 
 	@Test

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/json/JsonTestWithAutoConfigureJsonTestersTests.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/json/JsonTestWithAutoConfigureJsonTestersTests.java
@@ -25,6 +25,7 @@ import org.springframework.boot.test.autoconfigure.json.app.ExampleJsonApplicati
 import org.springframework.boot.test.json.BasicJsonTester;
 import org.springframework.boot.test.json.GsonTester;
 import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.boot.test.json.JsonbTester;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -50,6 +51,9 @@ public class JsonTestWithAutoConfigureJsonTestersTests {
 	@Autowired(required = false)
 	private GsonTester<ExampleBasicObject> gsonTester;
 
+	@Autowired(required = false)
+	private JsonbTester<ExampleBasicObject> jsonbTester;
+
 	@Test
 	public void basicJson() throws Exception {
 		assertThat(this.basicJson).isNull();
@@ -63,6 +67,11 @@ public class JsonTestWithAutoConfigureJsonTestersTests {
 	@Test
 	public void gson() throws Exception {
 		assertThat(this.gsonTester).isNull();
+	}
+
+	@Test
+	public void jsonb() throws Exception {
+		assertThat(this.jsonbTester).isNull();
 	}
 
 }

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/json/SpringBootTestWithAutoConfigureJsonTestersTests.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/json/SpringBootTestWithAutoConfigureJsonTestersTests.java
@@ -26,6 +26,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.json.BasicJsonTester;
 import org.springframework.boot.test.json.GsonTester;
 import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.boot.test.json.JsonbTester;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -50,6 +51,9 @@ public class SpringBootTestWithAutoConfigureJsonTestersTests {
 
 	@Autowired
 	private GsonTester<ExampleBasicObject> gsonTester;
+
+	@Autowired
+	JsonbTester<ExampleBasicObject> jsonbTester;
 
 	@Test
 	public void contextLoads() {

--- a/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/json/SpringBootTestWithAutoConfigureJsonTestersTests.java
+++ b/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/json/SpringBootTestWithAutoConfigureJsonTestersTests.java
@@ -53,12 +53,13 @@ public class SpringBootTestWithAutoConfigureJsonTestersTests {
 	private GsonTester<ExampleBasicObject> gsonTester;
 
 	@Autowired
-	JsonbTester<ExampleBasicObject> jsonbTester;
+	private JsonbTester<ExampleBasicObject> jsonbTester;
 
 	@Test
 	public void contextLoads() {
 		assertThat(this.basicJson).isNotNull();
 		assertThat(this.jacksonTester).isNotNull();
+		assertThat(this.jsonbTester).isNotNull();
 		assertThat(this.gsonTester).isNotNull();
 	}
 

--- a/spring-boot-test/pom.xml
+++ b/spring-boot-test/pom.xml
@@ -122,6 +122,11 @@
 		</dependency>
 		<!-- Test -->
 		<dependency>
+			<groupId>javax.json</groupId>
+			<artifactId>javax.json-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-test-support</artifactId>
 			<scope>test</scope>

--- a/spring-boot-test/pom.xml
+++ b/spring-boot-test/pom.xml
@@ -155,7 +155,6 @@
 		<dependency>
 			<groupId>org.eclipse</groupId>
 			<artifactId>yasson</artifactId>
-			<version>${javax-jsonb.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-test/pom.xml
+++ b/spring-boot-test/pom.xml
@@ -71,11 +71,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>javax.json</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-core</artifactId>
 			<optional>true</optional>
@@ -153,8 +148,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse</groupId>
-			<artifactId>yasson</artifactId>
+			<groupId>org.apache.johnzon</groupId>
+			<artifactId>johnzon-jsonb</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-test/pom.xml
+++ b/spring-boot-test/pom.xml
@@ -46,6 +46,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>javax.json.bind</groupId>
+			<artifactId>javax.json.bind-api</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 		<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<optional>true</optional>
@@ -63,6 +68,11 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.json</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -140,6 +150,12 @@
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-xml</artifactId>
 			<optional>true</optional>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse</groupId>
+			<artifactId>yasson</artifactId>
+			<version>${javax-jsonb.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-test/src/main/java/org/springframework/boot/test/json/JsonbTester.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/json/JsonbTester.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.json;
+
+import java.io.IOException;
+import java.io.Reader;
+
+import javax.json.bind.Jsonb;
+
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.core.ResolvableType;
+import org.springframework.util.Assert;
+
+/**
+ * AssertJ based JSON tester backed by Jsonb. Usually instantiated via
+ * {@link #initFields(Object, Jsonb)}, for example: <pre class="code">
+ * public class ExampleObjectJsonTests {
+ *
+ * 	private JsonbTester&lt;ExampleObject&gt; json;
+ *
+ * 	&#064;Before
+ * 	public void setup() {
+ * 		Jsonb jsonb = JsonbBuilder.create();
+ * 		JsonbTester.initFields(this, jsonb);
+ * 	}
+ *
+ * 	&#064;Test
+ * 	public void testWriteJson() throws IOException {
+ * 		ExampleObject object = // ...
+ * 		assertThat(json.write(object)).isEqualToJson(&quot;expected.json&quot;);
+ * 	}
+ *
+ * }
+ * </pre>
+ *
+ * See {@link AbstractJsonMarshalTester} for more details.
+ *
+ * @param <T> the type under test
+ * @author Eddú Meléndez
+ * @since 2.0.0
+ */
+public class JsonbTester<T> extends AbstractJsonMarshalTester<T> {
+
+	private final Jsonb jsonb;
+
+	/**
+	 * Create a new uninitialized {@link GsonTester} instance.
+	 * @param jsonb the Jsonb instance
+	 */
+	protected JsonbTester(Jsonb jsonb) {
+		Assert.notNull(jsonb, "Jsonb must not be null");
+		this.jsonb = jsonb;
+	}
+
+	/**
+	 * Create a new {@link JsonbTester} instance.
+	 * @param resourceLoadClass the source class used to load resources
+	 * @param type the type under test
+	 * @param jsonb the Jsonb instance
+	 * @see #initFields(Object, Jsonb)
+	 */
+	public JsonbTester(Class<?> resourceLoadClass, ResolvableType type, Jsonb jsonb) {
+		super(resourceLoadClass, type);
+		Assert.notNull(jsonb, "Jsonb must not be null");
+		this.jsonb = jsonb;
+	}
+
+	@Override
+	protected String writeObject(T value, ResolvableType type) throws IOException {
+		return this.jsonb.toJson(value, type.getType());
+	}
+
+	@Override
+	protected T readObject(Reader reader, ResolvableType type) throws IOException {
+		return this.jsonb.fromJson(reader, type.getType());
+	}
+
+	/**
+	 * Utility method to initialize {@link JsonbTester} fields. See {@link JsonbTester
+	 * class-level documentation} for example usage.
+	 * @param testInstance the test instance
+	 * @param jsonb the Gson instance
+	 */
+	public static void initFields(Object testInstance, Jsonb jsonb) {
+		new JsonbFieldInitializer().initFields(testInstance, jsonb);
+	}
+
+	/**
+	 * Utility method to initialize {@link JsonbTester} fields. See {@link JsonbTester
+	 * class-level documentation} for example usage.
+	 * @param testInstance the test instance
+	 * @param jsonb an object factory to create the Gson instance
+	 */
+	public static void initFields(Object testInstance, ObjectFactory<Jsonb> jsonb) {
+		new JsonbTester.JsonbFieldInitializer().initFields(testInstance, jsonb);
+	}
+
+	/**
+	 * {@link FieldInitializer} for Jsonb.
+	 */
+	private static class JsonbFieldInitializer extends FieldInitializer<Jsonb> {
+
+		protected JsonbFieldInitializer() {
+			super(JsonbTester.class);
+		}
+
+		@Override
+		protected AbstractJsonMarshalTester<Object> createTester(
+				Class<?> resourceLoadClass, ResolvableType type, Jsonb marshaller) {
+			return new JsonbTester<>(resourceLoadClass, type, marshaller);
+		}
+	}
+
+}

--- a/spring-boot-test/src/main/java/org/springframework/boot/test/json/JsonbTester.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/json/JsonbTester.java
@@ -58,7 +58,7 @@ public class JsonbTester<T> extends AbstractJsonMarshalTester<T> {
 	private final Jsonb jsonb;
 
 	/**
-	 * Create a new uninitialized {@link GsonTester} instance.
+	 * Create a new uninitialized {@link JsonbTester} instance.
 	 * @param jsonb the Jsonb instance
 	 */
 	protected JsonbTester(Jsonb jsonb) {
@@ -93,7 +93,7 @@ public class JsonbTester<T> extends AbstractJsonMarshalTester<T> {
 	 * Utility method to initialize {@link JsonbTester} fields. See {@link JsonbTester
 	 * class-level documentation} for example usage.
 	 * @param testInstance the test instance
-	 * @param jsonb the Gson instance
+	 * @param jsonb the Jsonb instance
 	 */
 	public static void initFields(Object testInstance, Jsonb jsonb) {
 		new JsonbFieldInitializer().initFields(testInstance, jsonb);
@@ -103,7 +103,7 @@ public class JsonbTester<T> extends AbstractJsonMarshalTester<T> {
 	 * Utility method to initialize {@link JsonbTester} fields. See {@link JsonbTester
 	 * class-level documentation} for example usage.
 	 * @param testInstance the test instance
-	 * @param jsonb an object factory to create the Gson instance
+	 * @param jsonb an object factory to create the Jsonb instance
 	 */
 	public static void initFields(Object testInstance, ObjectFactory<Jsonb> jsonb) {
 		new JsonbTester.JsonbFieldInitializer().initFields(testInstance, jsonb);

--- a/spring-boot-test/src/test/java/org/springframework/boot/test/json/JsonbTesterTests.java
+++ b/spring-boot-test/src/test/java/org/springframework/boot/test/json/JsonbTesterTests.java
@@ -63,7 +63,7 @@ public class JsonbTesterTests extends AbstractJsonMarshalTesterTests {
 	@Override
 	protected AbstractJsonMarshalTester<Object> createTester(Class<?> resourceLoadClass,
 			ResolvableType type) {
-		return new JsonbTester<Object>(resourceLoadClass, type, JsonbBuilder.create());
+		return new JsonbTester<>(resourceLoadClass, type, JsonbBuilder.create());
 	}
 
 	static abstract class InitFieldsBaseClass {

--- a/spring-boot-test/src/test/java/org/springframework/boot/test/json/JsonbTesterTests.java
+++ b/spring-boot-test/src/test/java/org/springframework/boot/test/json/JsonbTesterTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.json;
+
+import java.util.List;
+
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+
+import org.junit.Test;
+
+import org.springframework.core.ResolvableType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link JsonbTester}.
+ *
+ * @author Eddú Meléndez
+ */
+public class JsonbTesterTests extends AbstractJsonMarshalTesterTests {
+
+	@Test
+	public void initFieldsWhenTestIsNullShouldThrowException() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("TestInstance must not be null");
+		JsonbTester.initFields(null, JsonbBuilder.create());
+	}
+
+	@Test
+	public void initFieldsWhenMarshallerIsNullShouldThrowException() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Marshaller must not be null");
+		JsonbTester.initFields(new InitFieldsTestClass(), (Jsonb) null);
+	}
+
+	@Test
+	public void initFieldsShouldSetNullFields() {
+		InitFieldsTestClass test = new InitFieldsTestClass();
+		assertThat(test.test).isNull();
+		assertThat(test.base).isNull();
+		JsonbTester.initFields(test, JsonbBuilder.create());
+		assertThat(test.test).isNotNull();
+		assertThat(test.base).isNotNull();
+		assertThat(test.test.getType().resolve()).isEqualTo(List.class);
+		assertThat(test.test.getType().resolveGeneric()).isEqualTo(ExampleObject.class);
+	}
+
+	@Override
+	protected AbstractJsonMarshalTester<Object> createTester(Class<?> resourceLoadClass,
+			ResolvableType type) {
+		return new JsonbTester<Object>(resourceLoadClass, type, JsonbBuilder.create());
+	}
+
+	static abstract class InitFieldsBaseClass {
+
+		public JsonbTester<ExampleObject> base;
+
+		public JsonbTester<ExampleObject> baseSet = new JsonbTester<>(
+				InitFieldsBaseClass.class, ResolvableType.forClass(ExampleObject.class),
+				JsonbBuilder.create());
+
+	}
+
+	static class InitFieldsTestClass extends InitFieldsBaseClass {
+
+		public JsonbTester<List<ExampleObject>> test;
+
+		public JsonbTester<ExampleObject> testSet = new JsonbTester<>(
+				InitFieldsBaseClass.class, ResolvableType.forClass(ExampleObject.class),
+				JsonbBuilder.create());
+
+	}
+
+}


### PR DESCRIPTION
Spring Framework 5 will support Jsonb as a HttpMessageConverter, this
commit adds auto-configuration support. Also, support for Jsonb in the
@JsonTest has been added.

This implementation is running against Yasson (RI for Jsonb).

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->