### PR TITLE
Make UserDetailsServiceAutoConfiguration.getOrDeducePassword() private

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/UserDetailsServiceAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/UserDetailsServiceAutoConfiguration.java
@@ -75,7 +75,7 @@ public class UserDetailsServiceAutoConfiguration {
 				.roles(StringUtils.toStringArray(roles)).build());
 	}
 
-	public String getOrDeducePassword(SecurityProperties.User user,
+	private String getOrDeducePassword(SecurityProperties.User user,
 			PasswordEncoder encoder) {
 		String password = user.getPassword();
 		if (user.isPasswordGenerated()) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
It looks unnecessary to be `public`.