### PR TITLE
Use forEach() directly without map() in LambdaSafe.Callbacks.invoke()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/util/LambdaSafe.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/util/LambdaSafe.java
@@ -286,13 +286,11 @@ public final class LambdaSafe {
 		 * @param invoker the invoker used to invoke the callback
 		 */
 		public void invoke(Consumer<C> invoker) {
-			Function<C, InvocationResult<Void>> mapper = (callbackInstance) -> invoke(
+			this.callbackInstances.stream().forEach((callbackInstance) -> invoke(
 					callbackInstance, () -> {
 						invoker.accept(callbackInstance);
 						return null;
-					});
-			this.callbackInstances.stream().map(mapper).forEach((result) -> {
-			});
+					}));
 		}
 
 		/**


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR changes to use `forEach()` directly without `map()` in `LambdaSafe.Callbacks.invoke()`.