### PR TITLE
Upgrade maven dependency plugin version to 3.0.2

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -188,7 +188,7 @@
 		<maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
 		<maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
 		<maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-		<maven-dependency-plugin.version>3.0.1</maven-dependency-plugin.version>
+		<maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
 		<maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>


### PR DESCRIPTION
Dependency plugin version 3.0.1 has some problems with Java 9, as described and fixed here: https://issues.apache.org/jira/browse/MDEP-571

This commit upgrades dependency plugin to 3.0.2