### PR TITLE
Use InvocationOnMock.getArgument() where possible

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/support/MockCachingProvider.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/support/MockCachingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,12 +50,12 @@ public class MockCachingProvider implements CachingProvider {
 		final Map<String, Cache> caches = new HashMap<>();
 		given(cacheManager.getCacheNames()).willReturn(caches.keySet());
 		given(cacheManager.getCache(anyString())).willAnswer((invocation) -> {
-			String cacheName = (String) invocation.getArguments()[0];
+			String cacheName = invocation.getArgument(0);
 			return caches.get(cacheName);
 		});
 		given(cacheManager.createCache(anyString(), any(Configuration.class)))
 				.will((invocation) -> {
-					String cacheName = (String) invocation.getArguments()[0];
+					String cacheName = invocation.getArgument(0);
 					Cache cache = mock(Cache.class);
 					given(cache.getName()).willReturn(cacheName);
 					caches.put(cacheName, cache);

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/MockRestarter.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/MockRestarter.java
@@ -62,8 +62,8 @@ public class MockRestarter implements TestRule {
 		given(this.mock.getInitialUrls()).willReturn(new URL[] {});
 		given(this.mock.getOrAddAttribute(anyString(), (ObjectFactory) any()))
 				.willAnswer((invocation) -> {
-					String name = (String) invocation.getArguments()[0];
-					ObjectFactory factory = (ObjectFactory) invocation.getArguments()[1];
+					String name = invocation.getArgument(0);
+					ObjectFactory factory = invocation.getArgument(1);
 					Object attribute = MockRestarter.this.attributes.get(name);
 					if (attribute == null) {
 						attribute = factory.getObject();

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/tunnel/server/HttpTunnelServerTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/tunnel/server/HttpTunnelServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ public class HttpTunnelServerTests {
 		this.server = new HttpTunnelServer(this.serverConnection);
 		given(this.serverConnection.open(anyInt())).willAnswer((invocation) -> {
 			MockServerChannel channel = HttpTunnelServerTests.this.serverChannel;
-			channel.setTimeout((Integer) invocation.getArguments()[0]);
+			channel.setTimeout(invocation.getArgument(0));
 			return channel;
 		});
 		this.servletRequest = new MockHttpServletRequest();

--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/web/servlet/MockServletWebServer.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/web/servlet/MockServletWebServer.java
@@ -69,7 +69,7 @@ public abstract class MockServletWebServer {
 			given(this.servletContext.addServlet(anyString(), (Servlet) any()))
 					.willAnswer((invocation) -> {
 						RegisteredServlet registeredServlet = new RegisteredServlet(
-								(Servlet) invocation.getArguments()[1]);
+								invocation.getArgument(1));
 						MockServletWebServer.this.registeredServlets
 								.add(registeredServlet);
 						return registeredServlet.getRegistration();
@@ -77,7 +77,7 @@ public abstract class MockServletWebServer {
 			given(this.servletContext.addFilter(anyString(), (Filter) any()))
 					.willAnswer((invocation) -> {
 						RegisteredFilter registeredFilter = new RegisteredFilter(
-								(Filter) invocation.getArguments()[1]);
+								invocation.getArgument(1));
 						MockServletWebServer.this.registeredFilters.add(registeredFilter);
 						return registeredFilter.getRegistration();
 					});


### PR DESCRIPTION
Hi,

while working on #11817 I noticed some calls to `InvocationOnMock.getArguments()[int i]` that could be replaced with the single argument variant. This has the nice side-effect of getting rid of some casts.

NOTE: The copyright changes assume that PR #11817 is merged as well in order to avoid eventual conflicts when both are accepted.

Cheers,
Christoph