### PR TITLE
Add missing null check in FileSystemWatcher.stopAfter()

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSystemWatcher.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSystemWatcher.java
@@ -193,7 +193,7 @@ public class FileSystemWatcher {
 			}
 			this.watchThread = null;
 		}
-		if (Thread.currentThread() != thread) {
+		if (thread != null && Thread.currentThread() != thread) {
 			try {
 				thread.join();
 			}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
`null` check in `FileSystemWatcher.stopAfter()` looks missed in 71c15cb65e93eec439d3f86ab4b22986b64f4a6b.