### PR TITLE
Fix incorrect property name when initializing OAuth2 client

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/authserver/OAuth2AuthorizationServerConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/authserver/OAuth2AuthorizationServerConfiguration.java
@@ -164,7 +164,7 @@ public class OAuth2AuthorizationServerConfiguration
 			String prefix = "security.oauth2.client";
 			boolean defaultSecret = this.credentials.isDefaultSecret();
 			logger.info(String.format(
-					"Initialized OAuth2 Client%n%n%s.clientId = %s%n%s.secret = %s%n%n",
+					"Initialized OAuth2 Client%n%n%s.clientId = %s%n%s.client-secret = %s%n%n",
 					prefix, this.credentials.getClientId(), prefix,
 					defaultSecret ? this.credentials.getClientSecret() : "****"));
 		}

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/authserver/OAuth2AuthorizationServerConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/authserver/OAuth2AuthorizationServerConfiguration.java
@@ -164,7 +164,7 @@ public class OAuth2AuthorizationServerConfiguration
 			String prefix = "security.oauth2.client";
 			boolean defaultSecret = this.credentials.isDefaultSecret();
 			logger.info(String.format(
-					"Initialized OAuth2 Client%n%n%s.clientId = %s%n%s.client-secret = %s%n%n",
+					"Initialized OAuth2 Client%n%n%s.client-id = %s%n%s.client-secret = %s%n%n",
 					prefix, this.credentials.getClientId(), prefix,
 					defaultSecret ? this.credentials.getClientSecret() : "****"));
 		}


### PR DESCRIPTION
The actual property name is `security.oauth2.client.client-secret` instead of `security.oauth2.client.secret`

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->