### PR TITLE
Upgrade to Micrometer 1.0.0-rc.6

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogProperties.java
@@ -34,6 +34,18 @@ public class DatadogProperties extends StepRegistryProperties {
 	private String apiKey;
 
 	/**
+	 * Datadog application key. Not strictly required, but improves the Datadog
+	 * experience by sending meter descriptions, types, and base units to Datadog.
+	 */
+	private String applicationKey;
+
+	/**
+	 * Enable publishing descriptions metadata to Datadog. Turn
+	 * this off to minimize the amount of metadata sent.
+	 */
+	private Boolean descriptions;
+
+	/**
 	 * Tag that will be mapped to "host" when shipping metrics to Datadog. Can be
 	 * omitted if host should be omitted on publishing.
 	 */
@@ -51,6 +63,22 @@ public class DatadogProperties extends StepRegistryProperties {
 
 	public void setApiKey(String apiKey) {
 		this.apiKey = apiKey;
+	}
+
+	public String getApplicationKey() {
+		return this.applicationKey;
+	}
+
+	public void setApplicationKey(String applicationKey) {
+		this.applicationKey = applicationKey;
+	}
+
+	public Boolean getDescriptions() {
+		return this.descriptions;
+	}
+
+	public void setDescriptions(Boolean descriptions) {
+		this.descriptions = descriptions;
 	}
 
 	public String getHostTag() {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogPropertiesConfigAdapter.java
@@ -54,4 +54,8 @@ class DatadogPropertiesConfigAdapter
 		return get(DatadogProperties::getUri, DatadogConfig.super::uri);
 	}
 
+	@Override
+	public boolean descriptions() {
+		return get(DatadogProperties::getDescriptions, DatadogConfig.super::descriptions);
+	}
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogPropertiesConfigAdapter.java
@@ -40,6 +40,11 @@ class DatadogPropertiesConfigAdapter
 	}
 
 	@Override
+	public String applicationKey() {
+		return get(DatadogProperties::getApplicationKey, DatadogConfig.super::applicationKey);
+	}
+
+	@Override
 	public String hostTag() {
 		return get(DatadogProperties::getHostTag, DatadogConfig.super::hostTag);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxExportConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxExportConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.boot.actuate.autoconfigure.metrics.export.MetricsExpo
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -36,6 +37,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @ConditionalOnClass(JmxMeterRegistry.class)
+@EnableConfigurationProperties(JmxProperties.class)
 public class JmxExportConfiguration {
 
 	@Bean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxExportConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxExportConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.boot.actuate.autoconfigure.metrics.export.jmx;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.util.HierarchicalNameMapper;
+import io.micrometer.jmx.JmxConfig;
 import io.micrometer.jmx.JmxMeterRegistry;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.export.MetricsExporter;
@@ -38,9 +39,16 @@ import org.springframework.context.annotation.Configuration;
 public class JmxExportConfiguration {
 
 	@Bean
+	@ConditionalOnMissingBean
+	public JmxConfig jmxConfig(JmxProperties jmxProperties) {
+		return new JmxPropertiesConfigAdapter(jmxProperties);
+	}
+
+	@Bean
 	@ConditionalOnProperty(value = "management.metrics.export.jmx.enabled", matchIfMissing = true)
-	public MetricsExporter jmxExporter(HierarchicalNameMapper nameMapper, Clock clock) {
-		return () -> new JmxMeterRegistry(nameMapper, clock);
+	public MetricsExporter jmxExporter(JmxConfig config,
+			HierarchicalNameMapper nameMapper, Clock clock) {
+		return () -> new JmxMeterRegistry(config, nameMapper, clock);
 	}
 
 	@Bean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxProperties.java
@@ -18,6 +18,15 @@ package org.springframework.boot.actuate.autoconfigure.metrics.export.jmx;
 
 import java.time.Duration;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * {@link ConfigurationProperties} for configuring JMX metrics export.
+ *
+ * @author Jon Schneider
+ * @since 2.0.0
+ */
+@ConfigurationProperties(prefix = "management.metrics.export.jmx")
 public class JmxProperties {
 	/**
 	 * Step size (i.e. reporting frequency) to use.
@@ -25,7 +34,7 @@ public class JmxProperties {
 	private Duration step;
 
 	public Duration getStep() {
-		return step;
+		return this.step;
 	}
 
 	public void setStep(Duration step) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxProperties.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.export.jmx;
+
+import java.time.Duration;
+
+public class JmxProperties {
+	/**
+	 * Step size (i.e. reporting frequency) to use.
+	 */
+	private Duration step;
+
+	public Duration getStep() {
+		return step;
+	}
+
+	public void setStep(Duration step) {
+		this.step = step;
+	}
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxPropertiesConfigAdapter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.export.jmx;
+
+import java.time.Duration;
+
+import io.micrometer.jmx.JmxConfig;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.export.PropertiesConfigAdapter;
+
+/**
+ * Adapter to convert {@link JmxProperties} to a {@link JmxConfig}.
+ *
+ * @author Jon Schneider
+ */
+class JmxPropertiesConfigAdapter extends PropertiesConfigAdapter<JmxProperties>
+		implements JmxConfig {
+
+	JmxPropertiesConfigAdapter(JmxProperties properties) {
+		super(properties);
+	}
+
+	@Override
+	public String get(String k) {
+		return null;
+	}
+
+	@Override
+	public Duration step() {
+		return get(JmxProperties::getStep, JmxConfig.super::step);
+	}
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsConfiguration.java
@@ -18,14 +18,12 @@ package org.springframework.boot.actuate.autoconfigure.metrics.web.client;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties;
 import org.springframework.boot.actuate.metrics.web.client.DefaultRestTemplateExchangeTagsProvider;
 import org.springframework.boot.actuate.metrics.web.client.MetricsRestTemplateCustomizer;
 import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTagsProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -55,49 +53,6 @@ public class RestTemplateMetricsConfiguration {
 		return new MetricsRestTemplateCustomizer(meterRegistry, restTemplateTagConfigurer,
 				properties.getWeb().getClient().getRequestsMetricName(),
 				properties.getWeb().getClient().isRecordRequestPercentiles());
-	}
-
-	@Bean
-	public static BeanPostProcessor restTemplateInterceptorPostProcessor(
-			ApplicationContext applicationContext) {
-		return new MetricsInterceptorPostProcessor(applicationContext);
-	}
-
-	/**
-	 * {@link BeanPostProcessor} to apply {@link MetricsRestTemplateCustomizer} to any
-	 * directly registered {@link RestTemplate} beans.
-	 */
-	private static class MetricsInterceptorPostProcessor implements BeanPostProcessor {
-
-		private final ApplicationContext applicationContext;
-
-		private MetricsRestTemplateCustomizer customizer;
-
-		MetricsInterceptorPostProcessor(ApplicationContext applicationContext) {
-			this.applicationContext = applicationContext;
-		}
-
-		@Override
-		public Object postProcessBeforeInitialization(Object bean, String beanName) {
-			return bean;
-		}
-
-		@Override
-		public Object postProcessAfterInitialization(Object bean, String beanName) {
-			if (bean instanceof RestTemplate) {
-				getCustomizer().customize((RestTemplate) bean);
-			}
-			return bean;
-		}
-
-		private MetricsRestTemplateCustomizer getCustomizer() {
-			if (this.customizer == null) {
-				this.customizer = this.applicationContext
-						.getBean(MetricsRestTemplateCustomizer.class);
-			}
-			return this.customizer;
-		}
-
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationIntegrationTests.java
@@ -32,6 +32,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.metrics.web.client.DefaultRestTemplateExchangeTagsProvider;
+import org.springframework.boot.actuate.metrics.web.client.MetricsRestTemplateCustomizer;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
@@ -124,8 +126,12 @@ public class MetricsAutoConfigurationIntegrationTests {
 		}
 
 		@Bean
-		public RestTemplate restTemplate() {
-			return new RestTemplate();
+		public RestTemplate restTemplate(MeterRegistry registry) {
+			RestTemplate restTemplate = new RestTemplate();
+			MetricsRestTemplateCustomizer customizer = new MetricsRestTemplateCustomizer(
+					registry, new DefaultRestTemplateExchangeTagsProvider(), "http.client.requests", false);
+			customizer.customize(restTemplate);
+			return restTemplate;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationIntegrationTests.java
@@ -92,7 +92,6 @@ public class MetricsAutoConfigurationIntegrationTests {
 						"{\"message\": \"hello\"}", MediaType.APPLICATION_JSON));
 		assertThat(this.external.getForObject("/api/external", Map.class))
 				.containsKey("message");
-		MockClock.clock(this.registry).add(SimpleConfig.DEFAULT_STEP);
 		assertThat(this.registry.find("http.client.requests").value(Statistic.Count, 1.0)
 				.timer()).isPresent();
 	}
@@ -100,7 +99,6 @@ public class MetricsAutoConfigurationIntegrationTests {
 	@Test
 	public void requestMappingIsInstrumented() {
 		this.loopback.getForObject("/api/people", Set.class);
-		MockClock.clock(this.registry).add(SimpleConfig.DEFAULT_STEP);
 		assertThat(this.registry.find("http.server.requests").value(Statistic.Count, 1.0)
 				.timer()).isPresent();
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogPropertiesConfigAdapterTests.java
@@ -27,6 +27,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class DatadogPropertiesConfigAdapterTests {
 
+	@Test(expected = IllegalStateException.class)
+	public void apiKeyIsRequired() {
+		DatadogProperties properties = new DatadogProperties();
+		new DatadogPropertiesConfigAdapter(properties).apiKey();
+	}
+
 	@Test
 	public void uriCanBeSet() {
 		DatadogProperties properties = new DatadogProperties();

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogPropertiesConfigAdapterTests.java
@@ -28,14 +28,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DatadogPropertiesConfigAdapterTests {
 
 	@Test
-	public void apiKeyInferUri() {
-		DatadogProperties properties = new DatadogProperties();
-		properties.setApiKey("my-key");
-		assertThat(new DatadogPropertiesConfigAdapter(properties).uri())
-				.contains("?api_key=my-key");
-	}
-
-	@Test
 	public void uriCanBeSet() {
 		DatadogProperties properties = new DatadogProperties();
 		properties.setUri("https://app.example.com/api/v1/series");

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleExportConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleExportConfigurationTests.java
@@ -46,7 +46,8 @@ public class SimpleExportConfigurationTests {
 						"management.metrics.export.influx.enabled=false",
 						"management.metrics.export.jmx.enabled=false",
 						"management.metrics.export.prometheus.enabled=false",
-						"management.metrics.export.statsd.enabled=false")
+						"management.metrics.export.statsd.enabled=false",
+						"management.metrics.use-global-registry=false")
 				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class))
 				.run((context) -> {
 					CompositeMeterRegistry meterRegistry = context

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsConfigurationTest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsConfigurationTest.java
@@ -23,6 +23,23 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.cassandra.CassandraAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.cassandra.CassandraDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.neo4j.Neo4jDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.neo4j.Neo4jRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.solr.SolrRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.jest.JestAutoConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.autoconfigure.hazelcast.HazelcastAutoConfiguration;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
@@ -32,7 +49,7 @@ import org.springframework.web.client.RestTemplate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = ClientApp.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest(classes = RestTemplateMetricsConfigurationTest.ClientApp.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
 public class RestTemplateMetricsConfigurationTest {
 	@Autowired
 	private RestTemplate client;
@@ -50,17 +67,28 @@ public class RestTemplateMetricsConfigurationTest {
 		}
 		assertThat(this.registry.find("http.client.requests").meter()).isPresent();
 	}
-}
 
-@SpringBootApplication
-class ClientApp {
-	@Bean
-	public MeterRegistry registry() {
-		return new SimpleMeterRegistry();
+	@SpringBootApplication(exclude = {
+			FlywayAutoConfiguration.class, LiquibaseAutoConfiguration.class,
+			CassandraAutoConfiguration.class, CassandraDataAutoConfiguration.class,
+			Neo4jDataAutoConfiguration.class, Neo4jRepositoriesAutoConfiguration.class,
+			MongoAutoConfiguration.class, RepositoryRestMvcAutoConfiguration.class,
+			HazelcastAutoConfiguration.class, MongoDataAutoConfiguration.class,
+			ElasticsearchAutoConfiguration.class, ElasticsearchDataAutoConfiguration.class,
+			JestAutoConfiguration.class, SolrRepositoriesAutoConfiguration.class,
+			SolrAutoConfiguration.class, RedisAutoConfiguration.class,
+			RedisRepositoriesAutoConfiguration.class
+	})
+	static class ClientApp {
+		@Bean
+		public MeterRegistry registry() {
+			return new SimpleMeterRegistry();
+		}
+
+		@Bean
+		public RestTemplate restTemplate(RestTemplateBuilder builder) {
+			return builder.build();
+		}
 	}
 
-	@Bean
-	public RestTemplate restTemplate(RestTemplateBuilder builder) {
-		return builder.build();
-	}
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsConfigurationTest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsConfigurationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.web.client;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ClientApp.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class RestTemplateMetricsConfigurationTest {
+	@Autowired
+	private RestTemplate client;
+
+	@Autowired
+	private MeterRegistry registry;
+
+	@Test
+	public void restTemplatesCreatedWithBuilderAreInstrumented() {
+		try {
+			this.client.getForObject("http://google.com", String.class);
+		}
+		catch (Throwable ignored) {
+			// doesn't matter whether the request succeeded or not
+		}
+		assertThat(this.registry.find("http.client.requests").meter()).isPresent();
+	}
+}
+
+@SpringBootApplication
+class ClientApp {
+	@Bean
+	public MeterRegistry registry() {
+		return new SimpleMeterRegistry();
+	}
+
+	@Bean
+	public RestTemplate restTemplate(RestTemplateBuilder builder) {
+		return builder.build();
+	}
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsConfigurationTests.java
@@ -49,8 +49,8 @@ import org.springframework.web.client.RestTemplate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = RestTemplateMetricsConfigurationTest.ClientApp.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
-public class RestTemplateMetricsConfigurationTest {
+@SpringBootTest(classes = RestTemplateMetricsConfigurationTests.ClientApp.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class RestTemplateMetricsConfigurationTests {
 	@Autowired
 	private RestTemplate client;
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/cache/CaffeineCacheMeterBinderProvider.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/cache/CaffeineCacheMeterBinderProvider.java
@@ -34,7 +34,7 @@ public class CaffeineCacheMeterBinderProvider
 	@Override
 	public MeterBinder getMeterBinder(CaffeineCache cache, String name,
 			Iterable<Tag> tags) {
-		return new CaffeineCacheMetrics(cache.getNativeCache(), tags, name);
+		return new CaffeineCacheMetrics(cache.getNativeCache(), name, tags);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetrics.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetrics.java
@@ -94,7 +94,7 @@ public class WebMvcMetrics {
 
 	void preHandle(HttpServletRequest request, Object handler) {
 		if (request.getAttribute(TIMING_REQUEST_ATTRIBUTE) == null) {
-			request.setAttribute(TIMING_REQUEST_ATTRIBUTE, registry.config().clock().monotonicTime());
+			request.setAttribute(TIMING_REQUEST_ATTRIBUTE, this.registry.config().clock().monotonicTime());
 		}
 		request.setAttribute(HANDLER_REQUEST_ATTRIBUTE, handler);
 		longTaskTimed(handler).forEach((config) -> {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetrics.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetrics.java
@@ -93,7 +93,9 @@ public class WebMvcMetrics {
 	}
 
 	void preHandle(HttpServletRequest request, Object handler) {
-		request.setAttribute(TIMING_REQUEST_ATTRIBUTE, System.nanoTime());
+		if (request.getAttribute(TIMING_REQUEST_ATTRIBUTE) == null) {
+			request.setAttribute(TIMING_REQUEST_ATTRIBUTE, registry.config().clock().monotonicTime());
+		}
 		request.setAttribute(HANDLER_REQUEST_ATTRIBUTE, handler);
 		longTaskTimed(handler).forEach((config) -> {
 			if (config.getName() == null) {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilter.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilter.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExecutionChain;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
@@ -102,6 +103,7 @@ public class WebMvcMetricsFilter extends OncePerRequestFilter {
 			}
 		}
 		catch (NestedServletException ex) {
+			response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
 			metrics.record(request, response, ex.getCause());
 			throw ex;
 		}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointWebIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointWebIntegrationTests.java
@@ -64,14 +64,12 @@ public class MetricsEndpointWebIntegrationTests {
 
 	@Test
 	public void selectByName() {
-		MockClock.clock(registry).add(SimpleConfig.DEFAULT_STEP);
 		client.get().uri("/actuator/metrics/jvm.memory.used").exchange().expectStatus()
 				.isOk().expectBody().jsonPath("$.name").isEqualTo("jvm.memory.used");
 	}
 
 	@Test
 	public void selectByTag() {
-		MockClock.clock(registry).add(SimpleConfig.DEFAULT_STEP);
 		client.get()
 				.uri("/actuator/metrics/jvm.memory.used?tag=id:Compressed%20Class%20Space")
 				.exchange().expectStatus().isOk().expectBody().jsonPath("$.name")

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/client/MetricsRestTemplateCustomizerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/client/MetricsRestTemplateCustomizerTests.java
@@ -67,7 +67,6 @@ public class MetricsRestTemplateCustomizerTests {
 				.andRespond(MockRestResponseCreators.withSuccess("OK",
 						MediaType.APPLICATION_JSON));
 		String result = this.restTemplate.getForObject("/test/{id}", String.class, 123);
-		MockClock.clock(this.registry).add(SimpleConfig.DEFAULT_STEP);
 		assertThat(this.registry.find("http.client.requests")
 				.meters()).anySatisfy((m) -> assertThat(
 						StreamSupport.stream(m.getId().getTags().spliterator(), false)

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilterAutoTimedTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilterAutoTimedTests.java
@@ -76,7 +76,6 @@ public class WebMvcMetricsFilterAutoTimedTests {
 	public void metricsCanBeAutoTimed() throws Exception {
 		this.mvc.perform(get("/api/10")).andExpect(status().isOk());
 
-		this.clock.add(SimpleConfig.DEFAULT_STEP);
 		assertThat(
 				this.registry.find("http.server.requests").tags("status", "200").timer())
 						.hasValueSatisfying((t) -> assertThat(t.count()).isEqualTo(1));

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilterTests.java
@@ -167,7 +167,7 @@ public class WebMvcMetricsFilterTests {
 	public void unhandledError() {
 		assertThatCode(() -> this.mvc.perform(get("/api/c1/unhandledError/10"))
 				.andExpect(status().isOk()))
-						.hasRootCauseInstanceOf(RuntimeException.class);
+				.hasRootCauseInstanceOf(RuntimeException.class);
 		assertThat(this.registry.find("http.server.requests")
 				.tags("exception", "RuntimeException").value(Statistic.Count, 1.0)
 				.timer()).isPresent();
@@ -250,7 +250,7 @@ public class WebMvcMetricsFilterTests {
 				@Override
 				public MeterFilterReply accept(Meter.Id id) {
 					for (Tag tag : id.getTags()) {
-						if(tag.getKey().equals("uri") && (tag.getValue().contains("histogram") || tag.getValue().contains("percentiles"))) {
+						if (tag.getKey().equals("uri") && (tag.getValue().contains("histogram") || tag.getValue().contains("percentiles"))) {
 							return MeterFilterReply.ACCEPT;
 						}
 					}
@@ -377,7 +377,7 @@ public class WebMvcMetricsFilterTests {
 		@Override
 		protected void doFilterInternal(HttpServletRequest request,
 				HttpServletResponse response, FilterChain filterChain)
-						throws ServletException, IOException {
+				throws ServletException, IOException {
 			String misbehave = request.getHeader(TEST_MISBEHAVE_HEADER);
 			if (misbehave != null) {
 				response.setStatus(Integer.parseInt(misbehave));

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilterTests.java
@@ -21,6 +21,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 
@@ -30,10 +31,18 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Statistic;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.config.MeterFilterReply;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.CollectorRegistry;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +52,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -75,9 +85,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringRunner.class)
 @WebAppConfiguration
 public class WebMvcMetricsFilterTests {
+	@Autowired
+	private SimpleMeterRegistry registry;
 
 	@Autowired
-	private PrometheusMeterRegistry registry;
+	private PrometheusMeterRegistry prometheusRegistry;
 
 	@Autowired
 	private WebApplicationContext context;
@@ -196,15 +208,15 @@ public class WebMvcMetricsFilterTests {
 	@Test
 	public void recordQuantiles() throws Exception {
 		this.mvc.perform(get("/api/c1/percentiles/10")).andExpect(status().isOk());
-		assertThat(this.registry.scrape()).contains("quantile=\"0.5\"");
-		assertThat(this.registry.scrape()).contains("quantile=\"0.95\"");
+		assertThat(this.prometheusRegistry.scrape()).contains("quantile=\"0.5\"");
+		assertThat(this.prometheusRegistry.scrape()).contains("quantile=\"0.95\"");
 	}
 
 	@Test
 	public void recordHistogram() throws Exception {
 		this.mvc.perform(get("/api/c1/histogram/10")).andExpect(status().isOk());
-		assertThat(this.registry.scrape()).contains("le=\"0.001\"");
-		assertThat(this.registry.scrape()).contains("le=\"30.0\"");
+		assertThat(this.prometheusRegistry.scrape()).contains("le=\"0.001\"");
+		assertThat(this.prometheusRegistry.scrape()).contains("le=\"30.0\"");
 	}
 
 	@Target({ ElementType.METHOD })
@@ -218,11 +230,34 @@ public class WebMvcMetricsFilterTests {
 	@EnableWebMvc
 	@Import({ Controller1.class, Controller2.class })
 	static class MetricsFilterApp {
+		@Primary
+		@Bean
+		MeterRegistry meterRegistry(Collection<MeterRegistry> registries) {
+			CompositeMeterRegistry composite = new CompositeMeterRegistry();
+			registries.forEach(composite::add);
+			return composite;
+		}
 
 		@Bean
-		MeterRegistry meterRegistry() {
-			// one of the few registries that support aggregable percentiles
-			return new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+		SimpleMeterRegistry simple() {
+			return new SimpleMeterRegistry();
+		}
+
+		@Bean
+		PrometheusMeterRegistry prometheus() {
+			PrometheusMeterRegistry r = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, new CollectorRegistry(), Clock.SYSTEM);
+			r.config().meterFilter(new MeterFilter() {
+				@Override
+				public MeterFilterReply accept(Meter.Id id) {
+					for (Tag tag : id.getTags()) {
+						if(tag.getKey().equals("uri") && (tag.getValue().contains("histogram") || tag.getValue().contains("percentiles"))) {
+							return MeterFilterReply.ACCEPT;
+						}
+					}
+					return MeterFilterReply.DENY;
+				}
+			});
+			return r;
 		}
 
 		@Bean
@@ -333,7 +368,6 @@ public class WebMvcMetricsFilterTests {
 		public String successful(@PathVariable Long id) {
 			return id.toString();
 		}
-
 	}
 
 	static class RedirectAndNotFoundFilter extends OncePerRequestFilter {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsIntegrationTests.java
@@ -82,7 +82,6 @@ public class WebMvcMetricsIntegrationTests {
 	@Test
 	public void handledExceptionIsRecordedInMetricTag() throws Exception {
 		this.mvc.perform(get("/api/handledError")).andExpect(status().is5xxServerError());
-		this.clock.add(SimpleConfig.DEFAULT_STEP);
 		assertThat(this.registry.find("http.server.requests")
 				.tags("exception", "Exception1", "status", "500").value(Statistic.Count, 1.0).timer())
 						.isPresent();
@@ -92,7 +91,6 @@ public class WebMvcMetricsIntegrationTests {
 	public void rethrownExceptionIsRecordedInMetricTag() {
 		assertThatCode(() -> this.mvc.perform(get("/api/rethrownError"))
 				.andExpect(status().is5xxServerError()));
-		this.clock.add(SimpleConfig.DEFAULT_STEP);
 		assertThat(this.registry.find("http.server.requests")
 				.tags("exception", "Exception2", "status", "500").value(Statistic.Count, 1.0).timer())
 						.isPresent();

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsIntegrationTests.java
@@ -84,7 +84,7 @@ public class WebMvcMetricsIntegrationTests {
 		this.mvc.perform(get("/api/handledError")).andExpect(status().is5xxServerError());
 		this.clock.add(SimpleConfig.DEFAULT_STEP);
 		assertThat(this.registry.find("http.server.requests")
-				.tags("exception", "Exception1").value(Statistic.Count, 1.0).timer())
+				.tags("exception", "Exception1", "status", "500").value(Statistic.Count, 1.0).timer())
 						.isPresent();
 	}
 
@@ -94,7 +94,7 @@ public class WebMvcMetricsIntegrationTests {
 				.andExpect(status().is5xxServerError()));
 		this.clock.add(SimpleConfig.DEFAULT_STEP);
 		assertThat(this.registry.find("http.server.requests")
-				.tags("exception", "Exception2").value(Statistic.Count, 1.0).timer())
+				.tags("exception", "Exception2", "status", "500").value(Statistic.Count, 1.0).timer())
 						.isPresent();
 	}
 

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -113,7 +113,7 @@
 		<logback.version>1.2.3</logback.version>
 		<lombok.version>1.16.18</lombok.version>
 		<mariadb.version>2.2.1</mariadb.version>
-		<micrometer.version>1.0.0-rc.5</micrometer.version>
+		<micrometer.version>1.0.0-rc.6</micrometer.version>
 		<mssql-jdbc.version>6.2.2.jre8</mssql-jdbc.version>
 		<mockito.version>2.13.0</mockito.version>
 		<mongo-driver-reactivestreams.version>1.7.0</mongo-driver-reactivestreams.version>
@@ -877,6 +877,11 @@
 			<dependency>
 				<groupId>io.micrometer</groupId>
 				<artifactId>micrometer-registry-jmx</artifactId>
+				<version>${micrometer.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.micrometer</groupId>
+				<artifactId>micrometer-registry-new-relic</artifactId>
 				<version>${micrometer.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
cc / @snicoll 

Here are the updates for rc6. I wrote one commit per feature/fix from rc6 so you can reach back into Micrometer issues for context if you care to.

There are two bits left outstanding:

1. https://github.com/micrometer-metrics/micrometer/issues/122. We'll come back to this in a later commit. New Relic support was a bit tentative, and after some good chats I think we should support (by default) New Relic's assumption that every timing/distribution summary sample is sent to Insights to fully realize NRQL, in spite of the fact that we know this won't scale well. We'll keep the precomputed step aggregates we have now and allow users to switch to it if they see their costs rise with NR or performance degrade.

2. We added back Tomcat metrics in https://github.com/micrometer-metrics/micrometer/issues/257 and a few related issues. Boot 1.5 had a `TomcatPublicMetrics`, and this goes a bit further. The types we used in our backport to 1.5 aren't around anymore in Boot 2 and I honestly don't know the equivalent: https://github.com/micrometer-metrics/micrometer/blob/master/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/tomcat/TomcatMetricsConfiguration.java#L39