### PR TITLE
Log context path at startup

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
@@ -17,7 +17,9 @@
 package org.springframework.boot.web.embedded.jetty;
 
 import java.net.BindException;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -25,6 +27,7 @@ import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
@@ -44,6 +47,7 @@ import org.springframework.util.StringUtils;
  * @author David Liu
  * @author Eddú Meléndez
  * @author Brian Clozel
+ * @author Kristine Jetzke
  * @since 2.0.0
  * @see JettyReactiveWebServerFactory
  */
@@ -151,7 +155,8 @@ public class JettyWebServer implements WebServer {
 				}
 				this.started = true;
 				JettyWebServer.logger
-						.info("Jetty started on port(s) " + getActualPortsDescription());
+						.info("Jetty started on port(s) " + getActualPortsDescription()
+								+ " with context path " + getContextPath());
 			}
 			catch (WebServerException ex) {
 				throw ex;
@@ -188,6 +193,13 @@ public class JettyWebServer implements WebServer {
 	private String getProtocols(Connector connector) {
 		List<String> protocols = connector.getProtocols();
 		return " (" + StringUtils.collectionToDelimitedString(protocols, ", ") + ")";
+	}
+
+	private String getContextPath() {
+		return Arrays.stream(this.server.getHandlers())
+				.filter(ContextHandler.class::isInstance)
+				.map(handler -> ((ContextHandler) handler).getContextPath())
+				.collect(Collectors.joining(" "));
 	}
 
 	private void handleDeferredInitialize(Handler... handlers) throws Exception {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
@@ -16,9 +16,11 @@
 
 package org.springframework.boot.web.embedded.tomcat;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import javax.naming.NamingException;
 
@@ -43,6 +45,7 @@ import org.springframework.util.Assert;
  * should be created using the {@link TomcatReactiveWebServerFactory} and not directly.
  *
  * @author Brian Clozel
+ * @author Kristine Jetzke
  * @since 2.0.0
  */
 public class TomcatWebServer implements WebServer {
@@ -191,7 +194,8 @@ public class TomcatWebServer implements WebServer {
 				checkThatConnectorsHaveStarted();
 				this.started = true;
 				TomcatWebServer.logger
-						.info("Tomcat started on port(s): " + getPortsDescription(true));
+						.info("Tomcat started on port(s): " + getPortsDescription(true)
+								+ " with context path " + getContextPath());
 			}
 			catch (ConnectorStartFailedException ex) {
 				stopSilently();
@@ -320,6 +324,13 @@ public class TomcatWebServer implements WebServer {
 			return connector.getLocalPort();
 		}
 		return 0;
+	}
+
+	private String getContextPath() {
+		return Arrays.stream(this.tomcat.getHost().findChildren())
+				.filter(TomcatEmbeddedContext.class::isInstance)
+				.map(context -> ((TomcatEmbeddedContext) context).getPath())
+				.collect(Collectors.joining(" "));
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServer.java
@@ -62,6 +62,7 @@ import org.springframework.util.StringUtils;
  * @author Andy Wilkinson
  * @author Eddú Meléndez
  * @author Christoph Dreis
+ * @author Kristine Jetzke
  * @since 2.0.0
  * @see UndertowServletWebServerFactory
  */
@@ -156,7 +157,8 @@ public class UndertowServletWebServer implements WebServer {
 				this.undertow.start();
 				this.started = true;
 				UndertowServletWebServer.logger
-						.info("Undertow started on port(s) " + getPortsDescription());
+						.info("Undertow started on port(s) " + getPortsDescription()
+								+ " with context path " + this.contextPath);
 			}
 			catch (Exception ex) {
 				try {


### PR DESCRIPTION
Fix for #9299

with ``application.yml``

```
server:
  servlet:
    context-path: /foo
```


the following is logged:

```
2017-10-06 21:05:29.827  INFO 4053 --- [           main] o.s.b.web.embedded.jetty.JettyWebServer  : Jetty started on port(s) 8090 (http/1.1)
2017-10-06 21:05:36.246  INFO 4053 --- [           main] o.s.b.web.embedded.jetty.JettyWebServer  : Context path: /foo
```

```
2017-10-06 21:07:37.408  INFO 4193 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8080 (http)
2017-10-06 21:07:37.410  INFO 4193 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Context path: /foo
```

```
2017-10-06 21:08:31.762  INFO 4198 --- [           main] o.s.b.w.e.u.UndertowServletWebServer     : Undertow started on port(s) 8080 (http)
2017-10-06 21:08:31.762  INFO 4198 --- [           main] o.s.b.w.e.u.UndertowServletWebServer     : Context path: /foo
```