### PR TITLE
Infinispan 9.3.0 update

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -1869,11 +1869,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate</groupId>
-				<artifactId>hibernate-infinispan</artifactId>
-				<version>${hibernate.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-java8</artifactId>
 				<version>${hibernate.version}</version>
 			</dependency>
@@ -2009,7 +2004,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.infinispan</groupId>
-				<artifactId>infinispan-hibernate-cache</artifactId>
+				<artifactId>infinispan-hibernate-cache-v53</artifactId>
 				<version>${infinispan.version}</version>
 			</dependency>
 			<dependency>

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -76,7 +76,7 @@
 		<httpasyncclient.version>4.1.3</httpasyncclient.version>
 		<httpclient.version>4.5.5</httpclient.version>
 		<httpcore.version>4.4.10</httpcore.version>
-		<infinispan.version>9.1.7.Final</infinispan.version>
+		<infinispan.version>9.3.0.Final</infinispan.version>
 		<influxdb-java.version>2.9</influxdb-java.version>
 		<jackson.version>2.9.6</jackson.version>
 		<janino.version>3.0.8</janino.version>


### PR DESCRIPTION
* Update to Infinispan 9.3.0.Final.
* Remove Infinispan uber jar dependencies.
* Update to Hibernate to use Infinispan cache provider compatible with that Hibernate version.