### PR TITLE
RabbitMQ - RetryTemplate customization hook

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/AbstractRabbitListenerContainerFactoryConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/AbstractRabbitListenerContainerFactoryConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.amqp.rabbit.retry.MessageRecoverer;
 import org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.boot.autoconfigure.amqp.RabbitProperties.ListenerRetry;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
 
 /**
@@ -42,6 +43,8 @@ public abstract class AbstractRabbitListenerContainerFactoryConfigurer<T extends
 
 	private RabbitProperties rabbitProperties;
 
+	private RabbitListenerRetryTemplateCustomizer retryTemplateCustomizer;
+
 	/**
 	 * Set the {@link MessageConverter} to use or {@code null} if the out-of-the-box
 	 * converter should be used.
@@ -57,6 +60,14 @@ public abstract class AbstractRabbitListenerContainerFactoryConfigurer<T extends
 	 */
 	protected void setMessageRecoverer(MessageRecoverer messageRecoverer) {
 		this.messageRecoverer = messageRecoverer;
+	}
+
+	/**
+	 * Set the {@link RabbitListenerRetryTemplateCustomizer} to use.
+	 * @param retryTemplateCustomizer the customizer
+	 */
+	public void setRetryTemplateCustomizer(RabbitListenerRetryTemplateCustomizer retryTemplateCustomizer) {
+		this.retryTemplateCustomizer = retryTemplateCustomizer;
 	}
 
 	/**
@@ -107,9 +118,9 @@ public abstract class AbstractRabbitListenerContainerFactoryConfigurer<T extends
 			RetryInterceptorBuilder<?> builder = (retryConfig.isStateless()
 					? RetryInterceptorBuilder.stateless()
 					: RetryInterceptorBuilder.stateful());
-			builder.maxAttempts(retryConfig.getMaxAttempts());
-			builder.backOffOptions(retryConfig.getInitialInterval(),
-					retryConfig.getMultiplier(), retryConfig.getMaxInterval());
+			RetryTemplate template = RabbitAutoConfiguration.createRetryTemplate(retryConfig,
+					this.retryTemplateCustomizer);
+			builder.retryOperations(template);
 			MessageRecoverer recoverer = (this.messageRecoverer != null
 					? this.messageRecoverer : new RejectAndDontRequeueRecoverer());
 			builder.recoverer(recoverer);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAnnotationDrivenConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAnnotationDrivenConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,13 +45,17 @@ class RabbitAnnotationDrivenConfiguration {
 
 	private final ObjectProvider<MessageRecoverer> messageRecoverer;
 
+	private final ObjectProvider<RabbitListenerRetryTemplateCustomizer> retryTemplateCustomizer;
+
 	private final RabbitProperties properties;
 
 	RabbitAnnotationDrivenConfiguration(ObjectProvider<MessageConverter> messageConverter,
 			ObjectProvider<MessageRecoverer> messageRecoverer,
+			ObjectProvider<RabbitListenerRetryTemplateCustomizer> retryCustomizer,
 			RabbitProperties properties) {
 		this.messageConverter = messageConverter;
 		this.messageRecoverer = messageRecoverer;
+		this.retryTemplateCustomizer = retryCustomizer;
 		this.properties = properties;
 	}
 
@@ -61,6 +65,7 @@ class RabbitAnnotationDrivenConfiguration {
 		SimpleRabbitListenerContainerFactoryConfigurer configurer = new SimpleRabbitListenerContainerFactoryConfigurer();
 		configurer.setMessageConverter(this.messageConverter.getIfUnique());
 		configurer.setMessageRecoverer(this.messageRecoverer.getIfUnique());
+		configurer.setRetryTemplateCustomizer(this.retryTemplateCustomizer.getIfUnique());
 		configurer.setRabbitProperties(this.properties);
 		return configurer;
 	}
@@ -82,6 +87,7 @@ class RabbitAnnotationDrivenConfiguration {
 		DirectRabbitListenerContainerFactoryConfigurer configurer = new DirectRabbitListenerContainerFactoryConfigurer();
 		configurer.setMessageConverter(this.messageConverter.getIfUnique());
 		configurer.setMessageRecoverer(this.messageRecoverer.getIfUnique());
+		configurer.setRetryTemplateCustomizer(this.retryTemplateCustomizer.getIfUnique());
 		configurer.setRabbitProperties(this.properties);
 		return configurer;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitListenerRetryTemplateCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitListenerRetryTemplateCustomizer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.amqp;
+
+import org.springframework.boot.autoconfigure.retry.RetryTemplateCustomizer;
+
+/**
+ * A marker interface for a {@link RetryTemplateCustomizer} for RabbitMQ listeners.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public interface RabbitListenerRetryTemplateCustomizer extends RetryTemplateCustomizer {
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitTemplateRetryTemplateCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitTemplateRetryTemplateCustomizer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.amqp;
+
+import org.springframework.boot.autoconfigure.retry.RetryTemplateCustomizer;
+
+/**
+ * A marker interface for a {@link RetryTemplateCustomizer} for RabbitMQ templates.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public interface RabbitTemplateRetryTemplateCustomizer extends RetryTemplateCustomizer {
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/retry/RetryTemplateCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/retry/RetryTemplateCustomizer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.retry;
+
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * A customizer for a {@link RetryTemplate}, for example, to add a RetryListener.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public interface RetryTemplateCustomizer {
+
+	/**
+	 * Customize the template.
+	 * @param template the template.
+	 * @param properties the properties.
+	 */
+	void customize(RetryTemplate template);
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/retry/package-info.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/retry/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Spring Retry.
+ */
+package org.springframework.boot.autoconfigure.retry;


### PR DESCRIPTION
Provide a mechanism so that users can customize `RetryTemplate`s
used in `RabbitTemplate` and listeners.

An example would be to add a retry listener so the user can monitor/log
retry attempts.

https://stackoverflow.com/questions/48331502/logging-exceptions-thrown-by-message-listeners-for-spring-amqp/48332001#48332001

Or, to set a custom `RetryContextCache`.

temp

