### PR TITLE
Add RestTemplate customizer to log request/response bodies.

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/LoggingCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/LoggingCustomizer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.client;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * {@link RestTemplateCustomizer} that configures the {@link RestTemplate} to log requests
+ * and responses.
+ *
+ * @author Mark Hobson
+ * @since 2.0.0
+ */
+public class LoggingCustomizer implements RestTemplateCustomizer {
+
+	private final Log log;
+
+	public LoggingCustomizer() {
+		this(LogFactory.getLog(LoggingCustomizer.class));
+	}
+
+	public LoggingCustomizer(Log log) {
+		this.log = log;
+	}
+
+	@Override
+	public void customize(RestTemplate restTemplate) {
+		restTemplate.setRequestFactory(
+				new BufferingClientHttpRequestFactory(restTemplate.getRequestFactory()));
+		restTemplate.getInterceptors().add(new LoggingInterceptor(this.log));
+	}
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/LoggingInterceptor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/LoggingInterceptor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.client;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.logging.Log;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.StreamUtils;
+
+/**
+ * {@link ClientHttpRequestInterceptor} that logs request and response bodies.
+ *
+ * @author Mark Hobson
+ * @since 2.0.0
+ */
+public class LoggingInterceptor implements ClientHttpRequestInterceptor {
+
+	private final Log log;
+
+	public LoggingInterceptor(Log log) {
+		this.log = log;
+	}
+
+	@Override
+	public ClientHttpResponse intercept(HttpRequest request, byte[] body,
+			ClientHttpRequestExecution execution) throws IOException {
+		if (this.log.isDebugEnabled()) {
+			this.log.debug(String.format("Request: %s %s %s", request.getMethod(),
+					request.getURI(), new String(body, StandardCharsets.UTF_8)));
+		}
+
+		ClientHttpResponse response = execution.execute(request, body);
+
+		if (this.log.isDebugEnabled()) {
+			this.log.debug(String.format("Response: %s %s", response.getStatusCode().value(),
+					StreamUtils.copyToString(response.getBody(), StandardCharsets.UTF_8)));
+		}
+
+		return response;
+	}
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/LoggingCustomizerTest.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/LoggingCustomizerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.client;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+
+import org.apache.commons.logging.Log;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link LoggingCustomizer}.
+ *
+ * @author Mark Hobson
+ */
+public class LoggingCustomizerTest {
+
+	private LoggingCustomizer loggingCustomizer;
+
+	private RestTemplate restTemplate;
+
+	@Mock
+	private ClientHttpRequestFactory requestFactory;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+
+		Log log = mock(Log.class);
+		given(log.isDebugEnabled()).willReturn(true);
+		this.loggingCustomizer = new LoggingCustomizer(log);
+
+		this.restTemplate = new RestTemplate();
+		this.restTemplate.setRequestFactory(this.requestFactory);
+	}
+
+	@Test
+	public void customizeShouldBufferResponses() throws IOException {
+		MockClientHttpRequest request = new MockClientHttpRequest();
+		MockClientHttpResponse response = new MockClientHttpResponse(
+				singleUseStream("hello".getBytes()), HttpStatus.OK);
+		request.setResponse(response);
+		given(this.requestFactory.createRequest(URI.create("http://example.com"), HttpMethod.GET))
+				.willReturn(request);
+
+		this.loggingCustomizer.customize(this.restTemplate);
+
+		ClientHttpResponse actualResponse = this.restTemplate.getRequestFactory()
+				.createRequest(URI.create("http://example.com"), HttpMethod.GET)
+				.execute();
+		assertThat(actualResponse.getBody())
+				.hasSameContentAs(new ByteArrayInputStream("hello".getBytes()));
+	}
+
+	@Test
+	public void customizeShouldAddLoggingInterceptor() {
+		RestTemplate restTemplate = new RestTemplate();
+
+		this.loggingCustomizer.customize(restTemplate);
+
+		assertThat(restTemplate.getInterceptors())
+				.hasAtLeastOneElementOfType(LoggingInterceptor.class);
+	}
+
+	private static InputStream singleUseStream(byte[] bytes) {
+		return new InputStream() {
+			private int index = 0;
+
+			@Override
+			public int read() {
+				return this.index < bytes.length ? bytes[this.index++] : -1;
+			}
+		};
+	}
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/LoggingInterceptorTest.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/LoggingInterceptorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.client;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.commons.logging.Log;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link LoggingInterceptor}.
+ *
+ * @author Mark Hobson
+ */
+public class LoggingInterceptorTest {
+
+	@Mock
+	private Log log;
+
+	private LoggingInterceptor loggingInterceptor;
+
+	@Mock
+	private ClientHttpRequestExecution execution;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+
+		given(this.log.isDebugEnabled()).willReturn(true);
+
+		this.loggingInterceptor = new LoggingInterceptor(this.log);
+	}
+
+	@Test
+	public void canLogRequest() throws IOException, URISyntaxException {
+		MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.POST,
+				new URI("/hello"));
+		byte[] body = "world".getBytes();
+		given(this.execution.execute(request, body))
+				.willReturn(new MockClientHttpResponse(new byte[0], HttpStatus.OK));
+
+		this.loggingInterceptor.intercept(request, body, this.execution);
+
+		verify(this.log).debug("Request: POST /hello world");
+	}
+
+	@Test
+	public void canLogResponse() throws IOException, URISyntaxException {
+		MockClientHttpRequest request = new MockClientHttpRequest();
+		byte[] body = new byte[0];
+		given(this.execution.execute(request, body))
+				.willReturn(new MockClientHttpResponse("hello".getBytes(), HttpStatus.OK));
+
+		this.loggingInterceptor.intercept(request, body, this.execution);
+
+		verify(this.log).debug("Response: 200 hello");
+	}
+}


### PR DESCRIPTION
It's often useful to be able to log HTTP traffic when using `RestTemplate`. This `RestTemplateCustomizer` configures an interceptor that logs all request and response bodies, taking care of the associated buffering subtleties.