### PR TITLE
Make RabbitTemplate exchange and routingKey configurable

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -188,6 +188,9 @@ public class RabbitAutoConfiguration {
 			if (templateProperties.getReplyTimeout() != null) {
 				rabbitTemplate.setReplyTimeout(templateProperties.getReplyTimeout());
 			}
+			rabbitTemplate.setExchange(templateProperties.getExchange());
+			rabbitTemplate.setRoutingKey(templateProperties.getRoutingKey());
+			rabbitTemplate.setChannelTransacted(templateProperties.isChannelTransacted());
 			return rabbitTemplate;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -703,6 +703,21 @@ public class RabbitProperties {
 		 */
 		private Long replyTimeout;
 
+		/**
+		 * Name of the default exchange to use for send operations.
+		 */
+		private String exchange = "";
+
+		/**
+		 * Value of a default routing key to use for send operations.
+		 */
+		private String routingKey = "";
+
+		/**
+		 * Enable transactional channels.
+		 */
+		private boolean channelTransacted;
+
 		public Retry getRetry() {
 			return this.retry;
 		}
@@ -729,6 +744,30 @@ public class RabbitProperties {
 
 		public void setReplyTimeout(Long replyTimeout) {
 			this.replyTimeout = replyTimeout;
+		}
+
+		public String getExchange() {
+			return this.exchange;
+		}
+
+		public void setExchange(String exchange) {
+			this.exchange = exchange;
+		}
+
+		public String getRoutingKey() {
+			return this.routingKey;
+		}
+
+		public void setRoutingKey(String routingKey) {
+			this.routingKey = routingKey;
+		}
+
+		public boolean isChannelTransacted() {
+			return this.channelTransacted;
+		}
+
+		public void setChannelTransacted(boolean channelTransacted) {
+			this.channelTransacted = channelTransacted;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -104,6 +104,21 @@ public class RabbitAutoConfigurationTests {
 	}
 
 	@Test
+	public void testDefaultRabbitTemplateConfiguration() {
+		this.contextRunner.withUserConfiguration(TestConfiguration.class)
+				.run((context) -> {
+					RabbitTemplate rabbitTemplate = context.getBean(RabbitTemplate.class);
+					RabbitTemplate defaultRabbitTemplate = new RabbitTemplate();
+					assertThat(rabbitTemplate.getRoutingKey())
+							.isEqualTo(defaultRabbitTemplate.getRoutingKey());
+					assertThat(rabbitTemplate.getExchange())
+							.isEqualTo(defaultRabbitTemplate.getExchange());
+					assertThat(rabbitTemplate.isChannelTransacted())
+							.isEqualTo(defaultRabbitTemplate.isChannelTransacted());
+				});
+	}
+
+	@Test
 	public void testConnectionFactoryWithOverrides() {
 		this.contextRunner.withUserConfiguration(TestConfiguration.class)
 				.withPropertyValues("spring.rabbitmq.host:remote-server",


### PR DESCRIPTION
This adds three properties to `RabbitProperties.Template` and sets them on the auto-configured `RabbitTemplate` bean. These are the three properties our internal code sets the most and would love to be able to control them via external configuration.

Please let me know if there are any issues.

Thanks for the great work on Spring Boot!