### PR TITLE
Remove usage of deprecated Matchers class

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringBootExceptionHandlerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringBootExceptionHandlerTests.java
@@ -21,7 +21,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import org.junit.Test;
 
-import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -55,7 +54,7 @@ public class SpringBootExceptionHandlerTests {
 				"[stuff] Logback configuration error detected [stuff]");
 		this.handler.registerLoggedException(ex);
 		this.handler.uncaughtException(thread, ex);
-		verify(this.parent).uncaughtException(same(thread), same(ex));
+		verify(this.parent).uncaughtException(thread, ex);
 	}
 
 	@Test
@@ -65,7 +64,7 @@ public class SpringBootExceptionHandlerTests {
 				"[stuff] Logback configuration error detected [stuff]", new Exception()));
 		this.handler.registerLoggedException(ex);
 		this.handler.uncaughtException(thread, ex);
-		verify(this.parent).uncaughtException(same(thread), same(ex));
+		verify(this.parent).uncaughtException(thread, ex);
 	}
 
 }


### PR DESCRIPTION
Hi,

just noticed this deprecation warning. I guess it's safe to remove the call to `same()` alltogether and hence the need for the alternative `ArgumentMatchers` import as well. Default behaviour should be checking the parameters with `equals()` which is sufficient here in my opinion.

Let me know what you think.
Cheers,
Christoph