### PR TITLE
Adding Note in Documentation for Spring-cli

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/getting-started.adoc
@@ -276,6 +276,7 @@ instructions from the unpacked archive. In summary: there is a `spring` script
 can use `java -jar` with the `.jar` file (the script helps you to be sure that the
 classpath is set correctly).
 
+NOTE: when setting `JAVA_OPTS` on windows be sure to quote the entire instruction such as `set "JAVA_OPTS=-Xms256m -Xmx2048m"` this will ensure the values are passed properly to the process.
 
 
 [[getting-started-sdkman-cli-installation]]


### PR DESCRIPTION
Adding Note to instruct user to ensure they are properly setting JAVA_OPTS environment variable to ensure values are properly passed to CLI process

fixes gh-9779

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->