### PR TITLE
Add check for missing Liquibase's class `CustomResolverServiceLocator`

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/liquibase/LiquibaseServiceLocatorApplicationListener.java
+++ b/spring-boot/src/main/java/org/springframework/boot/liquibase/LiquibaseServiceLocatorApplicationListener.java
@@ -31,6 +31,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Phillip Webb
  * @author Dave Syer
+ * @author Eddú Meléndez
  */
 public class LiquibaseServiceLocatorApplicationListener
 		implements ApplicationListener<ApplicationStartingEvent> {
@@ -51,12 +52,14 @@ public class LiquibaseServiceLocatorApplicationListener
 	private static class LiquibasePresent {
 
 		public void replaceServiceLocator() {
-			CustomResolverServiceLocator customResolverServiceLocator = new CustomResolverServiceLocator(
-					new SpringPackageScanClassResolver(logger));
-			customResolverServiceLocator.addPackageToScan(
-					CommonsLoggingLiquibaseLogger.class.getPackage().getName());
-			ServiceLocator.setInstance(customResolverServiceLocator);
-			liquibase.logging.LogFactory.reset();
+			if (ClassUtils.isPresent("liquibase.servicelocator.CustomResolverServiceLocator", null)) {
+				CustomResolverServiceLocator customResolverServiceLocator = new CustomResolverServiceLocator(
+						new SpringPackageScanClassResolver(logger));
+				customResolverServiceLocator.addPackageToScan(
+						CommonsLoggingLiquibaseLogger.class.getPackage().getName());
+				ServiceLocator.setInstance(customResolverServiceLocator);
+				liquibase.logging.LogFactory.reset();
+			}
 		}
 
 	}


### PR DESCRIPTION
`CustomResolverServiceLocator` was introduced in Liquibase 2.0.4, this
check prevents failures during initialization when previous versions are
used.

See gh-11608

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->