### PR TITLE
Use more Tag constants

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTags.java
@@ -37,6 +37,12 @@ public final class WebFluxTags {
 
 	private static final Tag URI_REDIRECTION = Tag.of("uri", "REDIRECTION");
 
+	private static final Tag URI_ROOT = Tag.of("uri", "root");
+
+	private static final Tag URI_UNKNOWN = Tag.of("uri", "UNKNOWN");
+
+	private static final Tag EXCEPTION_NONE = Tag.of("exception", "None");
+
 	private WebFluxTags() {
 	}
 
@@ -87,9 +93,12 @@ public final class WebFluxTags {
 				return URI_NOT_FOUND;
 			}
 			String path = exchange.getRequest().getPath().value();
-			return Tag.of("uri", path.isEmpty() ? "root" : path);
+			if (path.isEmpty()) {
+				return URI_ROOT;
+			}
+			return Tag.of("uri", path);
 		}
-		return Tag.of("uri", "UNKNOWN");
+		return URI_UNKNOWN;
 	}
 
 	/**
@@ -102,7 +111,7 @@ public final class WebFluxTags {
 		if (exception != null) {
 			return Tag.of("exception", exception.getClass().getSimpleName());
 		}
-		return Tag.of("exception", "none");
+		return EXCEPTION_NONE;
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcTags.java
@@ -40,6 +40,8 @@ public final class WebMvcTags {
 
 	private static final Tag URI_REDIRECTION = Tag.of("uri", "REDIRECTION");
 
+	private static final Tag URI_ROOT = Tag.of("uri", "root");
+
 	private static final Tag URI_UNKNOWN = Tag.of("uri", "UNKNOWN");
 
 	private static final Tag EXCEPTION_NONE = Tag.of("exception", "None");
@@ -97,7 +99,10 @@ public final class WebMvcTags {
 				}
 			}
 			String pathInfo = getPathInfo(request);
-			return Tag.of("uri", pathInfo.isEmpty() ? "root" : pathInfo);
+			if (pathInfo.isEmpty()) {
+				return URI_ROOT;
+			}
+			return Tag.of("uri", pathInfo);
 		}
 		return URI_UNKNOWN;
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR changes to use more `Tag` constants where possible.

This PR also aligns "exception" tag value in `WebFluxTags` with one in `WebMvcTags`, hence from "none" to "None".