### PR TITLE
Remove unnecessary condition in ConfigurationPropertyName

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -409,12 +409,7 @@ public final class ConfigurationPropertyName
 	}
 
 	private static boolean isIndexed(CharSequence element) {
-		int length = element.length();
-		return charAt(element, 0) == '[' && charAt(element, length - 1) == ']';
-	}
-
-	private static char charAt(CharSequence element, int index) {
-		return (index < element.length() ? element.charAt(index) : 0);
+		return element.charAt(0) == '[' && element.charAt(element.length() - 1) == ']';
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
`index < element.length()` can't be `false`, so this PR removes the condition.