### PR TITLE
Use Supplier version of Assert.state()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/convert/DurationConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/convert/DurationConverter.java
@@ -90,7 +90,7 @@ class DurationConverter implements GenericConverter {
 				return Duration.parse(source);
 			}
 			Matcher matcher = SIMPLE.matcher(source);
-			Assert.state(matcher.matches(), "'" + source + "' is not a valid duration");
+			Assert.state(matcher.matches(), () -> "'" + source + "' is not a valid duration");
 			long amount = Long.parseLong(matcher.group(1));
 			ChronoUnit unit = getUnit(matcher.group(2), defaultUnit);
 			return Duration.of(amount, unit);
@@ -106,7 +106,7 @@ class DurationConverter implements GenericConverter {
 			return (defaultUnit != null ? defaultUnit.value() : ChronoUnit.MILLIS);
 		}
 		ChronoUnit unit = UNITS.get(value.toLowerCase());
-		Assert.state(unit != null, "Unknown unit '" + value + "'");
+		Assert.state(unit != null, () -> "Unknown unit '" + value + "'");
 		return unit;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/server/SessionStoreDirectory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/server/SessionStoreDirectory.java
@@ -51,9 +51,13 @@ class SessionStoreDirectory {
 		if (!dir.exists() && mkdirs) {
 			dir.mkdirs();
 		}
-		Assert.state(!mkdirs || dir.exists(), "Session dir " + dir + " does not exist");
-		Assert.state(!dir.isFile(), "Session dir " + dir + " points to a file");
+		assertDirectory(mkdirs, dir);
 		return dir;
+	}
+
+	private void assertDirectory(boolean mkdirs, File dir) {
+		Assert.state(!mkdirs || dir.exists(), () -> "Session dir " + dir + " does not exist");
+		Assert.state(!dir.isFile(), () -> "Session dir " + dir + " points to a file");
 	}
 
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR changes to use `Supplier` version of `Assert.state()` to avoid `String` concatenation when it's unused. 