### PR TITLE
Align Session auto-config with Redis namespace config support

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionProperties.java
@@ -33,7 +33,7 @@ public class RedisSessionProperties {
 	/**
 	 * Namespace for keys used to store sessions.
 	 */
-	private String namespace = "";
+	private String namespace = "spring:session";
 
 	/**
 	 * Sessions flush mode.

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/ReactiveSessionAutoConfigurationRedisTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/ReactiveSessionAutoConfigurationRedisTests.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Stephane Nicoll
  * @author Andy Wilkinson
+ * @author Vedran Pavic
  */
 public class ReactiveSessionAutoConfigurationRedisTests
 		extends AbstractSessionAutoConfigurationTests {
@@ -56,7 +57,7 @@ public class ReactiveSessionAutoConfigurationRedisTests
 		this.contextRunner.withPropertyValues("spring.session.store-type=redis")
 				.withConfiguration(AutoConfigurations.of(RedisAutoConfiguration.class,
 						RedisReactiveAutoConfiguration.class))
-				.run(validateSpringSessionUsesRedis(RedisFlushMode.ON_SAVE));
+				.run(validateSpringSessionUsesRedis("spring:session:", RedisFlushMode.ON_SAVE));
 	}
 
 	@Test
@@ -66,7 +67,7 @@ public class ReactiveSessionAutoConfigurationRedisTests
 						ReactiveMongoOperationsSessionRepository.class))
 				.withConfiguration(AutoConfigurations.of(RedisAutoConfiguration.class,
 						RedisReactiveAutoConfiguration.class))
-				.run(validateSpringSessionUsesRedis(RedisFlushMode.ON_SAVE));
+				.run(validateSpringSessionUsesRedis("spring:session:", RedisFlushMode.ON_SAVE));
 	}
 
 	@Test
@@ -77,16 +78,18 @@ public class ReactiveSessionAutoConfigurationRedisTests
 				.withPropertyValues("spring.session.store-type=redis",
 						"spring.session.redis.namespace=foo",
 						"spring.session.redis.flush-mode=immediate")
-				.run(validateSpringSessionUsesRedis(RedisFlushMode.IMMEDIATE));
+				.run(validateSpringSessionUsesRedis("foo:", RedisFlushMode.IMMEDIATE));
 	}
 
 	private ContextConsumer<AssertableReactiveWebApplicationContext> validateSpringSessionUsesRedis(
-			RedisFlushMode flushMode) {
+			String namespace, RedisFlushMode flushMode) {
 		return (context) -> {
 			System.out.println(new ConditionEvaluationReportMessage(
 					context.getBean(ConditionEvaluationReport.class)));
 			ReactiveRedisOperationsSessionRepository repository = validateSessionRepository(
 					context, ReactiveRedisOperationsSessionRepository.class);
+			assertThat(new DirectFieldAccessor(repository).getPropertyValue("namespace"))
+					.isEqualTo(namespace);
 			assertThat(new DirectFieldAccessor(repository)
 					.getPropertyValue("redisFlushMode")).isEqualTo(flushMode);
 		};

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationRedisTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationRedisTests.java
@@ -78,7 +78,7 @@ public class SessionAutoConfigurationRedisTests
 						"spring.session.redis.namespace=foo",
 						"spring.session.redis.flush-mode=immediate",
 						"spring.session.redis.cleanup-cron=0 0 12 * * *")
-				.run(validateSpringSessionUsesRedis("spring:session:foo:event:created:",
+				.run(validateSpringSessionUsesRedis("foo:event:created:",
 						RedisFlushMode.IMMEDIATE, "0 0 12 * * *"));
 	}
 


### PR DESCRIPTION
This PR aligns Session auto-configuration with recent updates to Redis namespace configuration support in Spring Session.

Redis namespace was made fully configurable in spring-projects/spring-session#919 whereas previously the `spring:session:` part of the key prefix was fixed.