### PR TITLE
Use type parameter for Supplier in AggregateBinder.merge()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/AggregateBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/AggregateBinder.java
@@ -60,7 +60,7 @@ abstract class AggregateBinder<T> {
 		if (result == null || value == null) {
 			return result;
 		}
-		return merge(value, (T) result);
+		return merge((Supplier<T>) value, (T) result);
 	}
 
 	/**
@@ -79,7 +79,7 @@ abstract class AggregateBinder<T> {
 	 * @param additional the additional elements to merge
 	 * @return the merged result
 	 */
-	protected abstract T merge(Supplier<?> existing, T additional);
+	protected abstract T merge(Supplier<T> existing, T additional);
 
 	/**
 	 * Return the context being used by this binder.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/ArrayBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/ArrayBinder.java
@@ -56,7 +56,7 @@ class ArrayBinder extends IndexedElementsBinder<Object> {
 	}
 
 	@Override
-	protected Object merge(Supplier<?> existing, Object additional) {
+	protected Object merge(Supplier<Object> existing, Object additional) {
 		return additional;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/CollectionBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/CollectionBinder.java
@@ -55,10 +55,9 @@ class CollectionBinder extends IndexedElementsBinder<Collection<Object>> {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	protected Collection<Object> merge(Supplier<?> existing,
+	protected Collection<Object> merge(Supplier<Collection<Object>> existing,
 			Collection<Object> additional) {
-		Collection<Object> existingCollection = (Collection<Object>) existing.get();
+		Collection<Object> existingCollection = existing.get();
 		if (existingCollection == null) {
 			return additional;
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
@@ -83,10 +83,9 @@ class MapBinder extends AggregateBinder<Map<Object, Object>> {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	protected Map<Object, Object> merge(Supplier<?> existing,
+	protected Map<Object, Object> merge(Supplier<Map<Object, Object>> existing,
 			Map<Object, Object> additional) {
-		Map<Object, Object> existingMap = (Map<Object, Object>) existing.get();
+		Map<Object, Object> existingMap = existing.get();
 		if (existingMap == null) {
 			return additional;
 		}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Applying type parameter `T` to `Supplier` parameter in `AggregateBinder.merge()` looks more natural, so this PR changes to use it.