### PR TITLE
Upgrade to Kotlin 1.2.41

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -114,7 +114,7 @@
 		<junit-jupiter.version>5.1.0</junit-jupiter.version>
 		<junit-platform.version>1.1.0</junit-platform.version>
 		<kafka.version>1.0.1</kafka.version>
-		<kotlin.version>1.2.31</kotlin.version>
+		<kotlin.version>1.2.41</kotlin.version>
 		<lettuce.version>5.0.3.RELEASE</lettuce.version>
 		<liquibase.version>3.5.5</liquibase.version>
 		<log4j2.version>2.10.0</log4j2.version>


### PR DESCRIPTION
Includes [KT-23973](https://youtrack.jetbrains.com/issue/KT-23973) critical regression fix.