### PR TITLE
Fix a Checkstyle rule violation in SecurityContext

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/SecurityContext.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/SecurityContext.java
@@ -29,7 +29,7 @@ public interface SecurityContext {
 	/**
 	 * Empty security context.
 	 */
-	public static SecurityContext NONE = new SecurityContext() {
+	SecurityContext NONE = new SecurityContext() {
 
 		@Override
 		public Principal getPrincipal() {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
When doing a full build, the following Checkstyle error has been reported:

```
[ERROR] /Users/izeye/IdeaProjects/spring-boot/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/SecurityContext.java:32:9: Redundant 'public' modifier. [RedundantModifier]
Audit done.
[INFO] There is 1 error reported by Checkstyle 8.5 with src/checkstyle/checkstyle.xml ruleset.
[ERROR] src/main/java/org/springframework/boot/actuate/endpoint/SecurityContext.java:[32,9] (modifier) RedundantModifier: Redundant 'public' modifier.
```

This PR fixes the Checkstyle rule violation in `SecurityContext`.