### PR TITLE
Enable reloads of individual CSS files in DevTools

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/OptionalLiveReloadServer.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/OptionalLiveReloadServer.java
@@ -28,6 +28,7 @@ import org.springframework.boot.devtools.livereload.LiveReloadServer;
  * gracefully fail to start (e.g. because of a port conflict) or may be omitted entirely.
  *
  * @author Phillip Webb
+ * @author Luka Žitnik
  * @since 1.3.0
  */
 public class OptionalLiveReloadServer {
@@ -68,11 +69,17 @@ public class OptionalLiveReloadServer {
 
 	/**
 	 * Trigger LiveReload if the server is up an running.
+	 * @param path path of file to reload, as full as possible/known, absolute path
+	 * preferred, file name only is OK
 	 */
-	public void triggerReload() {
+	public void triggerReload(String path) {
 		if (this.server != null) {
-			this.server.triggerReload();
+			this.server.triggerReload(path);
 		}
+	}
+
+	public void triggerReload() {
+		this.triggerReload(null);
 	}
 
 }

--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/livereload/Connection.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/livereload/Connection.java
@@ -35,6 +35,7 @@ import org.springframework.util.Base64Utils;
  * A {@link LiveReloadServer} connection.
  *
  * @author Phillip Webb
+ * @author Luka Žitnik
  */
 class Connection {
 
@@ -130,12 +131,15 @@ class Connection {
 
 	/**
 	 * Trigger livereload for the client using this connection.
+	 * @param path path of file to reload, as full as possible/known, absolute path
+	 * preferred, file name only is OK
 	 * @throws IOException in case of I/O errors
 	 */
-	public void triggerReload() throws IOException {
+	public void triggerReload(String path) throws IOException {
 		if (this.webSocket) {
 			logger.debug("Triggering LiveReload");
-			writeWebSocketFrame(new Frame("{\"command\":\"reload\",\"path\":\"/\"}"));
+			writeWebSocketFrame(
+					new Frame("{\"command\":\"reload\",\"path\":\"" + path + "\"}"));
 		}
 	}
 

--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/livereload/LiveReloadServer.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/livereload/LiveReloadServer.java
@@ -211,13 +211,15 @@ public class LiveReloadServer {
 
 	/**
 	 * Trigger livereload of all connected clients.
+	 * @param path path of file to reload, as full as possible/known, absolute path
+	 * preferred, file name only is OK
 	 */
-	public void triggerReload() {
+	public void triggerReload(String path) {
 		synchronized (this.monitor) {
 			synchronized (this.connections) {
 				for (Connection connection : this.connections) {
 					try {
-						connection.triggerReload();
+						connection.triggerReload(path);
 					}
 					catch (Exception ex) {
 						logger.debug("Unable to send reload message", ex);
@@ -225,6 +227,10 @@ public class LiveReloadServer {
 				}
 			}
 		}
+	}
+
+	public void triggerReload() {
+		this.triggerReload(null);
 	}
 
 	private void addConnection(Connection connection) {

--- a/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/client/RemoteClientConfigurationTests.java
+++ b/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/client/RemoteClientConfigurationTests.java
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.verify;
  * Tests for {@link RemoteClientConfiguration}.
  *
  * @author Phillip Webb
+ * @author Luka Žitnik
  */
 public class RemoteClientConfigurationTests {
 
@@ -123,7 +124,7 @@ public class RemoteClientConfigurationTests {
 		configuration.getExecutor().shutdown();
 		configuration.getExecutor().awaitTermination(2, TimeUnit.SECONDS);
 		LiveReloadServer server = this.clientContext.getBean(LiveReloadServer.class);
-		verify(server).triggerReload();
+		verify(server).triggerReload(null);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes gh-9668

Hi @philwebb,

These changes follow you guidance but I'm not sure they are exactly as you wanted them -- this is my first contribution to the project, so there's much to learn. E.g. these would always send the path of a single changed file, even if it's not a CSS file, but in that case the client would reload the whole page.