### PR TITLE
embeddedLaunchScript: Add support for FreeBSD.

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #    .   ____          _            __ _ _
 #   /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
@@ -28,11 +28,21 @@ WORKING_DIR="$(pwd)"
 [[ -n "$JARFILE" ]] && jarfile="$JARFILE"
 [[ -n "$APP_NAME" ]] && identity="$APP_NAME"
 
+if [[ -d /etc/rc\.d ]]; then
+  # System V init scripts folder on FreeBSD
+  sysv_dir="rc\.d"
+else
+  sysv_dir="init\.d"
+fi
+
 # Follow symlinks to find the real jar and detect init.d script
 cd "$(dirname "$0")" || exit 1
 [[ -z "$jarfile" ]] && jarfile=$(pwd)/$(basename "$0")
 while [[ -L "$jarfile" ]]; do
-  if [[ "$jarfile" =~ init\.d ]]; then
+  # Quoting the string argument to the [[ command's =~ operator forces
+  # string matching (as with the other pattern-matching operators).
+  # Since Bash v3.2.
+  if [[ "$jarfile" =~ $sysv_dir ]]; then
     init_script=$(basename "$jarfile")
   else
     configfile="${jarfile%.*}.conf"


### PR DESCRIPTION
The following things had to be changed:

* Shebang:
  * The default location of the Bash binary on FreeBSD is `/usr/local/bin/bash`.
    Usually one installs Bash on FreeBSD using the `pkg install bash` command.
  * On Linux the Bash binary is normally located at `/bin/bash`. Therefore we use `env` 
    to allow the interpreter to be looked up via the `PATH`.
  * Note: `env` is located at `/usr/bin/env` on both Linux and FreeBSD.
  * Also, creating a symlink to point from `/bin/bash` to `/usr/local/bin/bash` when
    using FreeBSD might not be feasable in cases where the `/bin/` directory is a
    shared directory between multiple FreeBSD jails.

* System V init script dir:
  * On FreeBSD the System V init scripts are stored
    under `/etc/rc.d/` instead of `/etc/init.d`.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->