### PR TITLE
Fix typo exception message in TestDatabaseAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jdbc/TestDatabaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jdbc/TestDatabaseAutoConfiguration.java
@@ -196,7 +196,7 @@ public class TestDatabaseAutoConfiguration {
 					"Failed to replace DataSource with an embedded database for tests. If "
 							+ "you want an embedded database please put a supported one "
 							+ "on the classpath or tune the replace attribute of "
-							+ "@AutoconfigureTestDatabase.");
+							+ "@AutoConfigureTestDatabase.");
 			return new EmbeddedDatabaseBuilder().generateUniqueName(true)
 					.setType(connection.getType()).build();
 		}


### PR DESCRIPTION
This PR fixes typo in TestDatabaseAutoConfiguration exception message(Annotation interface name).