### PR TITLE
Remove @Deprecated on CouchbaseProperties.Endpoints.setKeyValue()

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseProperties.java
@@ -142,7 +142,6 @@ public class CouchbaseProperties {
 			return this.keyValue;
 		}
 
-		@Deprecated
 		public void setKeyValue(int keyValue) {
 			this.keyValue = keyValue;
 		}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR removes `@Deprecated` on `CouchbaseProperties.Endpoints.setKeyValue()` as it looks accidentally added in 6692301d51d22e1a427180c8fc7754d6ea8e6df8.