### PR TITLE
Add a missing '=' condition to RandomAccessDataFile.read()

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/data/RandomAccessDataFile.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/data/RandomAccessDataFile.java
@@ -104,7 +104,7 @@ public class RandomAccessDataFile implements RandomAccessData {
 
 	private int read(byte[] bytes, long position, int offset, int length)
 			throws IOException {
-		if (position > this.length) {
+		if (position >= this.length) {
 			return -1;
 		}
 		return this.fileAccess.read(bytes, this.offset + position, offset, length);


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR adds an `=` condition to `RandomAccessDataFile.read()` as it looks missed.