### PR TITLE
Improve Narayana JDBC helper to create connections when needed for recovery

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/jta/narayana/ConnectionManager.java
+++ b/spring-boot/src/main/java/org/springframework/boot/jta/narayana/ConnectionManager.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jta.narayana;
+
+import java.sql.SQLException;
+
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Manager able to connect and disconnect when needed for the required operations. If SQL connection is already available, it
+ * will simply executed requested operation. If SQL connection is not available, it will create it, execute a requested
+ * operation, and close the connection.
+ *
+ * @author Gytis Trikleris
+ */
+class ConnectionManager {
+
+	private static final Log logger = LogFactory.getLog(DataSourceXAResourceRecoveryHelper.class);
+
+	private final XADataSource dataSource;
+
+	private final String user;
+
+	private final String password;
+
+	private XAConnection connection;
+
+	private XAResource resource;
+
+	/**
+	 * Create a new {@link ConnectionManager} instance.
+	 * @param dataSource DataSource to be used when handling connections.
+	 * @param user Username with which connection should be created.
+	 * @param password Password of the user.
+	 */
+	ConnectionManager(XADataSource dataSource, String user, String password) {
+		this.dataSource = dataSource;
+		this.user = user;
+		this.password = password;
+	}
+
+	/**
+	 * Invoke {@link XAResourceConsumer} accept method before making sure that SQL connection is available. Current connection
+	 * is used if one is available. If connection is not available, new connection is created before the accept call and closed
+	 * after it.
+	 *
+	 * @param consumer {@link XAResourceConsumer} to be executed.
+	 * @throws XAException if connection cannot be created or exception thrown by the consumer.
+	 */
+	void connectAndAccept(XAResourceConsumer consumer) throws XAException {
+		if (isConnected()) {
+			consumer.accept(this.resource);
+			return;
+		}
+
+		connect();
+		try {
+			consumer.accept(this.resource);
+		}
+		finally {
+			disconnect();
+		}
+	}
+
+	/**
+	 * Invoke {@link XAResourceFunction} apply method before making sure that SQL connection is available. Current connection is
+	 * used if one is available. If connection is not available, new connection is created before the apply call and closed
+	 * after it.
+	 *
+	 * @param function {@link XAResourceFunction} to be executed.
+	 * @param <T> Return type of the {@link XAResourceFunction}.
+	 * @return The result of {@link XAResourceFunction}.
+	 * @throws XAException if connection cannot be created or exception thrown by the function.
+	 */
+	<T> T connectAndApply(XAResourceFunction<T> function) throws XAException {
+		if (isConnected()) {
+			return function.apply(this.resource);
+		}
+
+		connect();
+		try {
+			return function.apply(this.resource);
+		}
+		finally {
+			disconnect();
+		}
+	}
+
+	/**
+	 * Create SQL connection if one is not available.
+	 *
+	 * @throws XAException if connection cannot be created.
+	 */
+	public void connect() throws XAException {
+		if (isConnected()) {
+			return;
+		}
+
+		try {
+			this.connection = getXaConnection();
+			this.resource = this.connection.getXAResource();
+		}
+		catch (SQLException e) {
+			if (this.connection != null) {
+				try {
+					this.connection.close();
+				}
+				catch (SQLException ignore) {
+				}
+			}
+			logger.warn("Failed to create connection", e);
+			throw new XAException(XAException.XAER_RMFAIL);
+		}
+	}
+
+	/**
+	 * Close current SQL connection.
+	 */
+	public void disconnect() {
+		if (!isConnected()) {
+			return;
+		}
+
+		try {
+			this.connection.close();
+		}
+		catch (SQLException e) {
+			logger.warn("Failed to close connection", e);
+		}
+		finally {
+			this.connection = null;
+			this.resource = null;
+		}
+	}
+
+	/**
+	 * Check if SQL connection is active.
+	 *
+	 * @return {@code true} if SQL connection is active.
+	 */
+	public boolean isConnected() {
+		return this.connection != null && this.resource != null;
+	}
+
+	private XAConnection getXaConnection() throws SQLException {
+		if (this.user == null && this.password == null) {
+			return this.dataSource.getXAConnection();
+		}
+		return this.dataSource.getXAConnection(this.user, this.password);
+	}
+
+}

--- a/spring-boot/src/main/java/org/springframework/boot/jta/narayana/NarayanaXADataSourceWrapper.java
+++ b/spring-boot/src/main/java/org/springframework/boot/jta/narayana/NarayanaXADataSourceWrapper.java
@@ -52,18 +52,11 @@ public class NarayanaXADataSourceWrapper implements XADataSourceWrapper {
 
 	@Override
 	public DataSource wrapDataSource(XADataSource dataSource) {
-		XAResourceRecoveryHelper recoveryHelper = getRecoveryHelper(dataSource);
+		ConnectionManager connectionManager = new ConnectionManager(dataSource, this.properties.getRecoveryDbUser(),
+				this.properties.getRecoveryDbPass());
+		XAResourceRecoveryHelper recoveryHelper = new DataSourceXAResourceRecoveryHelper(connectionManager);
 		this.recoveryManager.registerXAResourceRecoveryHelper(recoveryHelper);
 		return new NarayanaDataSourceBean(dataSource);
-	}
-
-	private XAResourceRecoveryHelper getRecoveryHelper(XADataSource dataSource) {
-		if (this.properties.getRecoveryDbUser() == null
-				&& this.properties.getRecoveryDbPass() == null) {
-			return new DataSourceXAResourceRecoveryHelper(dataSource);
-		}
-		return new DataSourceXAResourceRecoveryHelper(dataSource,
-				this.properties.getRecoveryDbUser(), this.properties.getRecoveryDbPass());
 	}
 
 }

--- a/spring-boot/src/main/java/org/springframework/boot/jta/narayana/XAResourceConsumer.java
+++ b/spring-boot/src/main/java/org/springframework/boot/jta/narayana/XAResourceConsumer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jta.narayana;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+
+/**
+ * Functional consumer interface which can throw {@link XAException}.
+ *
+ * @author Gytis Trikleris
+ */
+@FunctionalInterface
+public interface XAResourceConsumer {
+
+	void accept(XAResource xaResource) throws XAException;
+
+}

--- a/spring-boot/src/main/java/org/springframework/boot/jta/narayana/XAResourceFunction.java
+++ b/spring-boot/src/main/java/org/springframework/boot/jta/narayana/XAResourceFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jta.narayana;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+
+/**
+ * Functional function interface which can throw {@link XAException}.
+ *
+ * @author Gytis Trikleris
+ * @param <T> Function response type
+ */
+@FunctionalInterface
+public interface XAResourceFunction<T> {
+
+	T apply(XAResource xaResource) throws XAException;
+
+}

--- a/spring-boot/src/test/java/org/springframework/boot/jta/narayana/ConnectionManagerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/jta/narayana/ConnectionManagerTests.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jta.narayana;
+
+import java.sql.SQLException;
+
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link ConnectionManager}.
+ *
+ * @author Gytis Trikleris
+ */
+public class ConnectionManagerTests {
+
+	@Mock
+	private XADataSource xaDataSource;
+
+	@Mock
+	private XAConnection xaConnection;
+
+	@Mock
+	private XAResource xaResource;
+
+	private String user = "testUser";
+
+	private String pass = "testPass";
+
+	private ConnectionManager connectionManager;
+
+	@Before
+	public void before() throws SQLException {
+		MockitoAnnotations.initMocks(this);
+
+		given(this.xaDataSource.getXAConnection()).willReturn(this.xaConnection);
+		given(this.xaDataSource.getXAConnection(anyString(), anyString())).willReturn(this.xaConnection);
+		given(this.xaConnection.getXAResource()).willReturn(this.xaResource);
+
+		this.connectionManager = new ConnectionManager(this.xaDataSource, this.user, this.pass);
+	}
+
+	@Test
+	public void shouldConnectWithoutCredentials() throws XAException, SQLException {
+		this.connectionManager = new ConnectionManager(this.xaDataSource, null, null);
+		this.connectionManager.connect();
+		verify(this.xaDataSource, times(1)).getXAConnection();
+		verify(this.xaDataSource, times(0)).getXAConnection(anyString(), anyString());
+		assertThat(this.connectionManager.isConnected()).isTrue();
+	}
+
+	@Test
+	public void shouldConnectWithCredentials() throws XAException, SQLException {
+		this.connectionManager.connect();
+		verify(this.xaDataSource, times(0)).getXAConnection();
+		verify(this.xaDataSource, times(1)).getXAConnection(anyString(), anyString());
+		assertThat(this.connectionManager.isConnected()).isTrue();
+	}
+
+	@Test
+	public void shouldNotConnectWithExistingConnection() throws XAException, SQLException {
+		this.connectionManager.connect();
+		this.connectionManager.connect();
+		verify(this.xaDataSource, times(1)).getXAConnection(anyString(), anyString());
+		assertThat(this.connectionManager.isConnected()).isTrue();
+	}
+
+	@Test
+	public void shouldFailToConnect() throws XAException, SQLException {
+		given(this.xaDataSource.getXAConnection(anyString(), anyString())).willThrow(new SQLException("test"));
+		try {
+			this.connectionManager.connect();
+			fail("XAException was expected");
+		}
+		catch (XAException e) {
+			assertThat(e.errorCode).isEqualTo(XAException.XAER_RMFAIL);
+		}
+
+	}
+
+	@Test
+	public void shouldDisconnect() throws XAException, SQLException {
+		this.connectionManager.connect();
+		this.connectionManager.disconnect();
+		verify(this.xaConnection, times(1)).close();
+		assertThat(this.connectionManager.isConnected()).isFalse();
+	}
+
+	@Test
+	public void shouldFailToDisconnect() throws XAException, SQLException {
+		willThrow(new SQLException("test")).given(this.xaConnection).close();
+		this.connectionManager.connect();
+		this.connectionManager.disconnect();
+		verify(this.xaConnection, times(1)).close();
+		assertThat(this.connectionManager.isConnected()).isFalse();
+	}
+
+	@Test
+	public void shouldNotDisconnectWithoutConnection() throws XAException, SQLException {
+		this.connectionManager.disconnect();
+		verify(this.xaConnection, times(0)).close();
+		assertThat(this.connectionManager.isConnected()).isFalse();
+	}
+
+	@Test
+	public void shouldAcceptWithoutConnecting() throws XAException, SQLException {
+		this.connectionManager.connect();
+		this.connectionManager.connectAndAccept(XAResource::getTransactionTimeout);
+		verify(this.xaDataSource, times(1)).getXAConnection(anyString(), anyString());
+		verify(this.xaResource, times(1)).getTransactionTimeout();
+		assertThat(this.connectionManager.isConnected()).isTrue();
+	}
+
+	@Test
+	public void shouldConnectAndAccept() throws XAException, SQLException {
+		this.connectionManager.connectAndAccept(XAResource::getTransactionTimeout);
+		verify(this.xaDataSource, times(1)).getXAConnection(anyString(), anyString());
+		verify(this.xaConnection, times(1)).close();
+		verify(this.xaResource, times(1)).getTransactionTimeout();
+		assertThat(this.connectionManager.isConnected()).isFalse();
+	}
+
+	@Test
+	public void shouldFailToConnectAndNotAccept() throws XAException, SQLException {
+		given(this.xaDataSource.getXAConnection(anyString(), anyString())).willThrow(new SQLException("test"));
+		try {
+			this.connectionManager.connectAndAccept(XAResource::getTransactionTimeout);
+			fail("Exception expected");
+		}
+		catch (XAException ignored) {
+		}
+		verify(this.xaDataSource, times(1)).getXAConnection(anyString(), anyString());
+		verify(this.xaConnection, times(0)).close();
+		verify(this.xaConnection, times(0)).getXAResource();
+		verify(this.xaResource, times(0)).getTransactionTimeout();
+		assertThat(this.connectionManager.isConnected()).isFalse();
+	}
+
+	@Test
+	public void shouldApplyWithoutConnecting() throws XAException, SQLException {
+		this.connectionManager.connect();
+		this.connectionManager.connectAndApply(XAResource::getTransactionTimeout);
+		verify(this.xaDataSource, times(1)).getXAConnection(anyString(), anyString());
+		verify(this.xaConnection, times(1)).getXAResource();
+		verify(this.xaResource, times(1)).getTransactionTimeout();
+		assertThat(this.connectionManager.isConnected()).isTrue();
+	}
+
+	@Test
+	public void shouldConnectAndApply() throws XAException, SQLException {
+		this.connectionManager.connectAndApply(XAResource::getTransactionTimeout);
+		verify(this.xaDataSource, times(1)).getXAConnection(anyString(), anyString());
+		verify(this.xaConnection, times(1)).close();
+		verify(this.xaConnection, times(1)).getXAResource();
+		verify(this.xaResource, times(1)).getTransactionTimeout();
+		assertThat(this.connectionManager.isConnected()).isFalse();
+	}
+
+	@Test
+	public void shouldFailToConnectAndNotApply() throws XAException, SQLException {
+		given(this.xaDataSource.getXAConnection(anyString(), anyString())).willThrow(new SQLException("test"));
+		try {
+			this.connectionManager.connectAndApply(XAResource::getTransactionTimeout);
+			fail("Exception expected");
+		}
+		catch (XAException ignored) {
+		}
+		verify(this.xaDataSource, times(1)).getXAConnection(anyString(), anyString());
+		verify(this.xaConnection, times(0)).close();
+		verify(this.xaConnection, times(0)).getXAResource();
+		verify(this.xaResource, times(0)).getTransactionTimeout();
+		assertThat(this.connectionManager.isConnected()).isFalse();
+	}
+
+}

--- a/spring-boot/src/test/java/org/springframework/boot/jta/narayana/NarayanaXADataSourceWrapperTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/jta/narayana/NarayanaXADataSourceWrapperTests.java
@@ -63,7 +63,7 @@ public class NarayanaXADataSourceWrapperTests {
 		assertThat(wrapped).isInstanceOf(NarayanaDataSourceBean.class);
 		verify(this.recoveryManager, times(1)).registerXAResourceRecoveryHelper(
 				any(DataSourceXAResourceRecoveryHelper.class));
-		verify(this.properties, times(2)).getRecoveryDbUser();
+		verify(this.properties, times(1)).getRecoveryDbUser();
 		verify(this.properties, times(1)).getRecoveryDbPass();
 	}
 


### PR DESCRIPTION
Prior this pull request, database connection were created on `DataSourceXAResourceRecoveryHelper.getXAResources()` call and closed on `DataSourceXAResourceRecoveryHelper.recover(TMENDRSCAN)` call. While this workflow is still valid for most of the time, a change in one of Narayana recovery modules, allows commit/rollback calls to appear outside of this workflow. To make sure, that those calls will get through to the database, I've introduced a `ConnectionManager`, which makes sure that connection is created and closed whenever needed during recovery.