### PR TITLE
Fix jetty potentially binding to wrong IP address

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/jetty/JettyEmbeddedServletContainerFactory.java
@@ -101,6 +101,8 @@ import org.springframework.util.StringUtils;
  * @author Eddú Meléndez
  * @author Venil Noronha
  * @author Henri Kerola
+ * @author Henrich Krämer
+ *
  * @see #setPort(int)
  * @see #setConfigurations(Collection)
  * @see JettyEmbeddedServletContainer
@@ -895,7 +897,7 @@ public class JettyEmbeddedServletContainerFactory
 				ReflectionUtils.findMethod(connectorClass, "setPort", int.class)
 						.invoke(connector, address.getPort());
 				ReflectionUtils.findMethod(connectorClass, "setHost", String.class)
-						.invoke(connector, address.getHostName());
+						.invoke(connector, address.getHostString());
 				if (acceptors > 0) {
 					ReflectionUtils.findMethod(connectorClass, "setAcceptors", int.class)
 							.invoke(connector, acceptors);
@@ -924,7 +926,7 @@ public class JettyEmbeddedServletContainerFactory
 		public AbstractConnector createConnector(Server server, InetSocketAddress address,
 				int acceptors, int selectors) {
 			ServerConnector connector = new ServerConnector(server, acceptors, selectors);
-			connector.setHost(address.getHostName());
+			connector.setHost(address.getHostString());
 			connector.setPort(address.getPort());
 			for (ConnectionFactory connectionFactory : connector
 					.getConnectionFactories()) {


### PR DESCRIPTION
When jetty is configured to an IP address whose reverse name resolution
followed by a subsequent name resolution does not lead to the same IP
address, jetty binds to that different IP address.

This is configured with the server.address parameter.

Changed code to not use reveres name resolution.

Fixes gh-11860

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->