### PR TITLE
Add @Inherited on spring-boot-test-autoconfigure

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jdbc/AutoConfigureJdbc.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jdbc/AutoConfigureJdbc.java
@@ -18,6 +18,7 @@ package org.springframework.boot.test.autoconfigure.jdbc;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -36,6 +37,7 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @ImportAutoConfiguration
 public @interface AutoConfigureJdbc {
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jooq/AutoConfigureJooq.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jooq/AutoConfigureJooq.java
@@ -18,6 +18,7 @@ package org.springframework.boot.test.autoconfigure.jooq;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -35,6 +36,7 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @ImportAutoConfiguration
 public @interface AutoConfigureJooq {
 


### PR DESCRIPTION
I've added the `@Inherited` for fitting to similar other annotations (e.g. `@AutoConfigureDataJpa`, etc..). 
