### PR TITLE
Make ErrorProperties.whitelabel final

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ErrorProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ErrorProperties.java
@@ -44,7 +44,7 @@ public class ErrorProperties {
 	 */
 	private IncludeStacktrace includeStacktrace = IncludeStacktrace.NEVER;
 
-	private Whitelabel whitelabel = new Whitelabel();
+	private final Whitelabel whitelabel = new Whitelabel();
 
 	public String getPath() {
 		return this.path;
@@ -72,10 +72,6 @@ public class ErrorProperties {
 
 	public Whitelabel getWhitelabel() {
 		return this.whitelabel;
-	}
-
-	public void setWhitelabel(Whitelabel whitelabel) {
-		this.whitelabel = whitelabel;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR makes `ErrorProperties.whitelabel` `final`.