### PR TITLE
Server compression breaks webflux + actuator

### DIFF
--- a/spring-boot-samples/spring-boot-sample-webflux/src/test/java/sample/webflux/CompressedWebFluxApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-webflux/src/test/java/sample/webflux/CompressedWebFluxApplicationTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.webflux;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Validate webflux and actuator response when server compression is enabled.
+ *
+ * @author Adrien Lecharpentier
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(locations = "classpath:compressed-app.yml")
+public class CompressedWebFluxApplicationTests {
+
+	@Autowired
+	private WebTestClient webClient;
+
+	@Test
+	public void testActuatorStatus() {
+		this.webClient.get().uri("/actuator/health").accept(MediaType.APPLICATION_JSON)
+				.exchange().expectStatus().isOk().expectBody()
+				.json("{\"status\":\"UP\"}");
+	}
+}

--- a/spring-boot-samples/spring-boot-sample-webflux/src/test/resources/compressed-app.yml
+++ b/spring-boot-samples/spring-boot-sample-webflux/src/test/resources/compressed-app.yml
@@ -1,0 +1,1 @@
+server.compression.enabled: true


### PR DESCRIPTION
**Disclamer**
This is only a demonstration of a problem. 

---

When `server.compression.enable=true` is configured, even when request the response as `application/json`, the actuator responses end up in timeout. 

In Chrome, it is possible to see the answer, but the request is not closed by the application.

The code here is a additional test in the smallest sample I could find with webflux and actuator to see if I could reproduce the problem, and I could. 