### PR TITLE
resolving binding target type directly instead of via generic type

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/AggregateBinder.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/AggregateBinder.java
@@ -19,7 +19,6 @@ package org.springframework.boot.context.properties.bind;
 import java.util.function.Supplier;
 
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
-import org.springframework.core.ResolvableType;
 
 /**
  * Internal strategy used by {@link Binder} to bind aggregates (Maps, Lists, Arrays).
@@ -47,9 +46,7 @@ abstract class AggregateBinder<T> {
 	public final Object bind(ConfigurationPropertyName name, Bindable<?> target,
 			AggregateElementBinder itemBinder) {
 		Supplier<?> value = target.getValue();
-		Class<?> type = (value == null ? target.getType().resolve()
-				: ResolvableType.forClass(AggregateBinder.class, getClass())
-						.resolveGeneric());
+		Class<?> type = target.getType().resolve();
 		Object result = bind(name, target, itemBinder, type);
 		if (result == null || value == null || value.get() == null) {
 			return result;

--- a/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesBindingPostProcessorTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesBindingPostProcessorTests.java
@@ -16,9 +16,11 @@
 
 package org.springframework.boot.context.properties;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -585,6 +587,22 @@ public class ConfigurationPropertiesBindingPostProcessorTests {
 			this.lastName = lastName;
 		}
 
+	}
+
+	@Configuration
+	@EnableConfigurationProperties
+	@ConfigurationProperties(prefix = "test")
+	public static class ListProperty {
+
+		private List<String> colors = new ArrayList<>();
+
+		public List<String> getColors() {
+			return this.colors;
+		}
+
+		public void setColors(List<String> colors) {
+			this.colors = colors;
+		}
 	}
 
 }


### PR DESCRIPTION
The target type for a Collection binding is now directly
specified by target.getType() instead of being inferred by the generic
type of AggregateBinder. This way, a List binding is now typed
correctly to a List instead of to a Collection and can now contain
multiple elements. fixes #10106.