### PR TITLE
Use String.equalsIgnoreCase() where possible

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/AbstractErrorWebExceptionHandler.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/AbstractErrorWebExceptionHandler.java
@@ -130,7 +130,7 @@ public abstract class AbstractErrorWebExceptionHandler
 	 */
 	protected boolean isTraceEnabled(ServerRequest request) {
 		String parameter = request.queryParam("trace").orElse("false");
-		return !"false".equals(parameter.toLowerCase());
+		return !"false".equalsIgnoreCase(parameter);
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/AbstractErrorController.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/AbstractErrorController.java
@@ -76,10 +76,7 @@ public abstract class AbstractErrorController implements ErrorController {
 
 	protected boolean getTraceParameter(HttpServletRequest request) {
 		String parameter = request.getParameter("trace");
-		if (parameter == null) {
-			return false;
-		}
-		return !"false".equals(parameter.toLowerCase());
+		return !"false".equalsIgnoreCase(parameter);
 	}
 
 	protected HttpStatus getStatus(HttpServletRequest request) {


### PR DESCRIPTION
Hey,

this PR replaces two occurences of the pattern `someString.equals(otherString.toLowerCase())` with `someString.equalsIgnoreCase(otherString)`.

This avoid unnecessary allocations coming from lowercasing.

Cheers,
Christoph