### PR TITLE
RabbitMQ - RetryTemplate configuration hook

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAnnotationDrivenConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAnnotationDrivenConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,13 +45,17 @@ class RabbitAnnotationDrivenConfiguration {
 
 	private final ObjectProvider<MessageRecoverer> messageRecoverer;
 
+	private final ObjectProvider<RabbitListenerRetryTemplateConfigurer> retryTemplateConfigurer;
+
 	private final RabbitProperties properties;
 
 	RabbitAnnotationDrivenConfiguration(ObjectProvider<MessageConverter> messageConverter,
 			ObjectProvider<MessageRecoverer> messageRecoverer,
+			ObjectProvider<RabbitListenerRetryTemplateConfigurer> retryConfigurer,
 			RabbitProperties properties) {
 		this.messageConverter = messageConverter;
 		this.messageRecoverer = messageRecoverer;
+		this.retryTemplateConfigurer = retryConfigurer;
 		this.properties = properties;
 	}
 
@@ -61,6 +65,7 @@ class RabbitAnnotationDrivenConfiguration {
 		SimpleRabbitListenerContainerFactoryConfigurer configurer = new SimpleRabbitListenerContainerFactoryConfigurer();
 		configurer.setMessageConverter(this.messageConverter.getIfUnique());
 		configurer.setMessageRecoverer(this.messageRecoverer.getIfUnique());
+		configurer.setRetryTemplateConfigurer(this.retryTemplateConfigurer.getIfUnique());
 		configurer.setRabbitProperties(this.properties);
 		return configurer;
 	}
@@ -82,6 +87,7 @@ class RabbitAnnotationDrivenConfiguration {
 		DirectRabbitListenerContainerFactoryConfigurer configurer = new DirectRabbitListenerContainerFactoryConfigurer();
 		configurer.setMessageConverter(this.messageConverter.getIfUnique());
 		configurer.setMessageRecoverer(this.messageRecoverer.getIfUnique());
+		configurer.setRetryTemplateConfigurer(this.retryTemplateConfigurer.getIfUnique());
 		configurer.setRabbitProperties(this.properties);
 		return configurer;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitListenerRetryTemplateConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitListenerRetryTemplateConfigurer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.amqp;
+
+import org.springframework.boot.autoconfigure.retry.RetryTemplateConfigurer;
+
+/**
+ * A {@link RetryTemplateConfigurer} for RabbitMQ templates.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public class RabbitListenerRetryTemplateConfigurer extends RabbitRetryTemplateConfigurer {
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitRetryTemplateConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitRetryTemplateConfigurer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.amqp;
+
+import org.springframework.boot.autoconfigure.amqp.RabbitProperties.Retry;
+import org.springframework.boot.autoconfigure.retry.RetryTemplateConfigurer;
+import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * A {@link RetryTemplateConfigurer} for RabbitMQ.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public class RabbitRetryTemplateConfigurer implements RetryTemplateConfigurer<RabbitProperties.Retry> {
+
+	@Override
+	public void configure(RetryTemplate template, Retry properties) {
+		PropertyMapper map = PropertyMapper.get();
+		SimpleRetryPolicy policy = new SimpleRetryPolicy();
+		map.from(properties::getMaxAttempts).to(policy::setMaxAttempts);
+		template.setRetryPolicy(policy);
+		ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
+		map.from(properties::getInitialInterval)
+				.to(backOffPolicy::setInitialInterval);
+		map.from(properties::getMultiplier).to(backOffPolicy::setMultiplier);
+		map.from(properties::getMaxInterval).to(backOffPolicy::setMaxInterval);
+		template.setBackOffPolicy(backOffPolicy);
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitTemplateRetryTemplateConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitTemplateRetryTemplateConfigurer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.amqp;
+
+import org.springframework.boot.autoconfigure.retry.RetryTemplateConfigurer;
+
+/**
+ * A {@link RetryTemplateConfigurer} for RabbitMQ listeners.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public class RabbitTemplateRetryTemplateConfigurer extends RabbitRetryTemplateConfigurer {
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/retry/RetryTemplateConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/retry/RetryTemplateConfigurer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.retry;
+
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * A configurer for a {@link RetryTemplate}, for example, to add a RetryListener.
+ *
+ * @param <P> the properties type.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public interface RetryTemplateConfigurer<P> {
+
+	/**
+	 * Configure the template.
+	 * @param template the template.
+	 * @param properties the properties.
+	 */
+	void configure(RetryTemplate template, P properties);
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/retry/package-info.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/retry/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Spring Retry.
+ */
+package org.springframework.boot.autoconfigure.retry;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.security.NoSuchAlgorithmException;
 import javax.net.ssl.SSLSocketFactory;
 
 import com.rabbitmq.client.Address;
+
 import org.aopalliance.aop.Advice;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,11 +47,15 @@ import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.amqp.RabbitProperties.Retry;
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.interceptor.MethodInvocationRecoverer;
 import org.springframework.retry.policy.SimpleRetryPolicy;
@@ -332,11 +337,30 @@ public class RabbitAutoConfigurationTests {
 	@Test
 	public void testRabbitMessagingTemplateBackOff() {
 		this.contextRunner.withUserConfiguration(TestConfiguration4.class)
+				.withPropertyValues("spring.rabbitmq.listener.simple.retry.enabled=true",
+						"spring.rabbitmq.template.retry.enabled=true")
 				.run((context) -> {
 					RabbitMessagingTemplate messagingTemplate = context
 							.getBean(RabbitMessagingTemplate.class);
 					assertThat(messagingTemplate.getDefaultDestination())
 							.isEqualTo("fooBar");
+					SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory = context
+							.getBean("rabbitListenerContainerFactory",
+									SimpleRabbitListenerContainerFactory.class);
+					DirectFieldAccessor dfa = new DirectFieldAccessor(
+							rabbitListenerContainerFactory);
+					Advice[] adviceChain = (Advice[]) dfa.getPropertyValue("adviceChain");
+					assertThat(adviceChain).isNotNull();
+					assertThat(adviceChain.length).isEqualTo(1);
+					dfa = new DirectFieldAccessor(adviceChain[0]);
+					RetryTemplate retryTemplate = (RetryTemplate) dfa.getPropertyValue("retryOperations");
+					dfa = new DirectFieldAccessor(retryTemplate);
+					assertThat(((RetryListener[]) dfa.getPropertyValue("listeners")).length).isEqualTo(1);
+					RabbitTemplate rabbitTemplate = context.getBean("rabbitTemplate", RabbitTemplate.class);
+					dfa = new DirectFieldAccessor(rabbitTemplate);
+					retryTemplate = (RetryTemplate) dfa.getPropertyValue("retryTemplate");
+					dfa = new DirectFieldAccessor(retryTemplate);
+					assertThat(((RetryListener[]) dfa.getPropertyValue("listeners")).length).isEqualTo(1);
 				});
 	}
 
@@ -706,6 +730,62 @@ public class RabbitAutoConfigurationTests {
 					rabbitTemplate);
 			messagingTemplate.setDefaultDestination("fooBar");
 			return messagingTemplate;
+		}
+
+		@Bean
+		public RabbitTemplateRetryTemplateConfigurer trtc() {
+			return new RabbitTemplateRetryTemplateConfigurer() {
+
+				@Override
+				public void configure(RetryTemplate template, Retry properties) {
+					super.configure(template, properties);
+					template.registerListener(new RetryListener() {
+
+						@Override
+						public <T, E extends Throwable> boolean open(RetryContext arg0, RetryCallback<T, E> arg1) {
+							return true;
+						}
+
+						@Override
+						public <T, E extends Throwable> void onError(RetryContext arg0, RetryCallback<T, E> arg1, Throwable arg2) {
+						}
+
+						@Override
+						public <T, E extends Throwable> void close(RetryContext arg0, RetryCallback<T, E> arg1, Throwable arg2) {
+						}
+
+					});
+				}
+
+			};
+		}
+
+		@Bean
+		public RabbitListenerRetryTemplateConfigurer lrtc() {
+			return new RabbitListenerRetryTemplateConfigurer() {
+
+				@Override
+				public void configure(RetryTemplate template, Retry properties) {
+					super.configure(template, properties);
+					template.registerListener(new RetryListener() {
+
+						@Override
+						public <T, E extends Throwable> boolean open(RetryContext arg0, RetryCallback<T, E> arg1) {
+							return true;
+						}
+
+						@Override
+						public <T, E extends Throwable> void onError(RetryContext arg0, RetryCallback<T, E> arg1, Throwable arg2) {
+						}
+
+						@Override
+						public <T, E extends Throwable> void close(RetryContext arg0, RetryCallback<T, E> arg1, Throwable arg2) {
+						}
+
+					});
+				}
+
+			};
 		}
 
 	}


### PR DESCRIPTION
Provide a mechanism so that users can further configure `RetryTemplate`s
used in `RabbitTemplate` and listeners.

An example would be to add a retry listener so the user can monitor/log
retry attempts.

https://stackoverflow.com/questions/48331502/logging-exceptions-thrown-by-message-listeners-for-spring-amqp/48332001#48332001

Or, to set a custom `RetryContextCache`.
