### PR TITLE
Add support for configuring Spring Session cleanup cron

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java
@@ -67,6 +67,7 @@ class JdbcSessionConfiguration {
 				setMaxInactiveIntervalInSeconds(timeout);
 			}
 			setTableName(jdbcSessionProperties.getTableName());
+			setCleanupCron(jdbcSessionProperties.getCleanupCron());
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionProperties.java
@@ -33,6 +33,8 @@ public class JdbcSessionProperties {
 
 	private static final String DEFAULT_TABLE_NAME = "SPRING_SESSION";
 
+	private static final String DEFAULT_CLEANUP_CRON = "0 * * * * *";
+
 	/**
 	 * Path to the SQL file to use to initialize the database schema.
 	 */
@@ -42,6 +44,11 @@ public class JdbcSessionProperties {
 	 * Name of database table used to store sessions.
 	 */
 	private String tableName = DEFAULT_TABLE_NAME;
+
+	/**
+	 * Cron expression for expired session cleanup job.
+	 */
+	private String cleanupCron = DEFAULT_CLEANUP_CRON;
 
 	/**
 	 * Database schema initialization mode.
@@ -62,6 +69,14 @@ public class JdbcSessionProperties {
 
 	public void setTableName(String tableName) {
 		this.tableName = tableName;
+	}
+
+	public String getCleanupCron() {
+		return this.cleanupCron;
+	}
+
+	public void setCleanupCron(String cleanupCron) {
+		this.cleanupCron = cleanupCron;
 	}
 
 	public DataSourceInitializationMode getInitializeSchema() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionConfiguration.java
@@ -62,6 +62,7 @@ class RedisSessionConfiguration {
 			}
 			setRedisNamespace(redisSessionProperties.getNamespace());
 			setRedisFlushMode(redisSessionProperties.getFlushMode());
+			setCleanupCron(redisSessionProperties.getCleanupCron());
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionProperties.java
@@ -28,6 +28,8 @@ import org.springframework.session.data.redis.RedisFlushMode;
 @ConfigurationProperties(prefix = "spring.session.redis")
 public class RedisSessionProperties {
 
+	private static final String DEFAULT_CLEANUP_CRON = "0 * * * * *";
+
 	/**
 	 * Namespace for keys used to store sessions.
 	 */
@@ -37,6 +39,11 @@ public class RedisSessionProperties {
 	 * Sessions flush mode.
 	 */
 	private RedisFlushMode flushMode = RedisFlushMode.ON_SAVE;
+
+	/**
+	 * Cron expression for expired session cleanup job.
+	 */
+	private String cleanupCron = DEFAULT_CLEANUP_CRON;
 
 	public String getNamespace() {
 		return this.namespace;
@@ -52,6 +59,14 @@ public class RedisSessionProperties {
 
 	public void setFlushMode(RedisFlushMode flushMode) {
 		this.flushMode = flushMode;
+	}
+
+	public String getCleanupCron() {
+		return this.cleanupCron;
+	}
+
+	public void setCleanupCron(String cleanupCron) {
+		this.cleanupCron = cleanupCron;
 	}
 
 }

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -424,6 +424,7 @@ content into your application; rather pick only the properties that you need.
 	spring.session.hazelcast.map-name=spring:session:sessions # Name of the map used to store sessions.
 
 	# SPRING SESSION JDBC ({sc-spring-boot-autoconfigure}/session/JdbcSessionProperties.{sc-ext}[JdbcSessionProperties])
+	spring.session.jdbc.cleanup-cron=0 * * * * * # Cron expression for expired session cleanup job.
 	spring.session.jdbc.initialize-schema=embedded # Database schema initialization mode.
 	spring.session.jdbc.schema=classpath:org/springframework/session/jdbc/schema-@@platform@@.sql # Path to the SQL file to use to initialize the database schema.
 	spring.session.jdbc.table-name=SPRING_SESSION # Name of database table used to store sessions.
@@ -432,6 +433,7 @@ content into your application; rather pick only the properties that you need.
 	spring.session.mongodb.collection-name=sessions # Collection name used to store sessions.
 
 	# SPRING SESSION REDIS ({sc-spring-boot-autoconfigure}/session/RedisSessionProperties.{sc-ext}[RedisSessionProperties])
+	spring.session.redis.cleanup-cron=0 * * * * * # Cron expression for expired session cleanup job.
 	spring.session.redis.flush-mode=on-save # Sessions flush mode.
 	spring.session.redis.namespace= # Namespace for keys used to store sessions.
 


### PR DESCRIPTION
This PR adds support for configuring cron expression used for expired session cleanup job in Redis and JDBC session stores.

The two were recently introduced in Spring Session and will be available with the upcoming `2.0.0.RC1`.

~In order to be able to build this, I've also added a commit that updates Spring Session to current snapshot (see #10817).~