### PR TITLE
Reduce object creation in ConfigurationMetadata.findMatchingItemMetadata()

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/ConfigurationMetadata.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/ConfigurationMetadata.java
@@ -145,10 +145,11 @@ public class ConfigurationMetadata {
 	}
 
 	private ItemMetadata findMatchingItemMetadata(ItemMetadata metadata) {
-		List<ItemMetadata> candidates = getCandidates(metadata.getName());
-		if (candidates.isEmpty()) {
+		List<ItemMetadata> candidates = this.items.get(metadata.getName());
+		if (candidates == null || candidates.isEmpty()) {
 			return null;
 		}
+		candidates = new ArrayList<>(candidates);
 		candidates.removeIf((itemMetadata) -> !itemMetadata.hasSameType(metadata));
 		if (candidates.size() > 1 && metadata.getType() != null) {
 			candidates.removeIf(
@@ -163,11 +164,6 @@ public class ConfigurationMetadata {
 			}
 		}
 		return null;
-	}
-
-	private List<ItemMetadata> getCandidates(String name) {
-		List<ItemMetadata> candidates = this.items.get(name);
-		return (candidates != null ? new ArrayList<>(candidates) : new ArrayList<>());
 	}
 
 	private boolean nullSafeEquals(Object o1, Object o2) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR changes to use `Collections.emptyList()` in `ConfigurationMetadata.getCandidates()` to avoid object creation.