### PR TITLE
Remove an obsolete warning in doc

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -4476,8 +4476,6 @@ in properties files, you must include the index as part of the property name:
 
 ====
 
-WARNING: `spring.ldap.embedded.base-dn` supports multi base DN, so it must define as follows `spring.ldap.embedded.base-dn[0]=dc=spring,dc=io`
-
 By default, the server starts on a random port and triggers the regular LDAP support.
 There is no need to specify a `spring.ldap.urls` property.
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR removes an obsolete warning in doc as the limitation has been resolved via eab0b84a80e4e70bbf84289e1318e99c70ff899e.