### PR TITLE
Provide access to root URI from TestRestTemplate

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplate.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplate.java
@@ -78,6 +78,7 @@ import org.springframework.web.util.UriTemplateHandler;
  * @author Dave Syer
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Kristine Jetzke
  * @since 1.4.0
  */
 public class TestRestTemplate {
@@ -163,6 +164,15 @@ public class TestRestTemplate {
 	 */
 	public void setUriTemplateHandler(UriTemplateHandler handler) {
 		this.restTemplate.setUriTemplateHandler(handler);
+	}
+
+	public String getRootUri() {
+		UriTemplateHandler uriTemplateHandler = this.restTemplate.getUriTemplateHandler();
+		if (RootUriTemplateHandler.class
+				.isAssignableFrom(uriTemplateHandler.getClass())) {
+			return ((RootUriTemplateHandler) uriTemplateHandler).getRootUri();
+		}
+		return "";
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/TestRestTemplateTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/TestRestTemplateTests.java
@@ -63,6 +63,7 @@ import static org.mockito.Mockito.verify;
  * @author Phillip Webb
  * @author Stephane Nicoll
  * @author Andy Wilkinson
+ * @author Kristine Jetzke
  */
 public class TestRestTemplateTests {
 
@@ -79,6 +80,31 @@ public class TestRestTemplateTests {
 		// The Apache client is on the classpath so we get the fully-fledged factory
 		assertThat(new TestRestTemplate().getRestTemplate().getRequestFactory())
 				.isInstanceOf(HttpComponentsClientHttpRequestFactory.class);
+	}
+
+	@Test
+	public void getRootUriRootUriSetViaRestTemplateBuilder() {
+		String rootUri = "http://example.com";
+		RestTemplate delegate = new RestTemplateBuilder().rootUri(rootUri).build();
+
+		assertThat(new TestRestTemplate(delegate).getRootUri()).isEqualTo(rootUri);
+	}
+
+	@Test
+	public void getRootUriRootUriSetViaLocalHostUriTemplateHandler() {
+		String rootUri = "http://example.com";
+		TestRestTemplate template = new TestRestTemplate();
+		LocalHostUriTemplateHandler templateHandler = mock(
+				LocalHostUriTemplateHandler.class);
+		given(templateHandler.getRootUri()).willReturn(rootUri);
+		template.setUriTemplateHandler(templateHandler);
+
+		assertThat(template.getRootUri()).isEqualTo(rootUri);
+	}
+
+	@Test
+	public void getRootUriRootUriNotSet() {
+		assertThat(new TestRestTemplate().getRootUri()).isEqualTo("");
 	}
 
 	@Test


### PR DESCRIPTION
Fixes gh-6733

Wasn't sure what to do in case the URI handler is not a ``RootUriTemplateHandler``. Decided to return an empty string but maybe it's better to throw an exception? Let me know what you think.