### PR TITLE
Sort meter names in actuator metrics endpoint

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/MetricsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/MetricsEndpoint.java
@@ -21,10 +21,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -58,7 +58,7 @@ public class MetricsEndpoint {
 
 	@ReadOperation
 	public ListNamesResponse listNames() {
-		Set<String> names = new LinkedHashSet<>();
+		Set<String> names = new TreeSet<>();
 		collectNames(names, this.registry);
 		return new ListNamesResponse(names);
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointTests.java
@@ -74,6 +74,16 @@ public class MetricsEndpointTests {
 	}
 
 	@Test
+	public void listNamesProducesSortedMeterNames() {
+		this.registry.counter("com.example.foo");
+		this.registry.counter("com.example.bar");
+		this.registry.counter("com.acme");
+		MetricsEndpoint.ListNamesResponse result = this.endpoint.listNames();
+		assertThat(result.getNames()).containsExactly("com.acme", "com.example.bar",
+				"com.example.foo");
+	}
+
+	@Test
 	public void metricValuesAreTheSumOfAllTimeSeriesMatchingTags() {
 		this.registry.counter("cache", "result", "hit", "host", "1").increment(2);
 		this.registry.counter("cache", "result", "miss", "host", "1").increment(2);


### PR DESCRIPTION
This PR makes the actuator `metrics` endpoint return meter names alphabetically sorted.