### PR TITLE
clarified usage of spring.config.location and spring.config.name in the docs

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -528,7 +528,7 @@ in "/".
 If a property is not found in the locations specified in `spring.config.location`
 the default search path will be used (`classpath:,classpath:/config,file:,file:config/`).
 
-If spring.config.location contains multiple locations they will be searched from right
+If `spring.config.location` contains multiple locations they will be searched from right
 to left, i.e. the last location in the list has precedence (just like in the default
 search path). In that way you can set up default values for your application in
 `application.properties` (or whatever other basename you choose with `spring.config.name`)
@@ -565,7 +565,7 @@ NOTE: If you have specified any files in `spring.config.location`, profile-speci
 variants of those files will not be considered. Use directories in `spring.config.location`
 if you also want to use profile-specific properties. In that case, the base file name
 specified in `spring.config.name` (or `application` by default) and the profile-specific
-suffixes are appended to the directories before the config is being loaded.
+suffixes are appended to the directories before the properties are being loaded.
 
 
 

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -523,19 +523,16 @@ determine which files have to be loaded so they have to be defined as an environ
 property (typically OS env, system property or command line argument).
 
 If `spring.config.location` contains directories (as opposed to files) they should end
-in `/` (and will be appended with the names generated from `spring.config.name` before
-being loaded, including profile-specific file names). Files specified in
-`spring.config.location` are used as-is, with no support for profile-specific variants,
-and will be overridden by any profile-specific properties.
+in "/".
 
-The default search path `classpath:,classpath:/config,file:,file:config/`
-is always used, irrespective of the value of `spring.config.location`. This search path
-is ordered from lowest to highest precedence (`file:config/` wins). If you do specify
-your own locations, they take precedence over all of the default locations and use the
-same lowest to highest precedence ordering. In that way you can set up default values for
-your application in `application.properties` (or whatever other basename you choose with
-`spring.config.name`) and override it at runtime with a different file, keeping the
-defaults.
+If a property is not found in the locations specified in `spring.config.location`
+the default search path will be used (`classpath:,classpath:/config,file:,file:config/`).
+
+If spring.config.location contains multiple locations they will be searched from right
+to left, i.e. the last location in the list has precedence (just like in the default
+search path). In that way you can set up default values for your application in
+`application.properties` (or whatever other basename you choose with `spring.config.name`)
+and override it at runtime with a different file, keeping the defaults.
 
 NOTE: If you use environment variables rather than system properties, most operating
 systems disallow period-separated key names, but you can use underscores instead (e.g.
@@ -565,8 +562,10 @@ specified by the `spring.profiles.active` property are added after those configu
 the `SpringApplication` API and therefore take precedence.
 
 NOTE: If you have specified any files in `spring.config.location`, profile-specific
-variants of those files will not be considered. Use directories in
-`spring.config.location` if you also want to also use profile-specific properties.
+variants of those files will not be considered. Use directories in `spring.config.location`
+if you also want to use profile-specific properties. In that case, the base file name
+specified in `spring.config.name` (or `application` by default) and the profile-specific
+suffixes are appended to the directories before the config is being loaded.
 
 
 


### PR DESCRIPTION
Moved explanation concerning profile-specific properties into the
next section to make the explanation simpler.
Fixes #4062 when merged.

I also stumbled over this part in the docs, hope this makes it clearer.