### PR TITLE
Add reference to RabbitMQ (advanced usage) starter

### DIFF
--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -145,6 +145,9 @@ do as they were designed before this was clarified.
 | http://resteasy.jboss.org/[RESTEasy]
 | https://github.com/paypal/resteasy-spring-boot
 
+| https://www.rabbitmq.com/ [RabbitMq] (Advanced usage)
+| https://github.com/societe-generale/rabbitmq-advanced-spring-boot-starter
+
 | http://restfb.com/[RestFB] Messenger
 | https://github.com/marsbits/restfbmessenger
 


### PR DESCRIPTION
referencing rabbitmq-advanced-spring-boot-starter, that adds some of Spring Cloud Stream features, but at AMQP level