### PR TITLE
Use volatile for ReactiveTokenValidator.cacheTokenKeys

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveTokenValidator.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveTokenValidator.java
@@ -25,6 +25,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
 import reactor.core.publisher.Mono;
@@ -43,7 +44,7 @@ class ReactiveTokenValidator {
 
 	private final ReactiveCloudFoundrySecurityService securityService;
 
-	private Map<String, String> cachedTokenKeys = new ConcurrentHashMap<>();
+	private volatile ConcurrentMap<String, String> cachedTokenKeys = new ConcurrentHashMap<>();
 
 	ReactiveTokenValidator(ReactiveCloudFoundrySecurityService securityService) {
 		this.securityService = securityService;
@@ -91,8 +92,7 @@ class ReactiveTokenValidator {
 	}
 
 	private void cacheTokenKeys(Map<String, String> tokenKeys) {
-		this.cachedTokenKeys.clear();
-		this.cachedTokenKeys.putAll(tokenKeys);
+		this.cachedTokenKeys = new ConcurrentHashMap<>(tokenKeys);
 	}
 
 	private boolean hasValidSignature(Token token, String key) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveTokenValidatorTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveTokenValidatorTests.java
@@ -26,8 +26,8 @@ import java.security.Signature;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Before;
@@ -80,9 +80,9 @@ public class ReactiveTokenValidatorTests {
 			+ "r3F7aM9YpErzeYLrl0GhQr9BVJxOvXcVd4kmY+XkiCcrkyS1cnghnllh+LCwQu1s\n"
 			+ "YwIDAQAB\n-----END PUBLIC KEY-----";
 
-	private static final Map<String, String> INVALID_KEYS = new LinkedHashMap<>();
+	private static final Map<String, String> INVALID_KEYS = new ConcurrentHashMap<>();
 
-	private static final Map<String, String> VALID_KEYS = new LinkedHashMap<>();
+	private static final Map<String, String> VALID_KEYS = new ConcurrentHashMap<>();
 
 	@Before
 	public void setup() throws Exception {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
In `cacheTokenKeys()`, `clear()` and then `putAll()` are not atomic.

This PR changes to use `volatile` for `cacheTokenKeys` and also changes its type to `HashMap` because with `volatile` there's no modification now.