### PR TITLE
Fix small typo in docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -6740,7 +6740,7 @@ you provide web-specific configuration, your class may need to be applied after
 `WebMvcAutoConfiguration`.
 
 If you want to order certain auto-configurations that shouldn't have any direct
-knowledge of each other, you can also use `@AutoconfigureOrder`. That annotation has the
+knowledge of each other, you can also use `@AutoConfigureOrder`. That annotation has the
 same semantic as the regular `@Order` annotation but provides a dedicated order for
 auto-configuration classes.
 


### PR DESCRIPTION
This fixes a very small typo regarding `@AutoConfigureOrder`.