### PR TITLE
Possible NPE when handling result of AnnotationUtils.getAnnotations(Class<?>)

### DIFF
--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/properties/PropertyMappingContextCustomizer.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/properties/PropertyMappingContextCustomizer.java
@@ -79,12 +79,15 @@ class PropertyMappingContextCustomizer implements ContextCustomizer {
 			Set<Class<?>> components = new LinkedHashSet<>();
 			Set<Class<?>> propertyMappings = new LinkedHashSet<>();
 			while (beanClass != null) {
-				for (Annotation annotation : AnnotationUtils.getAnnotations(beanClass)) {
-					if (isAnnotated(annotation, Component.class)) {
-						components.add(annotation.annotationType());
-					}
-					if (isAnnotated(annotation, PropertyMapping.class)) {
-						propertyMappings.add(annotation.annotationType());
+				Annotation[] annotations = AnnotationUtils.getAnnotations(beanClass);
+				if (annotations != null) {
+					for (Annotation annotation : annotations) {
+						if (isAnnotated(annotation, Component.class)) {
+							components.add(annotation.annotationType());
+						}
+						if (isAnnotated(annotation, PropertyMapping.class)) {
+							propertyMappings.add(annotation.annotationType());
+						}
 					}
 				}
 				beanClass = beanClass.getSuperclass();


### PR DESCRIPTION
In case `AnnotationUtils` fails to introspect annotations on a class, it logs an error message and returns `null`.