### PR TITLE
Simplify retrieval of Narayana XARecoveryModule

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/jta/narayana/NarayanaRecoveryManagerBean.java
+++ b/spring-boot/src/main/java/org/springframework/boot/jta/narayana/NarayanaRecoveryManagerBean.java
@@ -16,8 +16,6 @@
 
 package org.springframework.boot.jta.narayana;
 
-import com.arjuna.ats.arjuna.recovery.RecoveryManager;
-import com.arjuna.ats.arjuna.recovery.RecoveryModule;
 import com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule;
 import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
 import com.arjuna.ats.jta.recovery.XAResourceRecoveryHelper;
@@ -53,20 +51,17 @@ public class NarayanaRecoveryManagerBean implements InitializingBean, Disposable
 		this.recoveryManagerService.destroy();
 	}
 
-	void registerXAResourceRecoveryHelper(
-			XAResourceRecoveryHelper xaResourceRecoveryHelper) {
-		getXARecoveryModule(RecoveryManager.manager())
-				.addXAResourceRecoveryHelper(xaResourceRecoveryHelper);
+	void registerXAResourceRecoveryHelper(XAResourceRecoveryHelper xaResourceRecoveryHelper) {
+		getXARecoveryModule().addXAResourceRecoveryHelper(xaResourceRecoveryHelper);
 	}
 
-	private XARecoveryModule getXARecoveryModule(RecoveryManager recoveryManager) {
-		for (RecoveryModule recoveryModule : recoveryManager.getModules()) {
-			if (recoveryModule instanceof XARecoveryModule) {
-				return (XARecoveryModule) recoveryModule;
-			}
+	private XARecoveryModule getXARecoveryModule() {
+		XARecoveryModule xaRecoveryModule = XARecoveryModule.getRegisteredXARecoveryModule();
+		if (xaRecoveryModule == null) {
+			throw new IllegalStateException(
+					"XARecoveryModule is not registered with recovery manager");
 		}
-		throw new IllegalStateException(
-				"XARecoveryModule is not registered with recovery manager");
+		return xaRecoveryModule;
 	}
 
 }


### PR DESCRIPTION
Simplify code by using XARecoveryModule.getRegisteredXARecoveryModule() instead of iterating the list to retrieve XARecoveryModule.