### PR TITLE
Polish stream creation in some PropertySources

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/AliasedIterableConfigurationPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/AliasedIterableConfigurationPropertySource.java
@@ -18,7 +18,6 @@ package org.springframework.boot.context.properties.source;
 
 import java.util.List;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import org.springframework.util.CollectionUtils;
 
@@ -39,7 +38,7 @@ class AliasedIterableConfigurationPropertySource
 
 	@Override
 	public Stream<ConfigurationPropertyName> stream() {
-		return StreamSupport.stream(getSource().spliterator(), false)
+		return getSource().stream()
 				.flatMap(this::addAliases);
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/AliasedIterableConfigurationPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/AliasedIterableConfigurationPropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,7 @@ class AliasedIterableConfigurationPropertySource
 
 	@Override
 	public Stream<ConfigurationPropertyName> stream() {
-		return getSource().stream()
-				.flatMap(this::addAliases);
+		return getSource().stream().flatMap(this::addAliases);
 	}
 
 	private Stream<ConfigurationPropertyName> addAliases(ConfigurationPropertyName name) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/FilteredIterableConfigurationPropertiesSource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/FilteredIterableConfigurationPropertiesSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/FilteredIterableConfigurationPropertiesSource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/FilteredIterableConfigurationPropertiesSource.java
@@ -18,7 +18,6 @@ package org.springframework.boot.context.properties.source;
 
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 /**
  * A filtered {@link IterableConfigurationPropertySource}.
@@ -38,7 +37,7 @@ class FilteredIterableConfigurationPropertiesSource
 
 	@Override
 	public Stream<ConfigurationPropertyName> stream() {
-		return StreamSupport.stream(getSource().spliterator(), false).filter(getFilter());
+		return getSource().stream().filter(getFilter());
 	}
 
 	@Override


### PR DESCRIPTION
Hi,

this PR replaces `StreamSupport.stream(getSource().spliterator(), false)` with essentially the same call to `stream()` where possible in PropertySource classes.

Cheers,
Christoph