### PR TITLE
Replace equals() and hashCode() calls on URL objects

### DIFF
--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/htmlunit/webdriver/LocalHostWebConnectionHtmlUnitDriverTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/htmlunit/webdriver/LocalHostWebConnectionHtmlUnitDriverTests.java
@@ -142,7 +142,7 @@ public class LocalHostWebConnectionHtmlUnitDriverTests {
 
 		@Override
 		public boolean matches(WebRequest argument) {
-			return argument.getUrl().equals(this.expectedUrl);
+			return argument.getUrl().toExternalForm().equals(this.expectedUrl.toExternalForm());
 		}
 
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/PropertiesLauncher.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/PropertiesLauncher.java
@@ -494,7 +494,7 @@ public class PropertiesLauncher extends Launcher {
 		Archive parent = this.parent;
 		String root = path;
 		if (!root.equals("/") && root.startsWith("/")
-				|| parent.getUrl().equals(this.home.toURI().toURL())) {
+				|| parent.getUrl().toURI().equals(this.home.toURI())) {
 			// If home dir is same as parent archive, no need to add it twice.
 			return null;
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/Handler.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/Handler.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.lang.ref.SoftReference;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLDecoder;
@@ -247,9 +248,9 @@ public class Handler extends URLStreamHandler {
 		String source = file.substring(0, separatorIndex);
 		String entry = canonicalize(file.substring(separatorIndex + 2));
 		try {
-			result += new URL(source).hashCode();
+			result += new URL(source).toURI().hashCode();
 		}
-		catch (MalformedURLException ex) {
+		catch (MalformedURLException | URISyntaxException ex) {
 			result += source.hashCode();
 		}
 		result += entry.hashCode();


### PR DESCRIPTION
Hey,

this PR replaces calls to `equals()` and `hashCode()` on URL objects. While this mostly means accessing local networks they can be still more unreliable than ones without netwerk access at all.

What do you think? I'm a bit conceirned about the additional allocations in  the `Handler` class when converting the URL to a URI. Is that a critical path?

Cheers,
Christoph