### PR TITLE
Fix Optional Check

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/condition/OnEnabledEndpointCondition.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/condition/OnEnabledEndpointCondition.java
@@ -78,7 +78,7 @@ class OnEnabledEndpointCondition extends SpringBootCondition {
 
 	private Boolean isEnabledByDefault(Environment environment) {
 		Optional<Boolean> enabledByDefault = enabledByDefaultCache.get(environment);
-		if (enabledByDefault == null) {
+		if (!enabledByDefault.isPresent()) {
 			enabledByDefault = Optional.ofNullable(
 					environment.getProperty(ENABLED_BY_DEFAULT_KEY, Boolean.class));
 			enabledByDefaultCache.put(environment, enabledByDefault);


### PR DESCRIPTION
when Optional is in use, there should never be a question of returning or receiving null from a call. Hence checking with isPresent