### PR TITLE
Remove redundant semicolons

### DIFF
--- a/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/Token.java
+++ b/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/Token.java
@@ -120,6 +120,6 @@ class Token {
 	@Override
 	public String toString() {
 		return this.encoded;
-	};
+	}
 
 }

--- a/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementContextAutoConfiguration.java
+++ b/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementContextAutoConfiguration.java
@@ -184,7 +184,7 @@ public class ManagementContextAutoConfiguration {
 			if (event instanceof ApplicationFailedEvent) {
 				onApplicationFailedEvent((ApplicationFailedEvent) event);
 			}
-		};
+		}
 
 		private void onContextClosedEvent(ContextClosedEvent event) {
 			propagateCloseIfNecessary(event.getApplicationContext());

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheType.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheType.java
@@ -74,6 +74,6 @@ public enum CacheType {
 	/**
 	 * No caching.
 	 */
-	NONE;
+	NONE
 
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
@@ -766,7 +766,7 @@ public class KafkaProperties {
 			/**
 			 * Invokes the endpoint with a batch of ConsumerRecords.
 			 */
-			BATCH;
+			BATCH
 
 		}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/StoreType.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/StoreType.java
@@ -49,6 +49,6 @@ public enum StoreType {
 	/**
 	 * No session data-store.
 	 */
-	NONE;
+	NONE
 
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/http/HttpMessageConvertersTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/http/HttpMessageConvertersTests.java
@@ -122,7 +122,7 @@ public class HttpMessageConvertersTests {
 					}
 				}
 				return converters;
-			};
+			}
 		};
 		List<Class<?>> converterClasses = new ArrayList<>();
 		for (HttpMessageConverter<?> converter : converters) {
@@ -152,7 +152,7 @@ public class HttpMessageConvertersTests {
 					}
 				}
 				return converters;
-			};
+			}
 		};
 		List<Class<?>> converterClasses = new ArrayList<>();
 		for (HttpMessageConverter<?> converter : extractFormPartConverters(

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/error/BasicErrorControllerDirectMockMvcTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/error/BasicErrorControllerDirectMockMvcTests.java
@@ -185,7 +185,7 @@ public class BasicErrorControllerDirectMockMvcTests {
 
 		@Pointcut("within(@org.springframework.stereotype.Controller *)")
 		private void controllerPointCut() {
-		};
+		}
 
 		@Around("controllerPointCut()")
 		public Object mvcAdvice(ProceedingJoinPoint pjp) throws Throwable {

--- a/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/CommandRunnerTests.java
+++ b/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/CommandRunnerTests.java
@@ -77,7 +77,7 @@ public class CommandRunnerTests {
 			protected void showUsage() {
 				CommandRunnerTests.this.calls.add(Call.SHOW_USAGE);
 				super.showUsage();
-			};
+			}
 
 			@Override
 			protected boolean errorMessage(String message) {

--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSystemWatcher.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSystemWatcher.java
@@ -242,7 +242,7 @@ public class FileSystemWatcher {
 				}
 				remainingScans = this.remainingScans.get();
 			}
-		};
+		}
 
 		private void scan() throws InterruptedException {
 			Thread.sleep(this.pollInterval - this.quietPeriod);

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonExcludeFilter.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonExcludeFilter.java
@@ -42,7 +42,7 @@ class JsonExcludeFilter extends AnnotationCustomizableTypeExcludeFilter {
 		includes.add(Module.class);
 		includes.add(JsonComponent.class);
 		DEFAULT_INCLUDES = Collections.unmodifiableSet(includes);
-	};
+	}
 
 	private final JsonTest annotation;
 

--- a/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTypeExcludeFilter.java
+++ b/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTypeExcludeFilter.java
@@ -57,7 +57,7 @@ class WebMvcTypeExcludeFilter extends AnnotationCustomizableTypeExcludeFilter {
 		includes.add(HttpMessageConverter.class);
 		includes.add(ErrorAttributes.class);
 		DEFAULT_INCLUDES = Collections.unmodifiableSet(includes);
-	};
+	}
 
 	private static final Set<Class<?>> DEFAULT_INCLUDES_AND_CONTROLLER;
 

--- a/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java
+++ b/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java
@@ -299,7 +299,7 @@ public final class TestPropertyValues {
 		@Override
 		public void close() {
 			this.previous.forEach(this::setOrClear);
-		};
+		}
 
 		private String setOrClear(String name, String value) {
 			Assert.notNull(name, "Name must not be null");

--- a/spring-boot-test/src/test/java/org/springframework/boot/test/mock/web/SpringBootMockServletContextTests.java
+++ b/spring-boot-test/src/test/java/org/springframework/boot/test/mock/web/SpringBootMockServletContextTests.java
@@ -80,7 +80,7 @@ public class SpringBootMockServletContextTests implements ServletContextAware {
 			protected String getResourceLocation(String path) {
 				// Don't include the Spring Boot defaults for this test
 				return getResourceBasePathLocation(path);
-			};
+			}
 		};
 		URL resource = context.getResource("/");
 		assertThat(resource).isNotEqualTo(nullValue());

--- a/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ApplicationPluginAction.java
+++ b/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ApplicationPluginAction.java
@@ -84,7 +84,7 @@ final class ApplicationPluginAction implements PluginApplicationAction {
 
 	private String loadResource(String name) {
 		try (InputStreamReader reader = new InputStreamReader(
-				getClass().getResourceAsStream(name));) {
+				getClass().getResourceAsStream(name))) {
 			char[] buffer = new char[4096];
 			int read = 0;
 			StringWriter writer = new StringWriter();

--- a/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/ZipCompression.java
+++ b/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/ZipCompression.java
@@ -34,6 +34,6 @@ public enum ZipCompression {
 	/**
 	 * The entry should be {@link ZipEntry#DEFLATED} in the archive.
 	 */
-	DEFLATED;
+	DEFLATED
 
 }

--- a/spring-boot/src/main/java/org/springframework/boot/SpringBootExceptionHandler.java
+++ b/spring-boot/src/main/java/org/springframework/boot/SpringBootExceptionHandler.java
@@ -123,7 +123,7 @@ class SpringBootExceptionHandler implements UncaughtExceptionHandler {
 					Thread.currentThread().getUncaughtExceptionHandler());
 			Thread.currentThread().setUncaughtExceptionHandler(handler);
 			return handler;
-		};
+		}
 
 	}
 

--- a/spring-boot/src/main/java/org/springframework/boot/WebApplicationType.java
+++ b/spring-boot/src/main/java/org/springframework/boot/WebApplicationType.java
@@ -41,6 +41,6 @@ public enum WebApplicationType {
 	 * The application should run as a reactive web application and should start an
 	 * embedded reactive web server.
 	 */
-	REACTIVE;
+	REACTIVE
 
 }

--- a/spring-boot/src/main/java/org/springframework/boot/json/JacksonJsonParser.java
+++ b/spring-boot/src/main/java/org/springframework/boot/json/JacksonJsonParser.java
@@ -65,10 +65,10 @@ public class JacksonJsonParser implements JsonParser {
 
 	private static class MapTypeReference extends TypeReference<Map<String, Object>> {
 
-	};
+	}
 
 	private static class ListTypeReference extends TypeReference<List<Object>> {
 
-	};
+	}
 
 }

--- a/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
@@ -957,7 +957,7 @@ public class SpringApplicationTests {
 						FailingConfig.class);
 				application.setWebApplicationType(WebApplicationType.NONE);
 				application.run();
-			};
+			}
 		};
 		thread.start();
 		thread.join(6000);

--- a/spring-boot/src/test/java/org/springframework/boot/context/properties/source/MapConfigurationPropertySourceTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/properties/source/MapConfigurationPropertySourceTests.java
@@ -113,6 +113,6 @@ public class MapConfigurationPropertySourceTests {
 		ConfigurationProperty property = source
 				.getConfigurationProperty(ConfigurationPropertyName.of(name));
 		return (property == null ? null : property.getValue());
-	};
+	}
 
 }

--- a/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BeanCurrentlyInCreationFailureAnalyzerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BeanCurrentlyInCreationFailureAnalyzerTests.java
@@ -144,7 +144,7 @@ public class BeanCurrentlyInCreationFailureAnalyzerTests {
 
 	private Exception createFailure(Class<?> configuration) {
 		try (ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
-				configuration);) {
+				configuration)) {
 			fail("Expected failure did not occur");
 			return null;
 		}

--- a/spring-boot/src/test/java/org/springframework/boot/jta/bitronix/PoolingConnectionFactoryBeanTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/jta/bitronix/PoolingConnectionFactoryBeanTests.java
@@ -36,7 +36,7 @@ public class PoolingConnectionFactoryBeanTests {
 		@Override
 		public synchronized void init() {
 			// Stub out for the tests
-		};
+		}
 	};
 
 	@Test

--- a/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
@@ -1227,7 +1227,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 			return this.initCount;
 		}
 
-	};
+	}
 
 	public interface BlockedPortAction {
 

--- a/spring-boot/src/test/java/org/springframework/boot/web/servlet/support/SpringBootServletInitializerTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/web/servlet/support/SpringBootServletInitializerTests.java
@@ -132,7 +132,7 @@ public class SpringBootServletInitializerTests {
 		protected WebApplicationContext run(SpringApplication application) {
 			SpringBootServletInitializerTests.this.application = application;
 			return null;
-		};
+		}
 
 	}
 


### PR DESCRIPTION
Hey,

I just noticed a redundant semicolon in `JacksonJsonParser` and did a quick search for others. So this PR removes redundant semicolons.

Cheers,
Christoph