### PR TITLE
Upgrade to HikariCP 2.7.1

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -86,7 +86,7 @@
 		<hazelcast-hibernate5.version>1.2.2</hazelcast-hibernate5.version>
 		<hibernate.version>5.2.10.Final</hibernate.version>
 		<hibernate-validator.version>5.4.1.Final</hibernate-validator.version>
-		<hikaricp.version>2.7.0</hikaricp.version>
+		<hikaricp.version>2.7.1</hikaricp.version>
 		<hsqldb.version>2.4.0</hsqldb.version>
 		<htmlunit.version>2.27</htmlunit.version>
 		<httpasyncclient.version>4.1.3</httpasyncclient.version>


### PR DESCRIPTION
Just an hour after #10206 was closed, HikariCP [2.7.1 was released](https://github.com/brettwooldridge/HikariCP/releases) and is already [available in Maven Central](https://search.maven.org/#artifactdetails%7Ccom.zaxxer%7CHikariCP%7C2.7.1%7Cbundle).