### PR TITLE
Remove ManagementServerProperties.addApplicationContextHeader

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementServerProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementServerProperties.java
@@ -56,11 +56,6 @@ public class ManagementServerProperties implements SecurityPrerequisite {
 	private Ssl ssl;
 
 	/**
-	 * Add the "X-Application-Context" HTTP header in each response.
-	 */
-	private boolean addApplicationContextHeader = false;
-
-	/**
 	 * Returns the management port or {@code null} if the
 	 * {@link ServerProperties#getPort() server port} should be used.
 	 * @return the port
@@ -97,14 +92,6 @@ public class ManagementServerProperties implements SecurityPrerequisite {
 
 	public Servlet getServlet() {
 		return this.servlet;
-	}
-
-	public boolean getAddApplicationContextHeader() {
-		return this.addApplicationContextHeader;
-	}
-
-	public void setAddApplicationContextHeader(boolean addApplicationContextHeader) {
-		this.addApplicationContextHeader = addApplicationContextHeader;
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1230,6 +1230,12 @@
       }
     },
     {
+      "name": "management.server.add-application-context-header",
+      "type": "java.lang.Boolean",
+      "description": "Add the \"X-Application-Context\" HTTP header in each response.",
+      "defaultValue": false
+    },
+    {
       "name": "management.shell.auth.jaas.domain",
       "type": "java.lang.String",
       "description": "JAAS domain.",

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementServerPropertiesTests.java
@@ -33,7 +33,6 @@ public class ManagementServerPropertiesTests {
 		ManagementServerProperties properties = new ManagementServerProperties();
 		assertThat(properties.getPort()).isNull();
 		assertThat(properties.getServlet().getContextPath()).isEqualTo("");
-		assertThat(properties.getAddApplicationContextHeader()).isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR removes `ManagementServerProperties.addApplicationContextHeader` as it's only used for generating metadata for the property.