### PR TITLE
SpringBootExceptionHandler does not identify a log configuration message if its exception is wrapped in an InvocationTargetException

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringBootExceptionHandler.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringBootExceptionHandler.java
@@ -86,6 +86,10 @@ class SpringBootExceptionHandler implements UncaughtExceptionHandler {
 	 * @return {@code true} if the exception contains a log configuration message
 	 */
 	private boolean isLogConfigurationMessage(Throwable ex) {
+		if (ex instanceof InvocationTargetException) {
+			return isLogConfigurationMessage(ex.getCause());
+		}
+
 		String message = ex.getMessage();
 		if (message != null) {
 			for (String candidate : LOG_CONFIGURATION_MESSAGES) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringBootExceptionHandlerTest.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringBootExceptionHandlerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+/**
+ * Tests for {@link SpringBootExceptionHandler}.
+ *
+ * @author Henri Tremblay
+ */
+public class SpringBootExceptionHandlerTest {
+
+	@Rule
+	public MockitoRule rule = MockitoJUnit.rule();
+
+	@Mock
+	private Thread.UncaughtExceptionHandler parent;
+
+	@InjectMocks
+	private SpringBootExceptionHandler handler;
+
+	@Test
+	public void uncaughtException_shouldNotForwardLoggedErrorToParent() {
+		Thread thread = Thread.currentThread();
+		Exception ex = new Exception();
+		this.handler.registerLoggedException(ex);
+
+		this.handler.uncaughtException(thread, ex);
+
+		verifyZeroInteractions(this.parent);
+	}
+
+	@Test
+	public void uncaughtException_shouldForwardLogConfigurationErrorToParent() {
+		Thread thread = Thread.currentThread();
+		Exception ex = new Exception("[stuff] Logback configuration error detected [stuff]");
+		this.handler.registerLoggedException(ex);
+
+		this.handler.uncaughtException(thread, ex);
+
+		verify(this.parent).uncaughtException(same(thread), same(ex));
+	}
+
+	@Test
+	public void uncaughtException_shouldForwardLogConfigurationErrorToParentEvenWhenWrapped() {
+		Thread thread = Thread.currentThread();
+		Exception ex = new InvocationTargetException(new Exception("[stuff] Logback configuration error detected [stuff]", new Exception()));
+		this.handler.registerLoggedException(ex);
+
+		this.handler.uncaughtException(thread, ex);
+
+		verify(this.parent).uncaughtException(same(thread), same(ex));
+	}
+}


### PR DESCRIPTION
The exception thrown by logback can be wrapped in an `InvocationTargetException`. In this case, it isn't forwarded to the parent and thus defeats the purpose.

This patch is solving that in a style similar to what is done in `isRegistered`.