### PR TITLE
Polish code: Avoid concatenating non-literals in a StringBuffer constructor or append()

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/jmx/DefaultEndpointObjectNameFactory.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/jmx/DefaultEndpointObjectNameFactory.java
@@ -52,14 +52,14 @@ class DefaultEndpointObjectNameFactory implements EndpointObjectNameFactory {
 			throws MalformedObjectNameException {
 		StringBuilder builder = new StringBuilder(this.properties.getDomain());
 		builder.append(":type=Endpoint");
-		builder.append(",name=" + StringUtils.capitalize(endpoint.getId()));
+		builder.append(",name=").append(StringUtils.capitalize(endpoint.getId()));
 		String baseName = builder.toString();
 		if (this.mBeanServer != null && hasMBean(baseName)) {
-			builder.append(",context=" + this.contextId);
+			builder.append(",context=").append(this.contextId);
 		}
 		if (this.properties.isUniqueNames()) {
 			String identity = ObjectUtils.getIdentityHexString(endpoint);
-			builder.append(",identity=" + identity);
+			builder.append(",identity=").append(identity);
 		}
 		builder.append(getStaticNames());
 		return ObjectNameManager.getInstance(builder.toString());
@@ -76,7 +76,7 @@ class DefaultEndpointObjectNameFactory implements EndpointObjectNameFactory {
 		}
 		StringBuilder builder = new StringBuilder();
 		this.properties.getStaticNames()
-				.forEach((name, value) -> builder.append("," + name + "=" + value));
+				.forEach((name, value) -> builder.append(",").append(name).append("=").append(value));
 		return builder.toString();
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/annotation/DiscoveredJmxOperation.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/annotation/DiscoveredJmxOperation.java
@@ -179,9 +179,9 @@ class DiscoveredJmxOperation extends AbstractDiscoveredOperation implements JmxO
 		public String toString() {
 			StringBuilder result = new StringBuilder(this.name);
 			if (this.description != null) {
-				result.append(" (" + this.description + ")");
+				result.append(" (").append(this.description).append(")");
 			}
-			result.append(":" + this.type);
+			result.append(":").append(this.type);
 			return result.toString();
 		}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/WebOperationRequestPredicate.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/WebOperationRequestPredicate.java
@@ -93,12 +93,10 @@ public final class WebOperationRequestPredicate {
 		StringBuilder result = new StringBuilder(
 				this.httpMethod + " to path '" + this.path + "'");
 		if (!CollectionUtils.isEmpty(this.consumes)) {
-			result.append(" consumes: "
-					+ StringUtils.collectionToCommaDelimitedString(this.consumes));
+			result.append(" consumes: ").append(StringUtils.collectionToCommaDelimitedString(this.consumes));
 		}
 		if (!CollectionUtils.isEmpty(this.produces)) {
-			result.append(" produces: "
-					+ StringUtils.collectionToCommaDelimitedString(this.produces));
+			result.append(" produces: ").append(StringUtils.collectionToCommaDelimitedString(this.produces));
 		}
 		return result.toString();
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionMessage.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionMessage.java
@@ -387,14 +387,13 @@ public final class ConditionMessage {
 			items = style.applyTo(items);
 			if ((this.condition == null || items.size() <= 1)
 					&& StringUtils.hasLength(this.singular)) {
-				message.append(" " + this.singular);
+				message.append(" ").append(this.singular);
 			}
 			else if (StringUtils.hasLength(this.plural)) {
-				message.append(" " + this.plural);
+				message.append(" ").append(this.plural);
 			}
 			if (items != null && !items.isEmpty()) {
-				message.append(
-						" " + StringUtils.collectionToDelimitedString(items, ", "));
+				message.append(" ").append(StringUtils.collectionToDelimitedString(items, ", "));
 			}
 			return this.condition.because(message.toString());
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -520,22 +520,22 @@ public class DataSourceProperties
 		private static String getMessage(EmbeddedDatabaseConnection connection,
 				Environment environment, String property) {
 			StringBuilder message = new StringBuilder();
-			message.append("Cannot determine embedded database " + property
-					+ " for database type " + connection + ". ");
-			message.append("If you want an embedded database please put a supported "
-					+ "one on the classpath. ");
-			message.append("If you have database settings to be loaded from a "
-					+ "particular profile you may need to active it");
+			message.append("Cannot determine embedded database ").append(property).
+					append(" for database type ").append(connection).append(". ");
+			message.append("If you want an embedded database please put a supported ").
+					append("one on the classpath. ");
+			message.append("If you have database settings to be loaded from a ").
+					append("particular profile you may need to active it");
 			if (environment != null) {
 				String[] profiles = environment.getActiveProfiles();
 				if (ObjectUtils.isEmpty(profiles)) {
 					message.append(" (no profiles are currently active)");
 				}
 				else {
-					message.append(" (the profiles \""
-							+ StringUtils.arrayToCommaDelimitedString(
-									environment.getActiveProfiles())
-							+ "\" are currently active)");
+					message.append(" (the profiles \"").
+							append(StringUtils.arrayToCommaDelimitedString(
+										environment.getActiveProfiles())).
+							append("\" are currently active)");
 
 				}
 			}

--- a/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/ServiceCapabilitiesReportGenerator.java
+++ b/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/ServiceCapabilitiesReportGenerator.java
@@ -80,13 +80,13 @@ class ServiceCapabilitiesReportGenerator {
 
 	private void reportAvailableDependencies(InitializrServiceMetadata metadata,
 			StringBuilder report) {
-		report.append("Available dependencies:" + NEW_LINE);
-		report.append("-----------------------" + NEW_LINE);
+		report.append("Available dependencies:").append(NEW_LINE);
+		report.append("-----------------------").append(NEW_LINE);
 		List<Dependency> dependencies = getSortedDependencies(metadata);
 		for (Dependency dependency : dependencies) {
-			report.append(dependency.getId() + " - " + dependency.getName());
+			report.append(dependency.getId()).append(" - ").append(dependency.getName());
 			if (dependency.getDescription() != null) {
-				report.append(": " + dependency.getDescription());
+				report.append(": ").append(dependency.getDescription());
 			}
 			report.append(NEW_LINE);
 		}
@@ -100,8 +100,8 @@ class ServiceCapabilitiesReportGenerator {
 
 	private void reportAvailableProjectTypes(InitializrServiceMetadata metadata,
 			StringBuilder report) {
-		report.append("Available project types:" + NEW_LINE);
-		report.append("------------------------" + NEW_LINE);
+		report.append("Available project types:").append(NEW_LINE);
+		report.append("------------------------").append(NEW_LINE);
 		SortedSet<Entry<String, ProjectType>> entries = new TreeSet<>(
 				Comparator.comparing(Entry::getKey));
 		entries.addAll(metadata.getProjectTypes().entrySet());
@@ -134,8 +134,8 @@ class ServiceCapabilitiesReportGenerator {
 
 	private void reportDefaults(StringBuilder report,
 			InitializrServiceMetadata metadata) {
-		report.append("Defaults:" + NEW_LINE);
-		report.append("---------" + NEW_LINE);
+		report.append("Defaults:").append(NEW_LINE);
+		report.append("---------").append(NEW_LINE);
 		List<String> defaultsKeys = new ArrayList<>(metadata.getDefaults().keySet());
 		Collections.sort(defaultsKeys);
 		for (String defaultsKey : defaultsKeys) {

--- a/spring-boot-project/spring-boot-configuration-analyzer/src/main/java/org/springframework/boot/configurationalayzer/LegacyPropertiesAnalysis.java
+++ b/spring-boot-project/spring-boot-configuration-analyzer/src/main/java/org/springframework/boot/configurationalayzer/LegacyPropertiesAnalysis.java
@@ -55,9 +55,9 @@ class LegacyPropertiesAnalysis {
 		appendProperties(report, content, metadata ->
 				"Replacement: " + metadata.getDeprecation().getReplacement());
 		report.append(String.format("%n"));
-		report.append("Each configuration key has been temporarily mapped to its "
-				+ "replacement for your convenience. To silence this warning, please "
-				+ "update your configuration to use the new keys.");
+		report.append("Each configuration key has been temporarily mapped to its ").
+				append("replacement for your convenience. To silence this warning, please ").
+				append("update your configuration to use the new keys.");
 		report.append(String.format("%n"));
 		return report.toString();
 	}
@@ -82,8 +82,8 @@ class LegacyPropertiesAnalysis {
 				"Reason: " + (StringUtils.hasText(metadata.getDeprecation().getReason())
 						? metadata.getDeprecation().getReason() : "none"));
 		report.append(String.format("%n"));
-		report.append("Please refer to the migration guide or reference guide for "
-				+ "potential alternatives.");
+		report.append("Please refer to the migration guide or reference guide for ").
+				append("potential alternatives.");
 		report.append(String.format("%n"));
 		return report.toString();
 	}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/properties/PropertyMappingContextCustomizer.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/properties/PropertyMappingContextCustomizer.java
@@ -116,7 +116,7 @@ class PropertyMappingContextCustomizer implements ContextCustomizer {
 			StringBuilder result = new StringBuilder();
 			for (Class<?> annotation : annotations) {
 				result.append(result.length() == 0 ? "" : ", ");
-				result.append("@" + ClassUtils.getShortName(annotation));
+				result.append("@").append(ClassUtils.getShortName(annotation));
 			}
 			result.insert(0, annotations.size() == 1 ? "annotation " : "annotations ");
 			return result.toString();

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/Metadata.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/Metadata.java
@@ -108,7 +108,7 @@ public final class Metadata {
 
 		private String createDescription() {
 			StringBuilder description = new StringBuilder();
-			description.append("an item named '" + this.name + "'");
+			description.append("an item named '").append(this.name).append("'");
 			if (this.type != null) {
 				description.append(" with dataType:").append(this.type);
 			}
@@ -258,7 +258,7 @@ public final class Metadata {
 
 		private String createDescription() {
 			StringBuilder description = new StringBuilder();
-			description.append("a hints name '" + this.name + "'");
+			description.append("a hints name '").append(this.name).append("'");
 			if (!this.valueConditions.isEmpty()) {
 				description.append(" with values:").append(this.valueConditions);
 			}
@@ -348,7 +348,7 @@ public final class Metadata {
 
 		private String createDescription() {
 			StringBuilder description = new StringBuilder();
-			description.append("value hint at index '" + this.index + "'");
+			description.append("value hint at index '").append(this.index).append("'");
 			if (this.value != null) {
 				description.append(" with value:").append(this.value);
 			}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/UnresolvedDependenciesAnalyzer.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/UnresolvedDependenciesAnalyzer.java
@@ -50,13 +50,13 @@ class UnresolvedDependenciesAnalyzer {
 		if (!this.dependenciesWithNoVersion.isEmpty()
 				&& !project.getPlugins().hasPlugin(DependencyManagementPlugin.class)) {
 			StringBuilder message = new StringBuilder();
-			message.append("\nDuring the build, one or more dependencies that were "
-					+ "declared without a version failed to resolve:\n");
+			message.append("\nDuring the build, one or more dependencies that were ").
+					append("declared without a version failed to resolve:\n");
 			this.dependenciesWithNoVersion
 					.forEach((dependency) -> message.append("    " + dependency + "\n"));
-			message.append("\nDid you forget to apply the "
-					+ "io.spring.dependency-management plugin to the " + project.getName()
-					+ " project?\n");
+			message.append("\nDid you forget to apply the " + "io.spring.dependency-management plugin to the ").
+					append(project.getName()).
+					append(" project?\n");
 			logger.warn(message.toString());
 		}
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
@@ -86,7 +86,7 @@ class StartupInfoLogger {
 		message.append(stopWatch.getTotalTimeSeconds());
 		try {
 			double uptime = ManagementFactory.getRuntimeMXBean().getUptime() / 1000.0;
-			message.append(" seconds (JVM running for " + uptime + ")");
+			message.append(" seconds (JVM running for ").append(uptime).append(")");
 		}
 		catch (Throwable ex) {
 			// No JVM time available

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/InvalidConfigurationPropertyValueFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/InvalidConfigurationPropertyValueFailureAnalyzer.java
@@ -85,8 +85,8 @@ class InvalidConfigurationPropertyValueFailureAnalyzer
 			InvalidConfigurationPropertyValueException cause,
 			List<Descriptor> descriptors) {
 		Descriptor mainDescriptor = descriptors.get(0);
-		message.append("Invalid value '" + mainDescriptor.getValue()
-				+ "' for configuration property '" + cause.getName() + "'");
+		message.append("Invalid value '").append(mainDescriptor.getValue());
+		message.append("' for configuration property '").append(cause.getName()).append("'");
 		mainDescriptor.appendOrigin(message);
 		message.append(".");
 	}
@@ -112,8 +112,8 @@ class InvalidConfigurationPropertyValueFailureAnalyzer
 							+ "property %s:%n%n",
 					others.size() > 1 ? "sources" : "source"));
 			for (Descriptor other : others) {
-				message.append("\t- In '" + other.getPropertySource() + "'");
-				message.append(" with the value '" + other.getValue() + "'");
+				message.append("\t- In '").append(other.getPropertySource()).append("'");
+				message.append(" with the value '").append(other.getValue()).append("'");
 				other.appendOrigin(message);
 				message.append(String.format(".%n"));
 			}
@@ -154,7 +154,7 @@ class InvalidConfigurationPropertyValueFailureAnalyzer
 
 		public void appendOrigin(StringBuilder message) {
 			if (this.origin != null) {
-				message.append(" (originating from '" + this.origin + "')");
+				message.append(" (originating from '").append(this.origin).append("')");
 			}
 		}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Avoid concatenating non-literals in a StringBuffer constructor or append() since intermediate buffers will need to be be created and destroyed by the JVM.

Rule [InefficientStringBuffering](http://pmd.sourceforge.net/pmd-5.1.1/rules/java/strings.html)
Since: PMD 3.4