### PR TITLE
Fix parameter order for RequestMatcherAssert.doesNotMatch()

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
@@ -78,14 +78,15 @@ public class EndpointRequestTests {
 	@Test
 	public void toAnyEndpointWhenServletPathNotEmptyShouldMatch() {
 		RequestMatcher matcher = EndpointRequest.toAnyEndpoint();
-		assertMatcher(matcher, "/actuator", "/spring", "/admin").matches("/actuator/foo",
-				"/spring", "/admin");
-		assertMatcher(matcher, "/actuator", "/spring", "/admin").matches("/actuator/bar",
-				"/spring", "/admin");
-		assertMatcher(matcher, "/actuator", "/spring").matches("/actuator", "/spring");
-		assertMatcher(matcher, "/actuator", "/spring").doesNotMatch("/actuator/baz",
-				"/spring");
-		assertMatcher(matcher, "/actuator", "/spring").doesNotMatch("/actuator/foo", "");
+		assertMatcher(matcher, "/actuator", "/spring", "/admin")
+				.matches(Arrays.asList("/spring", "/admin"), "/actuator/foo");
+		assertMatcher(matcher, "/actuator", "/spring", "/admin")
+				.matches(Arrays.asList("/spring", "/admin"), "/actuator/bar");
+		assertMatcher(matcher, "/actuator", "/spring").matches(Arrays.asList("/spring"),
+				"/actuator");
+		assertMatcher(matcher, "/actuator", "/spring").doesNotMatch("/spring",
+				"/actuator/baz");
+		assertMatcher(matcher, "/actuator", "/spring").doesNotMatch("", "/actuator/foo");
 	}
 
 	@Test
@@ -279,8 +280,8 @@ public class EndpointRequestTests {
 			matches(mockRequest(servletPath));
 		}
 
-		public void matches(String pathInfo, String... servletPaths) {
-			Arrays.stream(servletPaths).forEach((p) -> matches(mockRequest(p, pathInfo)));
+		public void matches(List<String> servletPaths, String pathInfo) {
+			servletPaths.forEach((p) -> matches(mockRequest(p, pathInfo)));
 		}
 
 		private void matches(HttpServletRequest request) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Callers for `RequestMatcherAssert.doesNotMatch()` have been updated to align with `RequestMatcherAssert.matches()` in fddc9e9c7e7300d93c0ba44ef702eb205326b3e2 but its signature itself hasn't been updated. This PR updates its parameter order to align with its callers.