### PR TITLE
Improve description of Endpoint exclude

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointProperties.java
@@ -81,7 +81,7 @@ public class WebEndpointProperties {
 		private Set<String> include = new LinkedHashSet<>();
 
 		/**
-		 * Endpoint IDs that should be excluded.
+		 * Endpoint IDs that should be excluded or '*' for all.
 		 */
 		private Set<String> exclude = new LinkedHashSet<>();
 


### PR DESCRIPTION
After reading the code notice that the `*` was also valid for exclusion and that was not documented as in included fields.

Example:

**ExposeExcludePropertyEndpointFilter.class**
```java
private boolean isExposed(ExposableEndpoint<?> endpoint) {
	if (this.include.isEmpty()) {
		return this.exposeDefaults.contains("*")
				|| contains(this.exposeDefaults, endpoint);
	}
	return this.include.contains("*") || contains(this.include, endpoint);
}

private boolean isExcluded(ExposableEndpoint<?> endpoint) {
	if (this.exclude.isEmpty()) {
		return false;
	}
	return this.exclude.contains("*") || contains(this.exclude, endpoint);
}
```