### PR TITLE
Add @Configuration to ScheduledTasksEndpointAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/scheduling/ScheduledTasksEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/scheduling/ScheduledTasksEndpointAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.boot.actuate.scheduling.ScheduledTasksEndpoint;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.config.ScheduledTaskHolder;
 
 /**
@@ -33,6 +34,7 @@ import org.springframework.scheduling.config.ScheduledTaskHolder;
  * @author Andy Wilkinson
  * @since 2.0.0
  */
+@Configuration
 public class ScheduledTasksEndpointAutoConfiguration {
 
 	@Bean


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
I guess it's working without it but this PR adds it for consistency with the other auto-configuration classes.