### PR TITLE
Log throwable on ApplicationFailedEvent

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/RemoteSpringApplication.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/RemoteSpringApplication.java
@@ -16,10 +16,6 @@
 
 package org.springframework.boot.devtools;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import org.springframework.boot.Banner;
 import org.springframework.boot.ResourceBanner;
 import org.springframework.boot.SpringApplication;
@@ -27,6 +23,7 @@ import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.context.config.AnsiOutputApplicationListener;
 import org.springframework.boot.context.config.ConfigFileApplicationListener;
 import org.springframework.boot.context.logging.ClasspathLoggingApplicationListener;
+import org.springframework.boot.context.logging.ExceptionLoggingApplicationListener;
 import org.springframework.boot.context.logging.LoggingApplicationListener;
 import org.springframework.boot.devtools.remote.client.RemoteClientConfiguration;
 import org.springframework.boot.devtools.restart.RestartInitializer;
@@ -35,6 +32,10 @@ import org.springframework.boot.devtools.restart.Restarter;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.io.ClassPathResource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Application that can be used to establish a link to remotely running Spring Boot code.
@@ -74,6 +75,7 @@ public final class RemoteSpringApplication {
 		listeners.add(new AnsiOutputApplicationListener());
 		listeners.add(new ConfigFileApplicationListener());
 		listeners.add(new ClasspathLoggingApplicationListener());
+		listeners.add(new ExceptionLoggingApplicationListener());
 		listeners.add(new LoggingApplicationListener());
 		listeners.add(new RemoteUrlPropertyExtractor());
 		return listeners;

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/RemoteSpringApplication.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/RemoteSpringApplication.java
@@ -16,6 +16,10 @@
 
 package org.springframework.boot.devtools;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import org.springframework.boot.Banner;
 import org.springframework.boot.ResourceBanner;
 import org.springframework.boot.SpringApplication;
@@ -32,10 +36,6 @@ import org.springframework.boot.devtools.restart.Restarter;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.io.ClassPathResource;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 /**
  * Application that can be used to establish a link to remotely running Spring Boot code.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/ExceptionLoggingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/ExceptionLoggingApplicationListener.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.context.logging;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.context.event.ApplicationFailedEvent;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.event.GenericApplicationListener;
+import org.springframework.core.ResolvableType;
+
+/**
+ * A {@link GenericApplicationListener} that reacts to {@link ApplicationFailedEvent failed
+ * events} by logging {@link Throwable} of the event
+ *
+ * @author Kerim Becic
+ * @since 2.0.0
+ */
+public final class ExceptionLoggingApplicationListener implements GenericApplicationListener {
+
+	private static final int ORDER = LoggingApplicationListener.DEFAULT_ORDER + 1;
+
+	private static final Log logger = LogFactory
+			.getLog(ClasspathLoggingApplicationListener.class);
+
+	@Override
+	public void onApplicationEvent(ApplicationEvent event) {
+		if (logger.isDebugEnabled()) {
+			if (event instanceof ApplicationFailedEvent) {
+				logger.debug("Application failed to start: ",
+						((ApplicationFailedEvent) event).getException());
+			}
+		}
+	}
+
+	@Override
+	public int getOrder() {
+		return ORDER;
+	}
+
+	@Override
+	public boolean supportsEventType(ResolvableType resolvableType) {
+		Class<?> type = resolvableType.getRawClass();
+		if (type == null) {
+			return false;
+		}
+		return ApplicationFailedEvent.class.isAssignableFrom(type);
+	}
+
+	@Override
+	public boolean supportsSourceType(Class<?> sourceType) {
+		return true;
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/ExceptionLoggingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/ExceptionLoggingApplicationListener.java
@@ -18,19 +18,21 @@ package org.springframework.boot.context.logging;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.boot.context.event.ApplicationFailedEvent;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.event.GenericApplicationListener;
 import org.springframework.core.ResolvableType;
 
 /**
- * A {@link GenericApplicationListener} that reacts to {@link ApplicationFailedEvent failed
- * events} by logging {@link Throwable} of the event
+ * A {@link GenericApplicationListener} that reacts to {@link ApplicationFailedEvent
+ * failed events} by logging {@link Throwable} of the event.
  *
  * @author Kerim Becic
  * @since 2.0.0
  */
-public final class ExceptionLoggingApplicationListener implements GenericApplicationListener {
+public final class ExceptionLoggingApplicationListener
+		implements GenericApplicationListener {
 
 	private static final int ORDER = LoggingApplicationListener.DEFAULT_ORDER + 1;
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/ExceptionLoggingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/ExceptionLoggingApplicationListener.java
@@ -35,7 +35,7 @@ public final class ExceptionLoggingApplicationListener implements GenericApplica
 	private static final int ORDER = LoggingApplicationListener.DEFAULT_ORDER + 1;
 
 	private static final Log logger = LogFactory
-			.getLog(ClasspathLoggingApplicationListener.class);
+			.getLog(ExceptionLoggingApplicationListener.class);
 
 	@Override
 	public void onApplicationEvent(ApplicationEvent event) {

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/spring.factories
@@ -27,6 +27,7 @@ org.springframework.boot.context.config.AnsiOutputApplicationListener,\
 org.springframework.boot.context.config.ConfigFileApplicationListener,\
 org.springframework.boot.context.config.DelegatingApplicationListener,\
 org.springframework.boot.context.logging.ClasspathLoggingApplicationListener,\
+org.springframework.boot.context.logging.ExceptionLoggingApplicationListener,\
 org.springframework.boot.context.logging.LoggingApplicationListener,\
 org.springframework.boot.liquibase.LiquibaseServiceLocatorApplicationListener
 


### PR DESCRIPTION
When `ApplicationFailedEvent` happens currently only Classpath is logged by `ClasspathLoggingApplicationListener`. 
Added logging of `Throwable` that caused `ApplicationFailedEvent`.