### PR TITLE
CharacterEncodingFilter has higher precedence than WebMvcMetricsFilter

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilter.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilter.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExecutionChain;
@@ -43,8 +42,7 @@ import org.springframework.web.util.NestedServletException;
  * @author Jon Schneider
  * @since 2.0.0
  */
-@Order(Ordered.HIGHEST_PRECEDENCE)
-public class WebMvcMetricsFilter extends OncePerRequestFilter {
+public class WebMvcMetricsFilter extends OncePerRequestFilter implements Ordered {
 
 	private static final Logger logger = LoggerFactory
 			.getLogger(WebMvcMetricsFilter.class);
@@ -54,6 +52,8 @@ public class WebMvcMetricsFilter extends OncePerRequestFilter {
 	private volatile WebMvcMetrics webMvcMetrics;
 
 	private volatile HandlerMappingIntrospector mappingIntrospector;
+
+	private int order = Ordered.HIGHEST_PRECEDENCE;
 
 	public WebMvcMetricsFilter(ApplicationContext context) {
 		this.context = context;
@@ -124,4 +124,16 @@ public class WebMvcMetricsFilter extends OncePerRequestFilter {
 		return this.webMvcMetrics;
 	}
 
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	/**
+	 * Set the order for this filter.
+	 * @param order the order to set
+	 */
+	public void setOrder(int order) {
+		this.order = order;
+	}
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsIntegrationTests.java
@@ -16,6 +16,13 @@
 
 package org.springframework.boot.actuate.metrics.web.servlet;
 
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.Filter;
+import javax.servlet.ServletContext;
+
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -23,16 +30,21 @@ import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.filter.OrderedCharacterEncodingFilter;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -40,14 +52,19 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -71,12 +88,12 @@ public class WebMvcMetricsIntegrationTests {
 	private MockMvc mvc;
 
 	@Autowired
-	private WebMvcMetricsFilter filter;
+	private Filter[] filters;
 
 	@Before
 	public void setupMockMvc() {
 		this.mvc = MockMvcBuilders.webAppContextSetup(this.context)
-				.addFilters(this.filter).build();
+				.addFilters(this.filters).build();
 	}
 
 	@Test
@@ -94,6 +111,18 @@ public class WebMvcMetricsIntegrationTests {
 		assertThat(this.registry.find("http.server.requests")
 				.tags("exception", "Exception2", "status", "500")
 				.value(Statistic.Count, 1.0).timer()).isPresent();
+	}
+
+	@Test
+	public void characterEncodingFilterMustHaveHigherPriorityThanMetricsFilter()
+			throws Exception {
+		final String utf8Param = "Vedran Pavić";
+		this.mvc.perform(
+				servletContext -> new ParamEncodingHttpServletRequest(servletContext,
+						HttpMethod.POST.name(), "/api/pv/post")
+								.contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+								.param("name", utf8Param))
+				.andExpect(content().string(utf8Param));
 	}
 
 	@Configuration
@@ -121,6 +150,15 @@ public class WebMvcMetricsIntegrationTests {
 			return new WebMvcMetricsFilter(context);
 		}
 
+		@Bean
+		public CharacterEncodingFilter characterEncodingFilter() {
+			final OrderedCharacterEncodingFilter encodingFilter = new OrderedCharacterEncodingFilter();
+			encodingFilter.setEncoding("UTF-8");
+			encodingFilter.setForceRequestEncoding(true);
+			encodingFilter.setForceResponseEncoding(true);
+			return encodingFilter;
+		}
+
 		@RestController
 		@RequestMapping("/api")
 		@Timed
@@ -139,6 +177,17 @@ public class WebMvcMetricsIntegrationTests {
 			@GetMapping("/rethrownError")
 			public String rethrownError() {
 				throw new Exception2();
+			}
+
+			@GetMapping(params = { "first", "second" })
+			public String getWithParams() {
+				return "getWithParams";
+			}
+
+			@PostMapping(path = "/{pv}/post", produces = "text/plain;charset=UTF-8")
+			public String handlePost(@PathVariable("pv") String pv,
+					@RequestParam("name") String name) {
+				return name;
 			}
 
 		}
@@ -171,6 +220,63 @@ public class WebMvcMetricsIntegrationTests {
 			throw ex;
 		}
 
+	}
+
+	private static class ParamEncodingHttpServletRequest extends MockHttpServletRequest {
+
+		private Map<String, String[]> parameterMap;
+
+		ParamEncodingHttpServletRequest(ServletContext servletContext, String method,
+				String requestUri) {
+			super(servletContext, method, requestUri);
+		}
+
+		ParamEncodingHttpServletRequest param(String name, String value) {
+			setParameter(name, value);
+			return this;
+		}
+
+		ParamEncodingHttpServletRequest contentType(String contentType) {
+			setContentType(contentType);
+			return this;
+		}
+
+		@Override
+		public String getCharacterEncoding() {
+			return StringUtils.defaultIfBlank(super.getCharacterEncoding(), "ISO-8859-1");
+		}
+
+		@Override
+		public Map<String, String[]> getParameterMap() {
+			if (this.parameterMap == null) {
+				initParamMap();
+			}
+			return this.parameterMap;
+		}
+
+		private void initParamMap() {
+			this.parameterMap = new HashMap<>(super.getParameterMap());
+			for (Map.Entry<String, String[]> entry : this.parameterMap.entrySet()) {
+				this.parameterMap.put(entry.getKey(), encodeParamValues(entry.getValue()));
+			}
+		}
+
+		@Override
+		public String[] getParameterValues(String name) {
+			if (this.parameterMap == null) {
+				initParamMap();
+			}
+			return this.parameterMap.get(name);
+		}
+
+		private String[] encodeParamValues(String[] values) {
+			final String[] encodedValues = new String[values.length];
+			for (int i = 0; i < values.length; i++) {
+				encodedValues[i] = new String(values[i].getBytes(),
+						Charset.forName(getCharacterEncoding()));
+			}
+			return encodedValues;
+		}
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/filter/OrderedCharacterEncodingFilter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/filter/OrderedCharacterEncodingFilter.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.web.servlet.filter;
 
 import org.springframework.core.Ordered;
+import org.springframework.core.PriorityOrdered;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 /**
@@ -26,7 +27,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
  * @since 2.0.0
  */
 public class OrderedCharacterEncodingFilter extends CharacterEncodingFilter
-		implements Ordered {
+		implements PriorityOrdered {
 
 	private int order = Ordered.HIGHEST_PRECEDENCE;
 


### PR DESCRIPTION
Made OrderedCharacterEncodingFilter to have higher precedence than WebMvcMetricsFilter

Made the OrderedCharacterEncodingFilter implement PriorityOrdered
Changed the WebMvcMetricsFilter to implement Ordered and provided
an option to change the order.

Fixes gh-11607

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->