### PR TITLE
Reduce StringBuilder creation in TypeExtractor.visitDeclared()

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
@@ -188,13 +188,15 @@ class TypeUtils {
 				return getQualifiedName(enclosingElement) + "$"
 						+ type.asElement().getSimpleName().toString();
 			}
-			StringBuilder name = new StringBuilder();
-			name.append(getQualifiedName(type.asElement()));
-			if (!type.getTypeArguments().isEmpty()) {
-				name.append(
-						"<" + type.getTypeArguments().stream().map(TypeMirror::toString)
-								.collect(Collectors.joining(",")) + ">");
+			String qualifiedName = getQualifiedName(type.asElement());
+			if (type.getTypeArguments().isEmpty()) {
+				return qualifiedName;
 			}
+			StringBuilder name = new StringBuilder();
+			name.append(qualifiedName);
+			name.append(
+					"<" + type.getTypeArguments().stream().map(TypeMirror::toString)
+							.collect(Collectors.joining(",")) + ">");
 			return name.toString();
 		}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR reduces `StringBuilder` creation in `TypeExtractor.visitDeclared()`.