### PR TITLE
Manage the Mockito/JUnit 5 dependency

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -122,7 +122,7 @@
 		<lombok.version>1.16.20</lombok.version>
 		<mariadb.version>2.2.3</mariadb.version>
 		<micrometer.version>1.0.3</micrometer.version>
-		<mockito.version>2.15.0</mockito.version>
+		<mockito.version>2.18.0</mockito.version>
 		<mongo-driver-reactivestreams.version>1.7.1</mongo-driver-reactivestreams.version>
 		<mongodb.version>3.6.3</mongodb.version>
 		<mssql-jdbc.version>6.2.2.jre8</mssql-jdbc.version>
@@ -2339,6 +2339,11 @@
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-inline</artifactId>
+				<version>${mockito.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-junit-jupiter</artifactId>
 				<version>${mockito.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
This requires an updated Mockito dependency as well, since it was introduced
in Mockito 2.17.0 but really works starting with 2.18.0.

Fixes #12789
