### PR TITLE
Make CouchbaseReactiveRepositoriesAutoConfigureRegistrar package-private

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/couchbase/CouchbaseReactiveRepositoriesAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/couchbase/CouchbaseReactiveRepositoriesAutoConfiguration.java
@@ -43,7 +43,7 @@ import org.springframework.data.couchbase.repository.support.ReactiveCouchbaseRe
 @ConditionalOnProperty(prefix = "spring.data.couchbase.reactiverepositories", name = "enabled", havingValue = "true", matchIfMissing = true)
 @ConditionalOnBean(ReactiveRepositoryOperationsMapping.class)
 @ConditionalOnMissingBean(ReactiveCouchbaseRepositoryFactoryBean.class)
-@Import(CouchbaseReactiveRepositoriesAutoConfigureRegistrar.class)
+@Import(CouchbaseReactiveRepositoriesRegistrar.class)
 @AutoConfigureAfter(CouchbaseReactiveDataAutoConfiguration.class)
 public class CouchbaseReactiveRepositoriesAutoConfiguration {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/couchbase/CouchbaseReactiveRepositoriesRegistrar.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/couchbase/CouchbaseReactiveRepositoriesRegistrar.java
@@ -29,9 +29,8 @@ import org.springframework.data.repository.config.RepositoryConfigurationExtensi
  * Reactive Repositories.
  *
  * @author Alex Derkach
- * @since 2.0.0
  */
-public class CouchbaseReactiveRepositoriesAutoConfigureRegistrar
+class CouchbaseReactiveRepositoriesRegistrar
 		extends AbstractRepositoryConfigurationSourceSupport {
 
 	@Override

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/couchbase/SpringBootCouchbaseReactiveDataConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/couchbase/SpringBootCouchbaseReactiveDataConfiguration.java
@@ -31,7 +31,6 @@ import org.springframework.data.couchbase.repository.config.ReactiveRepositoryOp
  * Configure Spring Data's reactive couchbase support.
  *
  * @author Alex Derkach
- * @since 2.0.0
  */
 @Configuration
 @ConditionalOnMissingBean(AbstractReactiveCouchbaseDataConfiguration.class)


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR makes `CouchbaseReactiveRepositoriesAutoConfigureRegistrar` package-private to align with `CouchbaseRepositoriesRegistrar` and renames to `CouchbaseReactiveRepositoriesRegistrar`.