### PR TITLE
Avoid allocations from lower-casing spec in Handler

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/Handler.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/Handler.java
@@ -159,7 +159,7 @@ public class Handler extends URLStreamHandler {
 
 	@Override
 	protected void parseURL(URL context, String spec, int start, int limit) {
-		if (spec.toLowerCase().startsWith(JAR_PROTOCOL)) {
+		if (spec.regionMatches(true, 0, JAR_PROTOCOL, 0, JAR_PROTOCOL.length())) {
 			setFile(context, getFileFromSpec(spec.substring(start, limit)));
 		}
 		else {


### PR DESCRIPTION
Hi,

while looking into the recent startup performance issues in 1.5.x I found a possible way to prevent allocations of `char[]` due to lower-casing the spec in `Handler`. In my case they are contributing to the heap pressure with several hundred MBs (roughly ~600MB) in 30 seconds.

Instead of lowercasing I do what `String.equalsIgnoreCase` internally does and call `String.regionMatches` with its case-insensitive variant.

Cheers,
Christoph