### PR TITLE
I see no reference to EnableReactor anywhere

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-cli.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-cli.adoc
@@ -154,9 +154,6 @@ The following items are used as "`grab hints`":
 |`@EnableRabbit`
 |RabbitMQ.
 
-|`@EnableReactor`
-|Project Reactor.
-
 |extends `Specification`
 |Spock test.
 


### PR DESCRIPTION
This appears to be a deprecated property from project reactor and should be removed from the docs.