### PR TITLE
Improved the error message, when no main class was found using the gradle-plugin.  #12712

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootArchiveSupport.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootArchiveSupport.java
@@ -35,6 +35,7 @@ import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.api.java.archives.ManifestException;
 
 /**
  * Support class for implementations of {@link BootArchive}.

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootArchiveSupport.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootArchiveSupport.java
@@ -76,7 +76,12 @@ class BootArchiveSupport {
 	void configureManifest(Jar jar, String mainClassName) {
 		Attributes attributes = jar.getManifest().getAttributes();
 		attributes.putIfAbsent("Main-Class", this.loaderMainClass);
-		attributes.putIfAbsent("Start-Class", mainClassName);
+		if (mainClassName == null && attributes.get("Start-Class") == null) {
+			throw new ManifestException("No main class could be resolved");
+		}
+		else {
+			attributes.putIfAbsent("Start-Class", mainClassName);
+		}
 	}
 
 	CopyAction createCopyAction(Jar jar) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootArchiveSupport.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootArchiveSupport.java
@@ -30,12 +30,12 @@ import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.internal.file.copy.CopyActionProcessingStream;
 import org.gradle.api.internal.file.copy.FileCopyDetailsInternal;
 import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.java.archives.ManifestException;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.util.PatternSet;
-import org.gradle.api.java.archives.ManifestException;
 
 /**
  * Support class for implementations of {@link BootArchive}.


### PR DESCRIPTION
Fixes #12712 - When building with the spring-boot-gradle-plugin the error mesage is now clear.

Previously the error message would say: `The value of a manifest attribute must not be null (Key=Start-Class)` .

It now says: `No main class could be resolved`