### PR TITLE
Add missing setter in SessionProperties for timeout

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionProperties.java
@@ -28,6 +28,7 @@ import org.springframework.session.hazelcast.HazelcastFlushMode;
  * @author Tommy Ludwig
  * @author Stephane Nicoll
  * @author Vedran Pavic
+ * @author Eddú Meléndez
  * @since 1.4.0
  */
 @ConfigurationProperties(prefix = "spring.session")
@@ -68,6 +69,10 @@ public class SessionProperties {
 	 */
 	public Integer getTimeout() {
 		return this.timeout;
+	}
+
+	public void setTimeout(Integer timeout) {
+		this.timeout = timeout;
 	}
 
 	public Hazelcast getHazelcast() {

--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -402,6 +402,7 @@ content into your application; rather pick only the properties that you need.
 	spring.session.redis.flush-mode=on-save # Sessions flush mode.
 	spring.session.redis.namespace= # Namespace for keys used to store sessions.
 	spring.session.store-type= # Session store type.
+	spring.session.timeout= # Session timeout in seconds.
 
 	# SPRING SOCIAL ({sc-spring-boot-autoconfigure}/social/SocialWebAutoConfiguration.{sc-ext}[SocialWebAutoConfiguration])
 	spring.social.auto-connection-views=false # Enable the connection status view for supported providers.


### PR DESCRIPTION
Currently, missing setter for `timeout` doesn't allow to generate
metadata. This commit adds setter and proper documentation update.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->