### PR TITLE
Remove mention of broken YAML subdocument profile negation

### DIFF
--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -784,11 +784,6 @@ profile, and it would have to be explicitly reset in all other profiles as neces
 	    password: weak
 ----
 
-Spring profiles designated using the "spring.profiles" element may optionally be negated
-using the `!` character. If both negated and non-negated profiles are specified for
-a single document, at least one non-negated profile must match and no negated profiles
-may match.
-
 
 
 [[boot-features-external-config-yaml-shortcomings]]


### PR DESCRIPTION
Documenting this feature misleads users into thinking it should work. The documentation can be added back once gh-8011 is fixed.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->