### PR TITLE
Invoke mapStatus() only when necessary

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthWebEndpointResponseMapper.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthWebEndpointResponseMapper.java
@@ -65,13 +65,13 @@ public class HealthWebEndpointResponseMapper {
 	 */
 	public WebEndpointResponse<Health> map(Health health, SecurityContext securityContext,
 			ShowDetails showDetails) {
-		Integer status = this.statusHttpMapper.mapStatus(health.getStatus());
 		if (showDetails == ShowDetails.NEVER
 				|| (showDetails == ShowDetails.WHEN_AUTHORIZED
 						&& (securityContext.getPrincipal() == null
 								|| !isUserInRole(securityContext)))) {
 			health = Health.status(health.getStatus()).build();
 		}
+		Integer status = this.statusHttpMapper.mapStatus(health.getStatus());
 		return new WebEndpointResponse<>(health, status);
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR changes to invoke `mapStatus()` only when necessary.