### PR TITLE
Align 'behavior' spelling to style guide

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/AbstractDevToolsDataSourceAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/AbstractDevToolsDataSourceAutoConfigurationTests.java
@@ -56,7 +56,7 @@ public abstract class AbstractDevToolsDataSourceAutoConfigurationTests {
 				DataSourcePropertiesConfiguration.class,
 				SingleDataSourceConfiguration.class);
 		DataSource dataSource = context.getBean(DataSource.class);
-		Statement statement = configureDataSourceBehaviour(dataSource);
+		Statement statement = configureDataSourceBehavior(dataSource);
 		verify(statement, times(0)).execute("SHUTDOWN");
 	}
 
@@ -68,7 +68,7 @@ public abstract class AbstractDevToolsDataSourceAutoConfigurationTests {
 		Collection<DataSource> dataSources = context.getBeansOfType(DataSource.class)
 				.values();
 		for (DataSource dataSource : dataSources) {
-			Statement statement = configureDataSourceBehaviour(dataSource);
+			Statement statement = configureDataSourceBehavior(dataSource);
 			verify(statement, times(0)).execute("SHUTDOWN");
 		}
 	}
@@ -86,7 +86,7 @@ public abstract class AbstractDevToolsDataSourceAutoConfigurationTests {
 		context.close();
 	}
 
-	protected final Statement configureDataSourceBehaviour(DataSource dataSource)
+	protected final Statement configureDataSourceBehavior(DataSource dataSource)
 			throws SQLException {
 		Connection connection = mock(Connection.class);
 		Statement statement = mock(Statement.class);

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/DevToolsEmbeddedDataSourceAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/DevToolsEmbeddedDataSourceAutoConfigurationTests.java
@@ -46,7 +46,7 @@ public class DevToolsEmbeddedDataSourceAutoConfigurationTests
 	public void autoConfiguredDataSourceIsNotShutdown() throws SQLException {
 		ConfigurableApplicationContext context = createContext(
 				DataSourceAutoConfiguration.class, DataSourceSpyConfiguration.class);
-		Statement statement = configureDataSourceBehaviour(
+		Statement statement = configureDataSourceBehavior(
 				context.getBean(DataSource.class));
 		context.close();
 		verify(statement, times(0)).execute("SHUTDOWN");

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/DevToolsPooledDataSourceAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/DevToolsPooledDataSourceAutoConfigurationTests.java
@@ -53,7 +53,7 @@ public class DevToolsPooledDataSourceAutoConfigurationTests
 	public void autoConfiguredInMemoryDataSourceIsShutdown() throws SQLException {
 		ConfigurableApplicationContext context = createContext(
 				DataSourceAutoConfiguration.class, DataSourceSpyConfiguration.class);
-		Statement statement = configureDataSourceBehaviour(
+		Statement statement = configureDataSourceBehavior(
 				context.getBean(DataSource.class));
 		context.close();
 		verify(statement).execute("SHUTDOWN");
@@ -63,7 +63,7 @@ public class DevToolsPooledDataSourceAutoConfigurationTests
 	public void autoConfiguredExternalDataSourceIsNotShutdown() throws SQLException {
 		ConfigurableApplicationContext context = createContext("org.postgresql.Driver",
 				DataSourceAutoConfiguration.class, DataSourceSpyConfiguration.class);
-		Statement statement = configureDataSourceBehaviour(
+		Statement statement = configureDataSourceBehavior(
 				context.getBean(DataSource.class));
 		context.close();
 		verify(statement, times(0)).execute("SHUTDOWN");
@@ -74,7 +74,7 @@ public class DevToolsPooledDataSourceAutoConfigurationTests
 		ConfigurableApplicationContext context = createContext("org.h2.Driver",
 				"jdbc:h2:hsql://localhost", DataSourceAutoConfiguration.class,
 				DataSourceSpyConfiguration.class);
-		Statement statement = configureDataSourceBehaviour(
+		Statement statement = configureDataSourceBehavior(
 				context.getBean(DataSource.class));
 		context.close();
 		verify(statement, times(0)).execute("SHUTDOWN");
@@ -85,7 +85,7 @@ public class DevToolsPooledDataSourceAutoConfigurationTests
 		ConfigurableApplicationContext context = createContext("org.h2.Driver",
 				"jdbc:h2:mem:test", DataSourceAutoConfiguration.class,
 				DataSourceSpyConfiguration.class);
-		Statement statement = configureDataSourceBehaviour(
+		Statement statement = configureDataSourceBehavior(
 				context.getBean(DataSource.class));
 		context.close();
 		verify(statement, times(1)).execute("SHUTDOWN");
@@ -96,7 +96,7 @@ public class DevToolsPooledDataSourceAutoConfigurationTests
 		ConfigurableApplicationContext context = createContext("org.hsqldb.jdbcDriver",
 				"jdbc:hsqldb:hsql://localhost", DataSourceAutoConfiguration.class,
 				DataSourceSpyConfiguration.class);
-		Statement statement = configureDataSourceBehaviour(
+		Statement statement = configureDataSourceBehavior(
 				context.getBean(DataSource.class));
 		context.close();
 		verify(statement, times(0)).execute("SHUTDOWN");
@@ -107,7 +107,7 @@ public class DevToolsPooledDataSourceAutoConfigurationTests
 		ConfigurableApplicationContext context = createContext("org.hsqldb.jdbcDriver",
 				"jdbc:hsqldb:mem:test", DataSourceAutoConfiguration.class,
 				DataSourceSpyConfiguration.class);
-		Statement statement = configureDataSourceBehaviour(
+		Statement statement = configureDataSourceBehavior(
 				context.getBean(DataSource.class));
 		context.close();
 		verify(statement, times(1)).execute("SHUTDOWN");
@@ -118,7 +118,7 @@ public class DevToolsPooledDataSourceAutoConfigurationTests
 		ConfigurableApplicationContext context = createContext(
 				"org.apache.derby.jdbc.ClientDriver", "jdbc:derby://localhost",
 				DataSourceAutoConfiguration.class, DataSourceSpyConfiguration.class);
-		Statement statement = configureDataSourceBehaviour(
+		Statement statement = configureDataSourceBehavior(
 				context.getBean(DataSource.class));
 		context.close();
 		verify(statement, times(0)).execute("SHUTDOWN");
@@ -129,7 +129,7 @@ public class DevToolsPooledDataSourceAutoConfigurationTests
 		ConfigurableApplicationContext context = createContext(
 				"org.apache.derby.jdbc.EmbeddedDriver", "jdbc:derby:memory:test",
 				DataSourceAutoConfiguration.class, DataSourceSpyConfiguration.class);
-		Statement statement = configureDataSourceBehaviour(
+		Statement statement = configureDataSourceBehavior(
 				context.getBean(DataSource.class));
 		context.close();
 		verify(statement, times(1)).execute("SHUTDOWN");

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/DuplicateJsonObjectContextCustomizerFactory.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/DuplicateJsonObjectContextCustomizerFactory.java
@@ -81,7 +81,7 @@ class DuplicateJsonObjectContextCustomizerFactory implements ContextCustomizerFa
 				message.append("\t" + jsonObject + "\n");
 			}
 			message.append("\nYou may wish to exclude one of them to ensure"
-					+ " predictable runtime behaviour\n");
+					+ " predictable runtime behavior\n");
 			this.logger.warn(message);
 		}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/site/apt/examples/repackage-classifier.apt.vm
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/site/apt/examples/repackage-classifier.apt.vm
@@ -7,7 +7,7 @@
  -----
 
   By default, the <<<repackage>>> goal will replace the original artifact with the
-  repackaged one. That's a sane behaviour for modules that represent an app but if
+  repackaged one. That's a sane behavior for modules that represent an app but if
   your module is used as a dependency of another module, you need to provide a
   classifier for the repackaged one.
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContext.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContext.java
@@ -95,7 +95,7 @@ public class ServletWebServerApplicationContext extends GenericWebApplicationCon
 	/**
 	 * Constant value for the DispatcherServlet bean name. A Servlet bean with this name
 	 * is deemed to be the "main" servlet and is automatically given a mapping of "/" by
-	 * default. To change the default behaviour you can use a
+	 * default. To change the default behavior you can use a
 	 * {@link ServletRegistrationBean} or a different bean name.
 	 */
 	public static final String DISPATCHER_SERVLET_NAME = "dispatcherServlet";


### PR DESCRIPTION
Hi,

this PR aligns the spelling of `behavio(u)r` with the style guide at https://github.com/Buzzardo/spring-style-guide/blob/master/spring-style-guide.adoc#spelling

Cheers,
Christoph