### PR TITLE
ServletEndpoints do not consider server.servlet.path 

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/ServletEndpointManagementContextConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/ServletEndpointManagementContextConfiguration.java
@@ -61,8 +61,9 @@ public class ServletEndpointManagementContextConfiguration {
 				WebEndpointProperties properties,
 				ServletEndpointsSupplier servletEndpointsSupplier) {
 			String servletPath = environment.getProperty("server.servlet.path");
-			if (servletPath.endsWith("/") && properties.getBasePath().startsWith("/"))
+			if (servletPath.endsWith("/") && properties.getBasePath().startsWith("/")) {
 				servletPath = servletPath.substring(0, servletPath.length() - 1);
+			}
 			return new ServletEndpointRegistrar(servletPath != null ? servletPath + properties.getBasePath() : properties.getBasePath(),
 					servletEndpointsSupplier.getEndpoints());
 		}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/ServletEndpointManagementContextConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/ServletEndpointManagementContextConfiguration.java
@@ -68,10 +68,13 @@ public class ServletEndpointManagementContextConfiguration {
 				WebEndpointProperties properties,
 				ServletEndpointsSupplier servletEndpointsSupplier) {
 			String servletPath = environment.getProperty("server.servlet.path");
-			if (servletPath.endsWith("/") && properties.getBasePath().startsWith("/")) {
+			if (servletPath == null) {
+				servletPath = "";
+			}
+			else if (servletPath.endsWith("/")) {
 				servletPath = servletPath.substring(0, servletPath.length() - 1);
 			}
-			return new ServletEndpointRegistrar(servletPath != null ? servletPath + properties.getBasePath() : properties.getBasePath(),
+			return new ServletEndpointRegistrar(servletPath + properties.getBasePath(),
 					servletEndpointsSupplier.getEndpoints());
 		}
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/ServletEndpointManagementContextConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/ServletEndpointManagementContextConfiguration.java
@@ -39,6 +39,14 @@ import org.springframework.core.env.Environment;
 @Configuration
 @ConditionalOnWebApplication(type = Type.SERVLET)
 public class ServletEndpointManagementContextConfiguration {
+	
+	@Bean
+	public ExposeExcludePropertyEndpointFilter<ExposableServletEndpoint> servletExposeExcludePropertyEndpointFilter(
+			WebEndpointProperties properties) {
+		WebEndpointProperties.Exposure exposure = properties.getExposure();
+		return new ExposeExcludePropertyEndpointFilter<>(ExposableServletEndpoint.class,
+				exposure.getInclude(), exposure.getExclude());
+	}
 
 	@Configuration
 	@ConditionalOnManagementPort(ManagementPortType.DIFFERENT)
@@ -68,13 +76,4 @@ public class ServletEndpointManagementContextConfiguration {
 					servletEndpointsSupplier.getEndpoints());
 		}
 	}
-
-	@Bean
-	public ExposeExcludePropertyEndpointFilter<ExposableServletEndpoint> servletExposeExcludePropertyEndpointFilter(
-			WebEndpointProperties properties) {
-		WebEndpointProperties.Exposure exposure = properties.getExposure();
-		return new ExposeExcludePropertyEndpointFilter<>(ExposableServletEndpoint.class,
-				exposure.getInclude(), exposure.getExclude());
-	}
-
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/ServletEndpointManagementContextConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/ServletEndpointManagementContextConfiguration.java
@@ -39,7 +39,6 @@ import org.springframework.core.env.Environment;
 @Configuration
 @ConditionalOnWebApplication(type = Type.SERVLET)
 public class ServletEndpointManagementContextConfiguration {
-	
 	@Bean
 	public ExposeExcludePropertyEndpointFilter<ExposableServletEndpoint> servletExposeExcludePropertyEndpointFilter(
 			WebEndpointProperties properties) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointProperties.java
@@ -38,7 +38,7 @@ public class WebEndpointProperties {
 	private final Exposure exposure = new Exposure();
 
 	/**
-	 * Base path for Web endpoints. Relative to server.servlet.context-path or
+	 * Base path for Web endpoints. Relative to server.servlet.context-path and server.servlet.path, or
 	 * management.server.servlet.context-path if management.server.port is configured.
 	 */
 	private String basePath = "/actuator";

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -1082,7 +1082,7 @@ The preceding `application.properties` example changes the endpoint from
 NOTE: Unless the management port has been configured to
 <<production-ready-customizing-management-server-port,expose endpoints by using a
 different HTTP port>>, `management.endpoints.web.base-path` is relative to
-`server.servlet.context-path`. If `management.server.port` is configured,
+`server.servlet.context-path` and `server.servlet.path`. If `management.server.port` is configured,
 `management.endpoints.web.base-path` is relative to
 `management.server.servlet.context-path`.
 


### PR DESCRIPTION
### Summary
I have changed ServletEndpointManagementContextConfiguration and documentation to support ServletEndpoints to have same path than web management endpoints.

### The problem
**If your server has no management port set** and there is a "server.servlet.path" set, the ServletEndpoint registration path would not consider "server.servlet.path" as all other web management endpoints. So the resulting path for servlet endpoints will look different from other web management paths.

In this case, for example, with jolokia:
How the jolokia endpoint is **currently**:
http://host:port/context-path/actuator/jolokia

Examples of other endpoints that I am trying to mimic:
http://host:port/context-path/servlet-path/actuator/health
http://host:port/context-path/servlet-path/actuator/auditevents
http://host:port/context-path/servlet-path/actuator/beans

How the jolokia endpoint **should** be:
http://host:port/context-path/servlet-path/actuator/jolokia

### The fix
This pull requests ensures the desired behaviour, and add to the documentation the information that it does consider "server.servlet.path" whenever management port is not set.

The way it was implemented is that ServletEndpointManagementContextConfiguration will have two configurations, one for different context (different management port), and another for same context.

The configuration for different context will be the same as before.
The configuration for same context will pull "server.servlet.path" from environment and add it to the servlet registration base path.