### PR TITLE
Add binding test with a map key prefixed with "/"

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
@@ -323,12 +323,11 @@ public class ConfigurationPropertiesTests {
 
 	@Test
 	public void loadWhenBindingToMapKeyWithForwardSlashShouldBind() {
-		load(MapProperties.class, "mymap[/test1]:test1", "mymap[/test2]:test2", "mymap[/test3/test31]:test31");
+		load(MapProperties.class, "mymap[/test1]:test1", "mymap[/test2]:test2",
+				"mymap[/test3/test31]:test31");
 		MapProperties bean = this.context.getBean(MapProperties.class);
-		assertThat(bean.mymap).containsOnly(
-				entry("/test1", "test1"),
-				entry("/test2", "test2"),
-				entry("/test3/test31", "test31"));
+		assertThat(bean.mymap).containsOnly(entry("/test1", "test1"),
+				entry("/test2", "test2"), entry("/test3/test31", "test31"));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
@@ -322,6 +322,16 @@ public class ConfigurationPropertiesTests {
 	}
 
 	@Test
+	public void loadWhenBindingToMapKeyWithForwardSlashShouldBind() {
+		load(MapProperties.class, "mymap[/test1]:test1", "mymap[/test2]:test2", "mymap[/test3/test31]:test31");
+		MapProperties bean = this.context.getBean(MapProperties.class);
+		assertThat(bean.mymap).containsOnly(
+				entry("/test1", "test1"),
+				entry("/test2", "test2"),
+				entry("/test3/test31", "test31"));
+	}
+
+	@Test
 	public void loadWhenPrefixedPropertiesAreReplacedOnBeanMethodShouldBind() {
 		load(PrefixedPropertiesReplacedOnBeanMethodConfiguration.class,
 				"external.name=bar", "spam.name=foo");


### PR DESCRIPTION
This PR adds a test case as a user guide showing how to configure keys like URL.
The proper way to configure URL alike keys in yaml should look like:

```yaml
application.yml 

shiro:
  testMap:
    "[/test1]": test1
    "[/test2]": test2
    "[/test3/test31]": test31
```

Fixes #13404 
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->