### PR TITLE
Update deployment tests to include Actuator

### DIFF
--- a/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-glassfish/pom.xml
+++ b/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-glassfish/pom.xml
@@ -32,6 +32,10 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<scope>provided</scope>

--- a/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-glassfish/src/test/java/sample/SampleGlassfishDeployApplicationIT.java
+++ b/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-glassfish/src/test/java/sample/SampleGlassfishDeployApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,16 @@ public class SampleGlassfishDeployApplicationIT {
 				String.class);
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
 		assertThat(entity.getBody()).isEqualTo("Hello World");
+	}
+
+	@Test
+	public void testHealth() throws Exception {
+		String url = "http://localhost:" + this.port + "/bootapp/actuator/health";
+		System.out.println(url);
+		ResponseEntity<String> entity = new TestRestTemplate().getForEntity(url,
+				String.class);
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(entity.getBody()).isEqualTo("{\"status\":\"UP\"}");
 	}
 
 }

--- a/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-tomcat/pom.xml
+++ b/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-tomcat/pom.xml
@@ -29,6 +29,10 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<scope>provided</scope>

--- a/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-tomcat/src/test/java/sample/SampleTomcatDeployApplicationIT.java
+++ b/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-tomcat/src/test/java/sample/SampleTomcatDeployApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,16 @@ public class SampleTomcatDeployApplicationIT {
 				String.class);
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
 		assertThat(entity.getBody()).isEqualTo("Hello World");
+	}
+
+	@Test
+	public void testHealth() throws Exception {
+		String url = "http://localhost:" + this.port + "/bootapp/actuator/health";
+		System.out.println(url);
+		ResponseEntity<String> entity = new TestRestTemplate().getForEntity(url,
+				String.class);
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(entity.getBody()).isEqualTo("{\"status\":\"UP\"}");
 	}
 
 }

--- a/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-tomee/pom.xml
+++ b/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-tomee/pom.xml
@@ -34,6 +34,10 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<scope>provided</scope>

--- a/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-tomee/src/test/java/sample/SampleTomEEDeployApplicationIT.java
+++ b/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-tomee/src/test/java/sample/SampleTomEEDeployApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,16 @@ public class SampleTomEEDeployApplicationIT {
 				String.class);
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
 		assertThat(entity.getBody()).isEqualTo("Hello World");
+	}
+
+	@Test
+	public void testHealth() throws Exception {
+		String url = "http://localhost:" + this.port + "/bootapp/actuator/health";
+		System.out.println(url);
+		ResponseEntity<String> entity = new TestRestTemplate().getForEntity(url,
+				String.class);
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(entity.getBody()).isEqualTo("{\"status\":\"UP\"}");
 	}
 
 }

--- a/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-wildfly/pom.xml
+++ b/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-wildfly/pom.xml
@@ -29,6 +29,10 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<scope>provided</scope>

--- a/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-wildfly/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-wildfly/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -7,6 +7,14 @@
 			<module name="com.fasterxml.jackson.core.jackson-databind" />
 			<module name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" />
 			<module name="org.jboss.resteasy.resteasy-jackson2-provider" />
+			<module name="org.slf4j" />
 		</exclusions>
+		<dependencies>
+			<system>
+				<paths>
+					<path name="com/sun/management" />
+				</paths>
+			</system>
+		</dependencies>
 	</deployment>
 </jboss-deployment-structure>

--- a/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-wildfly/src/test/java/sample/SampleWildFlyDeployApplicationIT.java
+++ b/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-wildfly/src/test/java/sample/SampleWildFlyDeployApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,16 @@ public class SampleWildFlyDeployApplicationIT {
 				String.class);
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
 		assertThat(entity.getBody()).isEqualTo("Hello World");
+	}
+
+	@Test
+	public void testHealth() throws Exception {
+		String url = "http://localhost:" + this.port + "/bootapp/actuator/health";
+		System.out.println(url);
+		ResponseEntity<String> entity = new TestRestTemplate().getForEntity(url,
+				String.class);
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(entity.getBody()).isEqualTo("{\"status\":\"UP\"}");
 	}
 
 }

--- a/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-wlp/pom.xml
+++ b/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-wlp/pom.xml
@@ -28,6 +28,10 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<scope>provided</scope>

--- a/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-wlp/src/test/java/sample/SampleWlpDeployApplicationIT.java
+++ b/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-wlp/src/test/java/sample/SampleWlpDeployApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,16 @@ public class SampleWlpDeployApplicationIT {
 				String.class);
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
 		assertThat(entity.getBody()).isEqualTo("Hello World");
+	}
+
+	@Test
+	public void testHealth() throws Exception {
+		String url = "http://localhost:" + this.port + "/bootapp/actuator/health";
+		System.out.println(url);
+		ResponseEntity<String> entity = new TestRestTemplate().getForEntity(url,
+				String.class);
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(entity.getBody()).isEqualTo("{\"status\":\"UP\"}");
 	}
 
 }


### PR DESCRIPTION
This PR updates the existing deployment test to include Actuator. With this change, deployment tests can be used to reproduce the issue reported in #11879.

Note that the WildFly test app also requires exclusion of `org.slf4j` module to work with Actuator. This can be confirmed by adding `management.metrics.binders.jvm.enabled=false` to avoid problem reported in #11879.