### PR TITLE
Upgrade Git Maven plugin to 2.2.3

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -201,7 +201,7 @@
 		<!-- Plugin versions -->
 		<build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
 		<exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
-		<git-commit-id-plugin.version>2.2.2</git-commit-id-plugin.version>
+		<git-commit-id-plugin.version>2.2.3</git-commit-id-plugin.version>
 		<maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
 		<maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
 		<maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>


### PR DESCRIPTION
[v2.2.3](https://github.com/ktoso/maven-git-commit-id-plugin/releases/tag/v2.2.3) has been released.

Closes gh-8806