### PR TITLE
Fix deprecation warning in OriginTrackedYamlLoader

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/OriginTrackedYamlLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/OriginTrackedYamlLoader.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.BaseConstructor;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -64,7 +65,9 @@ class OriginTrackedYamlLoader extends YamlProcessor {
 		Representer representer = new Representer();
 		DumperOptions dumperOptions = new DumperOptions();
 		LimitedResolver resolver = new LimitedResolver();
-		return new Yaml(constructor, representer, dumperOptions, resolver);
+		LoaderOptions loaderOptions = new LoaderOptions();
+		loaderOptions.setAllowDuplicateKeys(false);
+		return new Yaml(constructor, representer, dumperOptions, loaderOptions, resolver);
 	}
 
 	public List<Map<String, Object>> load() {
@@ -76,7 +79,7 @@ class OriginTrackedYamlLoader extends YamlProcessor {
 	/**
 	 * {@link Constructor} that tracks property origins.
 	 */
-	private class OriginTrackingConstructor extends StrictMapAppenderConstructor {
+	private class OriginTrackingConstructor extends Constructor {
 
 		@Override
 		protected Object constructObject(Node node) {


### PR DESCRIPTION
Hi,

since commit https://github.com/spring-projects/spring-framework/commit/138b0d0bbdf65b0da181a06e5fc79cda05fb1e71 StrictMapAppenderConstructor is deprecated.

Let me know what you think.

Cheers,
Christoph