### PR TITLE
Use Assert.state() with Supplier where possible

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/EndpointRequest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/EndpointRequest.java
@@ -163,7 +163,7 @@ public final class EndpointRequest {
 		private String getPathId(Class<?> source) {
 			Endpoint annotation = AnnotationUtils.findAnnotation(source, Endpoint.class);
 			Assert.state(annotation != null,
-					"Class " + source + " is not annotated with @Endpoint");
+					() -> "Class " + source + " is not annotated with @Endpoint");
 			return annotation.id();
 		}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/AnnotationEndpointDiscoverer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/AnnotationEndpointDiscoverer.java
@@ -140,7 +140,7 @@ public abstract class AnnotationEndpointDiscoverer<T extends Operation, K>
 			AnnotationAttributes endpointAttributes = AnnotatedElementUtils
 					.getMergedAnnotationAttributes(endpointType, Endpoint.class);
 			Assert.state(isExposedOver(endpointAttributes, exposure),
-					"Invalid extension " + beanType.getName() + "': endpoint '"
+					() -> "Invalid extension " + beanType.getName() + "': endpoint '"
 							+ endpointType.getName()
 							+ "' does not support such extension");
 			EndpointInfo<T> info = getEndpointInfo(endpoints, beanType, endpointType);
@@ -163,7 +163,7 @@ public abstract class AnnotationEndpointDiscoverer<T extends Operation, K>
 	private EndpointInfo<T> getEndpointInfo(Map<Class<?>, EndpointInfo<T>> endpoints,
 			Class<?> beanType, Class<?> endpointClass) {
 		EndpointInfo<T> endpoint = endpoints.get(endpointClass);
-		Assert.state(endpoint != null, "Invalid extension '" + beanType.getName()
+		Assert.state(endpoint != null, () -> "Invalid extension '" + beanType.getName()
 				+ "': no endpoint found with type '" + endpointClass.getName() + "'");
 		return endpoint;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheConfigurations.java
@@ -52,7 +52,7 @@ final class CacheConfigurations {
 
 	public static String getConfigurationClass(CacheType cacheType) {
 		Class<?> configurationClass = MAPPINGS.get(cacheType);
-		Assert.state(configurationClass != null, "Unknown cache type " + cacheType);
+		Assert.state(configurationClass != null, () -> "Unknown cache type " + cacheType);
 		return configurationClass.getName();
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
@@ -124,7 +124,7 @@ public class FlywayAutoConfiguration {
 						"Migration script locations not configured");
 				boolean exists = hasAtLeastOneLocation();
 				Assert.state(exists,
-						"Cannot find migrations location in: " + this.properties
+						() -> "Cannot find migrations location in: " + this.properties
 								.getLocations()
 						+ " (please add migrations or check your Flyway configuration)");
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -232,7 +232,7 @@ public class DataSourceProperties
 	public String determineDriverClassName() {
 		if (StringUtils.hasText(this.driverClassName)) {
 			Assert.state(driverClassIsLoadable(),
-					"Cannot load driver class: " + this.driverClassName);
+					() -> "Cannot load driver class: " + this.driverClassName);
 			return this.driverClassName;
 		}
 		String driverClassName = null;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -103,7 +103,7 @@ public class LiquibaseAutoConfiguration {
 				Resource resource = this.resourceLoader
 						.getResource(this.properties.getChangeLog());
 				Assert.state(resource.exists(),
-						"Cannot find changelog location: " + resource
+						() -> "Cannot find changelog location: " + resource
 								+ " (please add changelog or check your Liquibase "
 								+ "configuration)");
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionStoreMappings.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionStoreMappings.java
@@ -48,7 +48,7 @@ final class SessionStoreMappings {
 	public static String getConfigurationClass(StoreType sessionStoreType) {
 		Class<?> configurationClass = MAPPINGS.get(sessionStoreType);
 		Assert.state(configurationClass != null,
-				"Unknown session store type " + sessionStoreType);
+				() -> "Unknown session store type " + sessionStoreType);
 		return configurationClass.getName();
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/social/SocialWebAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/social/SocialWebAutoConfiguration.java
@@ -178,7 +178,7 @@ public class SocialWebAutoConfiguration {
 			SecurityContext context = SecurityContextHolder.getContext();
 			Authentication authentication = context.getAuthentication();
 			Assert.state(authentication != null,
-					"Unable to get a " + "ConnectionRepository: no user signed in");
+					"Unable to get a ConnectionRepository: no user signed in");
 			return authentication.getName();
 		}
 

--- a/spring-boot-project/spring-boot-cli/src/it/java/org/springframework/boot/cli/infrastructure/CommandLineInvoker.java
+++ b/spring-boot-project/spring-boot-cli/src/it/java/org/springframework/boot/cli/infrastructure/CommandLineInvoker.java
@@ -94,7 +94,7 @@ public final class CommandLineInvoker {
 		File bin = new File(unpacked.listFiles()[0], "bin");
 		File launchScript = new File(bin, isWindows() ? "spring.bat" : "spring");
 		Assert.state(launchScript.exists() && launchScript.isFile(),
-				"Could not find CLI launch script " + launchScript.getAbsolutePath());
+				() -> "Could not find CLI launch script " + launchScript.getAbsolutePath());
 		return launchScript;
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/ChangedFile.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/ChangedFile.java
@@ -76,7 +76,7 @@ public final class ChangedFile {
 		File file = this.file.getAbsoluteFile();
 		String folderName = StringUtils.cleanPath(folder.getPath());
 		String fileName = StringUtils.cleanPath(file.getPath());
-		Assert.state(fileName.startsWith(folderName), "The file " + fileName
+		Assert.state(fileName.startsWith(folderName), () -> "The file " + fileName
 				+ " is not contained in the source folder " + folderName);
 		return fileName.substring(folderName.length() + 1);
 	}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/server/HttpTunnelServer.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/server/HttpTunnelServer.java
@@ -299,7 +299,7 @@ public class HttpTunnelServer {
 				long timeout = HttpTunnelServer.this.disconnectTimeout;
 				long duration = System.currentTimeMillis() - this.lastHttpRequestTime;
 				Assert.state(duration < timeout,
-						"Disconnect timeout: " + timeout + " " + duration);
+						() -> "Disconnect timeout: " + timeout + " " + duration);
 			}
 		}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
@@ -67,7 +67,7 @@ final class SpringBootConfigurationFinder {
 			Set<BeanDefinition> components = this.scanner.findCandidateComponents(source);
 			if (!components.isEmpty()) {
 				Assert.state(components.size() == 1,
-						"Found multiple @SpringBootConfiguration annotated classes "
+						() -> "Found multiple @SpringBootConfiguration annotated classes "
 								+ components);
 				return ClassUtils.resolveClassName(
 						components.iterator().next().getBeanClassName(), null);

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootContextLoader.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootContextLoader.java
@@ -96,7 +96,7 @@ public class SpringBootContextLoader extends AbstractContextLoader {
 		Assert.state(
 				!ObjectUtils.isEmpty(configClasses)
 						|| !ObjectUtils.isEmpty(configLocations),
-				"No configuration classes "
+				() -> "No configuration classes "
 						+ "or locations found in @SpringApplicationConfiguration. "
 						+ "For default configuration detection to work you need "
 						+ "Spring 4.0.3 or better (found " + SpringVersion.getVersion()

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/DefinitionsParser.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/DefinitionsParser.java
@@ -76,7 +76,7 @@ class DefinitionsParser {
 	private void parseMockBeanAnnotation(MockBean annotation, AnnotatedElement element) {
 		Set<ResolvableType> typesToMock = getOrDeduceTypes(element, annotation.value());
 		Assert.state(!typesToMock.isEmpty(),
-				"Unable to deduce type to mock from " + element);
+				() -> "Unable to deduce type to mock from " + element);
 		if (StringUtils.hasLength(annotation.name())) {
 			Assert.state(typesToMock.size() == 1,
 					"The name attribute can only be used when mocking a single class");
@@ -93,7 +93,7 @@ class DefinitionsParser {
 	private void parseSpyBeanAnnotation(SpyBean annotation, AnnotatedElement element) {
 		Set<ResolvableType> typesToSpy = getOrDeduceTypes(element, annotation.value());
 		Assert.state(!typesToSpy.isEmpty(),
-				"Unable to deduce type to spy from " + element);
+				() -> "Unable to deduce type to spy from " + element);
 		if (StringUtils.hasLength(annotation.name())) {
 			Assert.state(typesToSpy.size() == 1,
 					"The name attribute can only be used when spying a single class");
@@ -109,7 +109,8 @@ class DefinitionsParser {
 	private void addDefinition(AnnotatedElement element, Definition definition,
 			String type) {
 		boolean isNewDefinition = this.definitions.add(definition);
-		Assert.state(isNewDefinition, "Duplicate " + type + " definition " + definition);
+		Assert.state(isNewDefinition,
+				() -> "Duplicate " + type + " definition " + definition);
 		if (element instanceof Field) {
 			Field field = (Field) element;
 			this.definitionFields.put(definition, field);

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -380,7 +380,7 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 	void inject(Field field, Object target, Definition definition) {
 		String beanName = this.beanNameRegistry.get(definition);
 		Assert.state(StringUtils.hasLength(beanName),
-				"No bean found for definition " + definition);
+				() -> "No bean found for definition " + definition);
 		inject(field, target, beanName, definition);
 	}
 
@@ -389,7 +389,7 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 		try {
 			field.setAccessible(true);
 			Assert.state(ReflectionUtils.getField(field, target) == null,
-					"The field " + field + " cannot have an existing value");
+					() -> "The field " + field + " cannot have an existing value");
 			Object bean = this.beanFactory.getBean(beanName, field.getType());
 			if (definition.isProxyTargetAware() && isAopProxy(bean)) {
 				MockitoAopProxyTargetInterceptor.applyTo(bean);

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/JavaExecutable.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/JavaExecutable.java
@@ -44,7 +44,7 @@ public class JavaExecutable {
 		File bin = new File(new File(javaHome), "bin");
 		File command = new File(bin, "java.exe");
 		command = (command.exists() ? command : new File(bin, "java"));
-		Assert.state(command.exists(), "Unable to find java in " + javaHome);
+		Assert.state(command.exists(), () -> "Unable to find java in " + javaHome);
 		return command;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ApplicationTemp.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ApplicationTemp.java
@@ -80,7 +80,7 @@ public class ApplicationTemp {
 				this.dir = new File(getTempDirectory(), toHexString(hash));
 				this.dir.mkdirs();
 				Assert.state(this.dir.exists(),
-						"Unable to create temp directory " + this.dir);
+						() -> "Unable to create temp directory " + this.dir);
 			}
 		}
 		return this.dir;
@@ -90,8 +90,8 @@ public class ApplicationTemp {
 		String property = System.getProperty("java.io.tmpdir");
 		Assert.state(StringUtils.hasLength(property), "No 'java.io.tmpdir' property set");
 		File file = new File(property);
-		Assert.state(file.exists(), "Temp directory" + file + " does not exist");
-		Assert.state(file.isDirectory(), "Temp location " + file + " is not a directory");
+		Assert.state(file.exists(), () -> "Temp directory" + file + " does not exist");
+		Assert.state(file.isDirectory(), () -> "Temp location " + file + " is not a directory");
 		return file;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonObjectDeserializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonObjectDeserializer.java
@@ -131,7 +131,7 @@ public abstract class JsonObjectDeserializer<T>
 		Assert.notNull(tree, "Tree must not be null");
 		JsonNode node = tree.get(fieldName);
 		Assert.state(node != null && !(node instanceof NullNode),
-				"Missing JSON field '" + fieldName + "'");
+				() -> "Missing JSON field '" + fieldName + "'");
 		return node;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
@@ -92,7 +92,7 @@ public class JettyWebServer implements WebServer {
 					@Override
 					protected void doStart() throws Exception {
 						for (Connector connector : JettyWebServer.this.connectors) {
-							Assert.state(connector.isStopped(), "Connector " + connector
+							Assert.state(connector.isStopped(), () -> "Connector " + connector
 									+ " has been started prematurely");
 						}
 						JettyWebServer.this.server.setConnectors(null);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
@@ -492,7 +492,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 
 	private void configurePersistSession(Manager manager) {
 		Assert.state(manager instanceof StandardManager,
-				"Unable to persist HTTP session state using manager type "
+				() -> "Unable to persist HTTP session state using manager type "
 						+ manager.getClass().getName());
 		File dir = getValidSessionStoreDir();
 		File file = new File(dir, "SESSIONS.ser");

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/RegistrationBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/RegistrationBean.java
@@ -135,7 +135,7 @@ public abstract class RegistrationBean implements ServletContextInitializer, Ord
 	 */
 	protected void configure(Registration.Dynamic registration) {
 		Assert.state(registration != null,
-				"Registration is null. Was something already registered for name=["
+				() -> "Registration is null. Was something already registered for name=["
 						+ this.name + "]?");
 		registration.setAsyncSupported(this.asyncSupported);
 		if (!this.initParameters.isEmpty()) {


### PR DESCRIPTION
Hey,

this PR replaces occurences of Assert.state() with string concatenations as assertion messages with its Supplier variant to avoid unnecessary String allocations.

Cheers,
Christoph