### PR TITLE
Use HttpStatus in HealthStatusHttpMapper

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/HealthStatusHttpMapper.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/HealthStatusHttpMapper.java
@@ -42,8 +42,8 @@ public class HealthStatusHttpMapper {
 	}
 
 	private void setupDefaultStatusMapping() {
-		addStatusMapping(Status.DOWN, 503);
-		addStatusMapping(Status.OUT_OF_SERVICE, 503);
+		addStatusMapping(Status.DOWN, HttpStatus.SERVICE_UNAVAILABLE.value());
+		addStatusMapping(Status.OUT_OF_SERVICE, HttpStatus.SERVICE_UNAVAILABLE.value());
 	}
 
 	/**
@@ -104,12 +104,10 @@ public class HealthStatusHttpMapper {
 		if (code != null) {
 			return this.statusMapping.keySet().stream()
 					.filter((key) -> code.equals(getUniformValue(key)))
-					.map(this.statusMapping::get).findFirst().orElse(200);
+					.map(this.statusMapping::get).findFirst().orElse(HttpStatus.OK.value());
 		}
-		return 200;
+		return HttpStatus.OK.value();
 	}
-
-
 
 	private String getUniformValue(String code) {
 		if (code == null) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR changes to use `HttpStatus` in favour of HTTP status code for readability in `HealthStatusHttpMapper`.