### PR TITLE
With Tomcat, enable HTTP/2 by default

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
@@ -50,6 +50,7 @@ import org.apache.catalina.WebResourceRoot.ResourceSetType;
 import org.apache.catalina.WebResourceSet;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.connector.Connector;
+import org.apache.catalina.core.AprLifecycleListener;
 import org.apache.catalina.loader.WebappLoader;
 import org.apache.catalina.session.StandardManager;
 import org.apache.catalina.startup.Tomcat;
@@ -122,7 +123,9 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 
 	private List<Valve> contextValves = new ArrayList<>();
 
-	private List<LifecycleListener> contextLifecycleListeners = new ArrayList<>();
+	private List<LifecycleListener> contextLifecycleListeners = new ArrayList<>(Arrays.asList(
+			new AprLifecycleListener()
+		));
 
 	private List<TomcatContextCustomizer> tomcatContextCustomizers = new ArrayList<>();
 

--- a/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
@@ -65,6 +65,7 @@ import org.apache.coyote.ProtocolHandler;
 import org.apache.coyote.http11.AbstractHttp11JsseProtocol;
 import org.apache.coyote.http11.AbstractHttp11Protocol;
 import org.apache.coyote.http11.Http11NioProtocol;
+import org.apache.coyote.http2.Http2Protocol;
 import org.apache.tomcat.util.net.SSLHostConfig;
 
 import org.springframework.boot.web.server.Compression;
@@ -176,6 +177,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 				: createTempDir("tomcat"));
 		tomcat.setBaseDir(baseDir.getAbsolutePath());
 		Connector connector = new Connector(this.protocol);
+		connector.addUpgradeProtocol(new Http2Protocol());
 		tomcat.getService().addConnector(connector);
 		customizeConnector(connector);
 		tomcat.setConnector(connector);


### PR DESCRIPTION
When using embedded Tomcat, enable HTTP/2 for connectors by default.

Tomcat's HTTP/2 support depends on tomcat-native/APR; if that's not available, Tomcat simply logs a message and continues on without HTTP/2 support (in other words, nothing is broken).

Since this change enables APR (if it's available), it also improves performance in general (if APR is available) by using the OpenSSL engine instead of JSSE, fixing #7376