### PR TITLE
Replace getParameterTypes().length with getParameterCount()

### DIFF
--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/filter/TypeExcludeFiltersContextCustomizer.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/filter/TypeExcludeFiltersContextCustomizer.java
@@ -62,7 +62,7 @@ class TypeExcludeFiltersContextCustomizer implements ContextCustomizer {
 		try {
 			Constructor<?> constructor = getTypeExcludeFilterConstructor(filterClass);
 			ReflectionUtils.makeAccessible(constructor);
-			if (constructor.getParameterTypes().length == 1) {
+			if (constructor.getParameterCount() == 1) {
 				return (TypeExcludeFilter) constructor.newInstance(testClass);
 			}
 			return (TypeExcludeFilter) constructor.newInstance();

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonTestersAutoConfiguration.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonTestersAutoConfiguration.java
@@ -142,7 +142,7 @@ public class JsonTestersAutoConfiguration {
 			}
 			Constructor<?>[] constructors = this.objectType.getDeclaredConstructors();
 			for (Constructor<?> constructor : constructors) {
-				if (constructor.getParameterTypes().length == 1
+				if (constructor.getParameterCount() == 1
 						&& constructor.getParameterTypes()[0]
 								.isInstance(this.marshaller)) {
 					ReflectionUtils.makeAccessible(constructor);


### PR DESCRIPTION
Hey,

I just found two occurences of getParameterTypes().length which could be replaced with JDK 8's getParameterCount().

Cheers,
Christoph