### PR TITLE
Fix query string encoding in TraceableHttpServletRequest

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/trace/servlet/TraceableHttpServletRequest.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/trace/servlet/TraceableHttpServletRequest.java
@@ -60,17 +60,14 @@ final class TraceableHttpServletRequest implements TraceableRequest {
 			return new URI(urlBuffer.toString());
 		}
 		catch (URISyntaxException ex) {
-			String encoded = UriUtils.encode(queryString, StandardCharsets.UTF_8);
+			String encoded = UriUtils.encodeQuery(queryString, StandardCharsets.UTF_8);
 			StringBuffer urlBuffer = appendQueryString(encoded);
 			return URI.create(urlBuffer.toString());
 		}
 	}
 
 	private StringBuffer appendQueryString(String queryString) {
-		StringBuffer urlBuffer = this.request.getRequestURL();
-		urlBuffer.append("?");
-		urlBuffer.append(queryString);
-		return urlBuffer;
+		return this.request.getRequestURL().append("?").append(queryString);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/web/trace/servlet/TraceableHttpServletRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/web/trace/servlet/TraceableHttpServletRequestTests.java
@@ -50,13 +50,13 @@ public class TraceableHttpServletRequestTests {
 	@Test
 	public void getUriWithSpecialCharactersInQueryStringShouldEncode() {
 		this.request.setQueryString("a=${b}");
-		validate("http://localhost/script?a%3D%24%7Bb%7D");
+		validate("http://localhost/script?a=$%7Bb%7D");
 	}
 
 	@Test
 	public void getUriWithSpecialCharactersEncodedShouldNotDoubleEncode() {
-		this.request.setQueryString("a%3D%24%7Bb%7D");
-		validate("http://localhost/script?a%3D%24%7Bb%7D");
+		this.request.setQueryString("a=$%7Bb%7D");
+		validate("http://localhost/script?a=$%7Bb%7D");
 	}
 
 	private void validate(String expectedUri) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR fixes query string encoding in `TraceableHttpServletRequest` as encoding "=" doesn't seem to be right.