### PR TITLE
HowTo 'Enable HTTPS when running behind a proxy server' uses incorrect properties

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -2255,8 +2255,8 @@ by adding some entries to `application.properties`, e.g.
 
 [source,properties,indent=0]
 ----
-	server.tomcat.remote_ip_header=x-forwarded-for
-	server.tomcat.protocol_header=x-forwarded-proto
+	server.tomcat.remote-ip-header=x-forwarded-for
+	server.tomcat.protocol-header=x-forwarded-proto
 ----
 
 (The presence of either of those properties will switch on the valve. Or you can add the


### PR DESCRIPTION
In contrast to the documentation and the code, the properties used in the **Enable HTTPS when running behind a proxy server** HowTo are with underline instead of dashes.

server.tomcat.remote_ip_header instead of server.tomcat.remote-ip-header
server.tomcat.protocol_header instead of server.tomcat.protocol-header