### PR TITLE
Fix references to management related properties

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -423,7 +423,7 @@
     "type": "java.lang.Boolean",
     "description": "Whether to enable the endpoint.",
     "deprecation": {
-      "replacement": "endpoints.threaddump.enabled",
+      "replacement": "management.endpoint.threaddump.enabled",
       "level": "error"
     }
   },
@@ -460,7 +460,7 @@
     "description": "Whether to enable endpoints.",
     "defaultValue": true,
     "deprecation": {
-      "replacement": "endpoints.default.enabled",
+      "replacement": "management.endpoints.enabled-by-default",
       "level": "error"
     }
   },
@@ -551,7 +551,7 @@
     "description": "Time to live for cached result, in milliseconds.",
     "defaultValue": 1000,
     "deprecation": {
-      "replacement": "endpoints.health.cache.time-to-live",
+      "replacement": "management.endpoint.health.cache.time-to-live",
       "level": "error"
     }
   },
@@ -625,7 +625,7 @@
     "description": "Whether to enable JMX export of all endpoints.",
     "defaultValue": true,
     "deprecation": {
-      "replacement": "endpoints.default.jmx.enabled",
+      "replacement": "management.endpoints.jmx.enabled",
       "level": "error"
     }
   },

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/ShutdownEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/ShutdownEndpointDocumentationTests.java
@@ -25,7 +25,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.test.context.TestPropertySource;
 
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -37,7 +36,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Andy Wilkinson
  */
-@TestPropertySource(properties = "endpoints.shutdown.enabled=true")
 public class ShutdownEndpointDocumentationTests
 		extends AbstractEndpointDocumentationTests {
 

--- a/spring-boot-samples/spring-boot-sample-cache/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-cache/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-endpoints.metrics.web.enabled=true
+management.endpoints.web.expose=metrics
 
 #
 # Infinispan configuration file location.

--- a/spring-boot-samples/spring-boot-sample-flyway/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-flyway/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-endpoints.flyway.web.enabled=true
+management.endpoints.web.expose=flyway
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.open-in-view=true
 spring.h2.console.enabled=true

--- a/spring-boot-samples/spring-boot-sample-liquibase/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-liquibase/src/main/resources/application.properties
@@ -1,3 +1,3 @@
-endpoints.liquibase.web.enabled=true
+management.endpoints.web.expose=liquibase
 
 spring.h2.console.enabled=true

--- a/spring-boot-samples/spring-boot-sample-session/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-session/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-endpoints.sessions.web.enabled=true
+management.endpoints.web.expose=sessions


### PR DESCRIPTION
There are quite a few places where references to `endpoints.*` properties haven't been updated to `management.endpoint[s].*` introduced in #10176.