### PR TITLE
Fix example to avoid wrong copy&paste

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -1924,8 +1924,8 @@ PID file, as shown in the following example:
 [indent=0]
 ----
 	org.springframework.context.ApplicationListener=\
-	org.springframework.boot.system.ApplicationPidFileWriter,\
-	org.springframework.boot.system.EmbeddedServerPortFileWriter
+	org.springframework.boot.context.ApplicationPidFileWriter,\
+	org.springframework.boot.web.context.WebServerPortFileWriter
 ----
 
 


### PR DESCRIPTION
Chapter 57.1 Process Monitoring - Extending Configuration actually has a wrong example which can lead to wrong copy&paste error.