### PR TITLE
Fix epub generation for reference document

### DIFF
--- a/spring-boot-project/spring-boot-docs/pom.xml
+++ b/spring-boot-project/spring-boot-docs/pom.xml
@@ -1154,7 +1154,7 @@
 					<plugin>
 						<groupId>com.agilejava.docbkx</groupId>
 						<artifactId>docbkx-maven-plugin</artifactId>
-						<version>2.0.17</version>
+						<version>2.0.16</version>
 						<configuration>
 							<sourceDirectory>${basedir}/target/generated-docs</sourceDirectory>
 							<includes>index.xml</includes>


### PR DESCRIPTION
Cannot open epub reference document in iOS/iBooks and some other epub readers, since 2.0.0 M5. Works fine with 2.0.0 M4. Can be caused by this commit: https://github.com/spring-projects/spring-boot/commit/4df84c53bca75ff9eb81fadded325628dbcd4fc7

Downgrade docbkx-maven-plugin to 2.0.16/2.0.15 fix the problem.
