### PR TITLE
Use Supplier variants of Assert methods

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/system/DiskSpaceHealthIndicatorProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/system/DiskSpaceHealthIndicatorProperties.java
@@ -50,8 +50,8 @@ public class DiskSpaceHealthIndicatorProperties {
 	}
 
 	public void setPath(File path) {
-		Assert.isTrue(path.exists(), "Path '" + path + "' does not exist");
-		Assert.isTrue(path.canRead(), "Path '" + path + "' cannot be read");
+		Assert.isTrue(path.exists(), () -> "Path '" + path + "' does not exist");
+		Assert.isTrue(path.canRead(), () -> "Path '" + path + "' cannot be read");
 		this.path = path;
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/test/MetricsRun.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/test/MetricsRun.java
@@ -105,7 +105,7 @@ public final class MetricsRun {
 			Class<?>[] exportAutoConfigurations) {
 		for (Class<?> configuration : exportAutoConfigurations) {
 			Assert.state(EXPORT_AUTO_CONFIGURATIONS.contains(configuration),
-					"Unknown export auto-configuration " + configuration.getName());
+					() -> "Unknown export auto-configuration " + configuration.getName());
 		}
 		return contextRunner
 				.withPropertyValues("management.metrics.use-global-registry=false")

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/EndpointDiscoverer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/EndpointDiscoverer.java
@@ -432,7 +432,7 @@ public abstract class EndpointDiscoverer<E extends ExposableEndpoint<O>, O exten
 			this.enabledByDefault = (Boolean) attributes.get("enableByDefault");
 			this.filter = getFilter(this.bean.getClass());
 			Assert.state(StringUtils.hasText(this.id),
-					"No @Endpoint id attribute specified for "
+					() -> "No @Endpoint id attribute specified for "
 							+ bean.getClass().getName());
 		}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/invoke/reflect/OperationMethodParameters.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/invoke/reflect/OperationMethodParameters.java
@@ -51,7 +51,7 @@ class OperationMethodParameters implements OperationParameters {
 		String[] parameterNames = parameterNameDiscoverer.getParameterNames(method);
 		Parameter[] parameters = method.getParameters();
 		Assert.state(parameterNames != null,
-				"Failed to extract parameter names for " + method);
+				() -> "Failed to extract parameter names for " + method);
 		this.operationParameters = getOperationParameters(parameters, parameterNames);
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelector.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelector.java
@@ -129,8 +129,9 @@ public class AutoConfigurationImportSelector
 		AnnotationAttributes attributes = AnnotationAttributes
 				.fromMap(metadata.getAnnotationAttributes(name, true));
 		Assert.notNull(attributes,
-				"No auto-configuration attributes found. Is " + metadata.getClassName()
-						+ " annotated with " + ClassUtils.getShortName(name) + "?");
+				() -> "No auto-configuration attributes found. Is "
+						+ metadata.getClassName() + " annotated with "
+						+ ClassUtils.getShortName(name) + "?");
 		return attributes;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,7 +149,7 @@ public class CacheAutoConfiguration {
 		@PostConstruct
 		public void checkHasCacheManager() {
 			Assert.notNull(this.cacheManager,
-					"No cache manager could "
+					() -> "No cache manager could "
 							+ "be auto-configured, check your configuration (caching "
 							+ "type is '" + this.cacheProperties.getType() + "')");
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@ public class CacheProperties {
 	 */
 	public Resource resolveConfigLocation(Resource config) {
 		if (config != null) {
-			Assert.isTrue(config.exists(), "Cache configuration does not exist '"
+			Assert.isTrue(config.exists(), () -> "Cache configuration does not exist '"
 					+ config.getDescription() + "'");
 			return config;
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnBeanCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnBeanCondition.java
@@ -503,8 +503,8 @@ class OnBeanCondition extends SpringBootCondition implements ConfigurationCondit
 
 		@Override
 		protected void validate(BeanTypeDeductionException ex) {
-			Assert.isTrue(getTypes().size() == 1, annotationName() + " annotations must "
-					+ "specify only one type (got " + getTypes() + ")");
+			Assert.isTrue(getTypes().size() == 1, () -> annotationName()
+					+ " annotations must specify only one type (got " + getTypes() + ")");
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class HazelcastProperties {
 		if (this.config == null) {
 			return null;
 		}
-		Assert.isTrue(this.config.exists(), "Hazelcast configuration does not exist '"
+		Assert.isTrue(this.config.exists(), () -> "Hazelcast configuration does not exist '"
 				+ this.config.getDescription() + "'");
 		return this.config;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
@@ -323,8 +323,8 @@ public class JacksonAutoConfiguration {
 				// that may be added by Jackson in the future)
 				Field field = ReflectionUtils.findField(PropertyNamingStrategy.class,
 						fieldName, PropertyNamingStrategy.class);
-				Assert.notNull(field, "Constant named '" + fieldName + "' not found on "
-						+ PropertyNamingStrategy.class.getName());
+				Assert.notNull(field, () -> "Constant named '" + fieldName
+						+ "' not found on " + PropertyNamingStrategy.class.getName());
 				try {
 					builder.propertyNamingStrategy(
 							(PropertyNamingStrategy) field.get(null));

--- a/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/archive/ArchiveCommand.java
+++ b/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/archive/ArchiveCommand.java
@@ -124,14 +124,14 @@ abstract class ArchiveCommand extends OptionParsingCommand {
 		protected ExitStatus run(OptionSet options) throws Exception {
 			List<?> nonOptionArguments = new ArrayList<Object>(
 					options.nonOptionArguments());
-			Assert.isTrue(nonOptionArguments.size() >= 2, "The name of the resulting "
+			Assert.isTrue(nonOptionArguments.size() >= 2, () -> "The name of the resulting "
 					+ this.type + " and at least one source file must be specified");
 
 			File output = new File((String) nonOptionArguments.remove(0));
 			Assert.isTrue(
 					output.getName().toLowerCase(Locale.ENGLISH)
 							.endsWith("." + this.type),
-					"The output '" + output + "' is not a "
+					() -> "The output '" + output + "' is not a "
 							+ this.type.toUpperCase(Locale.ENGLISH) + " file.");
 			deleteIfExists(output);
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FolderSnapshot.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FolderSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ class FolderSnapshot {
 		Assert.notNull(snapshot, "Snapshot must not be null");
 		File folder = this.folder;
 		Assert.isTrue(snapshot.folder.equals(folder),
-				"Snapshot source folder must be '" + folder + "'");
+				() -> "Snapshot source folder must be '" + folder + "'");
 		Set<ChangedFile> changes = new LinkedHashSet<>();
 		Map<File, FileSnapshot> previousFiles = getFilesMap();
 		for (FileSnapshot currentFile : snapshot.files) {

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/remote/client/ClassPathChangeUploader.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/remote/client/ClassPathChangeUploader.java
@@ -111,8 +111,9 @@ public class ClassPathChangeUploader
 					headers.setContentLength(bytes.length);
 					FileCopyUtils.copy(bytes, request.getBody());
 					ClientHttpResponse response = request.execute();
-					Assert.state(response.getStatusCode() == HttpStatus.OK,
-							"Unexpected " + response.getStatusCode()
+					HttpStatus statusCode = response.getStatusCode();
+					Assert.state(statusCode == HttpStatus.OK,
+							() -> "Unexpected " + statusCode
 									+ " response uploading class files");
 					logUpload(classLoaderFiles);
 					return;

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/classloader/ClassLoaderFile.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/classloader/ClassLoaderFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ public class ClassLoaderFile implements Serializable {
 	public ClassLoaderFile(Kind kind, long lastModified, byte[] contents) {
 		Assert.notNull(kind, "Kind must not be null");
 		Assert.isTrue(kind == Kind.DELETED ? contents == null : contents != null,
-				"Contents must " + (kind == Kind.DELETED ? "" : "not ") + "be null");
+				() -> "Contents must " + (kind == Kind.DELETED ? "" : "not ") + "be null");
 		this.kind = kind;
 		this.lastModified = lastModified;
 		this.contents = contents;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
@@ -73,7 +73,8 @@ class ConfigurationPropertiesBinder {
 	public void bind(Bindable<?> target) {
 		ConfigurationProperties annotation = target
 				.getAnnotation(ConfigurationProperties.class);
-		Assert.state(annotation != null, "Missing @ConfigurationProperties on " + target);
+		Assert.state(annotation != null,
+				() -> "Missing @ConfigurationProperties on " + target);
 		List<Validator> validators = getValidators(target);
 		BindHandler bindHandler = getBindHandler(annotation, validators);
 		getBinder().bind(annotation.prefix(), target, bindHandler);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/EnableConfigurationPropertiesImportSelector.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/EnableConfigurationPropertiesImportSelector.java
@@ -125,7 +125,7 @@ class EnableConfigurationPropertiesImportSelector implements ImportSelector {
 		private void assertHasAnnotation(Class<?> type) {
 			Assert.notNull(
 					AnnotationUtils.findAnnotation(type, ConfigurationProperties.class),
-					"No " + ConfigurationProperties.class.getSimpleName()
+					() -> "No " + ConfigurationProperties.class.getSimpleName()
 							+ " annotation found on  '" + type.getName() + "'.");
 		}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Bindable.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Bindable.java
@@ -153,7 +153,7 @@ public final class Bindable<T> {
 		Assert.isTrue(
 				existingValue == null || this.type.isArray()
 						|| this.boxedType.resolve().isInstance(existingValue),
-				"ExistingValue must be an instance of " + this.type);
+				() -> "ExistingValue must be an instance of " + this.type);
 		Supplier<T> value = (existingValue == null ? null : () -> existingValue);
 		return new Bindable<>(this.type, this.boxedType, value, NO_ANNOTATIONS);
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/StringToEnumIgnoringCaseConverterFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/StringToEnumIgnoringCaseConverterFactory.java
@@ -39,8 +39,8 @@ final class StringToEnumIgnoringCaseConverterFactory
 		while (enumType != null && !enumType.isEnum()) {
 			enumType = enumType.getSuperclass();
 		}
-		Assert.notNull(enumType,
-				"The target type " + targetType.getName() + " does not refer to an enum");
+		Assert.notNull(enumType, () -> "The target type " + targetType.getName()
+				+ " does not refer to an enum");
 		return new StringToEnum(enumType);
 	}
 


### PR DESCRIPTION
Hi,

this PR applies the Supplier variants of `Assert.isTrue` and alike if possible in order to avoid some unnecessary String allocations.

Cheers,
Christoph