### PR TITLE
Improve FailureAnalyzer for embedded datasource

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzer.java
@@ -44,7 +44,7 @@ class DataSourceBeanCreationFailureAnalyzer
 	private String createDescription(DataSourceBeanCreationException cause) {
 
 		StringBuilder message = new StringBuilder();
-		message.append("Cannot auto-configure DataSource. ");
+		message.append(cause.getMessage());
 		message.append("Property spring.datasource.url was not specified. ");
 		message.append("Cannot auto-configure embedded database as well. ");
 		message.append("Cannot determine embedded database ");

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzer.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.autoconfigure.jdbc;
 
+import java.util.Objects;
+
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties.DataSourceBeanCreationException;
 import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
 import org.springframework.boot.diagnostics.FailureAnalysis;
 import org.springframework.core.env.Environment;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
-
-import java.util.Objects;
 
 /**
  * An {@link AbstractFailureAnalyzer} for failures caused by a
@@ -71,10 +71,11 @@ class DataSourceBeanCreationFailureAnalyzer
 			String[] profiles = environment.getActiveProfiles();
 			if (ObjectUtils.isEmpty(profiles)) {
 				message.append(" (no profiles are currently active).");
-			} else {
-				message.append(" (the profiles \"")
-						.append(StringUtils.arrayToCommaDelimitedString(profiles))
-						.append("\" are currently active).");
+			}
+			else {
+				message.append(" (the profiles ");
+				message.append(StringUtils.arrayToCommaDelimitedString(profiles));
+				message.append(" are currently active).");
 			}
 		}
 		return message.toString();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzer.java
@@ -44,8 +44,8 @@ class DataSourceBeanCreationFailureAnalyzer
 	private String createDescription(DataSourceBeanCreationException cause) {
 
 		StringBuilder message = new StringBuilder();
-		message.append(cause.getMessage());
-		message.append(" Property spring.datasource.url was not specified. ");
+		message.append("Cannot auto-configure DataSource. ");
+		message.append("Property spring.datasource.url was not specified. ");
 		message.append("Cannot auto-configure embedded database as well. ");
 		message.append("Cannot determine embedded database ");
 		message.append(cause.getProperty());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzer.java
@@ -19,12 +19,18 @@ package org.springframework.boot.autoconfigure.jdbc;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties.DataSourceBeanCreationException;
 import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
 import org.springframework.boot.diagnostics.FailureAnalysis;
+import org.springframework.core.env.Environment;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.Objects;
 
 /**
  * An {@link AbstractFailureAnalyzer} for failures caused by a
  * {@link DataSourceBeanCreationException}.
  *
  * @author Andy Wilkinson
+ * @author Patryk Kostrzewa
  */
 class DataSourceBeanCreationFailureAnalyzer
 		extends AbstractFailureAnalyzer<DataSourceBeanCreationException> {
@@ -32,10 +38,45 @@ class DataSourceBeanCreationFailureAnalyzer
 	@Override
 	protected FailureAnalysis analyze(Throwable rootFailure,
 			DataSourceBeanCreationException cause) {
-		String message = cause.getMessage();
-		String description = message.substring(0, message.indexOf('.')).trim();
-		String action = message.substring(message.indexOf('.') + 1).trim();
-		return new FailureAnalysis(description, action, cause);
+		return getFailureAnalysis(createDescription(cause), cause);
 	}
 
+	private String createDescription(DataSourceBeanCreationException cause) {
+
+		StringBuilder message = new StringBuilder();
+		message.append(cause.getMessage());
+		message.append(" Property spring.datasource.url was not specified. ");
+		message.append("Cannot auto-configure embedded database as well. ");
+		message.append("Cannot determine embedded database ");
+		message.append(cause.getProperty());
+		message.append(" for database type ");
+		message.append(cause.getConnection());
+		message.append(".");
+		return message.toString();
+	}
+
+	private FailureAnalysis getFailureAnalysis(String description, DataSourceBeanCreationException cause) {
+
+		StringBuilder message = new StringBuilder();
+		message.append("If you want an embedded database please put a supported one on the classpath. ");
+		message.append("If you have database settings to be loaded from a particular profile you may need to activate it");
+		message.append(getActiveProfiles(cause.getEnvironment()));
+		return new FailureAnalysis(description, message.toString(), cause);
+	}
+
+	private String getActiveProfiles(Environment environment) {
+
+		StringBuilder message = new StringBuilder();
+		if (Objects.nonNull(environment)) {
+			String[] profiles = environment.getActiveProfiles();
+			if (ObjectUtils.isEmpty(profiles)) {
+				message.append(" (no profiles are currently active).");
+			} else {
+				message.append(" (the profiles \"")
+						.append(StringUtils.arrayToCommaDelimitedString(profiles))
+						.append("\" are currently active).");
+			}
+		}
+		return message.toString();
+	}
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -36,7 +36,6 @@ import org.springframework.context.EnvironmentAware;
 import org.springframework.core.env.Environment;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -47,6 +46,7 @@ import org.springframework.util.StringUtils;
  * @author Stephane Nicoll
  * @author Benedikt Ritter
  * @author Eddú Meléndez
+ * @author Patryk Kostrzewa
  * @since 1.1.0
  */
 @ConfigurationProperties(prefix = "spring.datasource")
@@ -520,37 +520,39 @@ public class DataSourceProperties
 
 	}
 
-	static class DataSourceBeanCreationException extends BeanCreationException {
+	class DataSourceBeanCreationException extends BeanCreationException {
 
-		private static EmbeddedDatabaseConnection connection;
+		private static final String EMPTY = "";
 
-		private static Environment environment;
+		private final EmbeddedDatabaseConnection connection;
 
-		private static String property;
+		private final Environment environment;
+
+		private final String property;
 
 		DataSourceBeanCreationException(EmbeddedDatabaseConnection connection,
 				Environment environment, String property) {
 
-			super(buildMessage());
-			DataSourceBeanCreationException.connection = connection;
-			DataSourceBeanCreationException.environment = environment;
-			DataSourceBeanCreationException.property = property;
+			super(EMPTY);
+			this.connection = connection;
+			this.environment = environment;
+			this.property = property;
 		}
 
-		private static String buildMessage() {
+		private String buildMessage() {
 			return "Cannot auto-configure DataSource.";
 		}
 
 		public EmbeddedDatabaseConnection getConnection() {
-			return connection;
+			return this.connection;
 		}
 
 		public Environment getEnvironment() {
-			return environment;
+			return this.environment;
 		}
 
 		public String getProperty() {
-			return property;
+			return this.property;
 		}
 	}
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -522,37 +522,35 @@ public class DataSourceProperties
 
 	static class DataSourceBeanCreationException extends BeanCreationException {
 
+		private static EmbeddedDatabaseConnection connection;
+
+		private static Environment environment;
+
+		private static String property;
+
 		DataSourceBeanCreationException(EmbeddedDatabaseConnection connection,
 				Environment environment, String property) {
-			super(getMessage(connection, environment, property));
+
+			super(buildMessage());
+			DataSourceBeanCreationException.connection = connection;
+			DataSourceBeanCreationException.environment = environment;
+			DataSourceBeanCreationException.property = property;
 		}
 
-		private static String getMessage(EmbeddedDatabaseConnection connection,
-				Environment environment, String property) {
-			StringBuilder message = new StringBuilder();
-			message.append("Cannot determine embedded database " + property
-					+ " for database type " + connection + ". ");
-			message.append("If you want an embedded database please put a supported "
-					+ "one on the classpath. ");
-			message.append("If you have database settings to be loaded from a "
-					+ "particular profile you may need to active it");
-			if (environment != null) {
-				String[] profiles = environment.getActiveProfiles();
-				if (ObjectUtils.isEmpty(profiles)) {
-					message.append(" (no profiles are currently active)");
-				}
-				else {
-					message.append(" (the profiles \""
-							+ StringUtils.arrayToCommaDelimitedString(
-									environment.getActiveProfiles())
-							+ "\" are currently active)");
-
-				}
-			}
-			message.append(".");
-			return message.toString();
+		private static String buildMessage() {
+			return "Cannot auto-configure DataSource.";
 		}
 
+		public EmbeddedDatabaseConnection getConnection() {
+			return connection;
+		}
+
+		public Environment getEnvironment() {
+			return environment;
+		}
+
+		public String getProperty() {
+			return property;
+		}
 	}
-
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -520,9 +520,7 @@ public class DataSourceProperties
 
 	}
 
-	class DataSourceBeanCreationException extends BeanCreationException {
-
-		private static final String EMPTY = "";
+	static class DataSourceBeanCreationException extends BeanCreationException {
 
 		private final EmbeddedDatabaseConnection connection;
 
@@ -533,14 +531,10 @@ public class DataSourceProperties
 		DataSourceBeanCreationException(EmbeddedDatabaseConnection connection,
 				Environment environment, String property) {
 
-			super(EMPTY);
+			super("Cannot auto-configure DataSource. ");
 			this.connection = connection;
 			this.environment = environment;
 			this.property = property;
-		}
-
-		private String buildMessage() {
-			return "Cannot auto-configure DataSource.";
 		}
 
 		public EmbeddedDatabaseConnection getConnection() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzerTests.java
@@ -41,14 +41,8 @@ public class DataSourceBeanCreationFailureAnalyzerTests {
 	@Test
 	public void failureAnalysisIsPerformed() {
 		FailureAnalysis failureAnalysis = performAnalysis(TestConfiguration.class);
-		assertThat(failureAnalysis.getDescription()).isEqualTo("Cannot auto-configure DataSource. "
-				+ "Property spring.datasource.url was not specified. "
-				+ "Cannot auto-configure embedded database as well. "
-				+ "Cannot determine embedded database driver class for database type NONE.");
-		assertThat(failureAnalysis.getAction()).isEqualTo("If you want an embedded "
-				+ "database please put a supported one on the classpath. If you have "
-				+ "database settings to be loaded from a particular profile you may "
-				+ "need to activate it (no profiles are currently active).");
+		assertThat(failureAnalysis.getDescription()).isEqualTo("Failed to determine a suitable driver class");
+		assertThat(failureAnalysis.getAction()).isEqualTo("If you want an embedded database please put a supported one on the classpath.");
 	}
 
 	private FailureAnalysis performAnalysis(Class<?> configuration) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzerTests.java
@@ -41,12 +41,14 @@ public class DataSourceBeanCreationFailureAnalyzerTests {
 	@Test
 	public void failureAnalysisIsPerformed() {
 		FailureAnalysis failureAnalysis = performAnalysis(TestConfiguration.class);
-		assertThat(failureAnalysis.getDescription()).isEqualTo(
-				"Cannot determine embedded database driver class for database type NONE");
+		assertThat(failureAnalysis.getDescription()).isEqualTo("Cannot auto-configure DataSource. "
+				+ "Property spring.datasource.url was not specified. "
+				+ "Cannot auto-configure embedded database as well. "
+				+ "Cannot determine embedded database driver class for database type NONE.");
 		assertThat(failureAnalysis.getAction()).isEqualTo("If you want an embedded "
 				+ "database please put a supported one on the classpath. If you have "
 				+ "database settings to be loaded from a particular profile you may "
-				+ "need to active it (no profiles are currently active).");
+				+ "need to activate it (no profiles are currently active).");
 	}
 
 	private FailureAnalysis performAnalysis(Class<?> configuration) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourcePropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourcePropertiesTests.java
@@ -72,7 +72,7 @@ public class DataSourcePropertiesTests {
 				new FilteredClassLoader("org.h2", "org.apache.derby", "org.hsqldb"));
 		properties.afterPropertiesSet();
 		this.thrown.expect(DataSourceProperties.DataSourceBeanCreationException.class);
-		this.thrown.expectMessage("Cannot determine embedded database url");
+		this.thrown.expectMessage("Cannot auto-configure DataSource.");
 		properties.determineUrl();
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourcePropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourcePropertiesTests.java
@@ -72,7 +72,7 @@ public class DataSourcePropertiesTests {
 				new FilteredClassLoader("org.h2", "org.apache.derby", "org.hsqldb"));
 		properties.afterPropertiesSet();
 		this.thrown.expect(DataSourceProperties.DataSourceBeanCreationException.class);
-		this.thrown.expectMessage("Cannot auto-configure DataSource.");
+		this.thrown.expectMessage("Failed to determine suitable jdbc url");
 		properties.determineUrl();
 	}
 


### PR DESCRIPTION
Fixes gh-8029.

* Moved and refactored logic related to failure analysis from exception to `DataSourceBeanCreationFailureAnalyzer`.