### PR TITLE
Add docker-api starter on spring-boot-starters' README

### DIFF
--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -175,7 +175,7 @@ do as they were designed before this was clarified.
 | http://alexo.github.io/wro4j/[Wro4j] (Advanced usage)
 | https://github.com/michael-simons/wro4j-spring-boot-starter
 
-| http://github.com/docker-java/docker-java/[docker-java]
-| https://github.com/jliu666/docker-java-spring-boot-starter/[docker-java-spring-boot-starter]
+| https://github.com/docker-java/docker-java/[docker-java]
+| https://github.com/jliu666/docker-java-spring-boot-starter
 
 |===

--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -175,4 +175,7 @@ do as they were designed before this was clarified.
 | http://alexo.github.io/wro4j/[Wro4j] (Advanced usage)
 | https://github.com/michael-simons/wro4j-spring-boot-starter
 
+| http://github.com/docker-java/docker-java/[docker-java]
+| https://github.com/jliu666/docker-java-spring-boot-starter/[docker-java-spring-boot-starter]
+
 |===

--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -175,7 +175,7 @@ do as they were designed before this was clarified.
 | http://alexo.github.io/wro4j/[Wro4j] (Advanced usage)
 | https://github.com/michael-simons/wro4j-spring-boot-starter
 
-| https://github.com/docker-java/docker-java/[docker-java]
-| https://github.com/jliu666/docker-java-spring-boot-starter
+| https://github.com/docker-java/docker-java/[docker-java] and https://github.com/spotify/docker-client/[docker-client]
+| https://github.com/jliu666/docker-api-spring-boot
 
 |===


### PR DESCRIPTION
Add docker-java starter on spring-boot-starters readme.
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->