### PR TITLE
Fix #13267

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/SslServerCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/SslServerCustomizer.java
@@ -204,9 +204,6 @@ class SslServerCustomizer implements JettyServerCustomizer {
 	}
 
 	private void configureSslTrustStore(SslContextFactory factory, Ssl ssl) {
-		if (ssl.getTrustStorePassword() != null) {
-			factory.setTrustStorePassword(ssl.getTrustStorePassword());
-		}
 		if (ssl.getTrustStore() != null) {
 			try {
 				URL url = ResourceUtils.getURL(ssl.getTrustStore());
@@ -216,12 +213,28 @@ class SslServerCustomizer implements JettyServerCustomizer {
 				throw new WebServerException(
 						"Could not find trust store '" + ssl.getTrustStore() + "'", ex);
 			}
+			if (ssl.getTrustStorePassword() != null) {
+				factory.setTrustStorePassword(ssl.getTrustStorePassword());
+			}
+			if (ssl.getTrustStoreType() != null) {
+				factory.setTrustStoreType(ssl.getTrustStoreType());
+			}
+			if (ssl.getTrustStoreProvider() != null) {
+				factory.setTrustStoreProvider(ssl.getTrustStoreProvider());
+			}
 		}
-		if (ssl.getTrustStoreType() != null) {
-			factory.setTrustStoreType(ssl.getTrustStoreType());
-		}
-		if (ssl.getTrustStoreProvider() != null) {
-			factory.setTrustStoreProvider(ssl.getTrustStoreProvider());
+		else {
+			// If no trust store is specified, Jetty will try to use the configured
+			// key store as trust store.
+			if (ssl.getKeyStorePassword() != null) {
+				factory.setTrustStorePassword(ssl.getKeyStorePassword());
+			}
+			if (ssl.getKeyStoreType() != null) {
+				factory.setTrustStoreType(ssl.getKeyStoreType());
+			}
+			if (ssl.getKeyStoreProvider() != null) {
+				factory.setTrustStoreProvider(ssl.getKeyStoreProvider());
+			}
 		}
 	}
 


### PR DESCRIPTION
When no trust store is configured in the `application.yaml`, Jetty loads the configured key store as trust store but with the wrong parameters.

For instance, if the `application.yaml` contains the following:

```
server.ssl.enabled: true
server.ssl.key-alias: my-application
server.ssl.key-store: classpath:keystore.p12
server.ssl.key-store-password: changeit
server.ssl.key-store-type: PKCS12
```

Jetty will try to load the same key store as trust store assuming the format is `JKS` because that is the deafult value for the trust store type.

While the above doesn't cause any issue with the Oracle JDK (1.8), because the concrete implementation of `java.security.KeyStoreSpi` (i.e. `sun.security.provider.JavaKeyStore$DualFormatJKS`) used to load the trust store seems to be resilient enough to try both `JKS` and `PKCS12` (speculating a bit here given the name), it is actually a problem in case of IBM JDK (1.8) which results in the following startup exception:

```
Caused by: java.io.IOException: Invalid keystore format
	at com.ibm.crypto.provider.JavaKeyStore.engineLoad(Unknown Source)
	at java.security.KeyStore.load(KeyStore.java:1456)
	at org.eclipse.jetty.util.security.CertificateUtils.getKeyStore(CertificateUtils.java:52)
	at org.eclipse.jetty.util.ssl.SslContextFactory.loadTrustStore(SslContextFactory.java:1055)
	at org.eclipse.jetty.util.ssl.SslContextFactory.load(SslContextFactory.java:257)
	at org.eclipse.jetty.util.ssl.SslContextFactory.doStart(SslContextFactory.java:222)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:131)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:113)
	at org.eclipse.jetty.server.SslConnectionFactory.doStart(SslConnectionFactory.java:72)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:131)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:113)
	at org.eclipse.jetty.server.AbstractConnector.doStart(AbstractConnector.java:276)
	at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:81)
	at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:238)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainer.start(JettyEmbeddedServletContainer.java:143)
```

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->