### PR TITLE
Standardized basic cache metrics

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/cache/EhCache2CacheMeterBinderProvider.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/cache/EhCache2CacheMeterBinderProvider.java
@@ -34,7 +34,7 @@ public class EhCache2CacheMeterBinderProvider
 	@Override
 	public MeterBinder getMeterBinder(EhCacheCache cache, String name,
 			Iterable<Tag> tags) {
-		return new EhCache2Metrics(cache.getNativeCache(), name, tags);
+		return new EhCache2Metrics(cache.getNativeCache(), tags);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/cache/HazelcastCacheMeterBinderProvider.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/cache/HazelcastCacheMeterBinderProvider.java
@@ -36,7 +36,7 @@ public class HazelcastCacheMeterBinderProvider
 	public MeterBinder getMeterBinder(HazelcastCache cache, String name,
 			Iterable<Tag> tags) {
 		return new HazelcastCacheMetrics((IMap<Object, Object>) cache.getNativeCache(),
-				name, tags);
+				tags);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/cache/JCacheCacheMeterBinderProvider.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/cache/JCacheCacheMeterBinderProvider.java
@@ -34,7 +34,7 @@ public class JCacheCacheMeterBinderProvider
 	@Override
 	public MeterBinder getMeterBinder(JCacheCache cache, String name,
 			Iterable<Tag> tags) {
-		return new JCacheMetrics(cache.getNativeCache(), name, tags);
+		return new JCacheMetrics(cache.getNativeCache(), tags);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/cache/CacheMetricsRegistrarTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/cache/CacheMetricsRegistrarTests.java
@@ -42,7 +42,7 @@ public class CacheMetricsRegistrarTests {
 				"root", Collections.singleton(new CaffeineCacheMeterBinderProvider()));
 		assertThat(registrar.bindCacheToRegistry(
 				new CaffeineCache("test", Caffeine.newBuilder().build()))).isTrue();
-		assertThat(this.meterRegistry.get("root.requests").tags("name", "test").meter())
+		assertThat(this.meterRegistry.get("cache.gets").tags("name", "test").meter())
 				.isNotNull();
 	}
 
@@ -52,7 +52,7 @@ public class CacheMetricsRegistrarTests {
 				"root", Collections.emptyList());
 		assertThat(registrar.bindCacheToRegistry(
 				new CaffeineCache("test", Caffeine.newBuilder().build()))).isFalse();
-		assertThat(this.meterRegistry.find("root.requests").tags("name", "test").meter())
+		assertThat(this.meterRegistry.find("cache.gets").tags("name", "test").meter())
 				.isNull();
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/cache/HazelcastCacheMeterBinderProviderTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/cache/HazelcastCacheMeterBinderProviderTests.java
@@ -24,7 +24,7 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.cache.HazelcastCacheMetrics;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,12 +37,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(MockitoJUnitRunner.class)
 public class HazelcastCacheMeterBinderProviderTests {
 
-	@Mock
-	private IMap<Object, Object> nativeCache;
-
+	@SuppressWarnings("unchecked")
 	@Test
 	public void hazelcastCacheProvider() {
-		HazelcastCache cache = new HazelcastCache(this.nativeCache);
+		IMap<Object, Object> nativeCache = Mockito.mock(IMap.class);
+
+		// It is not possible to create a real Hazelcast cache with a null name,
+		// so Micrometer's Hazelcast binder uses the name from the cache for its tag value.
+		Mockito.when(nativeCache.getName()).thenReturn("test");
+
+		HazelcastCache cache = new HazelcastCache(nativeCache);
+
 		MeterBinder meterBinder = new HazelcastCacheMeterBinderProvider()
 				.getMeterBinder(cache, "test", Collections.emptyList());
 		assertThat(meterBinder).isInstanceOf(HazelcastCacheMetrics.class);


### PR DESCRIPTION
In https://github.com/micrometer-metrics/micrometer/issues/393, a `CacheMetricsBinder` abstract class was introduced and cache binder implementations were made to extend it. Cache metrics are now uniformly prefixed with `cache.` to allow property-based configuration of cache metrics independent of the cache implementation.

The purpose is to standardize basic cache metrics like gets (hit and miss), puts, evictions, and size so from the perspective of monitoring there is some cache implementation independence.

This resulted in a handful of constructor changes which are reflected in this PR.