### PR TITLE
Upgrade to Mockito 2.13.0

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -114,7 +114,7 @@
 		<mariadb.version>2.2.0</mariadb.version>
 		<micrometer.version>1.0.0-rc.5</micrometer.version>
 		<mssql-jdbc.version>6.2.2.jre8</mssql-jdbc.version>
-		<mockito.version>2.12.0</mockito.version>
+		<mockito.version>2.13.0</mockito.version>
 		<mongo-driver-reactivestreams.version>1.6.0</mongo-driver-reactivestreams.version>
 		<mongodb.version>3.5.0</mongodb.version>
 		<mysql.version>5.1.44</mysql.version>


### PR DESCRIPTION
Mockito 2.12.0 used in Boot 2.0.0.M7 has a bug when using `mockito-inline`.

The Mockito team has just released 2.13.0 which fixes the issue: https://github.com/mockito/mockito/issues/1254