### PR TITLE
Add spring-boot-cli support for Windows MINGW environments

### DIFF
--- a/spring-boot-project/spring-boot-cli/src/main/executablecontent/bin/spring
+++ b/spring-boot-project/spring-boot-cli/src/main/executablecontent/bin/spring
@@ -8,6 +8,10 @@ case "`uname`" in
 		cygwin=true
 		;;
 
+	MINGW*)
+		cygwin=true
+		;;
+
 	Darwin*)
 		darwin=true
 		;;


### PR DESCRIPTION
Fixes #11846 

As MINGW actually contains a light version of cygwin it is compatible with cygwin. Therefore only the match for MINGW is necessary.
Tested in my environment and it works fine.
Unfortunatelly I don't see a way to easily test this with an integration test.