### PR TITLE
Clarify unit of time for async request timeout values.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcProperties.java
@@ -207,7 +207,7 @@ public class WebMvcProperties {
 	public static class Async {
 
 		/**
-		 * Amount of time before asynchronous request handling times out. If this value is
+		 * Amount of time, in milliseconds, before asynchronous request handling times out. If this value is
 		 * not set, the default timeout of the underlying implementation is used, e.g. 10
 		 * seconds on Tomcat with Servlet 3.
 		 */


### PR DESCRIPTION
The current description might be misinterpreted, since the examples are in seconds.