### PR TITLE
Remove CompoundEnumeration in RestartClassLoader

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/classloader/RestartClassLoader.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/classloader/RestartClassLoader.java
@@ -22,7 +22,10 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -98,7 +101,10 @@ public class RestartClassLoader extends URLClassLoader implements SmartClassLoad
 				resources.nextElement();
 			}
 			if (file.getKind() != Kind.DELETED) {
-				return new CompoundEnumeration<>(createFileUrl(name, file), resources);
+				List<URL> replacedResources = new ArrayList<>();
+				replacedResources.add(createFileUrl(name, file));
+				replacedResources.addAll(Collections.list(resources));
+				return Collections.enumeration(replacedResources);
 			}
 		}
 		return resources;
@@ -192,37 +198,6 @@ public class RestartClassLoader extends URLClassLoader implements SmartClassLoad
 	@Override
 	public boolean isClassReloadable(Class<?> classType) {
 		return (classType.getClassLoader() instanceof RestartClassLoader);
-	}
-
-	/**
-	 * Compound {@link Enumeration} that adds an additional item to the front.
-	 */
-	private static class CompoundEnumeration<E> implements Enumeration<E> {
-
-		private E firstElement;
-
-		private final Enumeration<E> enumeration;
-
-		CompoundEnumeration(E firstElement, Enumeration<E> enumeration) {
-			this.firstElement = firstElement;
-			this.enumeration = enumeration;
-		}
-
-		@Override
-		public boolean hasMoreElements() {
-			return (this.firstElement != null || this.enumeration.hasMoreElements());
-		}
-
-		@Override
-		public E nextElement() {
-			if (this.firstElement == null) {
-				return this.enumeration.nextElement();
-			}
-			E element = this.firstElement;
-			this.firstElement = null;
-			return element;
-		}
-
 	}
 
 }


### PR DESCRIPTION
Hi,

this PR removes the need for a special CompoundEnumeration in RestartClassLoader and replaces it with standard JDK functionality and therefore removes a bit complexity imho.

Let me know what you think.

Cheers,
Christoph