### PR TITLE
Update MySQL validation query to use lightweight ping

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
+++ b/spring-boot/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
@@ -67,7 +67,7 @@ public enum DatabaseDriver {
 	 * MySQL.
 	 */
 	MYSQL("MySQL", "com.mysql.jdbc.Driver",
-			"com.mysql.jdbc.jdbc2.optional.MysqlXADataSource", "SELECT 1"),
+			"com.mysql.jdbc.jdbc2.optional.MysqlXADataSource", "/* ping */ SELECT 1"),
 
 	/**
 	 * Maria DB.


### PR DESCRIPTION
Fixes gh-11958

Checked it also for Maria since often they are quite similiar.
But was rejected there https://jira.mariadb.org/browse/CONJ-51 .

This should also be relevant for 2.x.x