### PR TITLE
Upgrade to Maven Compiler Plugin 3.7.0

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -208,7 +208,7 @@
 		<maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
 		<maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
 		<maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
-		<maven-compiler-plugin.version>3.6.2</maven-compiler-plugin.version>
+		<maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
 		<maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>


### PR DESCRIPTION
According to [the release notes](http://blog.soebes.de/blog/2017/09/05/apache-maven-compiler-plugin-version-3-dot-7-0-released/) there are some fixes related to Java 9 compatibility, so it may be a good idea to consider this upgrade for Spring Boot 2 M5.