### PR TITLE
Remove a redundant trailing slash in doc

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/getting-started.adoc
@@ -189,7 +189,7 @@ scope.
 [[getting-started-gradle-installation]]
 ==== Gradle Installation
 Spring Boot is compatible with Gradle 4. If you do not already have Gradle installed, you
-can follow the instructions at https://gradle.org/.
+can follow the instructions at https://gradle.org.
 
 Spring Boot dependencies can be declared by using the `org.springframework.boot` `group`.
 Typically, your project declares dependencies to one or more


### PR DESCRIPTION
Spring Boot 2.0.0 Reference guide
> 10.1.1 Maven Installation
> Spring Boot is compatible with Apache Maven 3.2 or above. If you do not already have Maven installed, you can follow the instructions at maven.apache.org.
> 
> 10.1.2 Gradle Installation
> Spring Boot is compatible with Gradle 4. If you do not already have Gradle installed, you can follow the instructions at gradle.org/.
> 

The slash(/) after gradle.org seems unnecessary in Section 10.1.2.