### PR TITLE
Add autoconfiguration of Jetty micrometer statistics

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
@@ -209,6 +209,16 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-webapp</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.elasticsearch</groupId>
 			<artifactId>elasticsearch</artifactId>
 			<optional>true</optional>

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/jetty/JettyMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/jetty/JettyMetricsAutoConfiguration.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.web.jetty;
+
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.micrometer.core.instrument.binder.jetty.JettyStatisticsMetrics;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandlerContainer;
+import org.eclipse.jetty.server.handler.StatisticsHandler;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.boot.web.embedded.jetty.ConfigurableJettyWebServerFactory;
+import org.springframework.boot.web.embedded.jetty.JettyReactiveWebServerFactory;
+import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for {@link JettyStatisticsMetrics}.
+ *
+ * @author Even Holthe
+ * @since 2.1.0
+ */
+@ConditionalOnWebApplication
+@ConditionalOnClass({ JettyStatisticsMetrics.class, Server.class })
+public class JettyMetricsAutoConfiguration {
+	private volatile StatisticsHandler statsHandler;
+
+	@Bean
+	@ConditionalOnMissingBean(JettyStatisticsMetrics.class)
+	public JettyStatisticsMetrics jettyMetrics() {
+		return new JettyStatisticsMetrics(this.statsHandler, Collections.emptyList());
+	}
+
+	@Bean
+	@ConditionalOnWebApplication(type = Type.SERVLET)
+	public WebServerFactoryCustomizer<JettyServletWebServerFactory> serverCapturingServletJettyCustomizer() {
+		return this::statisticsCustomizer;
+	}
+
+	@Bean
+	@ConditionalOnWebApplication(type = Type.REACTIVE)
+	public WebServerFactoryCustomizer<JettyReactiveWebServerFactory> serverCapturingReactiveJettyCustomizer() {
+		return this::statisticsCustomizer;
+	}
+
+	private void extractExistingOrCreateStatisticsHandler(Server server) {
+		final Handler existingHandler = server.getHandler();
+		StatisticsHandler activeStatsHandler = null;
+
+		if (existingHandler instanceof StatisticsHandler) {
+			activeStatsHandler = (StatisticsHandler) existingHandler;
+		}
+
+		else if (existingHandler instanceof AbstractHandlerContainer) {
+			AbstractHandlerContainer abstractHandler = (AbstractHandlerContainer) existingHandler;
+			Handler[] existingHandlers = abstractHandler.getChildHandlers();
+
+			final List<StatisticsHandler> existingStatsHandlers = Stream.of(existingHandlers)
+					.filter(StatisticsHandler.class::isInstance)
+					.map(StatisticsHandler.class::cast)
+					.collect(Collectors.toList());
+
+			if (!existingStatsHandlers.isEmpty()) {
+				activeStatsHandler = existingStatsHandlers.get(0);
+			}
+		}
+
+		if (activeStatsHandler == null) {
+			activeStatsHandler = new StatisticsHandler();
+			activeStatsHandler.setHandler(existingHandler);
+			server.setHandler(activeStatsHandler);
+		}
+
+		this.statsHandler = activeStatsHandler;
+	}
+
+	private void statisticsCustomizer(ConfigurableJettyWebServerFactory jettyFactory) {
+		jettyFactory.addServerCustomizers(this::extractExistingOrCreateStatisticsHandler);
+	}
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/jetty/package-info.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/jetty/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Jetty actuator metrics.
+ */
+package org.springframework.boot.actuate.autoconfigure.metrics.web.jetty;

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -55,6 +55,7 @@ org.springframework.boot.actuate.autoconfigure.metrics.web.client.RestTemplateMe
 org.springframework.boot.actuate.autoconfigure.metrics.web.reactive.WebFluxMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvcMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.web.tomcat.TomcatMetricsAutoConfiguration,\
+  org.springframework.boot.actuate.autoconfigure.metrics.web.jetty.JettyMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.mongo.MongoHealthIndicatorAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.neo4j.Neo4jHealthIndicatorAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.redis.RedisHealthIndicatorAutoConfiguration,\

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/jetty/JettyMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/jetty/JettyMetricsAutoConfigurationTests.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.web.jetty;
+
+import java.util.Collections;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.jetty.JettyStatisticsMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.eclipse.jetty.server.handler.StatisticsHandler;
+import org.junit.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.reactive.ReactiveWebServerFactoryAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryAutoConfiguration;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.web.embedded.jetty.JettyReactiveWebServerFactory;
+import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
+import org.springframework.boot.web.reactive.context.AnnotationConfigReactiveWebServerApplicationContext;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.server.reactive.HttpHandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link JettyMetricsAutoConfiguration}.
+ *
+ * @author Even Holthe
+ */
+public class JettyMetricsAutoConfigurationTests {
+	@Test
+	public void autoConfiguresJettyStatisticsMetricsWithEmbeddedServletJetty() {
+		new WebApplicationContextRunner(
+				AnnotationConfigServletWebServerApplicationContext::new)
+					.withConfiguration(
+							AutoConfigurations.of(
+								JettyMetricsAutoConfiguration.class,
+								ServletWebServerFactoryAutoConfiguration.class))
+					.withUserConfiguration(JettyMetricsAutoConfigurationTests.ServletWebServerConfiguration.class)
+					.run((context) -> {
+						assertThat(context)
+								.hasSingleBean(JettyStatisticsMetrics.class);
+						SimpleMeterRegistry registry = new SimpleMeterRegistry();
+						context.getBean(JettyStatisticsMetrics.class)
+								.bindTo(registry);
+
+						assertThat(registry.find("jetty.requests").meter())
+								.isNotNull();
+						assertThat(registry.find("jetty.requests.active").gauge())
+								.isNotNull();
+					});
+	}
+
+	@Test
+	public void jettyMetricsAreAvailableWhenEarlyMeterBinderInitializationOccurs() {
+		new WebApplicationContextRunner(
+				AnnotationConfigServletWebServerApplicationContext::new)
+				.withConfiguration(AutoConfigurations.of(
+						JettyMetricsAutoConfiguration.class,
+						ServletWebServerFactoryAutoConfiguration.class))
+				.withUserConfiguration(JettyMetricsAutoConfigurationTests.ServletWebServerConfiguration.class,
+						JettyMetricsAutoConfigurationTests.EarlyMeterBinderInitializationConfiguration.class)
+				.run((context) -> {
+					assertThat(context).hasSingleBean(JettyStatisticsMetrics.class);
+					SimpleMeterRegistry registry = new SimpleMeterRegistry();
+					context.getBean(JettyStatisticsMetrics.class).bindTo(registry);
+
+					assertThat(registry.find("jetty.requests").meter())
+							.isNotNull();
+					assertThat(registry.find("jetty.requests.active").gauge())
+							.isNotNull();
+				});
+	}
+
+	@Test
+	public void autoConfiguresJettyStatisticsMetricsWithEmbeddedReactiveJetty() {
+		new ReactiveWebApplicationContextRunner(
+				AnnotationConfigReactiveWebServerApplicationContext::new)
+					.withConfiguration(AutoConfigurations.of(
+							JettyMetricsAutoConfiguration.class,
+							ReactiveWebServerFactoryAutoConfiguration.class))
+					.withUserConfiguration(JettyMetricsAutoConfigurationTests.ReactiveWebServerConfiguration.class)
+					.run((context) -> {
+						assertThat(context).hasSingleBean(JettyStatisticsMetrics.class);
+						SimpleMeterRegistry registry = new SimpleMeterRegistry();
+						context.getBean(JettyStatisticsMetrics.class).bindTo(registry);
+
+						assertThat(registry.find("jetty.requests").meter())
+								.isNotNull();
+						assertThat(registry.find("jetty.requests.active").gauge())
+								.isNotNull();
+					});
+	}
+
+	@Test
+	public void autoConfiguresJettyStatisticsMetricsWithStandaloneJetty() {
+		new WebApplicationContextRunner()
+				.withConfiguration(
+						AutoConfigurations.of(JettyMetricsAutoConfiguration.class))
+				.run((context) -> assertThat(context).hasSingleBean(JettyMetricsAutoConfiguration.class));
+	}
+
+	@Test
+	public void allowsCustomJettyStatisticsMetricsToBeUsed() {
+		new WebApplicationContextRunner()
+				.withConfiguration(
+						AutoConfigurations.of(JettyMetricsAutoConfiguration.class))
+				.withUserConfiguration(JettyMetricsAutoConfigurationTests.CustomJettyMetrics.class)
+				.run((context) -> assertThat(context).hasSingleBean(JettyStatisticsMetrics.class)
+						.hasBean("customJettyMetrics"));
+	}
+
+	@Test
+	public void autoConfiguresJettyStatisticsMetricsWithCustomJettyStatisticsHandler() {
+		new WebApplicationContextRunner(
+				AnnotationConfigServletWebServerApplicationContext::new)
+				.withConfiguration(AutoConfigurations.of(
+						JettyMetricsAutoConfiguration.class,
+						ServletWebServerFactoryAutoConfiguration.class))
+				.withUserConfiguration(JettyMetricsAutoConfigurationTests.ServletWebServerConfiguration.class,
+						JettyMetricsAutoConfigurationTests.CustomJettyStatisticsHandler.class)
+				.run((context -> {
+					assertThat(context).hasSingleBean(JettyStatisticsMetrics.class);
+					SimpleMeterRegistry registry = new SimpleMeterRegistry();
+					context.getBean(JettyStatisticsMetrics.class).bindTo(registry);
+
+					final Meter fixedMeter = registry.find("jetty.async.requests").meter();
+
+					assertThat(fixedMeter)
+							.isNotNull();
+
+					assertThat(fixedMeter.measure().iterator().next().getValue())
+							.isEqualTo(42.0);
+				}));
+	}
+
+	@Configuration
+	static class ServletWebServerConfiguration {
+
+		@Bean
+		public JettyServletWebServerFactory jettyFactory() {
+			return new JettyServletWebServerFactory(0);
+		}
+
+	}
+
+	@Configuration
+	static class ReactiveWebServerConfiguration {
+
+		@Bean
+		public JettyReactiveWebServerFactory tomcatFactory() {
+			return new JettyReactiveWebServerFactory(0);
+		}
+
+		@Bean
+		public HttpHandler httpHandler() {
+			return mock(HttpHandler.class);
+		}
+
+	}
+
+	@Configuration
+	static class CustomJettyMetrics {
+
+		@Bean
+		public JettyStatisticsMetrics customJettyMetrics() {
+			return new JettyStatisticsMetrics(null, Collections.emptyList());
+		}
+
+	}
+
+	@Configuration
+	static class CustomJettyStatisticsHandler {
+		@Bean
+		@Primary
+		public WebServerFactoryCustomizer<JettyServletWebServerFactory> customJettyStatisticsCustomizer() {
+			return factory -> {
+				factory.addServerCustomizers(server -> {
+					final StatisticsHandler statsHandler = new CustomStatisticsHandler();
+
+					statsHandler.setHandler(server.getHandler());
+					server.setHandler(statsHandler);
+				});
+			};
+		}
+
+		public class CustomStatisticsHandler extends StatisticsHandler {
+			@Override
+			public int getAsyncRequests() {
+				return 42;
+			}
+		}
+	}
+
+	@Configuration
+	static class EarlyMeterBinderInitializationConfiguration {
+		@Bean
+		public ServletContextInitializer earlyInitializer(ApplicationContext context) {
+			return (servletContext) -> context.getBeansOfType(MeterBinder.class);
+		}
+
+	}
+}


### PR DESCRIPTION
As suggested in #12090, auto-configuration of Jetty metrics would be an improvement. I've used the existing `TomcatMetricsAutoConfiguration`  as a starting point. I've also extended the `ServerProperties` configuration properties with `server.jetty.publish-statistics` in order for the user to be able toggle the functionality on or off (isolated in a separate commit).

This is my first contribution to the Spring (Boot) codebase, so feedback is very welcome!