### PR TITLE
Polish: deprecated elements should have both the annotation and the Javadoc tag. 

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyServletWebServerFactory.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
@@ -577,10 +578,24 @@ public class JettyServletWebServerFactory extends AbstractServletWebServerFactor
 			return this.delegate.length();
 		}
 
+		/**
+		 * URL representing the resource.
+		 * @return an URL representing the given resource
+		 * @deprecated use {{@link #getURI()}.toURL() instead.
+		 */
 		@Override
 		@Deprecated
 		public URL getURL() {
 			return this.delegate.getURL();
+		}
+
+		/**
+		 * URI representing the resource.
+		 * @return an URI representing the given resource
+		 */
+		@Override
+		public URI getURI() {
+			return this.delegate.getURI();
 		}
 
 		@Override


### PR DESCRIPTION
Deprecated elements should have both the annotation and the Javadoc tag. Expose alternative to deprecated method.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->