### PR TITLE
Upgrade to Kotlin 1.2

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -105,7 +105,7 @@
 		<junit.version>4.12</junit.version>
 		<junit-jupiter.version>5.0.2</junit-jupiter.version>
 		<junit-platform.version>1.0.2</junit-platform.version>
-		<kotlin.version>1.1.61</kotlin.version>
+		<kotlin.version>1.2.0</kotlin.version>
 		<lettuce.version>5.0.1.RELEASE</lettuce.version>
 		<liquibase.version>3.5.3</liquibase.version>
 		<log4j2.version>2.10.0</log4j2.version>

--- a/spring-boot-project/spring-boot-parent/pom.xml
+++ b/spring-boot-project/spring-boot-parent/pom.xml
@@ -287,6 +287,8 @@
 					<version>${kotlin.version}</version>
 					<configuration>
 						<jvmTarget>${java.version}</jvmTarget>
+						<apiVersion>1.1</apiVersion>
+						<languageVersion>1.1</languageVersion>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
With this pull request, Spring Boot 2 now builds against Kotlin 1.2 while still being Kotlin 1.1 compatible thanks to the usage of `apiVersion = 1.1` and `languageVersion = 1.1` configuration options, as confirmed with Kotlin team.

See [SPR-16239](https://jira.spring.io/browse/SPR-16239) related Spring Framework issue.