### PR TITLE
Modify Status Response when Using Custom ErrorAttributes

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/BasicErrorController.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/BasicErrorController.java
@@ -86,9 +86,9 @@ public class BasicErrorController extends AbstractErrorController {
 	@RequestMapping(produces = "text/html")
 	public ModelAndView errorHtml(HttpServletRequest request,
 			HttpServletResponse response) {
-		HttpStatus status = getStatus(request);
 		Map<String, Object> model = Collections.unmodifiableMap(getErrorAttributes(
 				request, isIncludeStackTrace(request, MediaType.TEXT_HTML)));
+		HttpStatus status = getStatus(request);
 		response.setStatus(status.value());
 		ModelAndView modelAndView = resolveErrorView(request, response, status, model);
 		return (modelAndView == null ? new ModelAndView("error", model) : modelAndView);


### PR DESCRIPTION
I modified ErrorAttributes to change `javax.servlet.error.status_code`, but the response status value does not change.

https://github.com/spring-projects/spring-boot/blob/3cb2246e7a6f4094b9dda8ff767117e5f78f2dea/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/AbstractErrorController.java#L82-L94