### PR TITLE
TestRestTemplate Kotlin extension improvements

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/kotlin/org/springframework/boot/test/web/client/TestRestTemplateExtensions.kt
+++ b/spring-boot-project/spring-boot-test/src/main/kotlin/org/springframework/boot/test/web/client/TestRestTemplateExtensions.kt
@@ -25,8 +25,10 @@ import org.springframework.web.client.RestClientException
 import java.net.URI
 
 /**
- * Extension for [TestRestTemplate.getForObject] avoiding specifying the type
- * parameter thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.getForObject] providing a `getForObject<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -36,8 +38,10 @@ inline fun <reified T : Any> TestRestTemplate.getForObject(url: String, vararg u
 		getForObject(url, T::class.java, *uriVariables)
 
 /**
- * Extension for [TestRestTemplate.getForObject] avoiding specifying the type
- * parameter thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.getForObject] providing a `getForObject<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -47,8 +51,10 @@ inline fun <reified T : Any> TestRestTemplate.getForObject(url: String, uriVaria
 		getForObject(url, T::class.java, uriVariables)
 
 /**
- * Extension for [TestRestTemplate.getForObject] avoiding specifying the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.getForObject] providing a `getForObject<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -58,8 +64,10 @@ inline fun <reified T : Any> TestRestTemplate.getForObject(url: URI): T? =
 		getForObject(url, T::class.java)
 
 /**
- * Extension for [TestRestTemplate.getForEntity] avoiding requiring the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.getForEntity] providing a `getForEntity<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -69,8 +77,10 @@ inline fun <reified T : Any> TestRestTemplate.getForEntity(url: URI): ResponseEn
 		getForEntity(url, T::class.java)
 
 /**
- * Extension for [TestRestTemplate.getForEntity] avoiding requiring the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.getForEntity] providing a `getForEntity<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -80,8 +90,10 @@ inline fun <reified T : Any> TestRestTemplate.getForEntity(url: String, vararg u
 		getForEntity(url, T::class.java, *uriVariables)
 
 /**
- * Extension for [TestRestTemplate.getForEntity] avoiding requiring the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.getForEntity] providing a `getForEntity<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -91,8 +103,10 @@ inline fun <reified T : Any> TestRestTemplate.getForEntity(url: String, uriVaria
 		getForEntity(url, T::class.java, uriVariables)
 
 /**
- * Extension for [TestRestTemplate.patchForObject] avoiding specifying the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.patchForObject] providing a `patchForObject<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -102,8 +116,10 @@ inline fun <reified T : Any> TestRestTemplate.patchForObject(url: String, reques
 		patchForObject(url, request, T::class.java, *uriVariables)
 
 /**
- * Extension for [TestRestTemplate.patchForObject] avoiding specifying the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.patchForObject] providing a `patchForObject<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -113,8 +129,10 @@ inline fun <reified T : Any> TestRestTemplate.patchForObject(url: String, reques
 		patchForObject(url, request, T::class.java, uriVariables)
 
 /**
- * Extension for [TestRestTemplate.patchForObject] avoiding specifying the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.patchForObject] providing a `patchForObject<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -124,8 +142,10 @@ inline fun <reified T : Any> TestRestTemplate.patchForObject(url: URI, request: 
 		patchForObject(url, request, T::class.java)
 
 /**
- * Extension for [TestRestTemplate.postForObject] avoiding specifying the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.postForObject] providing a `postForObject<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -135,8 +155,10 @@ inline fun <reified T : Any> TestRestTemplate.postForObject(url: String, request
 		postForObject(url, request, T::class.java, *uriVariables)
 
 /**
- * Extension for [TestRestTemplate.postForObject] avoiding specifying the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.postForObject] providing a `postForObject<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -146,8 +168,10 @@ inline fun <reified T : Any> TestRestTemplate.postForObject(url: String, request
 		postForObject(url, request, T::class.java, uriVariables)
 
 /**
- * Extension for [TestRestTemplate.postForObject] avoiding specifying the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.postForObject] providing a `postForObject<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -157,8 +181,10 @@ inline fun <reified T : Any> TestRestTemplate.postForObject(url: URI, request: A
 		postForObject(url, request, T::class.java)
 
 /**
- * Extension for [TestRestTemplate.postForEntity] avoiding specifying the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.postForEntity] providing a `postForEntity<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -168,8 +194,10 @@ inline fun <reified T : Any> TestRestTemplate.postForEntity(url: String, request
 		postForEntity(url, request, T::class.java, *uriVariables)
 
 /**
- * Extension for [TestRestTemplate.postForEntity] avoiding specifying the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.postForEntity] providing a `postForEntity<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -179,8 +207,10 @@ inline fun <reified T : Any> TestRestTemplate.postForEntity(url: String, request
 		postForEntity(url, request, T::class.java, uriVariables)
 
 /**
- * Extension for [TestRestTemplate.postForEntity] avoiding specifying the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.postForEntity] providing a `postForEntity<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -190,8 +220,9 @@ inline fun <reified T : Any> TestRestTemplate.postForEntity(url: URI, request: A
 		postForEntity(url, request, T::class.java)
 
 /**
- * Extension for [TestRestTemplate.exchange] avoiding specifying the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.exchange] providing an `exchange<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. This extension is not subject to
+ * type erasure and retains actual generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -201,8 +232,9 @@ inline fun <reified T : Any> TestRestTemplate.exchange(url: String, method: Http
 		exchange(url, method, requestEntity, object : ParameterizedTypeReference<T>() {}, *uriVariables)
 
 /**
- * Extension for [TestRestTemplate.exchange] avoiding specifying the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.exchange] providing an `exchange<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. This extension is not subject to
+ * type erasure and retains actual generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -212,8 +244,9 @@ inline fun <reified T : Any> TestRestTemplate.exchange(url: String, method: Http
 		exchange(url, method, requestEntity, object : ParameterizedTypeReference<T>() {}, uriVariables)
 
 /**
- * Extension for [TestRestTemplate.exchange] avoiding specifying the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.exchange] providing an `exchange<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. This extension is not subject to
+ * type erasure and retains actual generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0
@@ -223,8 +256,9 @@ inline fun <reified T : Any> TestRestTemplate.exchange(url: URI, method: HttpMet
 		exchange(url, method, requestEntity, object : ParameterizedTypeReference<T>() {})
 
 /**
- * Extension for [TestRestTemplate.exchange] avoiding specifying the type parameter
- * thanks to Kotlin reified type parameters.
+ * Extension for [TestRestTemplate.exchange] providing an `exchange<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. This extension is not subject to
+ * type erasure and retains actual generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 2.0.0

--- a/spring-boot-project/spring-boot-test/src/main/kotlin/org/springframework/boot/test/web/client/TestRestTemplateExtensions.kt
+++ b/spring-boot-project/spring-boot-test/src/main/kotlin/org/springframework/boot/test/web/client/TestRestTemplateExtensions.kt
@@ -112,7 +112,8 @@ inline fun <reified T : Any> TestRestTemplate.getForEntity(url: String, uriVaria
  * @since 2.0.0
  */
 @Throws(RestClientException::class)
-inline fun <reified T : Any> TestRestTemplate.patchForObject(url: String, request: Any, vararg uriVariables: Any): T? =
+inline fun <reified T : Any> TestRestTemplate.patchForObject(url: String, request: Any? = null,
+															 vararg uriVariables: Any): T? =
 		patchForObject(url, request, T::class.java, *uriVariables)
 
 /**
@@ -125,7 +126,8 @@ inline fun <reified T : Any> TestRestTemplate.patchForObject(url: String, reques
  * @since 2.0.0
  */
 @Throws(RestClientException::class)
-inline fun <reified T : Any> TestRestTemplate.patchForObject(url: String, request: Any, uriVariables: Map<String, *>): T? =
+inline fun <reified T : Any> TestRestTemplate.patchForObject(url: String, request: Any? = null,
+															 uriVariables: Map<String, *>): T? =
 		patchForObject(url, request, T::class.java, uriVariables)
 
 /**
@@ -138,7 +140,7 @@ inline fun <reified T : Any> TestRestTemplate.patchForObject(url: String, reques
  * @since 2.0.0
  */
 @Throws(RestClientException::class)
-inline fun <reified T : Any> TestRestTemplate.patchForObject(url: URI, request: Any): T? =
+inline fun <reified T : Any> TestRestTemplate.patchForObject(url: URI, request: Any? = null): T? =
 		patchForObject(url, request, T::class.java)
 
 /**
@@ -151,7 +153,8 @@ inline fun <reified T : Any> TestRestTemplate.patchForObject(url: URI, request: 
  * @since 2.0.0
  */
 @Throws(RestClientException::class)
-inline fun <reified T : Any> TestRestTemplate.postForObject(url: String, request: Any, vararg uriVariables: Any): T? =
+inline fun <reified T : Any> TestRestTemplate.postForObject(url: String, request: Any? = null,
+															vararg uriVariables: Any): T? =
 		postForObject(url, request, T::class.java, *uriVariables)
 
 /**
@@ -164,7 +167,8 @@ inline fun <reified T : Any> TestRestTemplate.postForObject(url: String, request
  * @since 2.0.0
  */
 @Throws(RestClientException::class)
-inline fun <reified T : Any> TestRestTemplate.postForObject(url: String, request: Any, uriVariables: Map<String, *>): T? =
+inline fun <reified T : Any> TestRestTemplate.postForObject(url: String, request: Any? = null,
+															uriVariables: Map<String, *>): T? =
 		postForObject(url, request, T::class.java, uriVariables)
 
 /**
@@ -177,7 +181,7 @@ inline fun <reified T : Any> TestRestTemplate.postForObject(url: String, request
  * @since 2.0.0
  */
 @Throws(RestClientException::class)
-inline fun <reified T : Any> TestRestTemplate.postForObject(url: URI, request: Any): T? =
+inline fun <reified T : Any> TestRestTemplate.postForObject(url: URI, request: Any? = null): T? =
 		postForObject(url, request, T::class.java)
 
 /**
@@ -190,7 +194,8 @@ inline fun <reified T : Any> TestRestTemplate.postForObject(url: URI, request: A
  * @since 2.0.0
  */
 @Throws(RestClientException::class)
-inline fun <reified T : Any> TestRestTemplate.postForEntity(url: String, request: Any, vararg uriVariables: Any): ResponseEntity<T> =
+inline fun <reified T : Any> TestRestTemplate.postForEntity(url: String, request: Any? = null,
+															vararg uriVariables: Any): ResponseEntity<T> =
 		postForEntity(url, request, T::class.java, *uriVariables)
 
 /**
@@ -203,7 +208,8 @@ inline fun <reified T : Any> TestRestTemplate.postForEntity(url: String, request
  * @since 2.0.0
  */
 @Throws(RestClientException::class)
-inline fun <reified T : Any> TestRestTemplate.postForEntity(url: String, request: Any, uriVariables: Map<String, *>): ResponseEntity<T> =
+inline fun <reified T : Any> TestRestTemplate.postForEntity(url: String, request: Any? = null,
+															uriVariables: Map<String, *>): ResponseEntity<T> =
 		postForEntity(url, request, T::class.java, uriVariables)
 
 /**
@@ -216,7 +222,7 @@ inline fun <reified T : Any> TestRestTemplate.postForEntity(url: String, request
  * @since 2.0.0
  */
 @Throws(RestClientException::class)
-inline fun <reified T : Any> TestRestTemplate.postForEntity(url: URI, request: Any): ResponseEntity<T> =
+inline fun <reified T : Any> TestRestTemplate.postForEntity(url: URI, request: Any? = null): ResponseEntity<T> =
 		postForEntity(url, request, T::class.java)
 
 /**
@@ -228,7 +234,8 @@ inline fun <reified T : Any> TestRestTemplate.postForEntity(url: URI, request: A
  * @since 2.0.0
  */
 @Throws(RestClientException::class)
-inline fun <reified T : Any> TestRestTemplate.exchange(url: String, method: HttpMethod, requestEntity: HttpEntity<*>, vararg uriVariables: Any): ResponseEntity<T> =
+inline fun <reified T : Any> TestRestTemplate.exchange(url: String, method: HttpMethod,
+		requestEntity: HttpEntity<*>? = null, vararg uriVariables: Any): ResponseEntity<T> =
 		exchange(url, method, requestEntity, object : ParameterizedTypeReference<T>() {}, *uriVariables)
 
 /**
@@ -240,7 +247,8 @@ inline fun <reified T : Any> TestRestTemplate.exchange(url: String, method: Http
  * @since 2.0.0
  */
 @Throws(RestClientException::class)
-inline fun <reified T : Any> TestRestTemplate.exchange(url: String, method: HttpMethod, requestEntity: HttpEntity<*>, uriVariables: Map<String, *>): ResponseEntity<T> =
+inline fun <reified T : Any> TestRestTemplate.exchange(url: String, method: HttpMethod,
+		requestEntity: HttpEntity<*>? = null, uriVariables: Map<String, *>): ResponseEntity<T> =
 		exchange(url, method, requestEntity, object : ParameterizedTypeReference<T>() {}, uriVariables)
 
 /**
@@ -252,7 +260,8 @@ inline fun <reified T : Any> TestRestTemplate.exchange(url: String, method: Http
  * @since 2.0.0
  */
 @Throws(RestClientException::class)
-inline fun <reified T : Any> TestRestTemplate.exchange(url: URI, method: HttpMethod, requestEntity: HttpEntity<*>): ResponseEntity<T> =
+inline fun <reified T : Any> TestRestTemplate.exchange(url: URI, method: HttpMethod,
+		requestEntity: HttpEntity<*>? = null): ResponseEntity<T> =
 		exchange(url, method, requestEntity, object : ParameterizedTypeReference<T>() {})
 
 /**

--- a/spring-boot-project/spring-boot-test/src/test/kotlin/org/springframework/boot/test/web/client/TestRestTemplateExtensionsTests.kt
+++ b/spring-boot-project/spring-boot-test/src/test/kotlin/org/springframework/boot/test/web/client/TestRestTemplateExtensionsTests.kt
@@ -123,6 +123,13 @@ class TestRestTemplateExtensionsTests {
 	}
 
 	@Test
+	fun `patchForObject with reified type parameters`() {
+		val url = "https://spring.io"
+		template.patchForObject<Foo>(url)
+		verify(template, times(1)).patchForObject(url, null, Foo::class.java)
+	}
+
+	@Test
 	fun `postForObject with reified type parameters, String, Any and varargs`() {
 		val url = "https://spring.io"
 		val body: Any = "body"
@@ -150,6 +157,13 @@ class TestRestTemplateExtensionsTests {
 	}
 
 	@Test
+	fun `postForObject with reified type parameters`() {
+			val url = "https://spring.io"
+			template.postForObject<Foo>(url)
+			verify(template, times(1)).postForObject(url, null, Foo::class.java)
+	}
+
+	@Test
 	fun `postForEntity with reified type parameters, String, Any and varargs`() {
 		val url = "https://spring.io"
 		val body: Any = "body"
@@ -174,6 +188,13 @@ class TestRestTemplateExtensionsTests {
 		val body: Any = "body"
 		template.postForEntity<Foo>(url, body)
 		verify(template, times(1)).postForEntity(url, body, Foo::class.java)
+	}
+
+	@Test
+	fun `postForEntity with reified type parameters`() {
+			val url = "https://spring.io"
+			template.postForEntity<Foo>(url)
+			verify(template, times(1)).postForEntity(url, null, Foo::class.java)
 	}
 
 	@Test
@@ -214,6 +235,15 @@ class TestRestTemplateExtensionsTests {
 		val entity = mock<RequestEntity<Foo>>()
 		template.exchange<List<Foo>>(entity)
 		verify(template, times(1)).exchange(entity,
+				object : ParameterizedTypeReference<List<Foo>>() {})
+	}
+
+	@Test
+	fun `exchange with reified type parameters, String and HttpMethod`() {
+		val url = "https://spring.io"
+		val method = HttpMethod.GET
+		template.exchange<List<Foo>>(url, method)
+		verify(template, times(1)).exchange(url, method, null,
 				object : ParameterizedTypeReference<List<Foo>>() {})
 	}
 


### PR DESCRIPTION
This pull request clarifies `TestRestTemplate` documentation about type erasure and makes Kotlin API consistent with `RestOperations` Java API null-safety using optional nullable parameters with `null` default value in order to provide more flexibility.