### PR TITLE
Unicode parsing in OriginTrackedPropertiesLoader does not work with all code points

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/OriginTrackedPropertiesLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/OriginTrackedPropertiesLoader.java
@@ -224,13 +224,13 @@ class OriginTrackedPropertiesLoader {
 			this.character = 0;
 			for (int i = 0; i < 4; i++) {
 				int digit = this.reader.read();
-				if (digit > -'0' && digit <= '9') {
+				if (digit >= '0' && digit <= '9') {
 					this.character = (this.character << 4) + digit - '0';
 				}
-				else if (digit > -'a' && digit <= 'f') {
+				else if (digit >= 'a' && digit <= 'f') {
 					this.character = (this.character << 4) + digit - 'a' + 10;
 				}
-				else if (digit > -'A' && digit <= 'F') {
+				else if (digit >= 'A' && digit <= 'F') {
 					this.character = (this.character << 4) + digit - 'A' + 10;
 				}
 				else {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/OriginTrackedPropertiesLoaderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/OriginTrackedPropertiesLoaderTests.java
@@ -81,7 +81,7 @@ public class OriginTrackedPropertiesLoaderTests {
 	@Test
 	public void getUnicodeProperty() {
 		OriginTrackedValue value = this.properties.get("test-unicode");
-		assertThat(getValue(value)).isEqualTo("properties&test");
+		assertThat(getValue(value)).isEqualTo("properties&testäö☃");
 		assertThat(getLocation(value)).isEqualTo("12:14");
 	}
 

--- a/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/env/test-properties.properties
+++ b/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/env/test-properties.properties
@@ -9,7 +9,7 @@ bling = a=b
 
 #commented-property=test
 test=properties
-test-unicode=properties\u0026test
+test-unicode=properties\u0026test\u00e4\u00F6\u2603
   # comment ending \
 test\=property=helloworld
 test-colon-separator: my-property


### PR DESCRIPTION
Unicode escape parsing in `OriginTrackedPropertiesLoader.CharacterReader` was broken and produced garbled data. There was a test for functionality, but selected escape `\u0026` happened to work correctly. Fixed the parsing and added three new code points to test value.

Closes #12671