### PR TITLE
Make all metrics exporters conditional on missing bean.

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/atlas/AtlasExportConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/atlas/AtlasExportConfiguration.java
@@ -40,13 +40,16 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(AtlasProperties.class)
 public class AtlasExportConfiguration {
 
+	public static final String ATLAS_EXPORTER_NAME = "atlasExporter";
+
 	@Bean
 	@ConditionalOnMissingBean(AtlasConfig.class)
 	public AtlasConfig atlasConfig(AtlasProperties atlasProperties) {
 		return new AtlasPropertiesConfigAdapter(atlasProperties);
 	}
 
-	@Bean
+	@Bean(name = ATLAS_EXPORTER_NAME)
+	@ConditionalOnMissingBean(name = ATLAS_EXPORTER_NAME)
 	@ConditionalOnProperty(value = "management.metrics.export.atlas.enabled", matchIfMissing = true)
 	public MetricsExporter atlasExporter(AtlasConfig atlasConfig, Clock clock) {
 		return () -> new AtlasMeterRegistry(atlasConfig, clock);

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogExportConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogExportConfiguration.java
@@ -40,13 +40,16 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(DatadogProperties.class)
 public class DatadogExportConfiguration {
 
+	public static final String DATALOG_EXPORTER_NAME = "datadogExporter";
+
 	@Bean
 	@ConditionalOnMissingBean
 	public DatadogConfig datadogConfig(DatadogProperties datadogProperties) {
 		return new DatadogPropertiesConfigAdapter(datadogProperties);
 	}
 
-	@Bean
+	@Bean(name = DATALOG_EXPORTER_NAME)
+	@ConditionalOnMissingBean(name = DATALOG_EXPORTER_NAME)
 	@ConditionalOnProperty(value = "management.metrics.export.datadog.enabled", matchIfMissing = true)
 	public MetricsExporter datadogExporter(DatadogConfig datadogConfig, Clock clock) {
 		return () -> new DatadogMeterRegistry(datadogConfig, clock);

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/ganglia/GangliaExportConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/ganglia/GangliaExportConfiguration.java
@@ -40,13 +40,16 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(GangliaProperties.class)
 public class GangliaExportConfiguration {
 
+	public static final String GANGLIA_EXPORTER_NAME = "gangliaExporter";
+
 	@Bean
 	@ConditionalOnMissingBean
 	public GangliaConfig gangliaConfig(GangliaProperties gangliaProperties) {
 		return new GangliaPropertiesConfigAdapter(gangliaProperties);
 	}
 
-	@Bean
+	@Bean(name = GANGLIA_EXPORTER_NAME)
+	@ConditionalOnMissingBean(name = GANGLIA_EXPORTER_NAME)
 	@ConditionalOnProperty(value = "management.metrics.export.ganglia.enabled", matchIfMissing = true)
 	public MetricsExporter gangliaExporter(GangliaConfig gangliaConfig,
 			HierarchicalNameMapper nameMapper, Clock clock) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphiteExportConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphiteExportConfiguration.java
@@ -40,13 +40,16 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(GraphiteProperties.class)
 public class GraphiteExportConfiguration {
 
+	public static final String GRAPHITE_EXPORTER_NAME = "graphiteExporter";
+
 	@Bean
 	@ConditionalOnMissingBean
 	public GraphiteConfig graphiteConfig(GraphiteProperties graphiteProperties) {
 		return new GraphitePropertiesConfigAdapter(graphiteProperties);
 	}
 
-	@Bean
+	@Bean(name = GRAPHITE_EXPORTER_NAME)
+	@ConditionalOnMissingBean(name = GRAPHITE_EXPORTER_NAME)
 	@ConditionalOnProperty(value = "management.metrics.export.graphite.enabled", matchIfMissing = true)
 	public MetricsExporter graphiteExporter(GraphiteConfig graphiteConfig,
 			HierarchicalNameMapper nameMapper, Clock clock) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxExportConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxExportConfiguration.java
@@ -39,13 +39,16 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(InfluxProperties.class)
 public class InfluxExportConfiguration {
 
+	public static final String INFLUX_EXPORTER_NAME = "influxExporter";
+
 	@Bean
 	@ConditionalOnMissingBean(InfluxConfig.class)
 	public InfluxConfig influxConfig(InfluxProperties influxProperties) {
 		return new InfluxPropertiesConfigAdapter(influxProperties);
 	}
 
-	@Bean
+	@Bean(name = INFLUX_EXPORTER_NAME)
+	@ConditionalOnMissingBean(name = INFLUX_EXPORTER_NAME)
 	@ConditionalOnProperty(value = "management.metrics.export.influx.enabled", matchIfMissing = true)
 	public MetricsExporter influxExporter(InfluxConfig influxConfig, Clock clock) {
 		return () -> new InfluxMeterRegistry(influxConfig, clock);

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxExportConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxExportConfiguration.java
@@ -40,13 +40,16 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(JmxProperties.class)
 public class JmxExportConfiguration {
 
+	public static final String JMX_EXPORTER_NAME = "jmxExporter";
+
 	@Bean
 	@ConditionalOnMissingBean
 	public JmxConfig jmxConfig(JmxProperties jmxProperties) {
 		return new JmxPropertiesConfigAdapter(jmxProperties);
 	}
 
-	@Bean
+	@Bean(name = JMX_EXPORTER_NAME)
+	@ConditionalOnMissingBean(name = JMX_EXPORTER_NAME)
 	@ConditionalOnProperty(value = "management.metrics.export.jmx.enabled", matchIfMissing = true)
 	public MetricsExporter jmxExporter(JmxConfig config,
 			HierarchicalNameMapper nameMapper, Clock clock) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/prometheus/PrometheusExportConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/prometheus/PrometheusExportConfiguration.java
@@ -42,13 +42,16 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(PrometheusProperties.class)
 public class PrometheusExportConfiguration {
 
+	public static final String PROMETHEUS_EXPORTER_NAME = "prometheusExporter";
+
 	@Bean
 	@ConditionalOnMissingBean
 	public PrometheusConfig prometheusConfig(PrometheusProperties prometheusProperties) {
 		return new PrometheusPropertiesConfigAdapter(prometheusProperties);
 	}
 
-	@Bean
+	@Bean(name = PROMETHEUS_EXPORTER_NAME)
+	@ConditionalOnMissingBean(name = PROMETHEUS_EXPORTER_NAME)
 	@ConditionalOnProperty(value = "management.metrics.export.prometheus.enabled", matchIfMissing = true)
 	public MetricsExporter prometheusExporter(PrometheusConfig prometheusConfig,
 			CollectorRegistry collectorRegistry, Clock clock) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdExportConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdExportConfiguration.java
@@ -40,13 +40,16 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(StatsdProperties.class)
 public class StatsdExportConfiguration {
 
+	public static final String STATSD_EXPORTER_NAME = "statsdExporter";
+
 	@Bean
 	@ConditionalOnMissingBean(StatsdConfig.class)
 	public StatsdConfig statsdConfig(StatsdProperties statsdProperties) {
 		return new StatsdPropertiesConfigAdapter(statsdProperties);
 	}
 
-	@Bean
+	@Bean(name = STATSD_EXPORTER_NAME)
+	@ConditionalOnMissingBean(name = STATSD_EXPORTER_NAME)
 	@ConditionalOnProperty(value = "management.metrics.export.statsd.enabled", matchIfMissing = true)
 	public MetricsExporter statsdExporter(StatsdConfig statsdConfig,
 			HierarchicalNameMapper hierarchicalNameMapper, Clock clock) {


### PR DESCRIPTION
I have a use case where I need to customize implementation of `JmxMeterRegistry` and export it by my own, but this is currently not possible because Spring Boot tries to autoconfigure `JmxMeterRegistry` exporter every time. There should be simple fix just to annotate metrics exporter of `JmxMeterRegistry` with `@ConditionalOnMissingBean`. I needed it only for JMX, but I have added it to all metrics exporters.