### PR TITLE
Add support of git and build info variables in banner

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/RemoteSpringApplication.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/RemoteSpringApplication.java
@@ -82,7 +82,7 @@ public final class RemoteSpringApplication {
 	private Banner getBanner() {
 		ClassPathResource banner = new ClassPathResource("remote-banner.txt",
 				RemoteSpringApplication.class);
-		return new ResourceBanner(banner);
+		return new ResourceBanner(banner, null, null);
 	}
 
 	private void waitIndefinitely() {

--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/RemoteSpringApplication.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/RemoteSpringApplication.java
@@ -82,7 +82,7 @@ public final class RemoteSpringApplication {
 	private Banner getBanner() {
 		ClassPathResource banner = new ClassPathResource("remote-banner.txt",
 				RemoteSpringApplication.class);
-		return new ResourceBanner(banner, null, null);
+		return new ResourceBanner(banner);
 	}
 
 	private void waitIndefinitely() {

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -100,7 +100,11 @@ converted into an ASCII art representation and printed above any text banner.
 
 Inside your `banner.txt` file you can use any of the following placeholders:
 
-.Banner variables
+WARNING: Banner variables are read from property files generated during build time. When the
+application is run from IDE these files are not available, therefore these properties won't
+be displayed.
+
+.Generic Banner variables
 |===
 | Variable | Description
 
@@ -126,6 +130,79 @@ brackets and prefixed with `v`). For example `(v{spring-boot-version})`.
 |`${application.title}`
 |The title of your application as declared in `MANIFEST.MF`. For example
 `Implementation-Title: MyApp` is printed as `MyApp`.
+|===
+
+
+.Git info variables
+
+WARNING: These variables are available when build info generation is enabled as described link:howto.adoc[here]
+
+|===
+| Variable | Description
+
+|`${git.commit.id.abbrev}`
+|as defined in `git.properties`.
+
+|`${git.commit.user.email}`
+|as defined in `git.properties`.
+
+|`${git.commit.message.full}`
+|as defined in `git.properties`.
+
+|`${git.commit.id}`
+|as defined in `git.properties`.
+
+|`${git.commit.message.short}`
+|as defined in `git.properties`.
+
+|`${git.commit.user.name}`
+|as defined in `git.properties`.
+
+|`${git.build.user.email}`
+|as defined in `git.properties`.
+
+|`${git.branch}`
+|as defined in `git.properties`.
+
+|`${git.commit.time}`
+|as defined in `git.properties`.
+
+|`${git.build.time}`
+|as defined in `git.properties`.
+
+|===
+
+.Build info Banner variables
+
+WARNING: These variables are available when build info generation is enabled as described link:howto.adoc[here]
+
+|===
+| Variable | Description
+
+|`${application.version}`
+|As defined in  `META_INF/build-info.properties`.
+
+|`${build.artifact}`
+|As defined in  `META_INF/build-info.properties`.
+
+|`${build.name}`
+|As defined in  `META_INF/build-info.properties`.
+
+|`${build.version}`
+|As defined in  `META_INF/build-info.properties`.
+
+|`${build.time}`
+|As defined in  `META_INF/build-info.properties`.
+
+|===
+
+.Property Banner variables
+|===
+| Variable | Description
+
+|`${any.property}`
+|Any property defined in properties, yml files or specified as an argument e.g..: ` --any.perpertzy=test`.
+
 |===
 
 TIP: The `SpringApplication.setBanner(...)` method can be used if you want to generate

--- a/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -132,11 +132,9 @@ brackets and prefixed with `v`). For example `(v{spring-boot-version})`.
 `Implementation-Title: MyApp` is printed as `MyApp`.
 |===
 
-
-.Git info variables
-
 WARNING: These variables are available when build info generation is enabled as described link:howto.adoc[here]
 
+.Git info variables
 |===
 | Variable | Description
 
@@ -172,10 +170,9 @@ WARNING: These variables are available when build info generation is enabled as 
 
 |===
 
-.Build info Banner variables
-
 WARNING: These variables are available when build info generation is enabled as described link:howto.adoc[here]
 
+.Build info Banner variables
 |===
 | Variable | Description
 
@@ -201,7 +198,7 @@ WARNING: These variables are available when build info generation is enabled as 
 | Variable | Description
 
 |`${any.property}`
-|Any property defined in properties, yml files or specified as an argument e.g..: ` --any.perpertzy=test`.
+|Any property defined in properties, yml files or specified as an argument e.g..: `--any.perpertzy=test` .
 
 |===
 
@@ -220,6 +217,7 @@ The printed banner will be registered as a singleton bean under the name
 ====
 YAML maps `off` to `false` so make sure to add quotes if you want to disable the
 banner in your application.
+
 
 [source,yaml,indent=0]
 ----

--- a/spring-boot/src/main/java/org/springframework/boot/ResourceBanner.java
+++ b/spring-boot/src/main/java/org/springframework/boot/ResourceBanner.java
@@ -57,12 +57,15 @@ public class ResourceBanner implements Banner {
 	private Resource buildInfoPropertiesResource;
 
 	public ResourceBanner(Resource bannerResource, Resource gitPropertiesResource, Resource buildInfoPropertiesResource) {
-		Assert.notNull(bannerResource, "Resource must not be null");
-		Assert.isTrue(bannerResource.exists(), "Resource must exist");
-		this.bannerResource = bannerResource;
+		this(bannerResource);
 		this.gitPropertiesResource = gitPropertiesResource;
 		this.buildInfoPropertiesResource = buildInfoPropertiesResource;
+	}
 
+	public ResourceBanner(Resource bannerResource) {
+		Assert.notNull(bannerResource, "Banner resource must not be null");
+		Assert.isTrue(bannerResource.exists(), "Banner resource must exist");
+		this.bannerResource = bannerResource;
 	}
 
 	@Override

--- a/spring-boot/src/main/java/org/springframework/boot/SpringApplicationBannerPrinter.java
+++ b/spring-boot/src/main/java/org/springframework/boot/SpringApplicationBannerPrinter.java
@@ -88,9 +88,11 @@ class SpringApplicationBannerPrinter {
 	private Banner getTextBanner(Environment environment) {
 		String location = environment.getProperty(BANNER_LOCATION_PROPERTY,
 				DEFAULT_BANNER_LOCATION);
-		Resource resource = this.resourceLoader.getResource(location);
-		if (resource.exists()) {
-			return new ResourceBanner(resource);
+		Resource banner = this.resourceLoader.getResource(location);
+		Resource gitProperties = this.resourceLoader.getResource("git.properties");
+		Resource buildInfoProperties = this.resourceLoader.getResource("META-INF/build-info.properties");
+		if (banner.exists()) {
+			return new ResourceBanner(banner, gitProperties, buildInfoProperties);
 		}
 		return null;
 	}


### PR DESCRIPTION
This PR will give support of git.properties and build info variables in the banner.txt. This is useful so even command line applications can display the informations that would be otherwise only available through actuator.