### PR TITLE
Return the metric names in sorted order

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/MetricsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/MetricsEndpoint.java
@@ -21,10 +21,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -58,7 +58,7 @@ public class MetricsEndpoint {
 
 	@ReadOperation
 	public ListNamesResponse listNames() {
-		Set<String> names = new LinkedHashSet<>();
+		Set<String> names = new TreeSet<>();
 		collectNames(names, this.registry);
 		return new ListNamesResponse(names);
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointTests.java
@@ -61,6 +61,15 @@ public class MetricsEndpointTests {
 	}
 
 	@Test
+	public void listNamesInSortedOrder() {
+		this.registry.counter("com.example.baz");
+		this.registry.counter("com.example.bar");
+		this.registry.counter("com.example.foo");
+		MetricsEndpoint.ListNamesResponse result = this.endpoint.listNames();
+		assertThat(result.getNames()).containsExactly("com.example.bar", "com.example.baz", "com.example.foo");
+	}
+
+	@Test
 	public void listNamesRecursesOverCompositeRegistries() {
 		CompositeMeterRegistry composite = new CompositeMeterRegistry();
 		SimpleMeterRegistry reg1 = new SimpleMeterRegistry();


### PR DESCRIPTION
It's helpful to have the metric names in a sorted order when visually inspecting them