### PR TITLE
recordRequestPercentiles has no effect on auto-timed RequestMappings

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsConfiguration.java
@@ -60,7 +60,8 @@ public class WebMvcMetricsConfiguration {
 		Server serverProperties = properties.getWeb().getServer();
 		WebMvcMetricsFilter filter = new WebMvcMetricsFilter(context, registry,
 				tagsProvider, serverProperties.getRequestsMetricName(),
-				serverProperties.isAutoTimeRequests());
+				serverProperties.isAutoTimeRequests(),
+				serverProperties.isRecordRequestPercentiles());
 		FilterRegistrationBean<WebMvcMetricsFilter> registration = new FilterRegistrationBean<>(
 				filter);
 		registration.setDispatcherTypes(DispatcherType.REQUEST, DispatcherType.ASYNC);

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilterTests.java
@@ -364,7 +364,7 @@ public class WebMvcMetricsFilterTests {
 		WebMvcMetricsFilter webMetricsFilter(MeterRegistry registry,
 				WebApplicationContext ctx) {
 			return new WebMvcMetricsFilter(ctx, registry, new DefaultWebMvcTagsProvider(),
-					"http.server.requests", true);
+					"http.server.requests", true, false);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsIntegrationTests.java
@@ -111,7 +111,7 @@ public class WebMvcMetricsIntegrationTests {
 		public WebMvcMetricsFilter webMetricsFilter(MeterRegistry registry,
 				WebApplicationContext ctx) {
 			return new WebMvcMetricsFilter(ctx, registry, new DefaultWebMvcTagsProvider(),
-					"http.server.requests", true);
+					"http.server.requests", true, false);
 		}
 
 		@RestController


### PR DESCRIPTION
Using Spring Boot 2.0.0.RC1 with the Actuator starter and setting `management.metrics.web.server.record-request-percentiles` to `true` does not have any effect. It should cause percentile histograms to be recorded for `RequestMapping` endpoints' timing.

The value of `recordRequestPercentiles` from the `MetricProperties` was not being considered to determine whether a histogram should be recorded for percentile usage. Now, setting `recordRequestPercentiles` has the expected effect of configuring histograms on auto timed requests.

/cc @jkschneider 