### PR TITLE
Improve FailureAnalyzer for embedded datasource. Fixes gh-8029

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzer.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.boot.diagnostics.FailureAnalysis;
  * {@link DataSourceBeanCreationException}.
  *
  * @author Andy Wilkinson
+ * @author Rostyslav Dudka
  */
 class DataSourceBeanCreationFailureAnalyzer
 		extends AbstractFailureAnalyzer<DataSourceBeanCreationException> {
@@ -32,9 +33,8 @@ class DataSourceBeanCreationFailureAnalyzer
 	@Override
 	protected FailureAnalysis analyze(Throwable rootFailure,
 			DataSourceBeanCreationException cause) {
-		String message = cause.getMessage();
-		String description = message.substring(0, message.indexOf(".")).trim();
-		String action = message.substring(message.indexOf(".") + 1).trim();
+		String description = cause.getDescription();
+		String action = cause.getAction();
 		return new FailureAnalysis(description, action, cause);
 	}
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzerTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link DataSourceBeanCreationFailureAnalyzer}.
  *
  * @author Andy Wilkinson
+ * @author Rostyslav Dudka
  */
 @RunWith(ModifiedClassPathRunner.class)
 @ClassPathExclusions({ "h2-*.jar", "hsqldb-*.jar" })
@@ -41,8 +42,10 @@ public class DataSourceBeanCreationFailureAnalyzerTests {
 	@Test
 	public void failureAnalysisIsPerformed() {
 		FailureAnalysis failureAnalysis = performAnalysis(TestConfiguration.class);
-		assertThat(failureAnalysis.getDescription()).isEqualTo(
-				"Cannot determine embedded database driver class for database type NONE");
+		assertThat(failureAnalysis.getDescription()).isEqualTo("Cannot auto-configure "
+				+ "DataSource. No spring.datasource.url property was specified. "
+				+ "Also cannot auto-configure embedded database. "
+				+ "No embedded database driver class for database type NONE. ");
 		assertThat(failureAnalysis.getAction()).isEqualTo("If you want an embedded "
 				+ "database please put a supported one on the classpath. If you have "
 				+ "database settings to be loaded from a particular profile you may "


### PR DESCRIPTION
This pull request fixes gh-8029.
I decided not to check if spring.datasource.url set, because if that exception is thrown we know that property isn't set
I also refactor DataSourceBeanCreationFailureAnalyzer. In my opinion it knows too much about message structure. So i decided to create description and action fields in DataSourceBeanCreationException and expose getters for them. Then i refactored getMessage method.