### PR TITLE
PR #9714: JVM arguments and options

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/run-disable-fork/verify.groovy
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/run-disable-fork/verify.groovy
@@ -2,6 +2,6 @@ import static org.junit.Assert.assertTrue
 
 def file = new File(basedir, "build.log")
 assertTrue file.text.contains("I haz been run")
-assertTrue file.text.contains("Fork mode disabled, ignoring JVM argument(s) [-Dfoo=bar]")
+assertTrue file.text.contains("Fork mode disabled, ignoring JVM argument(s) [-Dfoo=bar -Dproperty1=value1 -Dproperty2]")
 assertTrue file.text.contains("Fork mode disabled, ignoring working directory configuration")
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/run-jvm-system-props/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/run-jvm-system-props/pom.xml
@@ -3,7 +3,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.boot.maven.it</groupId>
-	<artifactId>run-disable-fork</artifactId>
+	<artifactId>run-jvmargs</artifactId>
 	<version>0.0.1.BUILD-SNAPSHOT</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -23,9 +23,7 @@
 							<goal>run</goal>
 						</goals>
 						<configuration>
-							<fork>false</fork>
-							<jvmArguments>-Dfoo=bar</jvmArguments>
-							<workingDirectory>${project.build.sourceDirectory}</workingDirectory>
+							<jvmArguments>-Dfoo="value 1" -Dbar=value2</jvmArguments>
 							<systemPropertyVariables>
 								<property1>value1</property1>
 								<property2/>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/run-jvm-system-props/src/main/java/org/test/SampleApplication.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/run-jvm-system-props/src/main/java/org/test/SampleApplication.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.test;
+
+public class SampleApplication {
+
+	public static void main(String[] args) {
+		String foo = System.getProperty("foo");
+		if (!"value 1".equals(foo)) {
+			throw new IllegalStateException("foo system property mismatch (got [" + foo + "]");
+		}
+		String bar = System.getProperty("bar");
+		if (!"value2".equals(bar)) {
+			throw new IllegalStateException("bar system property mismatch (got [" + bar + "]");
+		}
+
+		String property1 = System.getProperty("property1");
+		if (!"value1".equals(property1)) {
+			throw new IllegalStateException("property1 system property mismatch (got [" + property1 + "]");
+		}
+
+		String property2 = System.getProperty("property2");
+		if (!"".equals(property2)) {
+			throw new IllegalStateException("property1 system property mismatch (got [" + property2 + "]");
+		}
+
+		System.out.println("I haz been run");
+	}
+
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/run-jvm-system-props/verify.groovy
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/run-jvm-system-props/verify.groovy
@@ -1,0 +1,3 @@
+def file = new File(basedir, "build.log")
+return file.text.contains("I haz been run")
+

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/SystemPropertyFormatterTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/SystemPropertyFormatterTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.maven;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import org.springframework.boot.maven.AbstractRunMojo.SystemPropertyFormatter;
+
+/**
+ * Tests for {@link AbstractRunMojo.SystemPropertyFormatter}
+ */
+public class SystemPropertyFormatterTests {
+
+	@Test
+	public void parseEmpty() throws Exception {
+		Assertions.assertThat(SystemPropertyFormatter.format(null, null))
+				.isEqualTo("");
+	}
+
+	@Test
+	public void parseOnlyKey() throws Exception {
+		Assertions.assertThat(SystemPropertyFormatter.format("key1", null))
+				.isEqualTo("-Dkey1");
+	}
+
+	@Test
+	public void parseKeyWithValue() throws Exception {
+		Assertions.assertThat(SystemPropertyFormatter.format("key1", "value1"))
+				.isEqualTo("-Dkey1=value1");
+	}
+
+	@Test
+	public void parseKeyWithEmptyValue() throws Exception {
+		Assertions.assertThat(SystemPropertyFormatter.format("key1", ""))
+				.isEqualTo("-Dkey1");
+	}
+}


### PR DESCRIPTION
PR #9714 done.
* Added `systemPropertyVariables` configuration tag support for JVM system properties. (like [maven-surefire-plugin](http://maven.apache.org/components/surefire/maven-surefire-plugin/examples/system-properties.html) does).
* Added several unit and integration tests.

Example how to configure `jvmOptions` and `systemPropetries`
```
<plugin>
    <groupId>org.springframework.boot</groupId>
    <artifactId>spring-boot-maven-plugin</artifactId>
    <version>${some-version}</version>
    <executions>
        <execution>
            <configuration>
                <jvmArguments>-Dfoo="value 1" -Dbar=value2</jvmArguments>
                <systemPropertyVariables>
                    <property1>value1</property1>
                    <property2 />
                </systemPropertyVariables>
            </configuration>
        </execution>
    </executions>
</plugin>
```



