### PR TITLE
Use DEFAULT_MESSAGE in AbstractHealthIndicator()

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/AbstractHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/AbstractHealthIndicator.java
@@ -38,8 +38,6 @@ import org.springframework.util.StringUtils;
  */
 public abstract class AbstractHealthIndicator implements HealthIndicator {
 
-	private static final String NO_MESSAGE = null;
-
 	private static final String DEFAULT_MESSAGE = "Health check failed";
 
 	private final Log logger = LogFactory.getLog(getClass());
@@ -51,7 +49,7 @@ public abstract class AbstractHealthIndicator implements HealthIndicator {
 	 * {@code healthCheckFailedMessage}.
 	 */
 	public AbstractHealthIndicator() {
-		this(NO_MESSAGE);
+		this(DEFAULT_MESSAGE);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR changes to use `DEFAULT_MESSAGE` in `AbstractHealthIndicator()` as based on its Javadoc it looks intended to use `DEFAULT_MESSAGE`.