### PR TITLE
Remove "Securing the H2 console" section

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -3206,18 +3206,6 @@ path using the `spring.h2.console.path` property.
 
 
 
-[[boot-features-sql-h2-console-securing]]
-==== Securing the H2 console
-When Spring Security is on the classpath and basic auth is enabled, the H2 console will be
-automatically secured using basic auth. The following properties can be used to customize
-the security configuration:
-
-* `security.user.role`
-* `security.basic.authorize-mode`
-* `security.basic.enabled`
-
-
-
 [[boot-features-jooq]]
 === Using jOOQ
 Java Object Oriented Querying (http://www.jooq.org/[jOOQ]) is a popular product from


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Auto-configured security for H2 console has been dropped in #10435 but its documentation still remains. This PR removes it.