### PR TITLE
BUGFIX: UnsupportedOperationException when startup

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletComponentScanRegistrar.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletComponentScanRegistrar.java
@@ -84,8 +84,7 @@ class ServletComponentScanRegistrar implements ImportBeanDefinitionRegistrar {
 			packagesToScan.add(ClassUtils.getPackageName(basePackageClass));
 		}
 		if (packagesToScan.isEmpty()) {
-			return Collections
-					.singleton(ClassUtils.getPackageName(metadata.getClassName()));
+			packagesToScan.add(ClassUtils.getPackageName(metadata.getClassName()));
 		}
 		return packagesToScan;
 	}


### PR DESCRIPTION
# Description

When a project contains multiple `@ServletComponentScan` annotated class in classpath, and at least one annotation don't explicitly specify `basePackages` and `basePackageClass` attribute, the application MAY
fail on startup, caused by UnsupportedOperationException:

<pre>
java.lang.UnsupportedOperationException: null
	at java.util.AbstractCollection.add(AbstractCollection.java:262)
	at java.util.AbstractCollection.addAll(AbstractCollection.java:344)
	at org.springframework.boot.web.servlet.ServletComponentScanRegistrar.updatePostProcessor(ServletComponentScanRegistrar.java:62)
	at org.springframework.boot.web.servlet.ServletComponentScanRegistrar.registerBeanDefinitions(ServletComponentScanRegistrar.java:48)
	...
</pre>

# Reproduction

There is a single class application to reproduce this bug just for demostration.

<pre>
@SpringBootApplication
public class SpringBootTest1 {
    public static void main(String[] args) {
        SpringApplication.run(SpringBootTest1.class, args);
    }
    
    @ServletComponentScan
    public static class Config1 {
        
    }
    
    @ServletComponentScan
    public static class Config2 {
        
    }
}
</pre>

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->