### PR TITLE
Avoid substring() invocation when the result is itself

### DIFF
--- a/spring-boot-test/src/main/java/org/springframework/boot/test/util/EnvironmentTestUtils.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/util/EnvironmentTestUtils.java
@@ -73,7 +73,7 @@ public abstract class EnvironmentTestUtils {
 		Map<String, Object> map = getOrAdd(sources, name);
 		for (String pair : pairs) {
 			int index = getSeparatorIndex(pair);
-			String key = pair.substring(0, index > 0 ? index : pair.length());
+			String key = index > 0 ? pair.substring(0, index) : pair;
 			String value = index > 0 ? pair.substring(index + 1) : "";
 			map.put(key.trim(), value.trim());
 		}

--- a/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java
@@ -253,7 +253,7 @@ public final class TestPropertyValues {
 
 		public static Pair parse(String pair) {
 			int index = getSeparatorIndex(pair);
-			String key = pair.substring(0, index > 0 ? index : pair.length());
+			String key = index > 0 ? pair.substring(0, index) : pair;
 			String value = index > 0 ? pair.substring(index + 1) : "";
 			return of(key.trim(), value.trim());
 		}

--- a/spring-boot/src/main/java/org/springframework/boot/builder/SpringApplicationBuilder.java
+++ b/spring-boot/src/main/java/org/springframework/boot/builder/SpringApplicationBuilder.java
@@ -395,7 +395,7 @@ public class SpringApplicationBuilder {
 		Map<String, Object> map = new HashMap<>();
 		for (String property : properties) {
 			int index = lowestIndexOf(property, ":", "=");
-			String key = property.substring(0, index > 0 ? index : property.length());
+			String key = index > 0 ? property.substring(0, index) : property;
 			String value = index > 0 ? property.substring(index + 1) : "";
 			map.put(key, value);
 		}

--- a/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BindFailureAnalyzerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BindFailureAnalyzerTests.java
@@ -102,7 +102,7 @@ public class BindFailureAnalyzerTests {
 		Map<String, Object> map = new HashMap<>();
 		for (String pair : environment) {
 			int index = pair.indexOf("=");
-			String key = pair.substring(0, index > 0 ? index : pair.length());
+			String key = index > 0 ? pair.substring(0, index) : pair;
 			String value = index > 0 ? pair.substring(index + 1) : "";
 			map.put(key.trim(), value.trim());
 		}

--- a/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BindValidationFailureAnalyzerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BindValidationFailureAnalyzerTests.java
@@ -135,7 +135,7 @@ public class BindValidationFailureAnalyzerTests {
 		Map<String, Object> map = new HashMap<>();
 		for (String pair : environment) {
 			int index = pair.indexOf("=");
-			String key = pair.substring(0, index > 0 ? index : pair.length());
+			String key = index > 0 ? pair.substring(0, index) : pair;
 			String value = index > 0 ? pair.substring(index + 1) : "";
 			map.put(key.trim(), value.trim());
 		}

--- a/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/UnboundConfigurationPropertyFailureAnalyzerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/UnboundConfigurationPropertyFailureAnalyzerTests.java
@@ -98,7 +98,7 @@ public class UnboundConfigurationPropertyFailureAnalyzerTests {
 		Map<String, Object> map = new HashMap<>();
 		for (String pair : environment) {
 			int index = pair.indexOf("=");
-			String key = pair.substring(0, index > 0 ? index : pair.length());
+			String key = index > 0 ? pair.substring(0, index) : pair;
 			String value = index > 0 ? pair.substring(index + 1) : "";
 			map.put(key.trim(), value.trim());
 		}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR changes to avoid `substring()` invocation when its result is itself.