### PR TITLE
Consider @Primary annotation when using @MockBean, make @MockBean/@SpyBean behave consistently

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/Definition.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/Definition.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.test.mock.mockito;
 
+import org.springframework.core.ResolvableType;
+import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -36,12 +38,16 @@ abstract class Definition {
 
 	private final QualifierDefinition qualifier;
 
+	private final ResolvableType type;
+
 	Definition(String name, MockReset reset, boolean proxyTargetAware,
-			QualifierDefinition qualifier) {
+			QualifierDefinition qualifier, ResolvableType type) {
+		Assert.notNull(type, "type must not be null");
 		this.name = name;
 		this.reset = (reset != null ? reset : MockReset.AFTER);
 		this.proxyTargetAware = proxyTargetAware;
 		this.qualifier = qualifier;
+		this.type = type;
 	}
 
 	/**
@@ -76,6 +82,14 @@ abstract class Definition {
 		return this.qualifier;
 	}
 
+	/**
+	 * Get type to mock or spy.
+	 * @return the type; never {@code null}
+	 */
+	public ResolvableType getType() {
+		return this.type;
+	}
+
 	@Override
 	public int hashCode() {
 		int result = 1;
@@ -84,6 +98,7 @@ abstract class Definition {
 		result = MULTIPLIER * result
 				+ ObjectUtils.nullSafeHashCode(this.proxyTargetAware);
 		result = MULTIPLIER * result + ObjectUtils.nullSafeHashCode(this.qualifier);
+		result = MULTIPLIER * result + ObjectUtils.nullSafeHashCode(this.type);
 		return result;
 	}
 
@@ -102,6 +117,7 @@ abstract class Definition {
 		result = result && ObjectUtils.nullSafeEquals(this.proxyTargetAware,
 				other.proxyTargetAware);
 		result = result && ObjectUtils.nullSafeEquals(this.qualifier, other.qualifier);
+		result = result && ObjectUtils.nullSafeEquals(this.type, other.type);
 		return result;
 	}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
@@ -27,7 +27,6 @@ import org.mockito.Mockito;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.style.ToStringCreator;
-import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
@@ -40,8 +40,6 @@ class MockDefinition extends Definition {
 
 	private static final int MULTIPLIER = 31;
 
-	private final ResolvableType typeToMock;
-
 	private final Set<Class<?>> extraInterfaces;
 
 	private final Answers answer;
@@ -51,9 +49,7 @@ class MockDefinition extends Definition {
 	MockDefinition(String name, ResolvableType typeToMock, Class<?>[] extraInterfaces,
 			Answers answer, boolean serializable, MockReset reset,
 			QualifierDefinition qualifier) {
-		super(name, reset, false, qualifier);
-		Assert.notNull(typeToMock, "TypeToMock must not be null");
-		this.typeToMock = typeToMock;
+		super(name, reset, false, qualifier, typeToMock);
 		this.extraInterfaces = asClassSet(extraInterfaces);
 		this.answer = (answer != null ? answer : Answers.RETURNS_DEFAULTS);
 		this.serializable = serializable;
@@ -72,7 +68,7 @@ class MockDefinition extends Definition {
 	 * @return the type to mock; never {@code null}
 	 */
 	public ResolvableType getTypeToMock() {
-		return this.typeToMock;
+		return super.getType();
 	}
 
 	/**
@@ -102,7 +98,6 @@ class MockDefinition extends Definition {
 	@Override
 	public int hashCode() {
 		int result = super.hashCode();
-		result = MULTIPLIER * result + ObjectUtils.nullSafeHashCode(this.typeToMock);
 		result = MULTIPLIER * result + ObjectUtils.nullSafeHashCode(this.extraInterfaces);
 		result = MULTIPLIER * result + ObjectUtils.nullSafeHashCode(this.answer);
 		result = MULTIPLIER * result + Boolean.hashCode(this.serializable);
@@ -119,7 +114,6 @@ class MockDefinition extends Definition {
 		}
 		MockDefinition other = (MockDefinition) obj;
 		boolean result = super.equals(obj);
-		result = result && ObjectUtils.nullSafeEquals(this.typeToMock, other.typeToMock);
 		result = result && ObjectUtils.nullSafeEquals(this.extraInterfaces,
 				other.extraInterfaces);
 		result = result && ObjectUtils.nullSafeEquals(this.answer, other.answer);
@@ -130,7 +124,7 @@ class MockDefinition extends Definition {
 	@Override
 	public String toString() {
 		return new ToStringCreator(this).append("name", getName())
-				.append("typeToMock", this.typeToMock)
+				.append("typeToMock", super.getType())
 				.append("extraInterfaces", this.extraInterfaces)
 				.append("answer", this.answer).append("serializable", this.serializable)
 				.append("reset", getReset()).toString();
@@ -153,7 +147,7 @@ class MockDefinition extends Definition {
 		if (this.serializable) {
 			settings.serializable();
 		}
-		return (T) Mockito.mock(this.typeToMock.resolve(), settings);
+		return (T) Mockito.mock(this.getTypeToMock().resolve(), settings);
 	}
 
 }

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoBeanNameFinder.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoBeanNameFinder.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.mock.mockito;
+
+import org.springframework.aop.scope.ScopedProxyUtils;
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
+import org.springframework.beans.factory.support.DefaultBeanNameGenerator;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.core.ResolvableType;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Encapsulates the task to find the bean name which can be mocked or spied.
+ * Offers {@link MockitoBeanNameFinder#getOrGenerateBeanName} for that purpose.
+ * Used by {@link MockitoPostProcessor}.
+ *
+ * @author Andreas Neiser
+ */
+class MockitoBeanNameFinder {
+
+	private MockitoBeanNameFinder() {
+		// only static method calls
+	}
+
+    private static final String FACTORY_BEAN_OBJECT_TYPE = "factoryBeanObjectType";
+
+    private static final BeanNameGenerator BEAN_NAME_GENERATOR = new DefaultBeanNameGenerator();
+
+    static String getOrGenerateBeanName(ConfigurableListableBeanFactory beanFactory,
+											   BeanDefinitionRegistry registry, Definition definition,
+											   RootBeanDefinition beanDefinition) {
+        Set<String> existingBeans = findCandidateBeans(beanFactory, definition);
+        if (existingBeans.isEmpty()) {
+            return BEAN_NAME_GENERATOR.generateBeanName(beanDefinition, registry);
+        }
+        return getBeanName(registry, existingBeans, definition);
+    }
+
+    private static String getBeanName(BeanDefinitionRegistry registry,
+                               Set<String> existingBeanNames, Definition definition) {
+        if (StringUtils.hasText(definition.getName())) {
+            return definition.getName();
+        }
+        if (existingBeanNames.size() == 1) {
+            return existingBeanNames.iterator().next();
+        }
+        String beanName = findPrimaryBeanName(registry, existingBeanNames,
+                definition.getType());
+        if (beanName == null) {
+            throw new IllegalStateException("Unable to register bean "
+                    + definition.getType()
+                    + " expected a single matching/primary bean to replace but found "
+                    + existingBeanNames);
+        }
+        return beanName;
+    }
+
+    @Nullable
+    private static String findPrimaryBeanName(BeanDefinitionRegistry registry,
+                                       Set<String> existingBeanNames, ResolvableType type) {
+        String primaryBeanName = null;
+        for (String existingBeanName : existingBeanNames) {
+            BeanDefinition beanDefinition = registry.getBeanDefinition(existingBeanName);
+            if (beanDefinition.isPrimary()) {
+                if (primaryBeanName != null) {
+                    throw new NoUniqueBeanDefinitionException(type.resolve(),
+                            existingBeanNames.size(),
+                            "more than one 'primary' bean found among candidates: "
+                                    + existingBeanNames);
+                }
+                primaryBeanName = existingBeanName;
+            }
+        }
+        return primaryBeanName;
+    }
+
+    private static Set<String> findCandidateBeans(ConfigurableListableBeanFactory beanFactory,
+                                           Definition definition) {
+        QualifierDefinition qualifier = definition.getQualifier();
+        Set<String> candidates = new TreeSet<>();
+        for (String candidate : getExistingBeans(beanFactory, definition.getType())) {
+            if (qualifier == null || qualifier.matches(beanFactory, candidate)) {
+                candidates.add(candidate);
+            }
+        }
+        return candidates;
+    }
+
+    private static Set<String> getExistingBeans(ConfigurableListableBeanFactory beanFactory,
+                                         ResolvableType type) {
+        Set<String> beans = new LinkedHashSet<>(
+                Arrays.asList(beanFactory.getBeanNamesForType(type)));
+        String resolvedTypeName = type.resolve(Object.class).getName();
+        for (String beanName : beanFactory.getBeanNamesForType(FactoryBean.class)) {
+            beanName = BeanFactoryUtils.transformedBeanName(beanName);
+            BeanDefinition beanDefinition = beanFactory.getBeanDefinition(beanName);
+            if (resolvedTypeName
+                    .equals(beanDefinition.getAttribute(FACTORY_BEAN_OBJECT_TYPE))) {
+                beans.add(beanName);
+            }
+        }
+        beans.removeIf(ScopedProxyUtils::isScopedTarget);
+        return beans;
+    }
+}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoBeanNameFinder.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoBeanNameFinder.java
@@ -36,9 +36,9 @@ import java.util.Set;
 import java.util.TreeSet;
 
 /**
- * Encapsulates the task to find the bean name which can be mocked or spied.
- * Offers {@link MockitoBeanNameFinder#getOrGenerateBeanName} for that purpose.
- * Used by {@link MockitoPostProcessor}.
+ * Encapsulates the task to find the bean name which can be mocked or spied. Offers
+ * {@link MockitoBeanNameFinder#getOrGenerateBeanName} for that purpose. Used by
+ * {@link MockitoPostProcessor}.
  *
  * @author Andreas Neiser
  */
@@ -48,84 +48,84 @@ class MockitoBeanNameFinder {
 		// only static method calls
 	}
 
-    private static final String FACTORY_BEAN_OBJECT_TYPE = "factoryBeanObjectType";
+	private static final String FACTORY_BEAN_OBJECT_TYPE = "factoryBeanObjectType";
 
-    private static final BeanNameGenerator BEAN_NAME_GENERATOR = new DefaultBeanNameGenerator();
+	private static final BeanNameGenerator BEAN_NAME_GENERATOR = new DefaultBeanNameGenerator();
 
-    static String getOrGenerateBeanName(ConfigurableListableBeanFactory beanFactory,
-											   BeanDefinitionRegistry registry, Definition definition,
-											   RootBeanDefinition beanDefinition) {
-        Set<String> existingBeans = findCandidateBeans(beanFactory, definition);
-        if (existingBeans.isEmpty()) {
-            return BEAN_NAME_GENERATOR.generateBeanName(beanDefinition, registry);
-        }
-        return getBeanName(registry, existingBeans, definition);
-    }
+	static String getOrGenerateBeanName(ConfigurableListableBeanFactory beanFactory,
+			BeanDefinitionRegistry registry, Definition definition,
+			RootBeanDefinition beanDefinition) {
+		Set<String> existingBeans = findCandidateBeans(beanFactory, definition);
+		if (existingBeans.isEmpty()) {
+			return BEAN_NAME_GENERATOR.generateBeanName(beanDefinition, registry);
+		}
+		return getBeanName(registry, existingBeans, definition);
+	}
 
-    private static String getBeanName(BeanDefinitionRegistry registry,
-                               Set<String> existingBeanNames, Definition definition) {
-        if (StringUtils.hasText(definition.getName())) {
-            return definition.getName();
-        }
-        if (existingBeanNames.size() == 1) {
-            return existingBeanNames.iterator().next();
-        }
-        String beanName = findPrimaryBeanName(registry, existingBeanNames,
-                definition.getType());
-        if (beanName == null) {
-            throw new IllegalStateException("Unable to register bean "
-                    + definition.getType()
-                    + " expected a single matching/primary bean to replace but found "
-                    + existingBeanNames);
-        }
-        return beanName;
-    }
+	private static String getBeanName(BeanDefinitionRegistry registry,
+			Set<String> existingBeanNames, Definition definition) {
+		if (StringUtils.hasText(definition.getName())) {
+			return definition.getName();
+		}
+		if (existingBeanNames.size() == 1) {
+			return existingBeanNames.iterator().next();
+		}
+		String beanName = findPrimaryBeanName(registry, existingBeanNames,
+				definition.getType());
+		if (beanName == null) {
+			throw new IllegalStateException("Unable to register bean "
+					+ definition.getType()
+					+ " expected a single matching/primary bean to replace but found "
+					+ existingBeanNames);
+		}
+		return beanName;
+	}
 
-    @Nullable
-    private static String findPrimaryBeanName(BeanDefinitionRegistry registry,
-                                       Set<String> existingBeanNames, ResolvableType type) {
-        String primaryBeanName = null;
-        for (String existingBeanName : existingBeanNames) {
-            BeanDefinition beanDefinition = registry.getBeanDefinition(existingBeanName);
-            if (beanDefinition.isPrimary()) {
-                if (primaryBeanName != null) {
-                    throw new NoUniqueBeanDefinitionException(type.resolve(),
-                            existingBeanNames.size(),
-                            "more than one 'primary' bean found among candidates: "
-                                    + existingBeanNames);
-                }
-                primaryBeanName = existingBeanName;
-            }
-        }
-        return primaryBeanName;
-    }
+	@Nullable
+	private static String findPrimaryBeanName(BeanDefinitionRegistry registry,
+			Set<String> existingBeanNames, ResolvableType type) {
+		String primaryBeanName = null;
+		for (String existingBeanName : existingBeanNames) {
+			BeanDefinition beanDefinition = registry.getBeanDefinition(existingBeanName);
+			if (beanDefinition.isPrimary()) {
+				if (primaryBeanName != null) {
+					throw new NoUniqueBeanDefinitionException(type.resolve(),
+							existingBeanNames.size(),
+							"more than one 'primary' bean found among candidates: "
+									+ existingBeanNames);
+				}
+				primaryBeanName = existingBeanName;
+			}
+		}
+		return primaryBeanName;
+	}
 
-    private static Set<String> findCandidateBeans(ConfigurableListableBeanFactory beanFactory,
-                                           Definition definition) {
-        QualifierDefinition qualifier = definition.getQualifier();
-        Set<String> candidates = new TreeSet<>();
-        for (String candidate : getExistingBeans(beanFactory, definition.getType())) {
-            if (qualifier == null || qualifier.matches(beanFactory, candidate)) {
-                candidates.add(candidate);
-            }
-        }
-        return candidates;
-    }
+	private static Set<String> findCandidateBeans(
+			ConfigurableListableBeanFactory beanFactory, Definition definition) {
+		QualifierDefinition qualifier = definition.getQualifier();
+		Set<String> candidates = new TreeSet<>();
+		for (String candidate : getExistingBeans(beanFactory, definition.getType())) {
+			if (qualifier == null || qualifier.matches(beanFactory, candidate)) {
+				candidates.add(candidate);
+			}
+		}
+		return candidates;
+	}
 
-    private static Set<String> getExistingBeans(ConfigurableListableBeanFactory beanFactory,
-                                         ResolvableType type) {
-        Set<String> beans = new LinkedHashSet<>(
-                Arrays.asList(beanFactory.getBeanNamesForType(type)));
-        String resolvedTypeName = type.resolve(Object.class).getName();
-        for (String beanName : beanFactory.getBeanNamesForType(FactoryBean.class)) {
-            beanName = BeanFactoryUtils.transformedBeanName(beanName);
-            BeanDefinition beanDefinition = beanFactory.getBeanDefinition(beanName);
-            if (resolvedTypeName
-                    .equals(beanDefinition.getAttribute(FACTORY_BEAN_OBJECT_TYPE))) {
-                beans.add(beanName);
-            }
-        }
-        beans.removeIf(ScopedProxyUtils::isScopedTarget);
-        return beans;
-    }
+	private static Set<String> getExistingBeans(
+			ConfigurableListableBeanFactory beanFactory, ResolvableType type) {
+		Set<String> beans = new LinkedHashSet<>(
+				Arrays.asList(beanFactory.getBeanNamesForType(type)));
+		String resolvedTypeName = type.resolve(Object.class).getName();
+		for (String beanName : beanFactory.getBeanNamesForType(FactoryBean.class)) {
+			beanName = BeanFactoryUtils.transformedBeanName(beanName);
+			BeanDefinition beanDefinition = beanFactory.getBeanDefinition(beanName);
+			if (resolvedTypeName
+					.equals(beanDefinition.getAttribute(FACTORY_BEAN_OBJECT_TYPE))) {
+				beans.add(beanName);
+			}
+		}
+		beans.removeIf(ScopedProxyUtils::isScopedTarget);
+		return beans;
+	}
 }

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoBeanNameFinder.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoBeanNameFinder.java
@@ -16,6 +16,13 @@
 
 package org.springframework.boot.test.mock.mockito;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.annotation.Nullable;
+
 import org.springframework.aop.scope.ScopedProxyUtils;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.FactoryBean;
@@ -29,12 +36,6 @@ import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.core.ResolvableType;
 import org.springframework.util.StringUtils;
 
-import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.TreeSet;
-
 /**
  * Encapsulates the task to find the bean name which can be mocked or spied. Offers
  * {@link MockitoBeanNameFinder#getOrGenerateBeanName} for that purpose. Used by
@@ -42,7 +43,7 @@ import java.util.TreeSet;
  *
  * @author Andreas Neiser
  */
-class MockitoBeanNameFinder {
+final class MockitoBeanNameFinder {
 
 	private MockitoBeanNameFinder() {
 		// only static method calls

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -363,7 +363,7 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 	@Override
 	public PropertyValues postProcessPropertyValues(PropertyValues pvs,
 			PropertyDescriptor[] pds, final Object bean, String beanName)
-					throws BeansException {
+			throws BeansException {
 		ReflectionUtils.doWithFields(bean.getClass(),
 				(field) -> postProcessField(bean, field));
 		return pvs;

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -170,8 +170,8 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 			BeanDefinitionRegistry registry, MockDefinition definition, Field field) {
 		RootBeanDefinition beanDefinition = createBeanDefinition(definition);
 
-		String beanName = MockitoBeanNameFinder.getOrGenerateBeanName(beanFactory, registry, definition,
-				beanDefinition);
+		String beanName = MockitoBeanNameFinder.getOrGenerateBeanName(beanFactory,
+				registry, definition, beanDefinition);
 		String transformedBeanName = BeanFactoryUtils.transformedBeanName(beanName);
 
 		if (registry.containsBeanDefinition(transformedBeanName)) {
@@ -218,20 +218,20 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 	}
 
 	private void registerSpy(ConfigurableListableBeanFactory beanFactory,
-							 BeanDefinitionRegistry registry, SpyDefinition definition, Field field) {
+			BeanDefinitionRegistry registry, SpyDefinition definition, Field field) {
 
 		RootBeanDefinition beanDefinition = new RootBeanDefinition(
 				definition.getTypeToSpy().resolve());
 
-		String beanName = MockitoBeanNameFinder.getOrGenerateBeanName(beanFactory, registry, definition,
-				beanDefinition);
+		String beanName = MockitoBeanNameFinder.getOrGenerateBeanName(beanFactory,
+				registry, definition, beanDefinition);
 		String transformedBeanName = BeanFactoryUtils.transformedBeanName(beanName);
 
 		// as spy beans need the complete original bean, we can only
 		// create the the spy bean if there's nothing to be replaced
 		// it will be created via a callback to createSpyIfNecessary from the
 		// SpyPostProcessor
-		if(!registry.containsBeanDefinition(transformedBeanName)) {
+		if (!registry.containsBeanDefinition(transformedBeanName)) {
 			registry.registerBeanDefinition(beanName, beanDefinition);
 		}
 
@@ -426,5 +426,3 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 	}
 
 }
-
-

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -260,18 +260,6 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 	}
 
 	@Nullable
-	private String determineBeanName(Set<String> existingBeans, SpyDefinition definition,
-			BeanDefinitionRegistry registry) {
-		if (StringUtils.hasText(definition.getName())) {
-			return definition.getName();
-		}
-		if (existingBeans.size() == 1) {
-			return existingBeans.iterator().next();
-		}
-		return findPrimaryBeanName(registry, existingBeans, definition.getTypeToSpy());
-	}
-
-	@Nullable
 	private String findPrimaryBeanName(BeanDefinitionRegistry registry,
 			Set<String> existingBeanNames, ResolvableType type) {
 		String primaryBeanName = null;
@@ -298,8 +286,8 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 			createSpy(registry, definition, field);
 		}
 		else {
-			registerSpy(definition, field,
-					determineBeanName(existingBeans, definition, registry));
+			String beanName = findBeanName(registry, existingBeans, definition);
+			registerSpy(definition, field, beanName);
 		}
 	}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -261,20 +261,19 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 
 	@Nullable
 	private String determineBeanName(Set<String> existingBeans, SpyDefinition definition,
-									 BeanDefinitionRegistry registry) {
+			BeanDefinitionRegistry registry) {
 		if (StringUtils.hasText(definition.getName())) {
 			return definition.getName();
 		}
 		if (existingBeans.size() == 1) {
 			return existingBeans.iterator().next();
 		}
-		return findPrimaryBeanName(registry, existingBeans,
-				definition.getTypeToSpy());
+		return findPrimaryBeanName(registry, existingBeans, definition.getTypeToSpy());
 	}
 
 	@Nullable
 	private String findPrimaryBeanName(BeanDefinitionRegistry registry,
-									   Set<String> existingBeanNames, ResolvableType type) {
+			Set<String> existingBeanNames, ResolvableType type) {
 		String primaryBeanName = null;
 		for (String existingBeanName : existingBeanNames) {
 			BeanDefinition beanDefinition = registry.getBeanDefinition(existingBeanName);
@@ -353,14 +352,8 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 
 	private void registerSpies(BeanDefinitionRegistry registry, SpyDefinition definition,
 			Field field, Set<String> existingBeans) {
-		try {
-			registerSpy(definition, field,
-					determineBeanName(existingBeans, definition, registry));
-		}
-		catch (RuntimeException ex) {
-			throw new IllegalStateException(
-					"Unable to register spy bean " + definition.getTypeToSpy(), ex);
-		}
+		registerSpy(definition, field,
+				determineBeanName(existingBeans, definition, registry));
 	}
 
 	private void registerSpy(SpyDefinition definition, Field field, String beanName) {

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -261,11 +261,11 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 	}
 
 	private Set<String> findCandidateBeans(ConfigurableListableBeanFactory beanFactory,
-			MockDefinition mockDefinition) {
-		QualifierDefinition qualifier = mockDefinition.getQualifier();
+			Definition definition) {
+		QualifierDefinition qualifier = definition.getQualifier();
 		Set<String> candidates = new TreeSet<>();
 		for (String candidate : getExistingBeans(beanFactory,
-				mockDefinition.getTypeToMock())) {
+				definition.getType())) {
 			if (qualifier == null || qualifier.matches(beanFactory, candidate)) {
 				candidates.add(candidate);
 			}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -281,8 +281,7 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 
 	private void registerSpy(ConfigurableListableBeanFactory beanFactory,
 			BeanDefinitionRegistry registry, SpyDefinition definition, Field field) {
-		Set<String> existingBeans = getExistingBeans(beanFactory,
-				definition.getTypeToSpy());
+		Set<String> existingBeans = findCandidateBeans(beanFactory, definition);
 		if (ObjectUtils.isEmpty(existingBeans)) {
 			createSpy(registry, definition, field);
 		}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -334,18 +334,18 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 	}
 
 	private String determinePrimaryCandidate(BeanDefinitionRegistry registry,
-											 Set<String> candidateBeanNames, ResolvableType type) {
+											 Set<String> existingBeanNames, ResolvableType type) {
 		String primaryBeanName = null;
-		for (String candidateBeanName : candidateBeanNames) {
-			BeanDefinition beanDefinition = registry.getBeanDefinition(candidateBeanName);
+		for (String existingBeanName : existingBeanNames) {
+			BeanDefinition beanDefinition = registry.getBeanDefinition(existingBeanName);
 			if (beanDefinition.isPrimary()) {
 				if (primaryBeanName != null) {
 					throw new NoUniqueBeanDefinitionException(type.resolve(),
-							candidateBeanNames.size(),
+							existingBeanNames.size(),
 							"more than one 'primary' bean found among candidates: "
-									+ candidateBeanNames);
+									+ existingBeanNames);
 				}
-				primaryBeanName = candidateBeanName;
+				primaryBeanName = existingBeanName;
 			}
 		}
 		return primaryBeanName;

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -184,7 +184,8 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 			BeanDefinitionRegistry registry, MockDefinition definition, Field field) {
 		RootBeanDefinition beanDefinition = createBeanDefinition(definition);
 
-		String beanName = getOrGenerateBeanName(beanFactory, registry, definition, beanDefinition);
+		String beanName = getOrGenerateBeanName(beanFactory, registry, definition,
+				beanDefinition);
 		String transformedBeanName = BeanFactoryUtils.transformedBeanName(beanName);
 
 		if (registry.containsBeanDefinition(transformedBeanName)) {
@@ -226,13 +227,13 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 	 * @param name the bean name
 	 * @return the mock instance
 	 */
-	protected final Object createMock(MockDefinition mockDefinition, String name) {
+	private Object createMock(MockDefinition mockDefinition, String name) {
 		return mockDefinition.createMock(name + " bean");
 	}
 
 	private String getOrGenerateBeanName(ConfigurableListableBeanFactory beanFactory,
-										 BeanDefinitionRegistry registry, MockDefinition mockDefinition,
-										 RootBeanDefinition beanDefinition) {
+			BeanDefinitionRegistry registry, MockDefinition mockDefinition,
+			RootBeanDefinition beanDefinition) {
 		Set<String> existingBeans = findCandidateBeans(beanFactory, mockDefinition);
 		if (existingBeans.isEmpty()) {
 			return this.beanNameGenerator.generateBeanName(beanDefinition, registry);
@@ -241,14 +242,15 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 	}
 
 	private String getBeanName(BeanDefinitionRegistry registry,
-							   Set<String> existingBeanNames, Definition definition) {
+			Set<String> existingBeanNames, Definition definition) {
 		if (StringUtils.hasText(definition.getName())) {
 			return definition.getName();
 		}
 		if (existingBeanNames.size() == 1) {
 			return existingBeanNames.iterator().next();
 		}
-		String beanName = findPrimaryBeanName(registry, existingBeanNames, definition.getType());
+		String beanName = findPrimaryBeanName(registry, existingBeanNames,
+				definition.getType());
 		if (beanName == null) {
 			throw new IllegalStateException("Unable to register bean "
 					+ definition.getType()
@@ -346,8 +348,7 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 		}
 	}
 
-	protected Object createSpyIfNecessary(Object bean, String beanName)
-			throws BeansException {
+	Object createSpyIfNecessary(Object bean, String beanName) throws BeansException {
 		SpyDefinition definition = this.spies.get(beanName);
 		if (definition != null) {
 			bean = definition.createSpy(beanName, bean);
@@ -367,7 +368,7 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 	private void postProcessField(Object bean, Field field) {
 		RegisteredField registered = this.fieldRegistry.get(field);
 		if (registered != null && StringUtils.hasLength(registered.getBeanName())) {
-			inject(field, bean, registered.getBeanName(), registered.getDefinition());
+			inject(field, bean, registered.getBeanName());
 		}
 	}
 
@@ -375,11 +376,10 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 		String beanName = this.beanNameRegistry.get(definition);
 		Assert.state(StringUtils.hasLength(beanName),
 				() -> "No bean found for definition " + definition);
-		inject(field, target, beanName, definition);
+		inject(field, target, beanName);
 	}
 
-	private void inject(Field field, Object target, String beanName,
-			Definition definition) {
+	private void inject(Field field, Object target, String beanName) {
 		try {
 			field.setAccessible(true);
 			Assert.state(ReflectionUtils.getField(field, target) == null,

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -235,6 +235,11 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 		if (existingBeans.size() == 1) {
 			return existingBeans.iterator().next();
 		}
+		for (String existingBean : existingBeans) {
+			if (beanFactory.getBeanDefinition(existingBean).isPrimary()) {
+				return existingBean;
+			}
+		}
 		throw new IllegalStateException(
 				"Unable to register mock bean " + mockDefinition.getTypeToMock()
 						+ " expected a single matching bean to replace but found "

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -279,18 +279,6 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 		return primaryBeanName;
 	}
 
-	private void registerSpy(ConfigurableListableBeanFactory beanFactory,
-			BeanDefinitionRegistry registry, SpyDefinition definition, Field field) {
-		Set<String> existingBeans = findCandidateBeans(beanFactory, definition);
-		if (ObjectUtils.isEmpty(existingBeans)) {
-			createSpy(registry, definition, field);
-		}
-		else {
-			String beanName = getBeanName(registry, existingBeans, definition);
-			registerSpy(definition, field, beanName);
-		}
-	}
-
 	private Set<String> findCandidateBeans(ConfigurableListableBeanFactory beanFactory,
 			Definition definition) {
 		QualifierDefinition qualifier = definition.getQualifier();
@@ -326,6 +314,18 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 		}
 		catch (Throwable ex) {
 			return false;
+		}
+	}
+
+	private void registerSpy(ConfigurableListableBeanFactory beanFactory,
+							 BeanDefinitionRegistry registry, SpyDefinition definition, Field field) {
+		Set<String> existingBeans = findCandidateBeans(beanFactory, definition);
+		if (ObjectUtils.isEmpty(existingBeans)) {
+			createSpy(registry, definition, field);
+		}
+		else {
+			String beanName = getBeanName(registry, existingBeans, definition);
+			registerSpy(definition, field, beanName);
 		}
 	}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -237,17 +237,9 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 		if (existingBeans.isEmpty()) {
 			return this.beanNameGenerator.generateBeanName(beanDefinition, registry);
 		}
-		String beanName = findBeanName(registry, existingBeans, mockDefinition);
-		if (beanName == null) {
-			throw new IllegalStateException("Unable to register mock bean "
-					+ mockDefinition.getTypeToMock()
-					+ " expected a single matching/primary bean to replace but found "
-					+ existingBeans);
-		}
-		return beanName;
+		return findBeanName(registry, existingBeans, mockDefinition);
 	}
 
-	@Nullable
 	private String findBeanName(BeanDefinitionRegistry registry,
 			Set<String> existingBeanNames, Definition definition) {
 		if (StringUtils.hasText(definition.getName())) {
@@ -256,7 +248,14 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 		if (existingBeanNames.size() == 1) {
 			return existingBeanNames.iterator().next();
 		}
-		return findPrimaryBeanName(registry, existingBeanNames, definition.getType());
+		String beanName = findPrimaryBeanName(registry, existingBeanNames, definition.getType());
+		if (beanName == null) {
+			throw new IllegalStateException("Unable to register bean "
+					+ definition.getType()
+					+ " expected a single matching/primary bean to replace but found "
+					+ existingBeanNames);
+		}
+		return beanName;
 	}
 
 	@Nullable

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -184,7 +184,7 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 			BeanDefinitionRegistry registry, MockDefinition definition, Field field) {
 		RootBeanDefinition beanDefinition = createBeanDefinition(definition);
 
-		String beanName = getBeanName(beanFactory, registry, definition, beanDefinition);
+		String beanName = getOrGenerateBeanName(beanFactory, registry, definition, beanDefinition);
 		String transformedBeanName = BeanFactoryUtils.transformedBeanName(beanName);
 
 		if (registry.containsBeanDefinition(transformedBeanName)) {
@@ -230,18 +230,18 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 		return mockDefinition.createMock(name + " bean");
 	}
 
-	private String getBeanName(ConfigurableListableBeanFactory beanFactory,
-			BeanDefinitionRegistry registry, MockDefinition mockDefinition,
-			RootBeanDefinition beanDefinition) {
+	private String getOrGenerateBeanName(ConfigurableListableBeanFactory beanFactory,
+										 BeanDefinitionRegistry registry, MockDefinition mockDefinition,
+										 RootBeanDefinition beanDefinition) {
 		Set<String> existingBeans = findCandidateBeans(beanFactory, mockDefinition);
 		if (existingBeans.isEmpty()) {
 			return this.beanNameGenerator.generateBeanName(beanDefinition, registry);
 		}
-		return findBeanName(registry, existingBeans, mockDefinition);
+		return getBeanName(registry, existingBeans, mockDefinition);
 	}
 
-	private String findBeanName(BeanDefinitionRegistry registry,
-			Set<String> existingBeanNames, Definition definition) {
+	private String getBeanName(BeanDefinitionRegistry registry,
+							   Set<String> existingBeanNames, Definition definition) {
 		if (StringUtils.hasText(definition.getName())) {
 			return definition.getName();
 		}
@@ -285,7 +285,7 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 			createSpy(registry, definition, field);
 		}
 		else {
-			String beanName = findBeanName(registry, existingBeans, definition);
+			String beanName = getBeanName(registry, existingBeans, definition);
 			registerSpy(definition, field, beanName);
 		}
 	}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -237,7 +237,7 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 		if (existingBeans.isEmpty()) {
 			return this.beanNameGenerator.generateBeanName(beanDefinition, registry);
 		}
-		String beanName = findBeanName(existingBeans, registry, mockDefinition);
+		String beanName = findBeanName(registry, existingBeans, mockDefinition);
 		if (beanName == null) {
 			throw new IllegalStateException("Unable to register mock bean "
 					+ mockDefinition.getTypeToMock()
@@ -248,15 +248,15 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 	}
 
 	@Nullable
-	private String findBeanName(Set<String> existingBeans,
-			BeanDefinitionRegistry registry, Definition definition) {
+	private String findBeanName(BeanDefinitionRegistry registry,
+			Set<String> existingBeanNames, Definition definition) {
 		if (StringUtils.hasText(definition.getName())) {
 			return definition.getName();
 		}
-		if (existingBeans.size() == 1) {
-			return existingBeans.iterator().next();
+		if (existingBeanNames.size() == 1) {
+			return existingBeanNames.iterator().next();
 		}
-		return determinePrimaryCandidate(registry, existingBeans, definition.getType());
+		return findPrimaryBeanName(registry, existingBeanNames, definition.getType());
 	}
 
 	@Nullable
@@ -268,13 +268,13 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 		if (existingBeans.size() == 1) {
 			return existingBeans.iterator().next();
 		}
-		return determinePrimaryCandidate(registry, existingBeans,
+		return findPrimaryBeanName(registry, existingBeans,
 				definition.getTypeToSpy());
 	}
 
 	@Nullable
-	private String determinePrimaryCandidate(BeanDefinitionRegistry registry,
-											 Set<String> existingBeanNames, ResolvableType type) {
+	private String findPrimaryBeanName(BeanDefinitionRegistry registry,
+									   Set<String> existingBeanNames, ResolvableType type) {
 		String primaryBeanName = null;
 		for (String existingBeanName : existingBeanNames) {
 			BeanDefinition beanDefinition = registry.getBeanDefinition(existingBeanName);

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -186,6 +186,9 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 		beanDefinition.getConstructorArgumentValues().addIndexedArgumentValue(1,
 				beanName);
 		if (registry.containsBeanDefinition(transformedBeanName)) {
+			BeanDefinition toBeRemovedBeanDefinition = registry
+					.getBeanDefinition(transformedBeanName);
+			beanDefinition.setPrimary(toBeRemovedBeanDefinition.isPrimary());
 			registry.removeBeanDefinition(transformedBeanName);
 		}
 		registry.registerBeanDefinition(transformedBeanName, beanDefinition);

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -298,7 +298,8 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 			createSpy(registry, definition, field);
 		}
 		else {
-			registerSpies(registry, definition, field, existingBeans);
+			registerSpy(definition, field,
+					determineBeanName(existingBeans, definition, registry));
 		}
 	}
 
@@ -348,12 +349,6 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 				registry);
 		registry.registerBeanDefinition(beanName, beanDefinition);
 		registerSpy(definition, field, beanName);
-	}
-
-	private void registerSpies(BeanDefinitionRegistry registry, SpyDefinition definition,
-			Field field, Set<String> existingBeans) {
-		registerSpy(definition, field,
-				determineBeanName(existingBeans, definition, registry));
 	}
 
 	private void registerSpy(SpyDefinition definition, Field field, String beanName) {

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -19,7 +19,6 @@ package org.springframework.boot.test.mock.mockito;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -229,8 +228,7 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 		if (StringUtils.hasLength(mockDefinition.getName())) {
 			return mockDefinition.getName();
 		}
-		Set<String> existingBeans = findCandidateBeans(beanFactory, mockDefinition,
-				beanDefinition);
+		Set<String> existingBeans = findCandidateBeans(beanFactory, mockDefinition);
 		if (existingBeans.isEmpty()) {
 			return this.beanNameGenerator.generateBeanName(beanDefinition, registry);
 		}
@@ -255,23 +253,14 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 	}
 
 	private Set<String> findCandidateBeans(ConfigurableListableBeanFactory beanFactory,
-			MockDefinition mockDefinition, RootBeanDefinition mockBeanDefinition) {
+			MockDefinition mockDefinition) {
 		QualifierDefinition qualifier = mockDefinition.getQualifier();
 		Set<String> candidates = new TreeSet<>();
-		String primaryBeanName = null;
 		for (String candidate : getExistingBeans(beanFactory,
 				mockDefinition.getTypeToMock())) {
 			if (qualifier == null || qualifier.matches(beanFactory, candidate)) {
 				candidates.add(candidate);
 			}
-			if (beanFactory.containsBeanDefinition(candidate) &&
-					beanFactory.getBeanDefinition(candidate).isPrimary()) {
-				primaryBeanName = candidate;
-			}
-		}
-		if (qualifier == null && primaryBeanName != null) {
-			mockBeanDefinition.setPrimary(true);
-			return Collections.singleton(primaryBeanName);
 		}
 		return candidates;
 	}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -245,7 +245,7 @@ public class MockitoPostProcessor extends InstantiationAwareBeanPostProcessorAda
 		}
 		throw new IllegalStateException(
 				"Unable to register mock bean " + mockDefinition.getTypeToMock()
-						+ " expected a single matching bean to replace but found "
+						+ " expected a single matching/primary bean to replace but found "
 						+ existingBeans);
 	}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyDefinition.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyDefinition.java
@@ -25,7 +25,6 @@ import org.springframework.core.ResolvableType;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.test.util.AopTestUtils;
 import org.springframework.util.Assert;
-import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyDefinition.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyDefinition.java
@@ -37,24 +37,18 @@ class SpyDefinition extends Definition {
 
 	private static final int MULTIPLIER = 31;
 
-	private final ResolvableType typeToSpy;
-
 	SpyDefinition(String name, ResolvableType typeToSpy, MockReset reset,
 			boolean proxyTargetAware, QualifierDefinition qualifier) {
-		super(name, reset, proxyTargetAware, qualifier);
-		Assert.notNull(typeToSpy, "TypeToSpy must not be null");
-		this.typeToSpy = typeToSpy;
-
+		super(name, reset, proxyTargetAware, qualifier, typeToSpy);
 	}
 
 	public ResolvableType getTypeToSpy() {
-		return this.typeToSpy;
+		return super.getType();
 	}
 
 	@Override
 	public int hashCode() {
 		int result = super.hashCode();
-		result = MULTIPLIER * result + ObjectUtils.nullSafeHashCode(this.typeToSpy);
 		return result;
 	}
 
@@ -68,14 +62,13 @@ class SpyDefinition extends Definition {
 		}
 		SpyDefinition other = (SpyDefinition) obj;
 		boolean result = super.equals(obj);
-		result = result && ObjectUtils.nullSafeEquals(this.typeToSpy, other.typeToSpy);
 		return result;
 	}
 
 	@Override
 	public String toString() {
 		return new ToStringCreator(this).append("name", getName())
-				.append("typeToSpy", this.typeToSpy).append("reset", getReset())
+				.append("typeToSpy", super.getType()).append("reset", getReset())
 				.toString();
 	}
 
@@ -86,7 +79,9 @@ class SpyDefinition extends Definition {
 	@SuppressWarnings("unchecked")
 	public <T> T createSpy(String name, Object instance) {
 		Assert.notNull(instance, "Instance must not be null");
-		Assert.isInstanceOf(this.typeToSpy.resolve(), instance);
+		Class<?> resolvedTypeToSpy = this.getTypeToSpy().resolve();
+		Assert.notNull(resolvedTypeToSpy, "Type to spy resolved to null");
+		Assert.isInstanceOf(resolvedTypeToSpy, instance);
 		if (Mockito.mockingDetails(instance).isSpy()) {
 			return (T) instance;
 		}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockDefinitionTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockDefinitionTests.java
@@ -46,7 +46,7 @@ public class MockDefinitionTests {
 	@Test
 	public void classToMockMustNotBeNull() throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("TypeToMock must not be null");
+		this.thrown.expectMessage("type must not be null");
 		new MockDefinition(null, null, null, null, false, null, null);
 	}
 

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessorTests.java
@@ -53,7 +53,7 @@ public class MockitoPostProcessorTests {
 		this.thrown.expect(IllegalStateException.class);
 		this.thrown.expectMessage(
 				"Unable to register mock bean " + ExampleService.class.getName()
-						+ " expected a single matching bean to replace "
+						+ " expected a single matching/primary bean to replace "
 						+ "but found [example1, example2]");
 		context.refresh();
 	}
@@ -66,7 +66,7 @@ public class MockitoPostProcessorTests {
 		this.thrown.expect(IllegalStateException.class);
 		this.thrown.expectMessage(
 				"Unable to register mock bean " + ExampleService.class.getName()
-						+ " expected a single matching bean to replace "
+						+ " expected a single matching/primary bean to replace "
 						+ "but found [example1, example3]");
 		context.refresh();
 	}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessorTests.java
@@ -146,22 +146,24 @@ public class MockitoPostProcessorTests {
 				.isSpy()).isFalse();
 	}
 
-	@Configuration
-	static class SpyPrimaryBean {
-		@SpyBean(ExampleService.class)
-		private ExampleService spy;
-
-		@Bean
-		@Qualifier("test")
-		public ExampleService exampleQualified() {
-			return new RealExampleService("qualified");
-		}
-
-		@Bean
-		@Primary
-		public ExampleService examplePrimary() {
-			return new RealExampleService("primary");
-		}
+	@Test
+	public void canSpyQualifiedBeanWithPrimaryBeanPresent() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		MockitoPostProcessor.register(context);
+		context.register(SpyQualifiedBean.class);
+		context.refresh();
+		assertThat(Mockito.mockingDetails(
+				context.getBean(SpyQualifiedBean.class).spy)
+				.isSpy()).isTrue();
+		assertThat(Mockito.mockingDetails(
+				context.getBean(ExampleService.class))
+				.isSpy()).isTrue();
+		assertThat(Mockito.mockingDetails(
+				context.getBean("examplePrimary", ExampleService.class))
+				.isSpy()).isFalse();
+		assertThat(Mockito.mockingDetails(
+				context.getBean("exampleQualified", ExampleService.class))
+				.isSpy()).isTrue();
 	}
 
 	@Configuration
@@ -257,6 +259,46 @@ public class MockitoPostProcessorTests {
 		}
 
 	}
+
+	@Configuration
+	static class SpyPrimaryBean {
+		@SpyBean(ExampleService.class)
+		private ExampleService spy;
+
+		@Bean
+		@Qualifier("test")
+		public ExampleService exampleQualified() {
+			return new RealExampleService("qualified");
+		}
+
+		@Bean
+		@Primary
+		public ExampleService examplePrimary() {
+			return new RealExampleService("primary");
+		}
+	}
+
+	@Configuration
+	static class SpyQualifiedBean {
+
+		@SpyBean(ExampleService.class)
+		@Qualifier("test")
+		private ExampleService spy;
+
+		@Bean
+		@Qualifier("test")
+		public ExampleService exampleQualified() {
+			return new RealExampleService("qualified");
+		}
+
+		@Bean
+		@Primary
+		public ExampleService examplePrimary() {
+			return new RealExampleService("primary");
+		}
+
+	}
+
 
 	static class TestFactoryBean implements FactoryBean<Object> {
 

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessorTests.java
@@ -133,17 +133,17 @@ public class MockitoPostProcessorTests {
 		context.register(SpyPrimaryBean.class);
 		context.refresh();
 		assertThat(Mockito.mockingDetails(
-				context.getBean(MockQualifiedBean.class).mock)
+				context.getBean(SpyPrimaryBean.class).spy)
 				.isSpy()).isTrue();
 		assertThat(Mockito.mockingDetails(
 				context.getBean(ExampleService.class))
-				.isSpy()).isFalse();
+				.isSpy()).isTrue();
 		assertThat(Mockito.mockingDetails(
 				context.getBean("examplePrimary", ExampleService.class))
-				.isSpy()).isFalse();
+				.isSpy()).isTrue();
 		assertThat(Mockito.mockingDetails(
 				context.getBean("exampleQualified", ExampleService.class))
-				.isSpy()).isTrue();
+				.isSpy()).isFalse();
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessorTests.java
@@ -132,6 +132,7 @@ public class MockitoPostProcessorTests {
 		MockitoPostProcessor.register(context);
 		context.register(SpyPrimaryBean.class);
 		context.refresh();
+		// TODO why is this assert true for spies but false for mocks?
 		assertThat(Mockito.mockingDetails(
 				context.getBean(SpyPrimaryBean.class).spy)
 				.isSpy()).isTrue();
@@ -155,9 +156,11 @@ public class MockitoPostProcessorTests {
 		assertThat(Mockito.mockingDetails(
 				context.getBean(SpyQualifiedBean.class).spy)
 				.isSpy()).isTrue();
+		// TODO why is this assert true for spies but false for mocks?
 		assertThat(Mockito.mockingDetails(
 				context.getBean(ExampleService.class))
 				.isSpy()).isTrue();
+		// TODO figure out why @SpyBean appears to ignore the @Qualifier and thus the asserts fail.
 		assertThat(Mockito.mockingDetails(
 				context.getBean("examplePrimary", ExampleService.class))
 				.isSpy()).isFalse();

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessorTests.java
@@ -126,6 +126,44 @@ public class MockitoPostProcessorTests {
 				.isMock()).isTrue();
 	}
 
+	@Test
+	public void canSpyPrimaryBean() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		MockitoPostProcessor.register(context);
+		context.register(SpyPrimaryBean.class);
+		context.refresh();
+		assertThat(Mockito.mockingDetails(
+				context.getBean(MockQualifiedBean.class).mock)
+				.isSpy()).isTrue();
+		assertThat(Mockito.mockingDetails(
+				context.getBean(ExampleService.class))
+				.isSpy()).isFalse();
+		assertThat(Mockito.mockingDetails(
+				context.getBean("examplePrimary", ExampleService.class))
+				.isSpy()).isFalse();
+		assertThat(Mockito.mockingDetails(
+				context.getBean("exampleQualified", ExampleService.class))
+				.isSpy()).isTrue();
+	}
+
+	@Configuration
+	static class SpyPrimaryBean {
+		@SpyBean(ExampleService.class)
+		private ExampleService spy;
+
+		@Bean
+		@Qualifier("test")
+		public ExampleService exampleQualified() {
+			return new RealExampleService("qualified");
+		}
+
+		@Bean
+		@Primary
+		public ExampleService examplePrimary() {
+			return new RealExampleService("primary");
+		}
+	}
+
 	@Configuration
 	@MockBean(SomeInterface.class)
 	static class MockedFactoryBean {

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessorTests.java
@@ -52,7 +52,7 @@ public class MockitoPostProcessorTests {
 		context.register(MultipleBeans.class);
 		this.thrown.expect(IllegalStateException.class);
 		this.thrown.expectMessage(
-				"Unable to register mock bean " + ExampleService.class.getName()
+				"Unable to register bean " + ExampleService.class.getName()
 						+ " expected a single matching/primary bean to replace "
 						+ "but found [example1, example2]");
 		context.refresh();
@@ -65,7 +65,7 @@ public class MockitoPostProcessorTests {
 		context.register(MultipleQualifiedBeans.class);
 		this.thrown.expect(IllegalStateException.class);
 		this.thrown.expectMessage(
-				"Unable to register mock bean " + ExampleService.class.getName()
+				"Unable to register bean " + ExampleService.class.getName()
 						+ " expected a single matching/primary bean to replace "
 						+ "but found [example1, example3]");
 		context.refresh();

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessorTests.java
@@ -132,7 +132,6 @@ public class MockitoPostProcessorTests {
 		MockitoPostProcessor.register(context);
 		context.register(SpyPrimaryBean.class);
 		context.refresh();
-		// TODO why is this assert true for spies but false for mocks?
 		assertThat(Mockito.mockingDetails(
 				context.getBean(SpyPrimaryBean.class).spy)
 				.isSpy()).isTrue();
@@ -156,11 +155,9 @@ public class MockitoPostProcessorTests {
 		assertThat(Mockito.mockingDetails(
 				context.getBean(SpyQualifiedBean.class).spy)
 				.isSpy()).isTrue();
-		// TODO why is this assert true for spies but false for mocks?
 		assertThat(Mockito.mockingDetails(
 				context.getBean(ExampleService.class))
-				.isSpy()).isTrue();
-		// TODO figure out why @SpyBean appears to ignore the @Qualifier and thus the asserts fail.
+				.isSpy()).isFalse();
 		assertThat(Mockito.mockingDetails(
 				context.getBean("examplePrimary", ExampleService.class))
 				.isSpy()).isFalse();

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanOnTestFieldForExistingBeanWithQualifierIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanOnTestFieldForExistingBeanWithQualifierIntegrationTests.java
@@ -20,7 +20,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.example.*;
+import org.springframework.boot.test.mock.mockito.example.CustomQualifier;
+import org.springframework.boot.test.mock.mockito.example.CustomQualifierExampleService;
+import org.springframework.boot.test.mock.mockito.example.ExampleService;
+import org.springframework.boot.test.mock.mockito.example.ExampleServiceCaller;
+import org.springframework.boot.test.mock.mockito.example.RealExampleService;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanOnTestFieldForExistingBeanWithQualifierIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanOnTestFieldForExistingBeanWithQualifierIntegrationTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.mock.mockito;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.example.*;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test {@link SpyBean} on a test class field can be used to replace existing bean while
+ * preserving qualifiers.
+ *
+ * @author Andreas Neiser
+ */
+@RunWith(SpringRunner.class)
+public class SpyBeanOnTestFieldForExistingBeanWithQualifierIntegrationTests {
+
+	@SpyBean
+	@CustomQualifier
+	private ExampleService service;
+
+	@Autowired
+	private ExampleServiceCaller caller;
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Test
+	public void testMocking() throws Exception {
+		this.caller.sayGreeting();
+		verify(this.service).greeting();
+	}
+
+	@Test
+	public void onlyQualifiedBeanIsReplaced() {
+		assertThat(this.applicationContext.getBean("service")).isSameAs(this.service);
+		ExampleService anotherService = this.applicationContext.getBean("anotherService",
+				ExampleService.class);
+		assertThat(anotherService.greeting()).isEqualTo("Another");
+	}
+
+	@Configuration
+	static class TestConfig {
+
+		@Bean
+		public CustomQualifierExampleService service() {
+			return new CustomQualifierExampleService();
+		}
+
+		@Bean
+		public ExampleService anotherService() {
+			return new RealExampleService("Another");
+		}
+
+		@Bean
+		public ExampleServiceCaller controller(@CustomQualifier ExampleService service) {
+			return new ExampleServiceCaller(service);
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyDefinitionTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyDefinitionTests.java
@@ -47,7 +47,7 @@ public class SpyDefinitionTests {
 	@Test
 	public void classToSpyMustNotBeNull() throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("TypeToSpy must not be null");
+		this.thrown.expectMessage("type must not be null");
 		new SpyDefinition(null, null, null, true, null);
 	}
 


### PR DESCRIPTION
The discussion in #11066 revealed that the proposed solution is not ideal. Based on @alexandreBaronZnk's work, I created another pull request and tried to honor @philwebb's remarks.

I changed that `getBeanName` respects the `@Primary` annotation (and does not simply fail if more than one candidate is found) and I copied the primary flag from the removed bean to the mocked bean. This makes the tests work again (of course I removed the changes in `findCandidateBeans` first).  

I cannot push to @alexandreBaronZnk's branch, I hope it's okay that I created another pull request.