### PR TITLE
Change HibernateJpaConfiguration to public to be able to extend it

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.java
@@ -50,7 +50,7 @@ import org.springframework.util.ClassUtils;
  */
 @Configuration
 @ConditionalOnSingleCandidate(DataSource.class)
-class HibernateJpaConfiguration extends JpaBaseConfiguration {
+public class HibernateJpaConfiguration extends JpaBaseConfiguration {
 
 	private static final Log logger = LogFactory.getLog(HibernateJpaConfiguration.class);
 


### PR DESCRIPTION
Hello,

Since [this commit](https://github.com/spring-projects/spring-boot/commit/bd02edf2ce749b70dcc45563bbeec2ab503d875c), we can't extend anymore `HibernateJpaAutoConfiguration` class to specify hibernate mapping files [like this](https://stackoverflow.com/questions/32062828/spring-boot-load-orm-xml/40060677#40060677), but we can’t either extend `HibernateJpaConfiguration` class because it is package-protected.
This PR changes `HibernateJpaConfiguration` class modifier to `public` to be able to extend it. 
It could be a solution for [this question on SO](https://stackoverflow.com/questions/46784760/how-to-specifiy-hibernate-mappings-with-spring-boot-2-0).

Thanks!
