### PR TITLE
support user specified nested jar path like "app.jar!/foo.jar"

### DIFF
--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/PropertiesLauncher.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/PropertiesLauncher.java
@@ -489,6 +489,9 @@ public class PropertiesLauncher extends Launcher {
 	}
 
 	private Archive getArchive(File file) throws IOException {
+		if (!file.exists()) {
+			return null;
+		}
 		String name = file.getName().toLowerCase();
 		if (name.endsWith(".jar") || name.endsWith(".zip")) {
 			return new JarFileArchive(file);

--- a/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/PropertiesLauncherTests.java
+++ b/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/PropertiesLauncherTests.java
@@ -213,6 +213,15 @@ public class PropertiesLauncherTests {
 	}
 
 	@Test
+	public void testUserSpecifiedNestedJarPath() throws Exception {
+		System.setProperty("loader.path", "nested-jars/app.jar!/foo.jar");
+		System.setProperty("loader.main", "demo.Application");
+		PropertiesLauncher launcher = new PropertiesLauncher();
+		List<Archive> archives = launcher.getClassPathArchives();
+		assertThat(archives).hasSize(1).areExactly(1, endingWith("foo.jar!/"));
+	}
+
+	@Test
 	public void testUserSpecifiedDirectoryContainingJarFileWithNestedArchives()
 			throws Exception {
 		System.setProperty("loader.path", "nested-jars");


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
I use `PropertiesLauncher` to launch a subprocess，I want to specify  only some nested sub jar on the classpath, but not the whole parent jar, It's intended to narrow the Classes the subprocess can see for some reason.

I tried something like `-Dloader.path=app.jar!/foo.jar ...`, but `PropertiesLauncher` doesn't support it well. To demonstrate this, I added a test in `PropertiesLauncherTests`. Here is the code:

```java
	@Test
	public void testUserSpecifiedNestedJarPath() throws Exception {
		System.setProperty("loader.path", "nested-jars/app.jar!/foo.jar");
		System.setProperty("loader.main", "demo.Application");
		PropertiesLauncher launcher = new PropertiesLauncher();
		List<Archive> archives = launcher.getClassPathArchives();
		assertThat(archives).hasSize(1).areExactly(1, endingWith("foo.jar!/"));
	}
```

When run this test, We got the exception:

```
$ mvn test -pl spring-boot-tools/spring-boot-loader -Dtest=org.springframework.boot.loader.PropertiesLauncherTests#testUserSpecifiedNestedJarPath
# ... ...
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.springframework.boot.loader.PropertiesLauncherTests
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.071 sec <<< FAILURE! - in org.springframework.boot.loader.PropertiesLauncherTests
testUserSpecifiedNestedJarPath(org.springframework.boot.loader.PropertiesLauncherTests)  Time elapsed: 0.07 sec  <<< ERROR!
java.lang.IllegalArgumentException: File must exist
	at org.springframework.boot.loader.data.RandomAccessDataFile.<init>(RandomAccessDataFile.java:67)
	at org.springframework.boot.loader.data.RandomAccessDataFile.<init>(RandomAccessDataFile.java:51)
	at org.springframework.boot.loader.jar.JarFile.<init>(JarFile.java:83)
	at org.springframework.boot.loader.archive.JarFileArchive.<init>(JarFileArchive.java:61)
	at org.springframework.boot.loader.archive.JarFileArchive.<init>(JarFileArchive.java:57)
	at org.springframework.boot.loader.PropertiesLauncher.getArchive(PropertiesLauncher.java:494)
	at org.springframework.boot.loader.PropertiesLauncher.getClassPathArchives(PropertiesLauncher.java:473)
	at org.springframework.boot.loader.PropertiesLauncher.getClassPathArchives(PropertiesLauncher.java:443)
	at org.springframework.boot.loader.PropertiesLauncherTests.testUserSpecifiedNestedJarPath(PropertiesLauncherTests.java:220)
```

The problem is that `PropertiesLauncher.getArchive(File)` try to wrap `app.jar!/foo.jar` as `JarFileArchive`, but it is not a plain file on the file system(but a nested jar in the parent jar), then a "File must exist" exception occurs. I try to fix this by simply ignore the none exits file, Here is the code:

```java
	private Archive getArchive(File file) throws IOException {
		if (!file.exists()) {
			return null;
		}
		String name = file.getName().toLowerCase();
		if (name.endsWith(".jar") || name.endsWith(".zip")) {
			return new JarFileArchive(file);
		}
		return null;
	}
```
