### PR TITLE
Fix API adaptation changes for Reactor Netty

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/SslServerCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/SslServerCustomizer.java
@@ -26,6 +26,7 @@ import javax.net.ssl.TrustManagerFactory;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContextBuilder;
 import reactor.netty.http.server.HttpServer;
+import reactor.netty.tcp.SslProvider.DefaultConfigurationType;
 
 import org.springframework.boot.web.server.Ssl;
 import org.springframework.boot.web.server.SslStoreProvider;
@@ -52,7 +53,8 @@ public class SslServerCustomizer implements NettyServerCustomizer {
 	public HttpServer apply(HttpServer server) {
 		try {
 			return server
-					.secure((contextSpec) -> contextSpec.sslContext(getContextBuilder()));
+					.secure((contextSpec) -> contextSpec.sslContext(getContextBuilder())
+							.defaultConfiguration(DefaultConfigurationType.NONE));
 		}
 		catch (Exception ex) {
 			throw new IllegalStateException(ex);


### PR DESCRIPTION
Hi,

while working on two PRs in the last days I noticed failures in `NettyReactiveWebServerFactoryTests`. This PR is an attempt to fix them after commit 68a3c234bed2f8b01de8ec100cf1c01645a0365b adapted to the API changes in https://github.com/reactor/reactor-netty/issues/370, but imho misses to disable the default configuration and to therefore restore the previous behaviour.

Let me know what you think.

Cheers,
Christoph 