### PR TITLE
Use PropertySources.stream() where possible

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/EnvironmentEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/EnvironmentEndpointDocumentationTests.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -156,8 +155,7 @@ public class EnvironmentEndpointDocumentationTests
 				@Override
 				protected void customizePropertySources(
 						MutablePropertySources propertySources) {
-					StreamSupport
-							.stream(environment.getPropertySources().spliterator(), false)
+					environment.getPropertySources().stream()
 							.filter(this::includedPropertySource)
 							.forEach(propertySources::addLast);
 				}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/CompositePropertySources.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/CompositePropertySources.java
@@ -41,8 +41,7 @@ final class CompositePropertySources implements PropertySources {
 
 	@Override
 	public Iterator<PropertySource<?>> iterator() {
-		return this.propertySources.stream()
-				.flatMap(PropertySources::stream)
+		return this.propertySources.stream().flatMap(PropertySources::stream)
 				.collect(Collectors.toList()).iterator();
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/CompositePropertySources.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/CompositePropertySources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.PropertySources;
@@ -43,7 +42,7 @@ final class CompositePropertySources implements PropertySources {
 	@Override
 	public Iterator<PropertySource<?>> iterator() {
 		return this.propertySources.stream()
-				.flatMap((sources) -> StreamSupport.stream(sources.spliterator(), false))
+				.flatMap(PropertySources::stream)
 				.collect(Collectors.toList()).iterator();
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/FilteredPropertySources.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/FilteredPropertySources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.stream.StreamSupport;
 
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.PropertySources;
@@ -59,8 +58,7 @@ final class FilteredPropertySources implements PropertySources {
 
 	@Override
 	public Iterator<PropertySource<?>> iterator() {
-		return StreamSupport.stream(this.delegate.spliterator(), false)
-				.filter(this::included).iterator();
+		return this.delegate.stream().filter(this::included).iterator();
 	}
 
 	private boolean included(PropertySource<?> propertySource) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertySources.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertySources.java
@@ -18,13 +18,13 @@ package org.springframework.boot.context.properties.source;
 
 import java.util.Collections;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.PropertySource.StubPropertySource;
+import org.springframework.core.env.PropertySources;
 import org.springframework.core.env.PropertySourcesPropertyResolver;
 import org.springframework.util.Assert;
 
@@ -136,8 +136,8 @@ public final class ConfigurationPropertySources {
 	}
 
 	private static Stream<PropertySource<?>> streamPropertySources(
-			Iterable<PropertySource<?>> sources) {
-		return StreamSupport.stream(sources.spliterator(), false)
+			PropertySources sources) {
+		return sources.stream()
 				.flatMap(ConfigurationPropertySources::flatten)
 				.filter(ConfigurationPropertySources::isIncluded);
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertySources.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertySources.java
@@ -137,8 +137,7 @@ public final class ConfigurationPropertySources {
 
 	private static Stream<PropertySource<?>> streamPropertySources(
 			PropertySources sources) {
-		return sources.stream()
-				.flatMap(ConfigurationPropertySources::flatten)
+		return sources.stream().flatMap(ConfigurationPropertySources::flatten)
 				.filter(ConfigurationPropertySources::isIncluded);
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/InvalidConfigurationPropertyValueFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/InvalidConfigurationPropertyValueFailureAnalyzer.java
@@ -16,11 +16,9 @@
 
 package org.springframework.boot.diagnostics.analyzer;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
 import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
@@ -74,9 +72,10 @@ class InvalidConfigurationPropertyValueFailureAnalyzer
 	}
 
 	private Stream<PropertySource<?>> getPropertySources() {
-		Iterable<PropertySource<?>> sources = (this.environment != null
-				? this.environment.getPropertySources() : Collections.emptyList());
-		return StreamSupport.stream(sources.spliterator(), false)
+		if (this.environment == null) {
+			return Stream.empty();
+		}
+		return this.environment.getPropertySources().stream()
 				.filter((source) -> !ConfigurationPropertySources
 						.isAttachedConfigurationPropertySource(source));
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/SpringApplicationJsonEnvironmentPostProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/SpringApplicationJsonEnvironmentPostProcessor.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.StreamSupport;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -92,7 +91,7 @@ public class SpringApplicationJsonEnvironmentPostProcessor
 	public void postProcessEnvironment(ConfigurableEnvironment environment,
 			SpringApplication application) {
 		MutablePropertySources propertySources = environment.getPropertySources();
-		StreamSupport.stream(propertySources.spliterator(), false)
+		propertySources.stream()
 				.map(JsonPropertyValue::get).filter(Objects::nonNull).findFirst()
 				.ifPresent((v) -> processJson(environment, v));
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/SpringApplicationJsonEnvironmentPostProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/SpringApplicationJsonEnvironmentPostProcessor.java
@@ -91,9 +91,8 @@ public class SpringApplicationJsonEnvironmentPostProcessor
 	public void postProcessEnvironment(ConfigurableEnvironment environment,
 			SpringApplication application) {
 		MutablePropertySources propertySources = environment.getPropertySources();
-		propertySources.stream()
-				.map(JsonPropertyValue::get).filter(Objects::nonNull).findFirst()
-				.ifPresent((v) -> processJson(environment, v));
+		propertySources.stream().map(JsonPropertyValue::get).filter(Objects::nonNull)
+				.findFirst().ifPresent((v) -> processJson(environment, v));
 	}
 
 	private void processJson(ConfigurableEnvironment environment,


### PR DESCRIPTION
Hi,

based on a report of  mine in the Spring-Framework (see [SPR-16894](https://jira.spring.io/projects/SPR/issues/SPR-16894)) we can now use `PropertySources.stream()` instead of `StreamSupport.stream(sources.spliterator(), false)`. This PR adapts the Boot code to the new functionality.

Let me know what you think.
Cheers,
Christoph