### PR TITLE
Support the X-Forwarded-* headers in the actuator endpoint listing

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcEndpointHandlerMapping.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcEndpointHandlerMapping.java
@@ -67,8 +67,11 @@ public class WebMvcEndpointHandlerMapping extends AbstractWebMvcEndpointHandlerM
 	@ResponseBody
 	protected Map<String, Map<String, Link>> links(HttpServletRequest request,
 			HttpServletResponse response) {
-		String requestUrl = ServletUriComponentsBuilder.fromRequest(request).build().toString();
-		return Collections.singletonMap("_links", this.linksResolver.resolveLinks(requestUrl));
+        String requestUrl = ServletUriComponentsBuilder.fromRequest(request)
+                .build()
+                .toString();
+        return Collections.singletonMap("_links", 
+                this.linksResolver.resolveLinks(requestUrl));
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcEndpointHandlerMapping.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcEndpointHandlerMapping.java
@@ -67,11 +67,11 @@ public class WebMvcEndpointHandlerMapping extends AbstractWebMvcEndpointHandlerM
 	@ResponseBody
 	protected Map<String, Map<String, Link>> links(HttpServletRequest request,
 			HttpServletResponse response) {
-        String requestUrl = ServletUriComponentsBuilder.fromRequest(request)
-                .build()
-                .toString();
-        return Collections.singletonMap("_links", 
-                this.linksResolver.resolveLinks(requestUrl));
+		String requestUrl = ServletUriComponentsBuilder.fromRequest(request)
+				.build()
+				.toString();
+		return Collections.singletonMap("_links", 
+				this.linksResolver.resolveLinks(requestUrl));
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcEndpointHandlerMapping.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcEndpointHandlerMapping.java
@@ -70,7 +70,7 @@ public class WebMvcEndpointHandlerMapping extends AbstractWebMvcEndpointHandlerM
 		String requestUrl = ServletUriComponentsBuilder.fromRequest(request)
 				.build()
 				.toString();
-		return Collections.singletonMap("_links", 
+		return Collections.singletonMap("_links",
 				this.linksResolver.resolveLinks(requestUrl));
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcEndpointHandlerMapping.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcEndpointHandlerMapping.java
@@ -31,6 +31,7 @@ import org.springframework.boot.actuate.endpoint.web.Link;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 /**
  * A custom {@link HandlerMapping} that makes web endpoints available over HTTP using
@@ -66,8 +67,8 @@ public class WebMvcEndpointHandlerMapping extends AbstractWebMvcEndpointHandlerM
 	@ResponseBody
 	protected Map<String, Map<String, Link>> links(HttpServletRequest request,
 			HttpServletResponse response) {
-		return Collections.singletonMap("_links",
-				this.linksResolver.resolveLinks(request.getRequestURL().toString()));
+		String requestUrl = ServletUriComponentsBuilder.fromRequest(request).build().toString();
+		return Collections.singletonMap("_links", this.linksResolver.resolveLinks(requestUrl));
 	}
 
 }


### PR DESCRIPTION
I am running a Spring Boot server behind a Nginx reverse proxy. Both are running inside a Docker conntainer. I had the problem, that when I opened the URL `http://proxy-host:8080/my-api/actuator`, the links contained inside where using the internal hostname `http://my-api-service:80/actuator`. For this reason, they were wrong and not clickable.

The current implementation just takes the request URL from the servlet and constructs the links from it.

By using the `ServletUriComponentsBuilder#fromRequest` method, this also works, if we are behind a reverse proxy, if it provides the correct headers(`X-Forwared-Host`, `X-Forwarded-Port`, `X-Forwarded-Prefix`).

Here is an example Nginx-Config, that this will work with:
```
server {
    ...

    location /my-api/ {
        proxy_pass http://my-api-service/;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header X-Forwarded-Host $http_host;
        proxy_set_header X-Forwarded-Prefix /my-api;
    }
}
```

Therefore the URL shown will be correct in both cases.

Thanks & kind regards