### PR TITLE
Make Audit events Web endpoint `after` parameter required

### DIFF
--- a/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/audit/AuditEventsEndpointAutoConfiguration.java
+++ b/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/audit/AuditEventsEndpointAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.boot.actuate.autoconfigure.audit;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.boot.actuate.audit.AuditEventsEndpoint;
 import org.springframework.boot.actuate.audit.AuditEventsJmxEndpointExtension;
+import org.springframework.boot.actuate.audit.AuditEventsWebEndpointExtension;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnEnabledEndpoint;
 import org.springframework.boot.actuate.logging.LoggersEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -33,6 +34,7 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Vedran Pavic
  * @since 2.0.0
  */
 @Configuration
@@ -55,6 +57,15 @@ public class AuditEventsEndpointAutoConfiguration {
 	public AuditEventsJmxEndpointExtension auditEventsJmxEndpointExtension(
 			AuditEventsEndpoint auditEventsEndpoint) {
 		return new AuditEventsJmxEndpointExtension(auditEventsEndpoint);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnEnabledEndpoint
+	@ConditionalOnBean(AuditEventsEndpoint.class)
+	public AuditEventsWebEndpointExtension auditEventsWebEndpointExtension(
+			AuditEventsEndpoint auditEventsEndpoint) {
+		return new AuditEventsWebEndpointExtension(auditEventsEndpoint);
 	}
 
 }

--- a/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/audit/AuditEventsEndpointAutoConfigurationTests.java
+++ b/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/audit/AuditEventsEndpointAutoConfigurationTests.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import org.springframework.boot.actuate.audit.AuditEventsEndpoint;
 import org.springframework.boot.actuate.audit.AuditEventsJmxEndpointExtension;
+import org.springframework.boot.actuate.audit.AuditEventsWebEndpointExtension;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Vedran Pavic
  */
 public class AuditEventsEndpointAutoConfigurationTests {
 
@@ -47,6 +49,12 @@ public class AuditEventsEndpointAutoConfigurationTests {
 	public void runShouldHaveJmxExtensionBean() {
 		this.contextRunner.run((context) -> assertThat(context)
 				.hasSingleBean(AuditEventsJmxEndpointExtension.class));
+	}
+
+	@Test
+	public void runShouldHaveWebExtensionBean() {
+		this.contextRunner.run((context) -> assertThat(context)
+				.hasSingleBean(AuditEventsWebEndpointExtension.class));
 	}
 
 	@Test

--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/AuditEventsWebEndpointExtension.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/AuditEventsWebEndpointExtension.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.audit;
+
+import java.util.Date;
+
+import org.springframework.boot.actuate.audit.AuditEventsEndpoint.AuditEventsDescriptor;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
+import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpointExtension;
+import org.springframework.http.HttpStatus;
+
+/**
+ * {@link WebEndpointExtension} for the {@link AuditEventsEndpoint}.
+ *
+ * @author Vedran Pavic
+ * @since 2.0.0
+ */
+@WebEndpointExtension(endpoint = AuditEventsEndpoint.class)
+public class AuditEventsWebEndpointExtension {
+
+	private final AuditEventsEndpoint delegate;
+
+	public AuditEventsWebEndpointExtension(AuditEventsEndpoint delegate) {
+		this.delegate = delegate;
+	}
+
+	@ReadOperation
+	public WebEndpointResponse<AuditEventsDescriptor> eventsWithPrincipalDateAfterAndType(
+			String principal, Date after, String type) {
+		if (after == null) {
+			return new WebEndpointResponse<>(HttpStatus.BAD_REQUEST.value());
+		}
+		AuditEventsDescriptor auditEvents = this.delegate
+				.eventsWithPrincipalDateAfterAndType(principal, after, type);
+		return new WebEndpointResponse<>(auditEvents);
+	}
+
+}

--- a/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/audit/AuditEventsEndpointWebIntegrationTests.java
+++ b/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/audit/AuditEventsEndpointWebIntegrationTests.java
@@ -42,6 +42,12 @@ public class AuditEventsEndpointWebIntegrationTests {
 	private static WebTestClient client;
 
 	@Test
+	public void eventsWithoutParams() throws Exception {
+		client.get().uri((builder) -> builder.path("/application/auditevents").build())
+				.exchange().expectStatus().isBadRequest();
+	}
+
+	@Test
 	public void eventsWithDateAfter() throws Exception {
 		client.get()
 				.uri((builder) -> builder.path("/application/auditevents")
@@ -90,6 +96,12 @@ public class AuditEventsEndpointWebIntegrationTests {
 		@Bean
 		public AuditEventsEndpoint auditEventsEndpoint() {
 			return new AuditEventsEndpoint(auditEventsRepository());
+		}
+
+		@Bean
+		public AuditEventsWebEndpointExtension auditEventsWebEndpointExtension(
+				AuditEventsEndpoint auditEventsEndpoint) {
+			return new AuditEventsWebEndpointExtension(auditEventsEndpoint);
 		}
 
 		private AuditEvent createEvent(String instant, String principal, String type) {


### PR DESCRIPTION
With the changes to Actuator infrastructure the behavior of `auditevents` endpoint introduced in #9002 was lost so the problem described in #8560 is present again.

This PR fixes the original problem again by introducing `AuditEventsWebEndpointExtension`.