### PR TITLE
Replace EnvironmentTestUtils documentation with TestPropertyValues

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -7157,14 +7157,14 @@ which auto-configures one for you.
 
 
 [[boot-features-environment-test-utilities]]
-==== EnvironmentTestUtils
-`EnvironmentTestUtils` lets you quickly add properties to a
+==== TestPropertyValues
+`TestPropertyValues` lets you quickly add properties to a
 `ConfigurableEnvironment` or `ConfigurableApplicationContext`. You can call it with
 `key=value` strings, as follows:
 
 [source,java,indent=0]
 ----
-	EnvironmentTestUtils.addEnvironment(env, "org=Spring", "name=Boot");
+	TestPropertyValues.of("org=Spring", "name=Boot").applyTo(env);
 ----
 
 


### PR DESCRIPTION
[Documentation ](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-testing.html#boot-features-environment-test-utilities) still refers to the now deprecated `EnvironmentTestUtils` class instead of `TestPropertyValues` for setting environment values in tests.

This commit replaces it with `TestPropertyValues` and provides an equivalent code example.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->