### PR TITLE
Update documentation references to `/status` endpoint

### DIFF
--- a/spring-boot-project/spring-boot-actuator/README.adoc
+++ b/spring-boot-project/spring-boot-actuator/README.adoc
@@ -34,8 +34,8 @@ For Gradle, use the following declaration:
 == Features
 * **Endpoints** Actuator endpoints allow you to monitor and interact with your
   application. Spring Boot includes a number of built-in endpoints and you can also add
-  your own. For example the `status` endpoint provides basic application health
-  information. Run up a basic application and look at `/status`.
+  your own. For example the `health` endpoint provides basic application health
+  information. Run up a basic application and look at `/health`.
 * **Metrics** Spring Boot Actuator provides dimensional metrics by integrating with
   https://micrometer.io[Micrometer].
 * **Audit** Spring Boot Actuator has a flexible audit framework that will publish events

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -1108,7 +1108,7 @@ content into your application. Rather, pick only the properties that you need.
 
 	# ENDPOINTS WEB CONFIGURATION ({sc-spring-boot-actuator-autoconfigure}/endpoint/web/WebEndpointProperties.{sc-ext}[WebEndpointProperties])
 	management.endpoints.web.enabled=true # Whether web endpoints are enabled
-	management.endpoints.web.expose=info,status # Endpoint IDs that should be exposed or '*' for all.
+	management.endpoints.web.expose=info,health # Endpoint IDs that should be exposed or '*' for all.
 	management.endpoints.web.exclude= # Endpoint IDs that should be excluded.
 	management.endpoints.web.base-path=/actuator # Base path for Web endpoints. Relative to server.context-path or management.server.context-path if management.server.port is configured.
 	management.endpoints.web.path-mapping= # Mapping between endpoint IDs and the path that should expose them.


### PR DESCRIPTION
While migrating to `2.0.0.M7` I've discovered a few references to the removed `/status` endpoint. This was apparently missed in #11113.