### PR TITLE
Add support to set base in EmbeddedLdapAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapAutoConfiguration.java
@@ -106,6 +106,7 @@ public class EmbeddedLdapAutoConfiguration {
 			source.setUserDn(this.embeddedProperties.getCredential().getUsername());
 			source.setPassword(this.embeddedProperties.getCredential().getPassword());
 		}
+		source.setBase(this.embeddedProperties.getBaseDn().get(0));
 		source.setUrls(this.properties.determineUrls(this.environment));
 		return source;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapAutoConfigurationTests.java
@@ -133,7 +133,7 @@ public class EmbeddedLdapAutoConfigurationTests {
 					assertThat(context.getBeanNamesForType(LdapTemplate.class).length)
 							.isEqualTo(1);
 					LdapTemplate ldapTemplate = context.getBean(LdapTemplate.class);
-					assertThat(ldapTemplate.list("ou=company1,c=Sweden,dc=spring,dc=org"))
+					assertThat(ldapTemplate.list("ou=company1,c=Sweden"))
 							.hasSize(4);
 				});
 	}


### PR DESCRIPTION
Currently, full path should be present when queries are  performed.
This commit introduces support to set `base` in `EmbeddedLdapAutoConfiguration`.

By default, first entry in `spring.ldap.embedded.base-dn` will be
resolved.

See gh-11693

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->