### PR TITLE
Fix ModifiedClassPathRunner tests if run via IDEA

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/runner/classpath/ModifiedClassPathRunner.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/runner/classpath/ModifiedClassPathRunner.java
@@ -98,7 +98,7 @@ public class ModifiedClassPathRunner extends BlockJUnit4ClassRunner {
 	private URL[] extractUrls(ClassLoader classLoader) throws Exception {
 		List<URL> extractedUrls = new ArrayList<>();
 		doExtractUrls(classLoader).forEach((URL url) -> {
-			if (isSurefireBooterJar(url)) {
+			if (isManifestOnlyJar(url)) {
 				extractedUrls.addAll(extractUrlsFromManifestClassPath(url));
 			}
 			else {
@@ -125,8 +125,16 @@ public class ModifiedClassPathRunner extends BlockJUnit4ClassRunner {
 		}
 	}
 
+	private boolean isManifestOnlyJar(URL url) {
+		return isSurefireBooterJar(url) || isShortenedIntelliJJar(url);
+	}
+
 	private boolean isSurefireBooterJar(URL url) {
 		return url.getPath().contains("surefirebooter");
+	}
+
+	private boolean isShortenedIntelliJJar(URL url) {
+		return url.getPath().endsWith("classpath.jar");
 	}
 
 	private List<URL> extractUrlsFromManifestClassPath(URL booterJar) {


### PR DESCRIPTION
Hi,

while looking into some possible performance improvements for `OnBeanCondition` I noticed `OnBeanConditionTypeDeductionFailureTests` to fail when run via IntelliJ. After a bit of investigation it turned out to be a short-coming of `ModifiedClassPathRunner` instead of a broken change of mine.

IntelliJ can shorten the classpath to a single classpath.jar in order to circumvent errors originating from a too long classpath. This breaks the filtering inside ModifiedClassPathRunner as the classpath contains only a single jar to match against. This can be fixed by applying a similar mechanism already provided for Surefire manifest-only booter JARs, which extracts the real classpath from the JAR's Manifest file.

Let me know what you think.

Cheers,
Christoph