### PR TITLE
Restore behavior of management.metrics.export.simple.enabled

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleMetricsExportAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleMetricsExportAutoConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -46,6 +47,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnBean(Clock.class)
 @EnableConfigurationProperties(SimpleProperties.class)
 @ConditionalOnMissingBean(MeterRegistry.class)
+@ConditionalOnProperty(prefix = "management.metrics.export.simple", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class SimpleMetricsExportAutoConfiguration {
 
 	@Bean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleProperties.java
@@ -34,7 +34,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SimpleProperties {
 
 	/**
-	 * Enable publishing to the backend.
+	 * Enable in-memory metrics that aren't published anywhere (allows you to see
+	 * what metrics are collected in the metrics actuator endpoint).
 	 */
 	private boolean enabled;
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimplePropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimplePropertiesConfigAdapter.java
@@ -42,11 +42,6 @@ public class SimplePropertiesConfigAdapter
 	}
 
 	@Override
-	public boolean enabled() {
-		return get(SimpleProperties::getEnabled, SimpleConfig.super::enabled);
-	}
-
-	@Override
 	public Duration step() {
 		return get(SimpleProperties::getStep, SimpleConfig.super::step);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleMetricsExportAutoConfigurationTests.java
@@ -52,6 +52,15 @@ public class SimpleMetricsExportAutoConfigurationTests {
 	}
 
 	@Test
+	public void backsOffWhenSpecificallyDisabled() {
+		this.contextRunner.withUserConfiguration(BaseConfiguration.class)
+				.withPropertyValues("management.metrics.export.simple.enabled=false")
+				.run((context) -> assertThat(context)
+						.doesNotHaveBean(SimpleMeterRegistry.class)
+						.doesNotHaveBean(SimpleConfig.class));
+	}
+
+	@Test
 	public void allowsConfigToBeCustomized() {
 		this.contextRunner.withUserConfiguration(CustomConfigConfiguration.class)
 				.run((context) -> assertThat(context).hasSingleBean(SimpleConfig.class)


### PR DESCRIPTION
At some point when all the individual implementation configurations were changed to auto-configurations in Boot 2, the conditionalization of the config based on `managament.metrics.export.simple.enabled` was dropped. It existed previously so that users could flip off even in-memory metrics collection, leaving an empty CompositeMeterRegistry that was essentially a NOOP (see `CompositeMeterRegistryPostProcessorTests#registerWhenHasNoMeterRegistryShouldRegisterEmptyComposite`).

See https://github.com/spring-projects/spring-boot/issues/12089#issuecomment-366524703