### PR TITLE
Gradle plugin may check the unresolved dependencies of a configuration's copy, resulting in a StackOverflowError when combined with the nebula.resolution-rules plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ interpolated*.xml
 lib/
 manifest.yml
 overridedb.*
+out/
 settings.xml
 target
 transaction-logs

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/SpringBootPlugin.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/SpringBootPlugin.java
@@ -121,10 +121,14 @@ public class SpringBootPlugin implements Plugin<Project> {
 	private void unregisterUnresolvedDependenciesAnalyzer(Project project) {
 		UnresolvedDependenciesAnalyzer unresolvedDependenciesAnalyzer = new UnresolvedDependenciesAnalyzer();
 		project.getConfigurations().all((configuration) -> configuration.getIncoming()
-				.afterResolve((resolvableDependencies) -> unresolvedDependenciesAnalyzer
-						.analyze(configuration.getResolvedConfiguration()
-								.getLenientConfiguration()
-								.getUnresolvedModuleDependencies())));
+				.afterResolve((resolvableDependencies) -> {
+					if (configuration.getIncoming().equals(resolvableDependencies)) {
+						unresolvedDependenciesAnalyzer
+								.analyze(configuration.getResolvedConfiguration()
+										.getLenientConfiguration()
+										.getUnresolvedModuleDependencies());
+					}
+				}));
 		project.getGradle().buildFinished(
 				(buildResult) -> unresolvedDependenciesAnalyzer.buildFinished(project));
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/SpringBootPlugin.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/SpringBootPlugin.java
@@ -42,6 +42,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootWar;
  * @author Phillip Webb
  * @author Dave Syer
  * @author Andy Wilkinson
+ * @author Danny Hyun
  */
 public class SpringBootPlugin implements Plugin<Project> {
 


### PR DESCRIPTION
`Configuration#getResolvedConfiguration()` set to be deprecated in favor of using `DependencyResult` 

Future releases will have a direct method to find all unresolved deps in a more straightforward manner.
