### PR TITLE
Ensure kotlin compiler includes method param names

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -532,11 +532,10 @@ JSON request body. When exposed via JMX, the parameters are mapped to the parame
 the MBean's operations. Parameters are required by default. They can be made optional
 by annotating them with `@org.springframework.lang.Nullable`.
 
-NOTE: To allow the input to be mapped to the operation method's parameters, code
-implementing an endpoint should be compiled with `-parameters`. This will happen
-automatically if you are using Spring Boot's Gradle plugin or if you are using Maven
-and `spring-boot-starter-parent`.
-
+NOTE: To allow the input to be mapped to the operation method's parameters, java code
+implementing an endpoint should be compiled with `-parameters`, and kotlin code should
+be compiled with `-java-parameters`. This will happen automatically if you are using
+Spring Boot's Gradle plugin or if you are using Maven and `spring-boot-starter-parent`.
 
 
 [[production-ready-endpoints-custom-input-conversion]]

--- a/spring-boot-project/spring-boot-parent/pom.xml
+++ b/spring-boot-project/spring-boot-parent/pom.xml
@@ -294,6 +294,9 @@
 						<jvmTarget>${java.version}</jvmTarget>
 						<apiVersion>1.1</apiVersion>
 						<languageVersion>1.1</languageVersion>
+						<args>
+							<arg>-java-parameters</arg>
+						</args>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/spring-boot-project/spring-boot-parent/pom.xml
+++ b/spring-boot-project/spring-boot-parent/pom.xml
@@ -294,9 +294,7 @@
 						<jvmTarget>${java.version}</jvmTarget>
 						<apiVersion>1.1</apiVersion>
 						<languageVersion>1.1</languageVersion>
-						<args>
-							<arg>-java-parameters</arg>
-						</args>
+						<javaParameters>true</javaParameters>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/pom.xml
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/pom.xml
@@ -51,9 +51,7 @@
 					<version>${kotlin.version}</version>
 					<configuration>
 						<jvmTarget>${java.version}</jvmTarget>
-						<args>
-							<arg>-java-parameters</arg>
-						</args>
+						<javaParameters>true</javaParameters>
 					</configuration>
 					<executions>
 						<execution>

--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/pom.xml
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/pom.xml
@@ -51,6 +51,9 @@
 					<version>${kotlin.version}</version>
 					<configuration>
 						<jvmTarget>${java.version}</jvmTarget>
+						<args>
+							<arg>-java-parameters</arg>
+						</args>
 					</configuration>
 					<executions>
 						<execution>

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/asciidoc/reacting.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/asciidoc/reacting.adoc
@@ -24,7 +24,7 @@ plugin:
    the `bootJar` task.
 6. Configures any `JavaCompile` tasks with no configured encoding to use `UTF-8`.
 7. Configures any `JavaCompile` tasks to use the `-parameters` compiler argument.
-
+8. Configures any `KotlinCompile` tasks to use the `-java-parameters` compiler argument.
 
 
 [[reacting-to-other-plugins-kotlin]]

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/KotlinPluginAction.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/KotlinPluginAction.java
@@ -20,6 +20,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper;
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile;
 
 /**
  * {@link PluginApplicationAction} that reacts to Kotlin's Gradle plugin being applied by
@@ -39,6 +40,13 @@ class KotlinPluginAction implements PluginApplicationAction {
 		if (!extraProperties.has("kotlin.version")) {
 			extraProperties.set("kotlin.version", kotlinVersion);
 		}
+		enableJavaParametersOption(project);
+	}
+
+	private void enableJavaParametersOption(Project project) {
+		project.getTasks().withType(KotlinCompile.class, (compile) -> {
+			compile.getKotlinOptions().setJavaParameters(true);
+		});
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/KotlinPluginActionIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/KotlinPluginActionIntegrationTests.java
@@ -52,4 +52,17 @@ public class KotlinPluginActionIntegrationTests {
 				.containsPattern("org.jetbrains.kotlin:kotlin-stdlib-jdk8:* -> 1.2.10");
 	}
 
+	@Test
+	public void kotlinCompileTasksUseJavaParametersFlagByDefault() {
+		assertThat(this.gradleBuild.build("kotlinCompileTasksJavaParameters").getOutput())
+				.contains("compileKotlin java parameters: true")
+				.contains("compileTestKotlin java parameters: true");
+	}
+
+	@Test
+	public void kotlinCompileTasksCanOverrideDefaultJavaParametersFlag() {
+		assertThat(this.gradleBuild.build("kotlinCompileTasksJavaParameters").getOutput())
+				.contains("compileKotlin java parameters: false")
+				.contains("compileTestKotlin java parameters: false");
+	}
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/KotlinPluginActionIntegrationTests-kotlinCompileTasksCanOverrideDefaultJavaParametersFlag.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/KotlinPluginActionIntegrationTests-kotlinCompileTasksCanOverrideDefaultJavaParametersFlag.gradle
@@ -1,0 +1,25 @@
+buildscript {
+	dependencies {
+		classpath files(pluginClasspath.split(','))
+	}
+}
+
+plugins {
+	id 'org.jetbrains.kotlin.jvm' version '1.2.10'
+}
+
+apply plugin: 'org.springframework.boot'
+
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
+
+tasks.withType(KotlinCompile) {
+	kotlinOptions.javaParameters = false
+}
+
+task('kotlinCompileTasksJavaParameters') {
+	doFirst {
+		tasks.withType(KotlinCompile) {
+			println "$name java parameters: ${kotlinOptions.javaParameters}"
+		}
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/KotlinPluginActionIntegrationTests-kotlinCompileTasksUseJavaParametersFlagByDefault.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/KotlinPluginActionIntegrationTests-kotlinCompileTasksUseJavaParametersFlagByDefault.gradle
@@ -1,0 +1,21 @@
+buildscript {
+	dependencies {
+		classpath files(pluginClasspath.split(','))
+	}
+}
+
+plugins {
+	id 'org.jetbrains.kotlin.jvm' version '1.2.10'
+}
+
+apply plugin: 'org.springframework.boot'
+
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
+
+task('kotlinCompileTasksJavaParameters') {
+	doFirst {
+		tasks.withType(KotlinCompile) {
+			println "$name java parameters: ${kotlinOptions.javaParameters}"
+		}
+	}
+}


### PR DESCRIPTION
Configures kotlin-maven-plugin to include the `-java-parameters`
argument, so that method parameter names are included in bytecode.

See gh-9323
Fixes gh-12640

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->