### PR TITLE
Handle null early in Sanitizer.sanitize()

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
@@ -81,9 +81,12 @@ public class Sanitizer {
 	 * @return the potentially sanitized value
 	 */
 	public Object sanitize(String key, Object value) {
+		if (value == null) {
+			return null;
+		}
 		for (Pattern pattern : this.keysToSanitize) {
 			if (pattern.matcher(key).matches()) {
-				return (value == null ? null : "******");
+				return "******";
 			}
 		}
 		return value;


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR handles `null` value early in `Sanitizer.sanitize()` to avoid unnecessary `for` loop.