### PR TITLE
Closing database connection properly in Liquibase Actuator Endpoint

### DIFF
--- a/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/LiquibaseEndpoint.java
+++ b/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/LiquibaseEndpoint.java
@@ -38,6 +38,7 @@ import org.springframework.util.StringUtils;
  * {@link Endpoint} to expose liquibase info.
  *
  * @author Eddú Meléndez
+ * @author Dmitrii Sergeev
  * @since 1.3.0
  */
 @ConfigurationProperties(prefix = "endpoints.liquibase")
@@ -65,9 +66,9 @@ public class LiquibaseEndpoint extends AbstractEndpoint<List<LiquibaseReport>> {
 				DataSource dataSource = entry.getValue().getDataSource();
 				JdbcConnection connection = new JdbcConnection(
 						dataSource.getConnection());
+				Database database = null;
 				try {
-					Database database = factory
-							.findCorrectDatabaseImplementation(connection);
+					database = factory.findCorrectDatabaseImplementation(connection);
 					String defaultSchema = entry.getValue().getDefaultSchema();
 					if (StringUtils.hasText(defaultSchema)) {
 						database.setDefaultSchemaName(defaultSchema);
@@ -76,7 +77,9 @@ public class LiquibaseEndpoint extends AbstractEndpoint<List<LiquibaseReport>> {
 							service.queryDatabaseChangeLogTable(database)));
 				}
 				finally {
-					connection.close();
+					if (database != null) {
+						database.close();
+					}
 				}
 			}
 			catch (Exception ex) {


### PR DESCRIPTION
The Liquibase Actuator Endpoint is not closing the connection properly--It's doing it by calling `connection.close()`, however this does not revert the `autoCommit` property which is set to `false` by Liquibase in `AbstractJdbcDatabase` class, leading to the connection returning to the pool with an ongoing transaction, which can have devastating effects since this connection is reused by the application, making all subsequent queries  execute in the context of that transaction, which remains indefinitely open(default for postgres). Once the application is terminated the transaction is rolled back destroying all changes. 

This fix addresses this by closing the `database` object which in turn closes the connection.

For more details please see: https://github.com/liquibase/liquibase/pull/63
To see how Liquibase itself closes connection on schema update at the start of the application please see `SpringLiquibase.afterPropertiesSet` method

To reproduce this issue you can simply start a Spring Boot application with Liquibase enabled and call the /liquibase actuator, then examine the active transactions in your RDBMS. For postgres it would be pg_stat_activity, you will see the state being changed from 'idle' to 'idle in transaction'.
