### PR TITLE
Fix typos in ApplicationArguments and Library

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Library.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Library.java
@@ -71,7 +71,7 @@ public class Library {
 
 	/**
 	 * Return the name of file as it should be written.
-	 * @return then name.
+	 * @return the name
 	 */
 	public String getName() {
 		return this.name;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ApplicationArguments.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ApplicationArguments.java
@@ -34,7 +34,7 @@ public interface ApplicationArguments {
 	String[] getSourceArgs();
 
 	/**
-	 * Return then names of all option arguments. For example, if the arguments were
+	 * Return the names of all option arguments. For example, if the arguments were
 	 * "--foo=bar --debug" would return the values {@code ["foo", "debug"]}.
 	 * @return the option names or an empty set
 	 */


### PR DESCRIPTION
Hey,

noticed two more typos in `ApplicationArguments` and `Library` docs.

Cheers,
Christoph