### PR TITLE
Fix broken README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,6 @@
 = Spring Boot image:https://ci.spring.io/api/v1/teams/spring-boot/pipelines/spring-boot/jobs/build/badge["Build Status", link="https://ci.spring.io/teams/spring-boot/pipelines/spring-boot?groups=Build"] image:https://badges.gitter.im/Join Chat.svg["Chat",link="https://gitter.im/spring-projects/spring-boot?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
+:docs: http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference
+
 Spring Boot makes it easy to create Spring-powered, production-grade applications and
 services with absolute minimum fuss. It takes an opinionated view of the Spring platform
 so that new and existing users can quickly get to the bits they need.


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR fixes the `README.adoc` broken due to missing `docs` since ad92af1c9980e978a5c9dd521b2c571ab6396d83.