### PR TITLE
Dependency management for JUnit 5 is incomplete

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -2046,6 +2046,16 @@
 				<version>${junit-jupiter.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-params</artifactId>
+				<version>${junit-jupiter.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.junit.vintage</groupId>
+				<artifactId>junit-vintage-engine</artifactId>
+				<version>${junit-jupiter.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.liquibase</groupId>
 				<artifactId>liquibase-core</artifactId>
 				<version>${liquibase.version}</version>


### PR DESCRIPTION
Hello,

This PR add two new managed dependencies for Junit 5 :
- `junit-jupiter-params` : which is one of the major Junit 5 feature 
- `junit-vintage-engine` : which allow a painless migration from Junit 4.x to Junit 5

Have a nice day.