### PR TITLE
Add Spring Boot Starters for Content Stores and Services

### DIFF
--- a/spring-boot-starters/README.adoc
+++ b/spring-boot-starters/README.adoc
@@ -49,6 +49,9 @@ do as they were designed before this was clarified.
 | https://cloudant.com/[Cloudant]
 | https://github.com/icha024/cloudant-spring-boot-starter
 
+| https://paulcwarren.github.io/spring-content/[Content Stores & Services]
+| https://github.com/paulcwarren/spring-content
+
 | http://www.couchbase.com/[Couchbase] HTTP session
 | https://github.com/mkopylec/session-couchbase-spring-boot-starter
 


### PR DESCRIPTION
As per our conversation on [this issue](https://github.com/paulcwarren/spring-content/issues/8) we have renamed our spring boot starter modules and projects to comply with the Spring Boot naming conventions.

We would now like to add our starters to the main Spring Boot Starter readme. 
