### PR TITLE
Update version of gradle-git-properties in doc

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -2564,7 +2564,7 @@ plugin, as shown in the following example:
 [source,groovy,indent=0]
 ----
 	plugins {
-		id "com.gorylenko.gradle-git-properties" version "1.4.17"
+		id "com.gorylenko.gradle-git-properties" version "1.4.21"
 	}
 ----
 

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -2564,7 +2564,7 @@ plugin, as shown in the following example:
 [source,groovy,indent=0]
 ----
 	plugins {
-		id "com.gorylenko.gradle-git-properties" version "1.4.21"
+		id "com.gorylenko.gradle-git-properties" version "1.5.0"
 	}
 ----
 


### PR DESCRIPTION
upgrading to latest version solves the issue with newer gradle version.

This should be done only in 2.0.x+ branch as this plugin now needs[ java 8+](https://github.com/n0mer/gradle-git-properties)
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->