### PR TITLE
Fix Checkstyle violation

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/SecurityContext.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/SecurityContext.java
@@ -29,7 +29,7 @@ public interface SecurityContext {
 	/**
 	 * Empty security context.
 	 */
-	public static SecurityContext NONE = new SecurityContext() {
+	SecurityContext NONE = new SecurityContext() {
 
 		@Override
 		public Principal getPrincipal() {


### PR DESCRIPTION
Latest builds are failing with this Checkstyle violation.
https://ci.spring.io/teams/spring-boot/pipelines/spring-boot/jobs/build/builds/877

```
[INFO] There is 1 error reported by Checkstyle 8.5 with src/checkstyle/checkstyle.xml ruleset.
[ERROR] src/main/java/org/springframework/boot/actuate/endpoint/SecurityContext.java:[32,9] (modifier) RedundantModifier: Redundant 'public' modifier.
```

The `static` modifier is also redundant and a Checkstyle validation error.