### PR TITLE
configure ErrorReportValve for tomcat

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
@@ -231,8 +231,8 @@ public class TomcatEmbeddedServletContainerFactory
 
 		});
 		ServletContextInitializer[] initializersToUse = mergeInitializers(initializers);
-		configureContext(context, initializersToUse);
 		host.addChild(context);
+		configureContext(context, initializersToUse);
 		postProcessContext(context);
 	}
 


### PR DESCRIPTION
In my application I have disabled the spring-boot error handling via 

````java
@SpringBootApplication(exclude = ErrorMvcAutoConfiguration.class)
````

in this case if I use a command from #7936 then a stack trace with server version is printed by tomcat.

In tomcat it's done by `org.apache.catalina.valves.ErrorReportValve`, which is added by  `org.apache.catalina.core.StandardHost.startInternal()`, if not already there.
This class can be configured appropriately, but by default it prints everything.

In this patch if `include-stacktrace=never` then a properly configured `ErrorReportValve` is added to tomcat Host, avoiding the server info leaks.