### PR TITLE
git-commit-id-plugin should describe --always

### DIFF
--- a/spring-boot-starters/spring-boot-starter-parent/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-parent/pom.xml
@@ -146,6 +146,9 @@
 						<dateFormat>yyyy-MM-dd'T'HH:mm:ssZ</dateFormat>
 						<generateGitPropertiesFile>true</generateGitPropertiesFile>
 						<generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+						<gitDescribe>
+							<always>true</always>
+						</gitDescribe>
 					</configuration>
 				</plugin>
 				<!-- Support our own plugin -->


### PR DESCRIPTION
git-commit-id-plugin should pass `--always` to git when running describe to avoid git returning an error when describing a shallow clone.

See https://github.com/ktoso/maven-git-commit-id-plugin/issues/61

Without this change, an error will occurs when building in a shallow clone:
```
[ERROR] Failed to execute goal pl.project13.maven:git-commit-id-plugin:2.2.2:revision (default) on project mindsight: Could not complete Mojo execution... Unable to find commits until some tag: Walk failure. Missing commit a5bb6881b545cbcd0f54b6decfc2b1a41ca85279 -> [Help 1]
```