### PR TITLE
Adding missing libraries to dependencies pom

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -827,6 +827,16 @@
 			</dependency>
 			<dependency>
 				<groupId>io.dropwizard.metrics</groupId>
+				<artifactId>metrics-json</artifactId>
+				<version>${dropwizard-metrics.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.dropwizard.metrics</groupId>
+				<artifactId>metrics-jvm</artifactId>
+				<version>${dropwizard-metrics.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.dropwizard.metrics</groupId>
 				<artifactId>metrics-servlets</artifactId>
 				<version>${dropwizard-metrics.version}</version>
 			</dependency>
@@ -1007,6 +1017,11 @@
 			<dependency>
 				<groupId>net.java.dev.jna</groupId>
 				<artifactId>jna</artifactId>
+				<version>${jna.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>net.java.dev.jna</groupId>
+				<artifactId>jna-platform</artifactId>
 				<version>${jna.version}</version>
 			</dependency>
 			<dependency>
@@ -1315,7 +1330,32 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.solr</groupId>
+				<artifactId>solr-analytics</artifactId>
+				<version>${solr.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.solr</groupId>
+				<artifactId>solr-cell</artifactId>
+				<version>${solr.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.solr</groupId>
+				<artifactId>solr-clustering</artifactId>
+				<version>${solr.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.solr</groupId>
+				<artifactId>solr-core</artifactId>
+				<version>${solr.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.solr</groupId>
 				<artifactId>solr-solrj</artifactId>
+				<version>${solr.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.solr</groupId>
+				<artifactId>solr-test-framework</artifactId>
 				<version>${solr.version}</version>
 			</dependency>
 			<dependency>
@@ -1660,7 +1700,17 @@
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.jetty.websocket</groupId>
+				<artifactId>websocket-api</artifactId>
+				<version>${jetty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty.websocket</groupId>
 				<artifactId>websocket-client</artifactId>
+				<version>${jetty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty.websocket</groupId>
+				<artifactId>websocket-common</artifactId>
 				<version>${jetty.version}</version>
 			</dependency>
 			<dependency>
@@ -2142,6 +2192,11 @@
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
+				<version>${slf4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-ext</artifactId>
 				<version>${slf4j.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
We are working on the alignment of Apache Camel with Spring-Boot 2 ([CAMEL-11756](https://issues.apache.org/jira/browse/CAMEL-11756)) and we found some missing dependencies in the spring-boot dependencies pom that causes problems with Camel transitive dependencies.

E.g. spring-boot-dependencies forces version X metrics-core. One of our module is compiled with version Y of metrics-core and metrics-json, but it can work also with version X (we have integration tests to ensure it).
But when the user creates an application with our module, he gets version X of metrics-core, and version Y of metrics-json, because the spring-boot-dependencies pom does not include metrics-json in the dependencyManagement section. The same happens with other libraries.

We are trying to make sure that next versions of Camel support multiple versions of spring-boot, so we cannot keep these versions in our side. Spring-boot dependencies should be complete.

The 1.5.x branch would also benefit from this change.