### PR TITLE
Fix to allow empty argument in maven plugin. Fixes gh-9713

### DIFF
--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunArguments.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunArguments.java
@@ -18,6 +18,7 @@ package org.springframework.boot.maven;
 
 import java.util.Arrays;
 import java.util.LinkedList;
+import java.util.stream.Collectors;
 
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 
@@ -31,14 +32,17 @@ class RunArguments {
 
 	private static final String[] NO_ARGS = {};
 
-	private final LinkedList<String> args;
+	private final LinkedList<String> args = new LinkedList<>();
 
 	RunArguments(String arguments) {
 		this(parseArgs(arguments));
 	}
 
 	RunArguments(String[] args) {
-		this.args = new LinkedList<>(Arrays.asList(args));
+		if (args != null) {
+			this.args.addAll(Arrays.stream(args).filter(s -> s != null && !"".equals(s))
+					.collect(Collectors.toList()));
+		}
 	}
 
 	public LinkedList<String> getArgs() {

--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunArguments.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunArguments.java
@@ -18,9 +18,9 @@ package org.springframework.boot.maven;
 
 import java.util.Arrays;
 import java.util.LinkedList;
-import java.util.stream.Collectors;
 
 import org.codehaus.plexus.util.cli.CommandLineUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Parse and expose arguments specified in a single string.
@@ -40,8 +40,7 @@ class RunArguments {
 
 	RunArguments(String[] args) {
 		if (args != null) {
-			this.args.addAll(Arrays.stream(args).filter(s -> s != null && !"".equals(s))
-					.collect(Collectors.toList()));
+			Arrays.stream(args).filter(StringUtils::hasLength).forEach(this.args::add);
 		}
 	}
 

--- a/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunArguments.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunArguments.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 
 import org.codehaus.plexus.util.cli.CommandLineUtils;
+
 import org.springframework.util.StringUtils;
 
 /**

--- a/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/RunArgumentsTests.java
+++ b/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/RunArgumentsTests.java
@@ -35,6 +35,20 @@ public class RunArgumentsTests {
 	}
 
 	@Test
+	public void parseNullArray() {
+		String[] args = new RunArguments((String[]) null).asArray();
+		assertThat(args).isNotNull();
+		assertThat(args.length).isEqualTo(0);
+	}
+
+	@Test
+	public void parseArrayContainingNullValue() {
+		String[] args = new RunArguments(new String[]{null}).asArray();
+		assertThat(args).isNotNull();
+		assertThat(args.length).isEqualTo(0);
+	}
+
+	@Test
 	public void parseEmpty() {
 		String[] args = parseArgs("   ");
 		assertThat(args).isNotNull();


### PR DESCRIPTION
Change so the application can start even if the maven plugin xml configuration contains an empty argument element. #9713 