### PR TITLE
Bind StatsD queue gauges

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdMetricsExportAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdMetricsExportAutoConfiguration.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.util.HierarchicalNameMapper;
 import io.micrometer.statsd.StatsdConfig;
 import io.micrometer.statsd.StatsdMeterRegistry;
+import io.micrometer.statsd.StatsdMetrics;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
@@ -70,4 +71,8 @@ public class StatsdMetricsExportAutoConfiguration {
 		return HierarchicalNameMapper.DEFAULT;
 	}
 
+	@Bean
+	public StatsdMetrics statsdMetrics() {
+		return new StatsdMetrics();
+	}
 }


### PR DESCRIPTION
We needed to move these gauges from the constructor of `StatsdMeterRegistry` to a `MeterBinder` so that the queue metrics pick up common tags and filters.

See https://github.com/micrometer-metrics/micrometer/issues/440