### PR TITLE
Use currentHealth consistently in getHealth()

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/HealthMvcEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/HealthMvcEndpoint.java
@@ -164,7 +164,7 @@ public class HealthMvcEndpoint extends AbstractEndpointMvcAdapter<HealthEndpoint
 	private Health getHealth(HttpServletRequest request, Principal principal) {
 		Health currentHealth = getCurrentHealth();
 		if (exposeHealthDetails(request, principal)) {
-			return this.cachedHealth.health;
+			return currentHealth;
 		}
 		return Health.status(currentHealth.getStatus()).build();
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
I guess using the `currentHealth` there might be the original intention in 7a04708c41f54fe6f2307e3bd607b9bb7c103090 .