### PR TITLE
Changes conditional on class from Servlet to Flux

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/reactive/ReactiveManagementContextAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/reactive/ReactiveManagementContextAutoConfiguration.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.actuate.autoconfigure.web.reactive;
 
-import javax.servlet.Servlet;
-
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import reactor.core.publisher.Flux;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Servlet-specific management
@@ -33,7 +33,7 @@ import org.springframework.context.annotation.Configuration;
  * @since 2.0.0
  */
 @Configuration
-@ConditionalOnClass(Servlet.class)
+@ConditionalOnClass(Flux.class)
 @ConditionalOnWebApplication(type = Type.REACTIVE)
 public class ReactiveManagementContextAutoConfiguration {
 


### PR DESCRIPTION
Webflux doesn't require Servlet.class, when setting management.port, auto-configuration would fail with class not found exception.

fixes #10589
