### PR TITLE
Use Java 8 Javadoc URL

### DIFF
--- a/spring-boot-docs/pom.xml
+++ b/spring-boot-docs/pom.xml
@@ -821,7 +821,7 @@
 									<quiet>true</quiet>
 									<stylesheetfile>${basedir}/src/main/javadoc/spring-javadoc.css</stylesheetfile>
 									<links>
-										<link>http://docs.oracle.com/javase/7/docs/api/</link>
+										<link>http://docs.oracle.com/javase/8/docs/api/</link>
 										<link>http://docs.oracle.com/javaee/7/api/</link>
 										<link>http://docs.spring.io/spring-framework/docs/${spring.version}/javadoc-api/</link>
 										<link>http://docs.spring.io/spring-security/site/docs/${spring-security.version}/api/</link>

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -1345,7 +1345,7 @@ See _<<boot-features-external-config-profile-specific-properties>>_ for details.
 Spring Boot uses http://commons.apache.org/logging[Commons Logging] for all internal
 logging, but leaves the underlying log implementation open. Default configurations are
 provided for
-http://docs.oracle.com/javase/7/docs/api/java/util/logging/package-summary.html[Java Util Logging],
+http://docs.oracle.com/javase/8/docs/api/java/util/logging/package-summary.html[Java Util Logging],
 http://logging.apache.org/log4j/2.x/[Log4J2] and http://logback.qos.ch/[Logback]. In each
 case loggers are pre-configured to use console output with optional file output also
 available.


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR changes to use Java 8 Javadoc URL to avoid 404 like: https://docs.oracle.com/javase/7/docs/api/java/lang/FunctionalInterface.html?is-external=true