### PR TITLE
Remove usage of Vector collection

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/web/mappings/MappingsEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/web/mappings/MappingsEndpointTests.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 import javax.servlet.FilterRegistration;
 import javax.servlet.ServletContext;
@@ -73,9 +72,9 @@ public class MappingsEndpointTests {
 	public void servletWebMappings() {
 		ServletContext servletContext = mock(ServletContext.class);
 		given(servletContext.getInitParameterNames())
-				.willReturn(new Vector<String>().elements());
+				.willReturn(Collections.emptyEnumeration());
 		given(servletContext.getAttributeNames())
-				.willReturn(new Vector<String>().elements());
+				.willReturn(Collections.emptyEnumeration());
 		FilterRegistration filterRegistration = mock(FilterRegistration.class);
 		given((Map<String, FilterRegistration>) servletContext.getFilterRegistrations())
 				.willReturn(Collections.singletonMap("testFilter", filterRegistration));

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,10 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -336,7 +336,7 @@ public class HibernateJpaAutoConfigurationTests
 		@Override
 		public Enumeration<URL> getResources(String name) throws IOException {
 			if (HIDDEN_RESOURCES.contains(name)) {
-				return new Vector<URL>().elements();
+				return Collections.emptyEnumeration();
 			}
 			return super.getResources(name);
 		}


### PR DESCRIPTION
Hi,

this PR removes the usage of `Vector` in two tests and therefore from the codebase. As they simply create an empty Vector in order to have an Enumeration available, we can replace it with `Collections.emptyEnumeration()`.

Cheers,
Christoph