### PR TITLE
Dependency management for REST Assured is incomplete

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -932,6 +932,11 @@
 				<artifactId>rest-assured</artifactId>
 				<version>${rest-assured.version}</version>
 			</dependency>
+			 <dependency>
+                <groupId>io.rest-assured</groupId>
+                <artifactId>spring-mock-mvc</artifactId>
+                <version>${rest-assured.version}</version>
+            </dependency>
 			<dependency>
 				<groupId>io.searchbox</groupId>
 				<artifactId>jest</artifactId>


### PR DESCRIPTION
Added dependency of spring-mock-mvc with the same version as rest-assured.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->