### PR TITLE
Only display config delta on DEBUG log level when using DevTools

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/ConditionEvaluationDeltaLoggingListener.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/ConditionEvaluationDeltaLoggingListener.java
@@ -50,7 +50,8 @@ class ConditionEvaluationDeltaLoggingListener
 					this.logger.debug("Condition evaluation delta:"
 							+ new ConditionEvaluationReportMessage(delta,
 									"CONDITION EVALUATION DELTA"));
-				} else if (this.logger.isInfoEnabled()) {
+				}
+				else if (this.logger.isInfoEnabled()) {
 					this.logger.info("Condition evaluation changed. "
 							+ "To see the delta re-run your application with "
 							+ "'debug' enabled.");


### PR DESCRIPTION
To make DevTools behaviour consistent with [documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/howto-spring-boot-application.html#howto-troubleshoot-auto-configuration) and `ConditionEvaluationReportLoggingListener` class, only print configuration delta on debug level. Otherwise just report about the difference without acutally listing auto-configurations changed. 

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->