### PR TITLE
Add source, user and uri to slf4j MDC

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/SecurityFilterAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/SecurityFilterAutoConfiguration.java
@@ -16,11 +16,6 @@
 
 package org.springframework.boot.autoconfigure.security;
 
-import java.util.EnumSet;
-import java.util.stream.Collectors;
-
-import javax.servlet.DispatcherType;
-
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -63,18 +58,8 @@ public class SecurityFilterAutoConfiguration {
 		DelegatingFilterProxyRegistrationBean registration = new DelegatingFilterProxyRegistrationBean(
 				DEFAULT_FILTER_NAME);
 		registration.setOrder(securityProperties.getFilter().getOrder());
-		registration.setDispatcherTypes(getDispatcherTypes(securityProperties));
+		registration.setDispatcherTypes(securityProperties.getFilter().getServletDispatcherTypes());
 		return registration;
-	}
-
-	private EnumSet<DispatcherType> getDispatcherTypes(
-			SecurityProperties securityProperties) {
-		if (securityProperties.getFilter().getDispatcherTypes() == null) {
-			return null;
-		}
-		return securityProperties.getFilter().getDispatcherTypes().stream()
-				.map((type) -> DispatcherType.valueOf(type.name())).collect(Collectors
-						.collectingAndThen(Collectors.toSet(), EnumSet::copyOf));
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/SecurityProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/SecurityProperties.java
@@ -17,8 +17,10 @@
 package org.springframework.boot.autoconfigure.security;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.web.servlet.DispatcherType;
@@ -35,26 +37,27 @@ import org.springframework.core.Ordered;
 public class SecurityProperties implements SecurityPrerequisite {
 
 	/**
-	 * Order applied to the WebSecurityConfigurerAdapter that is used to configure basic
-	 * authentication for application endpoints. If you want to add your own
-	 * authentication for all or some of those endpoints the best thing to do is to add
-	 * your own WebSecurityConfigurerAdapter with lower order.
+	 * Order applied to the WebSecurityConfigurerAdapter that is used to
+	 * configure basic authentication for application endpoints. If you want to
+	 * add your own authentication for all or some of those endpoints the best
+	 * thing to do is to add your own WebSecurityConfigurerAdapter with lower
+	 * order.
 	 */
 	public static final int BASIC_AUTH_ORDER = Ordered.LOWEST_PRECEDENCE - 5;
 
 	/**
-	 * Order applied to the WebSecurityConfigurer that ignores standard static resource
-	 * paths.
+	 * Order applied to the WebSecurityConfigurer that ignores standard static
+	 * resource paths.
 	 */
 	public static final int IGNORED_ORDER = Ordered.HIGHEST_PRECEDENCE;
 
 	/**
-	 * Default order of Spring Security's Filter in the servlet container (i.e. amongst
-	 * other filters registered with the container). There is no connection between this
-	 * and the <code>@Order</code> on a WebSecurityConfigurer.
+	 * Default order of Spring Security's Filter in the servlet container (i.e.
+	 * amongst other filters registered with the container). There is no
+	 * connection between this and the <code>@Order</code> on a
+	 * WebSecurityConfigurer.
 	 */
-	public static final int DEFAULT_FILTER_ORDER = FilterRegistrationBean.REQUEST_WRAPPER_FILTER_MAX_ORDER
-			- 100;
+	public static final int DEFAULT_FILTER_ORDER = FilterRegistrationBean.REQUEST_WRAPPER_FILTER_MAX_ORDER - 100;
 
 	private final Filter filter = new Filter();
 
@@ -72,8 +75,8 @@ public class SecurityProperties implements SecurityPrerequisite {
 		/**
 		 * Security filter chain dispatcher types.
 		 */
-		private Set<DispatcherType> dispatcherTypes = new HashSet<>(Arrays.asList(
-				DispatcherType.ASYNC, DispatcherType.ERROR, DispatcherType.REQUEST));
+		private Set<DispatcherType> dispatcherTypes = new HashSet<>(
+				Arrays.asList(DispatcherType.ASYNC, DispatcherType.ERROR, DispatcherType.REQUEST));
 
 		public int getOrder() {
 			return this.order;
@@ -89,6 +92,14 @@ public class SecurityProperties implements SecurityPrerequisite {
 
 		public void setDispatcherTypes(Set<DispatcherType> dispatcherTypes) {
 			this.dispatcherTypes = dispatcherTypes;
+		}
+
+		public EnumSet<javax.servlet.DispatcherType> getServletDispatcherTypes() {
+			if (this.dispatcherTypes == null) {
+				return null;
+			}
+			return this.dispatcherTypes.stream().map((type) -> javax.servlet.DispatcherType.valueOf(type.name()))
+					.collect(Collectors.collectingAndThen(Collectors.toSet(), EnumSet::copyOf));
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/Slf4jMdcSecurityFilterAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/Slf4jMdcSecurityFilterAutoConfiguration.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.security;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.security.Principal;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.slf4j.MDC;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for the slf4j {@link MDC}
+ * providing Spring Security authenticate user's name as 'uid'. If there is no
+ * authenticated user, the corresponding MDC entry will not be created. This
+ * runs immediately after Spring Security's filter chain in order to make these
+ * settings available as early as possible to as much logging as possible.
+ *
+ * @author Bruce Brouwer
+ * @since 2.0
+ */
+@Configuration
+@ConditionalOnWebApplication(type = Type.SERVLET)
+@EnableConfigurationProperties(SecurityProperties.class)
+@ConditionalOnClass({ AbstractSecurityWebApplicationInitializer.class, MDC.class })
+@AutoConfigureAfter(SecurityFilterAutoConfiguration.class)
+public class Slf4jMdcSecurityFilterAutoConfiguration {
+
+	private static final String DEFAULT_FILTER_NAME = AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME;
+
+	@Bean
+	@ConditionalOnBean(name = DEFAULT_FILTER_NAME)
+	public FilterRegistrationBean<Slf4jMdcSecurityFilter> uidSlf4jMdcFilter(SecurityProperties securityProperties) {
+		final Slf4jMdcSecurityFilter filter = new Slf4jMdcSecurityFilter();
+		final FilterRegistrationBean<Slf4jMdcSecurityFilter> registration = new FilterRegistrationBean<>(filter);
+		registration.setOrder(securityProperties.getFilter().getOrder() + 1);
+		registration.setDispatcherTypes(securityProperties.getFilter().getServletDispatcherTypes());
+		return registration;
+	}
+
+	public static class Slf4jMdcSecurityFilter implements Filter {
+		private static final Log logger = LogFactory.getLog(Slf4jMdcSecurityFilter.class);
+
+		@Override
+		public void init(final FilterConfig filterConfig) throws ServletException {
+			// nothing to configure
+		}
+
+		@Override
+		public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
+				throws IOException, ServletException {
+			try (Closeable uid = putUidMDC(request)) {
+				chain.doFilter(request, response);
+			}
+		}
+
+		private Closeable putUidMDC(ServletRequest request) {
+			if (request instanceof HttpServletRequest) {
+				try {
+					final Principal user = ((HttpServletRequest) request).getUserPrincipal();
+					return MDC.putCloseable("uid", user == null ? null : user.getName());
+				} catch (Exception e) {
+					logger.error("Cannot add user principal details as 'uid' to the MDC", e);
+				}
+			}
+			return null;
+		}
+
+		@Override
+		public void destroy() {
+			// nothing to clean up
+		}
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/RequestSlf4jMdcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/RequestSlf4jMdcAutoConfiguration.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.web.servlet;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.EnumSet;
+import java.util.function.Function;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.slf4j.MDC;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for the slf4j {@link MDC}
+ * providing the {@link HttpServletRequest} source (as 'src'), URI (as 'uri')
+ * and user name (as 'uid'). If one does not exist for these or is empty, the
+ * corresponding MDC entry will not be created. This runs as early as possible
+ * in order to make these settings available to as much logging as possible.
+ * 
+ * @author Bruce Brouwer
+ * @since 2.0
+ */
+@Configuration
+@ConditionalOnWebApplication(type = Type.SERVLET)
+@ConditionalOnClass(MDC.class)
+public class RequestSlf4jMdcAutoConfiguration {
+
+	@Bean
+	public FilterRegistrationBean<RequestSlf4jMdcFilter> requestSlf4jMdcFilter() {
+		final RequestSlf4jMdcFilter filter = new RequestSlf4jMdcFilter();
+		final FilterRegistrationBean<RequestSlf4jMdcFilter> registration = new FilterRegistrationBean<>(filter);
+		registration.setDispatcherTypes(EnumSet.of(DispatcherType.REQUEST, DispatcherType.ERROR, DispatcherType.ASYNC));
+		registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+		return registration;
+	}
+
+	public static class RequestSlf4jMdcFilter implements Filter {
+		private static final Log logger = LogFactory.getLog(RequestSlf4jMdcFilter.class);
+
+		@Override
+		public void init(final FilterConfig filterConfig) throws ServletException {
+			// nothing to configure
+		}
+
+		@Override
+		public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
+				throws IOException, ServletException {
+			try (Closeable src = putMDC("src", RequestSlf4jMdcFilter::src, request)) {
+				try (Closeable uri = putMDC("uri", RequestSlf4jMdcFilter::uri, request)) {
+					try (Closeable uid = putMDC("uid", RequestSlf4jMdcFilter::uid, request)) {
+						chain.doFilter(request, response);
+					}
+				}
+			}
+		}
+
+		private static String src(HttpServletRequest request) {
+			final String xff = request.getHeader("X-Forwarded-For");
+			return StringUtils.hasLength(xff) ? xff : request.getRemoteHost();
+		}
+
+		private static String uri(HttpServletRequest request) {
+			return request.getRequestURI();
+		}
+
+		private static String uid(HttpServletRequest request) {
+			Principal user = request.getUserPrincipal();
+			return user == null ? null : user.getName();
+		}
+
+		private static Closeable putMDC(String key, Function<HttpServletRequest, String> value,
+				ServletRequest request) {
+			if (request instanceof HttpServletRequest) {
+				try {
+					final String val = value.apply((HttpServletRequest) request);
+					if (StringUtils.hasLength(val)) {
+						return MDC.putCloseable(key, val);
+					}
+				} catch (Exception e) {
+					logger.error("Cannot add '" + key + "' details to the MDC", e);
+				}
+			}
+			return null;
+		}
+
+		@Override
+		public void destroy() {
+			// nothing to clean up
+		}
+	}
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -103,6 +103,7 @@ org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoCon
 org.springframework.boot.autoconfigure.sendgrid.SendGridAutoConfiguration,\
 org.springframework.boot.autoconfigure.session.SessionAutoConfiguration,\
 org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration,\
+org.springframework.boot.autoconfigure.security.Slf4jMdcSecurityFilterAutoConfiguration,\
 org.springframework.boot.autoconfigure.social.SocialWebAutoConfiguration,\
 org.springframework.boot.autoconfigure.social.FacebookAutoConfiguration,\
 org.springframework.boot.autoconfigure.social.LinkedInAutoConfiguration,\
@@ -118,6 +119,7 @@ org.springframework.boot.autoconfigure.web.reactive.ReactiveWebServerAutoConfigu
 org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration,\
+org.springframework.boot.autoconfigure.web.servlet.RequestSlf4jMdcAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.servlet.HttpEncodingAutoConfiguration,\


### PR DESCRIPTION
This is the beginning of my solution for #7927. It involves 2 filters: one registered as early as possible to get the src and uri. One is registered after the spring security filter to grab the uid. 

The first filter also can grab the uid if one exists. I figured that way if this is deployed to an app server where user authentication is taken care of by the app server, this will grab the uid right away and make it available to the MDC. I'm actually having some difficulty writing an integration test for this because I can't seem to get the embedded Tomcat instance to setup security through Tomcat, rather than Spring Security.

I still need to write the automated tests for this. I also don't have a property yet to disable these filters. I'm looking for some feedback on where to go from here.