### PR TITLE
Create a different embedded database for each Datasource when using annotation AutoConfigureTestDatabase

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jdbc/TestDatabaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jdbc/TestDatabaseAutoConfiguration.java
@@ -42,6 +42,7 @@ import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
@@ -80,7 +81,7 @@ public class TestDatabaseAutoConfiguration {
 		return new EmbeddedDataSourceBeanFactoryPostProcessor();
 	}
 
-	@Order
+	@Order(Ordered.LOWEST_PRECEDENCE)
 	private static class EmbeddedDataSourceBeanFactoryPostProcessor
 			implements BeanDefinitionRegistryPostProcessor {
 
@@ -161,12 +162,12 @@ public class TestDatabaseAutoConfiguration {
 		}
 
 		@Override
-		public void afterPropertiesSet() {
+		public void afterPropertiesSet() throws Exception {
 			this.embeddedDatabase = this.factory.getEmbeddedDatabase();
 		}
 
 		@Override
-		public DataSource getObject() {
+		public DataSource getObject() throws Exception {
 			return this.embeddedDatabase;
 		}
 
@@ -190,7 +191,7 @@ public class TestDatabaseAutoConfiguration {
 			this.environment = environment;
 		}
 
-		EmbeddedDatabase getEmbeddedDatabase() {
+		public EmbeddedDatabase getEmbeddedDatabase() {
 			EmbeddedDatabaseConnection connection = this.environment.getProperty(
 					"spring.test.database.connection", EmbeddedDatabaseConnection.class,
 					EmbeddedDatabaseConnection.NONE);

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jdbc/AutoConfigureTestDatabaseWithMultipleDatasourcesIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jdbc/AutoConfigureTestDatabaseWithMultipleDatasourcesIntegrationTests.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -37,14 +38,18 @@ import static org.assertj.core.api.Assertions.assertThat;
  * datasources.
  *
  * @author Greg Potter
+ * @author Eric Bussieres
  */
 @RunWith(SpringRunner.class)
 @JdbcTest
-@AutoConfigureTestDatabase
 public class AutoConfigureTestDatabaseWithMultipleDatasourcesIntegrationTests {
 
 	@Autowired
 	private DataSource dataSource;
+
+	@Autowired
+	@Qualifier("secondaryDataSource")
+	private DataSource secondaryDataSource;
 
 	@Test
 	public void replacesDefinedDataSourceWithExplicit() throws Exception {
@@ -52,6 +57,21 @@ public class AutoConfigureTestDatabaseWithMultipleDatasourcesIntegrationTests {
 		String product = this.dataSource.getConnection().getMetaData()
 				.getDatabaseProductName();
 		assertThat(product).startsWith("H2");
+
+		String secondaryProduct = this.secondaryDataSource.getConnection().getMetaData()
+				.getDatabaseProductName();
+		assertThat(secondaryProduct).startsWith("H2");
+	}
+
+	@Test
+	public void createEmbeddedDatabaseForEachDatasource() throws Exception {
+		String dataSourceUrl = this.dataSource.getConnection().getMetaData().getURL();
+		String secondaryDataSourceUrl = this.secondaryDataSource.getConnection()
+				.getMetaData().getURL();
+
+		assertThat(dataSourceUrl).isNotEmpty();
+		assertThat(secondaryDataSourceUrl).isNotEmpty();
+		assertThat(dataSourceUrl).isNotEqualTo(secondaryDataSourceUrl);
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jdbc/AutoConfigureTestDatabaseWithMultipleDatasourcesIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jdbc/AutoConfigureTestDatabaseWithMultipleDatasourcesIntegrationTests.java
@@ -42,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @RunWith(SpringRunner.class)
 @JdbcTest
+@AutoConfigureTestDatabase
 public class AutoConfigureTestDatabaseWithMultipleDatasourcesIntegrationTests {
 
 	@Autowired


### PR DESCRIPTION
Currently, when using annotation @ AutoConfigureTestDatabase, there's only the primary datasource that trigger the creation of an embedded database.

This PR create a different embedded database for each Datasource when using annotation @ AutoConfigureTestDatabase