### PR TITLE
Remove hard-coded maven-resources-plugin version (2.6) in spring-boot-starter-parent POM

### DIFF
--- a/spring-boot-starters/spring-boot-starter-parent/pom.xml
+++ b/spring-boot-starters/spring-boot-starter-parent/pom.xml
@@ -123,7 +123,6 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>2.6</version>
 					<configuration>
 						<delimiters>
 							<delimiter>${resource.delimiter}</delimiter>


### PR DESCRIPTION
Removed hard-coded maven-resources-plugin version (2.6) as it overrides the one from spring-boot-dependencies (2.7). Unless there is a specific reason to do so?
Thanks!

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->