### PR TITLE
Use AprLifecycleListener with embedded Tomcat by default

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
@@ -50,6 +50,7 @@ import org.apache.catalina.WebResourceRoot.ResourceSetType;
 import org.apache.catalina.WebResourceSet;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.connector.Connector;
+import org.apache.catalina.core.AprLifecycleListener;
 import org.apache.catalina.loader.WebappLoader;
 import org.apache.catalina.session.StandardManager;
 import org.apache.catalina.startup.Tomcat;
@@ -122,7 +123,9 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 
 	private List<Valve> contextValves = new ArrayList<>();
 
-	private List<LifecycleListener> contextLifecycleListeners = new ArrayList<>();
+	private List<LifecycleListener> contextLifecycleListeners = new ArrayList<>(Arrays.asList(
+			new AprLifecycleListener()
+		));
 
 	private List<TomcatContextCustomizer> tomcatContextCustomizers = new ArrayList<>();
 


### PR DESCRIPTION
AprLifecycleListener enabled Tomcat to use APR for accelerating SSL and threading if APR is available (if it's not available, then pure Java is used and there is no loss): https://tomcat.apache.org/tomcat-8.0-doc/apr.html#AprLifecycleListener

The default configuration that Tomcat distributes enables AprLifecycleListener: https://github.com/apache/tomcat/blob/TOMCAT_8_0_0/conf/server.xml#L27 Therefore, since Tomcat has been enabling it by default for years, I think Spring Boot should as well (I was surprised it didn't).

Note that AprLifecycleListener does not enable HTTP/2 or anything else; it's purely a performance improvement.