### PR TITLE
Aggregate max statistics in metrics endpoint with Double#max

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/MetricsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/MetricsEndpoint.java
@@ -121,7 +121,11 @@ public class MetricsEndpoint {
 
 	private void mergeMeasurements(Map<Statistic, Double> samples, Meter meter) {
 		meter.measure().forEach((measurement) -> samples.merge(measurement.getStatistic(),
-				measurement.getValue(), Double::sum));
+				measurement.getValue(), mergeFunction(measurement.getStatistic())));
+	}
+
+	private BiFunction<Double, Double, Double> mergeFunction(Statistic statistic) {
+		return Statistic.MAX.equals(statistic) ? Double::max : Double::sum;
 	}
 
 	private Map<String, Set<String>> getAvailableTags(List<Meter> meters) {


### PR DESCRIPTION
When you visit a timer (or distribution summary) in the metrics actuator endpoint, there are several measurements present:

```
"measurements": [
        {
            "statistic": "Count",
            "value": 2.0
        },
        {
            "statistic": "TotalTime",
            "value": 0.218106262
        },
        {
            "statistic": "Max",
            "value": 0.1
        }
    ],
```

When you are viewing an aggregate metric (one that still has several "available tags" that you could drill down further on), these measurements are aggregated across the selected dimensions (or all dimensions if none have been selected particularly).

The correct aggregation function is `Double::sum` for all statistics except max, which should be `Double::max`.