### PR TITLE
Jersey auto-configuration does not find @ApplicationPath on a ResourceConfig created from an Application

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfiguration.java
@@ -117,7 +117,7 @@ public class JerseyAutoConfiguration implements ServletContextAware {
 		}
 		else {
 			this.path = findApplicationPath(AnnotationUtils
-					.findAnnotation(this.config.getClass(), ApplicationPath.class));
+					.findAnnotation(this.config.getApplication().getClass(), ApplicationPath.class));
 		}
 	}
 


### PR DESCRIPTION
Fixes #13116

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->