### PR TITLE
Updated bean name for environmentEndpointWebExtension.

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/env/EnvironmentEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/env/EnvironmentEndpointAutoConfiguration.java
@@ -61,7 +61,7 @@ public class EnvironmentEndpointAutoConfiguration {
 	@ConditionalOnMissingBean
 	@ConditionalOnEnabledEndpoint
 	@ConditionalOnBean(EnvironmentEndpoint.class)
-	public EnvironmentEndpointWebExtension environmentWebEndpointExtension(
+	public EnvironmentEndpointWebExtension environmentEndpointWebExtension(
 			EnvironmentEndpoint environmentEndpoint) {
 		return new EnvironmentEndpointWebExtension(environmentEndpoint);
 	}


### PR DESCRIPTION
`environmentEndpointWebExtension` bean name was wrongly mentioned as environmentWebEndpointExtension in `EnvironmentEndpointAutoConfiguration`.