### PR TITLE
Apply customize() to createCredentialNetworkMongoClient()

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactory.java
@@ -92,6 +92,10 @@ public class ReactiveMongoClientFactory {
 		ClusterSettings clusterSettings = ClusterSettings.builder()
 				.hosts(Collections.singletonList(new ServerAddress(host, port))).build();
 		builder.clusterSettings(clusterSettings);
+		return createMongoClient(builder);
+	}
+
+	private MongoClient createMongoClient(Builder builder) {
 		customize(builder);
 		return MongoClients.create(builder.build());
 	}
@@ -102,7 +106,7 @@ public class ReactiveMongoClientFactory {
 		}
 		ConnectionString connectionString = new ConnectionString(
 				this.properties.determineUri());
-		return MongoClients.create(createBuilder(settings, connectionString).build());
+		return createMongoClient(createBuilder(settings, connectionString));
 	}
 
 	private MongoClient createCredentialNetworkMongoClient(MongoClientSettings settings) {
@@ -117,7 +121,7 @@ public class ReactiveMongoClientFactory {
 		ServerAddress serverAddress = new ServerAddress(host, port);
 		builder.clusterSettings(ClusterSettings.builder()
 				.hosts(Collections.singletonList(serverAddress)).build());
-		return MongoClients.create(builder.build());
+		return createMongoClient(builder);
 	}
 
 	private void applyCredentials(Builder builder) {
@@ -155,7 +159,6 @@ public class ReactiveMongoClientFactory {
 		if (connection.getApplicationName() != null) {
 			builder.applicationName(connection.getApplicationName());
 		}
-		customize(builder);
 		return builder;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactoryTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactoryTests.java
@@ -161,6 +161,16 @@ public class ReactiveMongoClientFactoryTests {
 	}
 
 	@Test
+	public void customizerIsInvokedWhenHostIsSet() {
+		MongoProperties properties = new MongoProperties();
+		properties.setHost("localhost");
+		MongoClientSettingsBuilderCustomizer customizer = mock(
+				MongoClientSettingsBuilderCustomizer.class);
+		createMongoClient(properties, this.environment, customizer);
+		verify(customizer).customize(any(MongoClientSettings.Builder.class));
+	}
+
+	@Test
 	public void customizerIsInvokedForEmbeddedMongo() {
 		MongoProperties properties = new MongoProperties();
 		this.environment.setProperty("local.mongo.port", "27017");


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR applies `customize()` to `createCredentialNetworkMongoClient()` and adds a test for it.