### PR TITLE
Document default value change for proxy-target-class

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -50,7 +50,7 @@ content into your application; rather pick only the properties that you need.
 
 	# AOP
 	spring.aop.auto=true # Add @EnableAspectJAutoProxy.
-	spring.aop.proxy-target-class=false # Whether subclass-based (CGLIB) proxies are to be created (true) as opposed to standard Java interface-based proxies (false).
+	spring.aop.proxy-target-class= # Whether subclass-based (CGLIB) proxies are to be created (true) as opposed to standard Java interface-based proxies (false). Defaults to "true" when using Spring Transaction Management, otherwise "false".
 
 	# IDENTITY ({sc-spring-boot}/context/ContextIdApplicationContextInitializer.{sc-ext}[ContextIdApplicationContextInitializer])
 	spring.application.index= # Application index.


### PR DESCRIPTION
This commit documents the change to the default value for spring.aop.proxy-target-class by clarifying when the default is true vs false.

This change may warrant a blurb in the reference docs as well since its a deviation from the typical Spring Framework behavior.  For now, I've only targeted the _application.properties_ section of the docs.

I know this was mentioned in the release notes but a lot of folks go straight to the reference docs and might have missed this change.  Please tweak the wording as you see fit.

#5423