### PR TITLE
Changed status line to provide info about the application. Useful whe…

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -242,10 +242,10 @@ force_reload() {
 status() {
   working_dir=$(dirname "$jarfile")
   pushd "$working_dir" > /dev/null
-  [[ -f "$pid_file" ]] || { echoRed "Not running"; return 3; }
+  [[ -f "$pid_file" ]] || { echoRed "${identity} not running"; return 3; }
   pid=$(cat "$pid_file")
-  isRunning "$pid" || { echoRed "Not running (process ${pid} not found)"; return 1; }
-  echoGreen "Running [$pid]"
+  isRunning "$pid" || { echoRed "${identity} not running (process ${pid} not found)"; return 1; }
+  echoGreen "${identity} is running [$pid]"
   return 0
 }
 


### PR DESCRIPTION
…n listing more than one service at a time

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

The status line for spring-boot applications are lacking essential info when listing more than one service , e.g service --status-all
...
Running [13448]
Not running
cpuspeed is stopped
crond (pid  3774) is running...
cupsd (pid  2515) is running...
...

The two first one are spring-boot applications..
This PR will change those lines to: 
app-name is running [13448]
app-name is not running
