### PR TITLE
Replace commons-codec Base64 usage

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveTokenValidatorTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveTokenValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -337,7 +336,8 @@ public class ReactiveTokenValidatorTests {
 				+ "J/OOn5zOs8yf26os0q3+JUM=\n-----END PRIVATE KEY-----";
 		String privateKey = signingKey.replace("-----BEGIN PRIVATE KEY-----\n", "");
 		privateKey = privateKey.replace("-----END PRIVATE KEY-----", "");
-		byte[] pkcs8EncodedBytes = Base64.decodeBase64(privateKey);
+		privateKey = privateKey.replace("\n", "");
+		byte[] pkcs8EncodedBytes = Base64Utils.decodeFromString(privateKey);
 		PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(pkcs8EncodedBytes);
 		KeyFactory keyFactory = KeyFactory.getInstance("RSA");
 		return keyFactory.generatePrivate(keySpec);

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/TokenValidatorTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/TokenValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Collections;
 import java.util.Map;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -248,7 +247,8 @@ public class TokenValidatorTests {
 				+ "J/OOn5zOs8yf26os0q3+JUM=\n-----END PRIVATE KEY-----";
 		String privateKey = signingKey.replace("-----BEGIN PRIVATE KEY-----\n", "");
 		privateKey = privateKey.replace("-----END PRIVATE KEY-----", "");
-		byte[] pkcs8EncodedBytes = Base64.decodeBase64(privateKey);
+		privateKey = privateKey.replace("\n", "");
+		byte[] pkcs8EncodedBytes = Base64Utils.decodeFromString(privateKey);
 		PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(pkcs8EncodedBytes);
 		KeyFactory keyFactory = KeyFactory.getInstance("RSA");
 		return keyFactory.generatePrivate(keySpec);


### PR DESCRIPTION
Hi,

just noticed two usages of `org.apache.commons.codec.binary.Base64` in tests that could be removed in my opinion. I went for using the utility class from Spring-Framework (mainly because it was already imported as well). If you prefer using the `java.util.Base64` directly, I don't mind adjusting the PR. Just let me know.

Cheers,
Christoph

P.S.: It seems that Boot itself doesn't use any commons-codec code directly after this PR is merged.  I wonder if we could remove the dependency alltogether in a separate PR?