### PR TITLE
Adds auto-configuration of property useCodeAsDefaultMessage of MessageSource

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/MessageSourceAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/MessageSourceAutoConfiguration.java
@@ -75,6 +75,7 @@ public class MessageSourceAutoConfiguration {
 		messageSource.setFallbackToSystemLocale(properties.isFallbackToSystemLocale());
 		messageSource.setCacheSeconds(properties.getCacheSeconds());
 		messageSource.setAlwaysUseMessageFormat(properties.isAlwaysUseMessageFormat());
+		messageSource.setUseCodeAsDefaultMessage(properties.isUseCodeAsDefaultMessage());
 		return messageSource;
 	}
 

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/MessageSourceProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/MessageSourceProperties.java
@@ -22,6 +22,7 @@ import java.nio.charset.Charset;
  * Configuration properties for Message Source.
  *
  * @author Stephane Nicoll
+ * @author Kedar Joshi
  * @since 2.0.0
  */
 public class MessageSourceProperties {
@@ -56,6 +57,11 @@ public class MessageSourceProperties {
 	 * arguments.
 	 */
 	private boolean alwaysUseMessageFormat = false;
+
+	/**
+	 * Set whether to use the message code as default message instead of throwing a NoSuchMessageException.
+	 */
+	private boolean useCodeAsDefaultMessage = false;
 
 	public String getBasename() {
 		return this.basename;
@@ -97,4 +103,11 @@ public class MessageSourceProperties {
 		this.alwaysUseMessageFormat = alwaysUseMessageFormat;
 	}
 
+	public boolean isUseCodeAsDefaultMessage() {
+		return this.useCodeAsDefaultMessage;
+	}
+
+	public void setUseCodeAsDefaultMessage(final boolean useCodeAsDefaultMessage) {
+		this.useCodeAsDefaultMessage = useCodeAsDefaultMessage;
+	}
 }

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/context/MessageSourceAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/context/MessageSourceAutoConfigurationTests.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Dave Syer
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @author Kedar Joshi
  */
 public class MessageSourceAutoConfigurationTests {
 
@@ -140,6 +141,26 @@ public class MessageSourceAutoConfigurationTests {
 	private boolean isAlwaysUseMessageFormat(MessageSource messageSource) {
 		return (boolean) new DirectFieldAccessor(messageSource)
 				.getPropertyValue("alwaysUseMessageFormat");
+	}
+
+	@Test
+	public void testUseCodeAsDefaultMessageDefault() throws Exception {
+		load("spring.messages.basename:test/messages");
+		assertThat(isUseCodeAsDefaultMessage(this.context.getBean(MessageSource.class)))
+				.isFalse();
+	}
+
+	@Test
+	public void testUseCodeAsDefaultMessageOn() throws Exception {
+		load("spring.messages.basename:test/messages",
+				"spring.messages.use-code-as-default-message:true");
+		assertThat(isUseCodeAsDefaultMessage(this.context.getBean(MessageSource.class)))
+				.isTrue();
+	}
+
+	private boolean isUseCodeAsDefaultMessage(MessageSource messageSource) {
+		return (boolean) new DirectFieldAccessor(messageSource)
+				.getPropertyValue("useCodeAsDefaultMessage");
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #10146 by adding auto configuration of `useCodeAsDefaultMessage` in `MessageSourceAutoConfiguration`
