### PR TITLE
Allow validation api in the classpath without an implementation

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
@@ -55,7 +55,7 @@ class ConfigurationPropertiesBinder {
 
 	private final Validator configurationPropertiesValidator;
 
-	private final Validator jsr303Validator;
+	private Validator jsr303Validator;
 
 	private volatile Binder binder;
 
@@ -66,8 +66,7 @@ class ConfigurationPropertiesBinder {
 				.getPropertySources();
 		this.configurationPropertiesValidator = getConfigurationPropertiesValidator(
 				applicationContext, validatorBeanName);
-		this.jsr303Validator = ConfigurationPropertiesJsr303Validator
-				.getIfJsr303Present(applicationContext);
+
 	}
 
 	public void bind(Bindable<?> target) {
@@ -93,9 +92,12 @@ class ConfigurationPropertiesBinder {
 		if (this.configurationPropertiesValidator != null) {
 			validators.add(this.configurationPropertiesValidator);
 		}
-		if (this.jsr303Validator != null
-				&& target.getAnnotation(Validated.class) != null) {
-			validators.add(this.jsr303Validator);
+
+		if (target.getAnnotation(Validated.class) != null) {
+			this.jsr303Validator = ConfigurationPropertiesJsr303Validator.getIfJsr303Present(this.applicationContext);
+			if (this.jsr303Validator != null) {
+				validators.add(this.jsr303Validator);
+			}
 		}
 		if (target.getValue() != null && target.getValue().get() instanceof Validator) {
 			validators.add((Validator) target.getValue().get());

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/ValidationExceptionFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/ValidationExceptionFailureAnalyzerTests.java
@@ -25,6 +25,7 @@ import org.springframework.boot.diagnostics.FailureAnalysis;
 import org.springframework.boot.testsupport.runner.classpath.ClassPathExclusions;
 import org.springframework.boot.testsupport.runner.classpath.ModifiedClassPathRunner;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.validation.annotation.Validated;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -39,7 +40,7 @@ import static org.junit.Assert.fail;
 public class ValidationExceptionFailureAnalyzerTests {
 
 	@Test
-	public void test() {
+	public void validatedPropertiesTest() {
 		try {
 			new AnnotationConfigApplicationContext(TestConfiguration.class).close();
 			fail("Expected failure did not occur");
@@ -51,6 +52,11 @@ public class ValidationExceptionFailureAnalyzerTests {
 		}
 	}
 
+	@Test
+	public void nonValidatedPropertiesTest() {
+			new AnnotationConfigApplicationContext(NonValidatedTestConfiguration.class).close();
+	}
+
 	@EnableConfigurationProperties(TestProperties.class)
 	static class TestConfiguration {
 
@@ -60,8 +66,22 @@ public class ValidationExceptionFailureAnalyzerTests {
 	}
 
 	@ConfigurationProperties("test")
+	@Validated
 	private static class TestProperties {
 
 	}
 
+
+	@EnableConfigurationProperties(NonValidatedTestProperties.class)
+	static class NonValidatedTestConfiguration {
+
+		NonValidatedTestConfiguration(NonValidatedTestProperties testProperties) {
+		}
+
+	}
+
+	@ConfigurationProperties("test")
+	private static class NonValidatedTestProperties {
+
+	}
 }


### PR DESCRIPTION
Allows using validation api annotations for documentation / contract purposes. The original exception is now thrown only when actually requesting validation with `@Validated`.

Fixes Issue #12229 
