### PR TITLE
Harmonize database initializers

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AbstractDatabaseInitializer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AbstractDatabaseInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure;
 import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
 
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDatabaseConnection;
 import org.springframework.boot.jdbc.DatabaseDriver;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.jdbc.datasource.init.DatabasePopulatorUtils;
@@ -52,7 +53,8 @@ public abstract class AbstractDatabaseInitializer {
 
 	@PostConstruct
 	protected void initialize() {
-		if (!isEnabled()) {
+		if ((getMode() == DatabaseInitializerMode.EMBEDDED && !isEmbeddedDataSource())
+				|| getMode() == DatabaseInitializerMode.NEVER) {
 			return;
 		}
 		ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
@@ -66,7 +68,7 @@ public abstract class AbstractDatabaseInitializer {
 		DatabasePopulatorUtils.execute(populator, this.dataSource);
 	}
 
-	protected abstract boolean isEnabled();
+	protected abstract DatabaseInitializerMode getMode();
 
 	protected abstract String getSchemaLocation();
 
@@ -84,6 +86,10 @@ public abstract class AbstractDatabaseInitializer {
 		catch (MetaDataAccessException ex) {
 			throw new IllegalStateException("Unable to detect database type", ex);
 		}
+	}
+
+	private boolean isEmbeddedDataSource() {
+		return EmbeddedDatabaseConnection.isEmbedded(this.dataSource);
 	}
 
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/DatabaseInitializerMode.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/DatabaseInitializerMode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure;
+
+/**
+ * Supported {@link AbstractDatabaseInitializer database initializer} modes.
+ *
+ * @author Vedran Pavic
+ * @since 2.0.0
+ */
+public enum DatabaseInitializerMode {
+
+	/**
+	 * Always enabled.
+	 */
+	ALWAYS,
+
+	/**
+	 * Enabled when using an embedded database.
+	 */
+	EMBEDDED,
+
+	/**
+	 * Never enabled.
+	 */
+	NEVER
+
+}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchDatabaseInitializer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchDatabaseInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.batch;
 import javax.sql.DataSource;
 
 import org.springframework.boot.autoconfigure.AbstractDatabaseInitializer;
+import org.springframework.boot.autoconfigure.DatabaseInitializerMode;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.util.Assert;
 
@@ -40,8 +41,8 @@ public class BatchDatabaseInitializer extends AbstractDatabaseInitializer {
 	}
 
 	@Override
-	protected boolean isEnabled() {
-		return this.properties.getInitializer().isEnabled();
+	protected DatabaseInitializerMode getMode() {
+		return this.properties.getInitializeSchema();
 	}
 
 	@Override

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.autoconfigure.batch;
 
+import org.springframework.boot.autoconfigure.DatabaseInitializerMode;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -42,7 +43,10 @@ public class BatchProperties {
 	 */
 	private String tablePrefix;
 
-	private final Initializer initializer = new Initializer();
+	/**
+	 * Spring Batch database schema initialization mode.
+	 */
+	private DatabaseInitializerMode initializeSchema = DatabaseInitializerMode.EMBEDDED;
 
 	private final Job job = new Job();
 
@@ -62,36 +66,16 @@ public class BatchProperties {
 		this.tablePrefix = tablePrefix;
 	}
 
-	public Initializer getInitializer() {
-		return this.initializer;
+	public DatabaseInitializerMode getInitializeSchema() {
+		return this.initializeSchema;
+	}
+
+	public void setInitializeSchema(DatabaseInitializerMode initializeSchema) {
+		this.initializeSchema = initializeSchema;
 	}
 
 	public Job getJob() {
 		return this.job;
-	}
-
-	public class Initializer {
-
-		/**
-		 * Create the required batch tables on startup if necessary. Enabled automatically
-		 * if no custom table prefix is set or if a custom schema is configured.
-		 */
-		private Boolean enabled;
-
-		public boolean isEnabled() {
-			if (this.enabled != null) {
-				return this.enabled;
-			}
-			boolean defaultTablePrefix = BatchProperties.this.getTablePrefix() == null;
-			boolean customSchema = !DEFAULT_SCHEMA_LOCATION
-					.equals(BatchProperties.this.getSchema());
-			return (defaultTablePrefix || customSchema);
-		}
-
-		public void setEnabled(boolean enabled) {
-			this.enabled = enabled;
-		}
-
 	}
 
 	public static class Job {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -147,7 +147,6 @@ public class IntegrationAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		@ConditionalOnProperty(prefix = "spring.integration.jdbc.initializer", name = "enabled")
 		public IntegrationDatabaseInitializer integrationDatabaseInitializer(
 				DataSource dataSource, ResourceLoader resourceLoader,
 				IntegrationProperties properties) {

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationDatabaseInitializer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationDatabaseInitializer.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.integration;
 import javax.sql.DataSource;
 
 import org.springframework.boot.autoconfigure.AbstractDatabaseInitializer;
+import org.springframework.boot.autoconfigure.DatabaseInitializerMode;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.util.Assert;
 
@@ -40,8 +41,8 @@ public class IntegrationDatabaseInitializer extends AbstractDatabaseInitializer 
 	}
 
 	@Override
-	protected boolean isEnabled() {
-		return this.properties.getInitializer().isEnabled();
+	protected DatabaseInitializerMode getMode() {
+		return this.properties.getInitializeSchema();
 	}
 
 	@Override

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationProperties.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.autoconfigure.integration;
 
+import org.springframework.boot.autoconfigure.DatabaseInitializerMode;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -44,7 +45,10 @@ public class IntegrationProperties {
 		 */
 		private String schema = DEFAULT_SCHEMA_LOCATION;
 
-		private final Initializer initializer = new Initializer();
+		/**
+		 * Spring Integration database schema initialization mode.
+		 */
+		private DatabaseInitializerMode initializeSchema = DatabaseInitializerMode.EMBEDDED;
 
 		public String getSchema() {
 			return this.schema;
@@ -54,25 +58,12 @@ public class IntegrationProperties {
 			this.schema = schema;
 		}
 
-		public Initializer getInitializer() {
-			return this.initializer;
+		public DatabaseInitializerMode getInitializeSchema() {
+			return this.initializeSchema;
 		}
 
-		public class Initializer {
-
-			/**
-			 * Create the required integration tables on startup.
-			 */
-			private boolean enabled = false;
-
-			public boolean isEnabled() {
-				return this.enabled;
-			}
-
-			public void setEnabled(boolean enabled) {
-				this.enabled = enabled;
-			}
-
+		public void setInitializeSchema(DatabaseInitializerMode initializeSchema) {
+			this.initializeSchema = initializeSchema;
 		}
 
 	}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/quartz/QuartzDatabaseInitializer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/quartz/QuartzDatabaseInitializer.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.quartz;
 import javax.sql.DataSource;
 
 import org.springframework.boot.autoconfigure.AbstractDatabaseInitializer;
+import org.springframework.boot.autoconfigure.DatabaseInitializerMode;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.util.Assert;
 
@@ -40,8 +41,8 @@ public class QuartzDatabaseInitializer extends AbstractDatabaseInitializer {
 	}
 
 	@Override
-	protected boolean isEnabled() {
-		return this.properties.getJdbc().isInitializeSchema();
+	protected DatabaseInitializerMode getMode() {
+		return this.properties.getJdbc().getInitializeSchema();
 	}
 
 	@Override

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/quartz/QuartzProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/quartz/QuartzProperties.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.quartz;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.boot.autoconfigure.DatabaseInitializerMode;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -70,9 +71,9 @@ public class QuartzProperties {
 		private String schema = DEFAULT_SCHEMA_LOCATION;
 
 		/**
-		 * Create the required Quartz Scheduler tables on startup.
+		 * Quartz Scheduler database schema initialization mode.
 		 */
-		private boolean initializeSchema;
+		private DatabaseInitializerMode initializeSchema = DatabaseInitializerMode.EMBEDDED;
 
 		public String getSchema() {
 			return this.schema;
@@ -82,11 +83,11 @@ public class QuartzProperties {
 			this.schema = schema;
 		}
 
-		public boolean isInitializeSchema() {
+		public DatabaseInitializerMode getInitializeSchema() {
 			return this.initializeSchema;
 		}
 
-		public void setInitializeSchema(boolean initializeSchema) {
+		public void setInitializeSchema(DatabaseInitializerMode initializeSchema) {
 			this.initializeSchema = initializeSchema;
 		}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionDatabaseInitializer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionDatabaseInitializer.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.session;
 import javax.sql.DataSource;
 
 import org.springframework.boot.autoconfigure.AbstractDatabaseInitializer;
+import org.springframework.boot.autoconfigure.DatabaseInitializerMode;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.util.Assert;
 
@@ -40,8 +41,8 @@ public class JdbcSessionDatabaseInitializer extends AbstractDatabaseInitializer 
 	}
 
 	@Override
-	protected boolean isEnabled() {
-		return this.properties.getInitializer().isEnabled();
+	protected DatabaseInitializerMode getMode() {
+		return this.properties.getInitializeSchema();
 	}
 
 	@Override

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionProperties.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.autoconfigure.session;
 
+import org.springframework.boot.autoconfigure.DatabaseInitializerMode;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -42,7 +43,10 @@ public class JdbcSessionProperties {
 	 */
 	private String tableName = DEFAULT_TABLE_NAME;
 
-	private final Initializer initializer = new Initializer();
+	/**
+	 * Spring Session database schema initialization mode.
+	 */
+	private DatabaseInitializerMode initializeSchema = DatabaseInitializerMode.EMBEDDED;
 
 	public String getSchema() {
 		return this.schema;
@@ -60,32 +64,12 @@ public class JdbcSessionProperties {
 		this.tableName = tableName;
 	}
 
-	public Initializer getInitializer() {
-		return this.initializer;
+	public DatabaseInitializerMode getInitializeSchema() {
+		return this.initializeSchema;
 	}
 
-	public class Initializer {
-
-		/**
-		 * Create the required session tables on startup if necessary. Enabled
-		 * automatically if the default table name is set or a custom schema is
-		 * configured.
-		 */
-		private Boolean enabled;
-
-		public boolean isEnabled() {
-			if (this.enabled != null) {
-				return this.enabled;
-			}
-			boolean defaultTableName = DEFAULT_TABLE_NAME.equals(getTableName());
-			boolean customSchema = !DEFAULT_SCHEMA_LOCATION.equals(getSchema());
-			return (defaultTableName || customSchema);
-		}
-
-		public void setEnabled(boolean enabled) {
-			this.enabled = enabled;
-		}
-
+	public void setInitializeSchema(DatabaseInitializerMode initializeSchema) {
+		this.initializeSchema = initializeSchema;
 	}
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfigurationWithoutJpaTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfigurationWithoutJpaTests.java
@@ -27,6 +27,7 @@ import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.DatabaseInitializerMode;
 import org.springframework.boot.autoconfigure.TestAutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.test.City;
@@ -66,8 +67,9 @@ public class BatchAutoConfigurationWithoutJpaTests {
 					assertThat(
 							context.getBean(PlatformTransactionManager.class).toString())
 									.contains("DataSourceTransactionManager");
-					assertThat(context.getBean(BatchProperties.class).getInitializer()
-							.isEnabled()).isTrue();
+					assertThat(
+							context.getBean(BatchProperties.class).getInitializeSchema())
+									.isEqualTo(DatabaseInitializerMode.EMBEDDED);
 					assertThat(new JdbcTemplate(context.getBean(DataSource.class))
 							.queryForList("select * from BATCH_JOB_EXECUTION")).isEmpty();
 					assertThat(context.getBean(JobExplorer.class)

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
@@ -26,6 +26,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import org.springframework.boot.autoconfigure.DatabaseInitializerMode;
 import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration.IntegrationComponentScanAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
@@ -152,9 +153,9 @@ public class IntegrationAutoConfigurationTests {
 				DataSourceTransactionManagerAutoConfiguration.class,
 				JdbcTemplateAutoConfiguration.class, IntegrationAutoConfiguration.class },
 				"spring.datasource.generate-unique-name=true",
-				"spring.integration.jdbc.initializer.enabled=true");
+				"spring.integration.jdbc.initialize-schema=always");
 		assertThat(this.context.getBean(IntegrationProperties.class).getJdbc()
-				.getInitializer().isEnabled()).isTrue();
+				.getInitializeSchema()).isEqualTo(DatabaseInitializerMode.ALWAYS);
 		JdbcOperations jdbcOperations = this.context.getBean(JdbcOperations.class);
 		assertThat(jdbcOperations.queryForList("select * from INT_MESSAGE")).isEmpty();
 		assertThat(jdbcOperations.queryForList("select * from INT_GROUP_TO_MESSAGE"))
@@ -172,25 +173,24 @@ public class IntegrationAutoConfigurationTests {
 				DataSourceTransactionManagerAutoConfiguration.class,
 				JdbcTemplateAutoConfiguration.class, IntegrationAutoConfiguration.class },
 				"spring.datasource.generate-unique-name=true",
-				"spring.integration.jdbc.initializer.enabled=false");
+				"spring.integration.jdbc.initialize-schema=never");
 		assertThat(this.context.getBean(IntegrationProperties.class).getJdbc()
-				.getInitializer().isEnabled()).isFalse();
+				.getInitializeSchema()).isEqualTo(DatabaseInitializerMode.NEVER);
 		JdbcOperations jdbcOperations = this.context.getBean(JdbcOperations.class);
 		this.thrown.expect(BadSqlGrammarException.class);
 		jdbcOperations.queryForList("select * from INT_MESSAGE");
 	}
 
 	@Test
-	public void integrationJdbcDatabaseInitializerDisabledByDefault() {
+	public void integrationJdbcDatabaseInitializerEnabledByDefaultWithEmbeddedDb() {
 		load(new Class[] { EmbeddedDataSourceConfiguration.class,
 				DataSourceTransactionManagerAutoConfiguration.class,
 				JdbcTemplateAutoConfiguration.class, IntegrationAutoConfiguration.class },
 				"spring.datasource.generate-unique-name=true");
 		assertThat(this.context.getBean(IntegrationProperties.class).getJdbc()
-				.getInitializer().isEnabled()).isFalse();
+				.getInitializeSchema()).isEqualTo(DatabaseInitializerMode.EMBEDDED);
 		JdbcOperations jdbcOperations = this.context.getBean(JdbcOperations.class);
-		this.thrown.expect(BadSqlGrammarException.class);
-		jdbcOperations.queryForList("select * from INT_MESSAGE");
+		jdbcOperations.queryForList("select * from INT_MESSAGE").isEmpty();
 	}
 
 	private static void assertDomains(MBeanServer mBeanServer, boolean expected,

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/quartz/QuartzAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/quartz/QuartzAutoConfigurationTests.java
@@ -108,7 +108,7 @@ public class QuartzAutoConfigurationTests {
 				EmbeddedDataSourceConfiguration.class,
 				DataSourceTransactionManagerAutoConfiguration.class },
 				"spring.quartz.job-store-type=jdbc",
-				"spring.quartz.jdbc.initialize-schema=true");
+				"spring.quartz.jdbc.initialize-schema=always");
 		testWithDataSource();
 	}
 
@@ -117,7 +117,7 @@ public class QuartzAutoConfigurationTests {
 		load(new Class<?>[] { QuartzJobsConfiguration.class,
 				EmbeddedDataSourceConfiguration.class },
 				"spring.quartz.job-store-type=jdbc",
-				"spring.quartz.jdbc.initialize-schema=true");
+				"spring.quartz.jdbc.initialize-schema=always");
 		testWithDataSource();
 	}
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationJdbcTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationJdbcTests.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.boot.autoconfigure.DatabaseInitializerMode;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration;
@@ -54,8 +55,9 @@ public class SessionAutoConfigurationJdbcTests
 				JdbcOperationsSessionRepository.class);
 		assertThat(new DirectFieldAccessor(repository).getPropertyValue("tableName"))
 				.isEqualTo("SPRING_SESSION");
-		assertThat(this.context.getBean(JdbcSessionProperties.class).getInitializer()
-				.isEnabled()).isTrue();
+		assertThat(
+				this.context.getBean(JdbcSessionProperties.class).getInitializeSchema())
+						.isEqualTo(DatabaseInitializerMode.EMBEDDED);
 		assertThat(this.context.getBean(JdbcOperations.class)
 				.queryForList("select * from SPRING_SESSION")).isEmpty();
 	}
@@ -65,13 +67,14 @@ public class SessionAutoConfigurationJdbcTests
 		load(Arrays.asList(EmbeddedDataSourceConfiguration.class,
 				DataSourceTransactionManagerAutoConfiguration.class),
 				"spring.session.store-type=jdbc",
-				"spring.session.jdbc.initializer.enabled=false");
+				"spring.session.jdbc.initialize-schema=never");
 		JdbcOperationsSessionRepository repository = validateSessionRepository(
 				JdbcOperationsSessionRepository.class);
 		assertThat(new DirectFieldAccessor(repository).getPropertyValue("tableName"))
 				.isEqualTo("SPRING_SESSION");
-		assertThat(this.context.getBean(JdbcSessionProperties.class).getInitializer()
-				.isEnabled()).isFalse();
+		assertThat(
+				this.context.getBean(JdbcSessionProperties.class).getInitializeSchema())
+						.isEqualTo(DatabaseInitializerMode.NEVER);
 		this.thrown.expect(BadSqlGrammarException.class);
 		assertThat(this.context.getBean(JdbcOperations.class)
 				.queryForList("select * from SPRING_SESSION")).isEmpty();
@@ -88,27 +91,11 @@ public class SessionAutoConfigurationJdbcTests
 				JdbcOperationsSessionRepository.class);
 		assertThat(new DirectFieldAccessor(repository).getPropertyValue("tableName"))
 				.isEqualTo("FOO_BAR");
-		assertThat(this.context.getBean(JdbcSessionProperties.class).getInitializer()
-				.isEnabled()).isTrue();
+		assertThat(
+				this.context.getBean(JdbcSessionProperties.class).getInitializeSchema())
+						.isEqualTo(DatabaseInitializerMode.EMBEDDED);
 		assertThat(this.context.getBean(JdbcOperations.class)
 				.queryForList("select * from FOO_BAR")).isEmpty();
-	}
-
-	@Test
-	public void customTableNameWithDefaultSchemaDisablesInitializer() {
-		load(Arrays.asList(EmbeddedDataSourceConfiguration.class,
-				DataSourceTransactionManagerAutoConfiguration.class),
-				"spring.session.store-type=jdbc",
-				"spring.session.jdbc.table-name=FOO_BAR");
-		JdbcOperationsSessionRepository repository = validateSessionRepository(
-				JdbcOperationsSessionRepository.class);
-		assertThat(new DirectFieldAccessor(repository).getPropertyValue("tableName"))
-				.isEqualTo("FOO_BAR");
-		assertThat(this.context.getBean(JdbcSessionProperties.class).getInitializer()
-				.isEnabled()).isFalse();
-		this.thrown.expect(BadSqlGrammarException.class);
-		assertThat(this.context.getBean(JdbcOperations.class)
-				.queryForList("select * from SPRING_SESSION")).isEmpty();
 	}
 
 }

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -132,7 +132,7 @@ content into your application; rather pick only the properties that you need.
 	# QUARTZ SCHEDULER ({sc-spring-boot-autoconfigure}/quartz/QuartzProperties.{sc-ext}[QuartzProperties])
 	spring.quartz.job-store-type=memory # Quartz job store type.
 	spring.quartz.properties.*= # Additional Quartz Scheduler properties.
-	spring.quartz.jdbc.initialize-schema=false # Create the required Quartz Scheduler tables on startup.
+	spring.quartz.jdbc.initialize-schema=embedded # Quartz Scheduler database schema initialization mode.
 	spring.quartz.jdbc.schema=classpath:org/quartz/impl/jdbcjobstore/tables_@@platform@@.sql # Path to the SQL file to use to initialize the database schema.
 
 	# Reactor
@@ -418,7 +418,7 @@ content into your application; rather pick only the properties that you need.
 	# SPRING SESSION ({sc-spring-boot-autoconfigure}/session/SessionProperties.{sc-ext}[SessionProperties])
 	spring.session.hazelcast.flush-mode=on-save # Sessions flush mode.
 	spring.session.hazelcast.map-name=spring:session:sessions # Name of the map used to store sessions.
-	spring.session.jdbc.initializer.enabled= # Create the required session tables on startup if necessary. Enabled automatically if the default table name is set or a custom schema is configured.
+	spring.session.jdbc.initialize-schema=embedded # Spring Session database schema initialization mode.
 	spring.session.jdbc.schema=classpath:org/springframework/session/jdbc/schema-@@platform@@.sql # Path to the SQL file to use to initialize the database schema.
 	spring.session.jdbc.table-name=SPRING_SESSION # Name of database table used to store sessions.
 	spring.session.redis.flush-mode=on-save # Sessions flush mode.
@@ -940,14 +940,14 @@ content into your application; rather pick only the properties that you need.
 	spring.artemis.user= # Login user of the broker.
 
 	# SPRING BATCH ({sc-spring-boot-autoconfigure}/batch/BatchProperties.{sc-ext}[BatchProperties])
-	spring.batch.initializer.enabled= # Create the required batch tables on startup if necessary. Enabled automatically if no custom table prefix is set or if a custom schema is configured.
+	spring.batch.initialize-schema=embedded # Spring Batch database schema initialization mode.
 	spring.batch.job.enabled=true # Execute all Spring Batch jobs in the context on startup.
 	spring.batch.job.names= # Comma-separated list of job names to execute on startup (For instance `job1,job2`). By default, all Jobs found in the context are executed.
 	spring.batch.schema=classpath:org/springframework/batch/core/schema-@@platform@@.sql # Path to the SQL file to use to initialize the database schema.
 	spring.batch.table-prefix= # Table prefix for all the batch meta-data tables.
 
 	# SPRING INTEGRATION ({sc-spring-boot-autoconfigure}/integration/IntegrationProperties.{sc-ext}[IntegrationProperties])
-	spring.integration.jdbc.initializer.enabled=false # Create the required integration tables on startup.
+	spring.integration.jdbc.initialize-schema=embedded # Spring Integration database schema initialization mode.
 	spring.integration.jdbc.schema=classpath:org/springframework/integration/jdbc/schema-@@platform@@.sql # Path to the SQL file to use to initialize the database schema.
 
 	# JMS ({sc-spring-boot-autoconfigure}/jms/JmsProperties.{sc-ext}[JmsProperties])

--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -1936,11 +1936,12 @@ data.
 === Initialize a Spring Batch database
 If you are using Spring Batch then it comes pre-packaged with SQL initialization scripts
 for most popular database platforms. Spring Boot will detect your database type, and
-execute those scripts by default, and in this case will switch the fail fast setting to
-false (errors are logged but do not prevent the application from starting). This is
-because the scripts are known to be reliable and generally do not contain bugs, so errors
-are ignorable, and ignoring them makes the scripts idempotent. You can switch off the
-initialization explicitly using `spring.batch.initializer.enabled=false`.
+execute those scripts by default when using an embedded database, and in this case will
+switch the fail fast setting to false (errors are logged but do not prevent the
+application from starting). This is because the scripts are known to be reliable and
+generally do not contain bugs, so errors are ignorable, and ignoring them makes the
+scripts idempotent. You can switch off the initialization explicitly using
+`spring.batch.initialize-schema=never`.
 
 
 

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -5568,7 +5568,7 @@ on startup:
 
 [source,properties,indent=0]
 ----
-	spring.integration.jdbc.initializer.enabled=true
+	spring.integration.jdbc.initialize-schema=always
 ----
 
 See the


### PR DESCRIPTION
This commit updates database initializers configuration to enable them automatically only when an embedded `DataSource` is used. Related configuration properties have been updated to use a more expressive `DatabaseInitializerMode` enum rather than `Boolean` flag.

This resolves #8981.