### PR TITLE
Add support to set visibility via JacksonProperties

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
@@ -27,7 +27,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
@@ -73,6 +75,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Sebastien Deleuze
  * @author Johannes Edmeier
  * @author Phillip Webb
+ * @author Eddú Meléndez
  * @since 1.1.0
  */
 @Configuration
@@ -249,6 +252,7 @@ public class JacksonAutoConfiguration {
 				configurePropertyNamingStrategy(builder);
 				configureModules(builder);
 				configureLocale(builder);
+				configureVisibility(builder, this.jacksonProperties.getAccessor());
 			}
 
 			private void configureFeatures(Jackson2ObjectMapperBuilder builder,
@@ -345,6 +349,11 @@ public class JacksonAutoConfiguration {
 				if (locale != null) {
 					builder.locale(locale);
 				}
+			}
+
+			private void configureVisibility(Jackson2ObjectMapperBuilder builder,
+					Map<PropertyAccessor, JsonAutoDetect.Visibility> accessors) {
+				accessors.forEach(builder::visibility);
 			}
 
 			private static <T> Collection<T> getBeans(ListableBeanFactory beanFactory,

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonProperties.java
@@ -21,7 +21,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -105,6 +107,12 @@ public class JacksonProperties {
 	 */
 	private Locale locale;
 
+	/**
+	 * Jackson visibilities to auto-detect properties.
+	 */
+	private Map<PropertyAccessor, JsonAutoDetect.Visibility> accessor = new EnumMap<>(
+			PropertyAccessor.class);
+
 	public String getDateFormat() {
 		return this.dateFormat;
 	}
@@ -174,4 +182,11 @@ public class JacksonProperties {
 		this.locale = locale;
 	}
 
+	public Map<PropertyAccessor, JsonAutoDetect.Visibility> getAccessor() {
+		return this.accessor;
+	}
+
+	public void setAccessor(Map<PropertyAccessor, JsonAutoDetect.Visibility> accessor) {
+		this.accessor = accessor;
+	}
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfigurationTests.java
@@ -459,6 +459,19 @@ public class JacksonAutoConfigurationTests {
 		});
 	}
 
+	@Test
+	public void writeWithVisibility() {
+		this.contextRunner.withPropertyValues("spring.jackson.accessor.getter:NONE",
+				"spring.jackson.accessor.field:ANY")
+				.run((context) -> {
+					ObjectMapper mapper = context.getBean(ObjectMapper.class);
+					String json = mapper.writeValueAsString(new VisibilityBean());
+					assertThat(json).contains("property1");
+					assertThat(json).contains("property2");
+					assertThat(json).doesNotContain("property3");
+		});
+	}
+
 	private void assertParameterNamesModuleCreatorBinding(Mode expectedMode,
 			Class<?>... configClasses) {
 		this.contextRunner.withUserConfiguration(configClasses).run((context) -> {
@@ -612,6 +625,17 @@ public class JacksonAutoConfigurationTests {
 			return this.owners;
 		}
 
+	}
+
+	private static class VisibilityBean {
+
+		private String property1;
+
+		public String property2;
+
+		public String getProperty3() {
+			return null;
+		}
 	}
 
 }

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -151,7 +151,7 @@
 		<slf4j.version>1.7.25</slf4j.version>
 		<snakeyaml.version>1.19</snakeyaml.version>
 		<solr.version>7.2.1</solr.version>
-		<spring.version>5.0.6.RELEASE</spring.version>
+		<spring.version>5.1.0.BUILD-SNAPSHOT</spring.version>
 		<spring-amqp.version>2.0.3.RELEASE</spring-amqp.version>
 		<spring-batch.version>4.0.1.RELEASE</spring-batch.version>
 		<spring-cloud-connectors.version>2.0.1.RELEASE</spring-cloud-connectors.version>

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -329,6 +329,7 @@ content into your application. Rather, pick only the properties that you need.
 	spring.servlet.multipart.resolve-lazily=false # Whether to resolve the multipart request lazily at the time of file or parameter access.
 
 	# JACKSON ({sc-spring-boot-autoconfigure}/jackson/JacksonProperties.{sc-ext}[JacksonProperties])
+	spring.jackson.accessor.*= # Jackson visibilities to auto-detect properties.
 	spring.jackson.date-format= # Date format string or a fully-qualified date format class name. For instance, `yyyy-MM-dd HH:mm:ss`.
 	spring.jackson.default-property-inclusion= # Controls the inclusion of properties during serialization. Configured with one of the values in Jackson's JsonInclude.Include enumeration.
 	spring.jackson.deserialization.*= # Jackson on/off features that affect the way Java objects are deserialized.


### PR DESCRIPTION
In spring 5.1, new method `visibility` was added to `Jackson2ObjectMapperBuilder`.
This commit introduce the support to set visibility via 
`JacksonProperties`.

See gh-13176

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->