### PR TITLE
Configure default RedisSerializer

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/RedisCacheConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/RedisCacheConfiguration.java
@@ -32,6 +32,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.cache.RedisCacheManager.RedisCacheManagerBuilder;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer.RedisSerializer;
 
 /**
  * Redis cache configuration.
@@ -63,9 +65,10 @@ class RedisCacheConfiguration {
 	}
 
 	@Bean
-	public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+	public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory,
+										RedisSerializer<?> defaultRedisSerializer) {
 		RedisCacheManagerBuilder builder = RedisCacheManager
-				.builder(redisConnectionFactory).cacheDefaults(determineConfiguration());
+				.builder(redisConnectionFactory).cacheDefaults(determineConfiguration(defaultRedisSerializer));
 		List<String> cacheNames = this.cacheProperties.getCacheNames();
 		if (!cacheNames.isEmpty()) {
 			builder.initialCacheNames(new LinkedHashSet<>(cacheNames));
@@ -73,7 +76,7 @@ class RedisCacheConfiguration {
 		return this.customizerInvoker.customize(builder.build());
 	}
 
-	private org.springframework.data.redis.cache.RedisCacheConfiguration determineConfiguration() {
+	private org.springframework.data.redis.cache.RedisCacheConfiguration determineConfiguration(RedisSerializer<?> defaultRedisSerializer) {
 		if (this.redisCacheConfiguration != null) {
 			return this.redisCacheConfiguration;
 		}
@@ -92,7 +95,7 @@ class RedisCacheConfiguration {
 		if (!redisProperties.isUseKeyPrefix()) {
 			config = config.disableKeyPrefix();
 		}
-		return config;
+		return config.serializeValuesWith(SerializationPair.fromSerializer(defaultRedisSerializer));
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,13 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Spring Data's Redis support.
@@ -50,11 +53,20 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 public class RedisAutoConfiguration {
 
 	@Bean
+	@ConditionalOnMissingBean(name = "redisSerializer")
+	public JdkSerializationRedisSerializer redisSerializer(
+			ResourceLoader resourceLoader) {
+		return new JdkSerializationRedisSerializer(resourceLoader.getClassLoader());
+	}
+
+	@Bean
 	@ConditionalOnMissingBean(name = "redisTemplate")
 	public RedisTemplate<Object, Object> redisTemplate(
-			RedisConnectionFactory redisConnectionFactory) throws UnknownHostException {
+			RedisConnectionFactory redisConnectionFactory,
+			RedisSerializer<?> defaultRedisSerializer) throws UnknownHostException {
 		RedisTemplate<Object, Object> template = new RedisTemplate<>();
 		template.setConnectionFactory(redisConnectionFactory);
+		template.setDefaultSerializer(defaultRedisSerializer);
 		return template;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisReactiveAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisReactiveAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,11 +25,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
-import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Spring Data's reactive Redis
@@ -50,12 +49,9 @@ public class RedisReactiveAutoConfiguration {
 	@ConditionalOnBean(ReactiveRedisConnectionFactory.class)
 	public ReactiveRedisTemplate<Object, Object> reactiveRedisTemplate(
 			ReactiveRedisConnectionFactory reactiveRedisConnectionFactory,
-			ResourceLoader resourceLoader) {
-		JdkSerializationRedisSerializer jdkSerializer = new JdkSerializationRedisSerializer(
-				resourceLoader.getClassLoader());
+			RedisSerializer<?> defaultSerializer) {
 		RedisSerializationContext<Object, Object> serializationContext = RedisSerializationContext
-				.newSerializationContext().key(jdkSerializer).value(jdkSerializer)
-				.hashKey(jdkSerializer).hashValue(jdkSerializer).build();
+				.fromSerializer((RedisSerializer) defaultSerializer);
 		return new ReactiveRedisTemplate<>(reactiveRedisConnectionFactory,
 				serializationContext);
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
@@ -76,6 +76,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -942,6 +943,11 @@ public class CacheAutoConfigurationTests {
 		@Bean
 		public RedisConnectionFactory redisConnectionFactory() {
 			return mock(RedisConnectionFactory.class);
+		}
+
+		@Bean
+		public JdkSerializationRedisSerializer redisSerializer() {
+			return new JdkSerializationRedisSerializer();
 		}
 
 	}


### PR DESCRIPTION
We now configure a default `RedisSerializer` bean using JDK serialization with the appropriate ClassLoader. RedisSerializers are used in imperative/reactive Redis templates and for Redis Cache. This bean centralizes configuration and allows easier override of the default serialization mechanism.

---

Related to #11822.