### PR TITLE
Only apply autoconfiguration that injects DataSource by type, if there is a single or primary DataSource

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
 import org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadataProvidersConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -49,6 +50,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
  */
 @Configuration
 @ConditionalOnClass({ DataSource.class, EmbeddedDatabaseType.class })
+@ConditionalOnSingleCandidate(DataSource.class)
 @EnableConfigurationProperties(DataSourceProperties.class)
 @Import({ DataSourcePoolMetadataProvidersConfiguration.class,
 		DataSourceInitializationConfiguration.class })

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
@@ -44,6 +44,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  */
 @Configuration
 @ConditionalOnClass({ JdbcTemplate.class, PlatformTransactionManager.class })
+@ConditionalOnSingleCandidate(DataSource.class)
 @AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
 @EnableConfigurationProperties(DataSourceProperties.class)
 public class DataSourceTransactionManagerAutoConfiguration {

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -1701,13 +1701,15 @@ class for more details.
 
 [[howto-two-datasources]]
 === Configure Two DataSources
-If you need to configure multiple data sources, you can apply the same tricks that are
-described in the previous section. You must, however, mark one of the `DataSource`
-instances as `@Primary`, because various auto-configurations down the road expect to be
-able to get one by type.
+`DataSourceAutoConfiguration` and `DataSourceTransactionManagerAutoConfiguration` and both expect
+to be able to locate a `DataSource` by type and will be unable to do so if you configure multiple
+data sources. In this case these pieces of auto-configuration will back off completely.
 
-If you create your own `DataSource`, the auto-configuration backs off. In the following
-example, we provide the _exact_ same feature set as the auto-configuration provides
+You may mark one of the `DataSource` instances as `@Primary` to allow this auto-configuration to
+apply for this instance only. You then need to apply the same configuration manually to your other
+data sources if desired.
+
+In the following example, we provide the _exact_ same feature set as the auto-configuration provides
 on the primary data source:
 
 [source,java,indent=0,subs="verbatim,quotes,attributes"]
@@ -1715,7 +1717,7 @@ on the primary data source:
 include::{code-examples}/jdbc/SimpleTwoDataSourcesExample.java[tag=configuration]
 ----
 
-TIP: `firstDataSourceProperties` has to be flagged as `@Primary` so that the database
+TIP: `firstDataSourceProperties` has been marked as `@Primary` so that the database
 initializer feature uses your copy (if you use the initializer).
 
 Both data sources are also bound for advanced customizations. For instance, you could


### PR DESCRIPTION
Currently, an error is thrown if I add multiple `DataSource`s to my context.

There are two workarounds for this issue:

1. Mark one of the `DataSource`s as `@Primary`
2. Exclude all autoconfiguration that wants to inject `DataSource` by type

It is easy to do 1. but this can be arbitrary decision unless the user knows exactly what auto-configuration is being applied. It can lead to subtle differences in behaviour which can trip you up, especially if you don't understand what you are doing by choosing this option.

It is hard to do 2. without a full knowledge of which auto-configurations. A piece of auto-configuration knows if it wants to inject by type and can foresee that injecting a `DataSource` by type is likely to trip people up. Therefore, they should make use of `ConditionalOnSingleCandidate` so they don't trip anybody up. Afterall, if somebody has already added multiple DataSources without into their application, then they probably know what they want to do with them.

This was proposed in #5541 but the commit that closed that ticket did not actually add this annotation to either `DataSourceAutoConfiguration` nor `DataSourceTransactionManagerAutoConfiguration` so this PR fixes that and also updates the documentation to reflect this behaviour.