### PR TITLE
Add Spring Content

### DIFF
--- a/spring-boot-starters/README.adoc
+++ b/spring-boot-starters/README.adoc
@@ -112,4 +112,7 @@ do as they were designed before this was clarified.
 | http://restfb.com/[RestFB] Messenger
 | https://github.com/marsbits/restfbmessenger
 
+| Spring Content
+| https://github.com/paulcwarren/spring-content/
+
 |===


### PR DESCRIPTION
The DellEMC Dojo team would like to add our Spring Content project, that has boot-starters for all of it's modules; fs, s3, jpa, mongo and REST, to the boot-starter README.
 