### PR TITLE
Upgrade to HikariCP 2.7.2

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -86,7 +86,7 @@
 		<hazelcast-hibernate5.version>1.2.2</hazelcast-hibernate5.version>
 		<hibernate.version>5.2.11.Final</hibernate.version>
 		<hibernate-validator.version>6.0.2.Final</hibernate-validator.version>
-		<hikaricp.version>2.7.1</hikaricp.version>
+		<hikaricp.version>2.7.2</hikaricp.version>
 		<hsqldb.version>2.4.0</hsqldb.version>
 		<htmlunit.version>2.27</htmlunit.version>
 		<httpasyncclient.version>4.1.3</httpasyncclient.version>


### PR DESCRIPTION
2.7.2 was recently released with [these changes](https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES). Being close to the release target for the next milestone, I figured the semi-automated dependency upgrade process may have already been ran before this new version was released.