### PR TITLE
Fix typos in AutoConfigureRestDocs

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/AutoConfigureRestDocs.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/AutoConfigureRestDocs.java
@@ -49,7 +49,7 @@ import org.springframework.core.annotation.AliasFor;
 public @interface AutoConfigureRestDocs {
 
 	/**
-	 * The output directory to which generated snippets will be written. A alias for
+	 * The output directory to which generated snippets will be written. An alias for
 	 * {@link #outputDir}.
 	 * @return the output directory
 	 */
@@ -57,7 +57,7 @@ public @interface AutoConfigureRestDocs {
 	String value() default "";
 
 	/**
-	 * The output directory to which generated snippets will be written. A alias for
+	 * The output directory to which generated snippets will be written. An alias for
 	 * {@link #value}.
 	 * @return the output directory
 	 */


### PR DESCRIPTION
Hey,

just noticed two typos in `@AutoConfigureRestDocs`.

Cheers,
Christoph