### PR TITLE
Cannot initialize Quartz with scripts containing custom prefix comment

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceInitializer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceInitializer.java
@@ -194,6 +194,7 @@ class DataSourceInitializer {
 		ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
 		populator.setContinueOnError(this.properties.isContinueOnError());
 		populator.setSeparator(this.properties.getSeparator());
+		populator.setCommentPrefix(this.properties.getCommentPrefix());
 		if (this.properties.getSqlScriptEncoding() != null) {
 			populator.setSqlScriptEncoding(this.properties.getSqlScriptEncoding().name());
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 
 import javax.sql.DataSource;
 
+import org.springframework.jdbc.datasource.init.ScriptUtils;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.InitializingBean;
@@ -143,6 +144,11 @@ public class DataSourceProperties implements BeanClassLoaderAware, InitializingB
 	 * Statement separator in SQL initialization scripts.
 	 */
 	private String separator = ";";
+	
+	/**
+	 * Prefix that identifies single-line comments within the SQL scripts.
+	 */
+	private String commentPrefix = ScriptUtils.DEFAULT_COMMENT_PREFIX;
 
 	/**
 	 * SQL scripts encoding.
@@ -456,6 +462,14 @@ public class DataSourceProperties implements BeanClassLoaderAware, InitializingB
 
 	public void setSeparator(String separator) {
 		this.separator = separator;
+	}
+	
+	public String getCommentPrefix() {
+		return this.commentPrefix;
+	}
+	
+	public void setCommentPrefix(String commentPrefix) {
+		this.commentPrefix = commentPrefix;
 	}
 
 	public Charset getSqlScriptEncoding() {


### PR DESCRIPTION
Quartz comment prefix include "#"

org/quartz/impl/jdbcjobstore/tables_mysql_innodb.sql

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->