### PR TITLE
Upgrade to Jackson 2.9.5

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -77,7 +77,7 @@
 		<httpcore.version>4.4.9</httpcore.version>
 		<infinispan.version>9.1.7.Final</infinispan.version>
 		<influxdb-java.version>2.9</influxdb-java.version>
-		<jackson.version>2.9.4</jackson.version>
+		<jackson.version>2.9.5</jackson.version>
 		<janino.version>3.0.8</janino.version>
 		<javax-annotation.version>1.3.2</javax-annotation.version>
 		<javax-cache.version>1.1.0</javax-cache.version>


### PR DESCRIPTION
Upgrade to jackson 2.9.5 to fix the CVE-2018-7489 (FasterXML/jackson-databind#1931)