### PR TITLE
Prevent duplicate RequestMatcher in RequestMatcherFactory.antPath()

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
@@ -299,12 +299,12 @@ public final class EndpointRequest {
 		List<RequestMatcher> antPath(String... parts) {
 			List<RequestMatcher> matchers = new ArrayList<>();
 			this.servletPaths.stream().map((p) -> {
-				if (StringUtils.hasText(p)) {
+				if (StringUtils.hasText(p) && !p.equals("/")) {
 					return p;
 				}
 				return "";
 			}).distinct().forEach((path) -> {
-				String pattern = (path.equals("/") ? "" : path);
+				String pattern = path;
 				for (String part : parts) {
 					pattern += part;
 				}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
As "/" changes to "" after `distinct()`, "" can be duplicate with one before `distinct()`. This PR moves the "/" check before `distinct()`.