### PR TITLE
fix the random port bug.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
@@ -42,6 +42,7 @@ import org.springframework.core.env.Environment;
  *
  * @author Brian Clozel
  * @author Phillip Webb
+ * @author Yan Na
  * @since 2.0.0
  */
 public class JettyWebServerFactoryCustomizer implements
@@ -85,6 +86,8 @@ public class JettyWebServerFactoryCustomizer implements
 		propertyMapper.from(jettyProperties::getAccesslog)
 				.when(ServerProperties.Jetty.Accesslog::isEnabled)
 				.to((accesslog) -> customizeAccessLog(factory, accesslog));
+		WebServerFactoryUtils.coverEnvironmentServerPort(this.environment,
+				this.serverProperties);
 	}
 
 	private boolean isPositive(Integer value) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
@@ -46,6 +46,7 @@ import org.springframework.util.StringUtils;
  * @author Yulin Qin
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Yan Na
  * @since 2.0.0
  */
 public class TomcatWebServerFactoryCustomizer implements
@@ -103,6 +104,8 @@ public class TomcatWebServerFactoryCustomizer implements
 				.to((acceptCount) -> customizeAcceptCount(factory, acceptCount));
 		customizeStaticResources(factory);
 		customizeErrorReportValve(properties.getError(), factory);
+		WebServerFactoryUtils.coverEnvironmentServerPort(this.environment,
+				this.serverProperties);
 	}
 
 	private boolean isPositive(int value) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/UndertowWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/UndertowWebServerFactoryCustomizer.java
@@ -36,6 +36,7 @@ import org.springframework.core.env.Environment;
  * @author Yulin Qin
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Yan Na
  * @since 2.0.0
  */
 public class UndertowWebServerFactoryCustomizer implements
@@ -94,6 +95,8 @@ public class UndertowWebServerFactoryCustomizer implements
 						connectionTimeout));
 		factory.addDeploymentInfoCustomizers((deploymentInfo) -> deploymentInfo
 				.setEagerFilterInit(undertowProperties.isEagerFilterInit()));
+		WebServerFactoryUtils.coverEnvironmentServerPort(this.environment,
+				this.serverProperties);
 	}
 
 	private boolean isPositive(Number value) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/WebServerFactoryUtils.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/WebServerFactoryUtils.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.web.embedded;
+
+import java.util.LinkedHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * Utils for WebServerFactory.
+ *
+ * @author Yan Na
+ * @since 2.1.0
+ */
+public final class WebServerFactoryUtils {
+	private static final Logger logger = LoggerFactory
+			.getLogger(WebServerFactoryUtils.class);
+
+	private WebServerFactoryUtils() {
+
+	}
+
+	public static void coverEnvironmentServerPort(Environment environment,
+			ServerProperties serverProperties) {
+		if (environment == null) {
+			logger.error("environment is null! exit coverEnvironmentServerPort()");
+			return;
+		}
+		if (serverProperties == null) {
+			logger.error("serverProperties is null! exit coverEnvironmentServerPort()");
+			return;
+
+		}
+		boolean isSucceed = false;
+		MutablePropertySources propertySourcesList = ((ConfigurableEnvironment) environment)
+				.getPropertySources();
+		if (propertySourcesList != null) {
+			for (PropertySource<?> propertySource : propertySourcesList) {
+				if (propertySource != null
+						&& propertySource.containsProperty("server.port")) {
+					Object source = propertySource.getSource();
+					LinkedHashMap<String, String> sourceMap = null;
+					if (source instanceof LinkedHashMap) {
+						sourceMap = (LinkedHashMap<String, String>) source;
+					}
+					if (sourceMap != null && sourceMap.size() > 0) {
+						Integer port = serverProperties.getPort();
+						if (port != null && port > 0) {
+							sourceMap.put("server.port", String.valueOf(port));
+							isSucceed = true;
+						}
+					}
+				}
+			}
+		}
+		else {
+			logger.error(
+					"propertySourcesList is null! exit coverEnvironmentServerPort()");
+			return;
+		}
+		if (isSucceed) {
+			logger.info("Environment Port is " + serverProperties.getPort());
+		}
+		else {
+			logger.error("server.port cover failed");
+		}
+	}
+}


### PR DESCRIPTION
## random port bug about spring-boot and spring-cloud-eureka
it work fine in spring-boot.
but it take a mistake in spring-cloud-eureka.

application.yml
```
server:
  port: ${random.int[11001,12000]}
```

we know it is a random port for web server.

server.port still be random after the config covert to class
and it run random every time when we use it.

## Explain
it runs three times in spring-cloud application.


#### *First. it runs with initialized web server in spring-boot.
it is started port.

log:`11917`
```
Tomcat initialized with port(s): 11917 (http)
```

#### *Second. it runs for get serverPort in spring-cloud-eureka-client
it is eureka registration center URL port.

EurekaClientAutoConfiguration.eurekaInstanceConfigBean():`11158`
```
int serverPort = Integer.valueOf(env.getProperty("server.port", env.getProperty("port", "8080")));
```

#### *Third. it runs for instanceId in spring-cloud-commons
it is eureka client instanceId.

IdUtils.getDefaultInstanceId():`11168`
```
String indexPart = resolver.getProperty("spring.application.instance_id",	resolver.getProperty("server.port"));
```

## Run Result
result log：
```
DiscoveryClient_BULLET/192.168.0.5:bullet:11168 - registration status: 204

Tomcat started on port(s): 11917 (http) with context path ''
```


eureka client instanceId:
```
UP (1) - 192.168.0.5:bullet:11168
```

eureka registration center URL port:
```
<a href="http://192.168.0.5:11584/actuator/info" target="_blank">192.168.0.5:bullet:11168</a>
```

## Influence

* we can't visited /info in eureka registration center.
* every application can't fetch real registry list.

## Solution
i rewrite the code in three project.

* spring-boot-autoconfigure
* spring-cloud-commons
* spring-cloud-netflix-eureka-client

i had pull request them.


* nayan3480232@163.com
* nayan3480232@outlook.com

# Thank you for reading all of this!
