### PR TITLE
Remove a List creation in CompositePropertySources.iterator()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/CompositePropertySources.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/CompositePropertySources.java
@@ -19,7 +19,6 @@ package org.springframework.boot.context.properties;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.PropertySources;
@@ -41,8 +40,7 @@ final class CompositePropertySources implements PropertySources {
 
 	@Override
 	public Iterator<PropertySource<?>> iterator() {
-		return this.propertySources.stream().flatMap(PropertySources::stream)
-				.collect(Collectors.toList()).iterator();
+		return this.propertySources.stream().flatMap(PropertySources::stream).iterator();
 	}
 
 	@Override


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR removes a `List` creation in `CompositePropertySources.iterator()` as it doesn't seem necessary.