### PR TITLE
Introduce spring-boot.version property

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -31,6 +31,7 @@
 		</developer>
 	</developers>
 	<properties>
+		<spring-boot.version>${revision}</spring-boot.version>
 		<!-- Dependency versions -->
 		<activemq.version>5.15.3</activemq.version>
 		<antlr2.version>2.7.7</antlr2.version>


### PR DESCRIPTION
spring-boot.versioncould be used by used by child poms to resolve cases like the following:
https://stackoverflow.com/questions/50620293/maven-dependencymanagement-inherit-dependency-version-from-parent (5th approach)