### PR TITLE
cmdOptions configuration through application.properties for embedded mongodb autoconfigure

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
@@ -32,6 +32,7 @@ import de.flapdoodle.embed.mongo.MongodStarter;
 import de.flapdoodle.embed.mongo.config.DownloadConfigBuilder;
 import de.flapdoodle.embed.mongo.config.ExtractedArtifactStoreBuilder;
 import de.flapdoodle.embed.mongo.config.IMongodConfig;
+import de.flapdoodle.embed.mongo.config.MongoCmdOptionsBuilder;
 import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
@@ -75,6 +76,7 @@ import org.springframework.util.Assert;
  * @author Andy Wilkinson
  * @author Yogesh Lonkar
  * @author Mark Paluch
+ * @author Adrien Colson
  * @since 1.3.0
  */
 @Configuration
@@ -139,6 +141,35 @@ public class EmbeddedMongoAutoConfiguration {
 							this.embeddedProperties.getStorage().getOplogSize() != null
 									? this.embeddedProperties.getStorage().getOplogSize()
 									: 0));
+		}
+		if (this.embeddedProperties.getCmdOptions() != null) {
+			final MongoCmdOptionsBuilder cmdOptionsBuilder = new MongoCmdOptionsBuilder();
+			cmdOptionsBuilder.syncDelay(this.embeddedProperties.getCmdOptions().getSyncDelay() != null
+					? this.embeddedProperties.getCmdOptions().getSyncDelay()
+					: 0);
+			cmdOptionsBuilder.useStorageEngine(this.embeddedProperties.getCmdOptions().getStorageEngine());
+			cmdOptionsBuilder.verbose(this.embeddedProperties.getCmdOptions().isVerbose() != null
+					? this.embeddedProperties.getCmdOptions().isVerbose()
+					: false);
+			cmdOptionsBuilder.useNoPrealloc(this.embeddedProperties.getCmdOptions().isUseNoPrealloc() != null
+					? this.embeddedProperties.getCmdOptions().isUseNoPrealloc()
+					: true);
+			cmdOptionsBuilder.useSmallFiles(this.embeddedProperties.getCmdOptions().isUseSmallFiles() != null
+					? this.embeddedProperties.getCmdOptions().isUseSmallFiles()
+					: true);
+			cmdOptionsBuilder.useNoJournal(this.embeddedProperties.getCmdOptions().isUseNoJournal() != null
+					? this.embeddedProperties.getCmdOptions().isUseNoJournal()
+					: true);
+			cmdOptionsBuilder.enableTextSearch(this.embeddedProperties.getCmdOptions().isEnableTextSearch() != null
+					? this.embeddedProperties.getCmdOptions().isEnableTextSearch()
+					: false);
+			cmdOptionsBuilder.enableAuth(this.embeddedProperties.getCmdOptions().isAuth() != null
+					? this.embeddedProperties.getCmdOptions().isAuth()
+					: false);
+			cmdOptionsBuilder.master(this.embeddedProperties.getCmdOptions().isMaster() != null
+					? this.embeddedProperties.getCmdOptions().isMaster()
+					: false);
+			builder.cmdOptions(cmdOptionsBuilder.build());
 		}
 		Integer configuredPort = this.properties.getPort();
 		if (configuredPort != null && configuredPort > 0) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoProperties.java
@@ -29,6 +29,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Andy Wilkinson
  * @author Yogesh Lonkar
+ * @author Adrien Colson
  * @since 1.3.0
  */
 @ConfigurationProperties(prefix = "spring.mongodb.embedded")
@@ -40,6 +41,8 @@ public class EmbeddedMongoProperties {
 	private String version = "3.2.2";
 
 	private final Storage storage = new Storage();
+
+	private final CmdOptions cmdOptions = new CmdOptions();
 
 	/**
 	 * Comma-separated list of features to enable.
@@ -65,6 +68,10 @@ public class EmbeddedMongoProperties {
 
 	public Storage getStorage() {
 		return this.storage;
+	}
+
+	public CmdOptions getCmdOptions() {
+		return this.cmdOptions;
 	}
 
 	public static class Storage {
@@ -110,4 +117,97 @@ public class EmbeddedMongoProperties {
 
 	}
 
+	public static class CmdOptions {
+
+		private Integer syncDelay;
+
+		private String storageEngine;
+
+		private Boolean isVerbose;
+
+		private Boolean useNoPrealloc;
+
+		private Boolean useSmallFiles;
+
+		private Boolean useNoJournal;
+
+		private Boolean enableTextSearch;
+
+		private Boolean auth;
+
+		private Boolean master;
+
+		public Integer getSyncDelay() {
+			return this.syncDelay;
+		}
+
+		public void setSyncDelay(final Integer syncDelay) {
+			this.syncDelay = syncDelay;
+		}
+
+		public String getStorageEngine() {
+			return this.storageEngine;
+		}
+
+		public void setStorageEngine(final String storageEngine) {
+			this.storageEngine = storageEngine;
+		}
+
+		public Boolean isVerbose() {
+			return this.isVerbose;
+		}
+
+		public void setVerbose(final Boolean isVerbose) {
+			this.isVerbose = isVerbose;
+		}
+
+		public Boolean isUseNoPrealloc() {
+			return this.useNoPrealloc;
+		}
+
+		public void setUseNoPrealloc(final Boolean useNoPrealloc) {
+			this.useNoPrealloc = useNoPrealloc;
+		}
+
+		public Boolean isUseSmallFiles() {
+			return this.useSmallFiles;
+		}
+
+		public void setUseSmallFiles(final Boolean useSmallFiles) {
+			this.useSmallFiles = useSmallFiles;
+		}
+
+		public Boolean isUseNoJournal() {
+			return this.useNoJournal;
+		}
+
+		public void setUseNoJournal(final Boolean useNoJournal) {
+			this.useNoJournal = useNoJournal;
+		}
+
+		public Boolean isEnableTextSearch() {
+			return this.enableTextSearch;
+		}
+
+		public void setEnableTextSearch(final Boolean enableTextSearch) {
+			this.enableTextSearch = enableTextSearch;
+		}
+
+		public Boolean isAuth() {
+			return this.auth;
+		}
+
+		public void setAuth(final Boolean auth) {
+			this.auth = auth;
+		}
+
+		public Boolean isMaster() {
+			return this.master;
+		}
+
+		public void setMaster(final Boolean master) {
+			this.master = master;
+		}
+
+	}
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfigurationTests.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.net.UnknownHostException;
 
 import com.mongodb.MongoClient;
+import de.flapdoodle.embed.mongo.config.IMongoCmdOptions;
 import de.flapdoodle.embed.mongo.config.IMongodConfig;
 import de.flapdoodle.embed.mongo.config.Storage;
 import de.flapdoodle.embed.mongo.distribution.Feature;
@@ -151,6 +152,84 @@ public class EmbeddedMongoAutoConfigurationTests {
 		assertThat(
 				this.context.getBean(IMongodConfig.class).replication().getReplSetName())
 						.isEqualTo("testing");
+	}
+
+	@Test
+	public void defaultCmdOptionsConfiguration() {
+		load(MongoClientConfiguration.class);
+		IMongoCmdOptions cmdOptions = this.context.getBean(IMongodConfig.class).cmdOptions();
+		assertThat(cmdOptions.syncDelay()).isEqualTo(0);
+		assertThat(cmdOptions.storageEngine()).isNull();
+		assertThat(cmdOptions.isVerbose()).isFalse();
+		assertThat(cmdOptions.useNoPrealloc()).isTrue();
+		assertThat(cmdOptions.useSmallFiles()).isTrue();
+		assertThat(cmdOptions.useNoJournal()).isTrue();
+		assertThat(cmdOptions.enableTextSearch()).isFalse();
+		assertThat(cmdOptions.auth()).isFalse();
+		assertThat(cmdOptions.master()).isFalse();
+	}
+
+	@Test
+	public void customSyncDelayIsAppliedToConfiguration() {
+		load("spring.mongodb.embedded.cmdOptions.syncDelay=10");
+		assertThat(this.context.getBean(IMongodConfig.class).cmdOptions().syncDelay())
+				.isEqualTo(10);
+	}
+
+	@Test
+	public void customStorageEngineIsAppliedToConfiguration() {
+		load("spring.mongodb.embedded.cmdOptions.storageEngine=mmapv1");
+		assertThat(this.context.getBean(IMongodConfig.class).cmdOptions().storageEngine())
+				.isEqualTo("mmapv1");
+	}
+
+	@Test
+	public void customVerboseIsAppliedToConfiguration() {
+		load("spring.mongodb.embedded.cmdOptions.verbose=true");
+		assertThat(this.context.getBean(IMongodConfig.class).cmdOptions().isVerbose())
+				.isTrue();
+	}
+
+	@Test
+	public void customUseNoPreallocIsAppliedToConfiguration() {
+		load("spring.mongodb.embedded.cmdOptions.useNoPrealloc=false");
+		assertThat(this.context.getBean(IMongodConfig.class).cmdOptions().useNoPrealloc())
+				.isFalse();
+	}
+
+	@Test
+	public void customUseSmallFilesIsAppliedToConfiguration() {
+		load("spring.mongodb.embedded.cmdOptions.useSmallFiles=false");
+		assertThat(this.context.getBean(IMongodConfig.class).cmdOptions().useSmallFiles())
+				.isFalse();
+	}
+
+	@Test
+	public void customUseNoJournalIsAppliedToConfiguration() {
+		load("spring.mongodb.embedded.cmdOptions.useNoJournal=false");
+		assertThat(this.context.getBean(IMongodConfig.class).cmdOptions().useNoJournal())
+				.isFalse();
+	}
+
+	@Test
+	public void customEnableTextSearchIsAppliedToConfiguration() {
+		load("spring.mongodb.embedded.cmdOptions.enableTextSearch=true");
+		assertThat(this.context.getBean(IMongodConfig.class).cmdOptions().enableTextSearch())
+				.isTrue();
+	}
+
+	@Test
+	public void customAuthIsAppliedToConfiguration() {
+		load("spring.mongodb.embedded.cmdOptions.auth=true");
+		assertThat(this.context.getBean(IMongodConfig.class).cmdOptions().auth())
+				.isTrue();
+	}
+
+	@Test
+	public void customMasterIsAppliedToConfiguration() {
+		load("spring.mongodb.embedded.cmdOptions.master=true");
+		assertThat(this.context.getBean(IMongodConfig.class).cmdOptions().master())
+				.isTrue();
 	}
 
 	private void assertVersionConfiguration(String configuredVersion,

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfigurationTests.java
@@ -48,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Henryk Konsek
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author Adrien Colson
  */
 public class EmbeddedMongoAutoConfigurationTests {
 


### PR DESCRIPTION
Added feature to configure custom cmdOptions of embedded mongodb with spring boot.