### PR TITLE
Fix @EnableIntegrationManagement

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -120,7 +120,7 @@ public class IntegrationAutoConfiguration {
 	protected static class IntegrationManagementConfiguration {
 
 		@Configuration
-		@EnableIntegrationManagement(countsEnabled = "true")
+		@EnableIntegrationManagement(defaultCountsEnabled = "true")
 		protected static class EnableIntegrationManagementConfiguration {
 		}
 


### PR DESCRIPTION
Incorrect property set to `true` - `countsEnabled` is an array of bean name patterns.
`defaultCountsEnabled` is the default property.

Inadvertently changed when removing `defaultStatsEnabled` for Micrometer support.

