### PR TITLE
Add liquibase test rollback on update property

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -129,6 +129,7 @@ public class LiquibaseAutoConfiguration {
 			liquibase.setLabels(this.properties.getLabels());
 			liquibase.setChangeLogParameters(this.properties.getParameters());
 			liquibase.setRollbackFile(this.properties.getRollbackFile());
+			liquibase.setTestRollbackOnUpdate(this.properties.isTestRollbackOnUpdate());
 			return liquibase;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,6 +93,11 @@ public class LiquibaseProperties {
 	 * File to which rollback SQL is written when an update is performed.
 	 */
 	private File rollbackFile;
+
+	/**
+	 * Whether rollback should be tested before update is performed.
+	 */
+	private boolean testRollbackOnUpdate;
 
 	public String getChangeLog() {
 		return this.changeLog;
@@ -191,4 +196,11 @@ public class LiquibaseProperties {
 		this.rollbackFile = rollbackFile;
 	}
 
+	public boolean isTestRollbackOnUpdate() {
+		return this.testRollbackOnUpdate;
+	}
+
+	public void setTestRollbackOnUpdate(boolean testRollbackOnUpdate) {
+		this.testRollbackOnUpdate = testRollbackOnUpdate;
+	}
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
@@ -239,6 +239,17 @@ public class LiquibaseAutoConfigurationTests {
 	}
 
 	@Test
+	public void testRollbackOnUpdate() throws IOException {
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+				.withPropertyValues(
+						"spring.liquibase.test-rollback-on-update:true")
+				.run((context) -> {
+					SpringLiquibase liquibase = context.getBean(SpringLiquibase.class);
+					assertThat(liquibase.isTestRollbackOnUpdate());
+				});
+	}
+
+	@Test
 	public void liquibaseDataSource() {
 		this.contextRunner.withUserConfiguration(LiquibaseDataSourceConfiguration.class,
 				EmbeddedDataSourceConfiguration.class).run((context) -> {


### PR DESCRIPTION
New liquibase property that enables testing the rollback before executing update added to LiquibaseProperties. This functionality was added in liquibase-core in version 3.6 (liquibase/liquibase#571).