### PR TITLE
Remove JsonFormat from AuditEvent

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/AuditEvent.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/audit/AuditEvent.java
@@ -22,7 +22,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
@@ -110,7 +109,6 @@ public class AuditEvent implements Serializable {
 	 * Returns the date/time that the even was logged.
 	 * @return the time stamp
 	 */
-	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssZ")
 	public Date getTimestamp() {
 		return this.timestamp;
 	}


### PR DESCRIPTION
In order to align the timestamp format of auditevents with the traces
remove the `@JsonFormat` annotation. This way the date is serialized using
the object mapper's default configuration (as for the traces).
With the spring boot 2.0 default this results in milliseconds to be
serialized in the json. This allow finer grained querying for events via
http as it may be useful for subsequent requests fetching all new events
after the last knwon timestamp from the previous request.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
  