### PR TITLE
Set tarLongFileMod=posix in maven-assembly-plugin for spring-boot-cli

### DIFF
--- a/spring-boot-project/spring-boot-cli/pom.xml
+++ b/spring-boot-project/spring-boot-cli/pom.xml
@@ -267,6 +267,9 @@
 						</configuration>
 					</execution>
 				</executions>
+				<configuration>
+					<tarLongFileMode>posix</tarLongFileMode>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Building spring-boot with maven is failing on my system.
- MacOs Sierra 10.12.6
- Maven: 3.5
- JDK: 1.8.0_144

Error when doing `mvn clean install` from parent project:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.1.0:single (bin-package) on project spring-boot-cli: Execution bin-package of goal org.apache.maven.plugins:maven-assembly-plugin:3.1.0:single failed: group id '562225435' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit ->
```

Possible solution accodring to [Apache Maven Assembly Plugin official documentation](https://maven.apache.org/plugins/maven-assembly-plugin/faq.html): 
```
Tar complains about groupid value being too big
GNU tar has restrictions on max value of UID/GUID in tar files. Consider using the more well defined POSIX tar format, which should support larger values. Use tarLongFileMode=posix in the assembly:single goal.
```