### PR TITLE
Fix default HttpMessageConverters not being replaced

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/HttpMessageConverters.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/HttpMessageConverters.java
@@ -113,13 +113,17 @@ public class HttpMessageConverters implements Iterable<HttpMessageConverter<?>> 
 			List<HttpMessageConverter<?>> defaultConverters) {
 		List<HttpMessageConverter<?>> combined = new ArrayList<>();
 		List<HttpMessageConverter<?>> processing = new ArrayList<>(converters);
-		for (HttpMessageConverter<?> defaultConverter : defaultConverters) {
+		defaultConverters: for (HttpMessageConverter<?> defaultConverter : defaultConverters) {
 			Iterator<HttpMessageConverter<?>> iterator = processing.iterator();
 			while (iterator.hasNext()) {
 				HttpMessageConverter<?> candidate = iterator.next();
 				if (isReplacement(defaultConverter, candidate)) {
 					combined.add(candidate);
 					iterator.remove();
+					// We found a replacement for this default converter
+					// hence we need to continue with the next default converter
+					// instead of adding the default converter as well
+					continue defaultConverters;
 				}
 			}
 			combined.add(defaultConverter);


### PR DESCRIPTION
In case a `HttpMessageConverter` is a replacement for a default, we need to skip that default converter instead of adding both. Otherwise this results in duplicate converters, where one is completely unconfigured.

In the simplest case (empty project with just `org.springframework.boot:spring-boot-starter-web`) this causes two `MappingJackson2HttpMessageConverter` to be created and added to the web mvc systems. One of these converters is the default converter using a plain, unconfigured `ObjectMapper`, the other is the properly configured converter.