### PR TITLE
Update undertow to the last branch 2.0.9

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -176,7 +176,7 @@
 		<thymeleaf-extras-java8time.version>3.0.1.RELEASE</thymeleaf-extras-java8time.version>
 		<tomcat.version>8.5.31</tomcat.version>
 		<unboundid-ldapsdk.version>4.0.5</unboundid-ldapsdk.version>
-		<undertow.version>1.4.25.Final</undertow.version>
+		<undertow.version>2.0.9.Final</undertow.version>
 		<webjars-hal-browser.version>3325375</webjars-hal-browser.version>
 		<webjars-locator-core.version>0.35</webjars-locator-core.version>
 		<wsdl4j.version>1.6.3</wsdl4j.version>


### PR DESCRIPTION
Update undertow 2.0.9 the the last banch for Spring Boot 2.1.