### PR TITLE
Liquibase Endpoint is not resetting autoCommit property

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/liquibase/LiquibaseEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/liquibase/LiquibaseEndpoint.java
@@ -44,6 +44,7 @@ import org.springframework.util.StringUtils;
  * {@link Endpoint} to expose liquibase info.
  *
  * @author Eddú Meléndez
+ * @author Dmitrii Sergeev
  * @since 2.0.0
  */
 @Endpoint(id = "liquibase")
@@ -80,8 +81,9 @@ public class LiquibaseEndpoint {
 		try {
 			DataSource dataSource = liquibase.getDataSource();
 			JdbcConnection connection = new JdbcConnection(dataSource.getConnection());
+			Database database = null;
 			try {
-				Database database = factory.findCorrectDatabaseImplementation(connection);
+				database = factory.findCorrectDatabaseImplementation(connection);
 				String defaultSchema = liquibase.getDefaultSchema();
 				if (StringUtils.hasText(defaultSchema)) {
 					database.setDefaultSchemaName(defaultSchema);
@@ -91,7 +93,9 @@ public class LiquibaseEndpoint {
 						.map(ChangeSet::new).collect(Collectors.toList()));
 			}
 			finally {
-				connection.close();
+				if (database != null) {
+					database.close();
+				}
 			}
 		}
 		catch (Exception ex) {


### PR DESCRIPTION
The Liquibase Actuator Endpoint is not closing the connection properly--It's doing it by calling `connection.close()`, however this does not revert the `autoCommit` property which is set to `false` by Liquibase in `AbstractJdbcDatabase` class, leading to the connection returning to the pool with an ongoing transaction, which has devastating effects since this connection is reused by the application, making all subsequent queries  execute in the context of that transaction, which remains indefinitely open(default for postgres). Once the application is terminated the transaction is rolled back destroying all changes. 

This fix addresses this by closing the `database` object which in turn closes the connection.

For more details please see: https://github.com/liquibase/liquibase/pull/63
To see how Liquibase itself closes connection on schema update at the start of the application please see `SpringLiquibase.afterPropertiesSet` method

To reproduce this issue you can simply start a Spring Boot application with Liquibase enabled and call the actuator, then examine the active transactions in your RDBMS. For postgres it would be pg_stat_activity, you will see the state being changed from 'idle' to 'idle in transaction' on the next database health check or any query performed by the application.

All versions of Spring Boot are affected. Here's the PR for 1.5.x: https://github.com/spring-projects/spring-boot/pull/13559