### PR TITLE
Manage dependencies for kotlin-stdlib-jdk7/8

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -1940,6 +1940,16 @@
 			</dependency>
 			<dependency>
 				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib-jdk7</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib-jdk8</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-stdlib-jre7</artifactId>
 				<version>${kotlin.version}</version>
 			</dependency>


### PR DESCRIPTION
As explained in the "Split package compatibility" section of
https://blog.jetbrains.com/kotlin/2017/09/kotlin-1-2-beta-is-out/,
`kotlin-stdlib-jdk7` and `kotlin-stdlib-jdk8` are the recommended
dependencies to use with Kotlin 1.2 for Java 9+ compatibility.