### PR TITLE
Fix duplicated 'the' in Quartz scheduler doc section

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -5419,7 +5419,7 @@ Spring Boot offers several conveniences for working with the Quartz scheduler, i
 the `spring-boot-starter-quartz` '`Starter`'. If Quartz is available, a `Scheduler` will
 be auto-configured (via the `SchedulerFactoryBean` abstraction).
 
-Beans of the following types will be automatically picked up and associated with the
+Beans of the following types will be automatically picked up and associated with
 the `Scheduler`:
 
 * `JobDetail`: defines a particular Job. `JobDetail` instance can easily be built with


### PR DESCRIPTION
Hey,

noticed a duplicated "the" in the `spring-boot-features.adoc` section about the Quartz Scheduler.

Cheers,
Christoph