### PR TITLE
Fix WebMvcMetrics to meter async endpoints

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.web.servlet;
 
+import javax.servlet.DispatcherType;
+
 import io.micrometer.core.instrument.MeterRegistry;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties;
@@ -27,6 +29,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -60,8 +63,11 @@ public class WebMvcMetricsConfiguration {
 	}
 
 	@Bean
-	public WebMvcMetricsFilter webMetricsFilter(ApplicationContext context) {
-		return new WebMvcMetricsFilter(context);
+	public FilterRegistrationBean<WebMvcMetricsFilter> webMetricsFilter(ApplicationContext context) {
+		FilterRegistrationBean<WebMvcMetricsFilter> registrationBean = new FilterRegistrationBean<>(
+				new WebMvcMetricsFilter(context));
+		registrationBean.setDispatcherTypes(DispatcherType.REQUEST, DispatcherType.ASYNC);
+		return registrationBean;
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetrics.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetrics.java
@@ -123,7 +123,7 @@ public class WebMvcMetrics {
 	void record(HttpServletRequest request, HttpServletResponse response, Throwable ex) {
 		Object handler = request.getAttribute(HANDLER_REQUEST_ATTRIBUTE);
 		Long startTime = (Long) request.getAttribute(TIMING_REQUEST_ATTRIBUTE);
-		long endTime = System.nanoTime();
+		long endTime = this.registry.config().clock().monotonicTime();
 		completeLongTimerTasks(request, handler);
 		Throwable thrown = (ex != null ? ex
 				: (Throwable) request.getAttribute(EXCEPTION_ATTRIBUTE));


### PR DESCRIPTION
At the moment, async WebMvc requests are not metered. This PR attempts to fix that:

* After gh-7467 got fixed, `WebMvcMetricsFilter` wasn't running on `ASYNC` dispatch; it is explicitly enabled now.
* As `WebMvcMetricsFilter` is executed twice for async requests, `WebMvcMetrics` should
  not overwrite `TIMING_REQUEST_ATTRIBUTE` on second execution.
* To simplify testing and make measurements consistent with the ones
  coming from Micrometer code, nano time is taken from MeterRegistry's clock
  instead of directly calling `System.nanoTime()`.
