### PR TITLE
Add OAuth2 server implementation section to docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -3192,6 +3192,16 @@ In other words, the two configurations in the following example use the Google p
 ----
 
 
+[[boot-features-security-oauth2-server]]
+==== Server
+Currently, Spring Security does not provide support for implementing an OAuth 2.0
+Authorization Server or Resource Server. However, this functionality is available from
+the https://projects.spring.io/spring-security-oauth/[Spring Security OAuth] project,
+which will eventually be superseded by Spring Security completely. Until then, you can
+use the `spring-security-oauth2-autoconfigure` module to easily set up an OAuth 2.0 server;
+see its https://docs.spring.io/spring-security-oauth2-boot[documentation] for instructions.
+
+
 
 [[boot-features-security-actuator]]
 === Actuator Security


### PR DESCRIPTION
As auto-configuration for Spring Security OAuth has been removed. from Spring Boot 2.0 and Spring Security 5 doesn't have OAuth 2.0 Authorization / Resource Server support yet, it has not been obvious at all how to implement an OAuth 2.0 server with Boot 2.0.

For that reason, this new section briefly explains the current temporary situation and points to the spring-security-oauth2-autoconfigure module that restores the auto-configuration support for OAuth 2.0 Authorization and Resource Servers.