### PR TITLE
Load static resource jars with paths containing spaces.

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactory.java
@@ -22,6 +22,7 @@ import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
+import java.net.URLDecoder;
 import java.security.CodeSource;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -97,7 +98,7 @@ public abstract class AbstractEmbeddedServletContainerFactory
 			for (URL url : ((URLClassLoader) classLoader).getURLs()) {
 				try {
 					if ("file".equals(url.getProtocol())) {
-						File file = new File(url.getFile());
+						File file = new File(URLDecoder.decode(url.getFile(), "UTF-8"));
 						if (file.isDirectory()
 								&& new File(file, "META-INF/resources").isDirectory()) {
 							staticResourceUrls.add(url);

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactory.java
@@ -96,32 +96,39 @@ public abstract class AbstractEmbeddedServletContainerFactory
 		List<URL> staticResourceUrls = new ArrayList<URL>();
 		if (classLoader instanceof URLClassLoader) {
 			for (URL url : ((URLClassLoader) classLoader).getURLs()) {
-				try {
-					if ("file".equals(url.getProtocol())) {
-						File file = new File(URLDecoder.decode(url.getFile(), "UTF-8"));
-						if (file.isDirectory()
-								&& new File(file, "META-INF/resources").isDirectory()) {
-							staticResourceUrls.add(url);
-						}
-						else if (isResourcesJar(file)) {
-							staticResourceUrls.add(url);
-						}
-					}
-					else {
-						URLConnection connection = url.openConnection();
-						if (connection instanceof JarURLConnection) {
-							if (isResourcesJar((JarURLConnection) connection)) {
-								staticResourceUrls.add(url);
-							}
-						}
-					}
-				}
-				catch (IOException ex) {
-					throw new IllegalStateException(ex);
+				if (isStaticResource(url)) {
+					staticResourceUrls.add(url);
 				}
 			}
 		}
 		return staticResourceUrls;
+	}
+
+	protected boolean isStaticResource(URL url) {
+		try {
+			if ("file".equals(url.getProtocol())) {
+				File file = new File(URLDecoder.decode(url.getFile(), "UTF-8"));
+				if (file.isDirectory()
+						&& new File(file, "META-INF/resources").isDirectory()) {
+					return true;
+				}
+				else if (isResourcesJar(file)) {
+					return true;
+				}
+			}
+			else {
+				URLConnection connection = url.openConnection();
+				if (connection instanceof JarURLConnection) {
+					if (isResourcesJar((JarURLConnection) connection)) {
+						return true;
+					}
+				}
+			}
+		}
+		catch (IOException ex) {
+			throw new IllegalStateException(ex);
+		}
+		return false;
 	}
 
 	private boolean isResourcesJar(JarURLConnection connection) {

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactory.java
@@ -129,6 +129,7 @@ public abstract class AbstractEmbeddedServletContainerFactory
 			return isResourcesJar(connection.getJarFile());
 		}
 		catch (IOException ex) {
+			logger.warn("Unable to open jar to determine if it contains static resources", ex);
 			return false;
 		}
 	}
@@ -138,6 +139,7 @@ public abstract class AbstractEmbeddedServletContainerFactory
 			return isResourcesJar(new JarFile(file));
 		}
 		catch (IOException ex) {
+			logger.warn("Unable to open jar to determine if it contains static resources", ex);
 			return false;
 		}
 	}

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactory.java
@@ -136,7 +136,7 @@ public abstract class AbstractEmbeddedServletContainerFactory
 
 	private boolean isResourcesJar(File file) {
 		try {
-			return isResourcesJar(new JarFile(file));
+			return file.getName().endsWith(".jar") && isResourcesJar(new JarFile(file));
 		}
 		catch (IOException ex) {
 			logger.warn("Unable to open jar to determine if it contains static resources", ex);
@@ -146,8 +146,7 @@ public abstract class AbstractEmbeddedServletContainerFactory
 
 	private boolean isResourcesJar(JarFile jar) throws IOException {
 		try {
-			return jar.getName().endsWith(".jar")
-					&& (jar.getJarEntry("META-INF/resources") != null);
+			return jar.getJarEntry("META-INF/resources") != null;
 		}
 		finally {
 			jar.close();

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
@@ -1055,6 +1055,23 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 	}
 
 	@Test
+	public void includeJarWithStaticResourcesWithUrlEncodedSpaces() throws Exception {
+		AbstractEmbeddedServletContainerFactory factory = getFactory();
+		this.temporaryFolder.newFolder("test parent");
+		File jarFile = this.temporaryFolder.newFile("test parent/test.jar");
+		JarOutputStream jarOutputStream = new JarOutputStream(new FileOutputStream(jarFile));
+		JarEntry jarEntry = new JarEntry("META-INF/resources");
+		jarOutputStream.putNextEntry(jarEntry);
+		jarOutputStream.closeEntry();
+		jarOutputStream.close();
+		String path = "file:" + jarFile.getAbsolutePath().replaceAll(" ", "%20");
+
+		boolean isStaticResource = factory.isStaticResource(new URL(path));
+
+		assertThat(isStaticResource).isTrue();
+	}
+
+	@Test
 	public void excludeJarWithoutStaticResources() throws Exception {
 		AbstractEmbeddedServletContainerFactory factory = getFactory();
 		File jarFile = this.temporaryFolder.newFile("test.jar");

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
@@ -18,6 +18,7 @@ package org.springframework.boot.context.embedded;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -49,6 +50,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import java.util.zip.GZIPInputStream;
 
 import javax.net.ssl.SSLContext;
@@ -1033,6 +1036,37 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 		File codeSourceFile = this.temporaryFolder.newFile("test.war");
 		File documentRoot = factory.getExplodedWarFileDocumentRoot(codeSourceFile);
 		assertThat(documentRoot).isNull();
+	}
+
+	@Test
+	public void includeJarWithStaticResources() throws Exception {
+		AbstractEmbeddedServletContainerFactory factory = getFactory();
+		File jarFile = this.temporaryFolder.newFile("test.jar");
+		JarOutputStream jarOutputStream = new JarOutputStream(new FileOutputStream(jarFile));
+		JarEntry jarEntry = new JarEntry("META-INF/resources");
+		jarOutputStream.putNextEntry(jarEntry);
+		jarOutputStream.closeEntry();
+		jarOutputStream.close();
+		String path = "file:" + jarFile.getAbsolutePath();
+
+		boolean isStaticResource = factory.isStaticResource(new URL(path));
+
+		assertThat(isStaticResource).isTrue();
+	}
+
+	@Test
+	public void excludeJarWithoutStaticResources() throws Exception {
+		AbstractEmbeddedServletContainerFactory factory = getFactory();
+		File jarFile = this.temporaryFolder.newFile("test.jar");
+		JarOutputStream jarOutputStream = new JarOutputStream(
+				new FileOutputStream(jarFile));
+		jarOutputStream.closeEntry();
+		jarOutputStream.close();
+		String path = "file:" + jarFile.getAbsolutePath();
+
+		boolean isStaticResource = factory.isStaticResource(new URL(path));
+
+		assertThat(isStaticResource).isFalse();
 	}
 
 	protected abstract void addConnector(int port,


### PR DESCRIPTION
# Description

In Spring Boot 1.5.10.RELEASE, jar resources are not available from the ServletContext if the
they are served from the file system and exist in a location with a path that contains a space.

For example, this would occur, when running a web application via the Spring Boot Maven plugin and
with the local Maven repository existing at something like `C:\foo bar\.m2\repository`. It would
also occur when running directly from an IDE e.g. IntelliJ.

I've only checked for this bug on Windows. I've also verified that this bug occurs in 2.0.0.RC1.

This results in "works on my machine" problems as an application will work correctly on developer
machines that do not contain a space in their local Maven repository but will fail otherwise. There
is also no obvious indication that the space in the path was the cause of the issue.

# Steps to reproduce

* Checkout the [example repository](https://github.com/rupert654/space-in-path-bug)
  * Note that it depends on the Bootstrap Webjar in pom.xml
  * Note that it attempts to retrieve a valid CSS file from the ServletContext and will throw an
    exception during startup if it is not found in `com.github.rupert654.spaceinpathbug.Application`.
* Run with a local repository that does not contain a space:
  * `mvn clean spring-boot:run -Dmaven.repo.local="C:\foo\.m2\repository"`
* Verify that the application starts up without any exception.
* Run with a local repository that does contain a space:
  * `mvn clean spring-boot:run -Dmaven.repo.local="C:\foo bar\.m2\repository"`
* Verify that the application fails to start up with an exception.

# Root Cause

Resource jars are jars that contain a "META-INF/resources" directory.

All jars are retrieved from the class loader by: `((URLClassLoader) classLoader).getURLs()`. These
URLs are then filtered to those that contain this directory and are then
added to the ServletContext.

In 2.0.0.RC1, this process begins in `org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory.StaticResourceConfigurer.lifecycleEvent`.
In 1.5.10.RELEASE, it begins in `org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory.prepareContext`

The URLs are eventually passed into the constructor of `java.util.jar.JarFile` which
throws an IOException if it cannot load the jar.

However, the URLs are URL encoded yet `JarFile` does not expect them to be URL encoded. This means
that characters such as a space are translated to %20 but `JarFile` treats the encoded form
literally resulting in an exception.

Unfortunately, the problem is exacerbated as the exception is then swallowed meaning that jars that
are not resource jars and jars that cannot be loaded are treated equivalently. As a result, these
failures are silent.

# Proposal

Use `UrlDecoder.decode` on `URL.getFile` before it is used to construct a JarFile.

Add a WARN log line to the `isResourcesJar` methods if an IOException occurs so it is easier to
detect similar issues in the future. These methods are at
`org.springframework.boot.web.servlet.server.StaticResourceJars` in 2.0.0.RC1 and 
`org.springframework.boot.context.embedded.AbstractEmbeddedServletContainerFactory` in
1.5.10.RELEASE.

I will work on a PR against the 1.5.x and master branches so please let me know if you are not
happy with this proposal.