### PR TITLE
Set maven-surefire-plugin to version 2.21.0 to fix NPE

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -202,7 +202,7 @@
 		<maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
 		<maven-site-plugin.version>3.6</maven-site-plugin.version>
 		<maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-		<maven-surefire-plugin.version>2.20.1</maven-surefire-plugin.version>
+		<maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
 		<maven-war-plugin.version>3.1.0</maven-war-plugin.version>
 		<versions-maven-plugin.version>2.3</versions-maven-plugin.version>
 		<xml-maven-plugin.version>1.0.1</xml-maven-plugin.version>


### PR DESCRIPTION
When using a project created by Spring Initializr, it fails when calling `mvn clean install` using Java 10 and Maven 3.5.3. To fix this issue just set the property `maven-surefire-plugin.version` to `2.21.0`. Hence I propose to add this version to the parent POM of Spring Boot project by default.

```
[INFO] --- maven-surefire-plugin:2.20.1:test (default-test) @ demo ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 6.950 s
[INFO] Finished at: 2018-04-02T21:34:03+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.20.1:test (default-test) on project demo: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.20.1:test failed.: NullPointerException -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
```

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->