### PR TITLE
Add runApplication() Kotlin top level function

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -3025,6 +3025,11 @@
 					<version>${flyway.version}</version>
 				</plugin>
 				<plugin>
+					<groupId>kotlin-maven-plugin</groupId>
+					<artifactId>org.jetbrains.kotlin</artifactId>
+					<version>${kotlin.version}</version>
+				</plugin>
+				<plugin>
 					<groupId>pl.project13.maven</groupId>
 					<artifactId>git-commit-id-plugin</artifactId>
 					<version>${git-commit-id-plugin.version}</version>

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -107,6 +107,7 @@
 		<junit.version>4.12</junit.version>
 		<junit-jupiter.version>5.0.1</junit-jupiter.version>
 		<junit-platform.version>1.0.1</junit-platform.version>
+		<kotlin.version>1.1.51</kotlin.version>
 		<lettuce.version>5.0.0.RELEASE</lettuce.version>
 		<liquibase.version>3.5.3</liquibase.version>
 		<log4j2.version>2.9.1</log4j2.version>
@@ -2263,6 +2264,26 @@
 				<groupId>org.jooq</groupId>
 				<artifactId>jooq-codegen</artifactId>
 				<version>${jooq.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-reflect</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib-jre7</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib-jre8</artifactId>
+				<version>${kotlin.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.liquibase</groupId>

--- a/spring-boot-project/spring-boot/pom.xml
+++ b/spring-boot-project/spring-boot/pom.xml
@@ -13,6 +13,79 @@
 	<properties>
 		<main.basedir>${basedir}/../..</main.basedir>
 	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>kotlin-maven-plugin</artifactId>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<version>${kotlin.version}</version>
+				<configuration>
+					<jvmTarget>${java.version}</jvmTarget>
+				</configuration>
+				<executions>
+					<execution>
+						<id>compile</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+								<sourceDir>${project.basedir}/src/main/java</sourceDir>
+							</sourceDirs>
+						</configuration>
+					</execution>
+					<execution>
+						<id>test-compile</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>test-compile</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+								<sourceDir>${project.basedir}/src/test/java</sourceDir>
+							</sourceDirs>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+					<parameters>true</parameters>
+				</configuration>
+				<executions>
+					<execution>
+						<id>default-compile</id>
+						<phase>none</phase>
+					</execution>
+					<execution>
+						<id>default-testCompile</id>
+						<phase>none</phase>
+					</execution>
+					<execution>
+						<id>java-compile</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>java-test-compile</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 	<dependencies>
 		<!-- Compile -->
 		<dependency>
@@ -262,6 +335,16 @@
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<!-- Annotation processing -->

--- a/spring-boot-project/spring-boot/src/main/kotlin/org/springframework/boot/SpringApplicationExtensions.kt
+++ b/spring-boot-project/spring-boot/src/main/kotlin/org/springframework/boot/SpringApplicationExtensions.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot
+
+import org.springframework.context.ConfigurableApplicationContext
+import kotlin.reflect.KClass
+
+
+/**
+ * Top level function acting as a Kotlin shortcut allowing to write `runApplication<FooApplication>(arg1, arg2)`
+ * instead of `SpringApplication.run(FooApplication::class.java, arg1, arg2)`.
+ *
+ * @author Sebastien Deleuze
+ * @since 2.0.0
+ */
+inline fun <reified T : Any> runApplication(vararg args: String): ConfigurableApplicationContext =
+		SpringApplication.run(T::class.java, *args)
+
+/**
+ * Top level function acting as a Kotlin shortcut allowing to write `runApplication<FooApplication>(arg1, arg2) { // SpringApplication customization ... }`
+ * instead of instantiating `SpringApplication` class, customize it and then invoking `run(arg1, arg2)`.
+ *
+ * @author Sebastien Deleuze
+ * @since 2.0.0
+ */
+inline fun <reified T : Any> runApplication(vararg args: String, init: SpringApplication.() -> Unit): ConfigurableApplicationContext =
+		SpringApplication(T::class.java).apply(init).run(*args)
+
+
+/**
+ * Top level function acting as a Kotlin shortcut allowing to write
+ * `runApplication(arrayOf(FooApplication::class, FooConfiguration::class), arg1, arg2) { // Optional SpringApplication customization ... }`
+ * instead of instantiating `SpringApplication` class, customize it and then invoking `run(arrayOf(arg1, arg2))`.`
+ *
+ * @author Sebastien Deleuze
+ * @since 2.0.0
+ */
+fun runApplication(primarySources: Array<KClass<*>>, vararg args: String, init: SpringApplication.() -> Unit = {}): ConfigurableApplicationContext =
+		SpringApplication(*primarySources.map { it.java }.toTypedArray()).apply(init).run(*args)

--- a/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/SpringApplicationExtensionsTests.kt
+++ b/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/SpringApplicationExtensionsTests.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot
+
+import org.junit.Assert.*
+import org.junit.Test
+import org.springframework.beans.factory.getBean
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.StandardEnvironment
+
+/**
+ * Tests for `SpringApplicationExtensions`.
+ *
+ * @author Sebastien Deleuze
+ */
+class SpringApplicationExtensionsTests {
+
+	@Test
+	fun `Kotlin runApplication() top level function`() {
+		val context = runApplication<ExampleWebConfig>()
+		assertNotNull(context)
+	}
+
+	@Test
+	fun `Kotlin runApplication() top level function with a custom environment`() {
+		val environment = StandardEnvironment()
+		val context = runApplication<ExampleWebConfig> {
+			setEnvironment(environment)
+		}
+		assertNotNull(context)
+		assertEquals(environment, context.environment)
+	}
+
+	@Test
+	fun `Kotlin runApplication(arg1, arg2) top level function`() {
+		val context = runApplication<ExampleWebConfig>("--debug", "spring", "boot")
+		val args = context.getBean<ApplicationArguments>()
+		assertArrayEquals(arrayOf("spring", "boot"), args.nonOptionArgs.toTypedArray())
+		assertTrue(args.containsOption("debug"))
+	}
+
+	@Test
+	fun `Kotlin runApplication(arg1, arg2) top level function with a custom environment`() {
+		val environment = StandardEnvironment()
+		val context = runApplication<ExampleWebConfig>("--debug", "spring", "boot") {
+			setEnvironment(environment)
+		}
+		val args = context.getBean<ApplicationArguments>()
+		assertArrayEquals(arrayOf("spring", "boot"), args.nonOptionArgs.toTypedArray())
+		assertTrue(args.containsOption("debug"))
+		assertEquals(environment, context.environment)
+	}
+
+	@Test
+	fun `Kotlin runApplication(array of KClass) top level function`() {
+		val context = runApplication(arrayOf(ExampleConfig::class, ExampleWebConfig::class))
+		assertNotNull(context)
+	}
+
+	@Test
+	fun `Kotlin runApplication(array of KClass) top level function with a custom environment`() {
+		val environment = StandardEnvironment()
+		val context = runApplication(arrayOf(ExampleConfig::class, ExampleWebConfig::class)) {
+			setEnvironment(environment)
+		}
+		assertNotNull(context)
+		assertEquals(environment, context.environment)
+	}
+
+	@Test
+	fun `Kotlin runApplication(array of KClass, arg1, arg2) top level function`() {
+		val context = runApplication(arrayOf(ExampleConfig::class, ExampleWebConfig::class), "--debug", "spring", "boot")
+		val args = context.getBean<ApplicationArguments>()
+		assertArrayEquals(arrayOf("spring", "boot"), args.nonOptionArgs.toTypedArray())
+		assertTrue(args.containsOption("debug"))
+	}
+
+	@Test
+	fun `Kotlin runApplication(array of KClass, arg1, arg2) top level function with a custom environment`() {
+		val environment = StandardEnvironment()
+		val context = runApplication(arrayOf(ExampleConfig::class, ExampleWebConfig::class), "--debug", "spring", "boot") {
+			setEnvironment(environment)
+		}
+		val args = context.getBean<ApplicationArguments>()
+		assertArrayEquals(arrayOf("spring", "boot"), args.nonOptionArgs.toTypedArray())
+		assertTrue(args.containsOption("debug"))
+		assertEquals(environment, context.environment)
+	}
+
+
+	@Configuration
+	internal open class ExampleConfig
+
+	@Configuration
+	internal open class ExampleWebConfig {
+
+		@Bean
+		open fun webServer(): TomcatServletWebServerFactory {
+			return TomcatServletWebServerFactory(0)
+		}
+	}
+
+}


### PR DESCRIPTION
Since Kotlin extensions do not apply to static methods, this commit introduces a `runApplication()` Kotlin top level function that acts as a Kotlin shortcut for `SpringApplication.run()`.

This shortcut avoids to require using non-idiomatic code like `SpringApplication.run(FooApplication::class.java)` and provides a `runApplication<FooApplication>()` alternative (as well as an array of `KClass` based alternative when multiple classes need to be passed as parameter).

This commit also adds Kotlin main artifacts to Spring Boot dependency management and will be replaced by Kotlin BOM when it will be available (see [KT-18398](https://youtrack.jetbrains.com/issue/KT-18398)).

`runApplication<FooApplication>()` is a form usually preferred in Kotlin to `runApplication(FooApplication::class)` and consistent with what we do on Spring Framework side. 

The custom Maven configuration is the [typical way to deal with Java + Kotlin project](https://kotlinlang.org/docs/reference/using-maven.html#compiling-kotlin-and-java-sources), a similar configuration has been applied to [Spring Data Kay](https://github.com/spring-projects/spring-data-build/blob/beb9d5cfdfdd18b0055db7648f859b92b0a168e5/parent/pom.xml#L775).

Closes gh-8511
