### PR TITLE
WebServiceTemplateBuilder 

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/webservices/client/WebServiceTemplateAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/webservices/client/WebServiceTemplateAutoConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.webservices.client;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.webservices.client.WebServiceTemplateBuilder;
+import org.springframework.boot.webservices.client.WebServiceTemplateCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.oxm.Marshaller;
+import org.springframework.oxm.Unmarshaller;
+import org.springframework.util.CollectionUtils;
+import org.springframework.ws.client.core.WebServiceTemplate;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for {@link WebServiceTemplate}.
+ *
+ * @author Dmytro Nosan
+ */
+@Configuration
+@ConditionalOnClass({ WebServiceTemplateBuilder.class, WebServiceTemplate.class,
+		Unmarshaller.class, Marshaller.class })
+public class WebServiceTemplateAutoConfiguration {
+
+	private final ObjectProvider<List<WebServiceTemplateCustomizer>> webServiceTemplateCustomizers;
+
+	public WebServiceTemplateAutoConfiguration(
+			ObjectProvider<List<WebServiceTemplateCustomizer>> webServiceTemplateCustomizers) {
+		this.webServiceTemplateCustomizers = webServiceTemplateCustomizers;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public WebServiceTemplateBuilder webServiceTemplateBuilder() {
+		WebServiceTemplateBuilder builder = new WebServiceTemplateBuilder();
+		List<WebServiceTemplateCustomizer> customizers = this.webServiceTemplateCustomizers
+				.getIfAvailable();
+		if (!CollectionUtils.isEmpty(customizers)) {
+			customizers = new ArrayList<>(customizers);
+			AnnotationAwareOrderComparator.sort(customizers);
+			builder = builder.customizers(customizers);
+		}
+		return builder;
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/webservices/client/package-info.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/webservices/client/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Spring Web Services Clients.
+ */
+package org.springframework.boot.autoconfigure.webservices.client;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -126,7 +126,8 @@ org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration,\
 org.springframework.boot.autoconfigure.websocket.reactive.WebSocketReactiveAutoConfiguration,\
 org.springframework.boot.autoconfigure.websocket.servlet.WebSocketServletAutoConfiguration,\
 org.springframework.boot.autoconfigure.websocket.servlet.WebSocketMessagingAutoConfiguration,\
-org.springframework.boot.autoconfigure.webservices.WebServicesAutoConfiguration
+org.springframework.boot.autoconfigure.webservices.WebServicesAutoConfiguration,\
+org.springframework.boot.autoconfigure.webservices.client.WebServiceTemplateAutoConfiguration
 
 # Failure analyzers
 org.springframework.boot.diagnostics.FailureAnalyzer=\

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/webservices/client/WebServiceTemplateAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/webservices/client/WebServiceTemplateAutoConfigurationTests.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.webservices.client;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.springframework.boot.webservices.client.WebServiceTemplateBuilder;
+import org.springframework.boot.webservices.client.WebServiceTemplateCustomizer;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.oxm.jaxb.Jaxb2Marshaller;
+import org.springframework.ws.client.core.WebServiceTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link WebServiceTemplateAutoConfiguration
+ * WebServiceTemplateAutoConfiguration}.
+ *
+ * @author Dmytro Nosan
+ */
+public class WebServiceTemplateAutoConfigurationTests {
+
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void close() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void webServiceTemplateShouldNotHaveMarshallerAndUnmarshaller() {
+		load(WebServiceTemplateConfig.class);
+		WebServiceTemplate webServiceTemplate = this.context
+				.getBean(WebServiceTemplate.class);
+		assertThat(webServiceTemplate.getUnmarshaller()).isNull();
+		assertThat(webServiceTemplate.getMarshaller()).isNull();
+	}
+
+	@Test
+	public void webServiceTemplateShouldUserCustomBuilder() {
+		load(CustomWebServiceTemplateBuilderConfig.class, WebServiceTemplateConfig.class);
+		WebServiceTemplate webServiceTemplate = this.context
+				.getBean(WebServiceTemplate.class);
+		assertThat(webServiceTemplate.getMarshaller()).isNotNull();
+	}
+
+	@Test
+	public void webServiceTemplateShouldApplyCustomizer() {
+		load(WebServiceTemplateCustomizerConfig.class, WebServiceTemplateConfig.class);
+		WebServiceTemplate webServiceTemplate = this.context
+				.getBean(WebServiceTemplate.class);
+		assertThat(webServiceTemplate.getUnmarshaller()).isNotNull();
+	}
+
+	@Test
+	public void builderShouldBeFreshForEachUse() {
+		load(DirtyWebServiceTemplateConfig.class);
+	}
+
+	private void load(Class<?>... config) {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.register(config);
+		ctx.register(WebServiceTemplateAutoConfiguration.class);
+		ctx.refresh();
+		this.context = ctx;
+	}
+
+	@Configuration
+	static class WebServiceTemplateConfig {
+
+		@Bean
+		public WebServiceTemplate webServiceTemplate(WebServiceTemplateBuilder builder) {
+			return builder.build();
+		}
+
+	}
+
+	@Configuration
+	static class DirtyWebServiceTemplateConfig {
+
+		@Bean
+		public WebServiceTemplate webServiceTemplateOne(
+				WebServiceTemplateBuilder builder) {
+			try {
+				return builder.build();
+			}
+			finally {
+				breakBuilderOnNextCall(builder);
+			}
+		}
+
+		@Bean
+		public WebServiceTemplate webServiceTemplateTwo(
+				WebServiceTemplateBuilder builder) {
+			try {
+				return builder.build();
+			}
+			finally {
+				breakBuilderOnNextCall(builder);
+			}
+		}
+
+		private void breakBuilderOnNextCall(WebServiceTemplateBuilder builder) {
+			builder.additionalCustomizers((webServiceTemplate) -> {
+				throw new IllegalStateException();
+			});
+		}
+
+	}
+
+	@Configuration
+	static class CustomWebServiceTemplateBuilderConfig {
+
+		@Bean
+		public WebServiceTemplateBuilder webServiceTemplateBuilder() {
+			return new WebServiceTemplateBuilder().setMarshaller(new Jaxb2Marshaller());
+		}
+
+	}
+
+	@Configuration
+	static class WebServiceTemplateCustomizerConfig {
+
+		@Bean
+		public WebServiceTemplateCustomizer webServiceTemplateCustomizer() {
+			return (ws) -> ws.setUnmarshaller(new Jaxb2Marshaller());
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -5634,7 +5634,6 @@ The following code shows a typical example:
 ----
 
 
-
 [[boot-features-webclient-customization]]
 === WebClient Customization
 There are three main approaches to `WebClient` customization, depending on how broadly you
@@ -5653,6 +5652,35 @@ the point of injection.
 Finally, you can fall back to the original API and use `WebClient.create()`. In that case,
 no auto-configuration or `WebClientCustomizer` is applied.
 
+[[boot-features-webservicetemplate]]
+== Calling Web Services with `WebServiceTemplate`
+If you need to call remote WEB services from your application, you can use the Spring
+Framework's {spring-webservices-reference}#client-web-service-template[`WebServiceTemplate`] class. Since
+`WebServiceTemplate` instances often need to be customized before being used, Spring Boot does
+not provide any single auto-configured `WebServiceTemplate` bean. It does, however,
+auto-configure a `WebServiceTemplateBuilder`, which can be used to create `WebServiceTemplate`
+instances when needed.
+
+The following code shows a typical example:
+
+[source,java,indent=0]
+----
+	@Service
+	public class MyService {
+
+		private final WebServiceTemplate webServiceTemplate;
+
+		public MyService(WebServiceTemplateBuilder webServiceTemplateBuilder) {
+			this.webServiceTemplate = webServiceTemplateBuilder.build();
+		}
+
+		public DetailsResp someCall(DetailsReq detailsReq) {
+			 return (DetailsResp) this.webServiceTemplate.marshalSendAndReceive(detailsReq, new SoapActionCallback(ACTION));
+
+		}
+
+	}
+----
 
 
 [[boot-features-validation]]

--- a/spring-boot-project/spring-boot/pom.xml
+++ b/spring-boot-project/spring-boot/pom.xml
@@ -247,6 +247,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
+			<artifactId>spring-oxm</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
 			<optional>true</optional>
 		</dependency>
@@ -268,6 +273,11 @@
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-web</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.ws</groupId>
+			<artifactId>spring-ws-core</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/webservices/client/WebServiceTemplateBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/webservices/client/WebServiceTemplateBuilder.java
@@ -1,0 +1,592 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.webservices.client;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import javax.xml.transform.TransformerFactory;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.oxm.Marshaller;
+import org.springframework.oxm.Unmarshaller;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.ws.WebServiceMessageFactory;
+import org.springframework.ws.client.core.FaultMessageResolver;
+import org.springframework.ws.client.core.WebServiceTemplate;
+import org.springframework.ws.client.support.destination.DestinationProvider;
+import org.springframework.ws.client.support.interceptor.ClientInterceptor;
+import org.springframework.ws.transport.WebServiceMessageSender;
+
+/**
+ * Builder that can be used to configure and create a {@link WebServiceTemplate}. Provides
+ * convenience methods to register {@link #messageSenders(WebServiceMessageSender...)
+ * message senders}, {@link #interceptors(ClientInterceptor...) client interceptors} and
+ * {@link #customizers(Collection) customizers}.
+ * <p>
+ * In a typical auto-configured Spring Boot application this builder is available as a
+ * bean and can be injected whenever a {@link WebServiceTemplate} is needed.
+ *
+ * @author Dmytro Nosan
+ * @author Stephane Nicoll
+ * @since 2.1.0
+ */
+public class WebServiceTemplateBuilder {
+
+	private final Set<ClientInterceptor> interceptors;
+
+	private final Set<WebServiceTemplateCustomizer> internalCustomizers;
+
+	private final Set<WebServiceTemplateCustomizer> customizers;
+
+	private final Set<WebServiceMessageSender> webServiceMessageSenders;
+
+	private final Marshaller marshaller;
+
+	private final Unmarshaller unmarshaller;
+
+	private final DestinationProvider destinationProvider;
+
+	private final Class<? extends TransformerFactory> transformerFactoryClass;
+
+	private final WebServiceMessageFactory messageFactory;
+
+	public WebServiceTemplateBuilder(WebServiceTemplateCustomizer... customizers) {
+		this(Collections.emptySet(), Collections.emptySet(),
+				append(Collections.<WebServiceTemplateCustomizer>emptySet(), customizers),
+				Collections.emptySet(), null, null, null, null, null);
+	}
+
+	private WebServiceTemplateBuilder(Set<ClientInterceptor> interceptors,
+			Set<WebServiceTemplateCustomizer> internalCustomizers,
+			Set<WebServiceTemplateCustomizer> customizers,
+			Set<WebServiceMessageSender> webServiceMessageSenders, Marshaller marshaller,
+			Unmarshaller unmarshaller, DestinationProvider destinationProvider,
+			Class<? extends TransformerFactory> transformerFactoryClass,
+			WebServiceMessageFactory messageFactory) {
+		this.interceptors = interceptors;
+		this.internalCustomizers = internalCustomizers;
+		this.customizers = customizers;
+		this.webServiceMessageSenders = webServiceMessageSenders;
+		this.marshaller = marshaller;
+		this.unmarshaller = unmarshaller;
+		this.destinationProvider = destinationProvider;
+		this.transformerFactoryClass = transformerFactoryClass;
+		this.messageFactory = messageFactory;
+	}
+
+	/**
+	 * Set the {@link ClientInterceptor ClientInterceptors} that should be used with the
+	 * {@link WebServiceTemplate}. Setting this value will replace any previously defined
+	 * interceptors.
+	 * @param interceptors the interceptors to set
+	 * @return a new builder instance
+	 * @see #additionalInterceptors(ClientInterceptor...)
+	 */
+	public WebServiceTemplateBuilder interceptors(ClientInterceptor... interceptors) {
+		Assert.notNull(interceptors, "Interceptors must not be null");
+		return interceptors(Arrays.asList(interceptors));
+	}
+
+	/**
+	 * Set the {@link ClientInterceptor ClientInterceptors} that should be used with the
+	 * {@link WebServiceTemplate}. Setting this value will replace any previously defined
+	 * interceptors.
+	 * @param interceptors the interceptors to set
+	 * @return a new builder instance
+	 * @see #additionalInterceptors(Collection)
+	 */
+	public WebServiceTemplateBuilder interceptors(
+			Collection<? extends ClientInterceptor> interceptors) {
+		Assert.notNull(interceptors, "Interceptors must not be null");
+		return new WebServiceTemplateBuilder(
+				append(Collections.<ClientInterceptor>emptySet(), interceptors),
+				this.internalCustomizers, this.customizers, this.webServiceMessageSenders,
+				this.marshaller, this.unmarshaller, this.destinationProvider,
+				this.transformerFactoryClass, this.messageFactory);
+	}
+
+	/**
+	 * Add additional {@link ClientInterceptor ClientInterceptors} that should be used
+	 * with the {@link WebServiceTemplate}.
+	 * @param interceptors the interceptors to add
+	 * @return a new builder instance
+	 * @see #interceptors(ClientInterceptor...)
+	 */
+	public WebServiceTemplateBuilder additionalInterceptors(
+			ClientInterceptor... interceptors) {
+		Assert.notNull(interceptors, "Interceptors must not be null");
+		return additionalInterceptors(Arrays.asList(interceptors));
+	}
+
+	/**
+	 * Add additional {@link ClientInterceptor ClientInterceptors} that should be used
+	 * with the {@link WebServiceTemplate}.
+	 * @param interceptors the interceptors to add
+	 * @return a new builder instance
+	 * @see #interceptors(Collection)
+	 */
+	public WebServiceTemplateBuilder additionalInterceptors(
+			Collection<? extends ClientInterceptor> interceptors) {
+		Assert.notNull(interceptors, "Interceptors must not be null");
+		return new WebServiceTemplateBuilder(append(this.interceptors, interceptors),
+				this.internalCustomizers, this.customizers, this.webServiceMessageSenders,
+				this.marshaller, this.unmarshaller, this.destinationProvider,
+				this.transformerFactoryClass, this.messageFactory);
+	}
+
+	/**
+	 * Set {@link WebServiceTemplateCustomizer WebServiceTemplateCustomizers} that should
+	 * be applied to the {@link WebServiceTemplate}. Customizers are applied in the order
+	 * that they were added after builder configuration has been applied. Setting this
+	 * value will replace any previously configured customizers.
+	 * @param customizers the customizers to set
+	 * @return a new builder instance
+	 * @see #additionalCustomizers(WebServiceTemplateCustomizer...)
+	 */
+	public WebServiceTemplateBuilder customizers(
+			WebServiceTemplateCustomizer... customizers) {
+		Assert.notNull(customizers, "Customizers must not be null");
+		return customizers(Arrays.asList(customizers));
+	}
+
+	/**
+	 * Set {@link WebServiceTemplateCustomizer WebServiceTemplateCustomizers} that should
+	 * be applied to the {@link WebServiceTemplate}. Customizers are applied in the order
+	 * that they were added after builder configuration has been applied. Setting this
+	 * value will replace any previously configured customizers.
+	 * @param customizers the customizers to set
+	 * @return a new builder instance
+	 * @see #additionalCustomizers(Collection)
+	 */
+	public WebServiceTemplateBuilder customizers(
+			Collection<? extends WebServiceTemplateCustomizer> customizers) {
+		Assert.notNull(customizers, "Customizers must not be null");
+		return new WebServiceTemplateBuilder(this.interceptors, this.internalCustomizers,
+				append(Collections.<WebServiceTemplateCustomizer>emptySet(), customizers),
+				this.webServiceMessageSenders, this.marshaller, this.unmarshaller,
+				this.destinationProvider, this.transformerFactoryClass,
+				this.messageFactory);
+	}
+
+	/**
+	 * Add additional {@link WebServiceTemplateCustomizer WebServiceTemplateCustomizers}
+	 * that should be applied to the {@link WebServiceTemplate}. Customizers are applied
+	 * in the order that they were added after builder configuration has been applied.
+	 * @param customizers the customizers to add
+	 * @return a new builder instance
+	 * @see #customizers(WebServiceTemplateCustomizer...)
+	 */
+	public WebServiceTemplateBuilder additionalCustomizers(
+			WebServiceTemplateCustomizer... customizers) {
+		Assert.notNull(customizers, "Customizers must not be null");
+		return additionalCustomizers(Arrays.asList(customizers));
+	}
+
+	/**
+	 * Add additional {@link WebServiceTemplateCustomizer WebServiceTemplateCustomizers}
+	 * that should be applied to the {@link WebServiceTemplate}. Customizers are applied
+	 * in the order that they were added after builder configuration has been applied.
+	 * @param customizers the customizers to add
+	 * @return a new builder instance
+	 * @see #customizers(Collection)
+	 */
+	public WebServiceTemplateBuilder additionalCustomizers(
+			Collection<? extends WebServiceTemplateCustomizer> customizers) {
+		Assert.notNull(customizers, "Customizers must not be null");
+		return new WebServiceTemplateBuilder(this.interceptors, this.internalCustomizers,
+				append(this.customizers, customizers), this.webServiceMessageSenders,
+				this.marshaller, this.unmarshaller, this.destinationProvider,
+				this.transformerFactoryClass, this.messageFactory);
+	}
+
+	/**
+	 * Sets the {@link WebServiceMessageSender WebServiceMessageSenders} that should be
+	 * used with the {@link WebServiceTemplate}. Setting this value will replace any
+	 * previously defined message senders.
+	 * @param messageSenders the message senders to set
+	 * @return a new builder instance.
+	 * @see #additionalMessageSenders(WebServiceMessageSender...)
+	 */
+	public WebServiceTemplateBuilder messageSenders(
+			WebServiceMessageSender... messageSenders) {
+		Assert.notNull(messageSenders, "MessageSenders must not be null");
+		return messageSenders(Arrays.asList(messageSenders));
+	}
+
+	/**
+	 * Sets the {@link WebServiceMessageSender WebServiceMessageSenders} that should be
+	 * used with the {@link WebServiceTemplate}. Setting this value will replace any
+	 * previously defined message senders.
+	 * @param messageSenders the message senders to set
+	 * @return a new builder instance.
+	 * @see #additionalMessageSenders(Collection)
+	 */
+	public WebServiceTemplateBuilder messageSenders(
+			Collection<? extends WebServiceMessageSender> messageSenders) {
+		Assert.notNull(messageSenders, "MessageSenders must not be null");
+		return new WebServiceTemplateBuilder(this.interceptors, this.internalCustomizers,
+				this.customizers,
+				append(Collections.<WebServiceMessageSender>emptySet(), messageSenders),
+				this.marshaller, this.unmarshaller, this.destinationProvider,
+				this.transformerFactoryClass, this.messageFactory);
+	}
+
+	/**
+	 * Add additional {@link WebServiceMessageSender WebServiceMessageSenders} that should
+	 * be used with the {@link WebServiceTemplate}.
+	 * @param messageSenders the message senders to add
+	 * @return a new builder instance.
+	 * @see #messageSenders(WebServiceMessageSender...)
+	 */
+	public WebServiceTemplateBuilder additionalMessageSenders(
+			WebServiceMessageSender... messageSenders) {
+		Assert.notNull(messageSenders, "MessageSenders must not be null");
+		return additionalMessageSenders(Arrays.asList(messageSenders));
+	}
+
+	/**
+	 * Add additional {@link WebServiceMessageSender WebServiceMessageSenders} that should
+	 * be used with the {@link WebServiceTemplate}.
+	 * @param messageSenders the message senders to add
+	 * @return a new builder instance.
+	 * @see #messageSenders(Collection)
+	 */
+	public WebServiceTemplateBuilder additionalMessageSenders(
+			Collection<? extends WebServiceMessageSender> messageSenders) {
+		Assert.notNull(messageSenders, "MessageSenders must not be null");
+		return new WebServiceTemplateBuilder(this.interceptors, this.internalCustomizers,
+				this.customizers, append(this.webServiceMessageSenders, messageSenders),
+				this.marshaller, this.unmarshaller, this.destinationProvider,
+				this.transformerFactoryClass, this.messageFactory);
+	}
+
+	/**
+	 * Set {@link WebServiceTemplate#setCheckConnectionForFault(boolean)
+	 * setCheckConnectionForFault} on the underlying.
+	 * @param checkConnectionForFault Specify whether checkConnectionForFault should be
+	 * enabled or not.
+	 * @return a new builder instance.
+	 */
+	public WebServiceTemplateBuilder setCheckConnectionForFault(
+			boolean checkConnectionForFault) {
+		return new WebServiceTemplateBuilder(this.interceptors,
+				append(this.internalCustomizers,
+						new CheckConnectionFaultCustomizer(checkConnectionForFault)),
+				this.customizers, this.webServiceMessageSenders, this.marshaller,
+				this.unmarshaller, this.destinationProvider, this.transformerFactoryClass,
+				this.messageFactory);
+	}
+
+	/**
+	 * Set {@link WebServiceTemplate#setCheckConnectionForError(boolean)
+	 * setCheckConnectionForError} on the underlying.
+	 * @param checkConnectionForError Specify whether checkConnectionForError should be
+	 * enabled or not.
+	 * @return a new builder instance.
+	 */
+	public WebServiceTemplateBuilder setCheckConnectionForError(
+			boolean checkConnectionForError) {
+		return new WebServiceTemplateBuilder(this.interceptors,
+				append(this.internalCustomizers,
+						new CheckConnectionForErrorCustomizer(checkConnectionForError)),
+				this.customizers, this.webServiceMessageSenders, this.marshaller,
+				this.unmarshaller, this.destinationProvider, this.transformerFactoryClass,
+				this.messageFactory);
+	}
+
+	/**
+	 * Sets the message factory used for creating messages.
+	 * @param messageFactory instance of WebServiceMessageFactory
+	 * @return a new builder instance.
+	 * @see WebServiceTemplate#setMessageFactory(WebServiceMessageFactory)
+	 **/
+	public WebServiceTemplateBuilder setWebServiceMessageFactory(
+			WebServiceMessageFactory messageFactory) {
+		Assert.notNull(messageFactory, "MessageFactory must not be null");
+		return new WebServiceTemplateBuilder(this.interceptors, this.internalCustomizers,
+				this.customizers, this.webServiceMessageSenders, this.marshaller,
+				this.unmarshaller, this.destinationProvider, this.transformerFactoryClass,
+				messageFactory);
+	}
+
+	/**
+	 * Set {@link WebServiceTemplate#setUnmarshaller(Unmarshaller) unmarshaller} on the
+	 * underlying.
+	 * @param unmarshaller message unmarshaller
+	 * @return a new builder instance.
+	 * @see WebServiceTemplate#setUnmarshaller(Unmarshaller)
+	 **/
+	public WebServiceTemplateBuilder setUnmarshaller(Unmarshaller unmarshaller) {
+		Assert.notNull(unmarshaller, "Unmarshaller must not be null");
+		return new WebServiceTemplateBuilder(this.interceptors, this.internalCustomizers,
+				this.customizers, this.webServiceMessageSenders, this.marshaller,
+				unmarshaller, this.destinationProvider, this.transformerFactoryClass,
+				this.messageFactory);
+	}
+
+	/**
+	 * Set {@link WebServiceTemplate#setMarshaller(Marshaller) marshaller} on the
+	 * underlying.
+	 * @param marshaller message marshaller
+	 * @return a new builder instance.
+	 * @see WebServiceTemplate#setMarshaller(Marshaller)
+	 **/
+	public WebServiceTemplateBuilder setMarshaller(Marshaller marshaller) {
+		Assert.notNull(marshaller, "Marshaller must not be null");
+		return new WebServiceTemplateBuilder(this.interceptors, this.internalCustomizers,
+				this.customizers, this.webServiceMessageSenders, marshaller,
+				this.unmarshaller, this.destinationProvider, this.transformerFactoryClass,
+				this.messageFactory);
+	}
+
+	/**
+	 * Set {@link WebServiceTemplate#setFaultMessageResolver(FaultMessageResolver)
+	 * faultMessageResolver} on the underlying.
+	 * @param faultMessageResolver faultMessageResolver may be set to null to disable
+	 * fault handling.
+	 * @return a new builder instance.
+	 **/
+	public WebServiceTemplateBuilder setFaultMessageResolver(
+			FaultMessageResolver faultMessageResolver) {
+		return new WebServiceTemplateBuilder(this.interceptors,
+				append(this.internalCustomizers,
+						new FaultMessageResolverCustomizer(faultMessageResolver)),
+				this.customizers, this.webServiceMessageSenders, this.marshaller,
+				this.unmarshaller, this.destinationProvider, this.transformerFactoryClass,
+				this.messageFactory);
+	}
+
+	/**
+	 * Set {@link WebServiceTemplate#setTransformerFactoryClass(Class)
+	 * setTransformerFactoryClass} on the underlying.
+	 * @param transformerFactoryClass boolean value
+	 * @return a new builder instance.
+	 **/
+
+	public WebServiceTemplateBuilder setTransformerFactoryClass(
+			Class<? extends TransformerFactory> transformerFactoryClass) {
+		Assert.notNull(transformerFactoryClass,
+				"TransformerFactoryClass must not be null");
+		return new WebServiceTemplateBuilder(this.interceptors, this.internalCustomizers,
+				this.customizers, this.webServiceMessageSenders, this.marshaller,
+				this.unmarshaller, this.destinationProvider, transformerFactoryClass,
+				this.messageFactory);
+	}
+
+	/**
+	 * Set the default URI to be used on operations that do not have a URI parameter.
+	 *
+	 * <b>Note!</b>Typically, either this property is set, or
+	 * {@link #setDestinationProvider(DestinationProvider)}, but not both.
+	 * @param defaultUri the destination provider URI to be used on operations that do not
+	 * have a URI parameter.
+	 * @return a new builder instance.
+	 */
+	public WebServiceTemplateBuilder setDefaultUri(String defaultUri) {
+		Assert.hasText(defaultUri, "URI must not be empty");
+		return setDestinationProvider(() -> URI.create(defaultUri));
+	}
+
+	/**
+	 * Set {@link WebServiceTemplate#setDestinationProvider(DestinationProvider)
+	 * destinationProvider} on the underlying.
+	 *
+	 * <b>Note!</b>Typically, either this property is set, or
+	 * {@link #setDefaultUri(String)}, but not both.
+	 * @param destinationProvider the destination provider URI to be used on operations
+	 * that do not have a URI parameter.
+	 * @return a new builder instance.
+	 */
+	public WebServiceTemplateBuilder setDestinationProvider(
+			DestinationProvider destinationProvider) {
+		Assert.notNull(destinationProvider, "DestinationProvider must not be null");
+		return new WebServiceTemplateBuilder(this.interceptors, this.internalCustomizers,
+				this.customizers, this.webServiceMessageSenders, this.marshaller,
+				this.unmarshaller, destinationProvider, this.transformerFactoryClass,
+				this.messageFactory);
+	}
+
+	/**
+	 * Build a new {@link WebServiceTemplate} instance and configure it using this
+	 * builder.
+	 * @return a configured {@link WebServiceTemplate} instance.
+	 * @see #build(Class)
+	 * @see #configure(WebServiceTemplate)
+	 */
+	public WebServiceTemplate build() {
+		return build(WebServiceTemplate.class);
+	}
+
+	/**
+	 * Build a new {@link WebServiceTemplate} instance of the specified type and configure
+	 * it using this builder.
+	 * @param <T> the type of web service template
+	 * @param webServiceTemplateClass the template type to create
+	 * @return a configured {@link WebServiceTemplate} instance.
+	 * @see WebServiceTemplateBuilder#build()
+	 * @see #configure(WebServiceTemplate)
+	 */
+
+	public <T extends WebServiceTemplate> T build(Class<T> webServiceTemplateClass) {
+		Assert.notNull(webServiceTemplateClass,
+				"WebServiceTemplateClass must not be null");
+		return configure(BeanUtils.instantiateClass(webServiceTemplateClass));
+	}
+
+	/**
+	 * Configure the provided {@link WebServiceTemplate} instance using this builder.
+	 * @param <T> the type of web service template
+	 * @param webServiceTemplate the {@link WebServiceTemplate} to configure
+	 * @return the web service template instance
+	 * @see #build()
+	 * @see #build(Class)
+	 */
+	public <T extends WebServiceTemplate> T configure(T webServiceTemplate) {
+		Assert.notNull(webServiceTemplate, "WebServiceTemplate must not be null");
+
+		if (!CollectionUtils.isEmpty(this.internalCustomizers)) {
+			for (WebServiceTemplateCustomizer internalCustomizer : this.internalCustomizers) {
+				internalCustomizer.customize(webServiceTemplate);
+			}
+		}
+
+		if (!CollectionUtils.isEmpty(this.webServiceMessageSenders)) {
+			webServiceTemplate.setMessageSenders(append(this.webServiceMessageSenders,
+					webServiceTemplate.getMessageSenders())
+							.toArray(new WebServiceMessageSender[0]));
+		}
+
+		if (this.marshaller != null) {
+			webServiceTemplate.setMarshaller(this.marshaller);
+		}
+
+		if (this.unmarshaller != null) {
+			webServiceTemplate.setUnmarshaller(this.unmarshaller);
+		}
+
+		if (this.destinationProvider != null) {
+			webServiceTemplate.setDestinationProvider(this.destinationProvider);
+		}
+
+		if (this.transformerFactoryClass != null) {
+			webServiceTemplate.setTransformerFactoryClass(this.transformerFactoryClass);
+		}
+
+		if (this.messageFactory != null) {
+			webServiceTemplate.setMessageFactory(this.messageFactory);
+		}
+
+		if (!CollectionUtils.isEmpty(this.interceptors)) {
+			webServiceTemplate.setInterceptors(
+					append(this.interceptors, webServiceTemplate.getInterceptors())
+							.toArray(new ClientInterceptor[0]));
+		}
+
+		if (!CollectionUtils.isEmpty(this.customizers)) {
+			for (WebServiceTemplateCustomizer customizer : this.customizers) {
+				customizer.customize(webServiceTemplate);
+			}
+		}
+
+		return webServiceTemplate;
+	}
+
+	private static <T> Set<T> append(Set<T> set, T[] additions) {
+		return append(set, additions != null
+				? new LinkedHashSet<>(Arrays.asList(additions)) : Collections.emptySet());
+	}
+
+	private static <T> Set<T> append(Set<T> set, T addition) {
+		Set<T> result = new LinkedHashSet<>(set != null ? set : Collections.emptySet());
+		result.add(addition);
+		return Collections.unmodifiableSet(result);
+	}
+
+	private static <T> Set<T> append(Set<T> set, Collection<? extends T> additions) {
+		Set<T> result = new LinkedHashSet<>(set != null ? set : Collections.emptySet());
+		result.addAll(additions != null ? additions : Collections.emptyList());
+		return Collections.unmodifiableSet(result);
+	}
+
+	/**
+	 * {@link WebServiceTemplateCustomizer} to set
+	 * {@link WebServiceTemplate#checkConnectionForFault checkConnectionForFault }.
+	 */
+	private static final class CheckConnectionFaultCustomizer
+			implements WebServiceTemplateCustomizer {
+
+		private final boolean checkConnectionFault;
+
+		private CheckConnectionFaultCustomizer(boolean checkConnectionFault) {
+			this.checkConnectionFault = checkConnectionFault;
+		}
+
+		@Override
+		public void customize(WebServiceTemplate webServiceTemplate) {
+			webServiceTemplate.setCheckConnectionForFault(this.checkConnectionFault);
+		}
+
+	}
+
+	/**
+	 * {@link WebServiceTemplateCustomizer} to set
+	 * {@link WebServiceTemplate#checkConnectionForError checkConnectionForError }.
+	 */
+	private static final class CheckConnectionForErrorCustomizer
+			implements WebServiceTemplateCustomizer {
+
+		private final boolean checkConnectionForError;
+
+		private CheckConnectionForErrorCustomizer(boolean checkConnectionForError) {
+			this.checkConnectionForError = checkConnectionForError;
+		}
+
+		@Override
+		public void customize(WebServiceTemplate webServiceTemplate) {
+			webServiceTemplate.setCheckConnectionForError(this.checkConnectionForError);
+		}
+
+	}
+
+	/**
+	 * {@link WebServiceTemplateCustomizer} to set
+	 * {@link WebServiceTemplate#faultMessageResolver faultMessageResolver }.
+	 */
+	private static final class FaultMessageResolverCustomizer
+			implements WebServiceTemplateCustomizer {
+
+		private final FaultMessageResolver faultMessageResolver;
+
+		private FaultMessageResolverCustomizer(
+				FaultMessageResolver faultMessageResolver) {
+			this.faultMessageResolver = faultMessageResolver;
+		}
+
+		@Override
+		public void customize(WebServiceTemplate webServiceTemplate) {
+			webServiceTemplate.setFaultMessageResolver(this.faultMessageResolver);
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/webservices/client/WebServiceTemplateCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/webservices/client/WebServiceTemplateCustomizer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.webservices.client;
+
+import org.springframework.ws.client.core.WebServiceTemplate;
+
+/**
+ * Callback interface that can be used to customize a {@link WebServiceTemplate}.
+ *
+ * @author Dmytro Nosan
+ */
+public interface WebServiceTemplateCustomizer {
+
+	/**
+	 * Callback to customize a {@link WebServiceTemplate} instance.
+	 * @param webServiceTemplate the template to customize
+	 */
+	void customize(WebServiceTemplate webServiceTemplate);
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/webservices/client/package-info.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/webservices/client/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Web Services client utilities.
+ */
+package org.springframework.boot.webservices.client;

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/webservices/client/WebServiceTemplateBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/webservices/client/WebServiceTemplateBuilderTests.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.webservices.client;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.sax.SAXTransformerFactory;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.springframework.oxm.jaxb.Jaxb2Marshaller;
+import org.springframework.ws.client.core.FaultMessageResolver;
+import org.springframework.ws.client.core.WebServiceTemplate;
+import org.springframework.ws.client.support.interceptor.ClientInterceptor;
+import org.springframework.ws.soap.client.core.SoapFaultMessageResolver;
+import org.springframework.ws.soap.saaj.SaajSoapMessageFactory;
+import org.springframework.ws.transport.WebServiceMessageSender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link WebServiceTemplateBuilder}.
+ *
+ * @author Dmytro Nosan
+ */
+public class WebServiceTemplateBuilderTests {
+
+	private WebServiceTemplateBuilder builder = new WebServiceTemplateBuilder();
+
+	@Test
+	public void addInterceptors() {
+		ClientInterceptor f1 = Mockito.mock(ClientInterceptor.class);
+		ClientInterceptor f2 = Mockito.mock(ClientInterceptor.class);
+
+		WebServiceTemplate webServiceTemplate = this.builder.additionalInterceptors(f1)
+				.additionalInterceptors(f2).build();
+
+		assertThat(webServiceTemplate.getInterceptors()).containsExactlyInAnyOrder(f1,
+				f2);
+	}
+
+	@Test
+	public void addInterceptorsCollection() {
+		ClientInterceptor f1 = Mockito.mock(ClientInterceptor.class);
+		ClientInterceptor f2 = Mockito.mock(ClientInterceptor.class);
+
+		WebServiceTemplate webServiceTemplate = this.builder
+				.additionalInterceptors(Collections.singletonList(f1))
+				.additionalInterceptors(Collections.singleton(f2)).build();
+
+		assertThat(webServiceTemplate.getInterceptors()).containsExactlyInAnyOrder(f1,
+				f2);
+
+	}
+
+	@Test
+	public void setInterceptors() {
+		ClientInterceptor f1 = Mockito.mock(ClientInterceptor.class);
+		ClientInterceptor f2 = Mockito.mock(ClientInterceptor.class);
+
+		WebServiceTemplate webServiceTemplate = this.builder.interceptors(f1)
+				.interceptors(f2).build();
+
+		assertThat(webServiceTemplate.getInterceptors()).doesNotContain(f1).contains(f2);
+	}
+
+	@Test
+	public void setInterceptorsCollection() {
+		ClientInterceptor f1 = Mockito.mock(ClientInterceptor.class);
+		ClientInterceptor f2 = Mockito.mock(ClientInterceptor.class);
+
+		WebServiceTemplate webServiceTemplate = this.builder
+				.interceptors(Collections.singletonList(f1))
+				.interceptors(Collections.singleton(f2)).build();
+
+		assertThat(webServiceTemplate.getInterceptors()).doesNotContain(f1).contains(f2);
+
+	}
+
+	@Test
+	public void addCustomizers() {
+		Jaxb2Marshaller jaxb2Marshaller = new Jaxb2Marshaller();
+		WebServiceTemplateCustomizer customizer = (ws) -> ws
+				.setMarshaller(jaxb2Marshaller);
+		WebServiceTemplateCustomizer customizer1 = (ws) -> ws
+				.setUnmarshaller(jaxb2Marshaller);
+
+		WebServiceTemplate webServiceTemplate = this.builder
+				.additionalCustomizers(customizer).additionalCustomizers(customizer1)
+				.build();
+
+		assertThat(webServiceTemplate.getMarshaller()).isEqualTo(jaxb2Marshaller);
+		assertThat(webServiceTemplate.getUnmarshaller()).isEqualTo(jaxb2Marshaller);
+
+	}
+
+	@Test
+	public void addCustomizersCollection() {
+		Jaxb2Marshaller jaxb2Marshaller = new Jaxb2Marshaller();
+		WebServiceTemplateCustomizer customizer = (ws) -> ws
+				.setMarshaller(jaxb2Marshaller);
+		WebServiceTemplateCustomizer customizer1 = (ws) -> ws
+				.setUnmarshaller(jaxb2Marshaller);
+
+		WebServiceTemplate webServiceTemplate = this.builder
+				.additionalCustomizers(Collections.singleton(customizer))
+				.additionalCustomizers(Collections.singletonList(customizer1)).build();
+
+		assertThat(webServiceTemplate.getMarshaller()).isEqualTo(jaxb2Marshaller);
+		assertThat(webServiceTemplate.getUnmarshaller()).isEqualTo(jaxb2Marshaller);
+	}
+
+	@Test
+	public void setCustomizers() {
+		Jaxb2Marshaller jaxb2Marshaller = new Jaxb2Marshaller();
+		WebServiceTemplateCustomizer customizer = (ws) -> ws
+				.setMarshaller(jaxb2Marshaller);
+		WebServiceTemplateCustomizer customizer1 = (ws) -> ws
+				.setUnmarshaller(jaxb2Marshaller);
+
+		WebServiceTemplate webServiceTemplate = this.builder.customizers(customizer)
+				.customizers(customizer1).build();
+
+		assertThat(webServiceTemplate.getMarshaller()).isNull();
+		assertThat(webServiceTemplate.getUnmarshaller()).isEqualTo(jaxb2Marshaller);
+
+	}
+
+	@Test
+	public void setCustomizersCollection() {
+		Jaxb2Marshaller jaxb2Marshaller = new Jaxb2Marshaller();
+		WebServiceTemplateCustomizer customizer = (ws) -> ws
+				.setMarshaller(jaxb2Marshaller);
+		WebServiceTemplateCustomizer customizer1 = (ws) -> ws
+				.setUnmarshaller(jaxb2Marshaller);
+
+		WebServiceTemplate webServiceTemplate = this.builder
+				.customizers(Collections.singleton(customizer))
+				.customizers(Collections.singletonList(customizer1)).build();
+
+		assertThat(webServiceTemplate.getMarshaller()).isNull();
+		assertThat(webServiceTemplate.getUnmarshaller()).isEqualTo(jaxb2Marshaller);
+	}
+
+	@Test
+	public void addWebServiceMessageSenders() {
+		WebServiceMessageSender sender = Mockito.mock(WebServiceMessageSender.class);
+		WebServiceMessageSender sender1 = Mockito.mock(WebServiceMessageSender.class);
+
+		WebServiceTemplate webServiceTemplate = this.builder
+				.additionalMessageSenders(sender).additionalMessageSenders(sender1)
+				.build();
+
+		assertThat(webServiceTemplate.getMessageSenders()).hasSize(3);
+		assertThat(webServiceTemplate.getMessageSenders()).contains(sender, sender1);
+	}
+
+	@Test
+	public void setWebServiceMessageSenders() {
+		WebServiceMessageSender sender = Mockito.mock(WebServiceMessageSender.class);
+		WebServiceMessageSender sender1 = Mockito.mock(WebServiceMessageSender.class);
+
+		WebServiceTemplate webServiceTemplate = this.builder.messageSenders(sender)
+				.messageSenders(sender1).build();
+
+		assertThat(webServiceTemplate.getMessageSenders()).hasSize(2);
+		assertThat(webServiceTemplate.getMessageSenders()).doesNotContain(sender)
+				.contains(sender1);
+
+	}
+
+	@Test
+	public void setCheckConnectionForFault() {
+		MockWebServiceTemplate webServiceTemplate = this.builder
+				.setCheckConnectionForFault(false).build(MockWebServiceTemplate.class);
+
+		assertThat(webServiceTemplate.isCheckConnectionForFault()).isFalse();
+	}
+
+	@Test
+	public void setCheckConnectionForError() {
+
+		MockWebServiceTemplate webServiceTemplate = this.builder
+				.setCheckConnectionForError(false).build(MockWebServiceTemplate.class);
+
+		assertThat(webServiceTemplate.isCheckConnectionForError()).isFalse();
+
+	}
+
+	@Test
+	public void setTransformerFactoryClass() {
+		MockWebServiceTemplate webServiceTemplate = this.builder
+				.setTransformerFactoryClass(SAXTransformerFactory.class)
+				.build(MockWebServiceTemplate.class);
+
+		assertThat(webServiceTemplate.getTransformerFactoryClass())
+				.isEqualTo(SAXTransformerFactory.class);
+
+	}
+
+	@Test
+	public void setWebServiceMessageFactory() {
+
+		SaajSoapMessageFactory messageFactory = new SaajSoapMessageFactory();
+
+		WebServiceTemplate webServiceTemplate = this.builder
+				.setWebServiceMessageFactory(messageFactory).build();
+
+		assertThat(webServiceTemplate.getMessageFactory()).isEqualTo(messageFactory);
+
+	}
+
+	@Test
+	public void setMarshaller() {
+		Jaxb2Marshaller jaxb2Marshaller = new Jaxb2Marshaller();
+
+		WebServiceTemplate webServiceTemplate = this.builder
+				.setMarshaller(jaxb2Marshaller).build();
+		assertThat(webServiceTemplate.getMarshaller()).isEqualTo(jaxb2Marshaller);
+	}
+
+	@Test
+	public void setUnmarshaller() {
+		Jaxb2Marshaller jaxb2Unmarshaller = new Jaxb2Marshaller();
+
+		WebServiceTemplate webServiceTemplate = this.builder
+				.setUnmarshaller(jaxb2Unmarshaller).build();
+
+		assertThat(webServiceTemplate.getUnmarshaller()).isEqualTo(jaxb2Unmarshaller);
+	}
+
+	@Test
+	public void setFaultMessageResolver() {
+
+		FaultMessageResolver faultMessageResolver = new SoapFaultMessageResolver();
+		WebServiceTemplate webServiceTemplate = this.builder
+				.setFaultMessageResolver(faultMessageResolver).build();
+
+		assertThat(webServiceTemplate.getFaultMessageResolver())
+				.isEqualTo(faultMessageResolver);
+	}
+
+	@Test
+	public void setDefaultUri() {
+		URI uri = URI.create("http://localhost:8080");
+
+		WebServiceTemplate webServiceTemplate = this.builder.setDefaultUri(uri.toString())
+				.build();
+
+		assertThat(webServiceTemplate.getDestinationProvider().getDestination())
+				.isEqualTo(uri);
+
+	}
+
+	@Test
+	public void setDestinationProvider() {
+		URI uri = URI.create("http://localhost:8080");
+
+		WebServiceTemplate webServiceTemplate = this.builder
+				.setDestinationProvider(() -> uri).build();
+
+		assertThat(webServiceTemplate.getDestinationProvider().getDestination())
+				.isEqualTo(uri);
+
+	}
+
+	@Test
+	public void addInterceptorsToExistingWebServiceTemplate() {
+		ClientInterceptor f1 = Mockito.mock(ClientInterceptor.class);
+		ClientInterceptor f2 = Mockito.mock(ClientInterceptor.class);
+
+		WebServiceTemplate webServiceTemplate = new WebServiceTemplate();
+		webServiceTemplate.setInterceptors(new ClientInterceptor[] { f1 });
+
+		this.builder.additionalInterceptors(f2).configure(webServiceTemplate);
+
+		assertThat(webServiceTemplate.getInterceptors()).containsExactlyInAnyOrder(f2,
+				f1);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setInterceptorsArrayNull() {
+		this.builder.interceptors((ClientInterceptor[]) null).build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setInterceptorsCollectionNull() {
+		this.builder.interceptors((Collection<? extends ClientInterceptor>) null).build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void addInterceptorsArrayNull() {
+		this.builder.additionalInterceptors((ClientInterceptor[]) null).build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void addInterceptorsCollectionNull() {
+		this.builder
+				.additionalInterceptors((Collection<? extends ClientInterceptor>) null)
+				.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setCustomizersArrayNull() {
+		this.builder.customizers((WebServiceTemplateCustomizer[]) null).build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setCustomizersCollectionNull() {
+		this.builder
+				.customizers((Collection<? extends WebServiceTemplateCustomizer>) null)
+				.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void addCustomizersArrayNull() {
+		this.builder
+				.additionalCustomizers(
+						(Collection<? extends WebServiceTemplateCustomizer>) null)
+				.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void addCustomizersCollectionNull() {
+		this.builder
+				.additionalCustomizers(
+						(Collection<? extends WebServiceTemplateCustomizer>) null)
+				.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setWebServiceMessageSendersNull() {
+		this.builder.messageSenders((Collection<? extends WebServiceMessageSender>) null)
+				.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void addWebServiceMessageSendersNull() {
+		this.builder.additionalMessageSenders(
+				(Collection<? extends WebServiceMessageSender>) null).build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setWebServiceMessageFactoryNull() {
+		this.builder.setWebServiceMessageFactory(null).build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setUnmarshallerNull() {
+		this.builder.setUnmarshaller(null).build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setMarshallerNull() {
+		this.builder.setMarshaller(null).build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setTransformerFactoryClassNull() {
+		this.builder.setTransformerFactoryClass(null).build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setDefaultUriNull() {
+		this.builder.setDefaultUri(null).build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setDestinationProviderNull() {
+		this.builder.setDestinationProvider(null).build();
+	}
+
+	private static class MockWebServiceTemplate extends WebServiceTemplate {
+
+		private boolean checkConnectionForError;
+
+		private boolean checkConnectionForFault;
+
+		private Class<? extends TransformerFactory> transformerFactoryClass;
+
+		boolean isCheckConnectionForError() {
+			return this.checkConnectionForError;
+		}
+
+		@Override
+		public void setCheckConnectionForError(boolean checkConnectionForError) {
+			this.checkConnectionForError = checkConnectionForError;
+		}
+
+		boolean isCheckConnectionForFault() {
+			return this.checkConnectionForFault;
+		}
+
+		@Override
+		public void setCheckConnectionForFault(boolean checkConnectionForFault) {
+			this.checkConnectionForFault = checkConnectionForFault;
+		}
+
+		Class<? extends TransformerFactory> getTransformerFactoryClass() {
+			return this.transformerFactoryClass;
+		}
+
+		@Override
+		public void setTransformerFactoryClass(
+				Class<? extends TransformerFactory> transformerFactoryClass) {
+			this.transformerFactoryClass = transformerFactoryClass;
+		}
+
+	}
+
+}


### PR DESCRIPTION
Added the **WebServiceTemplateBuilder** (similar to the RestTemplateBuilder) helper class for building **WebServiceTemplate**.        

```
        WebServiceTemplateBuilder webServiceTemplateBuilder = new WebServiceTemplateBuilder();
        WebServiceTemplate webServiceTemplate = webServiceTemplateBuilder
                .setConnectionTimeout(connectTimeout)
                .setReadTimeout(readTimeout)
                .addCustomizers(customizers())
                .addInterceptors(interceptors())
                .addWebServiceMessageSenders(webServiceMessageSenders())
                .setCheckConnectionForFault(true)
                .setCheckConnectionForError(true)
                .setMarshaller(marshaller)
                .setUnmarshaller(unmarshaller)
                .setDefaultUri(defaultUri)
                ...
                .build();
```
In a typical auto-configured Spring Boot application this builder will be available as bean and can be injected whenever a WebServiceTemplate is needed.





