### PR TITLE
Remove value in @ConditionalOnMissingBean if possible

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfiguration.java
@@ -115,7 +115,7 @@ public class MetricsAutoConfiguration {
 		@ConditionalOnClass(name = { "ch.qos.logback.classic.LoggerContext",
 				"org.slf4j.LoggerFactory" })
 		@Conditional(LogbackLoggingCondition.class)
-		@ConditionalOnMissingBean(LogbackMetrics.class)
+		@ConditionalOnMissingBean
 		@ConditionalOnProperty(value = "management.metrics.binders.logback.enabled", matchIfMissing = true)
 		public LogbackMetrics logbackMetrics() {
 			return new LogbackMetrics();

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/atlas/AtlasMetricsExportAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/atlas/AtlasMetricsExportAutoConfiguration.java
@@ -52,7 +52,7 @@ import org.springframework.context.annotation.Configuration;
 public class AtlasMetricsExportAutoConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean(AtlasConfig.class)
+	@ConditionalOnMissingBean
 	public AtlasConfig atlasConfig(AtlasProperties atlasProperties) {
 		return new AtlasPropertiesConfigAdapter(atlasProperties);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxMetricsExportAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxMetricsExportAutoConfiguration.java
@@ -51,7 +51,7 @@ import org.springframework.context.annotation.Configuration;
 public class InfluxMetricsExportAutoConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean(InfluxConfig.class)
+	@ConditionalOnMissingBean
 	public InfluxConfig influxConfig(InfluxProperties influxProperties) {
 		return new InfluxPropertiesConfigAdapter(influxProperties);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleMetricsExportAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleMetricsExportAutoConfiguration.java
@@ -56,7 +56,7 @@ public class SimpleMetricsExportAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(SimpleConfig.class)
+	@ConditionalOnMissingBean
 	public SimpleConfig simpleConfig(SimpleProperties simpleProperties) {
 		return new SimplePropertiesConfigAdapter(simpleProperties);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdMetricsExportAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdMetricsExportAutoConfiguration.java
@@ -53,7 +53,7 @@ import org.springframework.context.annotation.Configuration;
 public class StatsdMetricsExportAutoConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean(StatsdConfig.class)
+	@ConditionalOnMissingBean
 	public StatsdConfig statsdConfig(StatsdProperties statsdProperties) {
 		return new StatsdPropertiesConfigAdapter(statsdProperties);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfiguration.java
@@ -51,7 +51,7 @@ import org.springframework.context.annotation.Configuration;
 public class WavefrontMetricsExportAutoConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean(WavefrontConfig.class)
+	@ConditionalOnMissingBean
 	public WavefrontConfig wavefrontConfig(WavefrontProperties props) {
 		return new WavefrontPropertiesConfigAdapter(props);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/tomcat/TomcatMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/tomcat/TomcatMetricsAutoConfiguration.java
@@ -46,7 +46,7 @@ public class TomcatMetricsAutoConfiguration {
 	private volatile Context context;
 
 	@Bean
-	@ConditionalOnMissingBean(TomcatMetrics.class)
+	@ConditionalOnMissingBean
 	public TomcatMetrics tomcatMetrics(ApplicationContext applicationContext) {
 		return new TomcatMetrics(this.context == null ? null : this.context.getManager(),
 				Collections.emptyList());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -167,7 +167,7 @@ public class RabbitAutoConfiguration {
 
 		@Bean
 		@ConditionalOnSingleCandidate(ConnectionFactory.class)
-		@ConditionalOnMissingBean(RabbitTemplate.class)
+		@ConditionalOnMissingBean
 		public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
 			PropertyMapper map = PropertyMapper.get();
 			RabbitTemplate template = new RabbitTemplate(connectionFactory);
@@ -213,7 +213,7 @@ public class RabbitAutoConfiguration {
 		@Bean
 		@ConditionalOnSingleCandidate(ConnectionFactory.class)
 		@ConditionalOnProperty(prefix = "spring.rabbitmq", name = "dynamic", matchIfMissing = true)
-		@ConditionalOnMissingBean(AmqpAdmin.class)
+		@ConditionalOnMissingBean
 		public AmqpAdmin amqpAdmin(ConnectionFactory connectionFactory) {
 			return new RabbitAdmin(connectionFactory);
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/dao/PersistenceExceptionTranslationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/dao/PersistenceExceptionTranslationAutoConfiguration.java
@@ -37,7 +37,7 @@ import org.springframework.dao.annotation.PersistenceExceptionTranslationPostPro
 public class PersistenceExceptionTranslationAutoConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean(PersistenceExceptionTranslationPostProcessor.class)
+	@ConditionalOnMissingBean
 	@ConditionalOnProperty(prefix = "spring.dao.exceptiontranslation", name = "enabled", matchIfMissing = true)
 	public static PersistenceExceptionTranslationPostProcessor persistenceExceptionTranslationPostProcessor(
 			Environment environment) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraReactiveDataAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraReactiveDataAutoConfiguration.java
@@ -49,7 +49,7 @@ import org.springframework.data.cassandra.core.cql.session.DefaultReactiveSessio
 public class CassandraReactiveDataAutoConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean(ReactiveSession.class)
+	@ConditionalOnMissingBean
 	public ReactiveSession reactiveCassandraSession(Session session) {
 		return new DefaultBridgedReactiveSession(session);
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfiguration.java
@@ -59,7 +59,7 @@ public class RedisAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(StringRedisTemplate.class)
+	@ConditionalOnMissingBean
 	public StringRedisTemplate stringRedisTemplate(
 			RedisConnectionFactory redisConnectionFactory) throws UnknownHostException {
 		StringRedisTemplate template = new StringRedisTemplate();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfiguration.java
@@ -43,7 +43,7 @@ import org.springframework.core.Ordered;
 public class GsonAutoConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean(GsonBuilder.class)
+	@ConditionalOnMissingBean
 	public GsonBuilder gsonBuilder(List<GsonBuilderCustomizer> customizers) {
 		GsonBuilder builder = new GsonBuilder();
 		customizers.forEach((c) -> c.customize(builder));
@@ -51,7 +51,7 @@ public class GsonAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(Gson.class)
+	@ConditionalOnMissingBean
 	public Gson gson(GsonBuilder gsonBuilder) {
 		return gsonBuilder.create();
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
@@ -98,7 +98,7 @@ public class JacksonAutoConfiguration {
 
 		@Bean
 		@Primary
-		@ConditionalOnMissingBean(ObjectMapper.class)
+		@ConditionalOnMissingBean
 		public ObjectMapper jacksonObjectMapper(Jackson2ObjectMapperBuilder builder) {
 			return builder.createXmlMapper(false).build();
 		}
@@ -161,7 +161,7 @@ public class JacksonAutoConfiguration {
 	static class ParameterNamesModuleConfiguration {
 
 		@Bean
-		@ConditionalOnMissingBean(ParameterNamesModule.class)
+		@ConditionalOnMissingBean
 		public ParameterNamesModule parameterNamesModule() {
 			return new ParameterNamesModule(JsonCreator.Mode.DEFAULT);
 		}
@@ -179,7 +179,7 @@ public class JacksonAutoConfiguration {
 		}
 
 		@Bean
-		@ConditionalOnMissingBean(Jackson2ObjectMapperBuilder.class)
+		@ConditionalOnMissingBean
 		public Jackson2ObjectMapperBuilder jacksonObjectMapperBuilder(
 				List<Jackson2ObjectMapperBuilderCustomizer> customizers) {
 			Jackson2ObjectMapperBuilder builder = new Jackson2ObjectMapperBuilder();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfiguration.java
@@ -97,7 +97,7 @@ public class JmxAutoConfiguration implements EnvironmentAware, BeanFactoryAware 
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(MBeanServer.class)
+	@ConditionalOnMissingBean
 	public MBeanServer mbeanServer() {
 		SpecificPlatform platform = SpecificPlatform.get();
 		if (platform != null) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfiguration.java
@@ -60,7 +60,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 public class JooqAutoConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean(DataSourceConnectionProvider.class)
+	@ConditionalOnMissingBean
 	public DataSourceConnectionProvider dataSourceConnectionProvider(
 			DataSource dataSource) {
 		return new DataSourceConnectionProvider(

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfiguration.java
@@ -131,7 +131,7 @@ public class KafkaAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(KafkaAdmin.class)
+	@ConditionalOnMissingBean
 	public KafkaAdmin kafkaAdmin() {
 		KafkaAdmin kafkaAdmin = new KafkaAdmin(this.properties.buildAdminProperties());
 		kafkaAdmin.setFatalIfBrokerNotAvailable(this.properties.getAdmin().isFailFast());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheAutoConfiguration.java
@@ -77,7 +77,7 @@ public class MustacheAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(Mustache.Compiler.class)
+	@ConditionalOnMissingBean
 	public Mustache.Compiler mustacheCompiler(TemplateLoader mustacheTemplateLoader) {
 		return Mustache.compiler().withLoader(mustacheTemplateLoader)
 				.withCollector(collector());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheReactiveWebConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheReactiveWebConfiguration.java
@@ -37,7 +37,7 @@ class MustacheReactiveWebConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(MustacheViewResolver.class)
+	@ConditionalOnMissingBean
 	public MustacheViewResolver mustacheViewResolver(Compiler mustacheCompiler) {
 		MustacheViewResolver resolver = new MustacheViewResolver(mustacheCompiler);
 		resolver.setPrefix(this.mustache.getPrefix());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheServletWebConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheServletWebConfiguration.java
@@ -37,7 +37,7 @@ class MustacheServletWebConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(MustacheViewResolver.class)
+	@ConditionalOnMissingBean
 	public MustacheViewResolver mustacheViewResolver(Compiler mustacheCompiler) {
 		MustacheViewResolver resolver = new MustacheViewResolver(mustacheCompiler);
 		this.mustache.applyToMvcViewResolver(resolver);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/JpaBaseConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/JpaBaseConfiguration.java
@@ -94,7 +94,7 @@ public abstract class JpaBaseConfiguration implements BeanFactoryAware {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(PlatformTransactionManager.class)
+	@ConditionalOnMissingBean
 	public PlatformTransactionManager transactionManager() {
 		JpaTransactionManager transactionManager = new JpaTransactionManager();
 		if (this.transactionManagerCustomizers != null) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/SecurityDataConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/SecurityDataConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.security.data.repository.query.SecurityEvaluationCont
 		EvaluationContextExtensionSupport.class })
 public class SecurityDataConfiguration {
 
-	@ConditionalOnMissingBean(SecurityEvaluationContextExtension.class)
+	@ConditionalOnMissingBean
 	@Bean
 	public SecurityEvaluationContextExtension securityEvaluationContextExtension() {
 		return new SecurityEvaluationContextExtension();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/sendgrid/SendGridAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/sendgrid/SendGridAutoConfiguration.java
@@ -50,7 +50,7 @@ public class SendGridAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(SendGrid.class)
+	@ConditionalOnMissingBean
 	public SendGrid sendGrid() {
 		if (this.properties.isProxyConfigured()) {
 			HttpHost proxy = new HttpHost(this.properties.getProxy().getHost(),

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
@@ -147,7 +147,7 @@ public class ThymeleafAutoConfiguration {
 		}
 
 		@Bean
-		@ConditionalOnMissingBean(SpringTemplateEngine.class)
+		@ConditionalOnMissingBean
 		public SpringTemplateEngine templateEngine() {
 			SpringTemplateEngine engine = new SpringTemplateEngine();
 			engine.setEnableSpringELCompiler(this.properties.isEnableSpringElCompiler());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/transaction/jta/NarayanaJtaConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/transaction/jta/NarayanaJtaConfiguration.java
@@ -139,7 +139,7 @@ public class NarayanaJtaConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(XADataSourceWrapper.class)
+	@ConditionalOnMissingBean
 	public XADataSourceWrapper xaDataSourceWrapper(
 			NarayanaRecoveryManagerBean narayanaRecoveryManagerBean,
 			NarayanaProperties narayanaProperties) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/HttpEncodingAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/HttpEncodingAutoConfiguration.java
@@ -54,7 +54,7 @@ public class HttpEncodingAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(CharacterEncodingFilter.class)
+	@ConditionalOnMissingBean
 	public CharacterEncodingFilter characterEncodingFilter() {
 		CharacterEncodingFilter filter = new OrderedCharacterEncodingFilter();
 		filter.setEncoding(this.properties.getCharset().name());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfiguration.java
@@ -170,7 +170,7 @@ public class ErrorMvcAutoConfiguration {
 		// If the user adds @EnableWebMvc then the bean name view resolver from
 		// WebMvcAutoConfiguration disappears, so add it back in to avoid disappointment.
 		@Bean
-		@ConditionalOnMissingBean(BeanNameViewResolver.class)
+		@ConditionalOnMissingBean
 		public BeanNameViewResolver beanNameViewResolver() {
 			BeanNameViewResolver resolver = new BeanNameViewResolver();
 			resolver.setOrder(Ordered.LOWEST_PRECEDENCE - 10);

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/RestDocsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/RestDocsAutoConfiguration.java
@@ -56,7 +56,7 @@ public class RestDocsAutoConfiguration {
 	static class RestDocsMockMvcAutoConfiguration {
 
 		@Bean
-		@ConditionalOnMissingBean(MockMvcRestDocumentationConfigurer.class)
+		@ConditionalOnMissingBean
 		public MockMvcRestDocumentationConfigurer restDocsMockMvcConfigurer(
 				ObjectProvider<RestDocsMockMvcConfigurationCustomizer> configurationCustomizerProvider,
 				RestDocumentationContextProvider contextProvider) {
@@ -88,7 +88,7 @@ public class RestDocsAutoConfiguration {
 	static class RestDocsRestAssuredAutoConfiguration {
 
 		@Bean
-		@ConditionalOnMissingBean(RequestSpecification.class)
+		@ConditionalOnMissingBean
 		public RequestSpecification restDocsRestAssuredConfigurer(
 				ObjectProvider<RestDocsRestAssuredConfigurationCustomizer> configurationCustomizerProvider,
 				RestDocumentationContextProvider contextProvider) {
@@ -117,7 +117,7 @@ public class RestDocsAutoConfiguration {
 	static class RestDocsWebTestClientAutoConfiguration {
 
 		@Bean
-		@ConditionalOnMissingBean(WebTestClientRestDocumentationConfigurer.class)
+		@ConditionalOnMissingBean
 		public WebTestClientRestDocumentationConfigurer restDocsWebTestClientConfigurer(
 				ObjectProvider<RestDocsWebTestClientConfigurationCustomizer> configurationCustomizerProvider,
 				RestDocumentationContextProvider contextProvider) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR removes `value` in `@ConditionalOnMissingBean` when it can be inferred from return type.