### PR TITLE
add Stripes Spring Boot starter to list of community-driven Spring Boot starters

### DIFF
--- a/spring-boot-starters/README.adoc
+++ b/spring-boot-starters/README.adoc
@@ -133,6 +133,9 @@ do as they were designed before this was clarified.
 | SSH Daemon
 | https://github.com/anand1st/sshd-shell-spring-boot
 
+| https://github.com/StripesFramework/stripes[Stripes]
+| https://github.com/juanpablo-santos/stripes-spring-boot
+
 | http://teiid.org/[Teiid]
 | https://github.com/teiid/teiid-spring-boot
 


### PR DESCRIPTION
add Spring Boot starter for [Stripes framework](http://www.stripesframework.org/).