### PR TITLE
Fix typo in DynamicRegistrationBean class name

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfiguration.java
@@ -56,7 +56,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.web.servlet.DynaimcRegistrationBean;
+import org.springframework.boot.web.servlet.DynamicRegistrationBean;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -181,7 +181,7 @@ public class JerseyAutoConfiguration implements ServletContextAware {
 		return ClassUtils.getUserClass(this.config.getClass()).getName();
 	}
 
-	private void addInitParameters(DynaimcRegistrationBean<?> registration) {
+	private void addInitParameters(DynamicRegistrationBean<?> registration) {
 		for (Entry<String, String> entry : this.jersey.getInit().entrySet()) {
 			registration.addInitParameter(entry.getKey(), entry.getValue());
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/AbstractFilterRegistrationBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/AbstractFilterRegistrationBean.java
@@ -42,7 +42,7 @@ import org.springframework.util.Assert;
  * @author Phillip Webb
  */
 abstract class AbstractFilterRegistrationBean<T extends Filter>
-		extends DynaimcRegistrationBean<FilterRegistration.Dynamic> {
+		extends DynamicRegistrationBean<Dynamic> {
 
 	/**
 	 * Filters that wrap the servlet request should be ordered less than or equal to this.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/DynamicRegistrationBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/DynamicRegistrationBean.java
@@ -37,7 +37,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @since 2.0.0
  */
-public abstract class DynaimcRegistrationBean<D extends Registration.Dynamic>
+public abstract class DynamicRegistrationBean<D extends Registration.Dynamic>
 		extends RegistrationBean {
 
 	private static final Log logger = LogFactory.getLog(RegistrationBean.class);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletContextInitializerBeans.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletContextInitializerBeans.java
@@ -246,7 +246,7 @@ public class ServletContextInitializerBeans
 	}
 
 	/**
-	 * Adapter to convert a given Bean type into a {@link DynaimcRegistrationBean} (and
+	 * Adapter to convert a given Bean type into a {@link DynamicRegistrationBean} (and
 	 * hence a {@link ServletContextInitializer}.
 	 */
 	private interface RegistrationBeanAdapter<T> {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletRegistrationBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletRegistrationBean.java
@@ -51,7 +51,7 @@ import org.springframework.util.ObjectUtils;
  * @see ServletContext#addServlet(String, Servlet)
  */
 public class ServletRegistrationBean<T extends Servlet>
-		extends DynaimcRegistrationBean<ServletRegistration.Dynamic> {
+		extends DynamicRegistrationBean<ServletRegistration.Dynamic> {
 
 	private static final Log logger = LogFactory.getLog(ServletRegistrationBean.class);
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR fixes typo in `DynamicRegistrationBean` class name.