### PR TITLE
Split compound if statement in two so that Graal's native image builder is happy

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/BeanDefinitionLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/BeanDefinitionLoader.java
@@ -147,12 +147,13 @@ class BeanDefinitionLoader {
 	}
 
 	private int load(Class<?> source) {
-		if (isGroovyPresent()
-				&& GroovyBeanDefinitionSource.class.isAssignableFrom(source)) {
-			// Any GroovyLoaders added in beans{} DSL can contribute beans here
-			GroovyBeanDefinitionSource loader = BeanUtils.instantiateClass(source,
-					GroovyBeanDefinitionSource.class);
-			load(loader);
+		if (isGroovyPresent()) {
+			if (GroovyBeanDefinitionSource.class.isAssignableFrom(source)) {
+				// Any GroovyLoaders added in beans{} DSL can contribute beans here
+				GroovyBeanDefinitionSource loader = BeanUtils.instantiateClass(source,
+						GroovyBeanDefinitionSource.class);
+				load(loader);
+			}
 		}
 		if (isComponent(source)) {
 			this.annotatedReader.register(source);


### PR DESCRIPTION
Some static analysis tools will barf on BeanDefinitionLoader when Groovy is not on the classpath (e.g. Graal VM native image builder). The problem can be avoided just by nesting the "if" clause containing the Groovy reference inside a defensive outer "if".