### PR TITLE
Improvements on Thymeleaf reactive configuration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
@@ -264,6 +264,8 @@ public class ThymeleafAutoConfiguration {
 				resolver.setResponseMaxChunkSizeBytes(
 						this.properties.getReactive().getMaxChunkSize());
 			}
+			resolver.setFullModeViewNames(this.properties.getReactive().getFullModeViewNames());
+			resolver.setChunkedModeViewNames(this.properties.getReactive().getChunkedModeViewNames());
 			// This resolver acts as a fallback resolver (e.g. like a
 			// InternalResourceViewResolver) so it needs to have low precedence
 			resolver.setOrder(Ordered.LOWEST_PRECEDENCE - 5);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafProperties.java
@@ -84,12 +84,12 @@ public class ThymeleafProperties {
 	private Integer templateResolverOrder;
 
 	/**
-	 * Comma-separated list of view names that can be resolved.
+	 * Comma-separated list of view names (patterns allowed) that can be resolved.
 	 */
 	private String[] viewNames;
 
 	/**
-	 * Comma-separated list of view names that should be excluded from resolution.
+	 * Comma-separated list of view names (patterns allowed) that should be excluded from resolution.
 	 */
 	private String[] excludedViewNames;
 
@@ -218,7 +218,8 @@ public class ThymeleafProperties {
 	public static class Reactive {
 
 		/**
-		 * Maximum size of data buffers used for writing to the response, in bytes.
+		 * Maximum size of data buffers used for writing to the response, in bytes. Templates will
+		 * execute in CHUNKED mode by default if this is set a value.
 		 */
 		private int maxChunkSize;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafProperties.java
@@ -227,6 +227,19 @@ public class ThymeleafProperties {
 		 */
 		private List<MediaType> mediaTypes;
 
+		/**
+		 * Comma-separated list of view names (patterns allowed) that should be executed in FULL mode
+		 * even if a max chunk size is set.
+		 */
+		private String[] fullModeViewNames;
+
+		/**
+		 * Comma-separated list of view names (patterns allowed) that should be the only ones executed
+		 * in CHUNKED mode when a max chunk size is set.
+		 */
+		private String[] chunkedModeViewNames;
+
+
 		public List<MediaType> getMediaTypes() {
 			return this.mediaTypes;
 		}
@@ -241,6 +254,22 @@ public class ThymeleafProperties {
 
 		public void setMaxChunkSize(int maxChunkSize) {
 			this.maxChunkSize = maxChunkSize;
+		}
+
+		public String[] getFullModeViewNames() {
+			return this.fullModeViewNames;
+		}
+
+		public void setFullModeViewNames(String[] fullModeViewNames) {
+			this.fullModeViewNames = fullModeViewNames;
+		}
+
+		public String[] getChunkedModeViewNames() {
+			return this.chunkedModeViewNames;
+		}
+
+		public void setChunkedModeViewNames(String[] chunkedModeViewNames) {
+			this.chunkedModeViewNames = chunkedModeViewNames;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafReactiveAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafReactiveAutoConfigurationTests.java
@@ -113,6 +113,22 @@ public class ThymeleafReactiveAutoConfigurationTests {
 	}
 
 	@Test
+	public void overrideFullModeViewNames() throws Exception {
+		load(BaseConfiguration.class, "spring.thymeleaf.reactive.fullModeViewNames:foo,bar");
+		ThymeleafReactiveViewResolver views = this.context
+				.getBean(ThymeleafReactiveViewResolver.class);
+		assertThat(views.getFullModeViewNames()).isEqualTo(new String[] { "foo", "bar" });
+	}
+
+	@Test
+	public void overrideChunkedModeViewNames() throws Exception {
+		load(BaseConfiguration.class, "spring.thymeleaf.reactive.chunkedModeViewNames:foo,bar");
+		ThymeleafReactiveViewResolver views = this.context
+				.getBean(ThymeleafReactiveViewResolver.class);
+		assertThat(views.getChunkedModeViewNames()).isEqualTo(new String[] { "foo", "bar" });
+	}
+
+	@Test
 	public void templateLocationDoesNotExist() throws Exception {
 		load(BaseConfiguration.class,
 				"spring.thymeleaf.prefix:classpath:/no-such-directory/");

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafReactiveAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafReactiveAutoConfigurationTests.java
@@ -113,6 +113,14 @@ public class ThymeleafReactiveAutoConfigurationTests {
 	}
 
 	@Test
+	public void overrideMaxChunkSize() throws Exception {
+		load(BaseConfiguration.class, "spring.thymeleaf.reactive.maxChunkSize:8192");
+		ThymeleafReactiveViewResolver views = this.context
+				.getBean(ThymeleafReactiveViewResolver.class);
+		assertThat(views.getResponseMaxChunkSizeBytes()).isEqualTo(Integer.valueOf(8192));
+	}
+
+	@Test
 	public void overrideFullModeViewNames() throws Exception {
 		load(BaseConfiguration.class, "spring.thymeleaf.reactive.fullModeViewNames:foo,bar");
 		ThymeleafReactiveViewResolver views = this.context


### PR DESCRIPTION
Thymeleaf 3.0.8 (see #10319) added two new configuration parameters to `ThymeleafReactiveViewResolver`:

   * `fullModeViewNames`
   * `chunkedModeViewNames`

When a maximum chunk size is specified (in Spring Boot: `spring.thymeleaf.reactive.max-chunk-size`) these two new parameters allow to optionally fine-tune specifically which templates will be applied the specified maximum chunk size (and thus be executed in `CHUNKED` mode) and which won't.

See thymeleaf/thymeleaf-spring#159 for a detailed description of this new behaviour.

This PR modifies `ThymeleafProperties` and `ThymeleafAutoConfiguration` to add the possibility to configure these two new properties from the Spring Boot configuration mechanism. A couple of tests have been added too.

Additionally, there are two more commits included in the PR which perform a slight improvement in the doc of `ThymeleafProperties` and add a test for the `spring.thymeleaf.reactive.max-chunk-size` configuration property.