### PR TITLE
add enforce-rule to ensure maven version >= 3.5.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -103,7 +103,7 @@ https://github.com/takari/maven-wrapper[maven wrapper]. You also need JDK 1.8.
 ----
 
 If you want to build with the regular `mvn` command, you will need
-https://maven.apache.org/run-maven/index.html[Maven v3.2.1 or above].
+https://maven.apache.org/run-maven/index.html[Maven v3.5.0 or above].
 
 NOTE: You may need to increase the amount of memory available to Maven by setting
 a `MAVEN_OPTS` environment variable with the value `-Xmx512m`. Remember

--- a/spring-boot-project/spring-boot-parent/pom.xml
+++ b/spring-boot-project/spring-boot-parent/pom.xml
@@ -628,6 +628,9 @@
 								<requireJavaVersion>
 									<version>[1.8,)</version>
 								</requireJavaVersion>
+								<requireMavenVersion>
+									<version>[3.5.0,)</version>
+								</requireMavenVersion>
 								<requireProperty>
 									<property>main.basedir</property>
 								</requireProperty>


### PR DESCRIPTION
Ensure maven version >= 3.5.0 to support `${revision}`.

https://maven.apache.org/docs/3.5.0/release-notes.html

When using maven 3.3.9, `${revision}` will not be replaced.