### PR TITLE
Providing a better error message when missing the SpringBootApplication annotation, fixes gh-861

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/event/FailedStartEventListener.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/event/FailedStartEventListener.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.context.event;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.event.ApplicationFailedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Event listener to catch all {@link ApplicationFailedEvent}'s and grab the sources and main application class for further
+ * analysis in failure analyzers.
+ *
+ * @author Dan King
+ */
+@Component
+public class FailedStartEventListener implements ApplicationListener<ApplicationFailedEvent> {
+
+	private static final Logger log = LoggerFactory.getLogger(FailedStartEventListener.class);
+
+	@Override
+	public void onApplicationEvent(ApplicationFailedEvent event) {
+		SpringApplication springApplication = event.getSpringApplication();
+		FailedStartupInfoHolder.setAllSources(springApplication.getAllSources());
+		FailedStartupInfoHolder.setMainApplication(springApplication.getMainApplicationClass());
+		log.warn("Failed to start.");
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/event/FailedStartupInfoHolder.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/event/FailedStartupInfoHolder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.context.event;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Holds the sources and main application class that is set in the {@link org.springframework.boot.SpringApplication} for future
+ * use in the event that analyzers require this information in the future.
+ *
+ * @author Dan King
+ */
+public final class FailedStartupInfoHolder {
+
+	private static Set<Object> ALL_SOURCES = Collections.emptySet();
+
+	private static Class<?> MAIN_APPLICATION = null;
+
+	private FailedStartupInfoHolder() {
+		// Hidden by design
+	}
+
+	public static Set<Object> getAllSources() {
+		return Collections.unmodifiableSet(ALL_SOURCES);
+	}
+
+	public static void setAllSources(Set<Object> allSources) {
+		ALL_SOURCES = allSources;
+	}
+
+	public static Class<?> getMainApplication() {
+		return MAIN_APPLICATION;
+	}
+
+	public static void setMainApplication(Class<?> mainApplication) {
+		MAIN_APPLICATION = mainApplication;
+	}
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/event/package-info.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/event/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration events for the Spring context.
+ */
+package org.springframework.boot.autoconfigure.context.event;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/diagnostics/analyzer/MissingAnnotationAnalyzer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/diagnostics/analyzer/MissingAnnotationAnalyzer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.diagnostics.analyzer;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.context.event.FailedStartupInfoHolder;
+import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+import org.springframework.context.ApplicationContextException;
+
+/**
+ * Provides some diagnostic abilities to try and determine if the developer missed adding SpringBootApplication to the relevant
+ * primary source class used during boot.
+ *
+ * @author Dan King
+ */
+public class MissingAnnotationAnalyzer extends AbstractFailureAnalyzer<ApplicationContextException> {
+
+	private static final String ISSUE_DESCRIPTION = "Missing %s annotation on main class.";
+
+	private static final String ACTION_DESCRIPTION = "Add %s to %s or the main primary source class.";
+
+	@Override
+	protected FailureAnalysis analyze(Throwable rootFailure, ApplicationContextException cause) {
+		Set<Object> sources = FailedStartupInfoHolder.getAllSources();
+
+		for (Object source : sources) {
+			if (source instanceof Class) {
+				Class type = (Class) source;
+
+				if (Arrays.stream(type.getAnnotations())
+						.anyMatch(annotation -> annotation.annotationType().equals(SpringBootApplication.class))) {
+					return null;
+				}
+			}
+		}
+
+		final String mainApplicationName = FailedStartupInfoHolder.getMainApplication().getName();
+
+		return new FailureAnalysis(String.format(ISSUE_DESCRIPTION, SpringBootApplication.class.getName()),
+				String.format(ACTION_DESCRIPTION, SpringBootApplication.class.getName(), mainApplicationName), cause);
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -5,7 +5,8 @@ org.springframework.boot.autoconfigure.logging.ConditionEvaluationReportLoggingL
 
 # Application Listeners
 org.springframework.context.ApplicationListener=\
-org.springframework.boot.autoconfigure.BackgroundPreinitializer
+org.springframework.boot.autoconfigure.BackgroundPreinitializer,\
+org.springframework.boot.autoconfigure.context.event.FailedStartEventListener
 
 # Auto Configuration Import Listeners
 org.springframework.boot.autoconfigure.AutoConfigurationImportListener=\
@@ -131,7 +132,8 @@ org.springframework.boot.diagnostics.FailureAnalyzer=\
 org.springframework.boot.autoconfigure.diagnostics.analyzer.NoSuchBeanDefinitionFailureAnalyzer,\
 org.springframework.boot.autoconfigure.jdbc.DataSourceBeanCreationFailureAnalyzer,\
 org.springframework.boot.autoconfigure.jdbc.HikariDriverConfigurationFailureAnalyzer,\
-org.springframework.boot.autoconfigure.session.NonUniqueSessionRepositoryFailureAnalyzer
+org.springframework.boot.autoconfigure.session.NonUniqueSessionRepositoryFailureAnalyzer,\
+org.springframework.boot.autoconfigure.diagnostics.analyzer.MissingAnnotationAnalyzer
 
 # Template availability providers
 org.springframework.boot.autoconfigure.template.TemplateAvailabilityProvider=\

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/diagnostics/analyzer/MissingAnnotationAnalyzerTest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/diagnostics/analyzer/MissingAnnotationAnalyzerTest.java
@@ -16,14 +16,15 @@
 
 package org.springframework.boot.autoconfigure.diagnostics.analyzer;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.elasticsearch.common.util.set.Sets;
 import org.junit.Test;
+
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.context.event.FailedStartupInfoHolder;
 import org.springframework.boot.diagnostics.FailureAnalysis;
 import org.springframework.context.ApplicationContextException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MissingAnnotationAnalyzerTest {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/diagnostics/analyzer/MissingAnnotationAnalyzerTest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/diagnostics/analyzer/MissingAnnotationAnalyzerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.diagnostics.analyzer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.elasticsearch.common.util.set.Sets;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.context.event.FailedStartupInfoHolder;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+import org.springframework.context.ApplicationContextException;
+
+public class MissingAnnotationAnalyzerTest {
+
+	private MissingAnnotationAnalyzer analyzer = new MissingAnnotationAnalyzer();
+
+	@Test
+	public void exceptionWithConfiguredClassReturnsNull() {
+		configureInfoHolder(ProperlyConfigured.class);
+
+		FailureAnalysis analysis = analyzeFailure(new ApplicationContextException("Test"));
+		assertThat(analysis).isNull();
+	}
+
+	@Test
+	public void exceptionWithUnconfiguredClassReturnsFailureAnalysis() {
+		configureInfoHolder(NotConfigured.class);
+
+		FailureAnalysis analysis = analyzeFailure(new ApplicationContextException("Test"));
+		assertThat(analysis).isNotNull();
+		assertThat(analysis.getAction()).contains(NotConfigured.class.getName());
+	}
+
+	@Test
+	public void exceptionWithUnconfiguredClassAndDifferentMain() {
+		FailedStartupInfoHolder.setAllSources(Sets.newHashSet(ProperlyConfigured.class));
+		FailedStartupInfoHolder.setMainApplication(NotConfigured.class);
+
+		FailureAnalysis analysis = analyzeFailure(new ApplicationContextException("Test"));
+		assertThat(analysis).isNull();
+	}
+
+	private void configureInfoHolder(Class<?> infoHolderClass) {
+		FailedStartupInfoHolder.setAllSources(Sets.newHashSet(infoHolderClass));
+		FailedStartupInfoHolder.setMainApplication(infoHolderClass);
+	}
+
+	private FailureAnalysis analyzeFailure(Exception failure) {
+		return this.analyzer.analyze(failure);
+	}
+
+	@SpringBootApplication
+	private static class ProperlyConfigured {
+
+	}
+
+	private static class NotConfigured {
+
+	}
+
+}


### PR DESCRIPTION
Fixes gh-861

Providing a better error message when missing the SpringBootApplication annotation.

Added FailedStartEventListener to get SpringApplication and populate the FailedStartupInfoHOlder. This is then used in the MissingAnnotationAnalyzer to determine of the app failed to start because of the missing SpringBootApplication annotation or for another reason.