### PR TITLE
Add support for multiple RestDocs customizer

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/RestDocsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/RestDocsAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.test.autoconfigure.restdocs;
 
+import java.util.List;
+
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 
@@ -58,14 +60,16 @@ public class RestDocsAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		public MockMvcRestDocumentationConfigurer restDocsMockMvcConfigurer(
-				ObjectProvider<RestDocsMockMvcConfigurationCustomizer> configurationCustomizerProvider,
+				ObjectProvider<List<RestDocsMockMvcConfigurationCustomizer>> configurationCustomizerProvider,
 				RestDocumentationContextProvider contextProvider) {
 			MockMvcRestDocumentationConfigurer configurer = MockMvcRestDocumentation
 					.documentationConfiguration(contextProvider);
-			RestDocsMockMvcConfigurationCustomizer configurationCustomizer = configurationCustomizerProvider
+			List<RestDocsMockMvcConfigurationCustomizer> configurationCustomizers = configurationCustomizerProvider
 					.getIfAvailable();
-			if (configurationCustomizer != null) {
-				configurationCustomizer.customize(configurer);
+			if (configurationCustomizers != null) {
+				configurationCustomizers
+						.forEach((configurationCustomizer) -> configurationCustomizer
+								.customize(configurer));
 			}
 			return configurer;
 		}
@@ -90,14 +94,16 @@ public class RestDocsAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		public RequestSpecification restDocsRestAssuredConfigurer(
-				ObjectProvider<RestDocsRestAssuredConfigurationCustomizer> configurationCustomizerProvider,
+				ObjectProvider<List<RestDocsRestAssuredConfigurationCustomizer>> configurationCustomizerProvider,
 				RestDocumentationContextProvider contextProvider) {
 			RestAssuredRestDocumentationConfigurer configurer = RestAssuredRestDocumentation
 					.documentationConfiguration(contextProvider);
-			RestDocsRestAssuredConfigurationCustomizer configurationCustomizer = configurationCustomizerProvider
+			List<RestDocsRestAssuredConfigurationCustomizer> configurationCustomizers = configurationCustomizerProvider
 					.getIfAvailable();
-			if (configurationCustomizer != null) {
-				configurationCustomizer.customize(configurer);
+			if (configurationCustomizers != null) {
+				configurationCustomizers
+						.forEach((configurationCustomizer) -> configurationCustomizer
+								.customize(configurer));
 			}
 			return new RequestSpecBuilder().addFilter(configurer).build();
 		}
@@ -119,14 +125,16 @@ public class RestDocsAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		public WebTestClientRestDocumentationConfigurer restDocsWebTestClientConfigurer(
-				ObjectProvider<RestDocsWebTestClientConfigurationCustomizer> configurationCustomizerProvider,
+				ObjectProvider<List<RestDocsWebTestClientConfigurationCustomizer>> configurationCustomizerProvider,
 				RestDocumentationContextProvider contextProvider) {
 			WebTestClientRestDocumentationConfigurer configurer = WebTestClientRestDocumentation
 					.documentationConfiguration(contextProvider);
-			RestDocsWebTestClientConfigurationCustomizer configurationCustomizer = configurationCustomizerProvider
+			List<RestDocsWebTestClientConfigurationCustomizer> configurationCustomizers = configurationCustomizerProvider
 					.getIfAvailable();
-			if (configurationCustomizer != null) {
-				configurationCustomizer.customize(configurer);
+			if (configurationCustomizers != null) {
+				configurationCustomizers
+						.forEach((configurationCustomizer) -> configurationCustomizer
+								.customize(configurer));
 			}
 			return configurer;
 		}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/restdocs/RestAssuredRestDocsAutoConfigurationAdvancedConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/restdocs/RestAssuredRestDocsAutoConfigurationAdvancedConfigurationIntegrationTests.java
@@ -39,6 +39,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 /**
@@ -77,6 +79,7 @@ public class RestAssuredRestDocsAutoConfigurationAdvancedConfigurationIntegratio
 		assertThat(new File(defaultSnippetsDir, "http-request.md"))
 				.has(contentContaining("api.example.com"));
 		assertThat(new File(defaultSnippetsDir, "http-response.md")).isFile();
+		assertThat(new File(defaultSnippetsDir, "response-fields.md")).isFile();
 	}
 
 	private Condition<File> contentContaining(String toContain) {
@@ -90,6 +93,18 @@ public class RestAssuredRestDocsAutoConfigurationAdvancedConfigurationIntegratio
 		@Override
 		public void customize(RestAssuredRestDocumentationConfigurer configurer) {
 			configurer.snippets().withTemplateFormat(TemplateFormats.markdown());
+		}
+
+	}
+
+	@TestConfiguration
+	public static class CustomizationConfiguration2
+			implements RestDocsRestAssuredConfigurationCustomizer {
+
+		@Override
+		public void customize(RestAssuredRestDocumentationConfigurer configurer) {
+			configurer.snippets().withAdditionalDefaults(
+					responseFields(fieldWithPath("_links.self").description("Main URL")));
 		}
 
 	}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/restdocs/WebTestClientRestDocsAutoConfigurationAdvancedConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/restdocs/WebTestClientRestDocsAutoConfigurationAdvancedConfigurationIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,34 +24,28 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentationConfigurer;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.templates.TemplateFormats;
+import org.springframework.restdocs.webtestclient.WebTestClientRestDocumentationConfigurer;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.util.FileSystemUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
-import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 /**
- * Integration tests for advanced configuration of {@link AutoConfigureRestDocs} with Mock
- * MVC.
+ * Integration tests for {@link RestDocsAutoConfiguration} with {@link WebTestClient}.
  *
- * @author Andy Wilkinson
+ * @author Eddú Meléndez
  */
 @RunWith(SpringRunner.class)
-@WebMvcTest(controllers = RestDocsTestController.class, secure = false)
-@AutoConfigureRestDocs
-public class MockMvcRestDocsAutoConfigurationAdvancedConfigurationIntegrationTests {
+@WebFluxTest
+@AutoConfigureRestDocs(uriScheme = "https", uriHost = "api.example.com", uriPort = 443)
+public class WebTestClientRestDocsAutoConfigurationAdvancedConfigurationIntegrationTests {
 
 	@Before
 	public void deleteSnippets() {
@@ -59,21 +53,19 @@ public class MockMvcRestDocsAutoConfigurationAdvancedConfigurationIntegrationTes
 	}
 
 	@Autowired
-	private MockMvc mvc;
-
-	@Autowired
-	private RestDocumentationResultHandler documentationHandler;
+	private WebTestClient webTestClient;
 
 	@Test
-	public void snippetGeneration() throws Exception {
-		this.mvc.perform(get("/")).andDo(this.documentationHandler.document(links(
-				linkWithRel("self").description("Canonical location of this resource"))));
-		File defaultSnippetsDir = new File(
-				"target/generated-snippets/snippet-generation");
+	public void defaultSnippetsAreWritten() throws Exception {
+		this.webTestClient.get().uri("/").exchange().expectBody()
+				.consumeWith(document("default-snippets"));
+		File defaultSnippetsDir = new File("target/generated-snippets/default-snippets");
 		assertThat(defaultSnippetsDir).exists();
 		assertThat(new File(defaultSnippetsDir, "curl-request.md"))
-				.has(contentContaining("'http://localhost:8080/'"));
-		assertThat(new File(defaultSnippetsDir, "links.md")).isFile();
+				.has(contentContaining("'https://api.example.com/'"));
+		assertThat(new File(defaultSnippetsDir, "http-request.md"))
+				.has(contentContaining("api.example.com"));
+		assertThat(new File(defaultSnippetsDir, "http-response.md")).isFile();
 		assertThat(new File(defaultSnippetsDir, "response-fields.md")).isFile();
 	}
 
@@ -83,15 +75,10 @@ public class MockMvcRestDocsAutoConfigurationAdvancedConfigurationIntegrationTes
 
 	@TestConfiguration
 	public static class CustomizationConfiguration
-			implements RestDocsMockMvcConfigurationCustomizer {
-
-		@Bean
-		public RestDocumentationResultHandler restDocumentation() {
-			return MockMvcRestDocumentation.document("{method-name}");
-		}
+			implements RestDocsWebTestClientConfigurationCustomizer {
 
 		@Override
-		public void customize(MockMvcRestDocumentationConfigurer configurer) {
+		public void customize(WebTestClientRestDocumentationConfigurer configurer) {
 			configurer.snippets().withTemplateFormat(TemplateFormats.markdown());
 		}
 
@@ -99,10 +86,10 @@ public class MockMvcRestDocsAutoConfigurationAdvancedConfigurationIntegrationTes
 
 	@TestConfiguration
 	public static class CustomizationConfiguration2
-			implements RestDocsMockMvcConfigurationCustomizer {
+			implements RestDocsWebTestClientConfigurationCustomizer {
 
 		@Override
-		public void customize(MockMvcRestDocumentationConfigurer configurer) {
+		public void customize(WebTestClientRestDocumentationConfigurer configurer) {
 			configurer.snippets().withAdditionalDefaults(
 					responseFields(fieldWithPath("_links.self").description("Main URL")));
 		}


### PR DESCRIPTION
This commit introduces support for multiple customizers for RestDocsMockMvc,
RestDocsRestAssured and RestDocsWebTestClient.

See gh-13491

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->