### PR TITLE
Fix typo

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/package-info.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Auto-configuration for for Spring MVC error handling.
+ * Auto-configuration for Spring MVC error handling.
  */
 package org.springframework.boot.autoconfigure.web.servlet.error;


### PR DESCRIPTION
Hi,

just noticed a small typo in the `package-info` file for the `org.springframework.boot.autoconfigure.web.servlet.error` package.

Cheers,
Christoph