### PR TITLE
Set classloader for JMX endpoints to application classloader

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/JmxEndpointExporter.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/jmx/JmxEndpointExporter.java
@@ -29,6 +29,7 @@ import javax.management.ObjectName;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.jmx.JmxException;
@@ -42,9 +43,11 @@ import org.springframework.util.Assert;
  * @author Phillip Webb
  * @since 2.0.0
  */
-public class JmxEndpointExporter implements InitializingBean, DisposableBean {
+public class JmxEndpointExporter implements InitializingBean, DisposableBean, BeanClassLoaderAware {
 
 	private static final Log logger = LogFactory.getLog(JmxEndpointExporter.class);
+
+	private ClassLoader classLoader;
 
 	private final MBeanServer mBeanServer;
 
@@ -71,6 +74,11 @@ public class JmxEndpointExporter implements InitializingBean, DisposableBean {
 	}
 
 	@Override
+	public void setBeanClassLoader(ClassLoader classLoader) {
+		this.classLoader = classLoader;
+	}
+
+	@Override
 	public void afterPropertiesSet() {
 		this.registered = register();
 	}
@@ -89,6 +97,7 @@ public class JmxEndpointExporter implements InitializingBean, DisposableBean {
 		try {
 			ObjectName name = this.objectNameFactory.getObjectName(endpoint);
 			EndpointMBean mbean = new EndpointMBean(this.responseMapper, endpoint);
+			mbean.setBeanClassLoader(this.classLoader);
 			this.mBeanServer.registerMBean(mbean, name);
 			return name;
 		}


### PR DESCRIPTION
Related to and fixes:  #12088 

Sets the Thread's classloader for JMX endpoints, before invoking the endpoint, to the classloader which was initially used to load the context.

Before:
```
--- Class Loaders
getClass().getClassLoader(): java.net.URLClassLoader@4ac20dd2
currentThread().getContextClassLoader(): sun.misc.Launcher$AppClassLoader@18b4aac2
ClassUtils.getDefaultClassLoader(): sun.misc.Launcher$AppClassLoader@18b4aac2
---
```

After:
```
--- Class Loaders
getClass().getClassLoader(): java.net.URLClassLoader@4ac20dd2
currentThread().getContextClassLoader(): java.net.URLClassLoader@4ac20dd2
ClassUtils.getDefaultClassLoader(): java.net.URLClassLoader@4ac20dd2
---
```

Test-Code (using sample Application from start.spring.io including web and actuator):

```java
@Component
@JmxEndpoint(id = "classloader")
public class JmxClassloaderEndpoint {
    @WriteOperation
    public void someOperation() {
        System.out.println("--- Class Loaders");
        System.out.println("getClass().getClassLoader(): " + getClass().getClassLoader());
        System.out.println("currentThread().getContextClassLoader(): " + Thread.currentThread().getContextClassLoader());
        System.out.println("ClassUtils.getDefaultClassLoader(): " + ClassUtils.getDefaultClassLoader());
        System.out.println("---");
    }
}
``` 