### PR TITLE
Move CorsEndpointProperties to the upper package

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/CorsEndpointProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/CorsEndpointProperties.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.actuate.autoconfigure.endpoint.web.servlet;
+package org.springframework.boot.actuate.autoconfigure.endpoint.web;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -23,9 +23,11 @@ import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.convert.DefaultDurationUnit;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.cors.CorsConfiguration;
 
 /**
- * Configuration properties for MVC endpoints' CORS support.
+ * Configuration properties for web endpoints' CORS support.
  *
  * @author Andy Wilkinson
  * @since 2.0.0
@@ -113,6 +115,30 @@ public class CorsEndpointProperties {
 
 	public void setMaxAge(Duration maxAge) {
 		this.maxAge = maxAge;
+	}
+
+	public CorsConfiguration toCorsConfiguration() {
+		if (CollectionUtils.isEmpty(this.allowedOrigins)) {
+			return null;
+		}
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(this.allowedOrigins);
+		if (!CollectionUtils.isEmpty(this.allowedHeaders)) {
+			configuration.setAllowedHeaders(this.allowedHeaders);
+		}
+		if (!CollectionUtils.isEmpty(this.allowedMethods)) {
+			configuration.setAllowedMethods(this.allowedMethods);
+		}
+		if (!CollectionUtils.isEmpty(this.exposedHeaders)) {
+			configuration.setExposedHeaders(this.exposedHeaders);
+		}
+		if (this.maxAge != null) {
+			configuration.setMaxAge(this.maxAge.getSeconds());
+		}
+		if (this.allowCredentials != null) {
+			configuration.setAllowCredentials(this.allowCredentials);
+		}
+		return configuration;
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/reactive/WebFluxEndpointManagementContextConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/reactive/WebFluxEndpointManagementContextConfiguration.java
@@ -16,8 +16,8 @@
 
 package org.springframework.boot.actuate.autoconfigure.endpoint.web.reactive;
 
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
-import org.springframework.boot.actuate.autoconfigure.endpoint.web.servlet.CorsEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.web.EndpointMediaTypes;
@@ -32,8 +32,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.endpoint.web.EndpointMapping;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.server.reactive.HttpHandler;
-import org.springframework.util.CollectionUtils;
-import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.reactive.DispatcherHandler;
 
 /**
@@ -58,31 +56,7 @@ public class WebFluxEndpointManagementContextConfiguration {
 			WebEndpointProperties webEndpointProperties) {
 		return new WebFluxEndpointHandlerMapping(
 				new EndpointMapping(webEndpointProperties.getBasePath()),
-				endpointDiscoverer.discoverEndpoints(), endpointMediaTypes, getCorsConfiguration(corsProperties));
-	}
-
-	private CorsConfiguration getCorsConfiguration(CorsEndpointProperties properties) {
-		if (CollectionUtils.isEmpty(properties.getAllowedOrigins())) {
-			return null;
-		}
-		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(properties.getAllowedOrigins());
-		if (!CollectionUtils.isEmpty(properties.getAllowedHeaders())) {
-			configuration.setAllowedHeaders(properties.getAllowedHeaders());
-		}
-		if (!CollectionUtils.isEmpty(properties.getAllowedMethods())) {
-			configuration.setAllowedMethods(properties.getAllowedMethods());
-		}
-		if (!CollectionUtils.isEmpty(properties.getExposedHeaders())) {
-			configuration.setExposedHeaders(properties.getExposedHeaders());
-		}
-		if (properties.getMaxAge() != null) {
-			configuration.setMaxAge(properties.getMaxAge().getSeconds());
-		}
-		if (properties.getAllowCredentials() != null) {
-			configuration.setAllowCredentials(properties.getAllowCredentials());
-		}
-		return configuration;
+				endpointDiscoverer.discoverEndpoints(), endpointMediaTypes, corsProperties.toCorsConfiguration());
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/servlet/WebMvcEndpointManagementContextConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/servlet/WebMvcEndpointManagementContextConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.endpoint.web.servlet;
 
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
@@ -30,8 +31,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.endpoint.web.EndpointMapping;
 import org.springframework.context.annotation.Bean;
-import org.springframework.util.CollectionUtils;
-import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.servlet.DispatcherServlet;
 
 /**
@@ -58,32 +57,8 @@ public class WebMvcEndpointManagementContextConfiguration {
 		WebMvcEndpointHandlerMapping handlerMapping = new WebMvcEndpointHandlerMapping(
 				new EndpointMapping(webEndpointProperties.getBasePath()),
 				endpointDiscoverer.discoverEndpoints(), endpointMediaTypes,
-				getCorsConfiguration(corsProperties));
+				corsProperties.toCorsConfiguration());
 		return handlerMapping;
-	}
-
-	private CorsConfiguration getCorsConfiguration(CorsEndpointProperties properties) {
-		if (CollectionUtils.isEmpty(properties.getAllowedOrigins())) {
-			return null;
-		}
-		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(properties.getAllowedOrigins());
-		if (!CollectionUtils.isEmpty(properties.getAllowedHeaders())) {
-			configuration.setAllowedHeaders(properties.getAllowedHeaders());
-		}
-		if (!CollectionUtils.isEmpty(properties.getAllowedMethods())) {
-			configuration.setAllowedMethods(properties.getAllowedMethods());
-		}
-		if (!CollectionUtils.isEmpty(properties.getExposedHeaders())) {
-			configuration.setExposedHeaders(properties.getExposedHeaders());
-		}
-		if (properties.getMaxAge() != null) {
-			configuration.setMaxAge(properties.getMaxAge().getSeconds());
-		}
-		if (properties.getAllowCredentials() != null) {
-			configuration.setAllowCredentials(properties.getAllowCredentials());
-		}
-		return configuration;
 	}
 
 }


### PR DESCRIPTION
`CorsEndpointProperties` lives in `org.springframework.boot.actuate.autoconfigure.endpoint.web.servlet` but is also used in `org.springframework.boot.actuate.autoconfigure.endpoint.web.reactive`, so this PR moves it to its common parent package.

This PR also extracts `CorsConfiguration` creation logic duplicated in `WebMvcEndpointManagementContextConfiguration` and `WebFluxEndpointManagementContextConfiguration` into `CorsEndpointProperties`.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->