### PR TITLE
Improve LDAP auto-configuration conditions

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfiguration.java
@@ -53,7 +53,7 @@ public class LdapAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ContextSource ldapContextSource() {
+	public LdapContextSource ldapContextSource() {
 		LdapContextSource source = new LdapContextSource();
 		source.setUserDn(this.properties.getUsername());
 		source.setPassword(this.properties.getPassword());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapAutoConfiguration.java
@@ -58,7 +58,6 @@ import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.type.AnnotatedTypeMetadata;
-import org.springframework.ldap.core.ContextSource;
 import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.util.StringUtils;
 
@@ -101,7 +100,7 @@ public class EmbeddedLdapAutoConfiguration {
 	@Bean
 	@DependsOn("directoryServer")
 	@ConditionalOnMissingBean
-	public ContextSource ldapContextSource() {
+	public LdapContextSource ldapContextSource() {
 		LdapContextSource source = new LdapContextSource();
 		if (hasCredentials(this.embeddedProperties.getCredential())) {
 			source.setUserDn(this.embeddedProperties.getCredential().getUsername());


### PR DESCRIPTION
At present, auto-configuration of `LdapContextSource` is conditional on presence of `ContextSource` bean. However, there are valid use cases which require multiple `ContextSource` bean, for instance `PooledContextSource`. With the current arrangement, the auto-configuration of `LdapContextSource` will back off if user provides `PooledContextSource` bean, while it would still be reasonable to reuse auto-configured `LdapContextSource`.

This PR improves `LdapContextSource` factory method return value and condition to back off only if users actually provide `LdapContextSource` bean themselves.

With this change in place, users can provide `PooledContextSource` bean and reuse auto-configured `LdapContextSource`. `PooledContextSource` bean should then be marked as `@Primary` to ensure it is injected in auto-configured `LdapTemplate`.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->