### PR TITLE
Fix JarFileTests.jarFileCanBeDeletedOnceItHasBeenClosed failing on Windows

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/data/RandomAccessDataFile.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/data/RandomAccessDataFile.java
@@ -16,7 +16,12 @@
 
 package org.springframework.boot.loader.data;
 
-import java.io.*;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.RandomAccessFile;
 
 /**
  * {@link RandomAccessData} implementation backed by a {@link RandomAccessFile}.

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/data/RandomAccessDataFile.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/data/RandomAccessDataFile.java
@@ -16,11 +16,7 @@
 
 package org.springframework.boot.loader.data;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.RandomAccessFile;
+import java.io.*;
 
 /**
  * {@link RandomAccessData} implementation backed by a {@link RandomAccessFile}.
@@ -28,7 +24,7 @@ import java.io.RandomAccessFile;
  * @author Phillip Webb
  * @author Andy Wilkinson
  */
-public class RandomAccessDataFile implements RandomAccessData {
+public class RandomAccessDataFile implements RandomAccessData, Closeable {
 
 	private final File file;
 
@@ -116,8 +112,9 @@ public class RandomAccessDataFile implements RandomAccessData {
 		return this.length;
 	}
 
+	@Override
 	public void close() throws IOException {
-
+		this.randomAccessFile.close();
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/TestJarCreator.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/TestJarCreator.java
@@ -40,7 +40,7 @@ public abstract class TestJarCreator {
 
 	public static void createTestJar(File file, boolean unpackNested) throws Exception {
 		try (FileOutputStream fileOutputStream = new FileOutputStream(file);
-			 JarOutputStream jarOutputStream = new JarOutputStream(fileOutputStream)) {
+				JarOutputStream jarOutputStream = new JarOutputStream(fileOutputStream)) {
 			writeManifest(jarOutputStream, "j1");
 			writeEntry(jarOutputStream, "1.dat", 1);
 			writeEntry(jarOutputStream, "2.dat", 2);

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/TestJarCreator.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/TestJarCreator.java
@@ -39,8 +39,8 @@ public abstract class TestJarCreator {
 	}
 
 	public static void createTestJar(File file, boolean unpackNested) throws Exception {
-		FileOutputStream fileOutputStream = new FileOutputStream(file);
-		try (JarOutputStream jarOutputStream = new JarOutputStream(fileOutputStream)) {
+		try (FileOutputStream fileOutputStream = new FileOutputStream(file);
+			 JarOutputStream jarOutputStream = new JarOutputStream(fileOutputStream)) {
 			writeManifest(jarOutputStream, "j1");
 			writeEntry(jarOutputStream, "1.dat", 1);
 			writeEntry(jarOutputStream, "2.dat", 2);
@@ -51,6 +51,7 @@ public abstract class TestJarCreator {
 
 			writeNestedEntry("nested.jar", unpackNested, jarOutputStream);
 			writeNestedEntry("another-nested.jar", unpackNested, jarOutputStream);
+
 		}
 	}
 


### PR DESCRIPTION
This pull request fixes the issue reported in #12296.

The problem was caused by unclosed `RandomAccessFile` instance inside `org.springframework.boot.loader.data.RandomAccessDataFile`.

`RandomAccessDataFile` already contained the signature of `close()` method, but it was empty. Now the RAF instance is closed within this method.

I have also found useful to add `implements Closeable` to `RandomAccessDataFile`.

Finally, there is a minor change in `TestJarCreator`, which moves the instantiation of `FileOutputStream` inside the neighboring try-with-resources block, allowing to auto-close it.