### PR TITLE
Make GsonAutoConfiguration align with JacksonAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfiguration.java
@@ -43,6 +43,7 @@ import org.springframework.core.Ordered;
 public class GsonAutoConfiguration {
 
 	@Bean
+	@ConditionalOnMissingBean(GsonBuilder.class)
 	public GsonBuilder gsonBuilder(List<GsonBuilderCustomizer> customizers) {
 		GsonBuilder builder = new GsonBuilder();
 		customizers.forEach(c -> c.customize(builder));


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR makes `GsonAutoConfiguration` align with `JacksonAutoConfiguration` by:

- Add `@ConditionalOnMissingBean` on `GsonBuilder` `@Bean` method similar to `Jackson2ObjectMapperBuilder`.
- Add `@Primary` to `Gson` `@Bean` method similar to `ObjectMapper`.