### PR TITLE
Make WebMvcMetrics#tagWithException public.

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetrics.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetrics.java
@@ -85,7 +85,7 @@ public class WebMvcMetrics {
 		this.recordAsPercentiles = recordAsPercentiles;
 	}
 
-	void tagWithException(Throwable exception) {
+	public void tagWithException(Throwable exception) {
 		RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
 		attributes.setAttribute(EXCEPTION_ATTRIBUTE, exception,
 				RequestAttributes.SCOPE_REQUEST);


### PR DESCRIPTION
This method was intended to be public, for use as documented in the Micrometer documentation at the bottom of section 6.2.1: http://micrometer.io/docs/atlas#_web_monitoring