### PR TITLE
Add to ApplicationFailedEvent.Exception information to debug log.

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/ClasspathLoggingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/ClasspathLoggingApplicationListener.java
@@ -54,7 +54,8 @@ public final class ClasspathLoggingApplicationListener
 			}
 			else if (event instanceof ApplicationFailedEvent) {
 				logger.debug(
-						"Application failed to start with classpath: " + getClasspath());
+						"Application failed to start with classpath: " + getClasspath(),
+						((ApplicationFailedEvent) event).getException());
 			}
 		}
 	}


### PR DESCRIPTION
This commit provides exception information that can be used as diagnostics to a user when their application fails to start.
