### PR TITLE
use propertyMapper to config webServerFactory

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/DefaultServletWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/DefaultServletWebServerFactoryCustomizer.java
@@ -20,6 +20,7 @@ import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.autoconfigure.web.embedded.jetty.JettyCustomizer;
 import org.springframework.boot.autoconfigure.web.embedded.tomcat.TomcatCustomizer;
 import org.springframework.boot.autoconfigure.web.embedded.undertow.UndertowCustomizer;
+import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
 import org.springframework.boot.web.embedded.tomcat.ConfigurableTomcatWebServerFactory;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
@@ -37,6 +38,7 @@ import org.springframework.util.ObjectUtils;
  * @author Brian Clozel
  * @author Stephane Nicoll
  * @author Olivier Lamy
+ * @author Yunkun Huang
  * @since 2.0.0
  */
 public class DefaultServletWebServerFactoryCustomizer
@@ -67,49 +69,30 @@ public class DefaultServletWebServerFactoryCustomizer
 
 	@Override
 	public void customize(ConfigurableServletWebServerFactory factory) {
-		if (this.serverProperties.getPort() != null) {
-			factory.setPort(this.serverProperties.getPort());
-		}
-		if (this.serverProperties.getAddress() != null) {
-			factory.setAddress(this.serverProperties.getAddress());
-		}
-		if (this.serverProperties.getServlet().getContextPath() != null) {
-			factory.setContextPath(this.serverProperties.getServlet().getContextPath());
-		}
-		if (this.serverProperties.getDisplayName() != null) {
-			factory.setDisplayName(this.serverProperties.getDisplayName());
-		}
-		factory.setSession(this.serverProperties.getServlet().getSession());
-		if (this.serverProperties.getSsl() != null) {
-			factory.setSsl(this.serverProperties.getSsl());
-		}
-		if (this.serverProperties.getServlet() != null) {
-			factory.setJsp(this.serverProperties.getServlet().getJsp());
-		}
-		if (this.serverProperties.getCompression() != null) {
-			factory.setCompression(this.serverProperties.getCompression());
-		}
-		if (this.serverProperties.getHttp2() != null) {
-			factory.setHttp2(this.serverProperties.getHttp2());
-		}
-		factory.setServerHeader(this.serverProperties.getServerHeader());
-		if (factory instanceof TomcatServletWebServerFactory) {
-			TomcatServletWebServerFactory tomcatFactory = (TomcatServletWebServerFactory) factory;
-			TomcatCustomizer.customizeTomcat(this.serverProperties, this.environment,
-					tomcatFactory);
-			TomcatServletCustomizer.customizeTomcat(this.serverProperties,
-					this.environment, tomcatFactory);
-		}
-		if (factory instanceof JettyServletWebServerFactory) {
-			JettyCustomizer.customizeJetty(this.serverProperties, this.environment,
-					(JettyServletWebServerFactory) factory);
-		}
-		if (factory instanceof UndertowServletWebServerFactory) {
-			UndertowCustomizer.customizeUndertow(this.serverProperties, this.environment,
-					(UndertowServletWebServerFactory) factory);
-		}
-		factory.setInitParameters(
-				this.serverProperties.getServlet().getContextParameters());
+		PropertyMapper map = PropertyMapper.get();
+		map.from(this.serverProperties::getPort).whenNonNull().to(factory::setPort);
+		map.from(this.serverProperties::getAddress).whenNonNull().to(factory::setAddress);
+		map.from(this.serverProperties.getServlet()::getContextPath).whenNonNull().to(factory::setContextPath);
+		map.from(this.serverProperties::getDisplayName).whenNonNull().to(factory::setDisplayName);
+		map.from(this.serverProperties.getServlet()::getSession).to(factory::setSession);
+		map.from(this.serverProperties::getSsl).whenNonNull().to(factory::setSsl);
+		map.from(this.serverProperties::getServlet).whenNonNull().as(ServerProperties.Servlet::getJsp).to(factory::setJsp);
+		map.from(this.serverProperties::getCompression).whenNonNull().to(factory::setCompression);
+		map.from(this.serverProperties::getHttp2).whenNonNull().to(factory::setHttp2);
+		map.from(this.serverProperties::getServerHeader).to(factory::setServerHeader);
+		map.from(() -> factory).when(configurableServletWebServerFactory -> factory instanceof TomcatServletWebServerFactory)
+				.to(configurableServletWebServerFactory -> {
+					TomcatServletWebServerFactory tomcatFactory = (TomcatServletWebServerFactory) factory;
+					TomcatCustomizer.customizeTomcat(this.serverProperties, this.environment, tomcatFactory);
+					TomcatServletCustomizer.customizeTomcat(this.serverProperties, this.environment, tomcatFactory);
+				});
+		map.from(() -> factory).when(configurableServletWebServerFactory -> factory instanceof JettyServletWebServerFactory)
+				.to(configurableServletWebServerFactory -> JettyCustomizer.customizeJetty(this.serverProperties, this.environment,
+						(JettyServletWebServerFactory) factory));
+		map.from(() -> factory).when(configurableServletWebServerFactory -> factory instanceof UndertowServletWebServerFactory)
+				.to(configurableServletWebServerFactory -> UndertowCustomizer.customizeUndertow(this.serverProperties, this.environment,
+						(UndertowServletWebServerFactory) factory));
+		map.from(this.serverProperties.getServlet()::getContextParameters).to(factory::setInitParameters);
 	}
 
 	private static class TomcatServletCustomizer {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/DefaultReactiveWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/DefaultReactiveWebServerFactoryCustomizerTests.java
@@ -46,6 +46,7 @@ import org.springframework.boot.web.embedded.tomcat.TomcatReactiveWebServerFacto
 import org.springframework.boot.web.embedded.tomcat.TomcatWebServer;
 import org.springframework.boot.web.embedded.undertow.UndertowReactiveWebServerFactory;
 import org.springframework.boot.web.reactive.server.ConfigurableReactiveWebServerFactory;
+import org.springframework.boot.web.server.Ssl;
 import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -60,6 +61,7 @@ import static org.mockito.Mockito.verify;
  * Tests for {@link DefaultReactiveWebServerFactoryCustomizer}.
  *
  * @author Brian Clozel
+ * @author Yunkun Huang
  */
 public class DefaultReactiveWebServerFactoryCustomizerTests {
 
@@ -89,6 +91,16 @@ public class DefaultReactiveWebServerFactoryCustomizerTests {
 		this.properties.setAddress(address);
 		this.customizer.customize(factory);
 		verify(factory).setAddress(address);
+	}
+
+	@Test
+	public void testCustomizeServerSsl() {
+		ConfigurableReactiveWebServerFactory factory = mock(
+				ConfigurableReactiveWebServerFactory.class);
+		Ssl ssl = mock(Ssl.class);
+		this.properties.setSsl(ssl);
+		this.customizer.customize(factory);
+		verify(factory).setSsl(ssl);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/DefaultServletWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/DefaultServletWebServerFactoryCustomizerTests.java
@@ -49,13 +49,16 @@ import org.springframework.boot.web.embedded.tomcat.TomcatContextCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.embedded.tomcat.TomcatWebServer;
 import org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory;
+import org.springframework.boot.web.server.Ssl;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.Jsp;
 import org.springframework.boot.web.servlet.server.Session;
 import org.springframework.boot.web.servlet.server.Session.Cookie;
 import org.springframework.mock.env.MockEnvironment;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -66,6 +69,7 @@ import static org.mockito.Mockito.verify;
  * Tests for {@link DefaultServletWebServerFactoryCustomizer}.
  *
  * @author Brian Clozel
+ * @author Yunkun Huang
  */
 public class DefaultServletWebServerFactoryCustomizerTests {
 
@@ -201,6 +205,24 @@ public class DefaultServletWebServerFactoryCustomizerTests {
 		this.properties.setDisplayName("TestName");
 		this.customizer.customize(factory);
 		verify(factory).setDisplayName("TestName");
+	}
+
+	@Test
+	public void testCustomizeSsl() {
+		ConfigurableServletWebServerFactory factory = mock(
+				ConfigurableServletWebServerFactory.class);
+		Ssl ssl = mock(Ssl.class);
+		this.properties.setSsl(ssl);
+		this.customizer.customize(factory);
+		verify(factory).setSsl(ssl);
+	}
+
+	@Test
+	public void testCustomizeJsp() {
+		ConfigurableServletWebServerFactory factory = mock(
+				ConfigurableServletWebServerFactory.class);
+		this.customizer.customize(factory);
+		verify(factory).setJsp(any(Jsp.class));
 	}
 
 	@Test


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Use property mapper to config DefaultServletWebServerFactoryCustomizer and DefaultReactiveWebServerFactoryCustomizer

fix #11687 