### PR TITLE
Read application.properties using ISO 8859-1

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/OriginTrackedPropertiesLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/OriginTrackedPropertiesLoader.java
@@ -154,7 +154,7 @@ class OriginTrackedPropertiesLoader {
 
 		CharacterReader(Resource resource) throws IOException {
 			this.reader = new LineNumberReader(
-					new InputStreamReader(resource.getInputStream()));
+					new InputStreamReader(resource.getInputStream(), "8859_1"));
 		}
 
 		@Override

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/OriginTrackedPropertiesLoaderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/OriginTrackedPropertiesLoaderTests.java
@@ -227,6 +227,12 @@ public class OriginTrackedPropertiesLoaderTests {
 		assertThat(getValue(mango)).isEqualTo("Mango");
 		assertThat(getLocation(mango)).isEqualTo("27:1");
 	}
+	
+	@Test
+	public void getPropertyWithISO88591Character() throws Exception {
+		OriginTrackedValue value = this.properties.get("test-iso8859-1-chars");
+		assertThat(getValue(value)).isEqualTo("æ×ÈÅÞßáñÀÿ");
+	}
 
 	private Object getValue(OriginTrackedValue value) {
 		return (value == null ? null : value.getValue());
@@ -238,5 +244,4 @@ public class OriginTrackedPropertiesLoaderTests {
 		}
 		return ((TextResourceOrigin) value.getOrigin()).getLocation().toString();
 	}
-
 }

--- a/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/env/test-properties.properties
+++ b/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/env/test-properties.properties
@@ -37,3 +37,6 @@ test-property-value-comment=foo \
 !bar #foo
 test-multiline-immediate-bang=\
 !foo
+
+#test ISO 8859-1
+test-iso8859-1-chars=æ×ÈÅŞßáñÀÿ


### PR DESCRIPTION
Fixes gh-10564

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->