### PR TITLE
Upgrade to Hazelcast 3.10.1

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/resources/cache/test-hazelcast.xml
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/resources/cache/test-hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.9.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
 		xmlns="http://www.hazelcast.com/schema/config"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<map name="books"/>

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/resources/hazelcast.xml
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/resources/hazelcast.xml
@@ -1,5 +1,5 @@
 <hazelcast
-		xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.9.xsd"
+		xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
 		xmlns="http://www.hazelcast.com/schema/config"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<map name="defaultCache" />

--- a/spring-boot-project/spring-boot-actuator/src/test/resources/cache/test-hazelcast.xml
+++ b/spring-boot-project/spring-boot-actuator/src/test/resources/cache/test-hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.9.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
 		xmlns="http://www.hazelcast.com/schema/config"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<map name="books"/>

--- a/spring-boot-project/spring-boot-actuator/src/test/resources/hazelcast.xml
+++ b/spring-boot-project/spring-boot-actuator/src/test/resources/hazelcast.xml
@@ -1,5 +1,5 @@
 <hazelcast
-		xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.9.xsd"
+		xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
 		xmlns="http://www.hazelcast.com/schema/config"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<map name="defaultCache" />

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/hazelcast.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/hazelcast.xml
@@ -1,5 +1,5 @@
 <hazelcast
-	xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.9.xsd"
+	xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
 	xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<instance-name>default-instance</instance-name>
 	<map name="defaultCache" />

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-client-specific.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-client-specific.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.8.xsd">
+		xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.10.xsd">
 
 </hazelcast-client>

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.xml
@@ -1,4 +1,4 @@
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.9.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
 		   xmlns="http://www.hazelcast.com/schema/config"
 		   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -65,7 +65,7 @@
 		<gson.version>2.8.5</gson.version>
 		<h2.version>1.4.197</h2.version>
 		<hamcrest.version>1.3</hamcrest.version>
-		<hazelcast.version>3.9.4</hazelcast.version>
+		<hazelcast.version>3.10.1</hazelcast.version>
 		<hazelcast-hibernate5.version>1.2.3</hazelcast-hibernate5.version>
 		<hibernate.version>5.2.17.Final</hibernate.version>
 		<hibernate-jpa-2.1-api.version>1.0.2.Final</hibernate-jpa-2.1-api.version>

--- a/spring-boot-samples/spring-boot-sample-cache/src/main/resources/hazelcast.xml
+++ b/spring-boot-samples/spring-boot-sample-cache/src/main/resources/hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.9.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
 		   xmlns="http://www.hazelcast.com/schema/config"
 		   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/spring-boot-samples/spring-boot-sample-session/src/main/resources/hazelcast.xml
+++ b/spring-boot-samples/spring-boot-sample-session/src/main/resources/hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.9.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
 		   xmlns="http://www.hazelcast.com/schema/config"
 		   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 


### PR DESCRIPTION
In 2.1, Spring Boot should align with Hazelcast's new minor release.