### PR TITLE
fix build status image

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= Spring Boot image:https://build.spring.io/plugins/servlet/buildStatusImage/BOOT-PUB["Build Status", link="https://build.spring.io/browse/BOOT-PUB"] image:https://badges.gitter.im/Join Chat.svg["Chat",link="https://gitter.im/spring-projects/spring-boot?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
+= Spring Boot image:https://build.spring.io/plugins/servlet/wittified/build-status/BOOT-PUB["Build Status", link="https://build.spring.io/browse/BOOT-PUB"] image:https://badges.gitter.im/Join Chat.svg["Chat",link="https://gitter.im/spring-projects/spring-boot?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
 :docs: http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference
 
 Spring Boot makes it easy to create Spring-powered, production-grade applications and


### PR DESCRIPTION
The image of the Build Status wasn't being displayed in the README file, so I opened up the other repositories that has the build status image correctly displayed and followed the url pattern.