### PR TITLE
Remove @ConditionalOnEnabledEndpoint on EndpointExtensions

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/audit/AuditEventsEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/audit/AuditEventsEndpointAutoConfiguration.java
@@ -52,7 +52,6 @@ public class AuditEventsEndpointAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnEnabledEndpoint
 	@ConditionalOnBean(AuditEventsEndpoint.class)
 	public AuditEventsJmxEndpointExtension auditEventsJmxEndpointExtension(
 			AuditEventsEndpoint auditEventsEndpoint) {
@@ -61,7 +60,6 @@ public class AuditEventsEndpointAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnEnabledEndpoint
 	@ConditionalOnBean(AuditEventsEndpoint.class)
 	public AuditEventsWebEndpointExtension auditEventsWebEndpointExtension(
 			AuditEventsEndpoint auditEventsEndpoint) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/env/EnvironmentEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/env/EnvironmentEndpointAutoConfiguration.java
@@ -59,7 +59,6 @@ public class EnvironmentEndpointAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnEnabledEndpoint
 	@ConditionalOnBean(EnvironmentEndpoint.class)
 	public EnvironmentWebEndpointExtension environmentWebEndpointExtension(
 			EnvironmentEndpoint environmentEndpoint) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/health/HealthWebEndpointManagementContextConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/health/HealthWebEndpointManagementContextConfiguration.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnEnabledEndpoint;
 import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
 import org.springframework.boot.actuate.health.CompositeReactiveHealthIndicatorFactory;
 import org.springframework.boot.actuate.health.HealthAggregator;
@@ -82,7 +81,6 @@ public class HealthWebEndpointManagementContextConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		@ConditionalOnEnabledEndpoint
 		@ConditionalOnBean(HealthEndpoint.class)
 		public HealthReactiveWebEndpointExtension healthWebEndpointExtension(
 				HealthStatusHttpMapper healthStatusHttpMapper) {
@@ -92,7 +90,6 @@ public class HealthWebEndpointManagementContextConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		@ConditionalOnEnabledEndpoint
 		@ConditionalOnBean(StatusEndpoint.class)
 		public StatusReactiveWebEndpointExtension statusWebEndpointExtension(
 				HealthStatusHttpMapper healthStatusHttpMapper) {
@@ -108,7 +105,6 @@ public class HealthWebEndpointManagementContextConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		@ConditionalOnEnabledEndpoint
 		@ConditionalOnBean(HealthEndpoint.class)
 		public HealthWebEndpointExtension healthWebEndpointExtension(
 				HealthEndpoint delegate, HealthStatusHttpMapper healthStatusHttpMapper) {
@@ -117,7 +113,6 @@ public class HealthWebEndpointManagementContextConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		@ConditionalOnEnabledEndpoint
 		@ConditionalOnBean(StatusEndpoint.class)
 		public StatusWebEndpointExtension statusWebEndpointExtension(
 				StatusEndpoint delegate, HealthStatusHttpMapper healthStatusHttpMapper) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/session/SessionsEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/session/SessionsEndpointAutoConfiguration.java
@@ -52,7 +52,6 @@ public class SessionsEndpointAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnEnabledEndpoint
 	@ConditionalOnBean(SessionsEndpoint.class)
 	public SessionsWebEndpointExtension sessionsWebEndpointExtension(
 			SessionsEndpoint sessionsEndpoint) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
EndpointExtension has `@ConditionalOnBean` on Endpoint which already has `@ConditionalOnEnabledEndpoint`, so they look redundant.

This PR removes them.