### PR TITLE
Precompile current dir pattern in Handler

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/Handler.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/Handler.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 /**
  * {@link URLStreamHandler} for Spring Boot loader {@link JarFile}s.
@@ -49,6 +50,8 @@ public class Handler extends URLStreamHandler {
 	private static final String SEPARATOR = "!/";
 
 	private static final String CURRENT_DIR = "/./";
+
+	private static final Pattern CURRENT_DIR_PATTERN = Pattern.compile(CURRENT_DIR);
 
 	private static final String PARENT_DIR = "/../";
 
@@ -237,7 +240,7 @@ public class Handler extends URLStreamHandler {
 	}
 
 	private String replaceCurrentDir(String file) {
-		return file.replace(CURRENT_DIR, "/");
+		return CURRENT_DIR_PATTERN.matcher(file).replaceAll("/");
 	}
 
 	@Override


### PR DESCRIPTION
Hi,

while looking into some of the recent startup performance issues in 1.5.x, I noticed that #9917 introduced quite an allocation heavy normalization step (in my case I'd say roughly ~4GB heap pressure only for char[] in 30 seconds) in the startup-phase.

Though I've not taken a too deep look into it (e.g. if it's possible to avoid the additional char[] allocations in some cases), I found one possible quick-win optimization that gets rid of the overhead of compiling the pattern for the current directory, which also accounts for ~600MB (170MB for the pattern itself + 470MB of int[] array).

Cheers,
Christoph