### PR TITLE
Update docs for OpenShift

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/deployment.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/deployment.adoc
@@ -226,7 +226,7 @@ Your application should now be up and running on Heroku.
 
 [[cloud-deployment-openshift]]
 === OpenShift
-https://www.openshift.com/[OpenShift] is the RedHat public (and enterprise) extension of the 
+https://www.openshift.com/[OpenShift] is the Red Hat public (and enterprise) extension of the 
 Kubernetes container orchestration platform.  Just as in Kubernetes, OpenShift has many 
 options for installing Spring Boot based applications. 
 

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/deployment.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/deployment.adoc
@@ -226,65 +226,16 @@ Your application should now be up and running on Heroku.
 
 [[cloud-deployment-openshift]]
 === OpenShift
-https://www.openshift.com/[OpenShift] is the RedHat public (and enterprise) PaaS solution.
-Like Heroku, it works by running scripts triggered by git commits, so you can script
-the launching of a Spring Boot application in pretty much any way you like as long as the
-Java runtime is available (which is a standard feature you can ask for at OpenShift).
-To do this you can use the
-https://www.openshift.com/developers/do-it-yourself[DIY Cartridge] and hooks in your
-repository under `.openshift/action_hooks`:
+https://www.openshift.com/[OpenShift] is the RedHat public (and enterprise) extension of the 
+Kubernetes container orchestration platform.  Just as in Kubernetes, OpenShift has many 
+options for installing Spring Boot based applications. 
 
-The basic model is to:
+OpenShift has many resources describing how to deploy Spring Boot applications, which include :
 
-1. Ensure Java and your build tool are installed remotely, e.g. using a `pre_build` hook
-   (Java and Maven are installed by default, Gradle is not)
-2. Use a `build` hook to build your jar (using Maven or Gradle), e.g.
-+
-[indent=0]
-----
-	#!/bin/bash
-	cd $OPENSHIFT_REPO_DIR
-	mvn package -s .openshift/settings.xml -DskipTests=true
-----
-+
-3. Add a `start` hook that calls `java -jar ...`
-+
-[indent=0]
-----
-	#!/bin/bash
-	cd $OPENSHIFT_REPO_DIR
-	nohup java -jar target/*.jar --server.port=${OPENSHIFT_DIY_PORT} --server.address=${OPENSHIFT_DIY_IP} &
-----
-+
-4. Use a `stop` hook (since the start is supposed to return cleanly), e.g.
-+
-[indent=0]
-----
-	#!/bin/bash
-	source $OPENSHIFT_CARTRIDGE_SDK_BASH
-	PID=$(ps -ef | grep java.*\.jar | grep -v grep | awk '{ print $2 }')
-	if [ -z "$PID" ]
-	then
-	    client_result "Application is already stopped"
-	else
-	    kill $PID
-	fi
-----
-+
-5. Embed service bindings from environment variables provided by the platform
-in your `application.properties`, e.g.
-+
-[indent=0]
-----
-	spring.datasource.url: jdbc:mysql://${OPENSHIFT_MYSQL_DB_HOST}:${OPENSHIFT_MYSQL_DB_PORT}/${OPENSHIFT_APP_NAME}
-	spring.datasource.username: ${OPENSHIFT_MYSQL_DB_USERNAME}
-	spring.datasource.password: ${OPENSHIFT_MYSQL_DB_PASSWORD}
-----
-
-There's a blog on https://www.openshift.com/blogs/run-gradle-builds-on-openshift[running
-Gradle in OpenShift] on their website that will get you started with a gradle build to
-run the app.
-
+* https://blog.openshift.com/using-openshift-enterprise-grade-spring-boot-deployments/[Using the S2I builder]
+* https://access.redhat.com/documentation/en-us/reference_architectures/2017/html-single/spring_boot_microservices_on_red_hat_openshift_container_platform_3/[Architecture guide]
+* https://blog.openshift.com/using-spring-boot-on-openshift/[Running as traditional web application on Wildfly]
+* https://blog.openshift.com/openshift-commons-briefing-96-cloud-native-applications-spring-rhoar/[OpenShift Commons Briefing]
 
 
 [[cloud-deployment-aws]]


### PR DESCRIPTION
The current documentation references mechanisms for OpenShift 2, which has been changed significantly with the latest releases, specifically the OpenShift 3 release. See gh-8349 for the philosophy behind removing specific instructions, rather linking to OpenShift documentation that may remain up to date.