### PR TITLE
Dependency management for Hibernate Validator's annotation processor uses the old redirected group ID

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -1872,7 +1872,7 @@
 				<version>${hibernate-validator.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.hibernate</groupId>
+				<groupId>org.hibernate.validator</groupId>
 				<artifactId>hibernate-validator-annotation-processor</artifactId>
 				<version>${hibernate-validator.version}</version>
 			</dependency>


### PR DESCRIPTION
…ate.validator groupId

Maven says: 

```
The artifact org.hibernate:hibernate-validator-annotation-processor:jar:6.0.7.Final has been relocated to org.hibernate.validator:hibernate-validator-annotation-processor:jar:6.0.7.Final
```

`hibernate-validator` artifact is already configured under `org.hibernate.validator` in this BOM

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->