### PR TITLE
Separate logging from getUrlMappings()

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/ServletEndpointRegistrar.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/ServletEndpointRegistrar.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.endpoint.web;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -76,18 +77,21 @@ public class ServletEndpointRegistrar implements ServletContextInitializer {
 		EndpointServlet endpointServlet = endpoint.getEndpointServlet();
 		Dynamic registration = servletContext.addServlet(name,
 				endpointServlet.getServlet());
-		registration.addMapping(getUrlMappings(endpoint.getRootPath(), name));
+		String[] urlMappings = getUrlMappings(endpoint.getRootPath());
+		registration.addMapping(urlMappings);
+		if (logger.isInfoEnabled()) {
+			Arrays.stream(urlMappings).forEach(
+					(mapping) -> logger.info("Registered '" + mapping + "' to " + name));
+		}
 		registration.setInitParameters(endpointServlet.getInitParameters());
 	}
 
-	private String[] getUrlMappings(String endpointPath, String name) {
-		return this.basePaths
-				.stream().map((basePath) -> (basePath != null
-						? basePath + "/" + endpointPath : "/" + endpointPath))
-				.distinct().map((path) -> {
-					logger.info("Registered '" + path + "' to " + name);
-					return (path.endsWith("/") ? path + "*" : path + "/*");
-				}).toArray(String[]::new);
+	private String[] getUrlMappings(String endpointPath) {
+		return this.basePaths.stream()
+				.map((basePath) -> (basePath != null ? basePath + "/" + endpointPath
+						: "/" + endpointPath))
+				.distinct().map((path) -> (path.endsWith("/") ? path + "*" : path + "/*"))
+				.toArray(String[]::new);
 	}
 
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Logging in "get*" methods doesn't seem usual, so this PR separates it from `getUrlMappings()` and places it to a similar place as before fddc9e9c7e7300d93c0ba44ef702eb205326b3e2.