### PR TITLE
Create Liquibase/Flyway DataSources's if user or url are specified.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java
@@ -133,7 +133,7 @@ public class FlywayProperties {
 	}
 
 	public boolean isCreateDataSource() {
-		return this.url != null && this.user != null;
+		return this.url != null || this.user != null;
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.data.jpa.EntityManagerFactoryDependsOnPostProcessor;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
@@ -58,6 +59,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Phillip Webb
  * @author Eddú Meléndez
  * @author Andy Wilkinson
+ * @author Dominic Gunn
  * @since 1.1.0
  */
 @Configuration
@@ -83,6 +85,8 @@ public class LiquibaseAutoConfiguration {
 
 		private final LiquibaseProperties properties;
 
+		private final DataSourceProperties dataSourceProperties;
+
 		private final ResourceLoader resourceLoader;
 
 		private final DataSource dataSource;
@@ -90,9 +94,11 @@ public class LiquibaseAutoConfiguration {
 		private final DataSource liquibaseDataSource;
 
 		public LiquibaseConfiguration(LiquibaseProperties properties,
-				ResourceLoader resourceLoader, ObjectProvider<DataSource> dataSource,
+				DataSourceProperties dataSourceProperties, ResourceLoader resourceLoader,
+				ObjectProvider<DataSource> dataSource,
 				@LiquibaseDataSource ObjectProvider<DataSource> liquibaseDataSource) {
 			this.properties = properties;
+			this.dataSourceProperties = dataSourceProperties;
 			this.resourceLoader = resourceLoader;
 			this.dataSource = dataSource.getIfUnique();
 			this.liquibaseDataSource = liquibaseDataSource.getIfAvailable();
@@ -140,16 +146,27 @@ public class LiquibaseAutoConfiguration {
 			if (this.liquibaseDataSource != null) {
 				return this.liquibaseDataSource;
 			}
-			if (this.properties.getUrl() == null) {
+			if (this.properties.getUrl() == null && this.properties.getUser() == null) {
 				return this.dataSource;
 			}
 			return null;
 		}
 
 		private DataSource createNewDataSource() {
-			return DataSourceBuilder.create().url(this.properties.getUrl())
-					.username(this.properties.getUser())
-					.password(this.properties.getPassword()).build();
+			String url = this.properties.getUrl() == null
+					? this.dataSourceProperties.getUrl()
+					: this.properties.getUrl();
+
+			String user = this.properties.getUser() == null
+					? this.dataSourceProperties.getUsername()
+					: this.properties.getUser();
+
+			String password = this.properties.getPassword() == null
+					? this.dataSourceProperties.getPassword()
+					: this.properties.getPassword();
+
+			return DataSourceBuilder.create().url(url).username(user).password(password)
+					.build();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
@@ -60,6 +60,7 @@ import static org.mockito.Mockito.mock;
  * @author Vedran Pavic
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @author Dominic Gunn
  */
 public class FlywayAutoConfigurationTests {
 
@@ -74,9 +75,19 @@ public class FlywayAutoConfigurationTests {
 	}
 
 	@Test
-	public void createDataSource() {
+	public void createDataSourceWithUrl() {
 		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
-				.withPropertyValues("spring.flyway.url:jdbc:hsqldb:mem:flywaytest",
+				.withPropertyValues("spring.flyway.url:jdbc:hsqldb:mem:flywaytest")
+				.run((context) -> {
+					assertThat(context).hasSingleBean(Flyway.class);
+					assertThat(context.getBean(Flyway.class).getDataSource()).isNotNull();
+				});
+	}
+
+	@Test
+	public void createDataSourceWithUser() {
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+				.withPropertyValues("spring.datasource.url:jdbc:hsqldb:mem:normal",
 						"spring.flyway.user:sa")
 				.run((context) -> {
 					assertThat(context).hasSingleBean(Flyway.class);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
@@ -58,6 +58,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Eddú Meléndez
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author Dominic Gunn
  */
 public class LiquibaseAutoConfigurationTests {
 
@@ -153,13 +154,27 @@ public class LiquibaseAutoConfigurationTests {
 	@Test
 	public void overrideDataSource() {
 		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
-				.withPropertyValues("spring.liquibase.url:jdbc:hsqldb:mem:liquibase",
-						"spring.liquibase.user:sa")
+				.withPropertyValues("spring.liquibase.url:jdbc:hsqldb:mem:liquibase")
 				.run(assertLiquibase((liquibase) -> {
 					DataSource dataSource = liquibase.getDataSource();
 					assertThat(((HikariDataSource) dataSource).isClosed()).isTrue();
 					assertThat(((HikariDataSource) dataSource).getJdbcUrl())
 							.isEqualTo("jdbc:hsqldb:mem:liquibase");
+				}));
+	}
+
+	@Test
+	public void overrideUser() {
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+				.withPropertyValues("spring.datasource.url:jdbc:hsqldb:mem:normal",
+						"spring.datasource.username:not-sa", "spring.liquibase.user:sa")
+				.run(assertLiquibase((liquibase) -> {
+					DataSource dataSource = liquibase.getDataSource();
+					assertThat(((HikariDataSource) dataSource).isClosed()).isTrue();
+					assertThat(((HikariDataSource) dataSource).getJdbcUrl())
+							.isEqualTo("jdbc:hsqldb:mem:normal");
+					assertThat(((HikariDataSource) dataSource).getUsername())
+							.isEqualTo("sa");
 				}));
 	}
 


### PR DESCRIPTION
This PR enables a more flexible Liquibase/Flyway configuration by allowing for a combination of both of the providers, and the primary DataSource's configurations. 

Allowing developers the flexibility to specify only a user or a url and having Liquibase/Flyway adapt to
existing properties, instead of ignoring them and falling back to the default data source.

Fixes #11747 