### PR TITLE
gh-852: Update SampleIntegrationTests to run tests against packaged CLI

### DIFF
--- a/spring-boot-cli/samples/template.groovy
+++ b/spring-boot-cli/samples/template.groovy
@@ -2,6 +2,8 @@ package org.test
 
 import static org.springframework.boot.groovy.GroovyTemplate.*;
 
+@Grab("groovy-templates")
+
 @Component
 class Example implements CommandLineRunner {
 

--- a/spring-boot-cli/src/test/resources/securityConfiguration.groovy
+++ b/spring-boot-cli/src/test/resources/securityConfiguration.groovy
@@ -1,0 +1,12 @@
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+
+@Configuration
+class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.authorizeRequests()
+                .antMatchers("/shutdown").permitAll()
+    }
+}

--- a/spring-boot-cli/src/test/resources/shutdown.groovy
+++ b/spring-boot-cli/src/test/resources/shutdown.groovy
@@ -1,0 +1,41 @@
+import org.springframework.beans.BeansException
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class Shutdown implements ApplicationContextAware {
+
+    ConfigurableApplicationContext applicationContext
+
+    @RequestMapping("/shutdown")
+    String shutdown() {
+        try {
+            return "Shutting down server"
+        } finally {
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                void run() {
+                    try {
+                        Thread.sleep(500L)
+                    }
+                    catch (InterruptedException ex) {
+                        Thread.currentThread().interrupt()
+                    }
+                    Shutdown.this.applicationContext.close()
+                }
+            });
+            thread.setContextClassLoader(getClass().getClassLoader())
+            thread.start()
+        }
+    }
+
+    @Override
+    void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        if (applicationContext instanceof ConfigurableApplicationContext) {
+            this.applicationContext = (ConfigurableApplicationContext) applicationContext
+        }
+    }
+}


### PR DESCRIPTION
This commit updates integration tests for Spring Boot CLI samples so that they use `CommandLineInvoker`.

One thing that might not be obvious is the handling of shutting down the server. As far as I know it is not possible to kill a process and all of its child processes with Java 8 API consistently on all OSes. Unfortunately, this is the case in these integration tests because `CommandLineInvoker` calls the `spring` command which then runs a `java` child process. The only handle to a process that we're having is the `spring` command process handle. So, when `java` process is a server process and stays there waiting for incoming connections, then it stays in the background even after killing the base `spring` command process.
The solution that I've implemented is to add an additional `shutdown` endpoint to all those server processes which gets called after each test. It shuts down the context and process exits as required.

Hopefully, this is acceptable.

Fixes #852