### PR TITLE
Fix typo in documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -2062,7 +2062,7 @@ particular controller and/or exception type.
 ----
 
 In the example above, if `YourException` is thrown by a controller defined in the same
-package as `FooController`, a json representation of the `CustomerErrorType` POJO will be
+package as `FooController`, a json representation of the `CustomErrorType` POJO will be
 used instead of the `ErrorAttributes` representation.
 
 


### PR DESCRIPTION
- As error handling sample is using `CustomErrorType`, fix
  description which mentions `CustomerErrorType`.
