### PR TITLE
Rename TestRestTemplateTestContextCustomizer*

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplateContextCustomizer.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplateContextCustomizer.java
@@ -42,12 +42,12 @@ import org.springframework.test.context.ContextCustomizer;
 import org.springframework.test.context.MergedContextConfiguration;
 
 /**
- * {@link ContextCustomizer} for {@link SpringBootTest}.
+ * {@link ContextCustomizer} for {@link TestRestTemplate}.
  *
  * @author Phillip Webb
  * @author Andy Wilkinson
  */
-class TestRestTemplateTestContextCustomizer implements ContextCustomizer {
+class TestRestTemplateContextCustomizer implements ContextCustomizer {
 
 	@Override
 	public void customizeContext(ConfigurableApplicationContext context,

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplateContextCustomizerFactory.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplateContextCustomizerFactory.java
@@ -25,19 +25,19 @@ import org.springframework.test.context.ContextCustomizer;
 import org.springframework.test.context.ContextCustomizerFactory;
 
 /**
- * {@link ContextCustomizerFactory} for {@link SpringBootTest}.
+ * {@link ContextCustomizerFactory} for {@link TestRestTemplate}.
  *
  * @author Andy Wilkinson
- * @see TestRestTemplateTestContextCustomizer
+ * @see TestRestTemplateContextCustomizer
  */
-class TestRestTemplateTestContextCustomizerFactory implements ContextCustomizerFactory {
+class TestRestTemplateContextCustomizerFactory implements ContextCustomizerFactory {
 
 	@Override
 	public ContextCustomizer createContextCustomizer(Class<?> testClass,
 			List<ContextConfigurationAttributes> configAttributes) {
 		if (AnnotatedElementUtils.findMergedAnnotation(testClass,
 				SpringBootTest.class) != null) {
-			return new TestRestTemplateTestContextCustomizer();
+			return new TestRestTemplateContextCustomizer();
 		}
 		return null;
 	}

--- a/spring-boot-project/spring-boot-test/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-test/src/main/resources/META-INF/spring.factories
@@ -4,7 +4,7 @@ org.springframework.boot.test.context.ImportsContextCustomizerFactory,\
 org.springframework.boot.test.context.filter.ExcludeFilterContextCustomizerFactory,\
 org.springframework.boot.test.json.DuplicateJsonObjectContextCustomizerFactory,\
 org.springframework.boot.test.mock.mockito.MockitoContextCustomizerFactory,\
-org.springframework.boot.test.web.client.TestRestTemplateTestContextCustomizerFactory,\
+org.springframework.boot.test.web.client.TestRestTemplateContextCustomizerFactory,\
 org.springframework.boot.test.web.reactive.server.WebTestClientContextCustomizerFactory
 
 # Test Execution Listeners

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/TestRestTemplateContextCustomizerIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/TestRestTemplateContextCustomizerIntegrationTests.java
@@ -40,14 +40,14 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration test for {@link TestRestTemplateTestContextCustomizer}.
+ * Integration tests for {@link TestRestTemplateContextCustomizer}.
  *
  * @author Phillip Webb
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext
-public class TestRestTemplateTestContextCustomizerIntegrationTests {
+public class TestRestTemplateContextCustomizerIntegrationTests {
 
 	@Autowired
 	private TestRestTemplate restTemplate;

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/TestRestTemplateContextCustomizerWithOverrideIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/TestRestTemplateContextCustomizerWithOverrideIntegrationTests.java
@@ -40,7 +40,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration test for {@link TestRestTemplateTestContextCustomizer} with a custom
+ * Integration tests for {@link TestRestTemplateContextCustomizer} with a custom
  * {@link TestRestTemplate} bean.
  *
  * @author Phillip Webb
@@ -48,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext
-public class TestRestTemplateTestContextCustomizerWithOverrideIntegrationTests {
+public class TestRestTemplateContextCustomizerWithOverrideIntegrationTests {
 
 	@Autowired
 	private TestRestTemplate restTemplate;


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

This PR renames `TestRestTemplateTestContextCustomizer*` to `TestRestTemplateContextCustomizer*` to align with `WebTestClientContextCustomizer` naming. I guess the "Test" is a leftover from the previous name when renaming them.