### PR TITLE
Support binding Maps with updated MapPropertySource

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySource.java
@@ -142,9 +142,7 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 	}
 
 	private Object getCacheKey() {
-		if (getPropertySource() instanceof MapPropertySource) {
-			return ((MapPropertySource) getPropertySource()).getSource().keySet();
-		}
+		// gh-13344
 		return getPropertySource().getPropertyNames();
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
@@ -76,6 +76,7 @@ import static org.hamcrest.Matchers.not;
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  * @author Ben Hale
+ * @author Fahim Farook
  */
 @RunWith(ModifiedClassPathRunner.class)
 @ClassPathExclusions("log4j*.jar")
@@ -501,11 +502,22 @@ public class LoggingApplicationListenerTests {
 	public void environmentPropertiesIgnoreUnresolvablePlaceholders() {
 		// gh-7719
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context,
+				"logging.pattern.console=console ${doesnotexist}");
+		this.initializer.initialize(this.context.getEnvironment(),
+				this.context.getClassLoader());
+		assertThat(System.getProperty(LoggingSystemProperties.CONSOLE_LOG_PATTERN))
+				.isEqualTo("console ${doesnotexist}");
+	}
+
+	@Test
+	public void environmentPropertiesResolvePlaceholders() {
+		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context,
 				"logging.pattern.console=console ${pid}");
 		this.initializer.initialize(this.context.getEnvironment(),
 				this.context.getClassLoader());
 		assertThat(System.getProperty(LoggingSystemProperties.CONSOLE_LOG_PATTERN))
-				.isEqualTo("console ${pid}");
+				.isEqualTo(this.context.getEnvironment()
+						.getProperty("logging.pattern.console"));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySourceTests.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Fahim Farook
  */
 public class SpringIterableConfigurationPropertySourceTests {
 
@@ -155,6 +156,24 @@ public class SpringIterableConfigurationPropertySourceTests {
 				.isEqualTo(ConfigurationPropertyState.ABSENT);
 		assertThat(adapter.containsDescendantOf(ConfigurationPropertyName.of("fof")))
 				.isEqualTo(ConfigurationPropertyState.ABSENT);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void propertySourceChangeReflects() {
+		// gh-13344
+		final Map<String, Object> source = new LinkedHashMap<>();
+		source.put("key1", "value1");
+		source.put("key2", "value2");
+		final EnumerablePropertySource<?> propertySource = new MapPropertySource("test",
+				source);
+		final SpringIterableConfigurationPropertySource adapter = new SpringIterableConfigurationPropertySource(
+				propertySource, DefaultPropertyMapper.INSTANCE);
+		assertThat(adapter.stream().count()).isEqualTo(2);
+
+		((Map<String, Object>) adapter.getPropertySource().getSource()).put("key3",
+				"value3");
+		assertThat(adapter.stream().count()).isEqualTo(3);
 	}
 
 	/**


### PR DESCRIPTION
## Issue
In spring-boot 2x `Maps` in `@ConfigurationProperties` are not being updated from the **second** `EnvironmentChangeEvent` onwards. i.e. Following test fails in spring-boot 2x, but passed in spring-boot 1x.

```java
@ConfigurationProperties
class Props {
   private Map<String, String> map = new HashMap<>();
   ...
}


TestPropertyValues.of("map.key1=value1").applyTo(this.environment);

// first EnvironmentChangeEvent
context.publishEvent(new EnvironmentChangeEvent(..."map.key1"));
// 'value1' gets reflected in @ConfigurationProperties bean - in both spring-boot 1x and 2x
assertEquals("value1", context.getBean(Props.class).getMap().get("key1"));

TestPropertyValues.of("map.key2=value2").applyTo(this.environment);

// second EnvironmentChangeEvent
context.publishEvent(new EnvironmentChangeEvent(..."map.key2"));

// 'value2' NOT getting reflected in @ConfigurationProperties bean - in spring-boot 2x.
assertEquals("value2", context.getBean(Props.class).getMap().get("key2"));
```

## Analysis
- In case of `MapPropertySource`, `SpringIterableConfigurationPropertySource#getCacheKey()`
[here](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySource.java#L146) always returns the reference to the same object in the heap (for different invocations), even though the property-source state has changed. i.e. <br/>
   `return ((MapPropertySource) getPropertySource()).getSource().keySet();`

- As a result, `if (ObjectUtils.nullSafeEquals(cacheKey, this.cacheKey))` [here](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySource.java#L136) always evaluates to true (same reference) and `getCache()` returns the old/ initial cache.

Consequently, `SpringIterableConfigurationPropertySource#iterator()` having reference only to the initial/ old property-keys - hence the `MapBinder` fails [here](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java#L152) to bind updated properties.

## Fix
`SpringIterableConfigurationPropertySource#getCacheKey()` should return a new object. This branch - `if (getPropertySource() instanceof MapPropertySource)` is not necessary.

```
private Object getCacheKey() {
   return getPropertySource().getPropertyNames(); // returns a new array
}
```

Whenever the `cacheKey` is updated, `Cache` is reinitialized (with all the property keys)

## Sample
* PoC [here](https://github.com/fahimfarookme/configuration-properties-maps-issue/tree/master) to confirm/ recreate the issue - the same set of test cases passed [here](https://github.com/fahimfarookme/configuration-properties-maps-issue/tree/master/spring-boot-1x-cloud-1x) (spring-boot 1x), but failed [here](https://github.com/fahimfarookme/configuration-properties-maps-issue/tree/master/spring-boot-2x-cloud-2x) (spring-boot 2x).


This issue supersedes [this one](https://github.com/spring-cloud/spring-cloud-netflix/issues/2538).