### PR TITLE
Update AbstractRepositoryConfigurationSourceSupport.java

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/AbstractRepositoryConfigurationSourceSupport.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/AbstractRepositoryConfigurationSourceSupport.java
@@ -65,7 +65,7 @@ public abstract class AbstractRepositoryConfigurationSourceSupport
 		StandardAnnotationMetadata metadata = new StandardAnnotationMetadata(
 				getConfiguration(), true);
 		return new AnnotationRepositoryConfigurationSource(metadata, getAnnotation(),
-				this.resourceLoader, this.environment, registry) {
+				this.resourceLoader, this.environment) {
 			@Override
 			public java.lang.Iterable<String> getBasePackages() {
 				return AbstractRepositoryConfigurationSourceSupport.this


### PR DESCRIPTION
the AnnotationRepositoryConfigurationSource constructor doesn't have 5 parameters anymore.
"registry" is not part of the class constructor.

My knowledge on this part of spring is very limited. Is it possible that someone have a dipper look on it?

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->