### PR TITLE
gh-5523: Use spring.mvc.date-format to also configure formatting of java.time.LocalDate

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
@@ -16,11 +16,15 @@
 
 package org.springframework.boot.autoconfigure.web.servlet;
 
+import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -253,6 +257,26 @@ public class WebMvcAutoConfiguration {
 		@ConditionalOnProperty(prefix = "spring.mvc", name = "date-format")
 		public Formatter<Date> dateFormatter() {
 			return new DateFormatter(this.mvcProperties.getDateFormat());
+		}
+
+		@Bean
+		@ConditionalOnProperty(prefix = "spring.mvc", name = "date-format")
+		public Formatter<LocalDate> localDateFormatter() {
+			return new Formatter<LocalDate>() {
+
+				@Override
+				public LocalDate parse(String text, Locale locale) throws ParseException {
+					return LocalDate.parse(text,
+							DateTimeFormatter.ofPattern(
+									WebMvcAutoConfigurationAdapter.this.mvcProperties.getDateFormat(), locale));
+				}
+
+				@Override
+				public String print(LocalDate object, Locale locale) {
+					return DateTimeFormatter.ofPattern(
+							WebMvcAutoConfigurationAdapter.this.mvcProperties.getDateFormat(), locale).format(object);
+				}
+			};
 		}
 
 		@Override

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.autoconfigure.web.servlet;
 
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -367,8 +368,13 @@ public class WebMvcAutoConfigurationTests {
 				.run((context) -> {
 					FormattingConversionService conversionService = context
 							.getBean(FormattingConversionService.class);
+
 					Date date = new DateTime(1988, 6, 25, 20, 30).toDate();
-					assertThat(conversionService.convert(date, String.class))
+					assertThat(conversionService.convert(date, String.class)).as("java.util.Date")
+							.isEqualTo("25*06*1988");
+
+					LocalDate localDate = LocalDate.of(1988, 6, 25);
+					assertThat(conversionService.convert(localDate, String.class)).as("java.time.LocalDate")
 							.isEqualTo("25*06*1988");
 				});
 	}


### PR DESCRIPTION
First attempt to fix #5523. 

The original issue asks for an easy way to configure the binding behavior of `java.time.LocalDate` as well as a default value set to `DateTimeFormat.ISO.DATE`.

This PR changes `WebMvcAutoConfiguration` to use `spring.mvc.date-format` to also configure formatting of `java.time.LocalDate`. This is only intended to be a basis for discussion, since I need some advices:

- should `spring.mvc.date-format` be reused or should there be some other property, for example `spring.mvc.local-date-pattern`
- should a default value be added? If so, should it be set to formatting according to `DateTimeFormat.ISO.DATE`
- Does my change even work because it requires Java 8 classes or do I have to implement some crazy reflection magic to find out whether we are running on Java 8?

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->