### PR TITLE
Add notes how to install Spring Boot CLI on Windows using Scoop

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/getting-started.adoc
@@ -387,6 +387,24 @@ completion scripts are automatically registered with your shell.
 
 
 
+[[getting-started-scoop-cli-installation]]
+==== Windows Scoop Installation
+If you are on a Windows and use http://scoop.sh/[Scoop], you can install the Spring Boot
+CLI by using the following commands:
+
+[indent=0]
+----
+	> scoop bucket add extras
+	> scoop install springboot
+----
+
+Scoop installs `spring` to `~/scoop/apps/springboot/current/bin`.
+
+NOTE: If you do not see the app manifest, your installation of scoop might be out-of-date. In
+that case, run `scoop update` and try again.
+
+
+
 [[getting-started-cli-example]]
 ==== Quick-start Spring CLI Example
 You can use the following web application to test your installation. To start, create a


### PR DESCRIPTION
App manifest for Spring Boot CLI is available in scoop-extras now (https://github.com/lukesampson/scoop-extras/pull/838)