### PR TITLE
use default `timeouts` for detected `HttpWebServiceMessageSender`.

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/webservices/client/WebServiceTemplateBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/webservices/client/WebServiceTemplateBuilder.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.webservices.client;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -523,18 +524,19 @@ public class WebServiceTemplateBuilder {
 	private void applyCustomizers(WebServiceTemplate webServiceTemplate,
 			Set<WebServiceTemplateCustomizer> customizers) {
 		if (!CollectionUtils.isEmpty(customizers)) {
-			for (WebServiceTemplateCustomizer internalCustomizer : customizers) {
-				internalCustomizer.customize(webServiceTemplate);
+			for (WebServiceTemplateCustomizer customizer : customizers) {
+				customizer.customize(webServiceTemplate);
 			}
 		}
 	}
 
-	private <T extends WebServiceTemplate> void configureMessageSenders(
-			T webServiceTemplate) {
+	private void configureMessageSenders(WebServiceTemplate webServiceTemplate) {
 		if (this.messageSenders.isOnlyAdditional() && this.detectHttpMessageSender) {
 			Set<WebServiceMessageSender> merged = append(
 					this.messageSenders.getMessageSenders(),
-					new HttpWebServiceMessageSenderBuilder().build());
+					new HttpWebServiceMessageSenderBuilder()
+							.setReadTimeout(Duration.ofMinutes(1))
+							.setConnectTimeout(Duration.ofMinutes(1)).build());
 			webServiceTemplate
 					.setMessageSenders(merged.toArray(new WebServiceMessageSender[0]));
 		}
@@ -574,21 +576,21 @@ public class WebServiceTemplateBuilder {
 			this.messageSenders = messageSenders;
 		}
 
-		public boolean isOnlyAdditional() {
+		boolean isOnlyAdditional() {
 			return this.onlyAdditional;
 		}
 
-		public Set<WebServiceMessageSender> getMessageSenders() {
+		Set<WebServiceMessageSender> getMessageSenders() {
 			return this.messageSenders;
 		}
 
-		public WebServiceMessageSenders set(
+		WebServiceMessageSenders set(
 				Collection<? extends WebServiceMessageSender> messageSenders) {
 			return new WebServiceMessageSenders(false,
 					new LinkedHashSet<>(messageSenders));
 		}
 
-		public WebServiceMessageSenders add(
+		WebServiceMessageSenders add(
 				Collection<? extends WebServiceMessageSender> messageSenders) {
 			return new WebServiceMessageSenders(this.onlyAdditional,
 					append(this.messageSenders, messageSenders));

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/webservices/client/WebServiceTemplateBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/webservices/client/WebServiceTemplateBuilderTests.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import javax.xml.transform.sax.SAXTransformerFactory;
 
+import org.apache.http.client.config.RequestConfig;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,6 +36,7 @@ import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.oxm.Marshaller;
 import org.springframework.oxm.Unmarshaller;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.FaultMessageResolver;
 import org.springframework.ws.client.core.WebServiceTemplate;
@@ -375,6 +377,11 @@ public class WebServiceTemplateBuilderTests {
 		ClientHttpRequestFactory requestFactory = sender.getRequestFactory();
 		assertThat(requestFactory)
 				.isInstanceOf(HttpComponentsClientHttpRequestFactory.class);
+		RequestConfig requestConfig = (RequestConfig) ReflectionTestUtils
+				.getField(requestFactory, "requestConfig");
+		assertThat(requestConfig).isNotNull();
+		assertThat(requestConfig.getConnectTimeout()).isEqualTo(60000);
+		assertThat(requestConfig.getSocketTimeout()).isEqualTo(60000);
 	}
 
 }


### PR DESCRIPTION
Currently, `WebServiceTemplateBuilder` doesn't use any default timeouts for detected `HttpWebServiceMessageSender`, however  `HttpUrlConnectionMessageSender` and `HttpComponentsMessageSender` has default timeouts `60 seconds`. 

This PR sets default timeouts for the detected sender as well.