### PR TITLE
Custom error.jsp page is not used when app is run as anything other than a packaged war

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/JspTemplateAvailabilityProvider.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/JspTemplateAvailabilityProvider.java
@@ -38,7 +38,8 @@ public class JspTemplateAvailabilityProvider implements TemplateAvailabilityProv
 			ClassLoader classLoader, ResourceLoader resourceLoader) {
 		if (ClassUtils.isPresent("org.apache.jasper.compiler.JspConfig", classLoader)) {
 			String resourceName = getResourceName(view, environment);
-			return resourceLoader.getResource(resourceName).exists();
+			return resourceLoader.getResource(resourceName).exists() ||
+					resourceLoader.getResource("file:./src/main/webapp" + resourceName).exists();
 		}
 		return false;
 	}


### PR DESCRIPTION
https://github.com/spring-projects/spring-boot/issues/12805

Try to look for the webapps folder so that [WhitelabelErrorViewConfiguration ](https://github.com/spring-projects/spring-boot/blob/1.5.x/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ErrorMvcAutoConfiguration.java) will not create another error bean view and let InternalResourceViewResolver resolve the error page in embedded container.