### PR TITLE
RabbitMQ: Add connectionNamePrefix property

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.amqp;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.rabbitmq.client.Channel;
 
@@ -42,6 +43,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for {@link RabbitTemplate}.
@@ -109,6 +111,11 @@ public class RabbitAutoConfiguration {
 			map.from(connection::getMode).whenNonNull().to(factory::setCacheMode);
 			map.from(connection::getSize).whenNonNull()
 					.to(factory::setConnectionCacheSize);
+			String connectionNamePrefix = properties.getConnectionNamePrefix();
+			if (StringUtils.hasText(connectionNamePrefix)) {
+				final AtomicInteger connectionNumber = new AtomicInteger();
+				factory.setConnectionNameStrategy(f -> connectionNamePrefix + "#" + connectionNumber.getAndIncrement());
+			}
 			return factory;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -99,6 +99,11 @@ public class RabbitProperties {
 	private Duration connectionTimeout;
 
 	/**
+	 * Prefix for connection names.
+	 */
+	private String connectionNamePrefix;
+
+	/**
 	 * Cache configuration.
 	 */
 	private final Cache cache = new Cache();
@@ -293,6 +298,14 @@ public class RabbitProperties {
 
 	public void setConnectionTimeout(Duration connectionTimeout) {
 		this.connectionTimeout = connectionTimeout;
+	}
+
+	public String getConnectionNamePrefix() {
+		return this.connectionNamePrefix;
+	}
+
+	public void setConnectionNamePrefix(String connectionNamePrefix) {
+		this.connectionNamePrefix = connectionNamePrefix;
 	}
 
 	public Cache getCache() {

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -1061,6 +1061,7 @@ content into your application. Rather, pick only the properties that you need.
 	spring.rabbitmq.cache.channel.size= # Number of channels to retain in the cache.
 	spring.rabbitmq.cache.connection.mode=channel # Connection factory cache mode.
 	spring.rabbitmq.cache.connection.size= # Number of connections to cache.
+	spring.rabbitmq.connection-name-prefix= # Prefix for connection names.
 	spring.rabbitmq.connection-timeout= # Connection timeout. Set it to zero to wait forever.
 	spring.rabbitmq.dynamic=true # Whether to create an AmqpAdmin bean.
 	spring.rabbitmq.host=localhost # RabbitMQ host.


### PR DESCRIPTION
Useful to identify which application owns a connection on the RabbitMQ management console.

See: https://stackoverflow.com/questions/49089915/how-to-set-custom-name-for-rabbitmq-connection/49090085#49090085