### PR TITLE
Use empty key-store/trust-store-password if SSL store provider present

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
@@ -405,6 +405,8 @@ public class TomcatEmbeddedServletContainerFactory
 					.getInstance();
 			instance.addUserFactory(
 					new SslStoreProviderUrlStreamHandlerFactory(getSslStoreProvider()));
+			protocol.setKeystorePass("");
+			protocol.setTruststorePass("");
 			protocol.setKeystoreFile(
 					SslStoreProviderUrlStreamHandlerFactory.KEY_STORE_URL);
 			protocol.setTruststoreFile(

--- a/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactoryTests.java
@@ -629,9 +629,11 @@ public abstract class AbstractEmbeddedServletContainerFactoryTests {
 	public void sslWithCustomSslStoreProvider() throws Exception {
 		AbstractEmbeddedServletContainerFactory factory = getFactory();
 		addTestTxtFile(factory);
-		Ssl ssl = new Ssl();
-		ssl.setClientAuth(ClientAuth.NEED);
+		Ssl ssl = getSsl(Ssl.ClientAuth.NEED, "password", "src/test/resources/test.jks", "src/test/resources/test.jks",
+				null, null);
 		ssl.setKeyPassword("password");
+		ssl.setKeyStorePassword("password");
+		ssl.setTrustStorePassword("password");
 		factory.setSsl(ssl);
 		SslStoreProvider sslStoreProvider = mock(SslStoreProvider.class);
 		given(sslStoreProvider.getKeyStore()).willReturn(loadStore());


### PR DESCRIPTION
For Tomcat, if an SslStoreProvider is configured,
`SslStoreProviderUrlStreamHandlerFactory` stores the
key-store/trust-store with an empty password. Previously, if a password
was supplied using the ssl.key-store/trust-store-password property, that
would be the password used to load the key-store/trust-store and the
connector would fail with "Password verification failed" exception for
key-store and a warning trust-store.

Fixes gh-12688

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->