### PR TITLE
Remove non short-circuit expression in Neo4jPropertiesTests

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jPropertiesTests.java
@@ -157,7 +157,7 @@ public class Neo4jPropertiesTests {
 	private static void assertCredentials(Configuration actual, String username,
 			String password) {
 		Credentials<?> credentials = actual.getCredentials();
-		if (username == null & password == null) {
+		if (username == null && password == null) {
 			assertThat(credentials).isNull();
 		}
 		else {


### PR DESCRIPTION
Hey,

this PR removes a non short-circuit expression in Neo4jPropertiesTests.

Cheers,
Christoph