### PR TITLE
Remove a redundant dash in TestPropertyValues.Type

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java
@@ -227,7 +227,7 @@ public final class TestPropertyValues {
 
 		Type(Class<? extends MapPropertySource> sourceClass, String suffix) {
 			this.sourceClass = sourceClass;
-			this.suffix = (suffix == null ? null : "-" + suffix);
+			this.suffix = suffix;
 		}
 
 		public Class<? extends MapPropertySource> getSourceClass() {

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/util/TestPropertyValuesTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/util/TestPropertyValuesTests.java
@@ -58,7 +58,7 @@ public class TestPropertyValuesTests {
 				Type.SYSTEM_ENVIRONMENT);
 		assertThat(this.environment.getProperty("foo.bar")).isEqualTo("BAZ");
 		assertThat(this.environment.getPropertySources().contains(
-				"test-" + StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME));
+				"test-" + StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME)).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
This PR also fixes a broken assertion in `TestPropertyValuesTests.applyToSystemPropertySource`.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->