### PR TITLE
When pool autocommit is disabled, inform Hibernate

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/jdbc/metadata/CommonsDbcp2DataSourcePoolMetadata.java
+++ b/spring-boot/src/main/java/org/springframework/boot/jdbc/metadata/CommonsDbcp2DataSourcePoolMetadata.java
@@ -53,4 +53,9 @@ public class CommonsDbcp2DataSourcePoolMetadata
 		return getDataSource().getValidationQuery();
 	}
 
+	@Override
+	public Boolean getDefaultAutoCommit() {
+		return getDataSource().getDefaultAutoCommit();
+	}
+
 }

--- a/spring-boot/src/main/java/org/springframework/boot/jdbc/metadata/DataSourcePoolMetadata.java
+++ b/spring-boot/src/main/java/org/springframework/boot/jdbc/metadata/DataSourcePoolMetadata.java
@@ -71,4 +71,12 @@ public interface DataSourcePoolMetadata {
 	 */
 	String getValidationQuery();
 
+	/**
+	 * The default auto-commit state of connections created by this pool.
+	 * If not set ({@code null}), default is JDBC driver default
+	 * (If set to null then the java.sql.Connection.setAutoCommit(boolean) method will not be called.)
+	 * @return the default auto-commit state or {@code null}
+	 */
+	Boolean getDefaultAutoCommit();
+
 }

--- a/spring-boot/src/main/java/org/springframework/boot/jdbc/metadata/HikariDataSourcePoolMetadata.java
+++ b/spring-boot/src/main/java/org/springframework/boot/jdbc/metadata/HikariDataSourcePoolMetadata.java
@@ -66,4 +66,9 @@ public class HikariDataSourcePoolMetadata
 		return getDataSource().getConnectionTestQuery();
 	}
 
+	@Override
+	public Boolean getDefaultAutoCommit() {
+		return getDataSource().isAutoCommit();
+	}
+
 }

--- a/spring-boot/src/main/java/org/springframework/boot/jdbc/metadata/TomcatDataSourcePoolMetadata.java
+++ b/spring-boot/src/main/java/org/springframework/boot/jdbc/metadata/TomcatDataSourcePoolMetadata.java
@@ -53,4 +53,9 @@ public class TomcatDataSourcePoolMetadata
 		return getDataSource().getValidationQuery();
 	}
 
+	@Override
+	public Boolean getDefaultAutoCommit() {
+		return getDataSource().isDefaultAutoCommit();
+	}
+
 }


### PR DESCRIPTION
Starting with Hibernate 5.2.10, the JPA property `hibernate.connection.provider_disables_autocommit`
should be set to true when the datasource has autocommit disabled in order to improve performance.

Fixes #9261

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->