### PR TITLE
AbstractReactiveHealthIndicator does not handle doHealth exceptions

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/AbstractReactiveHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/AbstractReactiveHealthIndicator.java
@@ -29,8 +29,17 @@ public abstract class AbstractReactiveHealthIndicator implements ReactiveHealthI
 
 	@Override
 	public final Mono<Health> health() {
-		return doHealthCheck(new Health.Builder())
-				.onErrorResume((ex) -> Mono.just(new Health.Builder().down(ex).build()));
+		try {
+			return doHealthCheck(new Health.Builder())
+					.onErrorResume(this::handleFailure);
+		}
+		catch (Throwable ex) {
+			return handleFailure(ex);
+		}
+	}
+
+	private Mono<Health> handleFailure(Throwable ex) {
+		return Mono.just(new Health.Builder().down(ex).build());
 	}
 
 	/**


### PR DESCRIPTION
Exceptions inside `AbstractReactiveHealthIndicator.doHealthCheck()`
method, outside of `Mono` pipeline, could fail the whole endpoint
response instead of returning `DOWN` status from the indicator.

This issue could be reproduced with `RedisReactiveHealthIndicator`.
If Redis becomes unavailable,
```java
ReactiveRedisConnection connection = this.connectionFactory.getReactiveConnection();
```
throws `io.lettuce.core.RedisConnectionException` outside of reactive `Mono` pipeline
so `onErrorResume` does not handle it.