### PR TITLE
Add reference to dozer-spring-boot-starter

### DIFF
--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -67,6 +67,9 @@ do as they were designed before this was clarified.
 | https://github.com/docker-java/docker-java/[Docker Java] and https://github.com/spotify/docker-client/[Docker Client]
 | https://github.com/jliu666/docker-api-spring-boot
 
+| https://github.com/DozerMapper/dozer[Dozer]
+| https://github.com/DozerMapper/dozer/blob/master/docs/asciidoc/documentation/springBootIntegration.adoc
+
 | ErroREST exception handler
 | https://github.com/mkopylec/errorest-spring-boot-starter
 


### PR DESCRIPTION
The [Dozer](https://github.com/DozerMapper/dozer) is the Java Bean mapper. Since the Dozer 6.2.0(current latest version), the dozer-spring-boot-starter module was added. Hence; I will introduce the it as community starter. 