### PR TITLE
Dispatcher servlets with a custom servlet name are not found by the mappings endpoint

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/web/mappings/MappingsEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/web/mappings/MappingsEndpointTests.java
@@ -41,6 +41,7 @@ import org.springframework.boot.actuate.web.mappings.servlet.ServletRegistration
 import org.springframework.boot.actuate.web.mappings.servlet.ServletsMappingDescriptionProvider;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -66,6 +67,7 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link MappingsEndpoint}.
  *
  * @author Andy Wilkinson
+ * @author Filip Hrisafov
  */
 public class MappingsEndpointTests {
 
@@ -98,9 +100,16 @@ public class MappingsEndpointTests {
 							"dispatcherServlets", "servletFilters", "servlets");
 					Map<String, List<DispatcherServletMappingDescription>> dispatcherServlets = mappings(
 							contextMappings, "dispatcherServlets");
-					assertThat(dispatcherServlets).containsOnlyKeys("dispatcherServlet");
+					assertThat(dispatcherServlets).containsOnlyKeys("dispatcherServlet",
+							"Registration Double servlet", "Registration Single servlet");
 					List<DispatcherServletMappingDescription> handlerMappings = dispatcherServlets
 							.get("dispatcherServlet");
+					assertThat(handlerMappings).hasSize(1);
+					handlerMappings = dispatcherServlets
+							.get("Registration Double servlet");
+					assertThat(handlerMappings).hasSize(1);
+					handlerMappings = dispatcherServlets
+							.get("Registration Single servlet");
 					assertThat(handlerMappings).hasSize(1);
 					List<ServletRegistrationMappingDescription> servlets = mappings(
 							contextMappings, "servlets");
@@ -206,6 +215,35 @@ public class MappingsEndpointTests {
 			DispatcherServlet dispatcherServlet = new DispatcherServlet(context);
 			dispatcherServlet.init(new MockServletConfig());
 			return dispatcherServlet;
+		}
+
+		@Bean
+		public DispatcherServlet registrationDispatcherServlet(
+				WebApplicationContext context) throws ServletException {
+			DispatcherServlet dispatcherServlet = new DispatcherServlet(context);
+			dispatcherServlet.init(new MockServletConfig());
+			return dispatcherServlet;
+		}
+
+		@Bean
+		public ServletRegistrationBean<DispatcherServlet> registrationBeanDouble(
+				DispatcherServlet registrationDispatcherServlet) {
+			ServletRegistrationBean<DispatcherServlet> registrationBean = new ServletRegistrationBean<>(
+					registrationDispatcherServlet);
+			registrationBean.setName("Registration Double servlet");
+			return registrationBean;
+		}
+
+		@Bean
+		public ServletRegistrationBean<DispatcherServlet> registrationBeanSingle(
+				WebApplicationContext context) throws ServletException {
+			DispatcherServlet servlet = new DispatcherServlet(context);
+			servlet.init(new MockServletConfig());
+			ServletRegistrationBean<DispatcherServlet> registrationBean = new ServletRegistrationBean<>(
+					servlet);
+			registrationBean.setName("Registration Single servlet");
+
+			return registrationBean;
 		}
 
 		@RequestMapping("/three")

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletRegistrationBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletRegistrationBean.java
@@ -104,7 +104,7 @@ public class ServletRegistrationBean<T extends Servlet>
 	 * Returns the servlet being registered.
 	 * @return the servlet
 	 */
-	protected T getServlet() {
+	public T getServlet() {
 		return this.servlet;
 	}
 


### PR DESCRIPTION

Iterates all ServletRegistrationBeans and adds their mappings in case their Servlet is a DispatcherServlet.
Makes sure that a servlet registered through ServletRegistrationBean and exposed as a Bean is not
described twice.

Fixes gh-13186

I did this against the 2.0.x branch as I think that it can be included in a maintenance version. In case you decide that it can't, it would be unfortunate (as we would need to wait for 2.1 😄), but I can modify the PR to target the master branch