### PR TITLE
Allow to use custom ConfigurableEnvironment when extend SpringBootContextLoader

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootContextLoader.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootContextLoader.java
@@ -105,7 +105,7 @@ public class SpringBootContextLoader extends AbstractContextLoader {
 		application.setMainApplicationClass(config.getTestClass());
 		application.addPrimarySources(Arrays.asList(configClasses));
 		application.getSources().addAll(Arrays.asList(configLocations));
-		ConfigurableEnvironment environment = new StandardEnvironment();
+		ConfigurableEnvironment environment = getConfigurableEnvironment();
 		if (!ObjectUtils.isEmpty(config.getActiveProfiles())) {
 			setActiveProfiles(environment, config.getActiveProfiles());
 		}
@@ -146,6 +146,15 @@ public class SpringBootContextLoader extends AbstractContextLoader {
 	 */
 	protected SpringApplication getSpringApplication() {
 		return new SpringApplication();
+	}
+
+
+	/**
+	 * Override this method to use custom ConfigurableEnvironment.
+	 * @return {@link org.springframework.core.env.StandardEnvironment} instance
+	 */
+	protected ConfigurableEnvironment getConfigurableEnvironment() {
+		return new StandardEnvironment();
 	}
 
 	private void setActiveProfiles(ConfigurableEnvironment environment,


### PR DESCRIPTION
This PR is to enable using custom `ConfigurableEnvironment` when extend `SpringBootContextLoader`. 

Since `SpringBootContextLoader` is using `StandardEnviroment` by default, it is tedious to create a custom
`ContextLoader`  with my own `ConfigurableEnvironment` (in my case is for resolving encrypted property).

I created `getConfigurableEnviroment` method, and allow to override to use custom `ConfigurableEnvironment`. For your review.