### PR TITLE
Remove @since tag from getServlet()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletRegistrationBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletRegistrationBean.java
@@ -112,7 +112,6 @@ public class ServletRegistrationBean<T extends Servlet>
 	/**
 	 * Return the servlet being registered.
 	 * @return the servlet
-	 * @since 2.0.4
 	 */
 	public T getServlet() {
 		return this.servlet;


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
> If a member changes from protected to public in a later release, the `@since` tag would not change, even though it is now usable by any caller, not just subclassers.

Based on the above description, it looks `@since` tag could be removed.

See http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html#@since