### PR TITLE
GitProperties, BuildProperties support unicode string.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/info/ProjectInfoAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/info/ProjectInfoAutoConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.support.EncodedResource;
 import org.springframework.core.io.support.PropertiesLoaderUtils;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
@@ -73,7 +74,7 @@ public class ProjectInfoAutoConfiguration {
 
 	protected Properties loadFrom(Resource location, String prefix) throws IOException {
 		String p = prefix.endsWith(".") ? prefix : prefix + ".";
-		Properties source = PropertiesLoaderUtils.loadProperties(location);
+		Properties source = PropertiesLoaderUtils.loadProperties(new EncodedResource(location, "UTF-8"));
 		Properties target = new Properties();
 		for (String key : source.stringPropertyNames()) {
 			if (key.startsWith(p)) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/info/ProjectInfoAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/info/ProjectInfoAutoConfigurationTests.java
@@ -93,6 +93,13 @@ public class ProjectInfoAutoConfigurationTests {
 	}
 
 	@Test
+	public void gitPropertiesWithUnicode() {
+		load("spring.info.git.location=classpath:/org/springframework/boot/autoconfigure/info/git.properties");
+		GitProperties gitProperties = this.context.getBean(GitProperties.class);
+		assertThat(gitProperties.get("commit.unicode")).isEqualTo("中文");
+	}
+
+	@Test
 	public void buildPropertiesDefaultLocation() {
 		load();
 		BuildProperties buildProperties = this.context.getBean(BuildProperties.class);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/info/git.properties
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/info/git.properties
@@ -2,3 +2,4 @@ git.commit.user.email=john@example.com
 git.commit.id=f95038ec09e29d8f91982fd1cbcc0f3b131b1d0a
 git.commit.user.name=John Smith
 git.commit.time=2016-03-03T10\:02\:00+0100
+git.commit.unicode=中文


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->