### PR TITLE
Add Flux to ConditionalOnClass for CouchbaseReactiveRepositoriesAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/couchbase/CouchbaseReactiveRepositoriesAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/couchbase/CouchbaseReactiveRepositoriesAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.data.couchbase;
 
 import com.couchbase.client.java.Bucket;
+import reactor.core.publisher.Flux;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -38,7 +39,7 @@ import org.springframework.data.couchbase.repository.support.ReactiveCouchbaseRe
  * @since 2.0.0
  */
 @Configuration
-@ConditionalOnClass({ Bucket.class, ReactiveCouchbaseRepository.class })
+@ConditionalOnClass({ Bucket.class, ReactiveCouchbaseRepository.class, Flux.class })
 @ConditionalOnProperty(prefix = "spring.data.couchbase.reactiverepositories", name = "enabled", havingValue = "true", matchIfMissing = true)
 @ConditionalOnBean(ReactiveRepositoryOperationsMapping.class)
 @ConditionalOnMissingBean(ReactiveCouchbaseRepositoryFactoryBean.class)


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR adds `Flux.class` to `@ConditionalOnClass` for `CouchbaseReactiveRepositoriesAutoConfiguration` to align with `CouchbaseReactiveDataAutoConfiguration` which has the same constraints.