### PR TITLE
Improve Spring Session auto-configuration tests

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/AbstractSessionAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/AbstractSessionAutoConfigurationTests.java
@@ -21,11 +21,13 @@ import org.springframework.boot.test.context.assertj.AssertableReactiveWebApplic
 import org.springframework.boot.test.context.assertj.AssertableWebApplicationContext;
 import org.springframework.session.ReactiveSessionRepository;
 import org.springframework.session.SessionRepository;
+import org.springframework.session.web.http.SessionRepositoryFilter;
+import org.springframework.web.server.session.WebSessionManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Share test utilities for {@link SessionAutoConfiguration} tests.
+ * Shared test utilities for {@link SessionAutoConfiguration} tests.
  *
  * @author Stephane Nicoll
  */
@@ -33,6 +35,7 @@ public abstract class AbstractSessionAutoConfigurationTests {
 
 	protected <T extends SessionRepository<?>> T validateSessionRepository(
 			AssertableWebApplicationContext context, Class<T> type) {
+		assertThat(context).hasSingleBean(SessionRepositoryFilter.class);
 		assertThat(context).hasSingleBean(SessionRepository.class);
 		SessionRepository<?> repository = context.getBean(SessionRepository.class);
 		assertThat(repository).as("Wrong session repository type").isInstanceOf(type);
@@ -46,6 +49,7 @@ public abstract class AbstractSessionAutoConfigurationTests {
 
 	protected <T extends ReactiveSessionRepository<?>> T validateSessionRepository(
 			AssertableReactiveWebApplicationContext context, Class<T> type) {
+		assertThat(context).hasSingleBean(WebSessionManager.class);
 		assertThat(context).hasSingleBean(ReactiveSessionRepository.class);
 		ReactiveSessionRepository<?> repository = context
 				.getBean(ReactiveSessionRepository.class);


### PR DESCRIPTION
While putting together a sample Spring Session WebFlux app (see #11055), I've ran into spring-projects/spring-session-data-mongodb#19 - this should have arguably been picked up in Spring Session auto-configuration tests.

IMO it would be reasonable to improve session repository validation to include a check for `SessionRepositoryFilter` bean in Servlet-based app, or `WebSessionManager` bean in reactive app.

I've added that change in this PR. This caused all of `ReactiveSessionAutoConfigurationMongoTests` to fail, as expected, until spring-projects/spring-session-data-mongodb#19 is fixed. But the change also causes `SessionAutoConfigurationJdbcTests#defaultConfigWithUniqueStoreImplementation` and `SessionAutoConfigurationHazelcastTests#defaultConfigWithUniqueStoreImplementation` - I haven't figured out why yet. Here are the details:

```
-------------------------------------------------------------------------------
Test set: org.springframework.boot.autoconfigure.session.SessionAutoConfigurationJdbcTests
-------------------------------------------------------------------------------
Tests run: 6, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.103 s <<< FAILURE! - in org.springframework.boot.autoconfigure.session.SessionAutoConfigurationJdbcTests
defaultConfigWithUniqueStoreImplementation(org.springframework.boot.autoconfigure.session.SessionAutoConfigurationJdbcTests)  Time elapsed: 0.219 s  <<< FAILURE!
java.lang.AssertionError: 

Expecting:
 <Started application org.springframework.web.context.support.AnnotationConfigWebApplicationContext@534a0b5e[id=org.springframework.web.context.support.AnnotationConfigWebApplicationContext@534a0b5e,applicationName=,beanDefinitionCount=51]>
to have a single bean of type:
 <org.springframework.session.web.http.SessionRepositoryFilter>
but found no beans of that type
	at org.springframework.boot.autoconfigure.session.AbstractSessionAutoConfigurationTests.validateSessionRepository(AbstractSessionAutoConfigurationTests.java:38)
	at org.springframework.boot.autoconfigure.session.SessionAutoConfigurationJdbcTests.validateDefaultConfig(SessionAutoConfigurationJdbcTests.java:78)
	at org.springframework.boot.test.context.runner.AbstractApplicationContextRunner.accept(AbstractApplicationContextRunner.java:292)
	at org.springframework.boot.test.context.runner.AbstractApplicationContextRunner.lambda$run$0(AbstractApplicationContextRunner.java:245)
	at org.springframework.boot.test.util.TestPropertyValues.applyToSystemProperties(TestPropertyValues.java:130)
	at org.springframework.boot.test.context.runner.AbstractApplicationContextRunner.run(AbstractApplicationContextRunner.java:243)
	at org.springframework.boot.autoconfigure.session.SessionAutoConfigurationJdbcTests.defaultConfigWithUniqueStoreImplementation(SessionAutoConfigurationJdbcTests.java:74)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.rules.ExpectedException$ExpectedExceptionStatement.evaluate(ExpectedException.java:239)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:369)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:275)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:239)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:160)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:373)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:334)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:119)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:407)
```

```
-------------------------------------------------------------------------------
Test set: org.springframework.boot.autoconfigure.session.SessionAutoConfigurationHazelcastTests
-------------------------------------------------------------------------------
Tests run: 4, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.482 s <<< FAILURE! - in org.springframework.boot.autoconfigure.session.SessionAutoConfigurationHazelcastTests
defaultConfigWithUniqueStoreImplementation(org.springframework.boot.autoconfigure.session.SessionAutoConfigurationHazelcastTests)  Time elapsed: 0.071 s  <<< FAILURE!
java.lang.AssertionError: 

Expecting:
 <Started application org.springframework.web.context.support.AnnotationConfigWebApplicationContext@49e3330c[id=org.springframework.web.context.support.AnnotationConfigWebApplicationContext@49e3330c,applicationName=,beanDefinitionCount=22]>
to have a single bean of type:
 <org.springframework.session.web.http.SessionRepositoryFilter>
but found no beans of that type
	at org.springframework.boot.autoconfigure.session.AbstractSessionAutoConfigurationTests.validateSessionRepository(AbstractSessionAutoConfigurationTests.java:38)
	at org.springframework.boot.autoconfigure.session.SessionAutoConfigurationHazelcastTests.validateDefaultConfig(SessionAutoConfigurationHazelcastTests.java:71)
	at org.springframework.boot.test.context.runner.AbstractApplicationContextRunner.accept(AbstractApplicationContextRunner.java:292)
	at org.springframework.boot.test.context.runner.AbstractApplicationContextRunner.lambda$run$0(AbstractApplicationContextRunner.java:245)
	at org.springframework.boot.test.util.TestPropertyValues.applyToSystemProperties(TestPropertyValues.java:130)
	at org.springframework.boot.test.context.runner.AbstractApplicationContextRunner.run(AbstractApplicationContextRunner.java:243)
	at org.springframework.boot.autoconfigure.session.SessionAutoConfigurationHazelcastTests.defaultConfigWithUniqueStoreImplementation(SessionAutoConfigurationHazelcastTests.java:67)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:369)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:275)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:239)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:160)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:373)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:334)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:119)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:407)
```