### PR TITLE
Improve WebFlux error logging

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandler.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandler.java
@@ -39,6 +39,7 @@ import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * Basic global {@link org.springframework.web.server.WebExceptionHandler}, rendering
@@ -188,16 +189,43 @@ public class DefaultErrorWebExceptionHandler extends AbstractErrorWebExceptionHa
 	}
 
 	/**
-	 * Log the original exception if handling it results in a Server Error.
+	 * Log the original exception if handling it results in a Server Error or a Bad Request
+	 * (Client Error with 400 status code) one.
 	 * @param request the source request
 	 * @param errorStatus the HTTP error status
 	 */
 	protected void logError(ServerRequest request, HttpStatus errorStatus) {
 		if (errorStatus.is5xxServerError()) {
 			Throwable ex = getError(request);
-			logger.error("Failed to handle request [" + request.methodName() + " "
-					+ request.uri() + "]", ex);
+			if (ex instanceof ResponseStatusException) {
+				logger.error(buildMessage(request, ex));
+			}
+			else {
+				logger.error(buildMessage(request, null), ex);
+			}
 		}
+		else if (errorStatus == HttpStatus.BAD_REQUEST) {
+			Throwable ex = getError(request);
+			if (ex instanceof ResponseStatusException) {
+				logger.warn(buildMessage(request, ex));
+			}
+			else {
+				logger.warn(buildMessage(request, null), ex);
+			}
+		}
+	}
+
+	private String buildMessage(ServerRequest request, Throwable ex) {
+		StringBuilder message = new StringBuilder("Failed to handle request [");
+		message.append(request.methodName());
+		message.append(" ");
+		message.append(request.uri());
+		message.append("]");
+		if (ex != null) {
+			message.append(": ");
+			message.append(ex.getMessage());
+		}
+		return message.toString();
 	}
 
 }


### PR DESCRIPTION
This PR has been discussed with @bclozel who is likely to review it before inclusion.

It avoids printing the stacktrace for `ResponseStatusException` in order to be consistent with WebFlux `ResponseStatusExceptionHandler` and because this stacktrace is usually not very useful in Reactive world and mainly pollutes the logs, only the message is logged in that case.

It also logs a `WARN` message for Bad Request (400) HTTP responses in order to have a feedback when an exception is thrown due to client error (unable to deserialize request body for example).

See related [SPR-15083](https://jira.spring.io/browse/SPR-15083) issue on Spring Framework side.