### PR TITLE
CompositeMeterRegistryPostProcessor now injects a non-null clock

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/CompositeMeterRegistryPostProcessor.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/CompositeMeterRegistryPostProcessor.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.ConstructorArgumentValues;
-import org.springframework.beans.factory.config.ConstructorArgumentValues.ValueHolder;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
@@ -106,8 +105,7 @@ class CompositeMeterRegistryPostProcessor
 		definition.setBeanClass(CompositeMeterRegistry.class);
 		definition.setPrimary(true);
 		ConstructorArgumentValues arguments = new ConstructorArgumentValues();
-		arguments.addIndexedArgumentValue(0,
-				new ValueHolder(null, Clock.class.getName()));
+		arguments.addIndexedArgumentValue(0, this.beanFactory.getBean(Clock.class));
 		arguments.addIndexedArgumentValue(1, getBeanReferences(registryBeans));
 		definition.setConstructorArgumentValues(arguments);
 		registry.registerBeanDefinition(COMPOSITE_BEAN_NAME, definition);

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/CompositeMeterRegistryPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/CompositeMeterRegistryPostProcessorTests.java
@@ -73,6 +73,7 @@ public class CompositeMeterRegistryPostProcessorTests {
 					assertThat(primary).isInstanceOf(CompositeMeterRegistry.class);
 					assertThat(((CompositeMeterRegistry) primary).getRegistries())
 							.hasSize(2);
+					assertThat(primary.config().clock()).isNotNull();
 				});
 	}
 


### PR DESCRIPTION
The new `CompositeMeterRegistryPostProcessor` passes `null` as the first argument to `CompositeMeterRegistry`. It should pass the autoconfigured `Clock` coming from `MetricsAutoConfiguration`.

This manifests itself as an NPE when attempting later to use a timer/long task timer.

See https://github.com/micrometer-metrics/micrometer/issues/384.