### PR TITLE
Add JvmThreadMetrics and JvmGcMetrics binders

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MeterBindersConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MeterBindersConfiguration.java
@@ -43,6 +43,20 @@ class MeterBindersConfiguration {
 		return new JvmMemoryMetrics();
 	}
 
+	@Bean	
+	@ConditionalOnProperty(value = "spring.metrics.binders.jvmthreads.enabled", matchIfMissing = true)
+	@ConditionalOnMissingBean(JvmThreadMetrics.class)
+	public JvmThreadMetrics jvmThreadMetrics() {
+		return new JvmThreadMetrics();
+	}
+
+	@Bean
+	@ConditionalOnProperty(value = "spring.metrics.binders.jvmgc.enabled", matchIfMissing = true)
+	@ConditionalOnMissingBean(JvmGcMetrics.class)
+	public JvmGcMetrics jvmGcMetrics() {
+		return new JvmGcMetrics();
+	}
+
 	@Bean
 	@ConditionalOnMissingBean(LogbackMetrics.class)
 	@ConditionalOnProperty(value = "management.metrics.binders.logback.enabled", matchIfMissing = true)


### PR DESCRIPTION
Micrometer 1.0.0.rc5 containt two more binders for JVM: `JvmThreadMetrics` and `JvmGcMetrics`. I believe it's worth having them out-of-the-box.