### PR TITLE
Allow customizing sanitization rules for /env

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/context/properties/ConfigurationPropertiesReportEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/context/properties/ConfigurationPropertiesReportEndpointAutoConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Phillip Webb
  * @author Stephane Nicoll
+ * @author Piotr Betkier
  * @since 2.0.0
  */
 @Configuration
@@ -47,12 +48,11 @@ public class ConfigurationPropertiesReportEndpointAutoConfiguration {
 	@ConditionalOnMissingBean
 	@ConditionalOnEnabledEndpoint
 	public ConfigurationPropertiesReportEndpoint configurationPropertiesReportEndpoint() {
-		ConfigurationPropertiesReportEndpoint endpoint = new ConfigurationPropertiesReportEndpoint();
 		String[] keysToSanitize = this.properties.getKeysToSanitize();
 		if (keysToSanitize != null) {
-			endpoint.setKeysToSanitize(keysToSanitize);
+			return new ConfigurationPropertiesReportEndpoint(keysToSanitize);
 		}
-		return endpoint;
+		return new ConfigurationPropertiesReportEndpoint();
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpoint.java
@@ -44,9 +44,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.BeansException;
-import org.springframework.boot.actuate.endpoint.Sanitizer;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.sanitize.Sanitizer;
 import org.springframework.boot.context.properties.ConfigurationBeanFactoryMetaData;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.ApplicationContext;
@@ -74,7 +74,7 @@ public class ConfigurationPropertiesReportEndpoint implements ApplicationContext
 
 	private static final String CONFIGURATION_PROPERTIES_FILTER_ID = "configurationPropertiesFilter";
 
-	private final Sanitizer sanitizer = new Sanitizer();
+	private final Sanitizer<String> sanitizer;
 
 	private ApplicationContext context;
 
@@ -83,8 +83,12 @@ public class ConfigurationPropertiesReportEndpoint implements ApplicationContext
 		this.context = context;
 	}
 
-	public void setKeysToSanitize(String... keysToSanitize) {
-		this.sanitizer.setKeysToSanitize(keysToSanitize);
+	public ConfigurationPropertiesReportEndpoint() {
+		this.sanitizer = Sanitizer.keyBlacklistSanitizer();
+	}
+
+	public ConfigurationPropertiesReportEndpoint(String... keysToSanitize) {
+		this.sanitizer = Sanitizer.keyBlacklistSanitizer(keysToSanitize);
 	}
 
 	@ReadOperation

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/sanitize/Sanitizer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/sanitize/Sanitizer.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.endpoint.sanitize;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Strategy that should be used by endpoint implementations to sanitize potentially
+ * sensitive keys.
+ *
+ * @param <T> the key type
+ * @author Christian Dupuis
+ * @author Toshiaki Maki
+ * @author Phillip Webb
+ * @author Nicolas Lejeune
+ * @author Stephane Nicoll
+ * @author Piotr Betkier
+ * @since 2.0.0
+ */
+public final class Sanitizer<T> {
+
+	private final Collection<Filter<T>> filters;
+
+	private Sanitizer(Collection<Filter<T>> filters) {
+		this.filters = filters;
+	}
+
+	/**
+	 * Creates a sanitizer that sanitizes keys matching the default blacklist.
+	 * @return a new sanitizer instance
+	 */
+	public static Sanitizer<String> keyBlacklistSanitizer() {
+		return new Sanitizer<>(
+				Collections.singleton(KeyBlacklistSanitizeFilter.matchingDefaultKeys()));
+	}
+
+	/**
+	 * Creates a sanitizer that sanitizes keys matching the given blacklist.
+	 * @param keysToSanitize the keys to match
+	 * @return a new sanitizer instance
+	 */
+	public static Sanitizer<String> keyBlacklistSanitizer(String... keysToSanitize) {
+		return new Sanitizer<>(Collections
+				.singleton(KeyBlacklistSanitizeFilter.matchingKeys(keysToSanitize)));
+	}
+
+	/**
+	 * Creates a sanitizer that sanitizes keys matched by any of the given filters.
+	 * @param filters the filters to use
+	 * @param <T> the key type
+	 * @return a new sanitizer instance
+	 */
+	public static <T> Sanitizer<T> customRulesSanitizer(Collection<Filter<T>> filters) {
+		return new Sanitizer<>(filters);
+	}
+
+	/**
+	 * Sanitize the given value if necessary.
+	 * @param key the value key, e.g. property name
+	 * @param value the value
+	 * @return the potentially sanitized value
+	 */
+	public Object sanitize(T key, Object value) {
+		if (value == null) {
+			return null;
+		}
+
+		if (this.filters.stream().anyMatch(f -> f.match(key))) {
+			return "******";
+		}
+
+		return value;
+	}
+
+	/**
+	 * Should the value for the given key be sanitized.
+	 * @param <T> the key type
+	 */
+	public interface Filter<T> {
+		boolean match(T key);
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointTests.java
@@ -175,12 +175,10 @@ public class ConfigurationPropertiesReportEndpointTests {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 				.withUserConfiguration(Config.class);
 		contextRunner.run((context) -> {
-			ConfigurationPropertiesReportEndpoint endpoint = context
-					.getBean(ConfigurationPropertiesReportEndpoint.class);
-			if (!CollectionUtils.isEmpty(keysToSanitize)) {
-				endpoint.setKeysToSanitize(
-						keysToSanitize.toArray(new String[keysToSanitize.size()]));
-			}
+			ConfigurationPropertiesReportEndpointFactory endpointFactory = context
+					.getBean(ConfigurationPropertiesReportEndpointFactory.class);
+			ConfigurationPropertiesReportEndpoint endpoint = endpointFactory
+					.create(context, keysToSanitize);
 			properties.accept(context, endpoint.configurationProperties());
 		});
 	}
@@ -196,13 +194,31 @@ public class ConfigurationPropertiesReportEndpointTests {
 
 	}
 
+	private static class ConfigurationPropertiesReportEndpointFactory {
+
+		ConfigurationPropertiesReportEndpoint create(ApplicationContext context,
+				List<String> keysToSanitize) {
+			ConfigurationPropertiesReportEndpoint endpoint;
+			if (!CollectionUtils.isEmpty(keysToSanitize)) {
+				endpoint = new ConfigurationPropertiesReportEndpoint(
+						keysToSanitize.toArray(new String[keysToSanitize.size()]));
+			}
+			else {
+				endpoint = new ConfigurationPropertiesReportEndpoint();
+			}
+			endpoint.setApplicationContext(context);
+			return endpoint;
+		}
+
+	}
+
 	@Configuration
 	@EnableConfigurationProperties
 	public static class Config {
 
 		@Bean
-		public ConfigurationPropertiesReportEndpoint endpoint() {
-			return new ConfigurationPropertiesReportEndpoint();
+		public ConfigurationPropertiesReportEndpointFactory factory() {
+			return new ConfigurationPropertiesReportEndpointFactory();
 		}
 
 		@Bean

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/env/EnvironmentEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/env/EnvironmentEndpointTests.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Test;
 
+import org.springframework.boot.actuate.endpoint.sanitize.KeyBlacklistSanitizeFilter;
 import org.springframework.boot.actuate.env.EnvironmentEndpoint.EnvironmentDescriptor;
 import org.springframework.boot.actuate.env.EnvironmentEndpoint.EnvironmentEntryDescriptor;
 import org.springframework.boot.actuate.env.EnvironmentEndpoint.PropertySourceDescriptor;
@@ -145,9 +146,12 @@ public class EnvironmentEndpointTests {
 	public void sensitiveKeysMatchingCustomNameHaveTheirValuesSanitized() {
 		TestPropertyValues.of("dbPassword=123456", "apiKey=123456")
 				.applyToSystemProperties(() -> {
+					KeyBlacklistSanitizeFilter filter =
+							KeyBlacklistSanitizeFilter.matchingKeys("key");
 					EnvironmentEndpoint endpoint = new EnvironmentEndpoint(
-							new StandardEnvironment());
-					endpoint.setKeysToSanitize("key");
+							new StandardEnvironment(),
+							Collections.singleton(EnvironmentEndpoint.SanitizeFilter.from(filter))
+					);
 					EnvironmentDescriptor descriptor = endpoint.environment(null);
 					Map<String, PropertyValueDescriptor> systemProperties = propertySources(
 							descriptor).get("systemProperties").getProperties();
@@ -163,9 +167,12 @@ public class EnvironmentEndpointTests {
 	public void sensitiveKeysMatchingCustomPatternHaveTheirValuesSanitized() {
 		TestPropertyValues.of("dbPassword=123456", "apiKey=123456")
 				.applyToSystemProperties(() -> {
+					KeyBlacklistSanitizeFilter filter =
+							KeyBlacklistSanitizeFilter.matchingKeys(".*pass.*");
 					EnvironmentEndpoint endpoint = new EnvironmentEndpoint(
-							new StandardEnvironment());
-					endpoint.setKeysToSanitize(".*pass.*");
+							new StandardEnvironment(),
+							Collections.singleton(EnvironmentEndpoint.SanitizeFilter.from(filter))
+					);
 					EnvironmentDescriptor descriptor = endpoint.environment(null);
 					Map<String, PropertyValueDescriptor> systemProperties = propertySources(
 							descriptor).get("systemProperties").getProperties();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/PropertySourcesPlaceholdersResolver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/PropertySourcesPlaceholdersResolver.java
@@ -29,6 +29,7 @@ import org.springframework.util.SystemPropertyUtils;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Piotr Betkier
  * @since 2.0.0
  */
 public class PropertySourcesPlaceholdersResolver implements PlaceholdersResolver {
@@ -63,16 +64,20 @@ public class PropertySourcesPlaceholdersResolver implements PlaceholdersResolver
 		return value;
 	}
 
-	protected String resolvePlaceholder(String placeholder) {
+	private String resolvePlaceholder(String placeholder) {
 		if (this.sources != null) {
 			for (PropertySource<?> source : this.sources) {
 				Object value = source.getProperty(placeholder);
 				if (value != null) {
-					return String.valueOf(value);
+					return convertResolvedValueToString(placeholder, value, source);
 				}
 			}
 		}
 		return null;
+	}
+
+	protected String convertResolvedValueToString(String placeholder, Object value, PropertySource<?> source) {
+		return String.valueOf(value);
 	}
 
 	private static PropertySources getSources(Environment environment) {


### PR DESCRIPTION
This PR introduces more flexible sanitization rules for /env actuator endpoint. 

Sanitization rules can be customized by registering one or more beans of type `EnvironmentEndpoint.SanitizeFilter`. Such filters decide whether to sanitize a given value basing on its property name and the property source it originates from. By default there is only one filter, `KeyBlacklistSanitizeFilter`, which contains the already existing logic of sanitizing based on the matching key names.

I made a couple of backwards-incompatible changes which I assumed are OK at this release stage. I pointed them in the PR comments. I also haven't wrote the docs for this feature assuming it won't be commonly used.

@philwebb @spencergibb you may be interested in this :)

Fixes gh-6587