### PR TITLE
Remove mock from Final Class.

### DIFF
--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/RootUriRequestExpectationManagerTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/RootUriRequestExpectationManagerTests.java
@@ -86,7 +86,7 @@ public class RootUriRequestExpectationManagerTests {
 
 	@Test
 	public void expectRequestShouldDelegateToExpectationManager() {
-		ExpectedCount count = mock(ExpectedCount.class);
+		ExpectedCount count = ExpectedCount.manyTimes();
 		RequestMatcher requestMatcher = mock(RequestMatcher.class);
 		this.manager.expectRequest(count, requestMatcher);
 		verify(this.delegate).expectRequest(count, requestMatcher);


### PR DESCRIPTION
After a PR I noticed the build was broken and after some investigation noticed that we were mocking a class that become final in SpringFramework(https://github.com/spring-projects/spring-framework/commit/eeebd51#diff-c3fe703036ed412c6797be9c6099f3b7). 

Currently Mockito supports mocking final classes but just as an experimental feature (https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#unmockable), so I decided remove the mock for that class as we don't need that for that specific test.