### PR TITLE
Use MongoClient consistently

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoDataAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoDataAutoConfiguration.java
@@ -20,7 +20,6 @@ import java.net.UnknownHostException;
 import java.util.Collections;
 
 import com.mongodb.DB;
-import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoDatabase;
 
@@ -73,7 +72,7 @@ import org.springframework.util.StringUtils;
  * @since 1.1.0
  */
 @Configuration
-@ConditionalOnClass({ Mongo.class, MongoTemplate.class })
+@ConditionalOnClass({ MongoClient.class, MongoTemplate.class })
 @EnableConfigurationProperties(MongoProperties.class)
 @AutoConfigureAfter(MongoAutoConfiguration.class)
 public class MongoDataAutoConfiguration {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoRepositoriesAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoRepositoriesAutoConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.autoconfigure.data.mongo;
 
-import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -53,7 +53,7 @@ import org.springframework.data.mongodb.repository.support.MongoRepositoryFactor
  * @see EnableMongoRepositories
  */
 @Configuration
-@ConditionalOnClass({ Mongo.class, MongoRepository.class })
+@ConditionalOnClass({ MongoClient.class, MongoRepository.class })
 @ConditionalOnMissingBean({ MongoRepositoryFactoryBean.class,
 		MongoRepositoryConfigurationExtension.class })
 @ConditionalOnRepositoryType(store = "mongodb", type = RepositoryType.IMPERATIVE)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
 import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
@@ -80,7 +79,7 @@ import org.springframework.util.Assert;
 @Configuration
 @EnableConfigurationProperties({ MongoProperties.class, EmbeddedMongoProperties.class })
 @AutoConfigureBefore(MongoAutoConfiguration.class)
-@ConditionalOnClass({ Mongo.class, MongodStarter.class })
+@ConditionalOnClass({ MongoClient.class, MongodStarter.class })
 public class EmbeddedMongoAutoConfiguration {
 
 	private static final byte[] IP4_LOOPBACK_ADDRESS = { 127, 0, 0, 1 };

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/mongo/MongoDataAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/mongo/MongoDataAutoConfigurationTests.java
@@ -20,7 +20,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Set;
 
-import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 import org.junit.After;
 import org.junit.Test;
 
@@ -96,7 +96,7 @@ public class MongoDataAutoConfigurationTests {
 				MongoAutoConfiguration.class, MongoDataAutoConfiguration.class);
 		this.context.refresh();
 		MongoTemplate template = this.context.getBean(MongoTemplate.class);
-		assertThat(template.getConverter().getConversionService().canConvert(Mongo.class,
+		assertThat(template.getConverter().getConversionService().canConvert(MongoClient.class,
 				Boolean.class)).isTrue();
 	}
 
@@ -203,10 +203,10 @@ public class MongoDataAutoConfigurationTests {
 
 	}
 
-	private static class MyConverter implements Converter<Mongo, Boolean> {
+	private static class MyConverter implements Converter<MongoClient, Boolean> {
 
 		@Override
-		public Boolean convert(Mongo source) {
+		public Boolean convert(MongoClient source) {
 			return null;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/mongo/MongoReactiveRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/mongo/MongoReactiveRepositoriesAutoConfigurationTests.java
@@ -60,8 +60,7 @@ public class MongoReactiveRepositoriesAutoConfigurationTests {
 	public void testDefaultRepositoryConfiguration() {
 		this.runner.withUserConfiguration(TestConfiguration.class).run((context) -> {
 			assertThat(context).hasSingleBean(ReactiveCityRepository.class);
-			MongoClient client = context.getBean(MongoClient.class);
-			assertThat(client).isInstanceOf(MongoClient.class);
+			assertThat(context).hasSingleBean(MongoClient.class);
 			MongoMappingContext mappingContext = context
 					.getBean(MongoMappingContext.class);
 			@SuppressWarnings("unchecked")

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/mongo/MongoRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/mongo/MongoRepositoriesAutoConfigurationTests.java
@@ -18,7 +18,6 @@ package org.springframework.boot.autoconfigure.data.mongo;
 
 import java.util.Set;
 
-import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
 import org.junit.Test;
 
@@ -56,8 +55,7 @@ public class MongoRepositoriesAutoConfigurationTests {
 	public void testDefaultRepositoryConfiguration() {
 		this.runner.withUserConfiguration(TestConfiguration.class).run((context) -> {
 			assertThat(context).hasSingleBean(CityRepository.class);
-			Mongo mongo = context.getBean(Mongo.class);
-			assertThat(mongo).isInstanceOf(MongoClient.class);
+			assertThat(context).hasSingleBean(MongoClient.class);
 			MongoMappingContext mappingContext = context
 					.getBean(MongoMappingContext.class);
 			@SuppressWarnings("unchecked")
@@ -70,8 +68,7 @@ public class MongoRepositoriesAutoConfigurationTests {
 	@Test
 	public void testNoRepositoryConfiguration() {
 		this.runner.withUserConfiguration(EmptyConfiguration.class).run((context) -> {
-			assertThat(context).hasSingleBean(Mongo.class);
-			assertThat(context.getBean(Mongo.class)).isInstanceOf(MongoClient.class);
+			assertThat(context).hasSingleBean(MongoClient.class);
 		});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoAutoConfigurationTests.java
@@ -18,7 +18,6 @@ package org.springframework.boot.autoconfigure.mongo;
 
 import javax.net.SocketFactory;
 
-import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import org.junit.After;
@@ -54,7 +53,7 @@ public class MongoAutoConfigurationTests {
 	public void clientExists() {
 		this.context = new AnnotationConfigApplicationContext(
 				PropertyPlaceholderAutoConfiguration.class, MongoAutoConfiguration.class);
-		assertThat(this.context.getBeanNamesForType(Mongo.class).length).isEqualTo(1);
+		assertThat(this.context.getBeanNamesForType(MongoClient.class)).hasSize(1);
 	}
 
 	@Test


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
`Mongo` and `MongoClient` are mixed and `MongoClient` is preferred based on `Mongo`'s Javadoc as follows:

```
Note: This class has been superseded by {@code MongoClient}, and may be deprecated in a future release.
```

So this PR changes to use `MongoClient` consistently.