### PR TITLE
Optimize deducing main class in SpringApplication

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -285,7 +285,8 @@ public class SpringApplication {
 	private Class<?> deduceMainApplicationClass() {
 		try {
 			StackTraceElement[] stackTrace = new RuntimeException().getStackTrace();
-			for (StackTraceElement stackTraceElement : stackTrace) {
+			for (int i = stackTrace.length - 1; i >= 0; i--) {
+				StackTraceElement stackTraceElement = stackTrace[i];
 				if ("main".equals(stackTraceElement.getMethodName())) {
 					return Class.forName(stackTraceElement.getClassName());
 				}


### PR DESCRIPTION
Hi,

I found a small optimization opportunity in `SpringApplication.deduceMainApplicationClass()` that iterates over a stacktrace to find the `main` method. Those methods are usually at the bottom of the stack, so we can start iterating from there.

This should save a few cycles - especially in tests where the `main` method is usually originating from some sort of test runner that creates some more stack elements.

Cheers,
Christoph