### PR TITLE
Use empty trust-store password if SSL store provider present

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/SslConnectorCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/SslConnectorCustomizer.java
@@ -118,6 +118,7 @@ class SslConnectorCustomizer implements TomcatConnectorCustomizer {
 						SslStoreProviderUrlStreamHandlerFactory.KEY_STORE_URL);
 			}
 			if (sslStoreProvider.getTrustStore() != null) {
+				protocol.setTruststorePass("");
 				protocol.setTruststoreFile(
 						SslStoreProviderUrlStreamHandlerFactory.TRUST_STORE_URL);
 			}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/SslConnectorCustomizerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/SslConnectorCustomizerTests.java
@@ -170,6 +170,7 @@ public class SslConnectorCustomizerTests {
 		Ssl ssl = new Ssl();
 		ssl.setKeyPassword("password");
 		ssl.setKeyStorePassword("secret");
+		ssl.setTrustStorePassword("trustStoreSecret");
 		SslStoreProvider sslStoreProvider = mock(SslStoreProvider.class);
 		given(sslStoreProvider.getTrustStore()).willReturn(loadStore());
 		given(sslStoreProvider.getKeyStore()).willReturn(loadStore());


### PR DESCRIPTION
For Tomcat, if an SslStoreProvider is configured,
`SslStoreProviderUrlStreamHandlerFactory` stores the trust-store with an
empty password. Previously, if a password was supplied using the
ssl.trust-store-password property, that would be the password used to
load the trust-store and the connector would warn with "Password
verification failed" message.

Fixes gh-12688

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->