### PR TITLE
Optimize ApplicationHome.isUnitTest()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/ApplicationHome.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/ApplicationHome.java
@@ -105,7 +105,9 @@ public class ApplicationHome {
 
 	private boolean isUnitTest() {
 		try {
-			for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
+			StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+			for (int i = stackTrace.length - 1; i >= 0; i--) {
+				StackTraceElement element = stackTrace[i];
 				if (element.getClassName().startsWith("org.junit.")) {
 					return true;
 				}


### PR DESCRIPTION
Hi,

I just found a possible optimization in `ApplicationHome.isUnitTest()` that loops through the results of `Thread.currentThread().getStackTrace()` to check for elements starting with `org.junit` in order to find out if the application is run from a unit test context.

Typically, invocations of `org.junit` are at the bottom of the stack, so we can invert the loop direction to save some cycles.

Let me know what you think.

Cheers,
Christoph