### PR TITLE
Mark auto-configured `RedisTemplate` as `@Primary`

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -42,6 +43,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
  * @author Stephane Nicoll
  * @author Marco Aust
  * @author Mark Paluch
+ * @author Vedran Pavic
  */
 @Configuration
 @ConditionalOnClass({ RedisOperations.class })
@@ -50,6 +52,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 public class RedisAutoConfiguration {
 
 	@Bean
+	@Primary
 	@ConditionalOnMissingBean(name = "redisTemplate")
 	public RedisTemplate<Object, Object> redisTemplate(
 			RedisConnectionFactory redisConnectionFactory) throws UnknownHostException {


### PR DESCRIPTION
Quite similarly to #6717, if one has a component that attempts to inject `RedisOperations<Object, Object>` (or simply raw `RedisOperations`), things will blow up in a project that uses Spring Session Redis.

The difference here that such situation is possible also with user provided `RedisOperations` bean since auto-config is conditional on bean name.

This PR marks the auto-configured `RedisTemplate` as `@Primary`. With the current situation it is fairly easy to end up with two `RedisTemplate` instances, either in fully auto-configured context (e.g. with Spring Session), or with user provided `RedisTemplate` bean due to auto-config being conditional on `redisTemplate` bean name.
