### PR TITLE
ignore OPTIONS requests by default

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/SpringBootWebSecurityConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/SpringBootWebSecurityConfiguration.java
@@ -196,9 +196,8 @@ public class SpringBootWebSecurityConfiguration {
 					matchers.add(new AntPathRequestMatcher(pattern, null));
 				}
 			}
-			if (!matchers.isEmpty()) {
-				configurer.requestMatchers(new OrRequestMatcher(matchers));
-			}
+			matchers.add(new AntPathRequestMatcher("/**", "OPTIONS"));
+			configurer.requestMatchers(new OrRequestMatcher(matchers));
 		}
 
 		private List<String> getIgnored(SecurityProperties security) {


### PR DESCRIPTION
If security is enabled, preflight requests are currently answered with 401. This is a problem e.g. for Angular users and you need to fix it with a custom security config. See reports in #5834, #6566 or on Stack Overflow https://stackoverflow.com/q/21696592/3156607, https://stackoverflow.com/q/28010307/3156607, https://stackoverflow.com/q/27501045/3156607

OPTIONS requests should not require authentication: https://stackoverflow.com/a/15734032/3156607