### PR TITLE
Replace casted Mockito.any() calls

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/security/AuthenticationAuditListenerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/security/AuthenticationAuditListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public class AuthenticationAuditListenerTests {
 		this.listener.onApplicationEvent(new InteractiveAuthenticationSuccessEvent(
 				new UsernamePasswordAuthenticationToken("user", "password"), getClass()));
 		// No need to audit this one (it shadows a regular AuthenticationSuccessEvent)
-		verify(this.publisher, never()).publishEvent((ApplicationEvent) any());
+		verify(this.publisher, never()).publishEvent(any(ApplicationEvent.class));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/client/RemoteClientConfigurationTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/client/RemoteClientConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,8 +178,8 @@ public class RemoteClientConfigurationTests {
 
 		public Dispatcher dispatcher() throws IOException {
 			Dispatcher dispatcher = mock(Dispatcher.class);
-			ServerHttpRequest anyRequest = (ServerHttpRequest) any();
-			ServerHttpResponse anyResponse = (ServerHttpResponse) any();
+			ServerHttpRequest anyRequest = any(ServerHttpRequest.class);
+			ServerHttpResponse anyResponse = any(ServerHttpResponse.class);
 			given(dispatcher.handle(anyRequest, anyResponse)).willReturn(true);
 			return dispatcher;
 		}

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/MockRestarter.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/MockRestarter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public class MockRestarter implements TestRule {
 	private void setup() {
 		Restarter.setInstance(this.mock);
 		given(this.mock.getInitialUrls()).willReturn(new URL[] {});
-		given(this.mock.getOrAddAttribute(anyString(), (ObjectFactory) any()))
+		given(this.mock.getOrAddAttribute(anyString(), any(ObjectFactory.class)))
 				.willAnswer((invocation) -> {
 					String name = (String) invocation.getArguments()[0];
 					ObjectFactory factory = (ObjectFactory) invocation.getArguments()[1];

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/OnInitializedRestarterConditionTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/OnInitializedRestarterConditionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ public class OnInitializedRestarterConditionTests {
 
 		public static void main(String... args) {
 			RestartInitializer initializer = mock(RestartInitializer.class);
-			given(initializer.getInitialUrls((Thread) any())).willReturn(new URL[0]);
+			given(initializer.getInitialUrls(any(Thread.class))).willReturn(new URL[0]);
 			Restarter.initialize(new String[0], false, initializer);
 			ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
 					Config.class);

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoTestExecutionListenerTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoTestExecutionListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public class MockitoTestExecutionListenerTests {
 		WithMockBean instance = new WithMockBean();
 		this.listener.prepareTestInstance(mockTestContext(instance));
 		verify(this.postProcessor).inject(this.fieldCaptor.capture(), eq(instance),
-				(MockDefinition) any());
+				any(MockDefinition.class));
 		assertThat(this.fieldCaptor.getValue().getName()).isEqualTo("mockBean");
 	}
 

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/RootUriRequestExpectationManagerTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/RootUriRequestExpectationManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@ public class RootUriRequestExpectationManagerTests {
 			throws Exception {
 		ClientHttpRequest request = mock(ClientHttpRequest.class);
 		given(request.getURI()).willReturn(new URI(this.uri + "/hello"));
-		given(this.delegate.validateRequest((ClientHttpRequest) any()))
+		given(this.delegate.validateRequest(any(ClientHttpRequest.class)))
 				.willThrow(new AssertionError(
 						"Request URI expected:</hello> was:<http://example.com/bad>"));
 		this.thrown.expect(AssertionError.class);

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/TestRestTemplateTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/TestRestTemplateTests.java
@@ -336,7 +336,7 @@ public class TestRestTemplateTests {
 		request.setResponse(new MockClientHttpResponse(new byte[0], HttpStatus.OK));
 		URI absoluteUri = URI
 				.create("http://localhost:8080/a/b/c.txt?param=%7Bsomething%7D");
-		given(requestFactory.createRequest(eq(absoluteUri), (HttpMethod) any()))
+		given(requestFactory.createRequest(eq(absoluteUri), any(HttpMethod.class)))
 				.willReturn(request);
 		RestTemplate delegate = new RestTemplate();
 		TestRestTemplate template = new TestRestTemplate(delegate);
@@ -346,7 +346,7 @@ public class TestRestTemplateTests {
 		template.setUriTemplateHandler(uriTemplateHandler);
 		callback.doWithTestRestTemplate(template,
 				URI.create("/a/b/c.txt?param=%7Bsomething%7D"));
-		verify(requestFactory).createRequest(eq(absoluteUri), (HttpMethod) any());
+		verify(requestFactory).createRequest(eq(absoluteUri), any(HttpMethod.class));
 	}
 
 	private void assertBasicAuthorizationInterceptorCredentials(

--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/web/servlet/MockServletWebServer.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/web/servlet/MockServletWebServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ public abstract class MockServletWebServer {
 	private void initialize() {
 		try {
 			this.servletContext = mock(ServletContext.class);
-			given(this.servletContext.addServlet(anyString(), (Servlet) any()))
+			given(this.servletContext.addServlet(anyString(), any(Servlet.class)))
 					.willAnswer((invocation) -> {
 						RegisteredServlet registeredServlet = new RegisteredServlet(
 								(Servlet) invocation.getArguments()[1]);
@@ -74,7 +74,7 @@ public abstract class MockServletWebServer {
 								.add(registeredServlet);
 						return registeredServlet.getRegistration();
 					});
-			given(this.servletContext.addFilter(anyString(), (Filter) any()))
+			given(this.servletContext.addFilter(anyString(), any(Filter.class)))
 					.willAnswer((invocation) -> {
 						RegisteredFilter registeredFilter = new RegisteredFilter(
 								(Filter) invocation.getArguments()[1]);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/type/classreading/ConcurrentReferenceCachingMetadataReaderFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/type/classreading/ConcurrentReferenceCachingMetadataReaderFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public class ConcurrentReferenceCachingMetadataReaderFactoryTests {
 		MetadataReader metadataReader1 = factory.getMetadataReader(getClass().getName());
 		MetadataReader metadataReader2 = factory.getMetadataReader(getClass().getName());
 		assertThat(metadataReader1).isSameAs(metadataReader2);
-		verify(factory, times(1)).createMetadataReader((Resource) any());
+		verify(factory, times(1)).createMetadataReader(any(Resource.class));
 	}
 
 	@Test
@@ -54,7 +54,7 @@ public class ConcurrentReferenceCachingMetadataReaderFactoryTests {
 		factory.clearCache();
 		MetadataReader metadataReader2 = factory.getMetadataReader(getClass().getName());
 		assertThat(metadataReader1).isNotEqualTo(sameInstance(metadataReader2));
-		verify(factory, times(2)).createMetadataReader((Resource) any());
+		verify(factory, times(2)).createMetadataReader(any(Resource.class));
 	}
 
 	private static class TestConcurrentReferenceCachingMetadataReaderFactory

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/RestTemplateBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/RestTemplateBuilderTests.java
@@ -350,7 +350,7 @@ public class RestTemplateBuilderTests {
 	public void customizersShouldBeAppliedLast() {
 		RestTemplate template = spy(new RestTemplate());
 		this.builder.additionalCustomizers((restTemplate) -> verify(restTemplate)
-				.setRequestFactory((ClientHttpRequestFactory) any()));
+				.setRequestFactory(any(ClientHttpRequestFactory.class)));
 		this.builder.configure(template);
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/RootUriTemplateHandlerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/RootUriTemplateHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ public class RootUriTemplateHandlerTests {
 		this.uri = new URI("http://example.com/hello");
 		this.handler = new RootUriTemplateHandler("http://example.com", this.delegate);
 		given(this.delegate.expand(anyString(), any(Map.class))).willReturn(this.uri);
-		given(this.delegate.expand(anyString(), (Object[]) any())).willReturn(this.uri);
+		given(this.delegate.expand(anyString(), any(Object[].class))).willReturn(this.uri);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ public class UndertowServletWebServerFactoryTests
 		this.webServer = factory.getWebServer();
 		InOrder ordered = inOrder((Object[]) customizers);
 		for (UndertowBuilderCustomizer customizer : customizers) {
-			ordered.verify(customizer).customize((Builder) any());
+			ordered.verify(customizer).customize(any(Builder.class));
 		}
 	}
 
@@ -139,7 +139,7 @@ public class UndertowServletWebServerFactoryTests
 		this.webServer = factory.getWebServer();
 		InOrder ordered = inOrder((Object[]) customizers);
 		for (UndertowDeploymentInfoCustomizer customizer : customizers) {
-			ordered.verify(customizer).customize((DeploymentInfo) any());
+			ordered.verify(customizer).customize(any(DeploymentInfo.class));
 		}
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/AbstractFilterRegistrationBeanTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/AbstractFilterRegistrationBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ public abstract class AbstractFilterRegistrationBeanTests {
 	@Before
 	public void setupMocks() {
 		MockitoAnnotations.initMocks(this);
-		given(this.servletContext.addFilter(anyString(), (Filter) any()))
+		given(this.servletContext.addFilter(anyString(), any(Filter.class)))
 				.willReturn(this.registration);
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/ServletRegistrationBeanTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/ServletRegistrationBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,9 +68,9 @@ public class ServletRegistrationBeanTests {
 	@Before
 	public void setupMocks() {
 		MockitoAnnotations.initMocks(this);
-		given(this.servletContext.addServlet(anyString(), (Servlet) any()))
+		given(this.servletContext.addServlet(anyString(), any(Servlet.class)))
 				.willReturn(this.registration);
-		given(this.servletContext.addFilter(anyString(), (Filter) any()))
+		given(this.servletContext.addFilter(anyString(), any(Filter.class)))
 				.willReturn(this.filterRegistration);
 	}
 
@@ -88,7 +88,7 @@ public class ServletRegistrationBeanTests {
 	public void startupWithDoubleRegistration() throws Exception {
 		ServletRegistrationBean<MockServlet> bean = new ServletRegistrationBean<>(
 				this.servlet);
-		given(this.servletContext.addServlet(anyString(), (Servlet) any()))
+		given(this.servletContext.addServlet(anyString(), any(Servlet.class)))
 				.willReturn(null);
 		bean.onStartup(this.servletContext);
 		verify(this.servletContext).addServlet("mockServlet", this.servlet);
@@ -207,7 +207,7 @@ public class ServletRegistrationBeanTests {
 		ServletRegistrationBean<MockServlet> bean = new ServletRegistrationBean<>(
 				this.servlet, false);
 		bean.onStartup(this.servletContext);
-		verify(this.registration, never()).addMapping((String[]) any());
+		verify(this.registration, never()).addMapping(any(String[].class));
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContextTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -371,8 +371,8 @@ public class ServletWebServerApplicationContextTests {
 		this.context.refresh();
 		ServletContext servletContext = getWebServerFactory().getServletContext();
 		verify(initializer).onStartup(servletContext);
-		verify(servletContext).addServlet(anyString(), (Servlet) any());
-		verify(servletContext).addFilter(anyString(), (Filter) any());
+		verify(servletContext).addServlet(anyString(), any(Servlet.class));
+		verify(servletContext).addFilter(anyString(), any(Filter.class));
 	}
 
 	@Test
@@ -388,8 +388,8 @@ public class ServletWebServerApplicationContextTests {
 		this.context.registerBeanDefinition("filterBean", beanDefinition(filter));
 		this.context.refresh();
 		ServletContext servletContext = getWebServerFactory().getServletContext();
-		verify(servletContext, atMost(1)).addServlet(anyString(), (Servlet) any());
-		verify(servletContext, atMost(1)).addFilter(anyString(), (Filter) any());
+		verify(servletContext, atMost(1)).addServlet(anyString(), any(Servlet.class));
+		verify(servletContext, atMost(1)).addFilter(anyString(), any(Filter.class));
 	}
 
 	@Test
@@ -402,7 +402,7 @@ public class ServletWebServerApplicationContextTests {
 		this.context.registerBeanDefinition("filterBean", beanDefinition(filter));
 		this.context.refresh();
 		ServletContext servletContext = getWebServerFactory().getServletContext();
-		verify(servletContext, atMost(1)).addFilter(anyString(), (Filter) any());
+		verify(servletContext, atMost(1)).addFilter(anyString(), any(Filter.class));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
@@ -313,7 +313,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 		this.webServer.start();
 		InOrder ordered = inOrder((Object[]) initializers);
 		for (ServletContextInitializer initializer : initializers) {
-			ordered.verify(initializer).onStartup((ServletContext) any());
+			ordered.verify(initializer).onStartup(any(ServletContext.class));
 		}
 	}
 


### PR DESCRIPTION
Hi,

this PR replaces casted `any()` calls with `any(Class)`. So `(Servlet) any()` will become `any(Servlet.class)` for example. Please note, that a few of those replacements were unnecessary casts as the type could be inferred. I kept the class around on purpose to not lose the (intended) expressiveness, but I have no strong feelings against using only `any()` for them.

Let me know what you think.

Cheers,
Christoph

 