### PR TITLE
Optimize checks for java classes in Binder

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java
@@ -45,7 +45,6 @@ import org.springframework.core.convert.ConverterNotFoundException;
 import org.springframework.core.env.Environment;
 import org.springframework.format.support.DefaultFormattingConversionService;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 
 /**
  * A container object which Binds objects from one or more
@@ -354,8 +353,7 @@ public class Binder {
 		if (resolved.isPrimitive() || NON_BEAN_CLASSES.contains(resolved)) {
 			return true;
 		}
-		String packageName = ClassUtils.getPackageName(resolved);
-		return packageName.startsWith("java.");
+		return resolved.getName().startsWith("java.");
 	}
 
 	private boolean containsNoDescendantOf(Stream<ConfigurationPropertySource> sources,

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
@@ -30,7 +30,6 @@ import org.springframework.boot.context.properties.source.ConfigurationPropertyS
 import org.springframework.boot.context.properties.source.IterableConfigurationPropertySource;
 import org.springframework.core.CollectionFactory;
 import org.springframework.core.ResolvableType;
-import org.springframework.util.ClassUtils;
 
 /**
  * {@link AggregateBinder} for Maps.
@@ -199,8 +198,7 @@ class MapBinder extends AggregateBinder<Map<Object, Object>> {
 		private boolean isScalarValue(ConfigurationPropertySource source,
 				ConfigurationPropertyName name) {
 			Class<?> resolved = this.valueType.resolve(Object.class);
-			String packageName = ClassUtils.getPackageName(resolved);
-			if (!packageName.startsWith("java.lang") && !resolved.isEnum()) {
+			if (!resolved.getName().startsWith("java.lang") && !resolved.isEnum()) {
 				return false;
 			}
 			ConfigurationProperty property = source.getConfigurationProperty(name);


### PR DESCRIPTION
Hi,

just noticed two occurences of `ClassUtils.getPackageName(clazz).startsWith("java.")` that could be replaced with `clazz.getName().startsWith("java.")` and therefore saves the overhead from creating a new string via substring().

Let me know what you think.
Cheers,
Christoph