### PR TITLE
Upgrade junit-platform version

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -104,7 +104,7 @@
 		<jtds.version>1.3.1</jtds.version>
 		<junit.version>4.12</junit.version>
 		<junit-jupiter.version>5.1.0</junit-jupiter.version>
-		<junit-platform.version>1.0.3</junit-platform.version>
+		<junit-platform.version>1.1.0</junit-platform.version>
 		<kotlin.version>1.2.21</kotlin.version>
 		<lettuce.version>5.0.2.RELEASE</lettuce.version>
 		<liquibase.version>3.5.5</liquibase.version>


### PR DESCRIPTION
After upgrading to 2.0.0.RC2 , we are receiving below error 

```
WARNING: TestEngine with ID 'junit-jupiter' failed to discover tests
java.lang.NoSuchMethodError: org.junit.platform.engine.support.filter.ClasspathScanningSupport.buildClassFilter(Lorg/junit/platform/engine/EngineDiscoveryRequest;Ljava/util/function/Predicate;)Lorg/junit/platform/commons/util/ClassFilter;
        at org.junit.jupiter.engine.discovery.DiscoverySelectorResolver.resolveSelectors(DiscoverySelectorResolver.java:49)
```

This is happening because junit-jupiter version 5.1.0 is not compatible with 1.0.3 version of junit-platform .To resolve this junit-platform should be upgraded to 1.1.0

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->