### PR TITLE
Add mockito-inline dependency

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -1987,6 +1987,11 @@
 				<version>${mockito.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-inline</artifactId>
+				<version>${mockito.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.mongodb</groupId>
 				<artifactId>bson</artifactId>
 				<version>${mongodb.version}</version>


### PR DESCRIPTION
Hello,

This PR adds mockito-inline to dependencies. Mockito-inline is a convenient module that allows final classes mocking.

As Spring Boot 2.x now has mockito>2 by default, I think this could be a welcome addition.