### PR TITLE
Remove an unnecessary method in EndpointDiscoverer

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/EndpointDiscoverer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/EndpointDiscoverer.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -315,10 +314,6 @@ public abstract class EndpointDiscoverer<E extends ExposableEndpoint<O>, O exten
 		return LambdaSafe.callback(EndpointFilter.class, filter, endpoint)
 				.withLogger(EndpointDiscoverer.class).invokeAnd((f) -> f.match(endpoint))
 				.get();
-	}
-
-	public <A, B> void doIt(Function<A, B> x) {
-
 	}
 
 	private E getFilterEndpoint(EndpointBean endpointBean) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR removes an unnecessary method which looks added accidentally in `EndpointDiscoverer`.