### PR TITLE
Move away from Couchbase's deprecated endpoint configuration methods 

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseAutoConfiguration.java
@@ -110,12 +110,12 @@ public class CouchbaseAutoConfiguration {
 			if (timeouts.getKeyValue() != null) {
 				builder = builder.kvTimeout(timeouts.getKeyValue().toMillis());
 			}
-			int minQuery = endpoints.getQuery() != 1 ? endpoints.getQuery() : endpoints.getMinQuery();
-			int maxQuery = endpoints.getQuery() != 1 ? endpoints.getQuery() : endpoints.getMaxQuery();
+			int minQuery = endpoints.getQuery() != 1 ? endpoints.getQuery() : endpoints.getQueryservice().getMinEndpoints();
+			int maxQuery = endpoints.getQuery() != 1 ? endpoints.getQuery() : endpoints.getQueryservice().getMaxEndpoints();
 			builder = builder.queryServiceConfig(QueryServiceConfig.create(minQuery, maxQuery));
 			if (timeouts.getQuery() != null) {
-				int minView = endpoints.getView() != 1 ? endpoints.getView() : endpoints.getMinView();
-				int maxView = endpoints.getView() != 1 ? endpoints.getView() : endpoints.getMaxView();
+				int minView = endpoints.getView() != 1 ? endpoints.getView() : endpoints.getViewservice().getMinEndpoints();
+				int maxView = endpoints.getView() != 1 ? endpoints.getView() : endpoints.getViewservice().getMaxEndpoints();
 				builder = builder.queryTimeout(timeouts.getQuery().toMillis())
 						.viewServiceConfig(ViewServiceConfig.create(minView, maxView));
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseAutoConfiguration.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.autoconfigure.couchbase;
 
+import com.couchbase.client.core.env.KeyValueServiceConfig;
+import com.couchbase.client.core.env.QueryServiceConfig;
+import com.couchbase.client.core.env.ViewServiceConfig;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.CouchbaseBucket;
@@ -40,6 +43,7 @@ import org.springframework.context.annotation.Primary;
  *
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @author Yulin Qin
  * @since 1.4.0
  */
 @Configuration
@@ -102,14 +106,18 @@ public class CouchbaseAutoConfiguration {
 			if (timeouts.getConnect() != null) {
 				builder = builder.connectTimeout(timeouts.getConnect().toMillis());
 			}
-			builder = builder.kvEndpoints(endpoints.getKeyValue());
+			builder = builder.keyValueServiceConfig(KeyValueServiceConfig.create(endpoints.getKeyValue()));
 			if (timeouts.getKeyValue() != null) {
 				builder = builder.kvTimeout(timeouts.getKeyValue().toMillis());
 			}
-			builder = builder.queryEndpoints(endpoints.getQuery());
+			int minQuery = endpoints.getQuery() != 1 ? endpoints.getQuery() : endpoints.getMinQuery();
+			int maxQuery = endpoints.getQuery() != 1 ? endpoints.getQuery() : endpoints.getMaxQuery();
+			builder = builder.queryServiceConfig(QueryServiceConfig.create(minQuery, maxQuery));
 			if (timeouts.getQuery() != null) {
+				int minView = endpoints.getView() != 1 ? endpoints.getView() : endpoints.getMinView();
+				int maxView = endpoints.getView() != 1 ? endpoints.getView() : endpoints.getMaxView();
 				builder = builder.queryTimeout(timeouts.getQuery().toMillis())
-						.viewEndpoints(endpoints.getView());
+						.viewServiceConfig(ViewServiceConfig.create(minView, maxView));
 			}
 			if (timeouts.getSocketConnect() != null) {
 				builder = builder.socketConnectTimeout(

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseProperties.java
@@ -123,30 +123,19 @@ public class CouchbaseProperties {
 		private int query = 1;
 
 		/**
-		 * Minimum Number of sockets per node against the query (N1QL) service.
-		 */
-		private int minQuery = 1;
-
-		/**
-		 * Maximum Number of sockets per node against the query (N1QL) service.
-		 */
-		private int maxQuery = 1;
-
-		/**
 		 * Number of sockets per node against the view service.
 		 */
 		private int view = 1;
 
 		/**
-		 * Minimum Number of sockets per node against the view service.
+		 * Dynamic query service configuration.
 		 */
-		private int minView = 1;
+		private Queryservice queryservice = new Queryservice();
 
 		/**
-		 * Maximum Number of sockets per node against the view service.
+		 * Dynamic view service configuration.
 		 */
-		private int maxView = 1;
-
+		private Viewservice viewservice = new Viewservice();
 
 		public int getKeyValue() {
 			return this.keyValue;
@@ -164,22 +153,6 @@ public class CouchbaseProperties {
 			this.query = query;
 		}
 
-		public int getMinQuery() {
-			return this.minQuery;
-		}
-
-		public void setMinQuery(int minQuery) {
-			this.minQuery = minQuery;
-		}
-
-		public int getMaxQuery() {
-			return this.maxQuery;
-		}
-
-		public void setMaxQuery(int maxQuery) {
-			this.maxQuery = maxQuery;
-		}
-
 		public int getView() {
 			return this.view;
 		}
@@ -188,22 +161,77 @@ public class CouchbaseProperties {
 			this.view = view;
 		}
 
-		public int getMinView() {
-			return this.minView;
+		public Queryservice getQueryservice() {
+			return this.queryservice;
 		}
 
-		public void setMinView(int minView) {
-			this.minView = minView;
+		public void setQueryservice(Queryservice queryservice) {
+			this.queryservice = queryservice;
 		}
 
-		public int getMaxView() {
-			return this.maxView;
+		public Viewservice getViewservice() {
+			return this.viewservice;
 		}
 
-		public void setMaxView(int maxView) {
-			this.maxView = maxView;
+		public void setViewservice(Viewservice viewservice) {
+			this.viewservice = viewservice;
+		}
+
+		public static class Queryservice {
+			/**
+			 * Minimum Number of sockets per node against the query (N1QL) service.
+			 */
+			private int minEndpoints = 1;
+			/**
+			 * Maximum Number of sockets per node against the query (N1QL) service.
+			 */
+			private int maxEndpoints = 1;
+
+			public int getMinEndpoints() {
+				return this.minEndpoints;
+			}
+
+			public void setMinEndpoints(int minEndpoints) {
+				this.minEndpoints = minEndpoints;
+			}
+
+			public int getMaxEndpoints() {
+				return this.maxEndpoints;
+			}
+
+			public void setMaxEndpoints(int maxEndpoints) {
+				this.maxEndpoints = maxEndpoints;
+			}
+		}
+
+		public static class Viewservice {
+			/**
+			 * Minimum Number of sockets per node against the view service.
+			 */
+			private int minEndpoints = 1;
+			/**
+			 * Maximum Number of sockets per node against the view service.
+			 */
+			private int maxEndpoints = 1;
+
+			public int getMinEndpoints() {
+				return this.minEndpoints;
+			}
+
+			public void setMinEndpoints(int minEndpoints) {
+				this.minEndpoints = minEndpoints;
+			}
+
+			public int getMaxEndpoints() {
+				return this.maxEndpoints;
+			}
+
+			public void setMaxEndpoints(int maxEndpoints) {
+				this.maxEndpoints = maxEndpoints;
+			}
 		}
 	}
+
 
 	public static class Ssl {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseProperties.java
@@ -27,6 +27,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @author Yulin Qin
  * @since 1.4.0
  */
 @ConfigurationProperties(prefix = "spring.couchbase")
@@ -122,9 +123,30 @@ public class CouchbaseProperties {
 		private int query = 1;
 
 		/**
+		 * Minimum Number of sockets per node against the query (N1QL) service.
+		 */
+		private int minQuery = 1;
+
+		/**
+		 * Maximum Number of sockets per node against the query (N1QL) service.
+		 */
+		private int maxQuery = 1;
+
+		/**
 		 * Number of sockets per node against the view service.
 		 */
 		private int view = 1;
+
+		/**
+		 * Minimum Number of sockets per node against the view service.
+		 */
+		private int minView = 1;
+
+		/**
+		 * Maximum Number of sockets per node against the view service.
+		 */
+		private int maxView = 1;
+
 
 		public int getKeyValue() {
 			return this.keyValue;
@@ -142,6 +164,22 @@ public class CouchbaseProperties {
 			this.query = query;
 		}
 
+		public int getMinQuery() {
+			return this.minQuery;
+		}
+
+		public void setMinQuery(int minQuery) {
+			this.minQuery = minQuery;
+		}
+
+		public int getMaxQuery() {
+			return this.maxQuery;
+		}
+
+		public void setMaxQuery(int maxQuery) {
+			this.maxQuery = maxQuery;
+		}
+
 		public int getView() {
 			return this.view;
 		}
@@ -150,6 +188,21 @@ public class CouchbaseProperties {
 			this.view = view;
 		}
 
+		public int getMinView() {
+			return this.minView;
+		}
+
+		public void setMinView(int minView) {
+			this.minView = minView;
+		}
+
+		public int getMaxView() {
+			return this.maxView;
+		}
+
+		public void setMaxView(int maxView) {
+			this.maxView = maxView;
+		}
 	}
 
 	public static class Ssl {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseProperties.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.util.StringUtils;
 
 /**
@@ -145,18 +146,24 @@ public class CouchbaseProperties {
 			this.keyValue = keyValue;
 		}
 
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "spring.couchbase.env.endpoints.queryservice")
 		public int getQuery() {
 			return this.query;
 		}
 
+		@Deprecated
 		public void setQuery(int query) {
 			this.query = query;
 		}
 
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "spring.couchbase.env.endpoints.viewservice")
 		public int getView() {
 			return this.view;
 		}
 
+		@Deprecated
 		public void setView(int view) {
 			this.view = view;
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseAutoConfigurationTests.java
@@ -94,13 +94,29 @@ public class CouchbaseAutoConfigurationTests {
 			assertThat(env.viewServiceConfig().minEndpoints()).isEqualTo(6);
 			assertThat(env.viewServiceConfig().maxEndpoints()).isEqualTo(6);
 		}, "spring.couchbase.env.endpoints.keyValue=4",
-				"spring.couchbase.env.endpoints.min-query=2",
-				"spring.couchbase.env.endpoints.max-query=3",
+				"spring.couchbase.env.endpoints.queryservice.min-endpoints=2",
+				"spring.couchbase.env.endpoints.queryservice.max-endpoints=3",
 				"spring.couchbase.env.endpoints.query=5",
-				"spring.couchbase.env.endpoints.min-view=2",
-				"spring.couchbase.env.endpoints.max-view=3",
+				"spring.couchbase.env.endpoints.viewservice.min-endpoints=2",
+				"spring.couchbase.env.endpoints.viewservice.max-endpoints=3",
 				"spring.couchbase.env.endpoints.view=6");
 	}
+
+
+	@Test
+	public void customizeEnvEndpointsWhenQueryAndViewStillWork() {
+		testCouchbaseEnv((env) -> {
+					assertThat(env.kvServiceConfig().minEndpoints()).isEqualTo(3);
+					assertThat(env.kvServiceConfig().maxEndpoints()).isEqualTo(3);
+					assertThat(env.queryServiceConfig().minEndpoints()).isEqualTo(2);
+					assertThat(env.queryServiceConfig().maxEndpoints()).isEqualTo(2);
+					assertThat(env.viewServiceConfig().minEndpoints()).isEqualTo(3);
+					assertThat(env.viewServiceConfig().maxEndpoints()).isEqualTo(3);
+				}, "spring.couchbase.env.endpoints.keyValue=3",
+				"spring.couchbase.env.endpoints.query=2",
+				"spring.couchbase.env.endpoints.view=3");
+	}
+
 
 	@Test
 	public void customizeEnvEndpointsIfOnlyDynamicEndpointsAreSet() {
@@ -112,10 +128,10 @@ public class CouchbaseAutoConfigurationTests {
 					assertThat(env.viewServiceConfig().minEndpoints()).isEqualTo(2);
 					assertThat(env.viewServiceConfig().maxEndpoints()).isEqualTo(3);
 				}, "spring.couchbase.env.endpoints.keyValue=4",
-				"spring.couchbase.env.endpoints.min-query=2",
-				"spring.couchbase.env.endpoints.max-query=3",
-				"spring.couchbase.env.endpoints.min-view=2",
-				"spring.couchbase.env.endpoints.max-view=3");
+				"spring.couchbase.env.endpoints.queryservice.min-endpoints=2",
+				"spring.couchbase.env.endpoints.queryservice.max-endpoints=3",
+				"spring.couchbase.env.endpoints.viewservice.min-endpoints=2",
+				"spring.couchbase.env.endpoints.viewservice.max-endpoints=3");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseAutoConfigurationTests.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @author Yulin Qin
  */
 public class CouchbaseAutoConfigurationTests {
 
@@ -84,14 +85,37 @@ public class CouchbaseAutoConfigurationTests {
 	}
 
 	@Test
-	public void customizeEnvEndpoints() {
+	public void customizeEnvEndpointsIfBothStaticAndDynamicAreSetThenStaticEndpointsTakePriorityForBackwardsCompatibility() {
 		testCouchbaseEnv((env) -> {
-			assertThat(env.kvEndpoints()).isEqualTo(4);
-			assertThat(env.queryEndpoints()).isEqualTo(5);
-			assertThat(env.viewEndpoints()).isEqualTo(6);
+			assertThat(env.kvServiceConfig().minEndpoints()).isEqualTo(4);
+			assertThat(env.kvServiceConfig().maxEndpoints()).isEqualTo(4);
+			assertThat(env.queryServiceConfig().minEndpoints()).isEqualTo(5);
+			assertThat(env.queryServiceConfig().maxEndpoints()).isEqualTo(5);
+			assertThat(env.viewServiceConfig().minEndpoints()).isEqualTo(6);
+			assertThat(env.viewServiceConfig().maxEndpoints()).isEqualTo(6);
 		}, "spring.couchbase.env.endpoints.keyValue=4",
+				"spring.couchbase.env.endpoints.min-query=2",
+				"spring.couchbase.env.endpoints.max-query=3",
 				"spring.couchbase.env.endpoints.query=5",
+				"spring.couchbase.env.endpoints.min-view=2",
+				"spring.couchbase.env.endpoints.max-view=3",
 				"spring.couchbase.env.endpoints.view=6");
+	}
+
+	@Test
+	public void customizeEnvEndpointsIfOnlyDynamicEndpointsAreSet() {
+		testCouchbaseEnv((env) -> {
+					assertThat(env.kvServiceConfig().minEndpoints()).isEqualTo(4);
+					assertThat(env.kvServiceConfig().maxEndpoints()).isEqualTo(4);
+					assertThat(env.queryServiceConfig().minEndpoints()).isEqualTo(2);
+					assertThat(env.queryServiceConfig().maxEndpoints()).isEqualTo(3);
+					assertThat(env.viewServiceConfig().minEndpoints()).isEqualTo(2);
+					assertThat(env.viewServiceConfig().maxEndpoints()).isEqualTo(3);
+				}, "spring.couchbase.env.endpoints.keyValue=4",
+				"spring.couchbase.env.endpoints.min-query=2",
+				"spring.couchbase.env.endpoints.max-query=3",
+				"spring.couchbase.env.endpoints.min-view=2",
+				"spring.couchbase.env.endpoints.max-view=3");
 	}
 
 	@Test


### PR DESCRIPTION
Replaced Couchbase's deprecated methods with alternative ones, meanwhile, makes them backwards compatibility #12518

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->