### PR TITLE
Auto-configure FileDescriptorMetrics and ClassLoaderMetrics

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfiguration.java
@@ -23,6 +23,7 @@ import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 
@@ -124,6 +125,13 @@ public class MetricsAutoConfiguration {
 		@ConditionalOnMissingBean
 		public ProcessorMetrics processorMetrics() {
 			return new ProcessorMetrics();
+		}
+
+		@Bean
+		@ConditionalOnProperty(name = "management.metrics.binders.fds.enabled", matchIfMissing = true)
+		@ConditionalOnMissingBean
+		public FileDescriptorMetrics fileDescriptorMetrics() {
+			return new FileDescriptorMetrics();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.boot.actuate.autoconfigure.metrics;
 
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
@@ -90,6 +91,12 @@ public class MetricsAutoConfiguration {
 		@ConditionalOnMissingBean
 		public JvmThreadMetrics jvmThreadMetrics() {
 			return new JvmThreadMetrics();
+		}
+
+		@Bean
+		@ConditionalOnMissingBean
+		public ClassLoaderMetrics classLoaderMetrics() {
+			return new ClassLoaderMetrics();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
@@ -26,6 +26,7 @@ import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
@@ -210,6 +211,28 @@ public class MetricsAutoConfigurationTests {
 						.hasBean("customProcessorMetrics"));
 	}
 
+	@Test
+	public void autoConfiguresFileDescriptorMetrics() {
+		this.runner.run(
+				(context) -> assertThat(context)
+						.hasSingleBean(FileDescriptorMetrics.class));
+	}
+
+	@Test
+	public void allowsFileDescriptorMetricsToBeDisabled() {
+		this.runner.withPropertyValues("management.metrics.binders.fds.enabled=false")
+				.run((context) -> assertThat(context)
+						.doesNotHaveBean(FileDescriptorMetrics.class));
+	}
+
+	@Test
+	public void allowsCustomFileDescriptorToBeUsed() {
+		this.runner.withUserConfiguration(CustomFileDescriptorMetricsConfiguration.class)
+				.run((context) -> assertThat(context)
+						.hasSingleBean(FileDescriptorMetrics.class)
+						.hasBean("customFileDescriptorMetrics"));
+	}
+
 	@Configuration
 	static class CustomClockConfiguration {
 
@@ -308,6 +331,16 @@ public class MetricsAutoConfigurationTests {
 		@Bean
 		ProcessorMetrics customProcessorMetrics() {
 			return new ProcessorMetrics();
+		}
+
+	}
+
+	@Configuration
+	static class CustomFileDescriptorMetricsConfiguration {
+
+		@Bean
+		FileDescriptorMetrics customFileDescriptorMetrics() {
+			return new FileDescriptorMetrics();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
@@ -21,6 +21,7 @@ import java.util.List;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
@@ -94,7 +95,8 @@ public class MetricsAutoConfigurationTests {
 	public void autoConfiguresJvmMetrics() {
 		this.runner.run((context) -> assertThat(context).hasSingleBean(JvmGcMetrics.class)
 				.hasSingleBean(JvmMemoryMetrics.class)
-				.hasSingleBean(JvmThreadMetrics.class));
+				.hasSingleBean(JvmThreadMetrics.class)
+				.hasSingleBean(ClassLoaderMetrics.class));
 	}
 
 	@Test
@@ -102,7 +104,8 @@ public class MetricsAutoConfigurationTests {
 		this.runner.withPropertyValues("management.metrics.binders.jvm.enabled=false")
 				.run((context) -> assertThat(context).doesNotHaveBean(JvmGcMetrics.class)
 						.doesNotHaveBean(JvmMemoryMetrics.class)
-						.doesNotHaveBean(JvmThreadMetrics.class));
+						.doesNotHaveBean(JvmThreadMetrics.class)
+						.doesNotHaveBean(ClassLoaderMetrics.class));
 	}
 
 	@Test
@@ -111,7 +114,8 @@ public class MetricsAutoConfigurationTests {
 				.run((context) -> assertThat(context).hasSingleBean(JvmGcMetrics.class)
 						.hasBean("customJvmGcMetrics")
 						.hasSingleBean(JvmMemoryMetrics.class)
-						.hasSingleBean(JvmThreadMetrics.class));
+						.hasSingleBean(JvmThreadMetrics.class)
+						.hasSingleBean(ClassLoaderMetrics.class));
 	}
 
 	@Test
@@ -120,7 +124,8 @@ public class MetricsAutoConfigurationTests {
 				.run((context) -> assertThat(context).hasSingleBean(JvmGcMetrics.class)
 						.hasSingleBean(JvmMemoryMetrics.class)
 						.hasBean("customJvmMemoryMetrics")
-						.hasSingleBean(JvmThreadMetrics.class));
+						.hasSingleBean(JvmThreadMetrics.class)
+						.hasSingleBean(ClassLoaderMetrics.class));
 	}
 
 	@Test
@@ -129,7 +134,18 @@ public class MetricsAutoConfigurationTests {
 				.run((context) -> assertThat(context).hasSingleBean(JvmGcMetrics.class)
 						.hasSingleBean(JvmMemoryMetrics.class)
 						.hasSingleBean(JvmThreadMetrics.class)
+						.hasSingleBean(ClassLoaderMetrics.class)
 						.hasBean("customJvmThreadMetrics"));
+	}
+
+	@Test
+	public void allowsCustomClassLoaderMetricsToBeUsed() {
+		this.runner.withUserConfiguration(CustomClassLoaderMetricsConfiguration.class)
+				.run((context) -> assertThat(context).hasSingleBean(JvmGcMetrics.class)
+						.hasSingleBean(JvmMemoryMetrics.class)
+						.hasSingleBean(JvmThreadMetrics.class)
+						.hasSingleBean(ClassLoaderMetrics.class)
+						.hasBean("customClassLoaderMetrics"));
 	}
 
 	@Test
@@ -252,6 +268,16 @@ public class MetricsAutoConfigurationTests {
 		@Bean
 		JvmThreadMetrics customJvmThreadMetrics() {
 			return new JvmThreadMetrics();
+		}
+
+	}
+
+	@Configuration
+	static class CustomClassLoaderMetricsConfiguration {
+
+		@Bean
+		ClassLoaderMetrics customClassLoaderMetrics() {
+			return new ClassLoaderMetrics();
 		}
 
 	}


### PR DESCRIPTION
Auto-configuration for these MeterBinders were missing and recently added to Micrometer's spring-legacy project in micrometer-metrics/micrometer#418 and micrometer-metrics/micrometer#413. This makes sure they're available in Spring Boot 2 also.

/cc @jkschneider 