### PR TITLE
Fix Document cache in ConfigFileApplicationListener

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
@@ -539,12 +539,12 @@ public class ConfigFileApplicationListener
 
 		private List<Document> loadDocuments(PropertySourceLoader loader, String name,
 				Resource resource) throws IOException {
-			loader.load(name, resource);
 			DocumentsCacheKey cacheKey = new DocumentsCacheKey(loader, resource);
 			List<Document> documents = this.loadDocumentsCache.get(cacheKey);
 			if (documents == null) {
 				List<PropertySource<?>> loaded = loader.load(name, resource);
 				documents = asDocuments(loaded);
+				this.loadDocumentsCache.put(cacheKey, documents);
 			}
 			return documents;
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/PropertySourceLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/PropertySourceLoader.java
@@ -41,7 +41,7 @@ public interface PropertySourceLoader {
 	/**
 	 * Load the resource into one or more property sources. Implementations may either
 	 * return a list containing a single source, or in the case of a multi-document format
-	 * such as yaml a source or each document in the resource.
+	 * such as yaml a source for each document in the resource.
 	 * @param name the root name of the property source. If multiple documents are loaded
 	 * an additional suffix should be added to the name for each source loaded.
 	 * @param resource the resource to load


### PR DESCRIPTION
Hi,

I just noticed that the `loadDocumentsCache` inside `ConfigFileApplicationListener` was never updated and as such never used as a cache. While being on it, I removed a - in my opinion superfluous - call to `PropertySourceLoader.load` and a typo in its doc.

Let me know what you think.
Cheers,
Christoph