### PR TITLE
Upgrade Hibernate dependency to 5.2.11.Final

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -84,7 +84,7 @@
 		<hamcrest.version>1.3</hamcrest.version>
 		<hazelcast.version>3.8.5</hazelcast.version>
 		<hazelcast-hibernate5.version>1.2.2</hazelcast-hibernate5.version>
-		<hibernate.version>5.2.10.Final</hibernate.version>
+		<hibernate.version>5.2.11.Final</hibernate.version>
 		<hibernate-validator.version>5.4.1.Final</hibernate-validator.version>
 		<hikaricp.version>2.7.1</hikaricp.version>
 		<hsqldb.version>2.4.0</hsqldb.version>


### PR DESCRIPTION
As 2.0.0.M4 is due today. attempting to make this available for this milestone release

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->