### PR TITLE
Update pom.xml to make spring-boot 1.5.x buildable on jdk-9

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -207,7 +207,7 @@
 		<maven-install-plugin.version>2.5.2</maven-install-plugin.version>
 		<maven-invoker-plugin.version>1.10</maven-invoker-plugin.version>
 		<maven-help-plugin.version>2.2</maven-help-plugin.version>
-		<maven-jar-plugin.version>2.6</maven-jar-plugin.version>
+		<maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
 		<maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
 		<maven-resources-plugin.version>2.7</maven-resources-plugin.version>
 		<maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>


### PR DESCRIPTION
The maven-jar-plugin 2.6 is not compatible with jdk-9. In order to make 1.5.x spring boot projects buildable under jdk-9 this dependency needs an upgrade. I discovered that 3.0.2 works very nice. 

A workaround could be for users to override the version in the plugin section:

```
      <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-jar-plugin</artifactId>
        <version>3.0.2</version>
      </plugin>
```

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->