### PR TITLE
Fix Security OAuth2 Client documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -2761,38 +2761,31 @@ makes use of the properties under `OAuth2ClientProperties`.
 You can register multiple OAuth2 clients and providers under the
 `spring.security.oauth2.client` prefix. For example:
 
-[source,yaml,indent=0]
+[source,properties,indent=0]
 ----
-	spring:
-		security:
-			oauth2:
-				client:
-					registration:
-						my-client-1:
-							client-id: abcd
-							client-secret: password
-							client-name: Client for user scope
-							provider: my-oauth-provider
-							scope: user
-							redirect-uri: http://my-redirect-uri.com
-							client-authentication-method: basic
-							authorization-grant-type: authorization_code
-						my-client2:
-							client-id: abcd
-							client-secret: password
-							client-name: Client for email scope
-							provider: my-oauth-provider
-							scope: email
-							redirect-uri: http://my-redirect-uri.com
-							client-authentication-method: basic
-							authorization-grant-type: authorization_code
-				provider:
-					my-oauth-provider:
-						authorization-uri: http://my-auth-server/oauth/authorize
-						token-uri: http://my-auth-server/oauth/token
-						user-info-uri: http://my-auth-server/userinfo
-						jwk-set-uri: http://my-auth-server/token_keys
-						user-name-attribute: name
+	spring.security.oauth2.client.registration.my-client-1.client-id:=abcd
+	spring.security.oauth2.client.registration.my-client-1.client-secret=password
+	spring.security.oauth2.client.registration.my-client-1.client-name=Client for user scope
+	spring.security.oauth2.client.registration.my-client-1.provider=my-oauth-provider
+	spring.security.oauth2.client.registration.my-client-1.scope=user
+	spring.security.oauth2.client.registration.my-client-1.redirect-uri=http://my-redirect-uri.com
+	spring.security.oauth2.client.registration.my-client-1.client-authentication-method=basic
+	spring.security.oauth2.client.registration.my-client-1.authorization-grant-type=authorization_code
+
+	spring.security.oauth2.client.registration.my-client-2.client-id=abcd
+	spring.security.oauth2.client.registration.my-client-2.client-secret=password
+	spring.security.oauth2.client.registration.my-client-2.client-name=Client for email scope
+	spring.security.oauth2.client.registration.my-client-2.provider=my-oauth-provider
+	spring.security.oauth2.client.registration.my-client-2.scope=email
+	spring.security.oauth2.client.registration.my-client-2.redirect-uri=http://my-redirect-uri.com
+	spring.security.oauth2.client.registration.my-client-2.client-authentication-method=basic
+	spring.security.oauth2.client.registration.my-client-2.authorization-grant-type=authorization_code
+
+	spring.security.oauth2.client.provider.my-oauth-provider.authorization-uri=http://my-auth-server/oauth/authorize
+	spring.security.oauth2.client.provider.my-oauth-provider.token-uri=http://my-auth-server/oauth/token
+	spring.security.oauth2.client.provider.my-oauth-provider.user-info-uri=http://my-auth-server/userinfo
+	spring.security.oauth2.client.provider.my-oauth-provider.jwk-set-uri=http://my-auth-server/token_keys
+	spring.security.oauth2.client.provider.my-oauth-provider.user-name-attribute=name
 ----
 
 NOTE: For common OAuth2 and OpenID providers such as Google, Github, Facebook and Okta,

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -2753,7 +2753,7 @@ explicitly configure the paths that you do want to override.
 [[boot-features-security-oauth2]]
 === OAuth2
 
-=== Client
+==== Client
 If you have `spring-security-oauth2-client` on your classpath you can take advantage of
 some auto-configuration to make it easy to set up an OAuth2 Client. This configuration
 makes use of the properties under `OAuth2ClientProperties`.
@@ -2775,7 +2775,7 @@ You can register multiple OAuth2 clients and providers under the
 							provider: my-oauth-provider
 							scope: user
 							redirect-uri: http://my-redirect-uri.com
-							authentication-method: basic
+							client-authentication-method: basic
 							authorization-grant-type: authorization_code
 						my-client2:
 							client-id: abcd
@@ -2784,7 +2784,7 @@ You can register multiple OAuth2 clients and providers under the
 							provider: my-oauth-provider
 							scope: email
 							redirect-uri: http://my-redirect-uri.com
-							authentication-method: basic
+							client-authentication-method: basic
 							authorization-grant-type: authorization_code
 				provider:
 					my-oauth-provider:


### PR DESCRIPTION
This PR fixes incorrect section level and sample configuration properties.

I've also included a second commit that changes the format of documented configuration example from YAML to properties as that seems both more readable and consistent with the rest of the documentation.