### PR TITLE
Fix wrong reference in cast operation

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/reactive/server/WebTestClientContextCustomizer.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/reactive/server/WebTestClientContextCustomizer.java
@@ -65,7 +65,7 @@ class WebTestClientContextCustomizer implements ContextCustomizer {
 	private void registerWebTestClient(ConfigurableApplicationContext context) {
 		ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
 		if (beanFactory instanceof BeanDefinitionRegistry) {
-			registerWebTestClient((BeanDefinitionRegistry) context);
+			registerWebTestClient((BeanDefinitionRegistry) beanFactory);
 		}
 	}
 


### PR DESCRIPTION
Because `beanFactory instanceof BeanDefinitionRegistry` is used former, so `beanFactory` should be used latter.

#13287