### PR TITLE
ZipHeaderPeekInputStream may advance its position too far when reading into a byte array

### DIFF
--- a/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/JarWriter.java
+++ b/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/JarWriter.java
@@ -364,8 +364,9 @@ public class JarWriter implements LoaderClassesWriter {
 				read = 0;
 			}
 			if (read < len) {
-				read += super.read(b, off + read, len - read);
-				this.position += read;
+				int readFromParent = super.read(b, off + read, len - read);
+				read += readFromParent;
+				this.position += readFromParent;
 			}
 			if (this.position >= this.headerLength) {
 				this.headerStream = null;


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR fixes `this.position` calculation in `JarWriter.read()` as the first `read` value looks accidentally added twice to `this.position`.