### PR TITLE
Issue #13514 - upgraded lombok to 1.18.0

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -121,7 +121,7 @@
 		<liquibase.version>3.6.1</liquibase.version>
 		<log4j2.version>2.10.0</log4j2.version>
 		<logback.version>1.2.3</logback.version>
-		<lombok.version>1.16.22</lombok.version>
+		<lombok.version>1.18.0</lombok.version>
 		<mariadb.version>2.2.5</mariadb.version>
 		<micrometer.version>1.0.5</micrometer.version>
 		<mockito.version>2.18.3</mockito.version>


### PR DESCRIPTION
Lombok 1.16.22 introduces some issues with constructor generation (reference https://github.com/rzwitserloot/lombok/issues/1731).  These bugs are fixed in 1.18.0.