### PR TITLE
replaced explicit null-checks by @NonNull for target method parameters

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveCloudFoundrySecurityService.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveCloudFoundrySecurityService.java
@@ -27,7 +27,7 @@ import org.springframework.boot.actuate.autoconfigure.cloudfoundry.CloudFoundryA
 import org.springframework.boot.actuate.autoconfigure.cloudfoundry.CloudFoundryAuthorizationException.Reason;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClient.RequestHeadersSpec;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -49,10 +49,8 @@ class ReactiveCloudFoundrySecurityService {
 
 	private Mono<String> uaaUrl;
 
-	ReactiveCloudFoundrySecurityService(WebClient.Builder webClientBuilder,
-			String cloudControllerUrl) {
-		Assert.notNull(webClientBuilder, "Webclient must not be null");
-		Assert.notNull(cloudControllerUrl, "CloudControllerUrl must not be null");
+	ReactiveCloudFoundrySecurityService(@NonNull WebClient.Builder webClientBuilder,
+			@NonNull String cloudControllerUrl) {
 		this.webClient = webClientBuilder.build();
 		this.cloudControllerUrl = cloudControllerUrl;
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundrySecurityService.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundrySecurityService.java
@@ -28,7 +28,7 @@ import org.springframework.boot.actuate.autoconfigure.cloudfoundry.CloudFoundryA
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.HttpStatusCodeException;
@@ -47,10 +47,8 @@ class CloudFoundrySecurityService {
 
 	private String uaaUrl;
 
-	CloudFoundrySecurityService(RestTemplateBuilder restTemplateBuilder,
-			String cloudControllerUrl, boolean skipSslValidation) {
-		Assert.notNull(restTemplateBuilder, "RestTemplateBuilder must not be null");
-		Assert.notNull(cloudControllerUrl, "CloudControllerUrl must not be null");
+	CloudFoundrySecurityService(@NonNull RestTemplateBuilder restTemplateBuilder,
+			@NonNull String cloudControllerUrl, boolean skipSslValidation) {
 		if (skipSslValidation) {
 			restTemplateBuilder = restTemplateBuilder
 					.requestFactory(SkipSslVerificationHttpRequestFactory.class);

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/ExposeExcludePropertyEndpointFilter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/ExposeExcludePropertyEndpointFilter.java
@@ -31,6 +31,7 @@ import org.springframework.boot.actuate.endpoint.Operation;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.core.env.Environment;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -53,10 +54,8 @@ public class ExposeExcludePropertyEndpointFilter<T extends Operation>
 	private final Set<String> exposeDefaults;
 
 	public ExposeExcludePropertyEndpointFilter(
-			Class<? extends EndpointDiscoverer<T>> discovererType,
-			Environment environment, String prefix, String... exposeDefaults) {
-		Assert.notNull(discovererType, "Discoverer Type must not be null");
-		Assert.notNull(environment, "Environment must not be null");
+			@NonNull Class<? extends EndpointDiscoverer<T>> discovererType,
+			@NonNull Environment environment, String prefix, String... exposeDefaults) {
 		Assert.hasText(prefix, "Prefix must not be empty");
 		Binder binder = Binder.get(environment);
 		this.discovererType = discovererType;
@@ -66,10 +65,9 @@ public class ExposeExcludePropertyEndpointFilter<T extends Operation>
 	}
 
 	public ExposeExcludePropertyEndpointFilter(
-			Class<? extends EndpointDiscoverer<T>> discovererType,
+			@NonNull Class<? extends EndpointDiscoverer<T>> discovererType,
 			Collection<String> expose, Collection<String> exclude,
 			String... exposeDefaults) {
-		Assert.notNull(discovererType, "Discoverer Type must not be null");
 		this.discovererType = discovererType;
 		this.expose = asSet(expose);
 		this.exclude = asSet(exclude);

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/DefaultEndpointPathProvider.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/DefaultEndpointPathProvider.java
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
 import org.springframework.boot.actuate.endpoint.EndpointDiscoverer;
 import org.springframework.boot.actuate.endpoint.EndpointInfo;
 import org.springframework.boot.actuate.endpoint.web.WebOperation;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Default {@link EndpointPathProvider} implementation.
@@ -50,8 +50,7 @@ public class DefaultEndpointPathProvider implements EndpointPathProvider {
 	}
 
 	@Override
-	public String getPath(String id) {
-		Assert.notNull(id, "ID must not be null");
+	public String getPath(@NonNull String id) {
 		return getEndpoints().filter((info) -> id.equals(info.getId())).findFirst()
 				.map(this::getPath).orElse(null);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/PropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/PropertiesConfigAdapter.java
@@ -18,7 +18,7 @@ package org.springframework.boot.actuate.autoconfigure.metrics.export;
 
 import java.util.function.Function;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Base class for properties to config adapters.
@@ -39,9 +39,7 @@ public class PropertiesConfigAdapter<T, C> {
 	 * @param properties the source properties
 	 * @param defaults a config implementation providing default values
 	 */
-	public PropertiesConfigAdapter(T properties, C defaults) {
-		Assert.notNull(properties, "Properties must not be null");
-		Assert.notNull(defaults, "Defaults must not be null");
+	public PropertiesConfigAdapter(@NonNull T properties, @NonNull C defaults) {
 		this.properties = properties;
 		this.defaults = defaults;
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementServerProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementServerProperties.java
@@ -23,7 +23,7 @@ import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.boot.web.server.Ssl;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.StringUtils;
 
 /**
@@ -107,8 +107,7 @@ public class ManagementServerProperties implements SecurityPrerequisite {
 		return this.contextPath;
 	}
 
-	public void setContextPath(String contextPath) {
-		Assert.notNull(contextPath, "ContextPath must not be null");
+	public void setContextPath(@NonNull String contextPath) {
 		this.contextPath = cleanContextPath(contextPath);
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/servlet/ManagementErrorEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/servlet/ManagementErrorEndpoint.java
@@ -20,8 +20,8 @@ import java.util.Map;
 
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Controller;
-import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.context.request.ServletWebRequest;
@@ -39,8 +39,7 @@ public class ManagementErrorEndpoint {
 
 	private final ErrorAttributes errorAttributes;
 
-	public ManagementErrorEndpoint(ErrorAttributes errorAttributes) {
-		Assert.notNull(errorAttributes, "ErrorAttributes must not be null");
+	public ManagementErrorEndpoint(@NonNull ErrorAttributes errorAttributes) {
 		this.errorAttributes = errorAttributes;
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/ExposeExcludePropertyEndpointFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/ExposeExcludePropertyEndpointFilterTests.java
@@ -58,7 +58,7 @@ public class ExposeExcludePropertyEndpointFilterTests {
 	@Test
 	public void createWhenDiscovererTypeIsNullShouldThrowException() throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("Discoverer Type must not be null");
+		this.thrown.expectMessage("DiscovererType must not be null");
 		new ExposeExcludePropertyEndpointFilter<>(null, this.environment, "foo");
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/amqp/RabbitHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/amqp/RabbitHealthIndicator.java
@@ -20,7 +20,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Simple implementation of a {@link HealthIndicator} returning status information for the
@@ -33,8 +33,7 @@ public class RabbitHealthIndicator extends AbstractHealthIndicator {
 
 	private final RabbitTemplate rabbitTemplate;
 
-	public RabbitHealthIndicator(RabbitTemplate rabbitTemplate) {
-		Assert.notNull(rabbitTemplate, "RabbitTemplate must not be null");
+	public RabbitHealthIndicator(@NonNull RabbitTemplate rabbitTemplate) {
 		this.rabbitTemplate = rabbitTemplate;
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/AuditEvent.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/AuditEvent.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * A value object representing an audit event: at a particular time, a particular user or
@@ -82,11 +82,8 @@ public class AuditEvent implements Serializable {
 	 * @param type the event type
 	 * @param data The event data
 	 */
-	public AuditEvent(Date timestamp, String principal, String type,
-			Map<String, Object> data) {
-		Assert.notNull(timestamp, "Timestamp must not be null");
-		Assert.notNull(principal, "Principal must not be null");
-		Assert.notNull(type, "Type must not be null");
+	public AuditEvent(@NonNull Date timestamp, @NonNull String principal,
+			@NonNull String type, Map<String, Object> data) {
 		this.timestamp = timestamp;
 		this.principal = principal;
 		this.type = type;

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/AuditEventsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/AuditEventsEndpoint.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link Endpoint} to expose audit events.
@@ -34,8 +34,7 @@ public class AuditEventsEndpoint {
 
 	private final AuditEventRepository auditEventRepository;
 
-	public AuditEventsEndpoint(AuditEventRepository auditEventRepository) {
-		Assert.notNull(auditEventRepository, "AuditEventRepository must not be null");
+	public AuditEventsEndpoint(@NonNull AuditEventRepository auditEventRepository) {
 		this.auditEventRepository = auditEventRepository;
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/InMemoryAuditEventRepository.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/InMemoryAuditEventRepository.java
@@ -20,7 +20,7 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * In-memory {@link AuditEventRepository} implementation.
@@ -61,8 +61,7 @@ public class InMemoryAuditEventRepository implements AuditEventRepository {
 	}
 
 	@Override
-	public void add(AuditEvent event) {
-		Assert.notNull(event, "AuditEvent must not be null");
+	public void add(@NonNull AuditEvent event) {
 		synchronized (this.monitor) {
 			this.tail = (this.tail + 1) % this.events.length;
 			this.events[this.tail] = event;

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/listener/AuditApplicationEvent.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/listener/AuditApplicationEvent.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.context.ApplicationEvent;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Spring {@link ApplicationEvent} to encapsulate {@link AuditEvent}s.
@@ -76,9 +76,8 @@ public class AuditApplicationEvent extends ApplicationEvent {
 	 * {@link AuditEvent}.
 	 * @param auditEvent the source of this event
 	 */
-	public AuditApplicationEvent(AuditEvent auditEvent) {
+	public AuditApplicationEvent(@NonNull AuditEvent auditEvent) {
 		super(auditEvent);
-		Assert.notNull(auditEvent, "AuditEvent must not be null");
 		this.auditEvent = auditEvent;
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/cassandra/CassandraHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/cassandra/CassandraHealthIndicator.java
@@ -24,7 +24,7 @@ import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.data.cassandra.core.CassandraOperations;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Simple implementation of a {@link HealthIndicator} returning status information for
@@ -41,8 +41,7 @@ public class CassandraHealthIndicator extends AbstractHealthIndicator {
 	 * Create a new {@link CassandraHealthIndicator} instance.
 	 * @param cassandraOperations the Cassandra operations
 	 */
-	public CassandraHealthIndicator(CassandraOperations cassandraOperations) {
-		Assert.notNull(cassandraOperations, "CassandraOperations must not be null");
+	public CassandraHealthIndicator(@NonNull CassandraOperations cassandraOperations) {
 		this.cassandraOperations = cassandraOperations;
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/couchbase/CouchbaseHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/couchbase/CouchbaseHealthIndicator.java
@@ -24,7 +24,7 @@ import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.data.couchbase.core.CouchbaseOperations;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.StringUtils;
 
 /**
@@ -37,8 +37,7 @@ public class CouchbaseHealthIndicator extends AbstractHealthIndicator {
 
 	private CouchbaseOperations couchbaseOperations;
 
-	public CouchbaseHealthIndicator(CouchbaseOperations couchbaseOperations) {
-		Assert.notNull(couchbaseOperations, "CouchbaseOperations must not be null");
+	public CouchbaseHealthIndicator(@NonNull CouchbaseOperations couchbaseOperations) {
 		this.couchbaseOperations = couchbaseOperations;
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/EndpointInfo.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/EndpointInfo.java
@@ -19,6 +19,7 @@ package org.springframework.boot.actuate.endpoint;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -43,9 +44,9 @@ public class EndpointInfo<T extends Operation> {
 	 * @param enableByDefault if the endpoint is enabled by default
 	 * @param operations the operations of the endpoint
 	 */
-	public EndpointInfo(String id, boolean enableByDefault, Collection<T> operations) {
+	public EndpointInfo(String id, boolean enableByDefault,
+			@NonNull Collection<T> operations) {
 		Assert.hasText(id, "ID must not be empty");
-		Assert.notNull(operations, "Operations must not be null");
 		this.id = id;
 		this.enableByDefault = enableByDefault;
 		this.operations = Collections.unmodifiableCollection(operations);

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
@@ -18,7 +18,7 @@ package org.springframework.boot.actuate.endpoint;
 
 import java.util.regex.Pattern;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Strategy that should be used by endpoint implementations to sanitize potentially
@@ -50,8 +50,7 @@ public class Sanitizer {
 	 * with or regular expressions.
 	 * @param keysToSanitize the keys to sanitize
 	 */
-	public void setKeysToSanitize(String... keysToSanitize) {
-		Assert.notNull(keysToSanitize, "KeysToSanitize must not be null");
+	public void setKeysToSanitize(@NonNull String... keysToSanitize) {
 		this.keysToSanitize = new Pattern[keysToSanitize.length];
 		for (int i = 0; i < keysToSanitize.length; i++) {
 			this.keysToSanitize[i] = getPattern(keysToSanitize[i]);

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/AnnotationEndpointDiscoverer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/AnnotationEndpointDiscoverer.java
@@ -43,6 +43,7 @@ import org.springframework.core.ResolvableType;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.style.ToStringCreator;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -83,15 +84,12 @@ public abstract class AnnotationEndpointDiscoverer<K, T extends Operation>
 	 * @param invokerAdvisors advisors used to add additional invoker advise
 	 * @param filters filters that must match for an endpoint to be exposed
 	 */
-	protected AnnotationEndpointDiscoverer(ApplicationContext applicationContext,
-			OperationFactory<T> operationFactory, Function<T, K> operationKeyFactory,
-			ParameterMapper parameterMapper,
+	protected AnnotationEndpointDiscoverer(@NonNull ApplicationContext applicationContext,
+			@NonNull OperationFactory<T> operationFactory,
+			@NonNull Function<T, K> operationKeyFactory,
+			@NonNull ParameterMapper parameterMapper,
 			Collection<? extends OperationMethodInvokerAdvisor> invokerAdvisors,
 			Collection<? extends EndpointFilter<T>> filters) {
-		Assert.notNull(applicationContext, "Application Context must not be null");
-		Assert.notNull(operationFactory, "Operation Factory must not be null");
-		Assert.notNull(operationKeyFactory, "Operation Key Factory must not be null");
-		Assert.notNull(parameterMapper, "Parameter Mapper must not be null");
 		this.applicationContext = applicationContext;
 		this.operationKeyFactory = operationKeyFactory;
 		this.operationsFactory = new OperationsFactory<>(operationFactory,
@@ -313,8 +311,8 @@ public abstract class AnnotationEndpointDiscoverer<K, T extends Operation>
 
 		private final Map<OperationKey, List<T>> operations;
 
-		private DiscoveredEndpoint(Class<?> type, EndpointInfo<T> info, boolean exposed) {
-			Assert.notNull(info, "Info must not be null");
+		private DiscoveredEndpoint(@NonNull Class<?> type, EndpointInfo<T> info,
+				boolean exposed) {
 			this.info = info;
 			this.exposed = exposed;
 			this.operations = indexEndpointOperations(type, info);
@@ -326,9 +324,8 @@ public abstract class AnnotationEndpointDiscoverer<K, T extends Operation>
 					indexOperations(info.getId(), endpointType, info.getOperations()));
 		}
 
-		private DiscoveredEndpoint(EndpointInfo<T> info, boolean exposed,
+		private DiscoveredEndpoint(@NonNull EndpointInfo<T> info, boolean exposed,
 				Map<OperationKey, List<T>> operations) {
-			Assert.notNull(info, "Info must not be null");
 			this.info = info;
 			this.exposed = exposed;
 			this.operations = operations;

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBeanRegistrar.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/EndpointMBeanRegistrar.java
@@ -28,7 +28,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.jmx.JmxException;
 import org.springframework.jmx.export.MBeanExportException;
 import org.springframework.jmx.export.MBeanExporter;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * JMX Registrar for {@link EndpointMBean}.
@@ -51,10 +51,8 @@ public class EndpointMBeanRegistrar {
 	 * @param mBeanServer the mbean exporter
 	 * @param objectNameFactory the {@link ObjectName} factory
 	 */
-	public EndpointMBeanRegistrar(MBeanServer mBeanServer,
-			EndpointObjectNameFactory objectNameFactory) {
-		Assert.notNull(mBeanServer, "MBeanServer must not be null");
-		Assert.notNull(objectNameFactory, "ObjectNameFactory must not be null");
+	public EndpointMBeanRegistrar(@NonNull MBeanServer mBeanServer,
+			@NonNull EndpointObjectNameFactory objectNameFactory) {
 		this.mBeanServer = mBeanServer;
 		this.objectNameFactory = objectNameFactory;
 	}
@@ -64,8 +62,7 @@ public class EndpointMBeanRegistrar {
 	 * @param endpoint the endpoint to register
 	 * @return the {@link ObjectName} used to register the {@code endpoint}
 	 */
-	public ObjectName registerEndpointMBean(EndpointMBean endpoint) {
-		Assert.notNull(endpoint, "Endpoint must not be null");
+	public ObjectName registerEndpointMBean(@NonNull EndpointMBean endpoint) {
 		try {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Registering endpoint with id '" + endpoint.getEndpointId()

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/reflect/OperationMethodInfo.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/reflect/OperationMethodInfo.java
@@ -25,6 +25,7 @@ import org.springframework.boot.actuate.endpoint.OperationType;
 import org.springframework.core.DefaultParameterNameDiscoverer;
 import org.springframework.core.ParameterNameDiscoverer;
 import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -46,11 +47,9 @@ public final class OperationMethodInfo {
 
 	private final ParameterNameDiscoverer parameterNameDiscoverer = DEFAULT_PARAMETER_NAME_DISCOVERER;
 
-	public OperationMethodInfo(Method method, OperationType operationType,
-			AnnotationAttributes annotationAttributes) {
-		Assert.notNull(method, "Method must not be null");
-		Assert.notNull(operationType, "Operation Type must not be null");
-		Assert.notNull(annotationAttributes, "Annotation Attributes must not be null");
+	public OperationMethodInfo(@NonNull Method method,
+			@NonNull OperationType operationType,
+			@NonNull AnnotationAttributes annotationAttributes) {
 		this.method = method;
 		this.operationType = operationType;
 		this.annotationAttributes = annotationAttributes;

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/reflect/ReflectiveOperationInvoker.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/reflect/ReflectiveOperationInvoker.java
@@ -23,8 +23,8 @@ import java.util.stream.Collectors;
 
 import org.springframework.boot.actuate.endpoint.OperationInvoker;
 import org.springframework.core.style.ToStringCreator;
+import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
 
 /**
@@ -51,11 +51,9 @@ public class ReflectiveOperationInvoker implements OperationInvoker {
 	 * @param methodInfo the method info
 	 * @param parameterMapper the parameter mapper
 	 */
-	public ReflectiveOperationInvoker(Object target, OperationMethodInfo methodInfo,
-			ParameterMapper parameterMapper) {
-		Assert.notNull(target, "Target must not be null");
-		Assert.notNull(methodInfo, "MethodInfo must not be null");
-		Assert.notNull(parameterMapper, "ParameterMapper must not be null");
+	public ReflectiveOperationInvoker(@NonNull Object target,
+			@NonNull OperationMethodInfo methodInfo,
+			@NonNull ParameterMapper parameterMapper) {
 		ReflectionUtils.makeAccessible(methodInfo.getMethod());
 		this.target = target;
 		this.methodInfo = methodInfo;

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/EndpointMediaTypes.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/EndpointMediaTypes.java
@@ -19,7 +19,7 @@ package org.springframework.boot.actuate.endpoint.web;
 import java.util.Collections;
 import java.util.List;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Media types that are, by default, produced and consumed by an endpoint.
@@ -40,9 +40,8 @@ public class EndpointMediaTypes {
 	 * be {@code null}.
 	 * @param consumed the default media types that are consumed by an endpoint. Must not
 	 */
-	public EndpointMediaTypes(List<String> produced, List<String> consumed) {
-		Assert.notNull(produced, () -> "Produced must not be null");
-		Assert.notNull(consumed, () -> "Consumed must not be null");
+	public EndpointMediaTypes(@NonNull List<String> produced,
+			@NonNull List<String> consumed) {
 		this.produced = Collections.unmodifiableList(produced);
 		this.consumed = Collections.unmodifiableList(consumed);
 	}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeHealthIndicator.java
@@ -19,7 +19,7 @@ package org.springframework.boot.actuate.health;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link HealthIndicator} that returns health indications from all registered delegates.
@@ -49,10 +49,8 @@ public class CompositeHealthIndicator implements HealthIndicator {
 	 * @param indicators a map of {@link HealthIndicator}s with the key being used as an
 	 * indicator name.
 	 */
-	public CompositeHealthIndicator(HealthAggregator healthAggregator,
-			Map<String, HealthIndicator> indicators) {
-		Assert.notNull(healthAggregator, "HealthAggregator must not be null");
-		Assert.notNull(indicators, "Indicators must not be null");
+	public CompositeHealthIndicator(@NonNull HealthAggregator healthAggregator,
+			@NonNull Map<String, HealthIndicator> indicators) {
 		this.indicators = new LinkedHashMap<>(indicators);
 		this.healthAggregator = healthAggregator;
 	}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeHealthIndicatorFactory.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeHealthIndicatorFactory.java
@@ -19,7 +19,7 @@ package org.springframework.boot.actuate.health;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Factory to create a {@link CompositeHealthIndicator}.
@@ -48,10 +48,8 @@ public class CompositeHealthIndicatorFactory {
 	 * {@code healthIndicators}.
 	 */
 	public CompositeHealthIndicator createHealthIndicator(
-			HealthAggregator healthAggregator,
-			Map<String, HealthIndicator> healthIndicators) {
-		Assert.notNull(healthAggregator, "HealthAggregator must not be null");
-		Assert.notNull(healthIndicators, "HealthIndicators must not be null");
+			@NonNull HealthAggregator healthAggregator,
+			@NonNull Map<String, HealthIndicator> healthIndicators) {
 		CompositeHealthIndicator healthIndicator = new CompositeHealthIndicator(
 				healthAggregator);
 		for (Map.Entry<String, HealthIndicator> entry : healthIndicators.entrySet()) {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeReactiveHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeReactiveHealthIndicator.java
@@ -25,7 +25,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link ReactiveHealthIndicator} that returns health indications from all registered
@@ -51,10 +51,8 @@ public class CompositeReactiveHealthIndicator implements ReactiveHealthIndicator
 		this(healthAggregator, new LinkedHashMap<>());
 	}
 
-	public CompositeReactiveHealthIndicator(HealthAggregator healthAggregator,
-			Map<String, ReactiveHealthIndicator> indicators) {
-		Assert.notNull(healthAggregator, "HealthAggregator must not be null");
-		Assert.notNull(indicators, "Indicators must not be null");
+	public CompositeReactiveHealthIndicator(@NonNull HealthAggregator healthAggregator,
+			@NonNull Map<String, ReactiveHealthIndicator> indicators) {
 		this.indicators = new LinkedHashMap<>(indicators);
 		this.healthAggregator = healthAggregator;
 		this.timeoutCompose = (mono) -> this.timeout != null ? mono.timeout(

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeReactiveHealthIndicatorFactory.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeReactiveHealthIndicatorFactory.java
@@ -20,7 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -56,12 +56,9 @@ public class CompositeReactiveHealthIndicatorFactory {
 	 * {@code reactiveHealthIndicators}.
 	 */
 	public CompositeReactiveHealthIndicator createReactiveHealthIndicator(
-			HealthAggregator healthAggregator,
-			Map<String, ReactiveHealthIndicator> reactiveHealthIndicators,
+			@NonNull HealthAggregator healthAggregator,
+			@NonNull Map<String, ReactiveHealthIndicator> reactiveHealthIndicators,
 			Map<String, HealthIndicator> healthIndicators) {
-		Assert.notNull(healthAggregator, "HealthAggregator must not be null");
-		Assert.notNull(reactiveHealthIndicators,
-				"ReactiveHealthIndicators must not be null");
 		CompositeReactiveHealthIndicator healthIndicator = new CompositeReactiveHealthIndicator(
 				healthAggregator);
 		merge(reactiveHealthIndicators, healthIndicators)

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Health.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Health.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Carries information about the health of a component or subsystem.
@@ -60,8 +60,7 @@ public final class Health {
 	 * Create a new {@link Health} instance with the specified status and details.
 	 * @param builder the Builder to use
 	 */
-	private Health(Builder builder) {
-		Assert.notNull(builder, "Builder must not be null");
+	private Health(@NonNull Builder builder) {
 		this.status = builder.status;
 		this.details = Collections.unmodifiableMap(builder.details);
 	}
@@ -187,8 +186,7 @@ public final class Health {
 		 * Create new Builder instance, setting status to given {@code status}.
 		 * @param status the {@link Status} to use
 		 */
-		public Builder(Status status) {
-			Assert.notNull(status, "Status must not be null");
+		public Builder(@NonNull Status status) {
 			this.status = status;
 			this.details = new LinkedHashMap<>();
 		}
@@ -199,9 +197,7 @@ public final class Health {
 		 * @param status the {@link Status} to use
 		 * @param details the details {@link Map} to use
 		 */
-		public Builder(Status status, Map<String, ?> details) {
-			Assert.notNull(status, "Status must not be null");
-			Assert.notNull(details, "Details must not be null");
+		public Builder(@NonNull Status status, @NonNull Map<String, ?> details) {
 			this.status = status;
 			this.details = new LinkedHashMap<>(details);
 		}
@@ -211,8 +207,7 @@ public final class Health {
 		 * @param ex the exception
 		 * @return this {@link Builder} instance
 		 */
-		public Builder withException(Throwable ex) {
-			Assert.notNull(ex, "Exception must not be null");
+		public Builder withException(@NonNull Throwable ex) {
 			return withDetail("error", ex.getClass().getName() + ": " + ex.getMessage());
 		}
 
@@ -222,9 +217,7 @@ public final class Health {
 		 * @param value the detail value
 		 * @return this {@link Builder} instance
 		 */
-		public Builder withDetail(String key, Object value) {
-			Assert.notNull(key, "Key must not be null");
-			Assert.notNull(value, "Value must not be null");
+		public Builder withDetail(@NonNull String key, @NonNull Object value) {
 			this.details.put(key, value);
 			return this;
 		}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthIndicatorReactiveAdapter.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthIndicatorReactiveAdapter.java
@@ -20,7 +20,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
 import reactor.core.scheduler.Schedulers;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Adapts a {@link HealthIndicator} to a {@link ReactiveHealthIndicator} so that it can be
@@ -33,8 +33,7 @@ public class HealthIndicatorReactiveAdapter implements ReactiveHealthIndicator {
 
 	private final HealthIndicator delegate;
 
-	public HealthIndicatorReactiveAdapter(HealthIndicator delegate) {
-		Assert.notNull(delegate, "Delegate must not be null");
+	public HealthIndicatorReactiveAdapter(@NonNull HealthIndicator delegate) {
 		this.delegate = delegate;
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthStatusHttpMapper.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthStatusHttpMapper.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Map a {@link Status} to an HTTP status code.
@@ -50,8 +50,7 @@ public class HealthStatusHttpMapper {
 	 * Set specific status mappings.
 	 * @param statusMapping a map of health status code to HTTP status code
 	 */
-	public void setStatusMapping(Map<String, Integer> statusMapping) {
-		Assert.notNull(statusMapping, "StatusMapping must not be null");
+	public void setStatusMapping(@NonNull Map<String, Integer> statusMapping) {
 		this.statusMapping = new HashMap<>(statusMapping);
 	}
 
@@ -59,8 +58,7 @@ public class HealthStatusHttpMapper {
 	 * Add specific status mappings to the existing set.
 	 * @param statusMapping a map of health status code to HTTP status code
 	 */
-	public void addStatusMapping(Map<String, Integer> statusMapping) {
-		Assert.notNull(statusMapping, "StatusMapping must not be null");
+	public void addStatusMapping(@NonNull Map<String, Integer> statusMapping) {
 		this.statusMapping.putAll(statusMapping);
 	}
 
@@ -69,9 +67,7 @@ public class HealthStatusHttpMapper {
 	 * @param status the status to map
 	 * @param httpStatus the http status
 	 */
-	public void addStatusMapping(Status status, Integer httpStatus) {
-		Assert.notNull(status, "Status must not be null");
-		Assert.notNull(httpStatus, "HttpStatus must not be null");
+	public void addStatusMapping(@NonNull Status status, @NonNull Integer httpStatus) {
 		addStatusMapping(status.getCode(), httpStatus);
 	}
 
@@ -80,9 +76,8 @@ public class HealthStatusHttpMapper {
 	 * @param statusCode the status code to map
 	 * @param httpStatus the http status
 	 */
-	public void addStatusMapping(String statusCode, Integer httpStatus) {
-		Assert.notNull(statusCode, "StatusCode must not be null");
-		Assert.notNull(httpStatus, "HttpStatus must not be null");
+	public void addStatusMapping(@NonNull String statusCode,
+			@NonNull Integer httpStatus) {
 		this.statusMapping.put(statusCode, httpStatus);
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/OrderedHealthAggregator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/OrderedHealthAggregator.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Default {@link HealthAggregator} implementation that aggregates {@link Health}
@@ -60,8 +60,7 @@ public class OrderedHealthAggregator extends AbstractHealthAggregator {
 	 * Set the ordering of the status.
 	 * @param statusOrder an ordered list of the status codes
 	 */
-	public void setStatusOrder(List<String> statusOrder) {
-		Assert.notNull(statusOrder, "StatusOrder must not be null");
+	public void setStatusOrder(@NonNull List<String> statusOrder) {
 		this.statusOrder = statusOrder;
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Status.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Status.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -77,9 +77,7 @@ public final class Status {
 	 * @param code the status code
 	 * @param description a description of the status
 	 */
-	public Status(String code, String description) {
-		Assert.notNull(code, "Code must not be null");
-		Assert.notNull(description, "Description must not be null");
+	public Status(@NonNull String code, @NonNull String description) {
 		this.code = code;
 		this.description = description;
 	}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/InfoEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/InfoEndpoint.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link Endpoint} to expose arbitrary application information.
@@ -40,8 +40,7 @@ public class InfoEndpoint {
 	 * Create a new {@link InfoEndpoint} instance.
 	 * @param infoContributors the info contributors to use
 	 */
-	public InfoEndpoint(List<InfoContributor> infoContributors) {
-		Assert.notNull(infoContributors, "Info contributors must not be null");
+	public InfoEndpoint(@NonNull List<InfoContributor> infoContributors) {
 		this.infoContributors = infoContributors;
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/SimpleInfoContributor.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/SimpleInfoContributor.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.actuate.info;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * A simple {@link InfoContributor} that exposes a single detail.
@@ -30,8 +30,7 @@ public class SimpleInfoContributor implements InfoContributor {
 
 	private final Object detail;
 
-	public SimpleInfoContributor(String prefix, Object detail) {
-		Assert.notNull(prefix, "Prefix must not be null");
+	public SimpleInfoContributor(@NonNull String prefix, Object detail) {
 		this.prefix = prefix;
 		this.detail = detail;
 	}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/ldap/LdapHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/ldap/LdapHealthIndicator.java
@@ -22,9 +22,9 @@ import javax.naming.directory.DirContext;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.lang.NonNull;
 import org.springframework.ldap.core.ContextExecutor;
 import org.springframework.ldap.core.LdapOperations;
-import org.springframework.util.Assert;
 
 /**
  * {@link HealthIndicator} for configured LDAP server(s).
@@ -39,8 +39,7 @@ public class LdapHealthIndicator extends AbstractHealthIndicator {
 
 	private final LdapOperations ldapOperations;
 
-	public LdapHealthIndicator(LdapOperations ldapOperations) {
-		Assert.notNull(ldapOperations, "LdapOperations must not be null");
+	public LdapHealthIndicator(@NonNull LdapOperations ldapOperations) {
 		this.ldapOperations = ldapOperations;
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/logging/LoggersEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/logging/LoggersEndpoint.java
@@ -31,8 +31,8 @@ import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.logging.LogLevel;
 import org.springframework.boot.logging.LoggerConfiguration;
 import org.springframework.boot.logging.LoggingSystem;
+import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
 
 /**
  * {@link Endpoint} to expose a collection of {@link LoggerConfiguration}s.
@@ -50,8 +50,7 @@ public class LoggersEndpoint {
 	 * Create a new {@link LoggersEndpoint} instance.
 	 * @param loggingSystem the logging system to expose
 	 */
-	public LoggersEndpoint(LoggingSystem loggingSystem) {
-		Assert.notNull(loggingSystem, "LoggingSystem must not be null");
+	public LoggersEndpoint(@NonNull LoggingSystem loggingSystem) {
 		this.loggingSystem = loggingSystem;
 	}
 
@@ -69,17 +68,15 @@ public class LoggersEndpoint {
 	}
 
 	@ReadOperation
-	public LoggerLevels loggerLevels(@Selector String name) {
-		Assert.notNull(name, "Name must not be null");
+	public LoggerLevels loggerLevels(@Selector @NonNull String name) {
 		LoggerConfiguration configuration = this.loggingSystem
 				.getLoggerConfiguration(name);
 		return (configuration == null ? null : new LoggerLevels(configuration));
 	}
 
 	@WriteOperation
-	public void configureLogLevel(@Selector String name,
+	public void configureLogLevel(@Selector @NonNull String name,
 			@Nullable LogLevel configuredLevel) {
-		Assert.notNull(name, "Name must not be empty");
 		this.loggingSystem.setLogLevel(name, configuredLevel);
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/jdbc/DataSourcePoolMetrics.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/jdbc/DataSourcePoolMetrics.java
@@ -29,7 +29,7 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 import org.springframework.boot.jdbc.metadata.CompositeDataSourcePoolMetadataProvider;
 import org.springframework.boot.jdbc.metadata.DataSourcePoolMetadata;
 import org.springframework.boot.jdbc.metadata.DataSourcePoolMetadataProvider;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ConcurrentReferenceHashMap;
 
 /**
@@ -56,11 +56,9 @@ public class DataSourcePoolMetrics implements MeterBinder {
 				name, tags);
 	}
 
-	public DataSourcePoolMetrics(DataSource dataSource,
-			DataSourcePoolMetadataProvider metadataProvider, String name,
+	public DataSourcePoolMetrics(@NonNull DataSource dataSource,
+			@NonNull DataSourcePoolMetadataProvider metadataProvider, String name,
 			Iterable<Tag> tags) {
-		Assert.notNull(dataSource, "DataSource must not be null");
-		Assert.notNull(metadataProvider, "MetadataProvider must not be null");
 		this.dataSource = dataSource;
 		this.metadataProvider = new CachingDataSourcePoolMetadataProvider(dataSource,
 				metadataProvider);

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/mongo/MongoHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/mongo/MongoHealthIndicator.java
@@ -22,7 +22,7 @@ import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Simple implementation of a {@link HealthIndicator} returning status information for
@@ -35,8 +35,7 @@ public class MongoHealthIndicator extends AbstractHealthIndicator {
 
 	private final MongoTemplate mongoTemplate;
 
-	public MongoHealthIndicator(MongoTemplate mongoTemplate) {
-		Assert.notNull(mongoTemplate, "MongoTemplate must not be null");
+	public MongoHealthIndicator(@NonNull MongoTemplate mongoTemplate) {
 		this.mongoTemplate = mongoTemplate;
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisHealthIndicator.java
@@ -26,7 +26,7 @@ import org.springframework.data.redis.connection.RedisClusterConnection;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisConnectionUtils;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Simple implementation of a {@link HealthIndicator} returning status information for
@@ -44,8 +44,7 @@ public class RedisHealthIndicator extends AbstractHealthIndicator {
 
 	private final RedisConnectionFactory redisConnectionFactory;
 
-	public RedisHealthIndicator(RedisConnectionFactory connectionFactory) {
-		Assert.notNull(connectionFactory, "ConnectionFactory must not be null");
+	public RedisHealthIndicator(@NonNull RedisConnectionFactory connectionFactory) {
 		this.redisConnectionFactory = connectionFactory;
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/Trace.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/Trace.java
@@ -19,7 +19,7 @@ package org.springframework.boot.actuate.trace;
 import java.util.Date;
 import java.util.Map;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * A value object representing a trace event: at a particular time with a simple (map)
@@ -33,9 +33,7 @@ public final class Trace {
 
 	private final Map<String, Object> info;
 
-	public Trace(Date timestamp, Map<String, Object> info) {
-		Assert.notNull(timestamp, "Timestamp must not be null");
-		Assert.notNull(info, "Info must not be null");
+	public Trace(@NonNull Date timestamp, @NonNull Map<String, Object> info) {
 		this.timestamp = timestamp;
 		this.info = info;
 	}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/TraceEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/TraceEndpoint.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link Endpoint} to expose {@link Trace} information.
@@ -37,8 +37,7 @@ public class TraceEndpoint {
 	 * Create a new {@link TraceEndpoint} instance.
 	 * @param repository the trace repository
 	 */
-	public TraceEndpoint(TraceRepository repository) {
-		Assert.notNull(repository, "Repository must not be null");
+	public TraceEndpoint(@NonNull TraceRepository repository) {
 		this.repository = repository;
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/audit/InMemoryAuditEventRepositoryTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/audit/InMemoryAuditEventRepositoryTests.java
@@ -66,7 +66,7 @@ public class InMemoryAuditEventRepositoryTests {
 	@Test
 	public void addNullAuditEvent() throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("AuditEvent must not be null");
+		this.thrown.expectMessage("Event must not be null");
 		InMemoryAuditEventRepository repository = new InMemoryAuditEventRepository();
 		repository.add(null);
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationSorter.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationSorter.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.core.type.classreading.MetadataReader;
 import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -44,9 +45,8 @@ class AutoConfigurationSorter {
 
 	private final AutoConfigurationMetadata autoConfigurationMetadata;
 
-	AutoConfigurationSorter(MetadataReaderFactory metadataReaderFactory,
+	AutoConfigurationSorter(@NonNull MetadataReaderFactory metadataReaderFactory,
 			AutoConfigurationMetadata autoConfigurationMetadata) {
-		Assert.notNull(metadataReaderFactory, "MetadataReaderFactory must not be null");
 		this.metadataReaderFactory = metadataReaderFactory;
 		this.autoConfigurationMetadata = autoConfigurationMetadata;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/AbstractRabbitListenerContainerFactoryConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/AbstractRabbitListenerContainerFactoryConfigurer.java
@@ -24,7 +24,7 @@ import org.springframework.amqp.rabbit.retry.MessageRecoverer;
 import org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.boot.autoconfigure.amqp.RabbitProperties.ListenerRetry;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Configure {@link RabbitListenerContainerFactory} with sensible defaults.
@@ -80,11 +80,9 @@ public abstract class AbstractRabbitListenerContainerFactoryConfigurer<T extends
 	 */
 	public abstract void configure(T factory, ConnectionFactory connectionFactory);
 
-	protected void configure(T factory, ConnectionFactory connectionFactory,
-			RabbitProperties.AmqpContainer configuration) {
-		Assert.notNull(factory, "Factory must not be null");
-		Assert.notNull(connectionFactory, "ConnectionFactory must not be null");
-		Assert.notNull(configuration, "Configuration must not be null");
+	protected void configure(@NonNull T factory,
+			@NonNull ConnectionFactory connectionFactory,
+			@NonNull RabbitProperties.AmqpContainer configuration) {
 		factory.setConnectionFactory(connectionFactory);
 		if (this.messageConverter != null) {
 			factory.setMessageConverter(this.messageConverter);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchDataSourceInitializer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchDataSourceInitializer.java
@@ -21,7 +21,7 @@ import javax.sql.DataSource;
 import org.springframework.boot.jdbc.AbstractDataSourceInitializer;
 import org.springframework.boot.jdbc.DataSourceInitializationMode;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Initialize the Spring Batch schema (ignoring errors, so should be idempotent).
@@ -34,9 +34,9 @@ public class BatchDataSourceInitializer extends AbstractDataSourceInitializer {
 	private final BatchProperties properties;
 
 	public BatchDataSourceInitializer(DataSource dataSource,
-			ResourceLoader resourceLoader, BatchProperties properties) {
+			ResourceLoader resourceLoader,
+			@NonNull BatchProperties properties) {
 		super(dataSource, resourceLoader);
-		Assert.notNull(properties, "BatchProperties must not be null");
 		this.properties = properties;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/AbstractNestedCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/AbstractNestedCondition.java
@@ -31,7 +31,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.core.type.classreading.MetadataReaderFactory;
 import org.springframework.core.type.classreading.SimpleMetadataReaderFactory;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -46,8 +46,7 @@ abstract class AbstractNestedCondition extends SpringBootCondition
 
 	private final ConfigurationPhase configurationPhase;
 
-	AbstractNestedCondition(ConfigurationPhase configurationPhase) {
-		Assert.notNull(configurationPhase, "ConfigurationPhase must not be null");
+	AbstractNestedCondition(@NonNull ConfigurationPhase configurationPhase) {
 		this.configurationPhase = configurationPhase;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionEvaluationReport.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionEvaluationReport.java
@@ -34,7 +34,7 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -74,11 +74,9 @@ public final class ConditionEvaluationReport {
 	 * @param condition the condition evaluated
 	 * @param outcome the condition outcome
 	 */
-	public void recordConditionEvaluation(String source, Condition condition,
-			ConditionOutcome outcome) {
-		Assert.notNull(source, "Source must not be null");
-		Assert.notNull(condition, "Condition must not be null");
-		Assert.notNull(outcome, "Outcome must not be null");
+	public void recordConditionEvaluation(@NonNull String source,
+			@NonNull Condition condition,
+			@NonNull ConditionOutcome outcome) {
 		this.unconditionalClasses.remove(source);
 		if (!this.outcomes.containsKey(source)) {
 			this.outcomes.put(source, new ConditionAndOutcomes());
@@ -91,8 +89,7 @@ public final class ConditionEvaluationReport {
 	 * Records the names of the classes that have been excluded from condition evaluation.
 	 * @param exclusions the names of the excluded classes
 	 */
-	public void recordExclusions(Collection<String> exclusions) {
-		Assert.notNull(exclusions, "exclusions must not be null");
+	public void recordExclusions(@NonNull Collection<String> exclusions) {
 		this.exclusions = new ArrayList<>(exclusions);
 	}
 
@@ -101,8 +98,7 @@ public final class ConditionEvaluationReport {
 	 * @param evaluationCandidates the names of the classes whose conditions will be
 	 * evaluated
 	 */
-	public void recordEvaluationCandidates(List<String> evaluationCandidates) {
-		Assert.notNull(evaluationCandidates, "evaluationCandidates must not be null");
+	public void recordEvaluationCandidates(@NonNull List<String> evaluationCandidates) {
 		this.unconditionalClasses = new HashSet<>(evaluationCandidates);
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionMessage.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionMessage.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -106,9 +106,8 @@ public final class ConditionMessage {
 	 * @see #andCondition(String, Object...)
 	 * @see #forCondition(Class, Object...)
 	 */
-	public Builder andCondition(Class<? extends Annotation> condition,
+	public Builder andCondition(@NonNull Class<? extends Annotation> condition,
 			Object... details) {
-		Assert.notNull(condition, "Condition must not be null");
 		return andCondition("@" + ClassUtils.getShortName(condition), details);
 	}
 
@@ -121,8 +120,7 @@ public final class ConditionMessage {
 	 * @see #andCondition(Class, Object...)
 	 * @see #forCondition(String, Object...)
 	 */
-	public Builder andCondition(String condition, Object... details) {
-		Assert.notNull(condition, "Condition must not be null");
+	public Builder andCondition(@NonNull String condition, Object... details) {
 		String detail = StringUtils.arrayToDelimitedString(details, " ");
 		if (StringUtils.hasLength(detail)) {
 			return new Builder(condition + " " + detail);
@@ -381,8 +379,7 @@ public final class ConditionMessage {
 		 * @param items the source of the items (may be {@code null})
 		 * @return a built {@link ConditionMessage}
 		 */
-		public ConditionMessage items(Style style, Collection<?> items) {
-			Assert.notNull(style, "Style must not be null");
+		public ConditionMessage items(@NonNull Style style, Collection<?> items) {
 			StringBuilder message = new StringBuilder(this.reason);
 			items = style.applyTo(items);
 			if ((this.condition == null || items.size() <= 1)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionOutcome.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionOutcome.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.autoconfigure.condition;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -46,8 +46,7 @@ public class ConditionOutcome {
 	 * @param match if the condition is a match
 	 * @param message the condition message
 	 */
-	public ConditionOutcome(boolean match, ConditionMessage message) {
-		Assert.notNull(message, "ConditionMessage must not be null");
+	public ConditionOutcome(boolean match, @NonNull ConditionMessage message) {
 		this.match = match;
 		this.message = message;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoDataAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoDataAutoConfiguration.java
@@ -52,7 +52,7 @@ import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.gridfs.GridFsTemplate;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.StringUtils;
 
 /**
@@ -155,9 +155,8 @@ public class MongoDataAutoConfiguration {
 
 		private final MongoProperties properties;
 
-		GridFsMongoDbFactory(MongoDbFactory mongoDbFactory, MongoProperties properties) {
-			Assert.notNull(mongoDbFactory, "MongoDbFactory must not be null");
-			Assert.notNull(properties, "Properties must not be null");
+		GridFsMongoDbFactory(@NonNull MongoDbFactory mongoDbFactory,
+				@NonNull MongoProperties properties) {
 			this.mongoDbFactory = mongoDbFactory;
 			this.properties = properties;
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/domain/EntityScanPackages.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/domain/EntityScanPackages.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.support.GenericBeanDefinition;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
@@ -94,9 +95,8 @@ public class EntityScanPackages {
 	 * @param registry the source registry
 	 * @param packageNames the package names to register
 	 */
-	public static void register(BeanDefinitionRegistry registry, String... packageNames) {
-		Assert.notNull(registry, "Registry must not be null");
-		Assert.notNull(packageNames, "PackageNames must not be null");
+	public static void register(@NonNull BeanDefinitionRegistry registry,
+			@NonNull String... packageNames) {
 		register(registry, Arrays.asList(packageNames));
 	}
 
@@ -105,10 +105,8 @@ public class EntityScanPackages {
 	 * @param registry the source registry
 	 * @param packageNames the package names to register
 	 */
-	public static void register(BeanDefinitionRegistry registry,
-			Collection<String> packageNames) {
-		Assert.notNull(registry, "Registry must not be null");
-		Assert.notNull(packageNames, "PackageNames must not be null");
+	public static void register(@NonNull BeanDefinitionRegistry registry,
+			@NonNull Collection<String> packageNames) {
 		if (registry.containsBeanDefinition(BEAN)) {
 			BeanDefinition beanDefinition = registry.getBeanDefinition(BEAN);
 			ConstructorArgumentValues constructorArguments = beanDefinition

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/domain/EntityScanner.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/domain/EntityScanner.java
@@ -27,7 +27,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
@@ -46,8 +46,7 @@ public class EntityScanner {
 	 * Create a new {@link EntityScanner} instance.
 	 * @param context the source application context
 	 */
-	public EntityScanner(ApplicationContext context) {
-		Assert.notNull(context, "Context must not be null");
+	public EntityScanner(@NonNull ApplicationContext context) {
 		this.context = context;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayMigrationInitializer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayMigrationInitializer.java
@@ -20,7 +20,7 @@ import org.flywaydb.core.Flyway;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.Ordered;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link InitializingBean} used to trigger {@link Flyway} migration via the
@@ -50,9 +50,8 @@ public class FlywayMigrationInitializer implements InitializingBean, Ordered {
 	 * @param flyway the flyway instance
 	 * @param migrationStrategy the migration strategy or {@code null}
 	 */
-	public FlywayMigrationInitializer(Flyway flyway,
+	public FlywayMigrationInitializer(@NonNull Flyway flyway,
 			FlywayMigrationStrategy migrationStrategy) {
-		Assert.notNull(flyway, "Flyway must not be null");
 		this.flyway = flyway;
 		this.migrationStrategy = migrationStrategy;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.h2;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -46,8 +47,7 @@ public class H2ConsoleProperties {
 		return this.path;
 	}
 
-	public void setPath(String path) {
-		Assert.notNull(path, "Path must not be null");
+	public void setPath(@NonNull String path) {
 		Assert.isTrue(path.isEmpty() || path.startsWith("/"),
 				"Path must start with / or be empty");
 		this.path = path;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientFactory.java
@@ -25,7 +25,7 @@ import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.core.HazelcastInstance;
 
 import org.springframework.core.io.Resource;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.StringUtils;
 
 /**
@@ -51,8 +51,7 @@ public class HazelcastClientFactory {
 	 * Create a {@link HazelcastClientFactory} for the specified configuration.
 	 * @param clientConfig the configuration
 	 */
-	public HazelcastClientFactory(ClientConfig clientConfig) {
-		Assert.notNull(clientConfig, "ClientConfig must not be null");
+	public HazelcastClientFactory(@NonNull ClientConfig clientConfig) {
 		this.clientConfig = clientConfig;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastConfigResourceCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastConfigResourceCondition.java
@@ -21,7 +21,7 @@ import org.springframework.boot.autoconfigure.condition.ResourceCondition;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link SpringBootCondition} used to check if the Hazelcast configuration is available.
@@ -37,10 +37,9 @@ public abstract class HazelcastConfigResourceCondition extends ResourceCondition
 
 	private final String configSystemProperty;
 
-	protected HazelcastConfigResourceCondition(String configSystemProperty,
+	protected HazelcastConfigResourceCondition(@NonNull String configSystemProperty,
 			String... resourceLocations) {
 		super("Hazelcast", "spring.hazelcast.config", resourceLocations);
-		Assert.notNull(configSystemProperty, "ConfigSystemProperty must not be null");
 		this.configSystemProperty = configSystemProperty;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastInstanceFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastInstanceFactory.java
@@ -25,7 +25,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 
 import org.springframework.core.io.Resource;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
 
@@ -45,8 +45,7 @@ public class HazelcastInstanceFactory {
 	 * @param configLocation the location of the configuration file
 	 * @throws IOException if the configuration location could not be read
 	 */
-	public HazelcastInstanceFactory(Resource configLocation) throws IOException {
-		Assert.notNull(configLocation, "ConfigLocation must not be null");
+	public HazelcastInstanceFactory(@NonNull Resource configLocation) throws IOException {
 		this.config = getConfig(configLocation);
 	}
 
@@ -54,8 +53,7 @@ public class HazelcastInstanceFactory {
 	 * Create a {@link HazelcastInstanceFactory} for the specified configuration.
 	 * @param config the configuration
 	 */
-	public HazelcastInstanceFactory(Config config) {
-		Assert.notNull(config, "Config must not be null");
+	public HazelcastInstanceFactory(@NonNull Config config) {
 		this.config = config;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationDataSourceInitializer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationDataSourceInitializer.java
@@ -21,7 +21,7 @@ import javax.sql.DataSource;
 import org.springframework.boot.jdbc.AbstractDataSourceInitializer;
 import org.springframework.boot.jdbc.DataSourceInitializationMode;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Initializer for Spring Integration schema.
@@ -34,9 +34,8 @@ public class IntegrationDataSourceInitializer extends AbstractDataSourceInitiali
 	private final IntegrationProperties.Jdbc properties;
 
 	public IntegrationDataSourceInitializer(DataSource dataSource,
-			ResourceLoader resourceLoader, IntegrationProperties properties) {
+			ResourceLoader resourceLoader, @NonNull IntegrationProperties properties) {
 		super(dataSource, resourceLoader);
-		Assert.notNull(properties, "IntegrationProperties must not be null");
 		this.properties = properties.getJdbc();
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/DefaultJmsListenerContainerFactoryConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/DefaultJmsListenerContainerFactoryConfigurer.java
@@ -21,8 +21,8 @@ import javax.jms.ConnectionFactory;
 import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
 import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.jms.support.destination.DestinationResolver;
+import org.springframework.lang.NonNull;
 import org.springframework.transaction.jta.JtaTransactionManager;
-import org.springframework.util.Assert;
 
 /**
  * Configure {@link DefaultJmsListenerContainerFactory} with sensible defaults.
@@ -81,10 +81,8 @@ public final class DefaultJmsListenerContainerFactoryConfigurer {
 	 * @param factory the {@link DefaultJmsListenerContainerFactory} instance to configure
 	 * @param connectionFactory the {@link ConnectionFactory} to use
 	 */
-	public void configure(DefaultJmsListenerContainerFactory factory,
-			ConnectionFactory connectionFactory) {
-		Assert.notNull(factory, "Factory must not be null");
-		Assert.notNull(connectionFactory, "ConnectionFactory must not be null");
+	public void configure(@NonNull DefaultJmsListenerContainerFactory factory,
+			@NonNull ConnectionFactory connectionFactory) {
 		factory.setConnectionFactory(connectionFactory);
 		factory.setPubSubDomain(this.jmsProperties.isPubSubDomain());
 		if (this.transactionManager != null) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQConnectionFactoryFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQConnectionFactoryFactory.java
@@ -23,7 +23,7 @@ import java.util.List;
 import org.apache.activemq.ActiveMQConnectionFactory;
 
 import org.springframework.boot.autoconfigure.jms.activemq.ActiveMQProperties.Packages;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.StringUtils;
 
 /**
@@ -44,9 +44,8 @@ class ActiveMQConnectionFactoryFactory {
 
 	private final List<ActiveMQConnectionFactoryCustomizer> factoryCustomizers;
 
-	ActiveMQConnectionFactoryFactory(ActiveMQProperties properties,
+	ActiveMQConnectionFactoryFactory(@NonNull ActiveMQProperties properties,
 			List<ActiveMQConnectionFactoryCustomizer> factoryCustomizers) {
-		Assert.notNull(properties, "Properties must not be null");
 		this.properties = properties;
 		this.factoryCustomizers = (factoryCustomizers != null ? factoryCustomizers
 				: Collections.emptyList());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisConnectionFactoryFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisConnectionFactoryFactory.java
@@ -29,7 +29,7 @@ import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 
 import org.springframework.beans.factory.ListableBeanFactory;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
@@ -49,10 +49,8 @@ class ArtemisConnectionFactoryFactory {
 
 	private final ListableBeanFactory beanFactory;
 
-	ArtemisConnectionFactoryFactory(ListableBeanFactory beanFactory,
-			ArtemisProperties properties) {
-		Assert.notNull(beanFactory, "BeanFactory must not be null");
-		Assert.notNull(properties, "Properties must not be null");
+	ArtemisConnectionFactoryFactory(@NonNull ListableBeanFactory beanFactory,
+			@NonNull ArtemisProperties properties) {
 		this.beanFactory = beanFactory;
 		this.properties = properties;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapProperties.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.env.Environment;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -107,8 +107,7 @@ public class LdapProperties {
 		return this.urls;
 	}
 
-	private int determinePort(Environment environment) {
-		Assert.notNull(environment, "Environment must not be null");
+	private int determinePort(@NonNull Environment environment) {
 		String localPort = environment.getProperty("local.ldap.port");
 		if (localPort != null) {
 			return Integer.valueOf(localPort);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import liquibase.integration.spring.SpringLiquibase;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Configuration properties to configure {@link SpringLiquibase}.
@@ -98,8 +98,7 @@ public class LiquibaseProperties {
 		return this.changeLog;
 	}
 
-	public void setChangeLog(String changeLog) {
-		Assert.notNull(changeLog, "ChangeLog must not be null");
+	public void setChangeLog(@NonNull String changeLog) {
 		this.changeLog = changeLog;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
@@ -66,7 +66,7 @@ import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
 import org.springframework.data.mongodb.core.MongoClientFactoryBean;
 import org.springframework.data.mongodb.core.ReactiveMongoClientFactoryBean;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Embedded Mongo.
@@ -254,9 +254,8 @@ public class EmbeddedMongoAutoConfiguration {
 
 		private final Set<Feature> features;
 
-		private ToStringFriendlyFeatureAwareVersion(String version,
+		private ToStringFriendlyFeatureAwareVersion(@NonNull String version,
 				Set<Feature> features) {
-			Assert.notNull(version, "version must not be null");
 			this.version = version;
 			this.features = (features == null ? Collections.emptySet() : features);
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/quartz/AutowireCapableBeanJobFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/quartz/AutowireCapableBeanJobFactory.java
@@ -19,8 +19,8 @@ package org.springframework.boot.autoconfigure.quartz;
 import org.quartz.spi.TriggerFiredBundle;
 
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.lang.NonNull;
 import org.springframework.scheduling.quartz.SpringBeanJobFactory;
-import org.springframework.util.Assert;
 
 /**
  * Subclass of {@link SpringBeanJobFactory} that supports auto-wiring job beans.
@@ -33,8 +33,7 @@ class AutowireCapableBeanJobFactory extends SpringBeanJobFactory {
 
 	private final AutowireCapableBeanFactory beanFactory;
 
-	AutowireCapableBeanJobFactory(AutowireCapableBeanFactory beanFactory) {
-		Assert.notNull(beanFactory, "Bean factory must not be null");
+	AutowireCapableBeanJobFactory(@NonNull AutowireCapableBeanFactory beanFactory) {
 		this.beanFactory = beanFactory;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/quartz/QuartzDataSourceInitializer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/quartz/QuartzDataSourceInitializer.java
@@ -21,7 +21,7 @@ import javax.sql.DataSource;
 import org.springframework.boot.jdbc.AbstractDataSourceInitializer;
 import org.springframework.boot.jdbc.DataSourceInitializationMode;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Initialize the Quartz Scheduler schema.
@@ -34,9 +34,8 @@ public class QuartzDataSourceInitializer extends AbstractDataSourceInitializer {
 	private final QuartzProperties properties;
 
 	public QuartzDataSourceInitializer(DataSource dataSource,
-			ResourceLoader resourceLoader, QuartzProperties properties) {
+			ResourceLoader resourceLoader, @NonNull QuartzProperties properties) {
 		super(dataSource, resourceLoader);
-		Assert.notNull(properties, "QuartzProperties must not be null");
 		this.properties = properties;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/StaticResourceRequest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/StaticResourceRequest.java
@@ -28,10 +28,10 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.security.ApplicationContextRequestMatcher;
+import org.springframework.lang.NonNull;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.util.Assert;
 
 /**
  * Factory that can be used to create a {@link RequestMatcher} for static resources in
@@ -80,8 +80,7 @@ public final class StaticResourceRequest {
 	 * @param locations the locations to include
 	 * @return the configured {@link RequestMatcher}
 	 */
-	public static StaticResourceRequestMatcher to(Set<Location> locations) {
-		Assert.notNull(locations, "Locations must not be null");
+	public static StaticResourceRequestMatcher to(@NonNull Set<Location> locations) {
 		return new StaticResourceRequestMatcher(new LinkedHashSet<>(locations));
 	}
 
@@ -156,8 +155,7 @@ public final class StaticResourceRequest {
 		 * @param locations the locations to exclude
 		 * @return a new {@link StaticResourceRequestMatcher}
 		 */
-		public StaticResourceRequestMatcher excluding(Set<Location> locations) {
-			Assert.notNull(locations, "Locations must not be null");
+		public StaticResourceRequestMatcher excluding(@NonNull Set<Location> locations) {
 			Set<Location> subset = new LinkedHashSet<>(this.locations);
 			subset.removeAll(locations);
 			return new StaticResourceRequestMatcher(subset);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionDataSourceInitializer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionDataSourceInitializer.java
@@ -21,7 +21,7 @@ import javax.sql.DataSource;
 import org.springframework.boot.jdbc.AbstractDataSourceInitializer;
 import org.springframework.boot.jdbc.DataSourceInitializationMode;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Initializer for Spring Session schema.
@@ -34,9 +34,8 @@ public class JdbcSessionDataSourceInitializer extends AbstractDataSourceInitiali
 	private final JdbcSessionProperties properties;
 
 	public JdbcSessionDataSourceInitializer(DataSource dataSource,
-			ResourceLoader resourceLoader, JdbcSessionProperties properties) {
+			ResourceLoader resourceLoader, @NonNull JdbcSessionProperties properties) {
 		super(dataSource, resourceLoader);
-		Assert.notNull(properties, "JdbcSessionProperties must not be null");
 		this.properties = properties;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/template/TemplateAvailabilityProviders.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/template/TemplateAvailabilityProviders.java
@@ -27,7 +27,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.SpringFactoriesLoader;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Collection of {@link TemplateAvailabilityProvider} beans that can be used to check
@@ -83,8 +83,7 @@ public class TemplateAvailabilityProviders {
 	 * Create a new {@link TemplateAvailabilityProviders} instance.
 	 * @param classLoader the source class loader
 	 */
-	public TemplateAvailabilityProviders(ClassLoader classLoader) {
-		Assert.notNull(classLoader, "ClassLoader must not be null");
+	public TemplateAvailabilityProviders(@NonNull ClassLoader classLoader) {
 		this.providers = SpringFactoriesLoader
 				.loadFactories(TemplateAvailabilityProvider.class, classLoader);
 	}
@@ -94,8 +93,7 @@ public class TemplateAvailabilityProviders {
 	 * @param providers the underlying providers
 	 */
 	protected TemplateAvailabilityProviders(
-			Collection<? extends TemplateAvailabilityProvider> providers) {
-		Assert.notNull(providers, "Providers must not be null");
+			@NonNull Collection<? extends TemplateAvailabilityProvider> providers) {
 		this.providers = new ArrayList<>(providers);
 	}
 
@@ -114,8 +112,7 @@ public class TemplateAvailabilityProviders {
 	 * @return a {@link TemplateAvailabilityProvider} or null
 	 */
 	public TemplateAvailabilityProvider getProvider(String view,
-			ApplicationContext applicationContext) {
-		Assert.notNull(applicationContext, "ApplicationContext must not be null");
+			@NonNull ApplicationContext applicationContext) {
 		return getProvider(view, applicationContext.getEnvironment(),
 				applicationContext.getClassLoader(), applicationContext);
 	}
@@ -128,12 +125,10 @@ public class TemplateAvailabilityProviders {
 	 * @param resourceLoader the resource loader
 	 * @return a {@link TemplateAvailabilityProvider} or null
 	 */
-	public TemplateAvailabilityProvider getProvider(String view, Environment environment,
-			ClassLoader classLoader, ResourceLoader resourceLoader) {
-		Assert.notNull(view, "View must not be null");
-		Assert.notNull(environment, "Environment must not be null");
-		Assert.notNull(classLoader, "ClassLoader must not be null");
-		Assert.notNull(resourceLoader, "ResourceLoader must not be null");
+	public TemplateAvailabilityProvider getProvider(@NonNull String view,
+			@NonNull Environment environment,
+			@NonNull ClassLoader classLoader,
+			@NonNull ResourceLoader resourceLoader) {
 		Boolean useCache = environment.getProperty("spring.template.provider.cache",
 				Boolean.class, true);
 		if (!useCache) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/template/TemplateLocation.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/template/TemplateLocation.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.ResourcePatternResolver;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Contains a location that templates can be loaded from.
@@ -33,8 +33,7 @@ public class TemplateLocation {
 
 	private final String path;
 
-	public TemplateLocation(String path) {
-		Assert.notNull(path, "Path must not be null");
+	public TemplateLocation(@NonNull String path) {
 		this.path = path;
 	}
 
@@ -44,8 +43,7 @@ public class TemplateLocation {
 	 * @param resolver the resolver used to test if the location exists
 	 * @return {@code true} if the location exists.
 	 */
-	public boolean exists(ResourcePatternResolver resolver) {
-		Assert.notNull(resolver, "Resolver must not be null");
+	public boolean exists(@NonNull ResourcePatternResolver resolver) {
 		if (resolver.getResource(this.path).exists()) {
 			return true;
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -37,7 +37,7 @@ import org.springframework.boot.web.server.Compression;
 import org.springframework.boot.web.server.Http2;
 import org.springframework.boot.web.server.Ssl;
 import org.springframework.boot.web.servlet.server.Jsp;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.StringUtils;
 
 /**
@@ -263,8 +263,7 @@ public class ServerProperties {
 			return this.path;
 		}
 
-		public void setPath(String path) {
-			Assert.notNull(path, "Path must not be null");
+		public void setPath(@NonNull String path) {
 			this.path = path;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/AbstractErrorWebExceptionHandler.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/AbstractErrorWebExceptionHandler.java
@@ -30,7 +30,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.Resource;
 import org.springframework.http.codec.HttpMessageReader;
 import org.springframework.http.codec.HttpMessageWriter;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.server.RouterFunction;
@@ -63,12 +63,9 @@ public abstract class AbstractErrorWebExceptionHandler
 
 	private List<ViewResolver> viewResolvers = Collections.emptyList();
 
-	public AbstractErrorWebExceptionHandler(ErrorAttributes errorAttributes,
-			ResourceProperties resourceProperties,
-			ApplicationContext applicationContext) {
-		Assert.notNull(errorAttributes, "ErrorAttributes must not be null");
-		Assert.notNull(resourceProperties, "ResourceProperties must not be null");
-		Assert.notNull(applicationContext, "ApplicationContext must not be null");
+	public AbstractErrorWebExceptionHandler(@NonNull ErrorAttributes errorAttributes,
+			@NonNull ResourceProperties resourceProperties,
+			@NonNull ApplicationContext applicationContext) {
 		this.errorAttributes = errorAttributes;
 		this.resourceProperties = resourceProperties;
 		this.applicationContext = applicationContext;
@@ -80,8 +77,7 @@ public abstract class AbstractErrorWebExceptionHandler
 	 * Configure HTTP message writers to serialize the response body with.
 	 * @param messageWriters the {@link HttpMessageWriter}s to use
 	 */
-	public void setMessageWriters(List<HttpMessageWriter<?>> messageWriters) {
-		Assert.notNull(messageWriters, "'messageWriters' must not be null");
+	public void setMessageWriters(@NonNull List<HttpMessageWriter<?>> messageWriters) {
 		this.messageWriters = messageWriters;
 	}
 
@@ -89,8 +85,7 @@ public abstract class AbstractErrorWebExceptionHandler
 	 * Configure HTTP message readers to deserialize the request body with.
 	 * @param messageReaders the {@link HttpMessageReader}s to use
 	 */
-	public void setMessageReaders(List<HttpMessageReader<?>> messageReaders) {
-		Assert.notNull(messageReaders, "'messageReaders' must not be null");
+	public void setMessageReaders(@NonNull List<HttpMessageReader<?>> messageReaders) {
 		this.messageReaders = messageReaders;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/AbstractErrorController.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/AbstractErrorController.java
@@ -27,8 +27,8 @@ import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.http.HttpStatus;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Controller;
-import org.springframework.util.Assert;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.ModelAndView;
@@ -51,9 +51,8 @@ public abstract class AbstractErrorController implements ErrorController {
 		this(errorAttributes, null);
 	}
 
-	public AbstractErrorController(ErrorAttributes errorAttributes,
+	public AbstractErrorController(@NonNull ErrorAttributes errorAttributes,
 			List<ErrorViewResolver> errorViewResolvers) {
-		Assert.notNull(errorAttributes, "ErrorAttributes must not be null");
 		this.errorAttributes = errorAttributes;
 		this.errorViewResolvers = sortErrorViewResolvers(errorViewResolvers);
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/BasicErrorController.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/BasicErrorController.java
@@ -30,8 +30,8 @@ import org.springframework.boot.web.servlet.server.AbstractServletWebServerFacto
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Controller;
-import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
@@ -72,9 +72,9 @@ public class BasicErrorController extends AbstractErrorController {
 	 * @param errorViewResolvers error view resolvers
 	 */
 	public BasicErrorController(ErrorAttributes errorAttributes,
-			ErrorProperties errorProperties, List<ErrorViewResolver> errorViewResolvers) {
+			@NonNull ErrorProperties errorProperties,
+			List<ErrorViewResolver> errorViewResolvers) {
 		super(errorAttributes, errorViewResolvers);
-		Assert.notNull(errorProperties, "ErrorProperties must not be null");
 		this.errorProperties = errorProperties;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/DefaultErrorViewResolver.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/DefaultErrorViewResolver.java
@@ -32,7 +32,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatus.Series;
 import org.springframework.http.MediaType;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
@@ -79,21 +79,17 @@ public class DefaultErrorViewResolver implements ErrorViewResolver, Ordered {
 	 * @param applicationContext the source application context
 	 * @param resourceProperties resource properties
 	 */
-	public DefaultErrorViewResolver(ApplicationContext applicationContext,
-			ResourceProperties resourceProperties) {
-		Assert.notNull(applicationContext, "ApplicationContext must not be null");
-		Assert.notNull(resourceProperties, "ResourceProperties must not be null");
+	public DefaultErrorViewResolver(@NonNull ApplicationContext applicationContext,
+			@NonNull ResourceProperties resourceProperties) {
 		this.applicationContext = applicationContext;
 		this.resourceProperties = resourceProperties;
 		this.templateAvailabilityProviders = new TemplateAvailabilityProviders(
 				applicationContext);
 	}
 
-	DefaultErrorViewResolver(ApplicationContext applicationContext,
-			ResourceProperties resourceProperties,
+	DefaultErrorViewResolver(@NonNull ApplicationContext applicationContext,
+			@NonNull ResourceProperties resourceProperties,
 			TemplateAvailabilityProviders templateAvailabilityProviders) {
-		Assert.notNull(applicationContext, "ApplicationContext must not be null");
-		Assert.notNull(resourceProperties, "ResourceProperties must not be null");
 		this.applicationContext = applicationContext;
 		this.resourceProperties = resourceProperties;
 		this.templateAvailabilityProviders = templateAvailabilityProviders;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/webservices/WebServicesProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/webservices/WebServicesProperties.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -43,8 +44,7 @@ public class WebServicesProperties {
 		return this.path;
 	}
 
-	public void setPath(String path) {
-		Assert.notNull(path, "Path must not be null");
+	public void setPath(@NonNull String path) {
 		Assert.isTrue(path.isEmpty() || path.startsWith("/"),
 				"Path must start with / or be empty");
 		this.path = path;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/quartz/QuartzAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/quartz/QuartzAutoConfigurationTests.java
@@ -54,10 +54,10 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.lang.NonNull;
 import org.springframework.scheduling.quartz.LocalDataSourceJobStore;
 import org.springframework.scheduling.quartz.LocalTaskExecutorThreadPool;
 import org.springframework.scheduling.quartz.QuartzJobBean;
-import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -348,8 +348,7 @@ public class QuartzAutoConfigurationTests {
 
 	public static class ComponentThatUsesScheduler {
 
-		public ComponentThatUsesScheduler(Scheduler scheduler) {
-			Assert.notNull(scheduler, "Scheduler must not be null");
+		public ComponentThatUsesScheduler(@NonNull Scheduler scheduler) {
 		}
 
 	}

--- a/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/CommandRunner.java
+++ b/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/CommandRunner.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 import org.springframework.boot.cli.command.status.ExitStatus;
 import org.springframework.boot.cli.util.Log;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.StringUtils;
 
 /**
@@ -70,8 +70,7 @@ public class CommandRunner implements Iterable<Command> {
 	 * Add the specified commands.
 	 * @param commands the commands to add
 	 */
-	public void addCommands(Iterable<Command> commands) {
-		Assert.notNull(commands, "Commands must not be null");
+	public void addCommands(@NonNull Iterable<Command> commands) {
 		for (Command command : commands) {
 			addCommand(command);
 		}
@@ -81,8 +80,7 @@ public class CommandRunner implements Iterable<Command> {
 	 * Add the specified command.
 	 * @param command the command to add.
 	 */
-	public void addCommand(Command command) {
-		Assert.notNull(command, "Command must not be null");
+	public void addCommand(@NonNull Command command) {
 		this.commands.add(command);
 	}
 
@@ -93,8 +91,7 @@ public class CommandRunner implements Iterable<Command> {
 	 * @param commandClasses the classes of option commands.
 	 * @see #isOptionCommand(Command)
 	 */
-	public void setOptionCommands(Class<?>... commandClasses) {
-		Assert.notNull(commandClasses, "CommandClasses must not be null");
+	public void setOptionCommands(@NonNull Class<?>... commandClasses) {
 		this.optionCommandClasses = commandClasses;
 	}
 
@@ -103,8 +100,7 @@ public class CommandRunner implements Iterable<Command> {
 	 * the available commands list).
 	 * @param commandClasses the classes of hidden commands
 	 */
-	public void setHiddenCommands(Class<?>... commandClasses) {
-		Assert.notNull(commandClasses, "CommandClasses must not be null");
+	public void setHiddenCommands(@NonNull Class<?>... commandClasses) {
 		this.hiddenCommandClasses = commandClasses;
 	}
 

--- a/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/dependencies/Dependency.java
+++ b/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/dependencies/Dependency.java
@@ -19,7 +19,7 @@ package org.springframework.boot.cli.compiler.dependencies;
 import java.util.Collections;
 import java.util.List;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * A single dependency.
@@ -54,12 +54,8 @@ public final class Dependency {
 	 * @param version the version
 	 * @param exclusions the exclusions
 	 */
-	public Dependency(String groupId, String artifactId, String version,
-			List<Exclusion> exclusions) {
-		Assert.notNull(groupId, "GroupId must not be null");
-		Assert.notNull(artifactId, "ArtifactId must not be null");
-		Assert.notNull(version, "Version must not be null");
-		Assert.notNull(exclusions, "Exclusions must not be null");
+	public Dependency(@NonNull String groupId, @NonNull String artifactId,
+			@NonNull String version, @NonNull List<Exclusion> exclusions) {
 		this.groupId = groupId;
 		this.artifactId = artifactId;
 		this.version = version;
@@ -143,9 +139,7 @@ public final class Dependency {
 
 		private final String artifactId;
 
-		Exclusion(String groupId, String artifactId) {
-			Assert.notNull(groupId, "GroupId must not be null");
-			Assert.notNull(groupId, "ArtifactId must not be null");
+		Exclusion(@NonNull String groupId, @NonNull String artifactId) {
 			this.groupId = groupId;
 			this.artifactId = artifactId;
 		}

--- a/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/util/ResourceUtils.java
+++ b/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/util/ResourceUtils.java
@@ -30,7 +30,7 @@ import org.springframework.core.io.FileSystemResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
@@ -151,8 +151,7 @@ public abstract class ResourceUtils {
 		}
 
 		@Override
-		public Resource getResource(String location) {
-			Assert.notNull(location, "Location must not be null");
+		public Resource getResource(@NonNull String location) {
 			if (location.startsWith(CLASSPATH_URL_PREFIX)) {
 				return new ClassPathResource(
 						location.substring(CLASSPATH_URL_PREFIX.length()),

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/TriggerFileFilter.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/TriggerFileFilter.java
@@ -19,7 +19,7 @@ package org.springframework.boot.devtools.autoconfigure;
 import java.io.File;
 import java.io.FileFilter;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link FileFilter} that accepts only a specific "trigger" file.
@@ -31,8 +31,7 @@ public class TriggerFileFilter implements FileFilter {
 
 	private final String name;
 
-	public TriggerFileFilter(String name) {
-		Assert.notNull(name, "Name must not be null");
+	public TriggerFileFilter(@NonNull String name) {
 		this.name = name;
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/classpath/ClassPathChangedEvent.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/classpath/ClassPathChangedEvent.java
@@ -20,7 +20,7 @@ import java.util.Set;
 
 import org.springframework.boot.devtools.filewatch.ChangedFiles;
 import org.springframework.context.ApplicationEvent;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link ApplicationEvent} containing details of a classpath change.
@@ -41,10 +41,9 @@ public class ClassPathChangedEvent extends ApplicationEvent {
 	 * @param changeSet the changed files
 	 * @param restartRequired if a restart is required due to the change
 	 */
-	public ClassPathChangedEvent(Object source, Set<ChangedFiles> changeSet,
+	public ClassPathChangedEvent(Object source, @NonNull Set<ChangedFiles> changeSet,
 			boolean restartRequired) {
 		super(source);
-		Assert.notNull(changeSet, "ChangeSet must not be null");
 		this.changeSet = changeSet;
 		this.restartRequired = restartRequired;
 	}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/classpath/ClassPathFileChangeListener.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/classpath/ClassPathFileChangeListener.java
@@ -24,7 +24,7 @@ import org.springframework.boot.devtools.filewatch.FileChangeListener;
 import org.springframework.boot.devtools.filewatch.FileSystemWatcher;
 import org.springframework.boot.devtools.restart.AgentReloader;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * A {@link FileChangeListener} to publish {@link ClassPathChangedEvent
@@ -48,11 +48,9 @@ class ClassPathFileChangeListener implements FileChangeListener {
 	 * @param fileSystemWatcherToStop the file system watcher to stop on a restart (or
 	 * {@code null})
 	 */
-	ClassPathFileChangeListener(ApplicationEventPublisher eventPublisher,
-			ClassPathRestartStrategy restartStrategy,
+	ClassPathFileChangeListener(@NonNull ApplicationEventPublisher eventPublisher,
+			@NonNull ClassPathRestartStrategy restartStrategy,
 			FileSystemWatcher fileSystemWatcherToStop) {
-		Assert.notNull(eventPublisher, "EventPublisher must not be null");
-		Assert.notNull(restartStrategy, "RestartStrategy must not be null");
 		this.eventPublisher = eventPublisher;
 		this.restartStrategy = restartStrategy;
 		this.fileSystemWatcherToStop = fileSystemWatcherToStop;

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/classpath/ClassPathFileSystemWatcher.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/classpath/ClassPathFileSystemWatcher.java
@@ -25,7 +25,7 @@ import org.springframework.boot.devtools.filewatch.FileSystemWatcher;
 import org.springframework.boot.devtools.filewatch.FileSystemWatcherFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Encapsulates a {@link FileSystemWatcher} to watch the local classpath folders for
@@ -53,11 +53,9 @@ public class ClassPathFileSystemWatcher
 	 * @param restartStrategy the classpath restart strategy
 	 * @param urls the URLs to watch
 	 */
-	public ClassPathFileSystemWatcher(FileSystemWatcherFactory fileSystemWatcherFactory,
-			ClassPathRestartStrategy restartStrategy, URL[] urls) {
-		Assert.notNull(fileSystemWatcherFactory,
-				"FileSystemWatcherFactory must not be null");
-		Assert.notNull(urls, "Urls must not be null");
+	public ClassPathFileSystemWatcher(
+			@NonNull FileSystemWatcherFactory fileSystemWatcherFactory,
+			ClassPathRestartStrategy restartStrategy, @NonNull URL[] urls) {
 		this.fileSystemWatcher = fileSystemWatcherFactory.getFileSystemWatcher();
 		this.restartStrategy = restartStrategy;
 		this.fileSystemWatcher.addSourceFolders(new ClassPathFolders(urls));

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/ChangedFile.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/ChangedFile.java
@@ -18,6 +18,7 @@ package org.springframework.boot.devtools.filewatch;
 
 import java.io.File;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -42,10 +43,8 @@ public final class ChangedFile {
 	 * @param file the file
 	 * @param type the type of change
 	 */
-	public ChangedFile(File sourceFolder, File file, Type type) {
-		Assert.notNull(sourceFolder, "SourceFolder must not be null");
-		Assert.notNull(file, "File must not be null");
-		Assert.notNull(type, "Type must not be null");
+	public ChangedFile(@NonNull File sourceFolder, @NonNull File file,
+			@NonNull Type type) {
 		this.sourceFolder = sourceFolder;
 		this.file = file;
 		this.type = type;

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSnapshot.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSnapshot.java
@@ -18,6 +18,7 @@ package org.springframework.boot.devtools.filewatch;
 
 import java.io.File;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -35,8 +36,7 @@ class FileSnapshot {
 
 	private final long lastModified;
 
-	FileSnapshot(File file) {
-		Assert.notNull(file, "File must not be null");
+	FileSnapshot(@NonNull File file) {
 		Assert.isTrue(file.isFile() || !file.exists(), "File must not be a folder");
 		this.file = file;
 		this.exists = file.exists();

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSystemWatcher.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSystemWatcher.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -78,10 +79,8 @@ public class FileSystemWatcher {
 	 * @param quietPeriod the amount of time required after a change has been detected to
 	 * ensure that updates have completed
 	 */
-	public FileSystemWatcher(boolean daemon, Duration pollInterval,
-			Duration quietPeriod) {
-		Assert.notNull(pollInterval, "PollInterval must not be null");
-		Assert.notNull(quietPeriod, "QuietPeriod must not be null");
+	public FileSystemWatcher(boolean daemon, @NonNull Duration pollInterval,
+			@NonNull Duration quietPeriod) {
 		Assert.isTrue(pollInterval.toMillis() > 0, "PollInterval must be positive");
 		Assert.isTrue(quietPeriod.toMillis() > 0, "QuietPeriod must be positive");
 		Assert.isTrue(pollInterval.toMillis() > quietPeriod.toMillis(),
@@ -96,8 +95,7 @@ public class FileSystemWatcher {
 	 * {@link #start() started}.
 	 * @param fileChangeListener the listener to add
 	 */
-	public void addListener(FileChangeListener fileChangeListener) {
-		Assert.notNull(fileChangeListener, "FileChangeListener must not be null");
+	public void addListener(@NonNull FileChangeListener fileChangeListener) {
 		synchronized (this.monitor) {
 			checkNotStarted();
 			this.listeners.add(fileChangeListener);
@@ -109,8 +107,7 @@ public class FileSystemWatcher {
 	 * {@link #start() started}.
 	 * @param folders the folders to monitor
 	 */
-	public void addSourceFolders(Iterable<File> folders) {
-		Assert.notNull(folders, "Folders must not be null");
+	public void addSourceFolders(@NonNull Iterable<File> folders) {
 		synchronized (this.monitor) {
 			for (File folder : folders) {
 				addSourceFolder(folder);
@@ -123,8 +120,7 @@ public class FileSystemWatcher {
 	 * {@link #start() started}.
 	 * @param folder the folder to monitor
 	 */
-	public void addSourceFolder(File folder) {
-		Assert.notNull(folder, "Folder must not be null");
+	public void addSourceFolder(@NonNull File folder) {
 		Assert.isTrue(folder.isDirectory(),
 				"Folder '" + folder + "' must exist and must" + " be a directory");
 		synchronized (this.monitor) {

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FolderSnapshot.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FolderSnapshot.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.springframework.boot.devtools.filewatch.ChangedFile.Type;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -50,8 +51,7 @@ class FolderSnapshot {
 	 * Create a new {@link FolderSnapshot} for the given folder.
 	 * @param folder the source folder
 	 */
-	FolderSnapshot(File folder) {
-		Assert.notNull(folder, "Folder must not be null");
+	FolderSnapshot(@NonNull File folder) {
 		Assert.isTrue(folder.isDirectory(), "Folder must not be a file");
 		this.folder = folder;
 		this.time = new Date();
@@ -74,9 +74,8 @@ class FolderSnapshot {
 		}
 	}
 
-	public ChangedFiles getChangedFiles(FolderSnapshot snapshot,
+	public ChangedFiles getChangedFiles(@NonNull FolderSnapshot snapshot,
 			FileFilter triggerFilter) {
-		Assert.notNull(snapshot, "Snapshot must not be null");
 		File folder = this.folder;
 		Assert.isTrue(snapshot.folder.equals(folder),
 				"Snapshot source folder must be '" + folder + "'");

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/livereload/Frame.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/livereload/Frame.java
@@ -19,6 +19,7 @@ package org.springframework.boot.devtools.livereload;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -39,14 +40,12 @@ class Frame {
 	 * payload.
 	 * @param payload the text payload
 	 */
-	Frame(String payload) {
-		Assert.notNull(payload, "Payload must not be null");
+	Frame(@NonNull String payload) {
 		this.type = Type.TEXT;
 		this.payload = payload.getBytes();
 	}
 
-	Frame(Type type) {
-		Assert.notNull(type, "Type must not be null");
+	Frame(@NonNull Type type) {
 		this.type = type;
 		this.payload = NO_BYTES;
 	}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/remote/client/ClassPathChangeUploader.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/remote/client/ClassPathChangeUploader.java
@@ -45,6 +45,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.FileCopyUtils;
 
@@ -74,9 +75,9 @@ public class ClassPathChangeUploader
 
 	private final ClientHttpRequestFactory requestFactory;
 
-	public ClassPathChangeUploader(String url, ClientHttpRequestFactory requestFactory) {
+	public ClassPathChangeUploader(String url,
+			@NonNull ClientHttpRequestFactory requestFactory) {
 		Assert.hasLength(url, "URL must not be empty");
-		Assert.notNull(requestFactory, "RequestFactory must not be null");
 		try {
 			this.uri = new URL(url).toURI();
 		}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/remote/client/DelayedLiveReloadTrigger.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/remote/client/DelayedLiveReloadTrigger.java
@@ -29,6 +29,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -59,10 +60,8 @@ class DelayedLiveReloadTrigger implements Runnable {
 
 	private long timeout = TIMEOUT;
 
-	DelayedLiveReloadTrigger(OptionalLiveReloadServer liveReloadServer,
-			ClientHttpRequestFactory requestFactory, String url) {
-		Assert.notNull(liveReloadServer, "LiveReloadServer must not be null");
-		Assert.notNull(requestFactory, "RequestFactory must not be null");
+	DelayedLiveReloadTrigger(@NonNull OptionalLiveReloadServer liveReloadServer,
+			@NonNull ClientHttpRequestFactory requestFactory, String url) {
 		Assert.hasLength(url, "URL must not be empty");
 		this.liveReloadServer = liveReloadServer;
 		this.requestFactory = requestFactory;

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/remote/server/Dispatcher.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/remote/server/Dispatcher.java
@@ -25,7 +25,7 @@ import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Dispatcher used to route incoming remote server requests to a {@link Handler}. Similar
@@ -42,9 +42,8 @@ public class Dispatcher {
 
 	private final List<HandlerMapper> mappers;
 
-	public Dispatcher(AccessManager accessManager, Collection<HandlerMapper> mappers) {
-		Assert.notNull(accessManager, "AccessManager must not be null");
-		Assert.notNull(mappers, "Mappers must not be null");
+	public Dispatcher(@NonNull AccessManager accessManager,
+			@NonNull Collection<HandlerMapper> mappers) {
 		this.accessManager = accessManager;
 		this.mappers = new ArrayList<>(mappers);
 		AnnotationAwareOrderComparator.sort(this.mappers);

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/remote/server/DispatcherFilter.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/remote/server/DispatcherFilter.java
@@ -31,7 +31,7 @@ import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.http.server.ServletServerHttpResponse;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Servlet filter providing integration with the remote server {@link Dispatcher}.
@@ -44,8 +44,7 @@ public class DispatcherFilter implements Filter {
 
 	private final Dispatcher dispatcher;
 
-	public DispatcherFilter(Dispatcher dispatcher) {
-		Assert.notNull(dispatcher, "Dispatcher must not be null");
+	public DispatcherFilter(@NonNull Dispatcher dispatcher) {
 		this.dispatcher = dispatcher;
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/remote/server/HttpStatusHandler.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/remote/server/HttpStatusHandler.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link Handler} that responds with a specific {@link HttpStatus}.
@@ -45,8 +45,7 @@ public class HttpStatusHandler implements Handler {
 	 * specified status.
 	 * @param status the status
 	 */
-	public HttpStatusHandler(HttpStatus status) {
-		Assert.notNull(status, "Status must not be null");
+	public HttpStatusHandler(@NonNull HttpStatus status) {
 		this.status = status;
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/MainMethod.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/MainMethod.java
@@ -19,7 +19,7 @@ package org.springframework.boot.devtools.restart;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * The "main" method located from a running thread.
@@ -34,8 +34,7 @@ class MainMethod {
 		this(Thread.currentThread());
 	}
 
-	MainMethod(Thread thread) {
-		Assert.notNull(thread, "Thread must not be null");
+	MainMethod(@NonNull Thread thread) {
 		this.method = getMainMethod(thread);
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/Restarter.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/Restarter.java
@@ -53,6 +53,7 @@ import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
 
@@ -129,11 +130,8 @@ public class Restarter {
 	 * @param initializer the restart initializer
 	 * @see #initialize(String[])
 	 */
-	protected Restarter(Thread thread, String[] args, boolean forceReferenceCleanup,
-			RestartInitializer initializer) {
-		Assert.notNull(thread, "Thread must not be null");
-		Assert.notNull(args, "Args must not be null");
-		Assert.notNull(initializer, "Initializer must not be null");
+	protected Restarter(@NonNull Thread thread, @NonNull String[] args,
+			boolean forceReferenceCleanup, @NonNull RestartInitializer initializer) {
 		this.logger.debug("Creating new Restarter for thread " + thread);
 		SilentExitExceptionHandler.setup(thread);
 		this.forceReferenceCleanup = forceReferenceCleanup;
@@ -207,8 +205,7 @@ public class Restarter {
 	 * Add additional URLs to be includes in the next restart.
 	 * @param urls the urls to add
 	 */
-	public void addUrls(Collection<URL> urls) {
-		Assert.notNull(urls, "Urls must not be null");
+	public void addUrls(@NonNull Collection<URL> urls) {
 		this.urls.addAll(urls);
 	}
 
@@ -216,8 +213,7 @@ public class Restarter {
 	 * Add additional {@link ClassLoaderFiles} to be included in the next restart.
 	 * @param classLoaderFiles the files to add
 	 */
-	public void addClassLoaderFiles(ClassLoaderFiles classLoaderFiles) {
-		Assert.notNull(classLoaderFiles, "ClassLoaderFiles must not be null");
+	public void addClassLoaderFiles(@NonNull ClassLoaderFiles classLoaderFiles) {
 		this.classLoaderFiles.addAll(classLoaderFiles);
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/classloader/ClassLoaderFile.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/classloader/ClassLoaderFile.java
@@ -18,6 +18,7 @@ package org.springframework.boot.devtools.restart.classloader;
 
 import java.io.Serializable;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -53,8 +54,7 @@ public class ClassLoaderFile implements Serializable {
 	 * @param lastModified the last modified time
 	 * @param contents the file contents
 	 */
-	public ClassLoaderFile(Kind kind, long lastModified, byte[] contents) {
-		Assert.notNull(kind, "Kind must not be null");
+	public ClassLoaderFile(@NonNull Kind kind, long lastModified, byte[] contents) {
 		Assert.isTrue(kind == Kind.DELETED ? contents == null : contents != null,
 				"Contents must " + (kind == Kind.DELETED ? "" : "not ") + "be null");
 		this.kind = kind;

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/classloader/ClassLoaderFiles.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/classloader/ClassLoaderFiles.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 import javax.management.loading.ClassLoaderRepository;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link ClassLoaderFileRepository} that maintains a collection of
@@ -54,8 +54,7 @@ public class ClassLoaderFiles implements ClassLoaderFileRepository, Serializable
 	 * Create a new {@link ClassLoaderFiles} instance.
 	 * @param classLoaderFiles the source classloader files.
 	 */
-	public ClassLoaderFiles(ClassLoaderFiles classLoaderFiles) {
-		Assert.notNull(classLoaderFiles, "ClassLoaderFiles must not be null");
+	public ClassLoaderFiles(@NonNull ClassLoaderFiles classLoaderFiles) {
 		this.sourceFolders = new LinkedHashMap<>(classLoaderFiles.sourceFolders);
 	}
 
@@ -64,8 +63,7 @@ public class ClassLoaderFiles implements ClassLoaderFileRepository, Serializable
 	 * instance.
 	 * @param files the files to add
 	 */
-	public void addAll(ClassLoaderFiles files) {
-		Assert.notNull(files, "Files must not be null");
+	public void addAll(@NonNull ClassLoaderFiles files) {
 		for (SourceFolder folder : files.getSourceFolders()) {
 			for (Map.Entry<String, ClassLoaderFile> entry : folder.getFilesEntrySet()) {
 				addFile(folder.getName(), entry.getKey(), entry.getValue());
@@ -88,10 +86,8 @@ public class ClassLoaderFiles implements ClassLoaderFileRepository, Serializable
 	 * @param name the name of the file
 	 * @param file the file to add
 	 */
-	public void addFile(String sourceFolder, String name, ClassLoaderFile file) {
-		Assert.notNull(sourceFolder, "SourceFolder must not be null");
-		Assert.notNull(name, "Name must not be null");
-		Assert.notNull(file, "File must not be null");
+	public void addFile(@NonNull String sourceFolder, @NonNull String name,
+			@NonNull ClassLoaderFile file) {
 		removeAll(name);
 		getOrCreateSourceFolder(sourceFolder).add(name, file);
 	}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/classloader/RestartClassLoader.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/classloader/RestartClassLoader.java
@@ -29,7 +29,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.boot.devtools.restart.classloader.ClassLoaderFile.Kind;
 import org.springframework.core.SmartClassLoader;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Disposable {@link ClassLoader} used to support application restarting. Provides parent
@@ -74,12 +74,9 @@ public class RestartClassLoader extends URLClassLoader implements SmartClassLoad
 	 * @param urls the urls managed by the classloader
 	 * @param logger the logger used for messages
 	 */
-	public RestartClassLoader(ClassLoader parent, URL[] urls,
-			ClassLoaderFileRepository updatedFiles, Log logger) {
+	public RestartClassLoader(@NonNull ClassLoader parent, URL[] urls,
+			@NonNull ClassLoaderFileRepository updatedFiles, @NonNull Log logger) {
 		super(urls, parent);
-		Assert.notNull(parent, "Parent must not be null");
-		Assert.notNull(updatedFiles, "UpdatedFiles must not be null");
-		Assert.notNull(logger, "Logger must not be null");
 		this.updatedFiles = updatedFiles;
 		this.logger = logger;
 		if (logger.isDebugEnabled()) {

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/server/HttpRestartServer.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/server/HttpRestartServer.java
@@ -26,6 +26,7 @@ import org.springframework.boot.devtools.restart.classloader.ClassLoaderFiles;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -47,8 +48,7 @@ public class HttpRestartServer {
 	 * @param sourceFolderUrlFilter the source filter used to link remote folder to the
 	 * local classpath
 	 */
-	public HttpRestartServer(SourceFolderUrlFilter sourceFolderUrlFilter) {
-		Assert.notNull(sourceFolderUrlFilter, "SourceFolderUrlFilter must not be null");
+	public HttpRestartServer(@NonNull SourceFolderUrlFilter sourceFolderUrlFilter) {
 		this.server = new RestartServer(sourceFolderUrlFilter);
 	}
 
@@ -56,8 +56,7 @@ public class HttpRestartServer {
 	 * Create a new {@link HttpRestartServer} instance.
 	 * @param restartServer the underlying restart server
 	 */
-	public HttpRestartServer(RestartServer restartServer) {
-		Assert.notNull(restartServer, "RestartServer must not be null");
+	public HttpRestartServer(@NonNull RestartServer restartServer) {
 		this.server = restartServer;
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/server/HttpRestartServerHandler.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/server/HttpRestartServerHandler.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import org.springframework.boot.devtools.remote.server.Handler;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Adapts {@link HttpRestartServer} to a {@link Handler}.
@@ -37,8 +37,7 @@ public class HttpRestartServerHandler implements Handler {
 	 * Create a new {@link HttpRestartServerHandler} instance.
 	 * @param server the server to adapt
 	 */
-	public HttpRestartServerHandler(HttpRestartServer server) {
-		Assert.notNull(server, "Server must not be null");
+	public HttpRestartServerHandler(@NonNull HttpRestartServer server) {
 		this.server = server;
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/server/RestartServer.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/server/RestartServer.java
@@ -33,7 +33,7 @@ import org.springframework.boot.devtools.restart.classloader.ClassLoaderFile;
 import org.springframework.boot.devtools.restart.classloader.ClassLoaderFile.Kind;
 import org.springframework.boot.devtools.restart.classloader.ClassLoaderFiles;
 import org.springframework.boot.devtools.restart.classloader.ClassLoaderFiles.SourceFolder;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.ResourceUtils;
 
@@ -67,10 +67,8 @@ public class RestartServer {
 	 * local classpath
 	 * @param classLoader the application classloader
 	 */
-	public RestartServer(SourceFolderUrlFilter sourceFolderUrlFilter,
-			ClassLoader classLoader) {
-		Assert.notNull(sourceFolderUrlFilter, "SourceFolderUrlFilter must not be null");
-		Assert.notNull(classLoader, "ClassLoader must not be null");
+	public RestartServer(@NonNull SourceFolderUrlFilter sourceFolderUrlFilter,
+			@NonNull ClassLoader classLoader) {
 		this.sourceFolderUrlFilter = sourceFolderUrlFilter;
 		this.classLoader = classLoader;
 	}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/client/HttpTunnelConnection.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/client/HttpTunnelConnection.java
@@ -40,6 +40,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -77,10 +78,10 @@ public class HttpTunnelConnection implements TunnelConnection {
 	 * @param requestFactory the HTTP request factory
 	 * @param executor the executor used to handle connections
 	 */
-	protected HttpTunnelConnection(String url, ClientHttpRequestFactory requestFactory,
+	protected HttpTunnelConnection(String url,
+			@NonNull ClientHttpRequestFactory requestFactory,
 			Executor executor) {
 		Assert.hasLength(url, "URL must not be empty");
-		Assert.notNull(requestFactory, "RequestFactory must not be null");
 		try {
 			this.uri = new URL(url).toURI();
 		}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/client/TunnelClient.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/client/TunnelClient.java
@@ -30,6 +30,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -56,9 +57,8 @@ public class TunnelClient implements SmartInitializingSingleton {
 
 	private ServerThread serverThread;
 
-	public TunnelClient(int listenPort, TunnelConnection tunnelConnection) {
+	public TunnelClient(int listenPort, @NonNull TunnelConnection tunnelConnection) {
 		Assert.isTrue(listenPort >= 0, "ListenPort must be greater than or equal to 0");
-		Assert.notNull(tunnelConnection, "TunnelConnection must not be null");
 		this.listenPort = listenPort;
 		this.tunnelConnection = tunnelConnection;
 	}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/client/TunnelClientListeners.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/client/TunnelClientListeners.java
@@ -20,7 +20,7 @@ import java.nio.channels.SocketChannel;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * A collection of {@link TunnelClientListener}.
@@ -31,13 +31,11 @@ class TunnelClientListeners {
 
 	private final List<TunnelClientListener> listeners = new CopyOnWriteArrayList<>();
 
-	public void addListener(TunnelClientListener listener) {
-		Assert.notNull(listener, "Listener must not be null");
+	public void addListener(@NonNull TunnelClientListener listener) {
 		this.listeners.add(listener);
 	}
 
-	public void removeListener(TunnelClientListener listener) {
-		Assert.notNull(listener, "Listener must not be null");
+	public void removeListener(@NonNull TunnelClientListener listener) {
 		this.listeners.remove(listener);
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/payload/HttpTunnelPayload.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/payload/HttpTunnelPayload.java
@@ -30,6 +30,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -58,9 +59,8 @@ public class HttpTunnelPayload {
 	 * @param sequence the sequence number of the payload
 	 * @param data the payload data
 	 */
-	public HttpTunnelPayload(long sequence, ByteBuffer data) {
+	public HttpTunnelPayload(long sequence, @NonNull ByteBuffer data) {
 		Assert.isTrue(sequence > 0, "Sequence must be positive");
-		Assert.notNull(data, "Data must not be null");
 		this.sequence = sequence;
 		this.data = data;
 	}
@@ -78,8 +78,7 @@ public class HttpTunnelPayload {
 	 * @param message the message to assign this payload to
 	 * @throws IOException in case of I/O errors
 	 */
-	public void assignTo(HttpOutputMessage message) throws IOException {
-		Assert.notNull(message, "Message must not be null");
+	public void assignTo(@NonNull HttpOutputMessage message) throws IOException {
 		HttpHeaders headers = message.getHeaders();
 		headers.setContentLength(this.data.remaining());
 		headers.add(SEQ_HEADER, Long.toString(getSequence()));
@@ -96,8 +95,7 @@ public class HttpTunnelPayload {
 	 * @param channel the channel to write to
 	 * @throws IOException in case of I/O errors
 	 */
-	public void writeTo(WritableByteChannel channel) throws IOException {
-		Assert.notNull(channel, "Channel must not be null");
+	public void writeTo(@NonNull WritableByteChannel channel) throws IOException {
 		while (this.data.hasRemaining()) {
 			channel.write(this.data);
 		}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/payload/HttpTunnelPayloadForwarder.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/payload/HttpTunnelPayloadForwarder.java
@@ -21,6 +21,7 @@ import java.nio.channels.WritableByteChannel;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -46,8 +47,7 @@ public class HttpTunnelPayloadForwarder {
 	 * Create a new {@link HttpTunnelPayloadForwarder} instance.
 	 * @param targetChannel the target channel
 	 */
-	public HttpTunnelPayloadForwarder(WritableByteChannel targetChannel) {
-		Assert.notNull(targetChannel, "TargetChannel must not be null");
+	public HttpTunnelPayloadForwarder(@NonNull WritableByteChannel targetChannel) {
 		this.targetChannel = targetChannel;
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/server/HttpTunnelServer.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/server/HttpTunnelServer.java
@@ -35,6 +35,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.server.ServerHttpAsyncRequestControl;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -129,8 +130,7 @@ public class HttpTunnelServer {
 	 * Creates a new {@link HttpTunnelServer} instance.
 	 * @param serverConnection the connection to the target server
 	 */
-	public HttpTunnelServer(TargetServerConnection serverConnection) {
-		Assert.notNull(serverConnection, "ServerConnection must not be null");
+	public HttpTunnelServer(@NonNull TargetServerConnection serverConnection) {
 		this.serverConnection = serverConnection;
 	}
 
@@ -221,8 +221,7 @@ public class HttpTunnelServer {
 
 		private long lastHttpRequestTime;
 
-		public ServerThread(ByteChannel targetServer) {
-			Assert.notNull(targetServer, "TargetServer must not be null");
+		public ServerThread(@NonNull ByteChannel targetServer) {
 			this.targetServer = targetServer;
 			this.httpConnections = new ArrayDeque<>(2);
 			this.payloadForwarder = new HttpTunnelPayloadForwarder(targetServer);
@@ -460,8 +459,7 @@ public class HttpTunnelServer {
 		 * @param status the status to send
 		 * @throws IOException in case of I/O errors
 		 */
-		public void respond(HttpStatus status) throws IOException {
-			Assert.notNull(status, "Status must not be null");
+		public void respond(@NonNull HttpStatus status) throws IOException {
 			this.response.setStatusCode(status);
 			complete();
 		}
@@ -471,8 +469,7 @@ public class HttpTunnelServer {
 		 * @param payload the payload to send
 		 * @throws IOException in case of I/O errors
 		 */
-		public void respond(HttpTunnelPayload payload) throws IOException {
-			Assert.notNull(payload, "Payload must not be null");
+		public void respond(@NonNull HttpTunnelPayload payload) throws IOException {
 			this.response.setStatusCode(HttpStatus.OK);
 			payload.assignTo(this.response);
 			complete();

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/server/HttpTunnelServerHandler.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/server/HttpTunnelServerHandler.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import org.springframework.boot.devtools.remote.server.Handler;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Adapts a {@link HttpTunnelServer} to a {@link Handler}.
@@ -37,8 +37,7 @@ public class HttpTunnelServerHandler implements Handler {
 	 * Create a new {@link HttpTunnelServerHandler} instance.
 	 * @param server the server to adapt
 	 */
-	public HttpTunnelServerHandler(HttpTunnelServer server) {
-		Assert.notNull(server, "Server must not be null");
+	public HttpTunnelServerHandler(@NonNull HttpTunnelServer server) {
 		this.server = server;
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/server/SocketTargetServerConnection.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/server/SocketTargetServerConnection.java
@@ -28,7 +28,7 @@ import java.nio.channels.SocketChannel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Socket based {@link TargetServerConnection}.
@@ -47,8 +47,7 @@ public class SocketTargetServerConnection implements TargetServerConnection {
 	 * Create a new {@link SocketTargetServerConnection}.
 	 * @param portProvider the port provider
 	 */
-	public SocketTargetServerConnection(PortProvider portProvider) {
-		Assert.notNull(portProvider, "PortProvider must not be null");
+	public SocketTargetServerConnection(@NonNull PortProvider portProvider) {
 		this.portProvider = portProvider;
 	}
 

--- a/spring-boot-project/spring-boot-parent/pom.xml
+++ b/spring-boot-project/spring-boot-parent/pom.xml
@@ -25,6 +25,7 @@
 		<aether.version>1.0.2.v20150114</aether.version>
 		<maven.version>3.1.1</maven.version>
 		<spock.version>1.0-groovy-2.4</spock.version>
+		<traute.version>1.0.10</traute.version>
 	</properties>
 	<scm>
 		<url>http://github.com/spring-projects/spring-boot</url>
@@ -263,6 +264,12 @@
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>tech.harmonysoft</groupId>
+			<artifactId>traute-javac</artifactId>
+			<version>${traute.version}</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 	<build>
@@ -558,6 +565,11 @@
 					<source>${java.version}</source>
 					<target>${java.version}</target>
 					<parameters>true</parameters>
+					<compilerArgs>
+						<arg>-Xplugin:Traute</arg>
+						<arg>-Atraute.exception.parameter=IllegalArgumentException</arg>
+						<arg>-Atraute.failure.text.parameter=$${capitalize(PARAMETER_NAME)} must not be null</arg>
+					</compilerArgs>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/filter/FilterAnnotations.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/filter/FilterAnnotations.java
@@ -34,6 +34,7 @@ import org.springframework.core.type.filter.AspectJTypeFilter;
 import org.springframework.core.type.filter.AssignableTypeFilter;
 import org.springframework.core.type.filter.RegexPatternTypeFilter;
 import org.springframework.core.type.filter.TypeFilter;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -48,8 +49,7 @@ public class FilterAnnotations implements Iterable<TypeFilter> {
 
 	private final List<TypeFilter> filters;
 
-	public FilterAnnotations(ClassLoader classLoader, Filter[] filters) {
-		Assert.notNull(filters, "Filters must not be null");
+	public FilterAnnotations(ClassLoader classLoader, @NonNull Filter[] filters) {
 		this.classLoader = classLoader;
 		this.filters = createTypeFilters(filters);
 	}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/orm/jpa/TestEntityManager.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/orm/jpa/TestEntityManager.java
@@ -20,6 +20,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceUnitUtil;
 
+import org.springframework.lang.NonNull;
 import org.springframework.orm.jpa.EntityManagerFactoryUtils;
 import org.springframework.util.Assert;
 
@@ -40,8 +41,7 @@ public class TestEntityManager {
 	 * {@link EntityManagerFactory}.
 	 * @param entityManagerFactory the source entity manager factory
 	 */
-	public TestEntityManager(EntityManagerFactory entityManagerFactory) {
-		Assert.notNull(entityManagerFactory, "EntityManagerFactory must not be null");
+	public TestEntityManager(@NonNull EntityManagerFactory entityManagerFactory) {
 		this.entityManagerFactory = entityManagerFactory;
 	}
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/SpringBootMockMvcBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/SpringBootMockMvcBuilderCustomizer.java
@@ -35,6 +35,7 @@ import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.boot.web.servlet.ServletContextInitializerBeans;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.lang.NonNull;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultHandler;
 import org.springframework.test.web.servlet.result.PrintingResultHandler;
@@ -66,8 +67,7 @@ public class SpringBootMockMvcBuilderCustomizer implements MockMvcBuilderCustomi
 	 * Create a new {@link SpringBootMockMvcBuilderCustomizer} instance.
 	 * @param context the source application context
 	 */
-	public SpringBootMockMvcBuilderCustomizer(WebApplicationContext context) {
-		Assert.notNull(context, "Context must not be null");
+	public SpringBootMockMvcBuilderCustomizer(@NonNull WebApplicationContext context) {
 		this.context = context;
 	}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -47,13 +48,11 @@ final class SpringBootConfigurationFinder {
 		this.scanner.setResourcePattern("*.class");
 	}
 
-	public Class<?> findFromClass(Class<?> source) {
-		Assert.notNull(source, "Source must not be null");
+	public Class<?> findFromClass(@NonNull Class<?> source) {
 		return findFromPackage(ClassUtils.getPackageName(source));
 	}
 
-	public Class<?> findFromPackage(String source) {
-		Assert.notNull(source, "Source must not be null");
+	public Class<?> findFromPackage(@NonNull String source) {
 		Class<?> configuration = cache.get(source);
 		if (configuration == null) {
 			configuration = scanPackage(source);

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssert.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssert.java
@@ -33,7 +33,7 @@ import org.assertj.core.error.BasicErrorMessageFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.ApplicationContext;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -58,9 +58,8 @@ public class ApplicationContextAssert<C extends ApplicationContext>
 	 * @param applicationContext the source application context
 	 * @param startupFailure the startup failure or {@code null}
 	 */
-	ApplicationContextAssert(C applicationContext, Throwable startupFailure) {
+	ApplicationContextAssert(@NonNull C applicationContext, Throwable startupFailure) {
 		super(applicationContext, ApplicationContextAssert.class);
-		Assert.notNull(applicationContext, "ApplicationContext must not be null");
 		this.startupFailure = startupFailure;
 	}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertProvider.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertProvider.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import org.assertj.core.api.AssertProvider;
 
 import org.springframework.context.ApplicationContext;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -101,11 +102,9 @@ public interface ApplicationContextAssertProvider<C extends ApplicationContext> 
 	 */
 	@SuppressWarnings("unchecked")
 	static <T extends ApplicationContextAssertProvider<C>, C extends ApplicationContext> T get(
-			Class<T> type, Class<? extends C> contextType,
+			@NonNull Class<T> type, @NonNull Class<? extends C> contextType,
 			Supplier<? extends C> contextSupplier) {
-		Assert.notNull(type, "Type must not be null");
 		Assert.isTrue(type.isInterface(), "Type must be an interface");
-		Assert.notNull(contextType, "ContextType must not be null");
 		Assert.isTrue(contextType.isInterface(), "ContextType must be an interface");
 		Class<?>[] interfaces = { type, contextType };
 		return (T) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/runner/AbstractApplicationContextRunner.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/runner/AbstractApplicationContextRunner.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.AnnotationConfigRegistry;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -126,14 +127,11 @@ abstract class AbstractApplicationContextRunner<SELF extends AbstractApplication
 	 * @param parent the parent
 	 * @param configurations the configuration
 	 */
-	protected AbstractApplicationContextRunner(Supplier<C> contextFactory,
-			TestPropertyValues environmentProperties, TestPropertyValues systemProperties,
+	protected AbstractApplicationContextRunner(@NonNull Supplier<C> contextFactory,
+			@NonNull TestPropertyValues environmentProperties,
+			@NonNull TestPropertyValues systemProperties,
 			ClassLoader classLoader, ApplicationContext parent,
-			List<Configurations> configurations) {
-		Assert.notNull(contextFactory, "ContextFactory must not be null");
-		Assert.notNull(environmentProperties, "EnvironmentProperties must not be null");
-		Assert.notNull(systemProperties, "SystemProperties must not be null");
-		Assert.notNull(configurations, "Configurations must not be null");
+			@NonNull List<Configurations> configurations) {
 		this.contextFactory = contextFactory;
 		this.environmentProperties = environmentProperties;
 		this.systemProperties = systemProperties;
@@ -213,8 +211,7 @@ abstract class AbstractApplicationContextRunner<SELF extends AbstractApplication
 	 * @param configurations the configurations to add
 	 * @return a new instance with the updated configuration
 	 */
-	public SELF withConfiguration(Configurations configurations) {
-		Assert.notNull(configurations, "Configurations must not be null");
+	public SELF withConfiguration(@NonNull Configurations configurations) {
 		return newInstance(this.contextFactory, this.environmentProperties,
 				this.systemProperties, this.classLoader, this.parent,
 				add(this.configurations, configurations));

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/AbstractJsonMarshalTester.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/AbstractJsonMarshalTester.java
@@ -35,6 +35,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
 
@@ -84,9 +85,8 @@ public abstract class AbstractJsonMarshalTester<T> {
 	 * resources
 	 * @param type the type under test
 	 */
-	public AbstractJsonMarshalTester(Class<?> resourceLoadClass, ResolvableType type) {
-		Assert.notNull(resourceLoadClass, "ResourceLoadClass must not be null");
-		Assert.notNull(type, "Type must not be null");
+	public AbstractJsonMarshalTester(@NonNull Class<?> resourceLoadClass,
+			@NonNull ResolvableType type) {
 		initialize(resourceLoadClass, type);
 	}
 
@@ -125,9 +125,8 @@ public abstract class AbstractJsonMarshalTester<T> {
 	 * @return the {@link JsonContent}
 	 * @throws IOException on write error
 	 */
-	public JsonContent<T> write(T value) throws IOException {
+	public JsonContent<T> write(@NonNull T value) throws IOException {
 		verify();
-		Assert.notNull(value, "Value must not be null");
 		String json = writeObject(value, this.type);
 		return new JsonContent<>(this.resourceLoadClass, this.type, json);
 	}
@@ -149,9 +148,8 @@ public abstract class AbstractJsonMarshalTester<T> {
 	 * @return the {@link ObjectContent}
 	 * @throws IOException on parse error
 	 */
-	public ObjectContent<T> parse(byte[] jsonBytes) throws IOException {
+	public ObjectContent<T> parse(@NonNull byte[] jsonBytes) throws IOException {
 		verify();
-		Assert.notNull(jsonBytes, "JsonBytes must not be null");
 		return read(new ByteArrayResource(jsonBytes));
 	}
 
@@ -172,9 +170,8 @@ public abstract class AbstractJsonMarshalTester<T> {
 	 * @return the {@link ObjectContent}
 	 * @throws IOException on parse error
 	 */
-	public ObjectContent<T> parse(String jsonString) throws IOException {
+	public ObjectContent<T> parse(@NonNull String jsonString) throws IOException {
 		verify();
-		Assert.notNull(jsonString, "JsonString must not be null");
 		return read(new StringReader(jsonString));
 	}
 
@@ -197,9 +194,8 @@ public abstract class AbstractJsonMarshalTester<T> {
 	 * @return the {@link ObjectContent}
 	 * @throws IOException on read error
 	 */
-	public ObjectContent<T> read(String resourcePath) throws IOException {
+	public ObjectContent<T> read(@NonNull String resourcePath) throws IOException {
 		verify();
-		Assert.notNull(resourcePath, "ResourcePath must not be null");
 		return read(new ClassPathResource(resourcePath, this.resourceLoadClass));
 	}
 
@@ -220,9 +216,8 @@ public abstract class AbstractJsonMarshalTester<T> {
 	 * @return the {@link ObjectContent}
 	 * @throws IOException on read error
 	 */
-	public ObjectContent<T> read(File file) throws IOException {
+	public ObjectContent<T> read(@NonNull File file) throws IOException {
 		verify();
-		Assert.notNull(file, "File must not be null");
 		return read(new FileSystemResource(file));
 	}
 
@@ -243,9 +238,8 @@ public abstract class AbstractJsonMarshalTester<T> {
 	 * @return the {@link ObjectContent}
 	 * @throws IOException on read error
 	 */
-	public ObjectContent<T> read(InputStream inputStream) throws IOException {
+	public ObjectContent<T> read(@NonNull InputStream inputStream) throws IOException {
 		verify();
-		Assert.notNull(inputStream, "InputStream must not be null");
 		return read(new InputStreamResource(inputStream));
 	}
 
@@ -266,9 +260,8 @@ public abstract class AbstractJsonMarshalTester<T> {
 	 * @return the {@link ObjectContent}
 	 * @throws IOException on read error
 	 */
-	public ObjectContent<T> read(Resource resource) throws IOException {
+	public ObjectContent<T> read(@NonNull Resource resource) throws IOException {
 		verify();
-		Assert.notNull(resource, "Resource must not be null");
 		InputStream inputStream = resource.getInputStream();
 		T object = readObject(inputStream, this.type);
 		closeQuietly(inputStream);
@@ -292,9 +285,8 @@ public abstract class AbstractJsonMarshalTester<T> {
 	 * @return the {@link ObjectContent}
 	 * @throws IOException on read error
 	 */
-	public ObjectContent<T> read(Reader reader) throws IOException {
+	public ObjectContent<T> read(@NonNull Reader reader) throws IOException {
 		verify();
-		Assert.notNull(reader, "Reader must not be null");
 		T object = readObject(reader, this.type);
 		closeQuietly(reader);
 		return new ObjectContent<>(this.type, object);
@@ -360,21 +352,17 @@ public abstract class AbstractJsonMarshalTester<T> {
 
 		@SuppressWarnings("rawtypes")
 		protected FieldInitializer(
-				Class<? extends AbstractJsonMarshalTester> testerClass) {
-			Assert.notNull(testerClass, "TesterClass must not be null");
+				@NonNull Class<? extends AbstractJsonMarshalTester> testerClass) {
 			this.testerClass = testerClass;
 		}
 
-		public void initFields(final Object testInstance, final M marshaller) {
-			Assert.notNull(testInstance, "TestInstance must not be null");
-			Assert.notNull(marshaller, "Marshaller must not be null");
+		public void initFields(@NonNull final Object testInstance,
+				@NonNull final M marshaller) {
 			initFields(testInstance, () -> marshaller);
 		}
 
-		public void initFields(final Object testInstance,
-				final ObjectFactory<M> marshaller) {
-			Assert.notNull(testInstance, "TestInstance must not be null");
-			Assert.notNull(marshaller, "Marshaller must not be null");
+		public void initFields(@NonNull final Object testInstance,
+				@NonNull final ObjectFactory<M> marshaller) {
 			ReflectionUtils.doWithFields(testInstance.getClass(),
 					(field) -> doWithField(field, testInstance, marshaller));
 		}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/BasicJsonTester.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/BasicJsonTester.java
@@ -22,6 +22,7 @@ import java.nio.charset.Charset;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.Resource;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -70,8 +71,7 @@ public class BasicJsonTester {
 	 * @param charset the charset used to load resources
 	 * @since 1.4.1
 	 */
-	public BasicJsonTester(Class<?> resourceLoadClass, Charset charset) {
-		Assert.notNull(resourceLoadClass, "ResourceLoadClass must not be null");
+	public BasicJsonTester(@NonNull Class<?> resourceLoadClass, Charset charset) {
 		this.loader = new JsonLoader(resourceLoadClass, charset);
 	}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/GsonTester.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/GsonTester.java
@@ -23,7 +23,7 @@ import com.google.gson.Gson;
 
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.core.ResolvableType;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * AssertJ based JSON tester backed by Gson. Usually instantiated via
@@ -61,8 +61,7 @@ public class GsonTester<T> extends AbstractJsonMarshalTester<T> {
 	 * Create a new uninitialized {@link GsonTester} instance.
 	 * @param gson the Gson instance
 	 */
-	protected GsonTester(Gson gson) {
-		Assert.notNull(gson, "Gson must not be null");
+	protected GsonTester(@NonNull Gson gson) {
 		this.gson = gson;
 	}
 
@@ -73,9 +72,9 @@ public class GsonTester<T> extends AbstractJsonMarshalTester<T> {
 	 * @param gson the Gson instance
 	 * @see #initFields(Object, Gson)
 	 */
-	public GsonTester(Class<?> resourceLoadClass, ResolvableType type, Gson gson) {
+	public GsonTester(Class<?> resourceLoadClass, ResolvableType type,
+			@NonNull Gson gson) {
 		super(resourceLoadClass, type);
-		Assert.notNull(gson, "Gson must not be null");
 		this.gson = gson;
 	}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/JacksonTester.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/JacksonTester.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.core.ResolvableType;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * AssertJ based JSON tester backed by Jackson. Usually instantiated via
@@ -68,8 +68,7 @@ public class JacksonTester<T> extends AbstractJsonMarshalTester<T> {
 	 * Create a new {@link JacksonTester} instance.
 	 * @param objectMapper the Jackson object mapper
 	 */
-	protected JacksonTester(ObjectMapper objectMapper) {
-		Assert.notNull(objectMapper, "ObjectMapper must not be null");
+	protected JacksonTester(@NonNull ObjectMapper objectMapper) {
 		this.objectMapper = objectMapper;
 	}
 
@@ -85,9 +84,8 @@ public class JacksonTester<T> extends AbstractJsonMarshalTester<T> {
 	}
 
 	public JacksonTester(Class<?> resourceLoadClass, ResolvableType type,
-			ObjectMapper objectMapper, Class<?> view) {
+			@NonNull ObjectMapper objectMapper, Class<?> view) {
 		super(resourceLoadClass, type);
-		Assert.notNull(objectMapper, "ObjectMapper must not be null");
 		this.objectMapper = objectMapper;
 		this.view = view;
 	}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/JsonContent.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/JsonContent.java
@@ -19,7 +19,7 @@ package org.springframework.boot.test.json;
 import org.assertj.core.api.AssertProvider;
 
 import org.springframework.core.ResolvableType;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * JSON content created usually from a JSON tester. Generally used only to
@@ -44,9 +44,8 @@ public final class JsonContent<T> implements AssertProvider<JsonContentAssert> {
 	 * @param type the type under test (or {@code null} if not known)
 	 * @param json the actual JSON content
 	 */
-	public JsonContent(Class<?> resourceLoadClass, ResolvableType type, String json) {
-		Assert.notNull(resourceLoadClass, "ResourceLoadClass must not be null");
-		Assert.notNull(json, "JSON must not be null");
+	public JsonContent(@NonNull Class<?> resourceLoadClass, ResolvableType type,
+			@NonNull String json) {
 		this.resourceLoadClass = resourceLoadClass;
 		this.type = type;
 		this.json = json;

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/JsonbTester.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/JsonbTester.java
@@ -23,7 +23,7 @@ import javax.json.bind.Jsonb;
 
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.core.ResolvableType;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * AssertJ based JSON tester backed by Jsonb. Usually instantiated via
@@ -61,8 +61,7 @@ public class JsonbTester<T> extends AbstractJsonMarshalTester<T> {
 	 * Create a new uninitialized {@link JsonbTester} instance.
 	 * @param jsonb the Jsonb instance
 	 */
-	protected JsonbTester(Jsonb jsonb) {
-		Assert.notNull(jsonb, "Jsonb must not be null");
+	protected JsonbTester(@NonNull Jsonb jsonb) {
 		this.jsonb = jsonb;
 	}
 
@@ -73,9 +72,9 @@ public class JsonbTester<T> extends AbstractJsonMarshalTester<T> {
 	 * @param jsonb the Jsonb instance
 	 * @see #initFields(Object, Jsonb)
 	 */
-	public JsonbTester(Class<?> resourceLoadClass, ResolvableType type, Jsonb jsonb) {
+	public JsonbTester(Class<?> resourceLoadClass, ResolvableType type,
+			@NonNull Jsonb jsonb) {
 		super(resourceLoadClass, type);
-		Assert.notNull(jsonb, "Jsonb must not be null");
 		this.jsonb = jsonb;
 	}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/ObjectContent.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/ObjectContent.java
@@ -19,7 +19,7 @@ package org.springframework.boot.test.json;
 import org.assertj.core.api.AssertProvider;
 
 import org.springframework.core.ResolvableType;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Object content usually created from {@link AbstractJsonMarshalTester}. Generally used
@@ -41,8 +41,7 @@ public final class ObjectContent<T> implements AssertProvider<ObjectContentAsser
 	 * @param type the type under test (or {@code null} if not known)
 	 * @param object the actual object content
 	 */
-	public ObjectContent(ResolvableType type, T object) {
-		Assert.notNull(object, "Object must not be null");
+	public ObjectContent(ResolvableType type, @NonNull T object) {
 		this.type = type;
 		this.object = object;
 	}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
@@ -27,7 +27,7 @@ import org.mockito.Mockito;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.style.ToStringCreator;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
@@ -48,11 +48,10 @@ class MockDefinition extends Definition {
 
 	private final boolean serializable;
 
-	MockDefinition(String name, ResolvableType typeToMock, Class<?>[] extraInterfaces,
-			Answers answer, boolean serializable, MockReset reset,
-			QualifierDefinition qualifier) {
+	MockDefinition(String name, @NonNull ResolvableType typeToMock,
+			Class<?>[] extraInterfaces, Answers answer, boolean serializable,
+			MockReset reset, QualifierDefinition qualifier) {
 		super(name, reset, false, qualifier);
-		Assert.notNull(typeToMock, "TypeToMock must not be null");
 		this.typeToMock = typeToMock;
 		this.extraInterfaces = asClassSet(extraInterfaces);
 		this.answer = (answer != null ? answer : Answers.RETURNS_DEFAULTS);

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockReset.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockReset.java
@@ -25,7 +25,7 @@ import org.mockito.listeners.InvocationListener;
 import org.mockito.listeners.MethodInvocationReport;
 import org.mockito.mock.MockCreationSettings;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Reset strategy used on a mock bean. Usually applied to a mock via the
@@ -87,8 +87,7 @@ public enum MockReset {
 	 * @param settings the settings
 	 * @return the configured settings
 	 */
-	public static MockSettings apply(MockReset reset, MockSettings settings) {
-		Assert.notNull(settings, "Settings must not be null");
+	public static MockSettings apply(MockReset reset, @NonNull MockSettings settings) {
 		if (reset != null && reset != NONE) {
 			settings.invocationListeners(new ResetInvocationListener(reset));
 		}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyDefinition.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyDefinition.java
@@ -23,6 +23,7 @@ import org.mockito.listeners.VerificationStartedListener;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.style.ToStringCreator;
+import org.springframework.lang.NonNull;
 import org.springframework.test.util.AopTestUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
@@ -39,10 +40,9 @@ class SpyDefinition extends Definition {
 
 	private final ResolvableType typeToSpy;
 
-	SpyDefinition(String name, ResolvableType typeToSpy, MockReset reset,
+	SpyDefinition(String name, @NonNull ResolvableType typeToSpy, MockReset reset,
 			boolean proxyTargetAware, QualifierDefinition qualifier) {
 		super(name, reset, proxyTargetAware, qualifier);
-		Assert.notNull(typeToSpy, "TypeToSpy must not be null");
 		this.typeToSpy = typeToSpy;
 
 	}
@@ -84,8 +84,7 @@ class SpyDefinition extends Definition {
 	}
 
 	@SuppressWarnings("unchecked")
-	public <T> T createSpy(String name, Object instance) {
-		Assert.notNull(instance, "Instance must not be null");
+	public <T> T createSpy(String name, @NonNull Object instance) {
 		Assert.isInstanceOf(this.typeToSpy.resolve(), instance);
 		if (Mockito.mockingDetails(instance).isSpy()) {
 			return (T) instance;

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java
@@ -36,6 +36,7 @@ import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.env.SystemEnvironmentPropertySource;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -109,10 +110,8 @@ public final class TestPropertyValues {
 	 * @param type the type of {@link PropertySource} to be added. See {@link Type}
 	 * @param name the name for the property source
 	 */
-	public void applyTo(ConfigurableEnvironment environment, Type type, String name) {
-		Assert.notNull(environment, "Environment must not be null");
-		Assert.notNull(type, "Property source type must not be null");
-		Assert.notNull(name, "Property source name must not be null");
+	public void applyTo(@NonNull ConfigurableEnvironment environment,
+			@NonNull Type type, @NonNull String name) {
 		MutablePropertySources sources = environment.getPropertySources();
 		addToSources(sources, type, name);
 		ConfigurationPropertySources.attach(environment);
@@ -310,8 +309,7 @@ public final class TestPropertyValues {
 			this.previous.forEach(this::setOrClear);
 		}
 
-		private String setOrClear(String name, String value) {
-			Assert.notNull(name, "Name must not be null");
+		private String setOrClear(@NonNull String name, String value) {
 			if (StringUtils.isEmpty(value)) {
 				return (String) System.getProperties().remove(name);
 			}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/LocalHostUriTemplateHandler.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/LocalHostUriTemplateHandler.java
@@ -18,7 +18,7 @@ package org.springframework.boot.test.web.client;
 
 import org.springframework.boot.web.client.RootUriTemplateHandler;
 import org.springframework.core.env.Environment;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriTemplateHandler;
 
@@ -57,10 +57,9 @@ public class LocalHostUriTemplateHandler extends RootUriTemplateHandler {
 	 * @param scheme the scheme of the root uri
 	 * @since 1.4.1
 	 */
-	public LocalHostUriTemplateHandler(Environment environment, String scheme) {
+	public LocalHostUriTemplateHandler(@NonNull Environment environment,
+			@NonNull String scheme) {
 		super(new DefaultUriBuilderFactory());
-		Assert.notNull(environment, "Environment must not be null");
-		Assert.notNull(scheme, "Scheme must not be null");
 		this.environment = environment;
 		this.scheme = scheme;
 	}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/MockServerRestTemplateCustomizer.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/MockServerRestTemplateCustomizer.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.boot.web.client.RestTemplateCustomizer;
+import org.springframework.lang.NonNull;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.client.RequestExpectationManager;
 import org.springframework.test.web.client.SimpleRequestExpectationManager;
@@ -66,8 +67,7 @@ public class MockServerRestTemplateCustomizer implements RestTemplateCustomizer 
 	}
 
 	public MockServerRestTemplateCustomizer(
-			Class<? extends RequestExpectationManager> expectationManager) {
-		Assert.notNull(expectationManager, "ExpectationManager must not be null");
+			@NonNull Class<? extends RequestExpectationManager> expectationManager) {
 		this.expectationManager = expectationManager;
 	}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/RootUriRequestExpectationManager.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/RootUriRequestExpectationManager.java
@@ -25,6 +25,7 @@ import org.springframework.boot.web.client.RootUriTemplateHandler;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.support.HttpRequestWrapper;
+import org.springframework.lang.NonNull;
 import org.springframework.mock.http.client.MockClientHttpRequest;
 import org.springframework.test.web.client.ExpectedCount;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -33,7 +34,6 @@ import org.springframework.test.web.client.RequestExpectationManager;
 import org.springframework.test.web.client.RequestMatcher;
 import org.springframework.test.web.client.ResponseActions;
 import org.springframework.test.web.client.SimpleRequestExpectationManager;
-import org.springframework.util.Assert;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriTemplateHandler;
 
@@ -59,10 +59,8 @@ public class RootUriRequestExpectationManager implements RequestExpectationManag
 
 	private final RequestExpectationManager expectationManager;
 
-	public RootUriRequestExpectationManager(String rootUri,
-			RequestExpectationManager expectationManager) {
-		Assert.notNull(rootUri, "RootUri must not be null");
-		Assert.notNull(expectationManager, "ExpectationManager must not be null");
+	public RootUriRequestExpectationManager(@NonNull String rootUri,
+			@NonNull RequestExpectationManager expectationManager) {
 		this.rootUri = rootUri;
 		this.expectationManager = expectationManager;
 	}
@@ -152,9 +150,9 @@ public class RootUriRequestExpectationManager implements RequestExpectationManag
 	 * @param expectationManager the source {@link RequestExpectationManager}
 	 * @return a {@link RequestExpectationManager} to be bound to the template
 	 */
-	public static RequestExpectationManager forRestTemplate(RestTemplate restTemplate,
+	public static RequestExpectationManager forRestTemplate(
+			@NonNull RestTemplate restTemplate,
 			RequestExpectationManager expectationManager) {
-		Assert.notNull(restTemplate, "RestTemplate must not be null");
 		UriTemplateHandler templateHandler = restTemplate.getUriTemplateHandler();
 		if (templateHandler instanceof RootUriTemplateHandler) {
 			return new RootUriRequestExpectationManager(

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplate.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplate.java
@@ -49,7 +49,7 @@ import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.client.support.BasicAuthorizationInterceptor;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.RequestCallback;
@@ -120,9 +120,8 @@ public class TestRestTemplate {
 		this(restTemplate, null, null);
 	}
 
-	public TestRestTemplate(RestTemplate restTemplate, String username, String password,
-			HttpClientOption... httpClientOptions) {
-		Assert.notNull(restTemplate, "RestTemplate must not be null");
+	public TestRestTemplate(@NonNull RestTemplate restTemplate, String username,
+			String password, HttpClientOption... httpClientOptions) {
 		this.httpClientOptions = httpClientOptions;
 		if (ClassUtils.isPresent("org.apache.http.client.config.RequestConfig", null)) {
 			restTemplate.setRequestFactory(
@@ -134,8 +133,7 @@ public class TestRestTemplate {
 	}
 
 	private static RestTemplate buildRestTemplate(
-			RestTemplateBuilder restTemplateBuilder) {
-		Assert.notNull(restTemplateBuilder, "RestTemplateBuilder must not be null");
+			@NonNull RestTemplateBuilder restTemplateBuilder) {
 		return restTemplateBuilder.build();
 	}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/htmlunit/LocalHostWebClient.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/htmlunit/LocalHostWebClient.java
@@ -24,7 +24,7 @@ import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebClient;
 
 import org.springframework.core.env.Environment;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link WebClient} will automatically prefix relative URLs with
@@ -37,8 +37,7 @@ public class LocalHostWebClient extends WebClient {
 
 	private final Environment environment;
 
-	public LocalHostWebClient(Environment environment) {
-		Assert.notNull(environment, "Environment must not be null");
+	public LocalHostWebClient(@NonNull Environment environment) {
 		this.environment = environment;
 	}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/htmlunit/webdriver/LocalHostWebConnectionHtmlUnitDriver.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/htmlunit/webdriver/LocalHostWebConnectionHtmlUnitDriver.java
@@ -20,8 +20,8 @@ import com.gargoylesoftware.htmlunit.BrowserVersion;
 import org.openqa.selenium.Capabilities;
 
 import org.springframework.core.env.Environment;
+import org.springframework.lang.NonNull;
 import org.springframework.test.web.servlet.htmlunit.webdriver.WebConnectionHtmlUnitDriver;
-import org.springframework.util.Assert;
 
 /**
  * {@link LocalHostWebConnectionHtmlUnitDriver} will automatically prefix relative URLs
@@ -34,29 +34,25 @@ public class LocalHostWebConnectionHtmlUnitDriver extends WebConnectionHtmlUnitD
 
 	private final Environment environment;
 
-	public LocalHostWebConnectionHtmlUnitDriver(Environment environment) {
-		Assert.notNull(environment, "Environment must not be null");
+	public LocalHostWebConnectionHtmlUnitDriver(@NonNull Environment environment) {
 		this.environment = environment;
 	}
 
-	public LocalHostWebConnectionHtmlUnitDriver(Environment environment,
+	public LocalHostWebConnectionHtmlUnitDriver(@NonNull Environment environment,
 			boolean enableJavascript) {
 		super(enableJavascript);
-		Assert.notNull(environment, "Environment must not be null");
 		this.environment = environment;
 	}
 
-	public LocalHostWebConnectionHtmlUnitDriver(Environment environment,
+	public LocalHostWebConnectionHtmlUnitDriver(@NonNull Environment environment,
 			BrowserVersion browserVersion) {
 		super(browserVersion);
-		Assert.notNull(environment, "Environment must not be null");
 		this.environment = environment;
 	}
 
-	public LocalHostWebConnectionHtmlUnitDriver(Environment environment,
+	public LocalHostWebConnectionHtmlUnitDriver(@NonNull Environment environment,
 			Capabilities capabilities) {
 		super(capabilities);
-		Assert.notNull(environment, "Environment must not be null");
 		this.environment = environment;
 	}
 

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/json/JsonContentTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/json/JsonContentTests.java
@@ -49,7 +49,7 @@ public class JsonContentTests {
 	@Test
 	public void createWhenJsonIsNullShouldThrowException() throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("JSON must not be null");
+		this.thrown.expectMessage("Json must not be null");
 		new JsonContent<ExampleObject>(getClass(), TYPE, null);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/assertj/Matched.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/assertj/Matched.java
@@ -20,7 +20,7 @@ import org.assertj.core.api.Condition;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Adapter class allowing a Hamcrest {@link Matcher} to be used as an AssertJ
@@ -33,8 +33,7 @@ public final class Matched<T> extends Condition<T> {
 
 	private final Matcher<? extends T> matcher;
 
-	private Matched(Matcher<? extends T> matcher) {
-		Assert.notNull(matcher, "Matcher must not be null");
+	private Matched(@NonNull Matcher<? extends T> matcher) {
 		this.matcher = matcher;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/BeanDefinitionLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/BeanDefinitionLoader.java
@@ -40,8 +40,8 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.core.type.filter.AbstractTypeHierarchyTraversingFilter;
 import org.springframework.core.type.filter.TypeFilter;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
-import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
@@ -74,9 +74,8 @@ class BeanDefinitionLoader {
 	 * @param registry the bean definition registry that will contain the loaded beans
 	 * @param sources the bean sources
 	 */
-	BeanDefinitionLoader(BeanDefinitionRegistry registry, Object... sources) {
-		Assert.notNull(registry, "Registry must not be null");
-		Assert.notEmpty(sources, "Sources must not be empty");
+	BeanDefinitionLoader(@NonNull BeanDefinitionRegistry registry,
+			@NonNull Object... sources) {
 		this.sources = sources;
 		this.annotatedReader = new AnnotatedBeanDefinitionReader(registry);
 		this.xmlReader = new XmlBeanDefinitionReader(registry);
@@ -129,8 +128,7 @@ class BeanDefinitionLoader {
 		return count;
 	}
 
-	private int load(Object source) {
-		Assert.notNull(source, "Source must not be null");
+	private int load(@NonNull Object source) {
 		if (source instanceof Class<?>) {
 			return load((Class<?>) source);
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DefaultApplicationArguments.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DefaultApplicationArguments.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.core.env.SimpleCommandLinePropertySource;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Default implementation of {@link ApplicationArguments}.
@@ -37,8 +37,7 @@ public class DefaultApplicationArguments implements ApplicationArguments {
 
 	private final String[] args;
 
-	public DefaultApplicationArguments(String[] args) {
-		Assert.notNull(args, "Args must not be null");
+	public DefaultApplicationArguments(@NonNull String[] args) {
 		this.source = new Source(args);
 		this.args = args;
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ExitCodeGenerators.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ExitCodeGenerators.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Maintains a collection of {@link ExitCodeGenerator} instances and allows the final exit
@@ -36,41 +36,34 @@ class ExitCodeGenerators implements Iterable<ExitCodeGenerator> {
 
 	private List<ExitCodeGenerator> generators = new ArrayList<>();
 
-	public void addAll(Throwable exception, ExitCodeExceptionMapper... mappers) {
-		Assert.notNull(exception, "Exception must not be null");
-		Assert.notNull(mappers, "Mappers must not be null");
+	public void addAll(@NonNull Throwable exception,
+			@NonNull ExitCodeExceptionMapper... mappers) {
 		addAll(exception, Arrays.asList(mappers));
 	}
 
-	public void addAll(Throwable exception,
-			Iterable<? extends ExitCodeExceptionMapper> mappers) {
-		Assert.notNull(exception, "Exception must not be null");
-		Assert.notNull(mappers, "Mappers must not be null");
+	public void addAll(@NonNull Throwable exception,
+			@NonNull Iterable<? extends ExitCodeExceptionMapper> mappers) {
 		for (ExitCodeExceptionMapper mapper : mappers) {
 			add(exception, mapper);
 		}
 	}
 
-	public void add(Throwable exception, ExitCodeExceptionMapper mapper) {
-		Assert.notNull(exception, "Exception must not be null");
-		Assert.notNull(mapper, "Mapper must not be null");
+	public void add(@NonNull Throwable exception,
+			@NonNull ExitCodeExceptionMapper mapper) {
 		add(new MappedExitCodeGenerator(exception, mapper));
 	}
 
-	public void addAll(ExitCodeGenerator... generators) {
-		Assert.notNull(generators, "Generators must not be null");
+	public void addAll(@NonNull ExitCodeGenerator... generators) {
 		addAll(Arrays.asList(generators));
 	}
 
-	public void addAll(Iterable<? extends ExitCodeGenerator> generators) {
-		Assert.notNull(generators, "Generators must not be null");
+	public void addAll(@NonNull Iterable<? extends ExitCodeGenerator> generators) {
 		for (ExitCodeGenerator generator : generators) {
 			add(generator);
 		}
 	}
 
-	public void add(ExitCodeGenerator generator) {
-		Assert.notNull(generator, "Generator must not be null");
+	public void add(@NonNull ExitCodeGenerator generator) {
 		this.generators.add(generator);
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ImageBanner.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ImageBanner.java
@@ -41,6 +41,7 @@ import org.springframework.boot.ansi.AnsiElement;
 import org.springframework.boot.ansi.AnsiOutput;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -67,8 +68,7 @@ public class ImageBanner implements Banner {
 
 	private final Resource image;
 
-	public ImageBanner(Resource image) {
-		Assert.notNull(image, "Image must not be null");
+	public ImageBanner(@NonNull Resource image) {
 		Assert.isTrue(image.exists(), "Image must exist");
 		this.image = image;
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ResourceBanner.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ResourceBanner.java
@@ -35,6 +35,7 @@ import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertyResolver;
 import org.springframework.core.env.PropertySourcesPropertyResolver;
 import org.springframework.core.io.Resource;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
 
@@ -51,8 +52,7 @@ public class ResourceBanner implements Banner {
 
 	private Resource resource;
 
-	public ResourceBanner(Resource resource) {
-		Assert.notNull(resource, "Resource must not be null");
+	public ResourceBanner(@NonNull Resource resource) {
 		Assert.isTrue(resource.exists(), "Resource must exist");
 		this.resource = resource;
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -67,6 +67,7 @@ import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.SpringFactoriesLoader;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
@@ -258,9 +259,9 @@ public class SpringApplication {
 	 * @see #setSources(Set)
 	 */
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public SpringApplication(ResourceLoader resourceLoader, Class<?>... primarySources) {
+	public SpringApplication(ResourceLoader resourceLoader,
+			@NonNull Class<?>... primarySources) {
 		this.resourceLoader = resourceLoader;
-		Assert.notNull(primarySources, "PrimarySources must not be null");
 		this.primarySources = new LinkedHashSet<>(Arrays.asList(primarySources));
 		this.webApplicationType = deduceWebApplicationType();
 		setInitializers((Collection) getSpringFactoriesInstances(
@@ -961,8 +962,7 @@ public class SpringApplication {
 	 * @param webApplicationType the web application type
 	 * @since 2.0.0
 	 */
-	public void setWebApplicationType(WebApplicationType webApplicationType) {
-		Assert.notNull(webApplicationType, "WebApplicationType must not be null");
+	public void setWebApplicationType(@NonNull WebApplicationType webApplicationType) {
 		this.webApplicationType = webApplicationType;
 	}
 
@@ -1108,8 +1108,7 @@ public class SpringApplication {
 	 * @see #SpringApplication(Class...)
 	 * @see #getAllSources()
 	 */
-	public void setSources(Set<String> sources) {
-		Assert.notNull(sources, "Sources must not be null");
+	public void setSources(@NonNull Set<String> sources) {
 		this.sources = new LinkedHashSet<>(sources);
 	}
 
@@ -1135,8 +1134,7 @@ public class SpringApplication {
 	 * Sets the {@link ResourceLoader} that should be used when loading resources.
 	 * @param resourceLoader the resource loader
 	 */
-	public void setResourceLoader(ResourceLoader resourceLoader) {
-		Assert.notNull(resourceLoader, "ResourceLoader must not be null");
+	public void setResourceLoader(@NonNull ResourceLoader resourceLoader) {
 		this.resourceLoader = resourceLoader;
 	}
 
@@ -1272,9 +1270,8 @@ public class SpringApplication {
 	 * @param exitCodeGenerators exist code generators
 	 * @return the outcome (0 if successful)
 	 */
-	public static int exit(ApplicationContext context,
+	public static int exit(@NonNull ApplicationContext context,
 			ExitCodeGenerator... exitCodeGenerators) {
-		Assert.notNull(context, "Context must not be null");
 		int exitCode = 0;
 		try {
 			try {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Callable;
 import org.apache.commons.logging.Log;
 
 import org.springframework.context.ApplicationContext;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StopWatch;
 import org.springframework.util.StringUtils;
@@ -42,8 +42,7 @@ class StartupInfoLogger {
 		this.sourceClass = sourceClass;
 	}
 
-	public void logStarting(Log log) {
-		Assert.notNull(log, "Log must not be null");
+	public void logStarting(@NonNull Log log) {
 		if (log.isInfoEnabled()) {
 			log.info(getStartupMessage());
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiColors.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiColors.java
@@ -23,7 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Utility for working with {@link AnsiColor} in the context of {@link Color AWT Colors}.
@@ -93,12 +93,11 @@ public final class AnsiColors {
 
 		private final double b;
 
-		LabColor(Integer rgb) {
-			this(rgb == null ? (Color) null : new Color(rgb));
+		LabColor(@NonNull Integer rgb) {
+			this(new Color(rgb));
 		}
 
-		LabColor(Color color) {
-			Assert.notNull(color, "Color must not be null");
+		LabColor(@NonNull Color color) {
 			float[] lab = fromXyz(color.getColorComponents(XYZ_COLOR_SPACE, null));
 			this.l = lab[0];
 			this.a = lab[1];

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiOutput.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiOutput.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.ansi;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Generates ANSI encoded output, automatically attempting to detect if the terminal
@@ -47,8 +47,7 @@ public abstract class AnsiOutput {
 	 * Sets if ANSI output is enabled.
 	 * @param enabled if ANSI is enabled, disabled or detected
 	 */
-	public static void setEnabled(Enabled enabled) {
-		Assert.notNull(enabled, "Enabled must not be null");
+	public static void setEnabled(@NonNull Enabled enabled) {
 		AnsiOutput.enabled = enabled;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/annotation/Configurations.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/annotation/Configurations.java
@@ -32,8 +32,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.OrderComparator;
 import org.springframework.core.Ordered;
+import org.springframework.lang.NonNull;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.util.Assert;
 
 /**
  * A set of {@link Configuration @Configuration} classes that can be registered in
@@ -59,8 +59,7 @@ public abstract class Configurations {
 
 	private final Set<Class<?>> classes;
 
-	protected Configurations(Collection<Class<?>> classes) {
-		Assert.notNull(classes, "Classes must not be null");
+	protected Configurations(@NonNull Collection<Class<?>> classes) {
 		Collection<Class<?>> sorted = sort(classes);
 		this.classes = Collections.unmodifiableSet(new LinkedHashSet<>(sorted));
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
@@ -57,6 +57,7 @@ import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.SpringFactoriesLoader;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
@@ -647,8 +648,7 @@ public class ConfigFileApplicationListener
 			this(name, false);
 		}
 
-		Profile(String name, boolean defaultProfile) {
-			Assert.notNull(name, "Name must not be null");
+		Profile(@NonNull String name, boolean defaultProfile) {
 			this.name = name;
 			this.defaultProfile = defaultProfile;
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
@@ -28,7 +28,7 @@ import org.springframework.boot.context.properties.source.ConfigurationPropertyS
 import org.springframework.boot.context.properties.source.UnboundElementsSourceFilter;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.env.PropertySource;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -50,9 +50,8 @@ class ConfigurationPropertiesBinder {
 
 	private Iterable<ConfigurationPropertySource> configurationSources;
 
-	ConfigurationPropertiesBinder(Iterable<PropertySource<?>> propertySources,
+	ConfigurationPropertiesBinder(@NonNull Iterable<PropertySource<?>> propertySources,
 			ConversionService conversionService, Validator validator) {
-		Assert.notNull(propertySources, "PropertySources must not be null");
 		this.propertySources = propertySources;
 		this.conversionService = conversionService;
 		this.validator = validator;
@@ -131,8 +130,7 @@ class ConfigurationPropertiesBinder {
 
 		private final Validator[] validators;
 
-		ChainingValidator(Validator... validators) {
-			Assert.notNull(validators, "Validators must not be null");
+		ChainingValidator(@NonNull Validator... validators) {
 			this.validators = validators;
 		}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinderBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinderBuilder.java
@@ -29,7 +29,7 @@ import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.PropertySource;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 import org.springframework.validation.Validator;
 
@@ -67,8 +67,8 @@ class ConfigurationPropertiesBinderBuilder {
 	 * Creates an instance with the {@link ApplicationContext} to use.
 	 * @param applicationContext the application context
 	 */
-	ConfigurationPropertiesBinderBuilder(ApplicationContext applicationContext) {
-		Assert.notNull(applicationContext, "ApplicationContext must not be null");
+	ConfigurationPropertiesBinderBuilder(
+			@NonNull ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/AbstractBindHandler.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/AbstractBindHandler.java
@@ -17,7 +17,7 @@
 package org.springframework.boot.context.properties.bind;
 
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Abstract base class for {@link BindHandler} implementations.
@@ -41,8 +41,7 @@ public abstract class AbstractBindHandler implements BindHandler {
 	 * Create a new binding handler instance with a specific parent.
 	 * @param parent the parent handler
 	 */
-	public AbstractBindHandler(BindHandler parent) {
-		Assert.notNull(parent, "Parent must not be null");
+	public AbstractBindHandler(@NonNull BindHandler parent) {
 		this.parent = parent;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/BindResult.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/BindResult.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.springframework.beans.BeanUtils;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -71,8 +71,7 @@ public final class BindResult<T> {
 	 * been bound.
 	 * @param consumer block to execute if a value has been bound
 	 */
-	public void ifBound(Consumer<? super T> consumer) {
-		Assert.notNull(consumer, "Consumer must not be null");
+	public void ifBound(@NonNull Consumer<? super T> consumer) {
 		if (this.value != null) {
 			consumer.accept(this.value);
 		}
@@ -87,8 +86,7 @@ public final class BindResult<T> {
 	 * @return an {@code BindResult} describing the result of applying a mapping function
 	 * to the value of this {@code BindResult}.
 	 */
-	public <U> BindResult<U> map(Function<? super T, ? extends U> mapper) {
-		Assert.notNull(mapper, "Mapper must not be null");
+	public <U> BindResult<U> map(@NonNull Function<? super T, ? extends U> mapper) {
 		return of(this.value == null ? null : mapper.apply(this.value));
 	}
 
@@ -119,8 +117,7 @@ public final class BindResult<T> {
 	 * @param type the type to create if no value was bound
 	 * @return the value, if bound, otherwise a new instance of {@code type}
 	 */
-	public T orElseCreate(Class<? extends T> type) {
-		Assert.notNull(type, "Type must not be null");
+	public T orElseCreate(@NonNull Class<? extends T> type) {
 		return (this.value != null ? this.value : BeanUtils.instantiateClass(type));
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Bindable.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Bindable.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.style.ToStringCreator;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
@@ -156,8 +157,7 @@ public final class Bindable<T> {
 	 * @see #withExistingValue(Object)
 	 */
 	@SuppressWarnings("unchecked")
-	public static <T> Bindable<T> ofInstance(T instance) {
-		Assert.notNull(instance, "Instance must not be null");
+	public static <T> Bindable<T> ofInstance(@NonNull T instance) {
 		Class<T> type = (Class<T>) instance.getClass();
 		return of(type).withExistingValue(instance);
 	}
@@ -169,8 +169,7 @@ public final class Bindable<T> {
 	 * @return a {@link Bindable} instance
 	 * @see #of(ResolvableType)
 	 */
-	public static <T> Bindable<T> of(Class<T> type) {
-		Assert.notNull(type, "Type must not be null");
+	public static <T> Bindable<T> of(@NonNull Class<T> type) {
 		return of(ResolvableType.forClass(type));
 	}
 
@@ -213,8 +212,7 @@ public final class Bindable<T> {
 	 * @return a {@link Bindable} instance
 	 * @see #of(Class)
 	 */
-	public static <T> Bindable<T> of(ResolvableType type) {
-		Assert.notNull(type, "Type must not be null");
+	public static <T> Bindable<T> of(@NonNull ResolvableType type) {
 		ResolvableType boxedType = box(type);
 		return new Bindable<>(type, boxedType, null, NO_ANNOTATIONS);
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java
@@ -40,7 +40,7 @@ import org.springframework.boot.context.properties.source.ConfigurationPropertyS
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.env.Environment;
 import org.springframework.format.support.DefaultFormattingConversionService;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -104,10 +104,9 @@ public class Binder {
 	 * @param placeholdersResolver strategy to resolve any property place-holders
 	 * @param conversionService the conversion service to convert values
 	 */
-	public Binder(Iterable<ConfigurationPropertySource> sources,
+	public Binder(@NonNull Iterable<ConfigurationPropertySource> sources,
 			PlaceholdersResolver placeholdersResolver,
 			ConversionService conversionService) {
-		Assert.notNull(sources, "Sources must not be null");
 		this.sources = sources;
 		this.placeholdersResolver = (placeholdersResolver != null ? placeholdersResolver
 				: PlaceholdersResolver.NONE);
@@ -177,10 +176,9 @@ public class Binder {
 	 * @param <T> the bound type
 	 * @return the binding result (never {@code null})
 	 */
-	public <T> BindResult<T> bind(ConfigurationPropertyName name, Bindable<T> target,
+	public <T> BindResult<T> bind(@NonNull ConfigurationPropertyName name,
+			@NonNull Bindable<T> target,
 			BindHandler handler) {
-		Assert.notNull(name, "Name must not be null");
-		Assert.notNull(target, "Target must not be null");
 		handler = (handler != null ? handler : BindHandler.DEFAULT);
 		Context context = new Context();
 		T bound = bind(name, target, handler, context, false);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/PropertySourcesPlaceholdersResolver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/PropertySourcesPlaceholdersResolver.java
@@ -20,6 +20,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.PropertySources;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.PropertyPlaceholderHelper;
 import org.springframework.util.SystemPropertyUtils;
@@ -75,8 +76,7 @@ public class PropertySourcesPlaceholdersResolver implements PlaceholdersResolver
 		return null;
 	}
 
-	private static PropertySources getSources(Environment environment) {
-		Assert.notNull(environment, "Environment must not be null");
+	private static PropertySources getSources(@NonNull Environment environment) {
 		Assert.isInstanceOf(ConfigurableEnvironment.class, environment,
 				"Environment must be a ConfigurableEnvironment");
 		return ((ConfigurableEnvironment) environment).getPropertySources();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/validation/BindValidationException.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/validation/BindValidationException.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.context.properties.bind.validation;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Error thrown when validation fails during a bind operation.
@@ -31,8 +31,7 @@ public class BindValidationException extends RuntimeException {
 
 	private final ValidationErrors validationErrors;
 
-	BindValidationException(ValidationErrors validationErrors) {
-		Assert.notNull(validationErrors, "ValidationErrors must not be null");
+	BindValidationException(@NonNull ValidationErrors validationErrors) {
 		this.validationErrors = validationErrors;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/validation/ValidationErrors.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/validation/ValidationErrors.java
@@ -27,7 +27,7 @@ import org.springframework.boot.context.properties.source.ConfigurationProperty;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName.Form;
 import org.springframework.boot.origin.Origin;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 
@@ -47,11 +47,9 @@ public class ValidationErrors implements Iterable<ObjectError> {
 
 	private final List<ObjectError> errors;
 
-	ValidationErrors(ConfigurationPropertyName name,
-			Set<ConfigurationProperty> boundProperties, List<ObjectError> errors) {
-		Assert.notNull(name, "Name must not be null");
-		Assert.notNull(boundProperties, "BoundProperties must not be null");
-		Assert.notNull(errors, "Errors must not be null");
+	ValidationErrors(@NonNull ConfigurationPropertyName name,
+			@NonNull Set<ConfigurationProperty> boundProperties,
+			@NonNull List<ObjectError> errors) {
 		this.name = name;
 		this.boundProperties = Collections.unmodifiableSet(boundProperties);
 		this.errors = convertErrors(name, boundProperties, errors);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/AliasedConfigurationPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/AliasedConfigurationPropertySource.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.context.properties.source;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * A {@link ConfigurationPropertySource} supporting name aliases.
@@ -30,18 +30,15 @@ class AliasedConfigurationPropertySource implements ConfigurationPropertySource 
 
 	private final ConfigurationPropertyNameAliases aliases;
 
-	AliasedConfigurationPropertySource(ConfigurationPropertySource source,
-			ConfigurationPropertyNameAliases aliases) {
-		Assert.notNull(source, "Source must not be null");
-		Assert.notNull(aliases, "Aliases must not be null");
+	AliasedConfigurationPropertySource(@NonNull ConfigurationPropertySource source,
+			@NonNull ConfigurationPropertyNameAliases aliases) {
 		this.source = source;
 		this.aliases = aliases;
 	}
 
 	@Override
 	public ConfigurationProperty getConfigurationProperty(
-			ConfigurationPropertyName name) {
-		Assert.notNull(name, "Name must not be null");
+			@NonNull ConfigurationPropertyName name) {
 		ConfigurationProperty result = getSource().getConfigurationProperty(name);
 		if (result == null) {
 			ConfigurationPropertyName aliasedName = getAliases().getNameForAlias(name);
@@ -52,8 +49,7 @@ class AliasedConfigurationPropertySource implements ConfigurationPropertySource 
 
 	@Override
 	public ConfigurationPropertyState containsDescendantOf(
-			ConfigurationPropertyName name) {
-		Assert.notNull(name, "Name must not be null");
+			@NonNull ConfigurationPropertyName name) {
 		ConfigurationPropertyState result = this.source.containsDescendantOf(name);
 		if (result != ConfigurationPropertyState.ABSENT) {
 			return result;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationProperty.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationProperty.java
@@ -20,7 +20,7 @@ import org.springframework.boot.origin.Origin;
 import org.springframework.boot.origin.OriginProvider;
 import org.springframework.boot.origin.OriginTrackedValue;
 import org.springframework.core.style.ToStringCreator;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -41,10 +41,8 @@ public final class ConfigurationProperty
 
 	private final Origin origin;
 
-	public ConfigurationProperty(ConfigurationPropertyName name, Object value,
-			Origin origin) {
-		Assert.notNull(name, "Name must not be null");
-		Assert.notNull(value, "Value must not be null");
+	public ConfigurationProperty(@NonNull ConfigurationPropertyName name,
+			@NonNull Object value, Origin origin) {
 		this.name = name;
 		this.value = value;
 		this.origin = origin;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
@@ -220,8 +221,7 @@ public final class ConfigurationPropertyName
 	 * @param name the name to check
 	 * @return {@code true} if this name is an ancestor
 	 */
-	public boolean isParentOf(ConfigurationPropertyName name) {
-		Assert.notNull(name, "Name must not be null");
+	public boolean isParentOf(@NonNull ConfigurationPropertyName name) {
 		if (this.getNumberOfElements() != name.getNumberOfElements() - 1) {
 			return false;
 		}
@@ -234,8 +234,7 @@ public final class ConfigurationPropertyName
 	 * @param name the name to check
 	 * @return {@code true} if this name is an ancestor
 	 */
-	public boolean isAncestorOf(ConfigurationPropertyName name) {
-		Assert.notNull(name, "Name must not be null");
+	public boolean isAncestorOf(@NonNull ConfigurationPropertyName name) {
 		if (this.getNumberOfElements() >= name.getNumberOfElements()) {
 			return false;
 		}
@@ -441,8 +440,7 @@ public final class ConfigurationPropertyName
 	 * @return a {@link ConfigurationPropertyName} instance
 	 * @throws InvalidConfigurationPropertyNameException if the name is not valid
 	 */
-	public static ConfigurationPropertyName of(CharSequence name) {
-		Assert.notNull(name, "Name must not be null");
+	public static ConfigurationPropertyName of(@NonNull CharSequence name) {
 		if (name.length() >= 1
 				&& (name.charAt(0) == '.' || name.charAt(name.length() - 1) == '.')) {
 			throw new InvalidConfigurationPropertyNameException(name,
@@ -489,10 +487,8 @@ public final class ConfigurationPropertyName
 	 * @param elementValueProcessor a function to process element values
 	 * @return a {@link ConfigurationPropertyName}
 	 */
-	static ConfigurationPropertyName adapt(CharSequence name, char separator,
-			Function<CharSequence, CharSequence> elementValueProcessor) {
-		Assert.notNull(name, "Name must not be null");
-		Assert.notNull(elementValueProcessor, "ElementValueProcessor must not be null");
+	static ConfigurationPropertyName adapt(@NonNull CharSequence name, char separator,
+			@NonNull Function<CharSequence, CharSequence> elementValueProcessor) {
 		if (name.length() == 0) {
 			return EMPTY;
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyNameAliases.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyNameAliases.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -49,18 +49,14 @@ public final class ConfigurationPropertyNameAliases {
 		addAliases(name, aliases);
 	}
 
-	public void addAliases(String name, String... aliases) {
-		Assert.notNull(name, "Name must not be null");
-		Assert.notNull(aliases, "Aliases must not be null");
+	public void addAliases(@NonNull String name, @NonNull String... aliases) {
 		addAliases(ConfigurationPropertyName.of(name),
 				Arrays.stream(aliases).map(ConfigurationPropertyName::of)
 						.toArray(ConfigurationPropertyName[]::new));
 	}
 
-	public void addAliases(ConfigurationPropertyName name,
-			ConfigurationPropertyName... aliases) {
-		Assert.notNull(name, "Name must not be null");
-		Assert.notNull(aliases, "Aliases must not be null");
+	public void addAliases(@NonNull ConfigurationPropertyName name,
+			@NonNull ConfigurationPropertyName... aliases) {
 		this.aliases.addAll(name, Arrays.asList(aliases));
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyState.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyState.java
@@ -18,7 +18,7 @@ package org.springframework.boot.context.properties.source;
 
 import java.util.function.Predicate;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * The state of content from a {@link ConfigurationPropertySource}.
@@ -55,10 +55,8 @@ public enum ConfigurationPropertyState {
 	 * @return {@link #PRESENT} if the iterable contains a matching item, otherwise
 	 * {@link #ABSENT}.
 	 */
-	static <T> ConfigurationPropertyState search(Iterable<T> source,
-			Predicate<T> predicate) {
-		Assert.notNull(source, "Source must not be null");
-		Assert.notNull(predicate, "Predicate must not be null");
+	static <T> ConfigurationPropertyState search(@NonNull Iterable<T> source,
+			@NonNull Predicate<T> predicate) {
 		for (T item : source) {
 			if (predicate.test(item)) {
 				return PRESENT;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/FilteredConfigurationPropertiesSource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/FilteredConfigurationPropertiesSource.java
@@ -18,7 +18,7 @@ package org.springframework.boot.context.properties.source;
 
 import java.util.function.Predicate;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * A filtered {@link ConfigurationPropertySource}.
@@ -32,10 +32,8 @@ class FilteredConfigurationPropertiesSource implements ConfigurationPropertySour
 
 	private final Predicate<ConfigurationPropertyName> filter;
 
-	FilteredConfigurationPropertiesSource(ConfigurationPropertySource source,
-			Predicate<ConfigurationPropertyName> filter) {
-		Assert.notNull(source, "Source must not be null");
-		Assert.notNull(filter, "Filter must not be null");
+	FilteredConfigurationPropertiesSource(@NonNull ConfigurationPropertySource source,
+			@NonNull Predicate<ConfigurationPropertyName> filter) {
 		this.source = source;
 		this.filter = filter;
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/MapConfigurationPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/MapConfigurationPropertySource.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.springframework.core.env.MapPropertySource;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * An {@link ConfigurationPropertySource} backed by a {@link Map} and using standard name
@@ -63,8 +63,7 @@ public class MapConfigurationPropertySource
 	 * Add all entries from the specified map.
 	 * @param map the source map
 	 */
-	public void putAll(Map<?, ?> map) {
-		Assert.notNull(map, "Map must not be null");
+	public void putAll(@NonNull Map<?, ?> map) {
 		assertNotReadOnlySystemAttributesMap(map);
 		map.forEach(this::put);
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringConfigurationPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringConfigurationPropertySource.java
@@ -29,7 +29,7 @@ import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.env.SystemEnvironmentPropertySource;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link ConfigurationPropertySource} backed by a non-enumerable Spring
@@ -71,11 +71,9 @@ class SpringConfigurationPropertySource implements ConfigurationPropertySource {
 	 * @param containsDescendantOf function used to implement
 	 * {@link #containsDescendantOf(ConfigurationPropertyName)} (may be {@code null})
 	 */
-	SpringConfigurationPropertySource(PropertySource<?> propertySource,
-			PropertyMapper mapper,
+	SpringConfigurationPropertySource(@NonNull PropertySource<?> propertySource,
+			@NonNull PropertyMapper mapper,
 			Function<ConfigurationPropertyName, ConfigurationPropertyState> containsDescendantOf) {
-		Assert.notNull(propertySource, "PropertySource must not be null");
-		Assert.notNull(mapper, "Mapper must not be null");
 		this.propertySource = propertySource;
 		this.mapper = new ExceptionSwallowingPropertyMapper(mapper);
 		this.containsDescendantOf = (containsDescendantOf != null ? containsDescendantOf
@@ -139,8 +137,8 @@ class SpringConfigurationPropertySource implements ConfigurationPropertySource {
 	 * @return a {@link SpringConfigurationPropertySource} or
 	 * {@link SpringIterableConfigurationPropertySource} instance
 	 */
-	public static SpringConfigurationPropertySource from(PropertySource<?> source) {
-		Assert.notNull(source, "Source must not be null");
+	public static SpringConfigurationPropertySource from(
+			@NonNull PropertySource<?> source) {
 		PropertyMapper mapper = getPropertyMapper(source);
 		if (isFullEnumerable(source)) {
 			return new SpringIterableConfigurationPropertySource(

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringConfigurationPropertySources.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringConfigurationPropertySources.java
@@ -27,7 +27,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.PropertySource.StubPropertySource;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -45,8 +45,7 @@ class SpringConfigurationPropertySources
 
 	private volatile List<ConfigurationPropertySource> adaptedSources;
 
-	SpringConfigurationPropertySources(Iterable<PropertySource<?>> sources) {
-		Assert.notNull(sources, "Sources must not be null");
+	SpringConfigurationPropertySources(@NonNull Iterable<PropertySource<?>> sources) {
 		this.sources = sources;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/FailureAnalyzers.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/FailureAnalyzers.java
@@ -29,7 +29,7 @@ import org.springframework.boot.SpringBootExceptionReporter;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.core.io.support.SpringFactoriesLoader;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
 
@@ -54,12 +54,11 @@ final class FailureAnalyzers implements SpringBootExceptionReporter {
 
 	private final List<FailureAnalyzer> analyzers;
 
-	FailureAnalyzers(ConfigurableApplicationContext context) {
+	FailureAnalyzers(@NonNull ConfigurableApplicationContext context) {
 		this(context, null);
 	}
 
-	FailureAnalyzers(ConfigurableApplicationContext context, ClassLoader classLoader) {
-		Assert.notNull(context, "Context must not be null");
+	FailureAnalyzers(@NonNull ConfigurableApplicationContext context, ClassLoader classLoader) {
 		this.classLoader = (classLoader == null ? context.getClassLoader() : classLoader);
 		this.analyzers = loadFailureAnalyzers(this.classLoader);
 		prepareFailureAnalyzers(this.analyzers, context);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/OriginTrackedPropertiesLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/OriginTrackedPropertiesLoader.java
@@ -29,7 +29,7 @@ import org.springframework.boot.origin.OriginTrackedValue;
 import org.springframework.boot.origin.TextResourceOrigin;
 import org.springframework.boot.origin.TextResourceOrigin.Location;
 import org.springframework.core.io.Resource;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Class to load {@code .properties} files into a map of {@code String} ->
@@ -48,8 +48,7 @@ class OriginTrackedPropertiesLoader {
 	 * Create a new {@link OriginTrackedPropertiesLoader} instance.
 	 * @param resource the resource of the {@code .properties} data
 	 */
-	OriginTrackedPropertiesLoader(Resource resource) {
-		Assert.notNull(resource, "Resource must not be null");
+	OriginTrackedPropertiesLoader(@NonNull Resource resource) {
 		this.resource = resource;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/InfoProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/InfoProperties.java
@@ -23,7 +23,7 @@ import java.util.Properties;
 
 import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.env.PropertySource;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Base class for components exposing unstructured data with dedicated methods for well
@@ -40,8 +40,7 @@ public class InfoProperties implements Iterable<InfoProperties.Entry> {
 	 * Create an instance with the specified entries.
 	 * @param entries the information to expose
 	 */
-	public InfoProperties(Properties entries) {
-		Assert.notNull(entries, "Entries must not be null");
+	public InfoProperties(@NonNull Properties entries) {
 		this.entries = copy(entries);
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonObjectDeserializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonObjectDeserializer.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -86,8 +87,7 @@ public abstract class JsonObjectDeserializer<T>
 	 * @return the node value or {@code null}
 	 */
 	@SuppressWarnings({ "unchecked" })
-	protected final <D> D nullSafeValue(JsonNode jsonNode, Class<D> type) {
-		Assert.notNull(type, "Type must not be null");
+	protected final <D> D nullSafeValue(JsonNode jsonNode, @NonNull Class<D> type) {
 		if (jsonNode == null) {
 			return null;
 		}
@@ -127,8 +127,7 @@ public abstract class JsonObjectDeserializer<T>
 	 * @param fieldName the field name to extract
 	 * @return the {@link JsonNode}
 	 */
-	protected final JsonNode getRequiredNode(JsonNode tree, String fieldName) {
-		Assert.notNull(tree, "Tree must not be null");
+	protected final JsonNode getRequiredNode(@NonNull JsonNode tree, String fieldName) {
 		JsonNode node = tree.get(fieldName);
 		Assert.state(node != null && !(node instanceof NullNode),
 				() -> "Missing JSON field '" + fieldName + "'");

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/AbstractDataSourceInitializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/AbstractDataSourceInitializer.java
@@ -24,7 +24,7 @@ import org.springframework.jdbc.datasource.init.DatabasePopulatorUtils;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.jdbc.support.JdbcUtils;
 import org.springframework.jdbc.support.MetaDataAccessException;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Base class used for {@link DataSource} initialization.
@@ -41,10 +41,8 @@ public abstract class AbstractDataSourceInitializer {
 
 	private final ResourceLoader resourceLoader;
 
-	protected AbstractDataSourceInitializer(DataSource dataSource,
-			ResourceLoader resourceLoader) {
-		Assert.notNull(dataSource, "DataSource must not be null");
-		Assert.notNull(resourceLoader, "ResourceLoader must not be null");
+	protected AbstractDataSourceInitializer(@NonNull DataSource dataSource,
+			@NonNull ResourceLoader resourceLoader) {
 		this.dataSource = dataSource;
 		this.resourceLoader = resourceLoader;
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jta/narayana/DataSourceXAResourceRecoveryHelper.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jta/narayana/DataSourceXAResourceRecoveryHelper.java
@@ -28,6 +28,7 @@ import com.arjuna.ats.jta.recovery.XAResourceRecoveryHelper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -69,9 +70,8 @@ public class DataSourceXAResourceRecoveryHelper
 	 * @param user the database user or {@code null}
 	 * @param password the database password or {@code null}
 	 */
-	public DataSourceXAResourceRecoveryHelper(XADataSource xaDataSource, String user,
-			String password) {
-		Assert.notNull(xaDataSource, "XADataSource must not be null");
+	public DataSourceXAResourceRecoveryHelper(@NonNull XADataSource xaDataSource,
+			String user, String password) {
 		this.xaDataSource = xaDataSource;
 		this.user = user;
 		this.password = password;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jta/narayana/NarayanaDataSourceBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jta/narayana/NarayanaDataSourceBean.java
@@ -29,7 +29,7 @@ import javax.sql.XADataSource;
 import com.arjuna.ats.internal.jdbc.ConnectionManager;
 import com.arjuna.ats.jdbc.TransactionalDriver;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -47,8 +47,7 @@ public class NarayanaDataSourceBean implements DataSource {
 	 * Create a new {@link NarayanaDataSourceBean} instance.
 	 * @param xaDataSource the XA DataSource
 	 */
-	public NarayanaDataSourceBean(XADataSource xaDataSource) {
-		Assert.notNull(xaDataSource, "XADataSource must not be null");
+	public NarayanaDataSourceBean(@NonNull XADataSource xaDataSource) {
 		this.xaDataSource = xaDataSource;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jta/narayana/NarayanaRecoveryManagerBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jta/narayana/NarayanaRecoveryManagerBean.java
@@ -22,7 +22,7 @@ import com.arjuna.ats.jta.recovery.XAResourceRecoveryHelper;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Bean to set up Narayana recovery manager.
@@ -34,8 +34,8 @@ public class NarayanaRecoveryManagerBean implements InitializingBean, Disposable
 
 	private final RecoveryManagerService recoveryManagerService;
 
-	public NarayanaRecoveryManagerBean(RecoveryManagerService recoveryManagerService) {
-		Assert.notNull(recoveryManagerService, "RecoveryManagerService must not be null");
+	public NarayanaRecoveryManagerBean(
+			@NonNull RecoveryManagerService recoveryManagerService) {
 		this.recoveryManagerService = recoveryManagerService;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jta/narayana/NarayanaXAConnectionFactoryWrapper.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jta/narayana/NarayanaXAConnectionFactoryWrapper.java
@@ -26,7 +26,7 @@ import org.jboss.narayana.jta.jms.JmsXAResourceRecoveryHelper;
 import org.jboss.narayana.jta.jms.TransactionHelperImpl;
 
 import org.springframework.boot.jta.XAConnectionFactoryWrapper;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link XAConnectionFactoryWrapper} that uses {@link ConnectionFactoryProxy} to wrap an
@@ -49,11 +49,10 @@ public class NarayanaXAConnectionFactoryWrapper implements XAConnectionFactoryWr
 	 * @param recoveryManager the underlying recovery manager
 	 * @param properties the Narayana properties
 	 */
-	public NarayanaXAConnectionFactoryWrapper(TransactionManager transactionManager,
-			NarayanaRecoveryManagerBean recoveryManager, NarayanaProperties properties) {
-		Assert.notNull(transactionManager, "TransactionManager must not be null");
-		Assert.notNull(recoveryManager, "RecoveryManager must not be null");
-		Assert.notNull(properties, "Properties must not be null");
+	public NarayanaXAConnectionFactoryWrapper(
+			@NonNull TransactionManager transactionManager,
+			@NonNull NarayanaRecoveryManagerBean recoveryManager,
+			@NonNull NarayanaProperties properties) {
 		this.transactionManager = transactionManager;
 		this.recoveryManager = recoveryManager;
 		this.properties = properties;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jta/narayana/NarayanaXADataSourceWrapper.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jta/narayana/NarayanaXADataSourceWrapper.java
@@ -22,7 +22,7 @@ import javax.sql.XADataSource;
 import com.arjuna.ats.jta.recovery.XAResourceRecoveryHelper;
 
 import org.springframework.boot.jta.XADataSourceWrapper;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link XADataSourceWrapper} that uses {@link NarayanaDataSourceBean} to wrap an
@@ -42,10 +42,9 @@ public class NarayanaXADataSourceWrapper implements XADataSourceWrapper {
 	 * @param recoveryManager the underlying recovery manager
 	 * @param properties the Narayana properties
 	 */
-	public NarayanaXADataSourceWrapper(NarayanaRecoveryManagerBean recoveryManager,
-			NarayanaProperties properties) {
-		Assert.notNull(recoveryManager, "RecoveryManager must not be null");
-		Assert.notNull(properties, "Properties must not be null");
+	public NarayanaXADataSourceWrapper(
+			@NonNull NarayanaRecoveryManagerBean recoveryManager,
+			@NonNull NarayanaProperties properties) {
 		this.recoveryManager = recoveryManager;
 		this.properties = properties;
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggerConfiguration.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggerConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.logging;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -39,10 +39,8 @@ public final class LoggerConfiguration {
 	 * @param configuredLevel the configured level of the logger
 	 * @param effectiveLevel the effective level of the logger
 	 */
-	public LoggerConfiguration(String name, LogLevel configuredLevel,
-			LogLevel effectiveLevel) {
-		Assert.notNull(name, "Name must not be null");
-		Assert.notNull(effectiveLevel, "EffectiveLevel must not be null");
+	public LoggerConfiguration(@NonNull String name, LogLevel configuredLevel,
+			@NonNull LogLevel effectiveLevel) {
 		this.name = name;
 		this.configuredLevel = configuredLevel;
 		this.effectiveLevel = effectiveLevel;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggerConfigurationComparator.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggerConfigurationComparator.java
@@ -18,7 +18,7 @@ package org.springframework.boot.logging;
 
 import java.util.Comparator;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * An implementation of {@link Comparator} for comparing {@link LoggerConfiguration}s.
@@ -34,8 +34,7 @@ class LoggerConfigurationComparator implements Comparator<LoggerConfiguration> {
 	 * Create a new {@link LoggerConfigurationComparator} instance.
 	 * @param rootLoggerName the name of the "root" logger
 	 */
-	LoggerConfigurationComparator(String rootLoggerName) {
-		Assert.notNull(rootLoggerName, "RootLoggerName must not be null");
+	LoggerConfigurationComparator(@NonNull String rootLoggerName) {
 		this.rootLoggerName = rootLoggerName;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
@@ -21,7 +21,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertyResolver;
 import org.springframework.core.env.PropertySourcesPropertyResolver;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Utility to set system properties that can later be used by log configuration files.
@@ -90,8 +90,7 @@ public class LoggingSystemProperties {
 	 * Create a new {@link LoggingSystemProperties} instance.
 	 * @param environment the source environment
 	 */
-	public LoggingSystemProperties(Environment environment) {
-		Assert.notNull(environment, "Environment must not be null");
+	public LoggingSystemProperties(@NonNull Environment environment) {
 		this.environment = environment;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/Slf4JLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/Slf4JLoggingSystem.java
@@ -18,7 +18,7 @@ package org.springframework.boot.logging;
 
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -48,8 +48,7 @@ public abstract class Slf4JLoggingSystem extends AbstractLoggingSystem {
 
 	@Override
 	protected void loadConfiguration(LoggingInitializationContext initializationContext,
-			String location, LogFile logFile) {
-		Assert.notNull(location, "Location must not be null");
+			@NonNull String location, LogFile logFile) {
 		if (initializationContext != null) {
 			applySystemProperties(initializationContext.getEnvironment(), logFile);
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/java/JavaLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/java/JavaLoggingSystem.java
@@ -33,7 +33,7 @@ import org.springframework.boot.logging.LogLevel;
 import org.springframework.boot.logging.LoggerConfiguration;
 import org.springframework.boot.logging.LoggingInitializationContext;
 import org.springframework.boot.logging.LoggingSystem;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
@@ -92,8 +92,7 @@ public class JavaLoggingSystem extends AbstractLoggingSystem {
 		loadConfiguration(location, logFile);
 	}
 
-	protected void loadConfiguration(String location, LogFile logFile) {
-		Assert.notNull(location, "Location must not be null");
+	protected void loadConfiguration(@NonNull String location, LogFile logFile) {
 		try {
 			String configuration = FileCopyUtils.copyToString(
 					new InputStreamReader(ResourceUtils.getURL(location).openStream()));

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -44,7 +44,7 @@ import org.springframework.boot.logging.LoggerConfiguration;
 import org.springframework.boot.logging.LoggingInitializationContext;
 import org.springframework.boot.logging.LoggingSystem;
 import org.springframework.boot.logging.Slf4JLoggingSystem;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
@@ -167,8 +167,7 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 		loadConfiguration(location, logFile);
 	}
 
-	protected void loadConfiguration(String location, LogFile logFile) {
-		Assert.notNull(location, "Location must not be null");
+	protected void loadConfiguration(@NonNull String location, LogFile logFile) {
 		try {
 			LoggerContext ctx = getLoggerContext();
 			URL url = ResourceUtils.getURL(location);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackConfigurator.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackConfigurator.java
@@ -30,6 +30,7 @@ import ch.qos.logback.core.spi.ContextAware;
 import ch.qos.logback.core.spi.LifeCycle;
 import ch.qos.logback.core.spi.PropertyContainer;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -42,8 +43,7 @@ class LogbackConfigurator {
 
 	private LoggerContext context;
 
-	LogbackConfigurator(LoggerContext context) {
-		Assert.notNull(context, "Context must not be null");
+	LogbackConfigurator(@NonNull LoggerContext context) {
 		this.context = context;
 	}
 
@@ -57,9 +57,8 @@ class LogbackConfigurator {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public void conversionRule(String conversionWord,
-			Class<? extends Converter> converterClass) {
+			@NonNull Class<? extends Converter> converterClass) {
 		Assert.hasLength(conversionWord, "Conversion word must not be empty");
-		Assert.notNull(converterClass, "Converter class must not be null");
 		Map<String, String> registry = (Map<String, String>) this.context
 				.getObject(CoreConstants.PATTERN_RULE_REGISTRY);
 		if (registry == null) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/origin/PropertySourceOrigin.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/origin/PropertySourceOrigin.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.origin;
 
 import org.springframework.core.env.PropertySource;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -36,8 +37,8 @@ public class PropertySourceOrigin implements Origin {
 	 * @param propertySource the property source
 	 * @param propertyName the name from the property source
 	 */
-	public PropertySourceOrigin(PropertySource<?> propertySource, String propertyName) {
-		Assert.notNull(propertySource, "PropertySource must not be null");
+	public PropertySourceOrigin(
+			@NonNull PropertySource<?> propertySource, String propertyName) {
 		Assert.hasLength(propertyName, "PropertyName must not be empty");
 		this.propertySource = propertySource;
 		this.propertyName = propertyName;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/origin/SystemEnvironmentOrigin.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/origin/SystemEnvironmentOrigin.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.origin;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
@@ -30,8 +31,7 @@ public class SystemEnvironmentOrigin implements Origin {
 
 	private final String property;
 
-	public SystemEnvironmentOrigin(String property) {
-		Assert.notNull(property, "Property name must not be null");
+	public SystemEnvironmentOrigin(@NonNull String property) {
 		Assert.hasText(property, "Property name must not be empty");
 		this.property = property;
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/orm/jpa/hibernate/SpringJtaPlatform.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/orm/jpa/hibernate/SpringJtaPlatform.java
@@ -21,8 +21,8 @@ import javax.transaction.UserTransaction;
 
 import org.hibernate.engine.transaction.jta.platform.internal.AbstractJtaPlatform;
 
+import org.springframework.lang.NonNull;
 import org.springframework.transaction.jta.JtaTransactionManager;
-import org.springframework.util.Assert;
 
 /**
  * Generic Hibernate {@link AbstractJtaPlatform} implementation that simply resolves the
@@ -39,8 +39,7 @@ public class SpringJtaPlatform extends AbstractJtaPlatform {
 
 	private final JtaTransactionManager transactionManager;
 
-	public SpringJtaPlatform(JtaTransactionManager transactionManager) {
-		Assert.notNull(transactionManager, "TransactionManager must not be null");
+	public SpringJtaPlatform(@NonNull JtaTransactionManager transactionManager) {
 		this.transactionManager = transactionManager;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/security/ApplicationContextRequestMatcher.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/security/ApplicationContextRequestMatcher.java
@@ -21,8 +21,8 @@ import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.ApplicationContext;
+import org.springframework.lang.NonNull;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.util.Assert;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 
@@ -47,8 +47,7 @@ public abstract class ApplicationContextRequestMatcher<C> implements RequestMatc
 
 	private Object contextLock = new Object();
 
-	public ApplicationContextRequestMatcher(Class<? extends C> contextClass) {
-		Assert.notNull(contextClass, "Context class must not be null");
+	public ApplicationContextRequestMatcher(@NonNull Class<? extends C> contextClass) {
 		this.contextClass = contextClass;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/ApplicationPidFileWriter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/ApplicationPidFileWriter.java
@@ -34,7 +34,7 @@ import org.springframework.boot.context.event.SpringApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.Environment;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * An {@link ApplicationListener} that saves application PID into file. This application
@@ -113,8 +113,7 @@ public class ApplicationPidFileWriter
 	 * Create a new {@link ApplicationPidFileWriter} instance with a specified file.
 	 * @param file the file containing pid
 	 */
-	public ApplicationPidFileWriter(File file) {
-		Assert.notNull(file, "File must not be null");
+	public ApplicationPidFileWriter(@NonNull File file) {
 		this.file = file;
 	}
 
@@ -127,8 +126,7 @@ public class ApplicationPidFileWriter
 	 * @param triggerEventType the trigger event type
 	 */
 	public void setTriggerEventType(
-			Class<? extends SpringApplicationEvent> triggerEventType) {
-		Assert.notNull(triggerEventType, "Trigger event type must not be null");
+			@NonNull Class<? extends SpringApplicationEvent> triggerEventType) {
 		this.triggerEventType = triggerEventType;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/EmbeddedServerPortFileWriter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/EmbeddedServerPortFileWriter.java
@@ -25,7 +25,7 @@ import org.springframework.boot.web.context.WebServerInitializedEvent;
 import org.springframework.boot.web.reactive.context.ReactiveWebApplicationContext;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.ConfigurableWebApplicationContext;
@@ -74,8 +74,7 @@ public class EmbeddedServerPortFileWriter
 	 * Create a new {@link EmbeddedServerPortFileWriter} instance with a specified file.
 	 * @param file the file containing port
 	 */
-	public EmbeddedServerPortFileWriter(File file) {
-		Assert.notNull(file, "File must not be null");
+	public EmbeddedServerPortFileWriter(@NonNull File file) {
 		String override = SystemProperties.get(PROPERTY_VARIABLES);
 		if (override != null) {
 			this.file = new File(override);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RestTemplateBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RestTemplateBuilder.java
@@ -35,7 +35,7 @@ import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.client.support.BasicAuthorizationInterceptor;
 import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ReflectionUtils;
@@ -100,8 +100,7 @@ public class RestTemplateBuilder {
 	 * @param customizers any {@link RestTemplateCustomizer RestTemplateCustomizers} that
 	 * should be applied when the {@link RestTemplate} is built
 	 */
-	public RestTemplateBuilder(RestTemplateCustomizer... customizers) {
-		Assert.notNull(customizers, "Customizers must not be null");
+	public RestTemplateBuilder(@NonNull RestTemplateCustomizer... customizers) {
 		this.detectRequestFactory = true;
 		this.rootUri = null;
 		this.messageConverters = null;
@@ -171,8 +170,7 @@ public class RestTemplateBuilder {
 	 * @see #additionalMessageConverters(HttpMessageConverter...)
 	 */
 	public RestTemplateBuilder messageConverters(
-			HttpMessageConverter<?>... messageConverters) {
-		Assert.notNull(messageConverters, "MessageConverters must not be null");
+			@NonNull HttpMessageConverter<?>... messageConverters) {
 		return messageConverters(Arrays.asList(messageConverters));
 	}
 
@@ -185,8 +183,7 @@ public class RestTemplateBuilder {
 	 * @see #additionalMessageConverters(HttpMessageConverter...)
 	 */
 	public RestTemplateBuilder messageConverters(
-			Collection<? extends HttpMessageConverter<?>> messageConverters) {
-		Assert.notNull(messageConverters, "MessageConverters must not be null");
+			@NonNull Collection<? extends HttpMessageConverter<?>> messageConverters) {
 		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
 				Collections.unmodifiableSet(
 						new LinkedHashSet<HttpMessageConverter<?>>(messageConverters)),
@@ -203,8 +200,7 @@ public class RestTemplateBuilder {
 	 * @see #messageConverters(HttpMessageConverter...)
 	 */
 	public RestTemplateBuilder additionalMessageConverters(
-			HttpMessageConverter<?>... messageConverters) {
-		Assert.notNull(messageConverters, "MessageConverters must not be null");
+			@NonNull HttpMessageConverter<?>... messageConverters) {
 		return additionalMessageConverters(Arrays.asList(messageConverters));
 	}
 
@@ -216,8 +212,7 @@ public class RestTemplateBuilder {
 	 * @see #messageConverters(HttpMessageConverter...)
 	 */
 	public RestTemplateBuilder additionalMessageConverters(
-			Collection<? extends HttpMessageConverter<?>> messageConverters) {
-		Assert.notNull(messageConverters, "MessageConverters must not be null");
+			@NonNull Collection<? extends HttpMessageConverter<?>> messageConverters) {
 		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
 				append(this.messageConverters, messageConverters), this.requestFactory,
 				this.uriTemplateHandler, this.errorHandler, this.basicAuthorization,
@@ -251,8 +246,7 @@ public class RestTemplateBuilder {
 	 * @see #additionalInterceptors(ClientHttpRequestInterceptor...)
 	 */
 	public RestTemplateBuilder interceptors(
-			ClientHttpRequestInterceptor... interceptors) {
-		Assert.notNull(interceptors, "interceptors must not be null");
+			@NonNull ClientHttpRequestInterceptor... interceptors) {
 		return interceptors(Arrays.asList(interceptors));
 	}
 
@@ -266,8 +260,7 @@ public class RestTemplateBuilder {
 	 * @see #additionalInterceptors(ClientHttpRequestInterceptor...)
 	 */
 	public RestTemplateBuilder interceptors(
-			Collection<ClientHttpRequestInterceptor> interceptors) {
-		Assert.notNull(interceptors, "interceptors must not be null");
+			@NonNull Collection<ClientHttpRequestInterceptor> interceptors) {
 		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactory, this.uriTemplateHandler,
 				this.errorHandler, this.basicAuthorization, this.restTemplateCustomizers,
@@ -284,8 +277,7 @@ public class RestTemplateBuilder {
 	 * @see #interceptors(ClientHttpRequestInterceptor...)
 	 */
 	public RestTemplateBuilder additionalInterceptors(
-			ClientHttpRequestInterceptor... interceptors) {
-		Assert.notNull(interceptors, "interceptors must not be null");
+			@NonNull ClientHttpRequestInterceptor... interceptors) {
 		return additionalInterceptors(Arrays.asList(interceptors));
 	}
 
@@ -298,8 +290,7 @@ public class RestTemplateBuilder {
 	 * @see #interceptors(ClientHttpRequestInterceptor...)
 	 */
 	public RestTemplateBuilder additionalInterceptors(
-			Collection<? extends ClientHttpRequestInterceptor> interceptors) {
-		Assert.notNull(interceptors, "interceptors must not be null");
+			@NonNull Collection<? extends ClientHttpRequestInterceptor> interceptors) {
 		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactory, this.uriTemplateHandler,
 				this.errorHandler, this.basicAuthorization, this.restTemplateCustomizers,
@@ -313,8 +304,7 @@ public class RestTemplateBuilder {
 	 * @return a new builder instance
 	 */
 	public RestTemplateBuilder requestFactory(
-			Class<? extends ClientHttpRequestFactory> requestFactory) {
-		Assert.notNull(requestFactory, "RequestFactory must not be null");
+			@NonNull Class<? extends ClientHttpRequestFactory> requestFactory) {
 		return requestFactory(createRequestFactory(requestFactory));
 	}
 
@@ -336,8 +326,8 @@ public class RestTemplateBuilder {
 	 * @param requestFactory the request factory to use
 	 * @return a new builder instance
 	 */
-	public RestTemplateBuilder requestFactory(ClientHttpRequestFactory requestFactory) {
-		Assert.notNull(requestFactory, "RequestFactory must not be null");
+	public RestTemplateBuilder requestFactory(
+			@NonNull ClientHttpRequestFactory requestFactory) {
 		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, requestFactory, this.uriTemplateHandler,
 				this.errorHandler, this.basicAuthorization, this.restTemplateCustomizers,
@@ -350,8 +340,8 @@ public class RestTemplateBuilder {
 	 * @param uriTemplateHandler the URI template handler to use
 	 * @return a new builder instance
 	 */
-	public RestTemplateBuilder uriTemplateHandler(UriTemplateHandler uriTemplateHandler) {
-		Assert.notNull(uriTemplateHandler, "UriTemplateHandler must not be null");
+	public RestTemplateBuilder uriTemplateHandler(
+			@NonNull UriTemplateHandler uriTemplateHandler) {
 		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactory, uriTemplateHandler,
 				this.errorHandler, this.basicAuthorization, this.restTemplateCustomizers,
@@ -364,8 +354,7 @@ public class RestTemplateBuilder {
 	 * @param errorHandler the error handler to use
 	 * @return a new builder instance
 	 */
-	public RestTemplateBuilder errorHandler(ResponseErrorHandler errorHandler) {
-		Assert.notNull(errorHandler, "ErrorHandler must not be null");
+	public RestTemplateBuilder errorHandler(@NonNull ResponseErrorHandler errorHandler) {
 		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactory, this.uriTemplateHandler,
 				errorHandler, this.basicAuthorization, this.restTemplateCustomizers,
@@ -397,9 +386,7 @@ public class RestTemplateBuilder {
 	 * @see #additionalCustomizers(RestTemplateCustomizer...)
 	 */
 	public RestTemplateBuilder customizers(
-			RestTemplateCustomizer... restTemplateCustomizers) {
-		Assert.notNull(restTemplateCustomizers,
-				"RestTemplateCustomizers must not be null");
+			@NonNull RestTemplateCustomizer... restTemplateCustomizers) {
 		return customizers(Arrays.asList(restTemplateCustomizers));
 	}
 
@@ -412,10 +399,8 @@ public class RestTemplateBuilder {
 	 * @return a new builder instance
 	 * @see #additionalCustomizers(RestTemplateCustomizer...)
 	 */
-	public RestTemplateBuilder customizers(
+	public RestTemplateBuilder customizers(@NonNull
 			Collection<? extends RestTemplateCustomizer> restTemplateCustomizers) {
-		Assert.notNull(restTemplateCustomizers,
-				"RestTemplateCustomizers must not be null");
 		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactory, this.uriTemplateHandler,
 				this.errorHandler, this.basicAuthorization,
@@ -433,9 +418,7 @@ public class RestTemplateBuilder {
 	 * @see #customizers(RestTemplateCustomizer...)
 	 */
 	public RestTemplateBuilder additionalCustomizers(
-			RestTemplateCustomizer... restTemplateCustomizers) {
-		Assert.notNull(restTemplateCustomizers,
-				"RestTemplateCustomizers must not be null");
+			@NonNull RestTemplateCustomizer... restTemplateCustomizers) {
 		return additionalCustomizers(Arrays.asList(restTemplateCustomizers));
 	}
 
@@ -448,8 +431,7 @@ public class RestTemplateBuilder {
 	 * @see #customizers(RestTemplateCustomizer...)
 	 */
 	public RestTemplateBuilder additionalCustomizers(
-			Collection<? extends RestTemplateCustomizer> customizers) {
-		Assert.notNull(customizers, "RestTemplateCustomizers must not be null");
+			@NonNull Collection<? extends RestTemplateCustomizer> customizers) {
 		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactory, this.uriTemplateHandler,
 				this.errorHandler, this.basicAuthorization,

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RootUriTemplateHandler.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RootUriTemplateHandler.java
@@ -19,7 +19,7 @@ package org.springframework.boot.web.client;
 import java.net.URI;
 import java.util.Map;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.DefaultUriBuilderFactory;
@@ -55,9 +55,8 @@ public class RootUriTemplateHandler implements UriTemplateHandler {
 	 * @param rootUri the root URI to be used to prefix relative URLs
 	 * @param handler the delegate handler
 	 */
-	public RootUriTemplateHandler(String rootUri, UriTemplateHandler handler) {
-		Assert.notNull(rootUri, "RootUri must not be null");
-		Assert.notNull(handler, "Handler must not be null");
+	public RootUriTemplateHandler(@NonNull String rootUri,
+			@NonNull UriTemplateHandler handler) {
 		this.rootUri = rootUri;
 		this.handler = handler;
 	}
@@ -89,9 +88,8 @@ public class RootUriTemplateHandler implements UriTemplateHandler {
 	 * @param rootUri the root URI
 	 * @return the added {@link RootUriTemplateHandler}.
 	 */
-	public static RootUriTemplateHandler addTo(RestTemplate restTemplate,
+	public static RootUriTemplateHandler addTo(@NonNull RestTemplate restTemplate,
 			String rootUri) {
-		Assert.notNull(restTemplate, "RestTemplate must not be null");
 		RootUriTemplateHandler handler = new RootUriTemplateHandler(rootUri,
 				restTemplate.getUriTemplateHandler());
 		restTemplate.setUriTemplateHandler(handler);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyReactiveWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyReactiveWebServerFactory.java
@@ -38,7 +38,7 @@ import org.springframework.boot.web.reactive.server.ReactiveWebServerFactory;
 import org.springframework.boot.web.server.WebServer;
 import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.http.server.reactive.JettyHttpHandlerAdapter;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link ReactiveWebServerFactory} that can be used to create {@link JettyWebServer}s.
@@ -150,8 +150,7 @@ public class JettyReactiveWebServerFactory extends AbstractReactiveWebServerFact
 	 * @param customizers the Jetty customizers to apply
 	 */
 	public void setServerCustomizers(
-			Collection<? extends JettyServerCustomizer> customizers) {
-		Assert.notNull(customizers, "Customizers must not be null");
+			@NonNull Collection<? extends JettyServerCustomizer> customizers) {
 		this.jettyServerCustomizers = new ArrayList<>(customizers);
 	}
 
@@ -169,8 +168,7 @@ public class JettyReactiveWebServerFactory extends AbstractReactiveWebServerFact
 	 * before it is started.
 	 * @param customizers the customizers to add
 	 */
-	public void addServerCustomizers(JettyServerCustomizer... customizers) {
-		Assert.notNull(customizers, "Customizers must not be null");
+	public void addServerCustomizers(@NonNull JettyServerCustomizer... customizers) {
 		this.jettyServerCustomizers.addAll(Arrays.asList(customizers));
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyServletWebServerFactory.java
@@ -72,7 +72,7 @@ import org.springframework.boot.web.servlet.server.AbstractServletWebServerFacto
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.StringUtils;
 
 /**
@@ -216,9 +216,8 @@ public class JettyServletWebServerFactory extends AbstractServletWebServerFactor
 	 * @param context the context to configure
 	 * @param initializers the set of initializers to apply
 	 */
-	protected final void configureWebAppContext(WebAppContext context,
+	protected final void configureWebAppContext(@NonNull WebAppContext context,
 			ServletContextInitializer... initializers) {
-		Assert.notNull(context, "Context must not be null");
 		context.setTempDirectory(getTempDirectory());
 		if (this.resourceLoader != null) {
 			context.setClassLoader(this.resourceLoader.getClassLoader());
@@ -310,8 +309,7 @@ public class JettyServletWebServerFactory extends AbstractServletWebServerFactor
 	 * Add Jetty's {@code DefaultServlet} to the given {@link WebAppContext}.
 	 * @param context the jetty {@link WebAppContext}
 	 */
-	protected final void addDefaultServlet(WebAppContext context) {
-		Assert.notNull(context, "Context must not be null");
+	protected final void addDefaultServlet(@NonNull WebAppContext context) {
 		ServletHolder holder = new ServletHolder();
 		holder.setName("default");
 		holder.setClassName("org.eclipse.jetty.servlet.DefaultServlet");
@@ -325,8 +323,7 @@ public class JettyServletWebServerFactory extends AbstractServletWebServerFactor
 	 * Add Jetty's {@code JspServlet} to the given {@link WebAppContext}.
 	 * @param context the jetty {@link WebAppContext}
 	 */
-	protected final void addJspServlet(WebAppContext context) {
-		Assert.notNull(context, "Context must not be null");
+	protected final void addJspServlet(@NonNull WebAppContext context) {
 		ServletHolder holder = new ServletHolder();
 		holder.setName("jsp");
 		holder.setClassName(getJsp().getClassName());
@@ -464,8 +461,7 @@ public class JettyServletWebServerFactory extends AbstractServletWebServerFactor
 	 * @param customizers the Jetty customizers to apply
 	 */
 	public void setServerCustomizers(
-			Collection<? extends JettyServerCustomizer> customizers) {
-		Assert.notNull(customizers, "Customizers must not be null");
+			@NonNull Collection<? extends JettyServerCustomizer> customizers) {
 		this.jettyServerCustomizers = new ArrayList<>(customizers);
 	}
 
@@ -483,8 +479,7 @@ public class JettyServletWebServerFactory extends AbstractServletWebServerFactor
 	 * before it is started.
 	 * @param customizers the customizers to add
 	 */
-	public void addServerCustomizers(JettyServerCustomizer... customizers) {
-		Assert.notNull(customizers, "Customizers must not be null");
+	public void addServerCustomizers(@NonNull JettyServerCustomizer... customizers) {
 		this.jettyServerCustomizers.addAll(Arrays.asList(customizers));
 	}
 
@@ -494,8 +489,8 @@ public class JettyServletWebServerFactory extends AbstractServletWebServerFactor
 	 * configurations.
 	 * @param configurations the Jetty configurations to apply
 	 */
-	public void setConfigurations(Collection<? extends Configuration> configurations) {
-		Assert.notNull(configurations, "Configurations must not be null");
+	public void setConfigurations(
+			@NonNull Collection<? extends Configuration> configurations) {
 		this.configurations = new ArrayList<>(configurations);
 	}
 
@@ -513,8 +508,7 @@ public class JettyServletWebServerFactory extends AbstractServletWebServerFactor
 	 * the server is started.
 	 * @param configurations the configurations to add
 	 */
-	public void addConfigurations(Configuration... configurations) {
-		Assert.notNull(configurations, "Configurations must not be null");
+	public void addConfigurations(@NonNull Configuration... configurations) {
 		this.configurations.addAll(Arrays.asList(configurations));
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
@@ -35,6 +35,7 @@ import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.springframework.boot.web.server.PortInUseException;
 import org.springframework.boot.web.server.WebServer;
 import org.springframework.boot.web.server.WebServerException;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
@@ -78,9 +79,8 @@ public class JettyWebServer implements WebServer {
 	 * @param server the underlying Jetty server
 	 * @param autoStart if auto-starting the server
 	 */
-	public JettyWebServer(Server server, boolean autoStart) {
+	public JettyWebServer(@NonNull Server server, boolean autoStart) {
 		this.autoStart = autoStart;
-		Assert.notNull(server, "Jetty Server must not be null");
 		this.server = server;
 		initialize();
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/ServletContextInitializerConfiguration.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/ServletContextInitializerConfiguration.java
@@ -24,7 +24,7 @@ import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 
 import org.springframework.boot.web.servlet.ServletContextInitializer;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Jetty {@link Configuration} that calls {@link ServletContextInitializer}s.
@@ -43,8 +43,7 @@ public class ServletContextInitializerConfiguration extends AbstractConfiguratio
 	 * @since 1.2.1
 	 */
 	public ServletContextInitializerConfiguration(
-			ServletContextInitializer... initializers) {
-		Assert.notNull(initializers, "Initializers must not be null");
+			@NonNull ServletContextInitializer... initializers) {
 		this.initializers = initializers;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/NettyReactiveWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/NettyReactiveWebServerFactory.java
@@ -30,7 +30,7 @@ import org.springframework.boot.web.reactive.server.ReactiveWebServerFactory;
 import org.springframework.boot.web.server.WebServer;
 import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link ReactiveWebServerFactory} that can be used to create {@link NettyWebServer}s.
@@ -72,8 +72,7 @@ public class NettyReactiveWebServerFactory extends AbstractReactiveWebServerFact
 	 * @param nettyServerCustomizers the customizers to set
 	 */
 	public void setNettyServerCustomizers(
-			Collection<? extends NettyServerCustomizer> nettyServerCustomizers) {
-		Assert.notNull(nettyServerCustomizers, "NettyServerCustomizers must not be null");
+			@NonNull Collection<? extends NettyServerCustomizer> nettyServerCustomizers) {
 		this.nettyServerCustomizers = new ArrayList<>(nettyServerCustomizers);
 	}
 
@@ -81,9 +80,8 @@ public class NettyReactiveWebServerFactory extends AbstractReactiveWebServerFact
 	 * Add {@link NettyServerCustomizer}s that should applied while building the server.
 	 * @param nettyServerCustomizer the customizers to add
 	 */
-	public void addContextCustomizers(NettyServerCustomizer... nettyServerCustomizer) {
-		Assert.notNull(nettyServerCustomizer,
-				"NettyWebServerCustomizer must not be null");
+	public void addContextCustomizers(
+			@NonNull NettyServerCustomizer... nettyServerCustomizer) {
 		this.nettyServerCustomizers.addAll(Arrays.asList(nettyServerCustomizer));
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/SslConnectorCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/SslConnectorCustomizer.java
@@ -28,6 +28,7 @@ import org.apache.tomcat.util.net.SSLHostConfig;
 import org.springframework.boot.web.server.Ssl;
 import org.springframework.boot.web.server.SslStoreProvider;
 import org.springframework.boot.web.server.WebServerException;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
@@ -43,8 +44,7 @@ class SslConnectorCustomizer implements TomcatConnectorCustomizer {
 
 	private final SslStoreProvider sslStoreProvider;
 
-	SslConnectorCustomizer(Ssl ssl, SslStoreProvider sslStoreProvider) {
-		Assert.notNull(ssl, "Ssl configuration should not be null");
+	SslConnectorCustomizer(@NonNull Ssl ssl, SslStoreProvider sslStoreProvider) {
 		this.ssl = ssl;
 		this.sslStoreProvider = sslStoreProvider;
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatReactiveWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatReactiveWebServerFactory.java
@@ -38,6 +38,7 @@ import org.springframework.boot.web.reactive.server.ReactiveWebServerFactory;
 import org.springframework.boot.web.server.WebServer;
 import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.http.server.reactive.TomcatHttpHandlerAdapter;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
@@ -166,10 +167,8 @@ public class TomcatReactiveWebServerFactory extends AbstractReactiveWebServerFac
 	 * {@link Context} . Calling this method will replace any existing customizers.
 	 * @param tomcatContextCustomizers the customizers to set
 	 */
-	public void setTomcatContextCustomizers(
+	public void setTomcatContextCustomizers(@NonNull
 			Collection<? extends TomcatContextCustomizer> tomcatContextCustomizers) {
-		Assert.notNull(tomcatContextCustomizers,
-				"TomcatContextCustomizers must not be null");
 		this.tomcatContextCustomizers = new ArrayList<>(tomcatContextCustomizers);
 	}
 
@@ -188,9 +187,7 @@ public class TomcatReactiveWebServerFactory extends AbstractReactiveWebServerFac
 	 * @param tomcatContextCustomizers the customizers to add
 	 */
 	public void addContextCustomizers(
-			TomcatContextCustomizer... tomcatContextCustomizers) {
-		Assert.notNull(tomcatContextCustomizers,
-				"TomcatContextCustomizers must not be null");
+			@NonNull TomcatContextCustomizer... tomcatContextCustomizers) {
 		this.tomcatContextCustomizers.addAll(Arrays.asList(tomcatContextCustomizers));
 	}
 
@@ -199,10 +196,8 @@ public class TomcatReactiveWebServerFactory extends AbstractReactiveWebServerFac
 	 * {@link Connector} . Calling this method will replace any existing customizers.
 	 * @param tomcatConnectorCustomizers the customizers to set
 	 */
-	public void setTomcatConnectorCustomizers(
+	public void setTomcatConnectorCustomizers(@NonNull
 			Collection<? extends TomcatConnectorCustomizer> tomcatConnectorCustomizers) {
-		Assert.notNull(tomcatConnectorCustomizers,
-				"TomcatConnectorCustomizers must not be null");
 		this.tomcatConnectorCustomizers = new ArrayList<>(tomcatConnectorCustomizers);
 	}
 
@@ -212,9 +207,7 @@ public class TomcatReactiveWebServerFactory extends AbstractReactiveWebServerFac
 	 * @param tomcatConnectorCustomizers the customizers to add
 	 */
 	public void addConnectorCustomizers(
-			TomcatConnectorCustomizer... tomcatConnectorCustomizers) {
-		Assert.notNull(tomcatConnectorCustomizers,
-				"TomcatConnectorCustomizers must not be null");
+			@NonNull TomcatConnectorCustomizer... tomcatConnectorCustomizers) {
 		this.tomcatConnectorCustomizers.addAll(Arrays.asList(tomcatConnectorCustomizers));
 	}
 
@@ -233,9 +226,7 @@ public class TomcatReactiveWebServerFactory extends AbstractReactiveWebServerFac
 	 * @param contextLifecycleListeners the listeners to set
 	 */
 	public void setContextLifecycleListeners(
-			Collection<? extends LifecycleListener> contextLifecycleListeners) {
-		Assert.notNull(contextLifecycleListeners,
-				"ContextLifecycleListeners must not be null");
+			@NonNull Collection<? extends LifecycleListener> contextLifecycleListeners) {
 		this.contextLifecycleListeners = new ArrayList<>(contextLifecycleListeners);
 	}
 
@@ -253,9 +244,7 @@ public class TomcatReactiveWebServerFactory extends AbstractReactiveWebServerFac
 	 * @param contextLifecycleListeners the listeners to add
 	 */
 	public void addContextLifecycleListeners(
-			LifecycleListener... contextLifecycleListeners) {
-		Assert.notNull(contextLifecycleListeners,
-				"ContextLifecycleListeners must not be null");
+			@NonNull LifecycleListener... contextLifecycleListeners) {
 		this.contextLifecycleListeners.addAll(Arrays.asList(contextLifecycleListeners));
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
@@ -70,6 +70,7 @@ import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.boot.web.servlet.server.AbstractServletWebServerFactory;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
@@ -439,8 +440,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	 * catalina.properties for typical values. Defaults to a list drawn from that source.
 	 * @param patterns the jar patterns to skip when scanning for TLDs etc
 	 */
-	public void setTldSkipPatterns(Collection<String> patterns) {
-		Assert.notNull(patterns, "Patterns must not be null");
+	public void setTldSkipPatterns(@NonNull Collection<String> patterns) {
 		this.tldSkipPatterns = new LinkedHashSet<>(patterns);
 	}
 
@@ -449,8 +449,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	 * catalina.properties for typical values.
 	 * @param patterns the additional jar patterns to skip when scanning for TLDs etc
 	 */
-	public void addTldSkipPatterns(String... patterns) {
-		Assert.notNull(patterns, "Patterns must not be null");
+	public void addTldSkipPatterns(@NonNull String... patterns) {
 		this.tldSkipPatterns.addAll(Arrays.asList(patterns));
 	}
 
@@ -469,8 +468,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	 * this method will replace any existing valves.
 	 * @param engineValves the valves to set
 	 */
-	public void setEngineValves(Collection<? extends Valve> engineValves) {
-		Assert.notNull(engineValves, "Valves must not be null");
+	public void setEngineValves(@NonNull Collection<? extends Valve> engineValves) {
 		this.engineValves = new ArrayList<>(engineValves);
 	}
 
@@ -487,8 +485,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	 * Add {@link Valve}s that should be applied to the Tomcat {@link Engine}.
 	 * @param engineValves the valves to add
 	 */
-	public void addEngineValves(Valve... engineValves) {
-		Assert.notNull(engineValves, "Valves must not be null");
+	public void addEngineValves(@NonNull Valve... engineValves) {
 		this.engineValves.addAll(Arrays.asList(engineValves));
 	}
 
@@ -497,8 +494,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	 * this method will replace any existing valves.
 	 * @param contextValves the valves to set
 	 */
-	public void setContextValves(Collection<? extends Valve> contextValves) {
-		Assert.notNull(contextValves, "Valves must not be null");
+	public void setContextValves(@NonNull Collection<? extends Valve> contextValves) {
 		this.contextValves = new ArrayList<>(contextValves);
 	}
 
@@ -516,8 +512,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	 * Add {@link Valve}s that should be applied to the Tomcat {@link Context}.
 	 * @param contextValves the valves to add
 	 */
-	public void addContextValves(Valve... contextValves) {
-		Assert.notNull(contextValves, "Valves must not be null");
+	public void addContextValves(@NonNull Valve... contextValves) {
 		this.contextValves.addAll(Arrays.asList(contextValves));
 	}
 
@@ -527,9 +522,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	 * @param contextLifecycleListeners the listeners to set
 	 */
 	public void setContextLifecycleListeners(
-			Collection<? extends LifecycleListener> contextLifecycleListeners) {
-		Assert.notNull(contextLifecycleListeners,
-				"ContextLifecycleListeners must not be null");
+			@NonNull Collection<? extends LifecycleListener> contextLifecycleListeners) {
 		this.contextLifecycleListeners = new ArrayList<>(contextLifecycleListeners);
 	}
 
@@ -547,9 +540,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	 * @param contextLifecycleListeners the listeners to add
 	 */
 	public void addContextLifecycleListeners(
-			LifecycleListener... contextLifecycleListeners) {
-		Assert.notNull(contextLifecycleListeners,
-				"ContextLifecycleListeners must not be null");
+			@NonNull LifecycleListener... contextLifecycleListeners) {
 		this.contextLifecycleListeners.addAll(Arrays.asList(contextLifecycleListeners));
 	}
 
@@ -558,10 +549,8 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	 * {@link Context} . Calling this method will replace any existing customizers.
 	 * @param tomcatContextCustomizers the customizers to set
 	 */
-	public void setTomcatContextCustomizers(
+	public void setTomcatContextCustomizers(@NonNull
 			Collection<? extends TomcatContextCustomizer> tomcatContextCustomizers) {
-		Assert.notNull(tomcatContextCustomizers,
-				"TomcatContextCustomizers must not be null");
 		this.tomcatContextCustomizers = new ArrayList<>(tomcatContextCustomizers);
 	}
 
@@ -580,9 +569,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	 * @param tomcatContextCustomizers the customizers to add
 	 */
 	public void addContextCustomizers(
-			TomcatContextCustomizer... tomcatContextCustomizers) {
-		Assert.notNull(tomcatContextCustomizers,
-				"TomcatContextCustomizers must not be null");
+			@NonNull TomcatContextCustomizer... tomcatContextCustomizers) {
 		this.tomcatContextCustomizers.addAll(Arrays.asList(tomcatContextCustomizers));
 	}
 
@@ -591,10 +578,8 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	 * {@link Connector} . Calling this method will replace any existing customizers.
 	 * @param tomcatConnectorCustomizers the customizers to set
 	 */
-	public void setTomcatConnectorCustomizers(
+	public void setTomcatConnectorCustomizers(@NonNull
 			Collection<? extends TomcatConnectorCustomizer> tomcatConnectorCustomizers) {
-		Assert.notNull(tomcatConnectorCustomizers,
-				"TomcatConnectorCustomizers must not be null");
 		this.tomcatConnectorCustomizers = new ArrayList<>(tomcatConnectorCustomizers);
 	}
 
@@ -604,9 +589,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	 * @param tomcatConnectorCustomizers the customizers to add
 	 */
 	public void addConnectorCustomizers(
-			TomcatConnectorCustomizer... tomcatConnectorCustomizers) {
-		Assert.notNull(tomcatConnectorCustomizers,
-				"TomcatConnectorCustomizers must not be null");
+			@NonNull TomcatConnectorCustomizer... tomcatConnectorCustomizers) {
 		this.tomcatConnectorCustomizers.addAll(Arrays.asList(tomcatConnectorCustomizers));
 	}
 
@@ -623,8 +606,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	 * Add {@link Connector}s in addition to the default connector, e.g. for SSL or AJP
 	 * @param connectors the connectors to add
 	 */
-	public void addAdditionalTomcatConnectors(Connector... connectors) {
-		Assert.notNull(connectors, "Connectors must not be null");
+	public void addAdditionalTomcatConnectors(@NonNull Connector... connectors) {
 		this.additionalTomcatConnectors.addAll(Arrays.asList(connectors));
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
@@ -38,7 +38,7 @@ import org.apache.naming.ContextBindings;
 
 import org.springframework.boot.web.server.WebServer;
 import org.springframework.boot.web.server.WebServerException;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link WebServer} that can be used to control a Tomcat web server. Usually this class
@@ -77,8 +77,7 @@ public class TomcatWebServer implements WebServer {
 	 * @param tomcat the underlying Tomcat server
 	 * @param autoStart if the server should be started
 	 */
-	public TomcatWebServer(Tomcat tomcat, boolean autoStart) {
-		Assert.notNull(tomcat, "Tomcat Server must not be null");
+	public TomcatWebServer(@NonNull Tomcat tomcat, boolean autoStart) {
 		this.tomcat = tomcat;
 		this.autoStart = autoStart;
 		initialize();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowReactiveWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowReactiveWebServerFactory.java
@@ -29,7 +29,7 @@ import org.springframework.boot.web.reactive.server.ReactiveWebServerFactory;
 import org.springframework.boot.web.server.WebServer;
 import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.http.server.reactive.UndertowHttpHandlerAdapter;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link ReactiveWebServerFactory} that can be used to create {@link UndertowWebServer}s.
@@ -137,8 +137,7 @@ public class UndertowReactiveWebServerFactory extends AbstractReactiveWebServerF
 	 * @param customizers the customizers to set
 	 */
 	public void setBuilderCustomizers(
-			Collection<? extends UndertowBuilderCustomizer> customizers) {
-		Assert.notNull(customizers, "Customizers must not be null");
+			@NonNull Collection<? extends UndertowBuilderCustomizer> customizers) {
 		this.builderCustomizers = new ArrayList<>(customizers);
 	}
 
@@ -156,8 +155,7 @@ public class UndertowReactiveWebServerFactory extends AbstractReactiveWebServerF
 	 * Undertow {@link io.undertow.Undertow.Builder Builder}.
 	 * @param customizers the customizers to add
 	 */
-	public void addBuilderCustomizers(UndertowBuilderCustomizer... customizers) {
-		Assert.notNull(customizers, "Customizers must not be null");
+	public void addBuilderCustomizers(@NonNull UndertowBuilderCustomizer... customizers) {
 		this.builderCustomizers.addAll(Arrays.asList(customizers));
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactory.java
@@ -68,6 +68,7 @@ import org.springframework.boot.web.servlet.server.AbstractServletWebServerFacto
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -153,8 +154,7 @@ public class UndertowServletWebServerFactory extends AbstractServletWebServerFac
 	 * @param customizers the customizers to set
 	 */
 	public void setBuilderCustomizers(
-			Collection<? extends UndertowBuilderCustomizer> customizers) {
-		Assert.notNull(customizers, "Customizers must not be null");
+			@NonNull Collection<? extends UndertowBuilderCustomizer> customizers) {
 		this.builderCustomizers = new ArrayList<>(customizers);
 	}
 
@@ -172,8 +172,7 @@ public class UndertowServletWebServerFactory extends AbstractServletWebServerFac
 	 * Undertow {@link Builder}.
 	 * @param customizers the customizers to add
 	 */
-	public void addBuilderCustomizers(UndertowBuilderCustomizer... customizers) {
-		Assert.notNull(customizers, "Customizers must not be null");
+	public void addBuilderCustomizers(@NonNull UndertowBuilderCustomizer... customizers) {
 		this.builderCustomizers.addAll(Arrays.asList(customizers));
 	}
 
@@ -184,8 +183,7 @@ public class UndertowServletWebServerFactory extends AbstractServletWebServerFac
 	 * @param customizers the customizers to set
 	 */
 	public void setDeploymentInfoCustomizers(
-			Collection<? extends UndertowDeploymentInfoCustomizer> customizers) {
-		Assert.notNull(customizers, "Customizers must not be null");
+			@NonNull Collection<? extends UndertowDeploymentInfoCustomizer> customizers) {
 		this.deploymentInfoCustomizers = new ArrayList<>(customizers);
 	}
 
@@ -204,8 +202,7 @@ public class UndertowServletWebServerFactory extends AbstractServletWebServerFac
 	 * @param customizers the customizers to add
 	 */
 	public void addDeploymentInfoCustomizers(
-			UndertowDeploymentInfoCustomizer... customizers) {
-		Assert.notNull(customizers, "UndertowDeploymentInfoCustomizers must not be null");
+			@NonNull UndertowDeploymentInfoCustomizer... customizers) {
 		this.deploymentInfoCustomizers.addAll(Arrays.asList(customizers));
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/AbstractConfigurableWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/AbstractConfigurableWebServerFactory.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Abstract base class for {@link ConfigurableWebServerFactory} implementations.
@@ -107,14 +107,12 @@ public class AbstractConfigurableWebServerFactory
 	}
 
 	@Override
-	public void setErrorPages(Set<? extends ErrorPage> errorPages) {
-		Assert.notNull(errorPages, "ErrorPages must not be null");
+	public void setErrorPages(@NonNull Set<? extends ErrorPage> errorPages) {
 		this.errorPages = new LinkedHashSet<>(errorPages);
 	}
 
 	@Override
-	public void addErrorPages(ErrorPage... errorPages) {
-		Assert.notNull(errorPages, "ErrorPages must not be null");
+	public void addErrorPages(@NonNull ErrorPage... errorPages) {
 		this.errorPages.addAll(Arrays.asList(errorPages));
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/MimeMappings.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/MimeMappings.java
@@ -22,7 +22,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Simple server-independent abstraction for mime mappings. Roughly equivalent to the
@@ -241,8 +241,7 @@ public final class MimeMappings implements Iterable<MimeMappings.Mapping> {
 	 * @param mappings the source mappings with extension as the key and mime-type as the
 	 * value
 	 */
-	public MimeMappings(Map<String, String> mappings) {
-		Assert.notNull(mappings, "Mappings must not be null");
+	public MimeMappings(@NonNull Map<String, String> mappings) {
 		this.map = new LinkedHashMap<>();
 		for (Map.Entry<String, String> entry : mappings.entrySet()) {
 			add(entry.getKey(), entry.getValue());
@@ -254,8 +253,7 @@ public final class MimeMappings implements Iterable<MimeMappings.Mapping> {
 	 * @param mappings source mappings
 	 * @param mutable if the new object should be mutable.
 	 */
-	private MimeMappings(MimeMappings mappings, boolean mutable) {
-		Assert.notNull(mappings, "Mappings must not be null");
+	private MimeMappings(@NonNull MimeMappings mappings, boolean mutable) {
 		this.map = (mutable ? new LinkedHashMap<>(mappings.map)
 				: Collections.unmodifiableMap(mappings.map));
 	}
@@ -343,9 +341,7 @@ public final class MimeMappings implements Iterable<MimeMappings.Mapping> {
 
 		private final String mimeType;
 
-		public Mapping(String extension, String mimeType) {
-			Assert.notNull(extension, "Extension must not be null");
-			Assert.notNull(mimeType, "MimeType must not be null");
+		public Mapping(@NonNull String extension, @NonNull String mimeType) {
 			this.extension = extension;
 			this.mimeType = mimeType;
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/AbstractFilterRegistrationBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/AbstractFilterRegistrationBean.java
@@ -32,6 +32,7 @@ import javax.servlet.ServletException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -68,9 +69,7 @@ abstract class AbstractFilterRegistrationBean<T extends Filter> extends Registra
 	 * @param servletRegistrationBeans associate {@link ServletRegistrationBean}s
 	 */
 	AbstractFilterRegistrationBean(
-			ServletRegistrationBean<?>... servletRegistrationBeans) {
-		Assert.notNull(servletRegistrationBeans,
-				"ServletRegistrationBeans must not be null");
+			@NonNull ServletRegistrationBean<?>... servletRegistrationBeans) {
 		Collections.addAll(this.servletRegistrationBeans, servletRegistrationBeans);
 	}
 
@@ -78,10 +77,8 @@ abstract class AbstractFilterRegistrationBean<T extends Filter> extends Registra
 	 * Set {@link ServletRegistrationBean}s that the filter will be registered against.
 	 * @param servletRegistrationBeans the Servlet registration beans
 	 */
-	public void setServletRegistrationBeans(
+	public void setServletRegistrationBeans(@NonNull
 			Collection<? extends ServletRegistrationBean<?>> servletRegistrationBeans) {
-		Assert.notNull(servletRegistrationBeans,
-				"ServletRegistrationBeans must not be null");
 		this.servletRegistrationBeans = new LinkedHashSet<>(servletRegistrationBeans);
 	}
 
@@ -102,9 +99,7 @@ abstract class AbstractFilterRegistrationBean<T extends Filter> extends Registra
 	 * @see #setServletRegistrationBeans
 	 */
 	public void addServletRegistrationBeans(
-			ServletRegistrationBean<?>... servletRegistrationBeans) {
-		Assert.notNull(servletRegistrationBeans,
-				"ServletRegistrationBeans must not be null");
+			@NonNull ServletRegistrationBean<?>... servletRegistrationBeans) {
 		Collections.addAll(this.servletRegistrationBeans, servletRegistrationBeans);
 	}
 
@@ -115,8 +110,7 @@ abstract class AbstractFilterRegistrationBean<T extends Filter> extends Registra
 	 * @see #setServletRegistrationBeans
 	 * @see #setUrlPatterns
 	 */
-	public void setServletNames(Collection<String> servletNames) {
-		Assert.notNull(servletNames, "ServletNames must not be null");
+	public void setServletNames(@NonNull Collection<String> servletNames) {
 		this.servletNames = new LinkedHashSet<>(servletNames);
 	}
 
@@ -133,8 +127,7 @@ abstract class AbstractFilterRegistrationBean<T extends Filter> extends Registra
 	 * Add servlet names for the filter.
 	 * @param servletNames the servlet names to add
 	 */
-	public void addServletNames(String... servletNames) {
-		Assert.notNull(servletNames, "ServletNames must not be null");
+	public void addServletNames(@NonNull String... servletNames) {
 		this.servletNames.addAll(Arrays.asList(servletNames));
 	}
 
@@ -145,8 +138,7 @@ abstract class AbstractFilterRegistrationBean<T extends Filter> extends Registra
 	 * @see #setServletRegistrationBeans
 	 * @see #setServletNames
 	 */
-	public void setUrlPatterns(Collection<String> urlPatterns) {
-		Assert.notNull(urlPatterns, "UrlPatterns must not be null");
+	public void setUrlPatterns(@NonNull Collection<String> urlPatterns) {
 		this.urlPatterns = new LinkedHashSet<>(urlPatterns);
 	}
 
@@ -163,8 +155,7 @@ abstract class AbstractFilterRegistrationBean<T extends Filter> extends Registra
 	 * Add URL patterns that the filter will be registered against.
 	 * @param urlPatterns the URL patterns
 	 */
-	public void addUrlPatterns(String... urlPatterns) {
-		Assert.notNull(urlPatterns, "UrlPatterns must not be null");
+	public void addUrlPatterns(@NonNull String... urlPatterns) {
 		Collections.addAll(this.urlPatterns, urlPatterns);
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/FilterRegistrationBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/FilterRegistrationBean.java
@@ -19,7 +19,7 @@ package org.springframework.boot.web.servlet;
 import javax.servlet.Filter;
 import javax.servlet.ServletContext;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * A {@link ServletContextInitializer} to register {@link Filter}s in a Servlet 3.0+
@@ -62,10 +62,9 @@ public class FilterRegistrationBean<T extends Filter>
 	 * @param filter the filter to register
 	 * @param servletRegistrationBeans associate {@link ServletRegistrationBean}s
 	 */
-	public FilterRegistrationBean(T filter,
+	public FilterRegistrationBean(@NonNull T filter,
 			ServletRegistrationBean<?>... servletRegistrationBeans) {
 		super(servletRegistrationBeans);
-		Assert.notNull(filter, "Filter must not be null");
 		this.filter = filter;
 	}
 
@@ -78,8 +77,7 @@ public class FilterRegistrationBean<T extends Filter>
 	 * Set the filter to be registered.
 	 * @param filter the filter
 	 */
-	public void setFilter(T filter) {
-		Assert.notNull(filter, "Filter must not be null");
+	public void setFilter(@NonNull T filter) {
 		this.filter = filter;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/RegistrationBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/RegistrationBean.java
@@ -23,6 +23,7 @@ import javax.servlet.Registration;
 
 import org.springframework.core.Conventions;
 import org.springframework.core.Ordered;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -96,8 +97,7 @@ public abstract class RegistrationBean implements ServletContextInitializer, Ord
 	 * @see #getInitParameters
 	 * @see #addInitParameter
 	 */
-	public void setInitParameters(Map<String, String> initParameters) {
-		Assert.notNull(initParameters, "InitParameters must not be null");
+	public void setInitParameters(@NonNull Map<String, String> initParameters) {
 		this.initParameters = new LinkedHashMap<>(initParameters);
 	}
 
@@ -114,8 +114,7 @@ public abstract class RegistrationBean implements ServletContextInitializer, Ord
 	 * @param name the init-parameter name
 	 * @param value the init-parameter value
 	 */
-	public void addInitParameter(String name, String value) {
-		Assert.notNull(name, "Name must not be null");
+	public void addInitParameter(@NonNull String name, String value) {
 		this.initParameters.put(name, value);
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletListenerRegistrationBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletListenerRegistrationBean.java
@@ -33,6 +33,7 @@ import javax.servlet.http.HttpSessionListener;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -88,8 +89,7 @@ public class ServletListenerRegistrationBean<T extends EventListener>
 	 * Create a new {@link ServletListenerRegistrationBean} instance.
 	 * @param listener the listener to register
 	 */
-	public ServletListenerRegistrationBean(T listener) {
-		Assert.notNull(listener, "Listener must not be null");
+	public ServletListenerRegistrationBean(@NonNull T listener) {
 		Assert.isTrue(isSupportedType(listener), "Listener is not of a supported type");
 		this.listener = listener;
 	}
@@ -98,8 +98,7 @@ public class ServletListenerRegistrationBean<T extends EventListener>
 	 * Set the listener that will be registered.
 	 * @param listener the listener to register
 	 */
-	public void setListener(T listener) {
-		Assert.notNull(listener, "Listener must not be null");
+	public void setListener(@NonNull T listener) {
 		Assert.isTrue(isSupportedType(listener), "Listener is not of a supported type");
 		this.listener = listener;
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletRegistrationBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletRegistrationBean.java
@@ -31,6 +31,7 @@ import javax.servlet.ServletRegistration.Dynamic;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
@@ -91,10 +92,8 @@ public class ServletRegistrationBean<T extends Servlet> extends RegistrationBean
 	 * @param alwaysMapUrl if omitted URL mappings should be replaced with '/*'
 	 * @param urlMappings the URLs being mapped
 	 */
-	public ServletRegistrationBean(T servlet, boolean alwaysMapUrl,
-			String... urlMappings) {
-		Assert.notNull(servlet, "Servlet must not be null");
-		Assert.notNull(urlMappings, "UrlMappings must not be null");
+	public ServletRegistrationBean(@NonNull T servlet, boolean alwaysMapUrl,
+			@NonNull String... urlMappings) {
 		this.servlet = servlet;
 		this.alwaysMapUrl = alwaysMapUrl;
 		this.urlMappings.addAll(Arrays.asList(urlMappings));
@@ -112,8 +111,7 @@ public class ServletRegistrationBean<T extends Servlet> extends RegistrationBean
 	 * Sets the servlet to be registered.
 	 * @param servlet the servlet
 	 */
-	public void setServlet(T servlet) {
-		Assert.notNull(servlet, "Servlet must not be null");
+	public void setServlet(@NonNull T servlet) {
 		this.servlet = servlet;
 	}
 
@@ -123,8 +121,7 @@ public class ServletRegistrationBean<T extends Servlet> extends RegistrationBean
 	 * @param urlMappings the mappings to set
 	 * @see #addUrlMappings(String...)
 	 */
-	public void setUrlMappings(Collection<String> urlMappings) {
-		Assert.notNull(urlMappings, "UrlMappings must not be null");
+	public void setUrlMappings(@NonNull Collection<String> urlMappings) {
 		this.urlMappings = new LinkedHashSet<>(urlMappings);
 	}
 
@@ -141,8 +138,7 @@ public class ServletRegistrationBean<T extends Servlet> extends RegistrationBean
 	 * @param urlMappings the mappings to add
 	 * @see #setUrlMappings(Collection)
 	 */
-	public void addUrlMappings(String... urlMappings) {
-		Assert.notNull(urlMappings, "UrlMappings must not be null");
+	public void addUrlMappings(@NonNull String... urlMappings) {
 		this.urlMappings.addAll(Arrays.asList(urlMappings));
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/WebApplicationContextServletContextAwareProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/WebApplicationContextServletContextAwareProcessor.java
@@ -19,7 +19,7 @@ package org.springframework.boot.web.servlet.context;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.web.context.ConfigurableWebApplicationContext;
 import org.springframework.web.context.support.ServletContextAwareProcessor;
 
@@ -37,8 +37,7 @@ public class WebApplicationContextServletContextAwareProcessor
 	private final ConfigurableWebApplicationContext webApplicationContext;
 
 	public WebApplicationContextServletContextAwareProcessor(
-			ConfigurableWebApplicationContext webApplicationContext) {
-		Assert.notNull(webApplicationContext, "WebApplicationContext must not be null");
+			@NonNull ConfigurableWebApplicationContext webApplicationContext) {
 		this.webApplicationContext = webApplicationContext;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactory.java
@@ -33,7 +33,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.boot.web.server.AbstractConfigurableWebServerFactory;
 import org.springframework.boot.web.server.MimeMappings;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -120,8 +120,7 @@ public abstract class AbstractServletWebServerFactory
 		this.contextPath = contextPath;
 	}
 
-	private void checkContextPath(String contextPath) {
-		Assert.notNull(contextPath, "ContextPath must not be null");
+	private void checkContextPath(@NonNull String contextPath) {
 		if (!contextPath.isEmpty()) {
 			if ("/".equals(contextPath)) {
 				throw new IllegalArgumentException(
@@ -215,14 +214,13 @@ public abstract class AbstractServletWebServerFactory
 	}
 
 	@Override
-	public void setInitializers(List<? extends ServletContextInitializer> initializers) {
-		Assert.notNull(initializers, "Initializers must not be null");
+	public void setInitializers(
+			@NonNull List<? extends ServletContextInitializer> initializers) {
 		this.initializers = new ArrayList<>(initializers);
 	}
 
 	@Override
-	public void addInitializers(ServletContextInitializer... initializers) {
-		Assert.notNull(initializers, "Initializers must not be null");
+	public void addInitializers(@NonNull ServletContextInitializer... initializers) {
 		this.initializers.addAll(Arrays.asList(initializers));
 	}
 
@@ -244,8 +242,8 @@ public abstract class AbstractServletWebServerFactory
 	}
 
 	@Override
-	public void setLocaleCharsetMappings(Map<Locale, Charset> localeCharsetMappings) {
-		Assert.notNull(localeCharsetMappings, "localeCharsetMappings must not be null");
+	public void setLocaleCharsetMappings(
+			@NonNull Map<Locale, Charset> localeCharsetMappings) {
 		this.localeCharsetMappings = localeCharsetMappings;
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/origin/MockOrigin.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/origin/MockOrigin.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.origin;
 
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 /**
  * Mock {@link Origin} implementation used for testing.
@@ -27,8 +27,7 @@ public final class MockOrigin implements Origin {
 
 	private final String value;
 
-	private MockOrigin(String value) {
-		Assert.notNull(value, "Value must not be null");
+	private MockOrigin(@NonNull String value) {
 		this.value = value;
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/security/ApplicationContextRequestMatcherTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/security/ApplicationContextRequestMatcherTests.java
@@ -43,7 +43,7 @@ public class ApplicationContextRequestMatcherTests {
 	@Test
 	public void createWhenContextClassIsNullShouldThrowException() throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("Context class must not be null");
+		this.thrown.expectMessage("ContextClass must not be null");
 		new TestApplicationContextRequestMatcher<>(null);
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/RestTemplateBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/RestTemplateBuilderTests.java
@@ -205,7 +205,7 @@ public class RestTemplateBuilderTests {
 	public void interceptorsWhenInterceptorsAreNullShouldThrowException()
 			throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("interceptors must not be null");
+		this.thrown.expectMessage("Interceptors must not be null");
 		this.builder.interceptors((ClientHttpRequestInterceptor[]) null);
 	}
 
@@ -213,7 +213,7 @@ public class RestTemplateBuilderTests {
 	public void interceptorsCollectionWhenInterceptorsAreNullShouldThrowException()
 			throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("interceptors must not be null");
+		this.thrown.expectMessage("Interceptors must not be null");
 		this.builder.interceptors((Set<ClientHttpRequestInterceptor>) null);
 	}
 
@@ -235,7 +235,7 @@ public class RestTemplateBuilderTests {
 	public void additionalInterceptorsWhenInterceptorsAreNullShouldThrowException()
 			throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("interceptors must not be null");
+		this.thrown.expectMessage("Interceptors must not be null");
 		this.builder.additionalInterceptors((ClientHttpRequestInterceptor[]) null);
 	}
 
@@ -243,7 +243,7 @@ public class RestTemplateBuilderTests {
 	public void additionalInterceptorsCollectionWhenInterceptorsAreNullShouldThrowException()
 			throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("interceptors must not be null");
+		this.thrown.expectMessage("Interceptors must not be null");
 		this.builder.additionalInterceptors((Set<ClientHttpRequestInterceptor>) null);
 	}
 
@@ -386,7 +386,7 @@ public class RestTemplateBuilderTests {
 	public void additionalCustomizersCollectionWhenCustomizersAreNullShouldThrowException()
 			throws Exception {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("RestTemplateCustomizers must not be null");
+		this.thrown.expectMessage("Customizers must not be null");
 		this.builder.additionalCustomizers((Set<RestTemplateCustomizer>) null);
 	}
 


### PR DESCRIPTION
It's rather tedious to write explicit null-checks (Assert.notNull()) for target method parameters.  
An alternative is to mark those parameters by *@NotNull* annotation and generate the checks during compilation. Benefits:  
* less code (it's not necessary to write Assert.notNull())
* better contract definition - it's immediately clear that particular method parameter should not be *null*

The magic is done by the [Traute](http://traute.oss.harmonysoft.tech/) javac plugin, it's configured in the *spring-boot-parent*'s *pom.xml*.  

Please note that all tests pass from the command line (*mvn package*) but tests which ensure *null*-checks processing fail from the *IDE* at the moment (at least IntelliJ), e.g. [AbstractFilterRegistrationBeanTests.setServletRegistrationBeanMustNotBeNull()](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/AbstractFilterRegistrationBeanTests.java#L131). We can use at least two approaches to fix that:
1. Remove all tests which check *@NonNull* parameters validation
2. Modify those *null*-check tests in a way to stop processing unless particular system property (like *'ci'*) is defined, i.e. run them on CI server but skip during *IDE* runs
I recommend the second approach, along with the official recommendation to avoid creating such tests in future. Also, I'm fine with preparing corresponding pull request when we agree on what is the desired approach.

TESTED: mvn clean package

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->