### PR TITLE
Use StandardCharsets where possible

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/MessageSourceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/MessageSourceProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.context;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Configuration properties for Message Source.
@@ -37,7 +38,7 @@ public class MessageSourceProperties {
 	/**
 	 * Message bundles encoding.
 	 */
-	private Charset encoding = Charset.forName("UTF-8");
+	private Charset encoding = StandardCharsets.UTF_8;
 
 	/**
 	 * Loaded resource bundle files cache expiration, in seconds. When set to -1, bundles

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/HttpEncodingProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/HttpEncodingProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.http;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Map;
 
@@ -32,7 +33,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "spring.http.encoding")
 public class HttpEncodingProperties {
 
-	public static final Charset DEFAULT_CHARSET = Charset.forName("UTF-8");
+	public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
 	/**
 	 * Charset of HTTP requests and responses. Added to the "Content-Type" header if not

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mail/MailProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mail/MailProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.mail;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,7 +34,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "spring.mail")
 public class MailProperties {
 
-	private static final Charset DEFAULT_CHARSET = Charset.forName("UTF-8");
+	private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
 	/**
 	 * SMTP server host.

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/template/AbstractViewResolverProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/template/AbstractViewResolverProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.template;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -36,7 +37,7 @@ public abstract class AbstractViewResolverProperties {
 
 	private static final MimeType DEFAULT_CONTENT_TYPE = MimeType.valueOf("text/html");
 
-	private static final Charset DEFAULT_CHARSET = Charset.forName("UTF-8");
+	private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
 	/**
 	 * Enable MVC view resolution for this technology.

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.thymeleaf;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -34,7 +35,7 @@ import org.springframework.util.MimeType;
 @ConfigurationProperties(prefix = "spring.thymeleaf")
 public class ThymeleafProperties {
 
-	private static final Charset DEFAULT_ENCODING = Charset.forName("UTF-8");
+	private static final Charset DEFAULT_ENCODING = StandardCharsets.UTF_8;
 
 	public static final String DEFAULT_PREFIX = "classpath:/templates/";
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/template/ViewResolverPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/template/ViewResolverPropertiesTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.autoconfigure.template;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
@@ -47,7 +47,7 @@ public class ViewResolverPropertiesTests {
 	@Test
 	public void defaultContentTypeCustomCharset() {
 		ViewResolverProperties properties = new ViewResolverProperties();
-		properties.setCharset(Charset.forName("UTF-16"));
+		properties.setCharset(StandardCharsets.UTF_16);
 		assertThat(properties.getContentType()).hasToString("text/html;charset=UTF-16");
 	}
 
@@ -55,7 +55,7 @@ public class ViewResolverPropertiesTests {
 	public void customContentTypeCustomCharset() {
 		ViewResolverProperties properties = new ViewResolverProperties();
 		properties.setContentType(MimeTypeUtils.parseMimeType("text/plain"));
-		properties.setCharset(Charset.forName("UTF-16"));
+		properties.setCharset(StandardCharsets.UTF_16);
 		assertThat(properties.getContentType()).hasToString("text/plain;charset=UTF-16");
 	}
 
@@ -63,7 +63,7 @@ public class ViewResolverPropertiesTests {
 	public void customContentTypeWithPropertyAndCustomCharset() {
 		ViewResolverProperties properties = new ViewResolverProperties();
 		properties.setContentType(MimeTypeUtils.parseMimeType("text/plain;foo=bar"));
-		properties.setCharset(Charset.forName("UTF-16"));
+		properties.setCharset(StandardCharsets.UTF_16);
 		assertThat(properties.getContentType())
 				.hasToString("text/plain;charset=UTF-16;foo=bar");
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/fieldvalues/javac/JavaCompilerFieldValuesParser.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/fieldvalues/javac/JavaCompilerFieldValuesParser.java
@@ -94,6 +94,10 @@ public class JavaCompilerFieldValuesParser implements FieldValuesParser {
 			Map<String, Object> values = new HashMap<>();
 			values.put("Boolean.TRUE", true);
 			values.put("Boolean.FALSE", false);
+			values.put("StandardCharsets.ISO_8859_1", "ISO-8859-1");
+			values.put("StandardCharsets.UTF_8", "UTF-8");
+			values.put("StandardCharsets.UTF_16", "UTF-16");
+			values.put("StandardCharsets.US_ASCII", "US-ASCII");
 			wellKnownStaticFinals = Collections.unmodifiableMap(values);
 		}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/fieldvalues/FieldValues.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/fieldvalues/FieldValues.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.configurationsample.fieldvalues;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.springframework.boot.configurationsample.ConfigurationProperties;
 import org.springframework.util.MimeType;
@@ -41,7 +42,7 @@ public class FieldValues {
 
 	private static final Integer INTEGER_OBJ_CONST = 4;
 
-	private static final Charset DEFAULT_CHARSET = Charset.forName("UTF-8");
+	private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
 	private static final MimeType DEFAULT_MIME_TYPE = MimeType.valueOf("text/plain");
 
@@ -77,7 +78,7 @@ public class FieldValues {
 
 	private Integer integerObjectConst = INTEGER_OBJ_CONST;
 
-	private Charset charset = Charset.forName("US-ASCII");
+	private Charset charset = StandardCharsets.US_ASCII;
 
 	private Charset charsetConst = DEFAULT_CHARSET;
 


### PR DESCRIPTION
Hi,

this PR replaces `Charset.forName(...)` with its StandardCharsets counterparts if possible,

Cheers,
Christoph