### PR TITLE
Add .gitignore for Gradle Plugin module

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/.gitignore
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/build/
+/out/


### PR DESCRIPTION
If one attempts to compile Spring Boot project in IntelliJ, there are errors in `spring-boot-gradle-plugin` module unless that module is imported as Gradle project. Doing so (by default) generates `out/` directory with compilation output and these files are not ignored by Git ATM.

This PR ~updates `.gitignore` to add `out/` pattern~ adds .gitignore for Gradle Plugin module.