### PR TITLE
Redis Sentinel database support

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Paluch
  * @author Stephane Nicoll
+ * @author Alen Turkovic
  */
 abstract class RedisConnectionConfiguration {
 
@@ -81,6 +82,7 @@ abstract class RedisConnectionConfiguration {
 			if (this.properties.getPassword() != null) {
 				config.setPassword(RedisPassword.of(this.properties.getPassword()));
 			}
+			config.setDatabase(this.properties.getDatabase());
 			return config;
 		}
 		return null;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -196,8 +196,8 @@ public class RedisAutoConfigurationTests {
 	public void testRedisConfigurationWithSentinelAndDatabase() {
 		this.contextRunner
 				.withPropertyValues("spring.redis.database:1",
-				                    "spring.redis.sentinel.master:mymaster",
-				                    "spring.redis.sentinel.nodes:127.0.0.1:26379,  127.0.0.1:26380")
+				        "spring.redis.sentinel.master:mymaster",
+						"spring.redis.sentinel.nodes:127.0.0.1:26379,  127.0.0.1:26380")
 				.run((context) -> {
 					LettuceConnectionFactory connectionFactory = context
 							.getBean(LettuceConnectionFactory.class);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -49,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Marco Aust
  * @author Mark Paluch
  * @author Stephane Nicoll
+ * @author Alen Turkovic
  */
 public class RedisAutoConfigurationTests {
 
@@ -189,6 +190,20 @@ public class RedisAutoConfigurationTests {
 				.run((context) -> assertThat(context
 						.getBean(LettuceConnectionFactory.class).isRedisSentinelAware())
 								.isTrue());
+	}
+
+	@Test
+	public void testRedisConfigurationWithSentinelAndDatabase() {
+		this.contextRunner
+				.withPropertyValues("spring.redis.database:1",
+				                    "spring.redis.sentinel.master:mymaster",
+				                    "spring.redis.sentinel.nodes:127.0.0.1:26379,  127.0.0.1:26380")
+				.run((context) -> {
+					LettuceConnectionFactory connectionFactory = context
+							.getBean(LettuceConnectionFactory.class);
+					assertThat(connectionFactory.getDatabase()).isEqualTo(1);
+					assertThat(connectionFactory.isRedisSentinelAware()).isTrue();
+				});
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -196,7 +196,7 @@ public class RedisAutoConfigurationTests {
 	public void testRedisConfigurationWithSentinelAndDatabase() {
 		this.contextRunner
 				.withPropertyValues("spring.redis.database:1",
-				        "spring.redis.sentinel.master:mymaster",
+						"spring.redis.sentinel.master:mymaster",
 						"spring.redis.sentinel.nodes:127.0.0.1:26379,  127.0.0.1:26380")
 				.run((context) -> {
 					LettuceConnectionFactory connectionFactory = context


### PR DESCRIPTION
This pull requests will configure the underlying RedisSentinelConfiguration to use the configured database.