### PR TITLE
Fix Kotlin @ConfigurationProperties example

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -7745,7 +7745,7 @@ class KotlinExampleProperties {
 
 	lateinit var foo2: String
 
-	lateinit val bar = Bar()
+	val bar = Bar()
 
 	class Bar {
 


### PR DESCRIPTION
`lateinit` should not be used on `val` properties initialized with a default value, see https://github.com/mixitconf/mixit/blob/master/src/main/kotlin/mixit/MixitProperties.kt for a concrete example.