### PR TITLE
Typo in external config documentation

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -980,7 +980,7 @@ does not inject other beans from the context. Having said that, The
 `@EnableConfigurationProperties` annotation is _also_ automatically applied to your project
 so that any _existing_ bean annotated with `@ConfigurationProperties` will be configured
 from the `Environment`. You could shortcut `MyConfiguration` above by making sure
-`FooProperties` is a already a bean:
+`FooProperties` is already a bean:
 
 [source,java,indent=0]
 ----


### PR DESCRIPTION
Hey,

just noticed a typo in the [externalized config](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/html/boot-features-external-config.html#boot-features-external-config-typesafe-configuration-properties) section.

Cheers,
Christoph