### PR TITLE
 Fix assert for H2ConsoleProperties and WebServicesProperties path

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleProperties.java
@@ -18,6 +18,7 @@ package org.springframework.boot.autoconfigure.h2;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Configuration properties for H2's console.
@@ -25,6 +26,7 @@ import org.springframework.util.Assert;
  * @author Andy Wilkinson
  * @author Marten Deinum
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  * @since 1.3.0
  */
 @ConfigurationProperties(prefix = "spring.h2.console")
@@ -48,8 +50,8 @@ public class H2ConsoleProperties {
 
 	public void setPath(String path) {
 		Assert.notNull(path, "Path must not be null");
-		Assert.isTrue(path.isEmpty() || path.startsWith("/"),
-				"Path must start with / or be empty");
+		Assert.isTrue(path.startsWith("/") && StringUtils.hasText(path)
+				&& path.length() > 1, "Path must start with `/`. E.g. `/h2-console`");
 		this.path = path;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/webservices/WebServicesProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/webservices/WebServicesProperties.java
@@ -21,12 +21,14 @@ import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link ConfigurationProperties} for Spring Web Services.
  *
  * @author Vedran Pavic
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  * @since 1.4.0
  */
 @ConfigurationProperties(prefix = "spring.webservices")
@@ -45,8 +47,8 @@ public class WebServicesProperties {
 
 	public void setPath(String path) {
 		Assert.notNull(path, "Path must not be null");
-		Assert.isTrue(path.isEmpty() || path.startsWith("/"),
-				"Path must start with / or be empty");
+		Assert.isTrue(path.startsWith("/") && StringUtils.hasText(path)
+				&& path.length() > 1, "Path must start with `/`. E.g. `/services`");
 		this.path = path;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/h2/H2ConsoleAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/h2/H2ConsoleAutoConfigurationTests.java
@@ -78,6 +78,15 @@ public class H2ConsoleAutoConfigurationTests {
 	}
 
 	@Test
+	public void customPathMustNotHaveOnlySlash() {
+		this.contextRunner.withPropertyValues("spring.h2.console.enabled:true",
+				"spring.h2.console.path:/")
+				.run((context) -> assertThat(context).getFailure()
+						.isInstanceOf(BeanCreationException.class).hasMessageContaining(
+								"Failed to bind properties under 'spring.h2.console'"));
+	}
+
+	@Test
 	public void customPath() {
 		this.contextRunner.withPropertyValues("spring.h2.console.enabled:true",
 				"spring.h2.console.path:/custom")

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/webservices/WebServicesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/webservices/WebServicesAutoConfigurationTests.java
@@ -58,6 +58,14 @@ public class WebServicesAutoConfigurationTests {
 	}
 
 	@Test
+	public void customPathMustNotHaveOnlySlash() {
+		this.contextRunner.withPropertyValues("spring.webservices.path=/")
+				.run((context) -> assertThat(context).getFailure()
+						.isInstanceOf(BeanCreationException.class).hasMessageContaining(
+								"Failed to bind properties under 'spring.webservices'"));
+	}
+
+	@Test
 	public void customPath() {
 		this.contextRunner.withPropertyValues("spring.webservices.path=/valid").run(
 				(context) -> assertThat(getUrlMappings(context)).contains("/valid/*"));


### PR DESCRIPTION
Path must start with `/` and it has length greater than 1.

See gh-12485