### PR TITLE
Fix NullPointer when requesting a session that does not exist

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/session/SessionsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/session/SessionsEndpoint.java
@@ -60,6 +60,9 @@ public class SessionsEndpoint {
 	@ReadOperation
 	public SessionDescriptor getSession(@Selector String sessionId) {
 		Session session = this.sessionRepository.findById(sessionId);
+		if (session == null) {
+			return null;
+		}
 		return new SessionDescriptor(session);
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/session/SessionsEndpointWebIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/session/SessionsEndpointWebIntegrationTests.java
@@ -80,6 +80,12 @@ public class SessionsEndpointWebIntegrationTests {
 				.isEqualTo(new JSONArray().appendElement(session.getId()));
 	}
 
+	@Test
+	public void sessionForIdNotFound() {
+		client.get().uri((builder) -> builder.path("/actuator/sessions/some-session-id-that-does-not-exist")
+										.build()).exchange().expectStatus().isNotFound();
+	}
+
 	@Configuration
 	protected static class TestConfiguration {
 


### PR DESCRIPTION
Add a null-pointer check to avoid null-pointer exception in the `SessionEndpoint` actuator in case
there is no session for the given id.

Close: #11201

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->