### PR TITLE
RestTemplateCustomizers should be applied at the end of the `build` method

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RestTemplateBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RestTemplateBuilder.java
@@ -531,12 +531,13 @@ public class RestTemplateBuilder {
 		if (this.basicAuthorization != null) {
 			restTemplate.getInterceptors().add(this.basicAuthorization);
 		}
+		restTemplate.getInterceptors().addAll(this.interceptors);
+
 		if (!CollectionUtils.isEmpty(this.restTemplateCustomizers)) {
 			for (RestTemplateCustomizer customizer : this.restTemplateCustomizers) {
 				customizer.customize(restTemplate);
 			}
 		}
-		restTemplate.getInterceptors().addAll(this.interceptors);
 		return restTemplate;
 	}
 


### PR DESCRIPTION
Expected behavior is `Customizers` will be applied at the end of the `RestTemplateBuilder#build`, but currently  `Interceptors` at the end of the phase. 
This PR fixes this. 