### PR TITLE
Expose metrics hiding recursively inside a composite registry

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointTests.java
@@ -17,13 +17,12 @@
 package org.springframework.boot.actuate.metrics;
 
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Statistic;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
 
@@ -43,9 +42,8 @@ public class MetricsEndpointTests {
 
 	@Test
 	public void listNamesHandlesEmptyListOfMeters() {
-		Map<String, List<String>> result = this.endpoint.listNames();
-		assertThat(result).containsOnlyKeys("names");
-		assertThat(result.get("names")).isEmpty();
+		MetricsEndpoint.ListNamesResponse result = this.endpoint.listNames();
+		assertThat(result.getNames()).isEmpty();
 	}
 
 	@Test
@@ -53,10 +51,24 @@ public class MetricsEndpointTests {
 		this.registry.counter("com.example.foo");
 		this.registry.counter("com.example.bar");
 		this.registry.counter("com.example.foo");
-		Map<String, List<String>> result = this.endpoint.listNames();
-		assertThat(result).containsOnlyKeys("names");
-		assertThat(result.get("names")).containsOnlyOnce("com.example.foo",
+		MetricsEndpoint.ListNamesResponse result = this.endpoint.listNames();
+		assertThat(result.getNames()).containsOnlyOnce("com.example.foo",
 				"com.example.bar");
+	}
+
+	@Test
+	public void listNamesRecursesOverCompositeRegistries() {
+		CompositeMeterRegistry composite = new CompositeMeterRegistry();
+		SimpleMeterRegistry reg1 = new SimpleMeterRegistry();
+		SimpleMeterRegistry reg2 = new SimpleMeterRegistry();
+		composite.add(reg1);
+		composite.add(reg2);
+
+		reg1.counter("counter1").increment();
+		reg2.counter("counter2").increment();
+
+		MetricsEndpoint endpoint = new MetricsEndpoint(composite);
+		assertThat(endpoint.listNames().getNames()).containsOnly("counter1", "counter2");
 	}
 
 	@Test
@@ -64,7 +76,7 @@ public class MetricsEndpointTests {
 		this.registry.counter("cache", "result", "hit", "host", "1").increment(2);
 		this.registry.counter("cache", "result", "miss", "host", "1").increment(2);
 		this.registry.counter("cache", "result", "hit", "host", "2").increment(2);
-		MetricsEndpoint.Response response = this.endpoint.metric("cache",
+		MetricsEndpoint.MetricResponse response = this.endpoint.metric("cache",
 				Collections.emptyList());
 		assertThat(response.getName()).isEqualTo("cache");
 		assertThat(availableTagKeys(response)).containsExactly("result", "host");
@@ -77,7 +89,7 @@ public class MetricsEndpointTests {
 	@Test
 	public void metricWithSpaceInTagValue() {
 		this.registry.counter("counter", "key", "a space").increment(2);
-		MetricsEndpoint.Response response = this.endpoint.metric("counter",
+		MetricsEndpoint.MetricResponse response = this.endpoint.metric("counter",
 				Collections.singletonList("key:a space"));
 		assertThat(response.getName()).isEqualTo("counter");
 		assertThat(availableTagKeys(response)).isEmpty();
@@ -85,21 +97,37 @@ public class MetricsEndpointTests {
 	}
 
 	@Test
+	public void metricPresentInOneRegistryOfACompositeAndNotAnother() {
+		CompositeMeterRegistry composite = new CompositeMeterRegistry();
+		SimpleMeterRegistry reg1 = new SimpleMeterRegistry();
+		SimpleMeterRegistry reg2 = new SimpleMeterRegistry();
+		composite.add(reg1);
+		composite.add(reg2);
+
+		reg1.counter("counter1").increment();
+		reg2.counter("counter2").increment();
+
+		MetricsEndpoint endpoint = new MetricsEndpoint(composite);
+		assertThat(endpoint.metric("counter1", Collections.emptyList())).isNotNull();
+		assertThat(endpoint.metric("counter2", Collections.emptyList())).isNotNull();
+	}
+
+	@Test
 	public void nonExistentMetric() {
-		MetricsEndpoint.Response response = this.endpoint.metric("does.not.exist",
+		MetricsEndpoint.MetricResponse response = this.endpoint.metric("does.not.exist",
 				Collections.emptyList());
 		assertThat(response).isNull();
 	}
 
-	private Optional<Double> getCount(MetricsEndpoint.Response response) {
+	private Optional<Double> getCount(MetricsEndpoint.MetricResponse response) {
 		return response.getMeasurements().stream()
 				.filter((ms) -> ms.getStatistic().equals(Statistic.Count)).findAny()
-				.map(MetricsEndpoint.Response.Sample::getValue);
+				.map(MetricsEndpoint.MetricResponse.Sample::getValue);
 	}
 
-	private Stream<String> availableTagKeys(MetricsEndpoint.Response response) {
+	private Stream<String> availableTagKeys(MetricsEndpoint.MetricResponse response) {
 		return response.getAvailableTags().stream()
-				.map(MetricsEndpoint.Response.AvailableTag::getTag);
+				.map(MetricsEndpoint.MetricResponse.AvailableTag::getTag);
 	}
 
 }


### PR DESCRIPTION
This supports an unusual case such as the one found in `spring-cloud-stream` where registries that are members of a composite registry have metrics that are not found in the composite.

For `spring-cloud-stream`, an application may be ran with a parent and several child application contexts. The intent is to inject a registry into each child application context which will be configured with a common tag representing the "app" that it represents. 

cc / @viniciusccarvalho 
cc / @wilkinsona 