### PR TITLE
Add influx property to govern whether db is auto-created or not

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxProperties.java
@@ -67,6 +67,11 @@ public class InfluxProperties extends StepRegistryProperties {
 	 */
 	private Boolean compressed;
 
+	/**
+	 * Check if Influx database exists before attempting to publish metrics to it, creating it if it does not exist.
+	 */
+	private Boolean autoCreateDb;
+
 	public String getDb() {
 		return this.db;
 	}
@@ -123,4 +128,11 @@ public class InfluxProperties extends StepRegistryProperties {
 		this.compressed = compressed;
 	}
 
+	public Boolean getAutoCreateDb() {
+		return this.autoCreateDb;
+	}
+
+	public void setAutoCreateDb(Boolean autoCreateDb) {
+		this.autoCreateDb = autoCreateDb;
+	}
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxPropertiesConfigAdapter.java
@@ -70,4 +70,8 @@ class InfluxPropertiesConfigAdapter extends
 		return get(InfluxProperties::getCompressed, InfluxConfig.super::compressed);
 	}
 
+	@Override
+	public boolean autoCreateDb() {
+		return get(InfluxProperties::getAutoCreateDb, InfluxConfig.super::autoCreateDb);
+	}
 }


### PR DESCRIPTION
See https://github.com/micrometer-metrics/micrometer/issues/389.

Authentication to Influx when attempting to create a DB is a Micrometer implementation detail that requires no change to Boot.