### PR TITLE
Fix: additional-spring-configuration-metadata.json is not being merged when building with Gradle 4

### DIFF
--- a/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataStore.java
+++ b/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataStore.java
@@ -110,8 +110,8 @@ public class MetadataStore {
 
 	private InputStream getAdditionalMetadataStream() throws IOException {
 		// Most build systems will have copied the file to the class output location
-		FileObject fileObject = this.environment.getFiler()
-				.getResource(StandardLocation.CLASS_OUTPUT, "", ADDITIONAL_METADATA_PATH);
+		FileObject fileObject = this.environment.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "", ADDITIONAL_METADATA_PATH);
+				
 		File file = new File(fileObject.toUri());
 
 		if (!file.exists()) {
@@ -120,16 +120,22 @@ public class MetadataStore {
 
 			int index = path.lastIndexOf(CLASSES_FOLDER);
 			if (index >= 0) {
-				File resourcesFolder = new File(path.substring(0, index) + RESOURCES_FOLDER);
-				file = new File(resourcesFolder, path.substring(index + CLASSES_FOLDER.length()));
-				if (!file.exists()) {
-					/*
+				/*
 					Gradle 4 introduces a new 'java' directory which causes issues for one-to-one path mapping
 					of class locations and resources. Ensure resources can be found under '/build/resources/main'
 					rather than '/build/resources/java/main'.
-					 */
-					file = new File(resourcesFolder, "main/" + ADDITIONAL_METADATA_PATH);
-				}
+				 */
+				final String pathBeforeClassFolder = path.substring(0, index);
+				/*
+				In order to retrieve the the class output resource, we MUST pass in a relative path.
+				An empty path causes a InvalidArgumentException as it must be resolvable. In reality,
+				this means nothing since we are going to traverse upstream to its parent to locate
+				the 'main' directory.
+				 */
+				FileObject classOutputLocation = this.environment.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "", "dummy");
+				File classesFolder = new File(classOutputLocation.toUri());
+				File resourcesFolder = new File(pathBeforeClassFolder + RESOURCES_FOLDER + '/' + classesFolder.getParentFile().getName());
+				file = new File(resourcesFolder, ADDITIONAL_METADATA_PATH);
 			}
 
 		}

--- a/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataStore.java
+++ b/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataStore.java
@@ -47,8 +47,6 @@ public class MetadataStore {
 
 	private static final String CLASSES_FOLDER = "classes";
 
-	private static final String JAVA_FOLDER = "java";
-
 	private final ProcessingEnvironment environment;
 
 	public MetadataStore(ProcessingEnvironment environment) {
@@ -132,8 +130,10 @@ public class MetadataStore {
 					of class locations and resources. Ensure resources can be found under '/build/resources/main'
 					rather than '/build/resources/java/main'.
 					 */
-					path = path.replace('/' + JAVA_FOLDER, "");
-					file = new File(path);
+					while (file != null && !file.getName().equals(RESOURCES_FOLDER)) {
+						file = file.getParentFile();
+					}
+					file = new File(file, "main/" + ADDITIONAL_METADATA_PATH);
 				}
 			}
 

--- a/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataStore.java
+++ b/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataStore.java
@@ -120,20 +120,15 @@ public class MetadataStore {
 
 			int index = path.lastIndexOf(CLASSES_FOLDER);
 			if (index >= 0) {
-				path = path.substring(0, index) + RESOURCES_FOLDER
-						+ path.substring(index + CLASSES_FOLDER.length());
-				file = new File(path);
-
+				File resourcesFolder = new File(path.substring(0, index) + RESOURCES_FOLDER);
+				file = new File(resourcesFolder, path.substring(index + CLASSES_FOLDER.length()));
 				if (!file.exists()) {
 					/*
 					Gradle 4 introduces a new 'java' directory which causes issues for one-to-one path mapping
 					of class locations and resources. Ensure resources can be found under '/build/resources/main'
 					rather than '/build/resources/java/main'.
 					 */
-					while (file != null && !file.getName().equals(RESOURCES_FOLDER)) {
-						file = file.getParentFile();
-					}
-					file = new File(file, "main/" + ADDITIONAL_METADATA_PATH);
+					file = new File(resourcesFolder, "main/" + ADDITIONAL_METADATA_PATH);
 				}
 			}
 


### PR DESCRIPTION
Closes #9732 

As an additional check, try to locate the json metadata by taking into account the presence of a new 'java' directory in the path.

