### PR TITLE
Consistent prefix for datasource pool metrics

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/jdbc/DataSourcePoolMetrics.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/jdbc/DataSourcePoolMetrics.java
@@ -84,7 +84,7 @@ public class DataSourcePoolMetrics implements MeterBinder {
 	private <N extends Number> void bindDataSource(MeterRegistry registry,
 			String metricName, Function<DataSource, N> function) {
 		if (function.apply(this.dataSource) != null) {
-			registry.gauge("jdbc." + metricName + ".connections", this.tags,
+			registry.gauge("jdbc.connections." + metricName, this.tags,
 					this.dataSource, (m) -> function.apply(m).doubleValue());
 		}
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/jdbc/DataSourcePoolMetricsTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/jdbc/DataSourcePoolMetricsTests.java
@@ -50,7 +50,7 @@ public class DataSourcePoolMetricsTests {
 						"metrics.use-global-registry=false")
 				.run((context) -> {
 					context.getBean(DataSource.class).getConnection().getMetaData();
-					context.getBean(MeterRegistry.class).get("jdbc.max.connections")
+					context.getBean(MeterRegistry.class).get("jdbc.connections.max")
 							.meter();
 				});
 	}


### PR DESCRIPTION
This yields a similar naming scheme to that employed by `FileDescriptorMetrics`

See https://github.com/micrometer-metrics/micrometer/issues/449