### PR TITLE
Improve docs on custom metrics

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -1749,9 +1749,25 @@ factories with a metric named `rabbitmq`.
 
 [[production-ready-metrics-custom]]
 === Registering custom metrics
-To register custom metrics, create a `MeterBinder` bean. By default, all `MeterBinder`
-beans will be automatically applied to the micrometer `MeterRegistry.Config`.
+To register custom metrics, inject `MeterRegistry` into your component:
 
+[source,java,indent=0]
+----
+class Dictionary {
+	private List<String> words = new CopyOnWriteArrayList<>();
+
+	public MyComponent(MeterRegistry registry) {
+		registry.gaugeCollectionSize("dictionary.size", Tags.empty(), words);
+	}
+
+	...
+}
+----
+
+If you find that you repeatedly instrument a suite of metrics across components or
+applications, you may encapsulate this suite in a `MeterBinder` implementation. By
+default, metrics from all `MeterBinder` beans will be automatically bound to
+the Spring-managed `MeterRegistry`.
 
 
 [[production-ready-metrics-per-meter-properties]]


### PR DESCRIPTION
Indicate that simple injection is preferred unless you have a reusable suite of metrics for which `MeterBinder` encapsulation is helpful.

cc / @snicoll This is the improved verbiage as promised.