### PR TITLE
Detect jOOQ SQLDialect through jOOQ's JDBCUtils

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/SqlDialectLookup.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/SqlDialectLookup.java
@@ -16,17 +16,13 @@
 
 package org.springframework.boot.autoconfigure.jooq;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import javax.sql.DataSource;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jooq.SQLDialect;
+import org.jooq.tools.jdbc.JDBCUtils;
 
-import org.springframework.boot.jdbc.DatabaseDriver;
 import org.springframework.jdbc.support.JdbcUtils;
 import org.springframework.jdbc.support.MetaDataAccessException;
 
@@ -34,24 +30,11 @@ import org.springframework.jdbc.support.MetaDataAccessException;
  * Utility to lookup well known {@link SQLDialect SQLDialects} from a {@link DataSource}.
  *
  * @author Michael Simons
+ * @author Lukas Eder
  */
 final class SqlDialectLookup {
 
 	private static final Log logger = LogFactory.getLog(SqlDialectLookup.class);
-
-	private static final Map<DatabaseDriver, SQLDialect> LOOKUP;
-
-	static {
-		Map<DatabaseDriver, SQLDialect> map = new HashMap<>();
-		map.put(DatabaseDriver.DERBY, SQLDialect.DERBY);
-		map.put(DatabaseDriver.H2, SQLDialect.H2);
-		map.put(DatabaseDriver.HSQLDB, SQLDialect.HSQLDB);
-		map.put(DatabaseDriver.MARIADB, SQLDialect.MARIADB);
-		map.put(DatabaseDriver.MYSQL, SQLDialect.MYSQL);
-		map.put(DatabaseDriver.POSTGRESQL, SQLDialect.POSTGRES);
-		map.put(DatabaseDriver.SQLITE, SQLDialect.SQLITE);
-		LOOKUP = Collections.unmodifiableMap(map);
-	}
 
 	private SqlDialectLookup() {
 	}
@@ -67,8 +50,7 @@ final class SqlDialectLookup {
 		}
 		try {
 			String url = JdbcUtils.extractDatabaseMetaData(dataSource, "getURL");
-			DatabaseDriver driver = DatabaseDriver.fromJdbcUrl(url);
-			SQLDialect sqlDialect = LOOKUP.get(driver);
+			SQLDialect sqlDialect = JDBCUtils.dialect(url);
 			if (sqlDialect != null) {
 				return sqlDialect;
 			}


### PR DESCRIPTION
This change amends the previous PR #9355 by @michael-simons, passing the JDBC URL from the `DataSource` directly to jOOQ's `JDBCUtils` rather than creating an additional mapping between `org.springframework.boot.jdbc.DatabaseDriver` and `org.jooq.SQLDialect`.

This has the advantages that:

1. jOOQ's `SQLDialect` to URL mappings are already maintained by jOOQ, so no additional changes will be necessary to Spring Boot, in the future
2. The suggested PR also works for the commercial jOOQ distributions, e.g. when working with DB2, Oracle, SQL Server, etc., as the `JDBCUtils` of the commercial distribution also contains the relevant logic to map to e.g. `SQLDialect.DB2`, `SQLDialect.ORACLE`, `SQLDialect.SQLSERVER` (which are not available from the open source distribution linked by Spring Boot by default).

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->