### PR TITLE
PatternSyntaxException may be thrown when looking for an environment entry or metric with a name that looks a bit like a regular expression

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/NamePatternFilter.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/NamePatternFilter.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Utility class that can be used to filter source data using a name regular expression.
@@ -31,6 +32,7 @@ import java.util.regex.Pattern;
  * @author Phillip Webb
  * @author Sergei Egorov
  * @author Andy Wilkinson
+ * @author Dylian Bego
  * @since 1.3.0
  */
 abstract class NamePatternFilter<T> {
@@ -44,13 +46,13 @@ abstract class NamePatternFilter<T> {
 	}
 
 	public Map<String, Object> getResults(String name) {
-		if (!isRegex(name)) {
+		Pattern pattern = getRegexPattern(name);
+		if (pattern == null) { // this is not a regex
 			Object value = getValue(this.source, name);
 			Map<String, Object> result = new HashMap<>();
 			result.put(name, value);
 			return result;
 		}
-		Pattern pattern = Pattern.compile(name);
 		ResultCollectingNameCallback resultCollector = new ResultCollectingNameCallback(
 				pattern);
 		getNames(this.source, resultCollector);
@@ -58,13 +60,18 @@ abstract class NamePatternFilter<T> {
 
 	}
 
-	private boolean isRegex(String name) {
+	private Pattern getRegexPattern(String name) {
 		for (String part : REGEX_PARTS) {
 			if (name.contains(part)) {
-				return true;
+				try {
+					return Pattern.compile(name);
+				}
+				catch (PatternSyntaxException e) {
+					return null;
+				}
 			}
 		}
-		return false;
+		return null;
 	}
 
 	protected abstract void getNames(T source, NameCallback callback);

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/NamePatternFilterTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/mvc/NamePatternFilterTests.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Dylian Bego
  */
 public class NamePatternFilterTests {
 
@@ -35,6 +36,13 @@ public class NamePatternFilterTests {
 		MockNamePatternFilter filter = new MockNamePatternFilter();
 		assertThat(filter.getResults("not.a.regex")).containsEntry("not.a.regex",
 				"not.a.regex");
+		assertThat(filter.isGetNamesCalled()).isFalse();
+	}
+
+	@Test
+	public void nonRegexThatContainsRegexPart() throws Exception {
+		MockNamePatternFilter filter = new MockNamePatternFilter();
+		assertThat(filter.getResults("*")).containsEntry("*", "*");
 		assertThat(filter.isGetNamesCalled()).isFalse();
 	}
 

--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -136,7 +136,7 @@
 		<mysql.version>5.1.42</mysql.version>
 		<narayana.version>5.6.2.Final</narayana.version>
 		<nekohtml.version>1.9.22</nekohtml.version>
-		<neo4j-ogm.version>3.0.0-M02</neo4j-ogm.version>
+		<neo4j-ogm.version>3.0.0-RC1</neo4j-ogm.version>
 		<netty.version>4.1.13.Final</netty.version>
 		<postgresql.version>42.1.1</postgresql.version>
 		<quartz.version>2.3.0</quartz.version>


### PR DESCRIPTION
Sometimes, Spring detects a string as a regex because it contains regex parts. The problem is this string is not a regex and a PatternSyntaxException is raised when pattern try to compile it.

This modification checks if the regex compilation is possible, else we consider it is just a simple string.