### PR TITLE
Updates for Micrometer 1.0.0-rc.2

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
@@ -123,6 +123,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-statsd</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>io.searchbox</groupId>
 			<artifactId>jest</artifactId>
 			<optional>true</optional>

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MeterBindersConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MeterBindersConfiguration.java
@@ -16,15 +16,15 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics;
 
-import io.micrometer.core.instrument.binder.JvmMemoryMetrics;
-import io.micrometer.core.instrument.binder.LogbackMetrics;
-import io.micrometer.core.instrument.binder.MeterBinder;
-import io.micrometer.core.instrument.binder.UptimeMetrics;
-
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 
 /**
  * Configuration for various {@link MeterBinder MeterBinders}.

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MeterBindersConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MeterBindersConfiguration.java
@@ -16,15 +16,15 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * Configuration for various {@link MeterBinder MeterBinders}.

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.boot.actuate.autoconfigure.metrics.export.influx.Infl
 import org.springframework.boot.actuate.autoconfigure.metrics.export.jmx.JmxExportConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusExportConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleExportConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.statsd.StatsdExportConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.reactive.server.WebFluxMetricsConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.web.client.RestTemplateMetricsConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvcMetricsConfiguration;
@@ -67,7 +68,8 @@ import org.springframework.integration.support.management.IntegrationManagementC
 		AtlasExportConfiguration.class, DatadogExportConfiguration.class,
 		GangliaExportConfiguration.class, GraphiteExportConfiguration.class,
 		InfluxExportConfiguration.class, JmxExportConfiguration.class,
-		PrometheusExportConfiguration.class, SimpleExportConfiguration.class })
+		PrometheusExportConfiguration.class, SimpleExportConfiguration.class,
+		StatsdExportConfiguration.class })
 public class MetricsAutoConfiguration {
 
 	@Bean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphiteProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphiteProperties.java
@@ -21,6 +21,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import io.micrometer.graphite.GraphiteProtocol;
+
 /**
  * {@link ConfigurationProperties} for configuring Graphite metrics export.
  *
@@ -58,6 +60,11 @@ public class GraphiteProperties {
 	 * Graphite port used for publishing.
 	 */
 	private Integer port;
+
+	/**
+	 * Protocol to use while shipping data to Graphite.
+	 */
+	private GraphiteProtocol protocol = GraphiteProtocol.Pickled;
 
 	public Boolean getEnabled() {
 		return this.enabled;
@@ -105,5 +112,13 @@ public class GraphiteProperties {
 
 	public void setPort(Integer port) {
 		this.port = port;
+	}
+
+	public GraphiteProtocol getProtocol() {
+		return protocol;
+	}
+
+	public void setProtocol(GraphiteProtocol protocol) {
+		this.protocol = protocol;
 	}
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphiteProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphiteProperties.java
@@ -19,9 +19,9 @@ package org.springframework.boot.actuate.autoconfigure.metrics.export.graphite;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 import io.micrometer.graphite.GraphiteProtocol;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * {@link ConfigurationProperties} for configuring Graphite metrics export.
@@ -115,7 +115,7 @@ public class GraphiteProperties {
 	}
 
 	public GraphiteProtocol getProtocol() {
-		return protocol;
+		return this.protocol;
 	}
 
 	public void setProtocol(GraphiteProtocol protocol) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphitePropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphitePropertiesConfigAdapter.java
@@ -19,10 +19,10 @@ package org.springframework.boot.actuate.autoconfigure.metrics.export.graphite;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-import org.springframework.boot.actuate.autoconfigure.metrics.export.PropertiesConfigAdapter;
-
 import io.micrometer.graphite.GraphiteConfig;
 import io.micrometer.graphite.GraphiteProtocol;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.export.PropertiesConfigAdapter;
 
 /**
  * Adapter to convert {@link GraphiteProperties} to a {@link GraphiteConfig}.

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphitePropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphitePropertiesConfigAdapter.java
@@ -19,9 +19,10 @@ package org.springframework.boot.actuate.autoconfigure.metrics.export.graphite;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-import io.micrometer.graphite.GraphiteConfig;
-
 import org.springframework.boot.actuate.autoconfigure.metrics.export.PropertiesConfigAdapter;
+
+import io.micrometer.graphite.GraphiteConfig;
+import io.micrometer.graphite.GraphiteProtocol;
 
 /**
  * Adapter to convert {@link GraphiteProperties} to a {@link GraphiteConfig}.
@@ -74,4 +75,8 @@ class GraphitePropertiesConfigAdapter
 		return get(GraphiteProperties::getPort, GraphiteConfig::port);
 	}
 
+	@Override
+	public GraphiteProtocol protocol() {
+		return get(GraphiteProperties::getProtocol, GraphiteConfig::protocol);
+	}
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdExportConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdExportConfiguration.java
@@ -1,4 +1,24 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.actuate.autoconfigure.metrics.export.statsd;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.statsd.StatsdConfig;
+import io.micrometer.statsd.StatsdMeterRegistry;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.export.MetricsExporter;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.StringToDurationConverter;
@@ -9,10 +29,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-
-import io.micrometer.core.instrument.Clock;
-import io.micrometer.statsd.StatsdConfig;
-import io.micrometer.statsd.StatsdMeterRegistry;
 
 /**
  * Configuration for exporting metrics to StatsD.

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdExportConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdExportConfiguration.java
@@ -1,0 +1,47 @@
+package org.springframework.boot.actuate.autoconfigure.metrics.export.statsd;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.export.MetricsExporter;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.StringToDurationConverter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.statsd.StatsdConfig;
+import io.micrometer.statsd.StatsdMeterRegistry;
+
+/**
+ * Configuration for exporting metrics to StatsD.
+ *
+ * @author Jon Schneider
+ * @since 2.0.0
+ */
+@Configuration
+@ConditionalOnClass(StatsdMeterRegistry.class)
+@Import(StringToDurationConverter.class)
+@EnableConfigurationProperties(StatsdProperties.class)
+public class StatsdExportConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean(StatsdConfig.class)
+	public StatsdConfig statsdConfig(StatsdProperties statsdProperties) {
+		return new StatsdPropertiesConfigAdapter(statsdProperties);
+	}
+
+	@Bean
+	@ConditionalOnProperty(value = "spring.metrics.statsd.enabled", matchIfMissing = true)
+	public MetricsExporter statsdExporter(StatsdConfig statsdConfig, Clock clock) {
+		return () -> new StatsdMeterRegistry(statsdConfig, clock);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public Clock clock() {
+		return Clock.SYSTEM;
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdProperties.java
@@ -1,8 +1,25 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.actuate.autoconfigure.metrics.export.statsd;
 
 import java.time.Duration;
 
 import io.micrometer.statsd.StatsdFlavor;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -65,7 +82,7 @@ public class StatsdProperties {
 	private Duration timerPercentilesMin = Duration.ofMillis(10);
 
 	public Duration getTimerPercentilesMax() {
-		return timerPercentilesMax;
+		return this.timerPercentilesMax;
 	}
 
 	public void setTimerPercentilesMax(Duration timerPercentilesMax) {
@@ -73,7 +90,7 @@ public class StatsdProperties {
 	}
 
 	public Duration getTimerPercentilesMin() {
-		return timerPercentilesMin;
+		return this.timerPercentilesMin;
 	}
 
 	public void setTimerPercentilesMin(Duration timerPercentilesMin) {
@@ -81,7 +98,7 @@ public class StatsdProperties {
 	}
 
 	public Boolean getEnabled() {
-		return enabled;
+		return this.enabled;
 	}
 
 	public void setEnabled(Boolean enabled) {
@@ -89,7 +106,7 @@ public class StatsdProperties {
 	}
 
 	public StatsdFlavor getFlavor() {
-		return flavor;
+		return this.flavor;
 	}
 
 	public void setFlavor(StatsdFlavor flavor) {
@@ -97,7 +114,7 @@ public class StatsdProperties {
 	}
 
 	public String getHost() {
-		return host;
+		return this.host;
 	}
 
 	public void setHost(String host) {
@@ -105,7 +122,7 @@ public class StatsdProperties {
 	}
 
 	public Integer getPort() {
-		return port;
+		return this.port;
 	}
 
 	public void setPort(Integer port) {
@@ -113,7 +130,7 @@ public class StatsdProperties {
 	}
 
 	public Integer getMaxPacketLength() {
-		return maxPacketLength;
+		return this.maxPacketLength;
 	}
 
 	public void setMaxPacketLength(Integer maxPacketLength) {
@@ -121,7 +138,7 @@ public class StatsdProperties {
 	}
 
 	public Duration getPollingFrequency() {
-		return pollingFrequency;
+		return this.pollingFrequency;
 	}
 
 	public void setPollingFrequency(Duration pollingFrequency) {
@@ -129,7 +146,7 @@ public class StatsdProperties {
 	}
 
 	public Integer getQueueSize() {
-		return queueSize;
+		return this.queueSize;
 	}
 
 	public void setQueueSize(Integer queueSize) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdProperties.java
@@ -1,0 +1,138 @@
+package org.springframework.boot.actuate.autoconfigure.metrics.export.statsd;
+
+import java.time.Duration;
+
+import io.micrometer.statsd.StatsdFlavor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * {@link ConfigurationProperties} for configuring Influx metrics export.
+ *
+ * @author Jon Schneider
+ * @since 2.0.0
+ */
+@ConfigurationProperties(prefix = "spring.metrics.statsd")
+public class StatsdProperties {
+	/**
+	 * Enable publishing to the backend.
+	 */
+	private Boolean enabled = true;
+
+	/**
+	 * Choose which variant of the StatsD line protocol to use.
+	 */
+	private StatsdFlavor flavor = StatsdFlavor.Datadog;
+
+	/**
+	 * The host name of the StatsD agent.
+	 */
+	private String host = "localhost";
+
+	/**
+	 * The UDP port of the StatsD agent.
+	 */
+	private Integer port = 8125;
+
+	/**
+	 * The total length of a single payload should be kept within your network's MTU.
+	 */
+	private Integer maxPacketLength = 1400;
+
+	/**
+	 * Determines how often gauges will be polled. When a gauge is polled, its value is
+	 * recalculated. If the value has changed, it is sent to the StatsD server.
+	 */
+	private Duration pollingFrequency = Duration.ofSeconds(10);
+
+	/**
+	 * Governs the maximum size of the queue of items waiting to be sent to a StatsD agent
+	 * over UDP.
+	 */
+	private Integer queueSize = Integer.MAX_VALUE;
+
+	/**
+	 * Used to create a bucket filter clamping the bucket domain of timer percentiles
+	 * histograms to some max value. This is used to limit the number of buckets shipped
+	 * to Prometheus to save on storage.
+	 */
+	private Duration timerPercentilesMax = Duration.ofMinutes(2);
+
+	/**
+	 * Used to create a bucket filter clamping the bucket domain of timer percentiles
+	 * histograms to some min value. This is used to limit the number of buckets shipped
+	 * to Prometheus to save on storage.
+	 */
+	private Duration timerPercentilesMin = Duration.ofMillis(10);
+
+	public Duration getTimerPercentilesMax() {
+		return timerPercentilesMax;
+	}
+
+	public void setTimerPercentilesMax(Duration timerPercentilesMax) {
+		this.timerPercentilesMax = timerPercentilesMax;
+	}
+
+	public Duration getTimerPercentilesMin() {
+		return timerPercentilesMin;
+	}
+
+	public void setTimerPercentilesMin(Duration timerPercentilesMin) {
+		this.timerPercentilesMin = timerPercentilesMin;
+	}
+
+	public Boolean getEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(Boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public StatsdFlavor getFlavor() {
+		return flavor;
+	}
+
+	public void setFlavor(StatsdFlavor flavor) {
+		this.flavor = flavor;
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public Integer getPort() {
+		return port;
+	}
+
+	public void setPort(Integer port) {
+		this.port = port;
+	}
+
+	public Integer getMaxPacketLength() {
+		return maxPacketLength;
+	}
+
+	public void setMaxPacketLength(Integer maxPacketLength) {
+		this.maxPacketLength = maxPacketLength;
+	}
+
+	public Duration getPollingFrequency() {
+		return pollingFrequency;
+	}
+
+	public void setPollingFrequency(Duration pollingFrequency) {
+		this.pollingFrequency = pollingFrequency;
+	}
+
+	public Integer getQueueSize() {
+		return queueSize;
+	}
+
+	public void setQueueSize(Integer queueSize) {
+		this.queueSize = queueSize;
+	}
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapter.java
@@ -1,11 +1,27 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.actuate.autoconfigure.metrics.export.statsd;
 
 import java.time.Duration;
 
-import org.springframework.boot.actuate.autoconfigure.metrics.export.PropertiesConfigAdapter;
-
 import io.micrometer.statsd.StatsdConfig;
 import io.micrometer.statsd.StatsdFlavor;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.export.PropertiesConfigAdapter;
 
 /**
  * Adapter to convert {@link StatsdProperties} to a {@link StatsdConfig}.

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapter.java
@@ -1,0 +1,64 @@
+package org.springframework.boot.actuate.autoconfigure.metrics.export.statsd;
+
+import java.time.Duration;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.export.PropertiesConfigAdapter;
+
+import io.micrometer.statsd.StatsdConfig;
+import io.micrometer.statsd.StatsdFlavor;
+
+/**
+ * Adapter to convert {@link StatsdProperties} to a {@link StatsdConfig}.
+ *
+ * @author Jon Schneider
+ * @since 2.0.0
+ */
+public class StatsdPropertiesConfigAdapter extends
+		PropertiesConfigAdapter<StatsdProperties, StatsdConfig> implements StatsdConfig {
+
+	private static final StatsdConfig DEFAULTS = (key) -> null;
+
+	public StatsdPropertiesConfigAdapter(StatsdProperties properties) {
+		super(properties, DEFAULTS);
+	}
+
+	@Override
+	public String get(String s) {
+		return null;
+	}
+
+	@Override
+	public StatsdFlavor flavor() {
+		return get(StatsdProperties::getFlavor, StatsdConfig::flavor);
+	}
+
+	@Override
+	public boolean enabled() {
+		return get(StatsdProperties::getEnabled, StatsdConfig::enabled);
+	}
+
+	@Override
+	public String host() {
+		return get(StatsdProperties::getHost, StatsdConfig::host);
+	}
+
+	@Override
+	public int port() {
+		return get(StatsdProperties::getPort, StatsdConfig::port);
+	}
+
+	@Override
+	public int maxPacketLength() {
+		return get(StatsdProperties::getMaxPacketLength, StatsdConfig::maxPacketLength);
+	}
+
+	@Override
+	public Duration pollingFrequency() {
+		return get(StatsdProperties::getPollingFrequency, StatsdConfig::pollingFrequency);
+	}
+
+	@Override
+	public int queueSize() {
+		return get(StatsdProperties::getQueueSize, StatsdConfig::queueSize);
+	}
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/package-info.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for exporting actuator metrics to StatsD.
+ */
+package org.springframework.boot.actuate.autoconfigure.metrics.export.statsd;

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
@@ -16,19 +16,18 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Statistic;
-import io.micrometer.core.instrument.binder.JvmMemoryMetrics;
-import io.micrometer.core.instrument.binder.LogbackMetrics;
-import io.micrometer.core.instrument.binder.MeterBinder;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
@@ -52,11 +51,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.client.ExpectedCount.once;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Statistic;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 /**
  * Tests for {@link MetricsAutoConfiguration}.

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
@@ -16,18 +16,19 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.client.ExpectedCount.once;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
-
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Statistic;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
@@ -51,12 +52,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Statistic;
-import io.micrometer.core.instrument.binder.MeterBinder;
-import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
-import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 /**
  * Tests for {@link MetricsAutoConfiguration}.

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleExportConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleExportConfigurationTests.java
@@ -16,17 +16,17 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.simple;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link SimpleExportConfiguration}.

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleExportConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleExportConfigurationTests.java
@@ -16,17 +16,17 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.simple;
 
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 /**
  * Tests for {@link SimpleExportConfiguration}.
@@ -45,7 +45,8 @@ public class SimpleExportConfigurationTests {
 						"spring.metrics.graphite.enabled=false",
 						"spring.metrics.influx.enabled=false",
 						"spring.metrics.jmx.enabled=false",
-						"spring.metrics.prometheus.enabled=false")
+						"spring.metrics.prometheus.enabled=false",
+						"spring.metrics.statsd.enabled=false")
 				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class))
 				.run((context) -> {
 					CompositeMeterRegistry meterRegistry = context

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/MetricsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/MetricsEndpoint.java
@@ -31,6 +31,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.Tag;
 
+import org.springframework.boot.actuate.endpoint.DefaultEnablement;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
@@ -43,7 +44,7 @@ import org.springframework.util.Assert;
  * @author Jon Schneider
  * @since 2.0.0
  */
-@Endpoint(id = "metrics")
+@Endpoint(id = "metrics", defaultEnablement = DefaultEnablement.ENABLED)
 public class MetricsEndpoint {
 
 	private final MeterRegistry registry;

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointTests.java
@@ -16,20 +16,18 @@
 
 package org.springframework.boot.actuate.metrics;
 
-import static java.util.Collections.emptyList;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.junit.Test;
-
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link MetricsEndpoint}.
@@ -53,9 +51,9 @@ public class MetricsEndpointTests {
 
 	@Test
 	public void listNamesProducesListOfUniqueMeterNames() {
-		registry.counter("com.example.foo");
-		registry.counter("com.example.bar");
-		registry.counter("com.example.foo");
+		this.registry.counter("com.example.foo");
+		this.registry.counter("com.example.bar");
+		this.registry.counter("com.example.foo");
 
 		Map<String, List<String>> result = this.endpoint.listNames();
 
@@ -66,11 +64,11 @@ public class MetricsEndpointTests {
 
 	@Test
 	public void metricValuesAreTheSumOfAllTimeSeriesMatchingTags() {
-		registry.counter("cache", "result", "hit", "host", "1").increment(2);
-		registry.counter("cache", "result", "miss", "host", "1").increment(2);
-		registry.counter("cache", "result", "hit", "host", "2").increment(2);
+		this.registry.counter("cache", "result", "hit", "host", "1").increment(2);
+		this.registry.counter("cache", "result", "miss", "host", "1").increment(2);
+		this.registry.counter("cache", "result", "hit", "host", "2").increment(2);
 
-		MetricsEndpoint.Response response = this.endpoint.metric("cache", emptyList());
+		MetricsEndpoint.Response response = this.endpoint.metric("cache", Collections.emptyList());
 		assertThat(response.getName()).isEqualTo("cache");
 		assertThat(availableTagKeys(response)).containsExactly("result", "host");
 		assertThat(getCount(response)).hasValue(6.0);
@@ -82,7 +80,7 @@ public class MetricsEndpointTests {
 
 	@Test
 	public void metricWithSpaceInTagValue() {
-		registry.counter("counter", "key", "a space").increment(2);
+		this.registry.counter("counter", "key", "a space").increment(2);
 
 		MetricsEndpoint.Response response = this.endpoint.metric("counter",
 				Collections.singletonList("key:a space"));
@@ -94,7 +92,7 @@ public class MetricsEndpointTests {
 	@Test
 	public void nonExistentMetric() {
 		MetricsEndpoint.Response response = this.endpoint.metric("does.not.exist",
-				emptyList());
+				Collections.emptyList());
 
 		assertThat(response).isNull();
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointTests.java
@@ -16,58 +16,97 @@
 
 package org.springframework.boot.actuate.metrics;
 
-import java.util.Arrays;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
 
-import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.Meter.Id;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleCounter;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Statistic;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 /**
  * Tests for {@link MetricsEndpoint}.
  *
  * @author Andy Wilkinson
+ * @author Jon Schneider
  */
 public class MetricsEndpointTests {
 
-	private final MeterRegistry registry = mock(MeterRegistry.class);
+	private final MeterRegistry registry = new SimpleMeterRegistry();
 
 	private final MetricsEndpoint endpoint = new MetricsEndpoint(this.registry);
 
 	@Test
 	public void listNamesHandlesEmptyListOfMeters() {
-		given(this.registry.getMeters()).willReturn(Arrays.asList());
 		Map<String, List<String>> result = this.endpoint.listNames();
+
 		assertThat(result).containsOnlyKeys("names");
 		assertThat(result.get("names")).isEmpty();
 	}
 
 	@Test
 	public void listNamesProducesListOfUniqueMeterNames() {
-		List<Meter> meters = Arrays.asList(createCounter("com.example.foo"),
-				createCounter("com.example.bar"), createCounter("com.example.foo"));
-		given(this.registry.getMeters()).willReturn(meters);
+		registry.counter("com.example.foo");
+		registry.counter("com.example.bar");
+		registry.counter("com.example.foo");
+
 		Map<String, List<String>> result = this.endpoint.listNames();
+
 		assertThat(result).containsOnlyKeys("names");
 		assertThat(result.get("names")).containsOnlyOnce("com.example.foo",
 				"com.example.bar");
 	}
 
-	private Meter createCounter(String name) {
-		return new SimpleCounter(createMeterId(name));
+	@Test
+	public void metricValuesAreTheSumOfAllTimeSeriesMatchingTags() {
+		registry.counter("cache", "result", "hit", "host", "1").increment(2);
+		registry.counter("cache", "result", "miss", "host", "1").increment(2);
+		registry.counter("cache", "result", "hit", "host", "2").increment(2);
+
+		MetricsEndpoint.Response response = this.endpoint.metric("cache", emptyList());
+		assertThat(response.getName()).isEqualTo("cache");
+		assertThat(availableTagKeys(response)).containsExactly("result", "host");
+		assertThat(getCount(response)).hasValue(6.0);
+
+		response = this.endpoint.metric("cache", Collections.singletonList("result:hit"));
+		assertThat(availableTagKeys(response)).containsExactly("host");
+		assertThat(getCount(response)).hasValue(4.0);
 	}
 
-	private Id createMeterId(String name) {
-		Id id = mock(Id.class);
-		given(id.getName()).willReturn(name);
-		return id;
+	@Test
+	public void metricWithSpaceInTagValue() {
+		registry.counter("counter", "key", "a space").increment(2);
+
+		MetricsEndpoint.Response response = this.endpoint.metric("counter",
+				Collections.singletonList("key:a space"));
+		assertThat(response.getName()).isEqualTo("counter");
+		assertThat(availableTagKeys(response)).isEmpty();
+		assertThat(getCount(response)).hasValue(2.0);
 	}
 
+	@Test
+	public void nonExistentMetric() {
+		MetricsEndpoint.Response response = this.endpoint.metric("does.not.exist",
+				emptyList());
+
+		assertThat(response).isNull();
+	}
+
+	private Optional<Double> getCount(MetricsEndpoint.Response response) {
+		return response.getMeasurements().stream()
+				.filter(ms -> ms.getStatistic().equals(Statistic.Count)).findAny()
+				.map(MetricsEndpoint.Response.Sample::getValue);
+	}
+
+	private Stream<String> availableTagKeys(MetricsEndpoint.Response response) {
+		return response.getAvailableTags().stream()
+				.map(MetricsEndpoint.Response.AvailableTag::getTag);
+	}
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointWebIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointWebIntegrationTests.java
@@ -63,8 +63,15 @@ public class MetricsEndpointWebIntegrationTests {
 		MetricsEndpointWebIntegrationTests.client.get()
 				.uri("/application/metrics/jvm.memory.used").exchange().expectStatus()
 				.isOk().expectBody()
-				.jsonPath("['jvmMemoryUsed.area.nonheap.id.Compressed_Class_Space']")
-				.exists().jsonPath("['jvmMemoryUsed.area.heap.id.PS_Old_Gen']");
+				.jsonPath("$.name").isEqualTo("jvm.memory.used");
+	}
+
+	@Test
+	public void selectByTag() {
+		MetricsEndpointWebIntegrationTests.client.get()
+				.uri("/application/metrics/jvm.memory.used?tag=id:PS%20Old%20Gen").exchange().expectStatus()
+				.isOk().expectBody()
+				.jsonPath("$.name").isEqualTo("jvm.memory.used");
 	}
 
 	@Configuration
@@ -86,7 +93,6 @@ public class MetricsEndpointWebIntegrationTests {
 			memoryMetrics.bindTo(meterRegistry);
 			return memoryMetrics;
 		}
-
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointWebIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointWebIntegrationTests.java
@@ -16,24 +16,23 @@
 
 package org.springframework.boot.actuate.metrics;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.boot.actuate.endpoint.web.test.WebEndpointRunners;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Web integration tests for {@link MetricsEndpoint}.

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointWebIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointWebIntegrationTests.java
@@ -16,23 +16,24 @@
 
 package org.springframework.boot.actuate.metrics;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.JvmMemoryMetrics;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.boot.actuate.endpoint.web.test.WebEndpointRunners;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 /**
  * Web integration tests for {@link MetricsEndpoint}.

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -113,7 +113,7 @@
 		<logback.version>1.2.3</logback.version>
 		<lombok.version>1.16.18</lombok.version>
 		<mariadb.version>2.1.2</mariadb.version>
-		<micrometer.version>1.0.0-rc.1</micrometer.version>
+		<micrometer.version>1.0.0-SNAPSHOT</micrometer.version>
 		<mssql-jdbc.version>6.2.1.jre8</mssql-jdbc.version>
 		<mockito.version>2.10.0</mockito.version>
 		<mongo-driver-reactivestreams.version>1.6.0</mongo-driver-reactivestreams.version>
@@ -940,6 +940,11 @@
 			<dependency>
 				<groupId>io.micrometer</groupId>
 				<artifactId>micrometer-registry-prometheus</artifactId>
+				<version>${micrometer.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.micrometer</groupId>
+				<artifactId>micrometer-registry-statsd</artifactId>
 				<version>${micrometer.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Fixes and improvements made for rc.2 are listed [here](https://github.com/micrometer-metrics/micrometer/milestone/13?closed=1). Significantly, the gap on cache metrics has been closed.

The impact on Boot 2 is:

1. A new autoconfig for the StatsD registry.
2. A new protocol property for Graphite.
3. A reworked metrics actuator endpoint.