### PR TITLE
Rename nested *AutoConfiguration classes to *Configuration

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointAutoConfiguration.java
@@ -138,7 +138,7 @@ public class WebEndpointAutoConfiguration {
 
 	@Configuration
 	@ConditionalOnWebApplication(type = Type.SERVLET)
-	static class WebEndpointServletAutoConfiguration {
+	static class WebEndpointServletConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(ServletEndpointsSupplier.class)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -132,7 +132,7 @@ public class IntegrationAutoConfiguration {
 	 */
 	@ConditionalOnMissingBean(GatewayProxyFactoryBean.class)
 	@Import(IntegrationAutoConfigurationScanRegistrar.class)
-	protected static class IntegrationComponentScanAutoConfiguration {
+	protected static class IntegrationComponentScanConfiguration {
 
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
@@ -24,7 +24,7 @@ import org.junit.rules.ExpectedException;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration.IntegrationComponentScanAutoConfiguration;
+import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration.IntegrationComponentScanConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration;
@@ -70,18 +70,18 @@ public class IntegrationAutoConfigurationTests {
 		this.contextRunner.run((context) -> {
 			assertThat(context).hasSingleBean(TestGateway.class);
 			assertThat(context)
-					.hasSingleBean(IntegrationComponentScanAutoConfiguration.class);
+					.hasSingleBean(IntegrationComponentScanConfiguration.class);
 		});
 	}
 
 	@Test
 	public void explicitIntegrationComponentScan() {
 		this.contextRunner
-				.withUserConfiguration(IntegrationComponentScanConfiguration.class)
+				.withUserConfiguration(CustomIntegrationComponentScanConfiguration.class)
 				.run((context) -> {
 					assertThat(context).hasSingleBean(TestGateway.class);
 					assertThat(context).doesNotHaveBean(
-							IntegrationComponentScanAutoConfiguration.class);
+							IntegrationComponentScanConfiguration.class);
 				});
 	}
 
@@ -223,7 +223,7 @@ public class IntegrationAutoConfigurationTests {
 
 	@Configuration
 	@IntegrationComponentScan
-	static class IntegrationComponentScanConfiguration {
+	static class CustomIntegrationComponentScanConfiguration {
 
 	}
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/RestDocsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/RestDocsAutoConfiguration.java
@@ -53,7 +53,7 @@ public class RestDocsAutoConfiguration {
 	@ConditionalOnClass(MockMvcRestDocumentation.class)
 	@ConditionalOnWebApplication(type = Type.SERVLET)
 	@EnableConfigurationProperties(RestDocsProperties.class)
-	static class RestDocsMockMvcAutoConfiguration {
+	static class RestDocsMockMvcConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
@@ -85,7 +85,7 @@ public class RestDocsAutoConfiguration {
 	@ConditionalOnClass({ RequestSpecification.class,
 			RestAssuredRestDocumentation.class })
 	@EnableConfigurationProperties(RestDocsProperties.class)
-	static class RestDocsRestAssuredAutoConfiguration {
+	static class RestDocsRestAssuredConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
@@ -114,7 +114,7 @@ public class RestDocsAutoConfiguration {
 	@ConditionalOnClass(WebTestClientRestDocumentation.class)
 	@ConditionalOnWebApplication(type = Type.REACTIVE)
 	@EnableConfigurationProperties(RestDocsProperties.class)
-	static class RestDocsWebTestClientAutoConfiguration {
+	static class RestDocsWebTestClientConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR renames nested `*AutoConfiguration` classes to `*Configuration` to align with the others.