### PR TITLE
Persistent Kafka AdminClient for health checks

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/kafka/KafkaHealthIndicatorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/kafka/KafkaHealthIndicatorAutoConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -40,6 +41,7 @@ import org.springframework.kafka.core.KafkaAdmin;
  * {@link EnableAutoConfiguration Auto-configuration} for {@link KafkaHealthIndicator}.
  *
  * @author Juan Rada
+ * @author Gary Russell
  * @since 2.0.0
  */
 @Configuration
@@ -56,10 +58,14 @@ public class KafkaHealthIndicatorAutoConfiguration
 
 	private final KafkaHealthIndicatorProperties properties;
 
+	private final KafkaProperties kafkaProperties;
+
 	public KafkaHealthIndicatorAutoConfiguration(Map<String, KafkaAdmin> admins,
-			KafkaHealthIndicatorProperties properties) {
+			KafkaHealthIndicatorProperties properties,
+			KafkaProperties kafkaProperties) {
 		this.admins = admins;
 		this.properties = properties;
+		this.kafkaProperties = kafkaProperties;
 	}
 
 	@Bean
@@ -71,7 +77,7 @@ public class KafkaHealthIndicatorAutoConfiguration
 	@Override
 	protected KafkaHealthIndicator createHealthIndicator(KafkaAdmin source) {
 		Duration responseTimeout = this.properties.getResponseTimeout();
-		return new KafkaHealthIndicator(source, responseTimeout.toMillis());
+		return new KafkaHealthIndicator(source, this.kafkaProperties, responseTimeout.toMillis());
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/kafka/KafkaHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/kafka/KafkaHealthIndicator.java
@@ -19,14 +19,19 @@ package org.springframework.boot.actuate.kafka;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.DescribeClusterOptions;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.ConfigResource.Type;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health.Builder;
 import org.springframework.boot.actuate.health.HealthIndicator;
@@ -38,13 +43,18 @@ import org.springframework.util.Assert;
  * {@link HealthIndicator} for Kafka cluster.
  *
  * @author Juan Rada
+ * @author Gary Russell
  * @since 2.0.0
  */
-public class KafkaHealthIndicator extends AbstractHealthIndicator {
+public class KafkaHealthIndicator extends AbstractHealthIndicator implements DisposableBean {
+
+	private static final Log logger = LogFactory.getLog(KafkaHealthIndicator.class);
 
 	static final String REPLICATION_PROPERTY = "transaction.state.log.replication.factor";
 
-	private final KafkaAdmin kafkaAdmin;
+	private static final long CLOSE_TIMEOUT = 30L;
+
+	private final AdminClient adminClient;
 
 	private final DescribeClusterOptions describeOptions;
 
@@ -56,32 +66,44 @@ public class KafkaHealthIndicator extends AbstractHealthIndicator {
 	 */
 	public KafkaHealthIndicator(KafkaAdmin kafkaAdmin, long requestTimeout) {
 		Assert.notNull(kafkaAdmin, "KafkaAdmin must not be null");
-		this.kafkaAdmin = kafkaAdmin;
+		this.adminClient = AdminClient.create(kafkaAdmin.getConfig());
 		this.describeOptions = new DescribeClusterOptions()
 				.timeoutMs((int) requestTimeout);
 	}
 
 	@Override
 	protected void doHealthCheck(Builder builder) throws Exception {
-		try (AdminClient adminClient = AdminClient.create(this.kafkaAdmin.getConfig())) {
-			DescribeClusterResult result = adminClient
-					.describeCluster(this.describeOptions);
-			String brokerId = result.controller().get().idString();
-			int replicationFactor = getReplicationFactor(brokerId, adminClient);
-			int nodes = result.nodes().get().size();
-			Status status = nodes >= replicationFactor ? Status.UP : Status.DOWN;
-			builder.status(status).withDetail("clusterId", result.clusterId().get())
-					.withDetail("brokerId", brokerId).withDetail("nodes", nodes);
+		DescribeClusterResult result = this.adminClient.describeCluster(this.describeOptions);
+		String brokerId = result.controller().get().idString();
+		int replicationFactor = getReplicationFactor(brokerId, adminClient);
+		int nodes = result.nodes().get().size();
+		Status status = nodes >= replicationFactor ? Status.UP : Status.DOWN;
+		builder.status(status).withDetail("clusterId", result.clusterId().get())
+				.withDetail("brokerId", brokerId).withDetail("nodes", nodes);
+	}
+
+	private int getReplicationFactor(String brokerId, AdminClient adminClient) throws Exception {
+		try {
+			ConfigResource configResource = new ConfigResource(Type.BROKER, brokerId);
+			Map<ConfigResource, Config> kafkaConfig = adminClient
+					.describeConfigs(Collections.singletonList(configResource)).all().get();
+			Config brokerConfig = kafkaConfig.get(configResource);
+			return Integer.parseInt(brokerConfig.get(REPLICATION_PROPERTY).value());
+		}
+		catch (ExecutionException e) {
+			if (e.getCause() instanceof UnsupportedVersionException) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Broker does not support obtaining replication factor, assuming 1");
+				}
+				return 1;
+			}
+			throw e;
 		}
 	}
 
-	private int getReplicationFactor(String brokerId, AdminClient adminClient)
-			throws ExecutionException, InterruptedException {
-		ConfigResource configResource = new ConfigResource(Type.BROKER, brokerId);
-		Map<ConfigResource, Config> kafkaConfig = adminClient
-				.describeConfigs(Collections.singletonList(configResource)).all().get();
-		Config brokerConfig = kafkaConfig.get(configResource);
-		return Integer.parseInt(brokerConfig.get(REPLICATION_PROPERTY).value());
+	@Override
+	public void destroy() throws Exception {
+		this.adminClient.close(CLOSE_TIMEOUT, TimeUnit.SECONDS);
 	}
 
 }


### PR DESCRIPTION
Use a single `AdminClient` in `KafkaHealthIndicator` instead of opening a new connection
each time.

Also fixes #12198

If the replication factor can't be determined (older broker), don't perform the replication
factor health check.

