### PR TITLE
Remove carriage returns in TypeUtils.getJavaDoc()

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
@@ -142,8 +142,7 @@ class TypeUtils {
 		String javadoc = (element != null
 				? this.env.getElementUtils().getDocComment(element) : null);
 		if (javadoc != null) {
-			javadoc = javadoc.replaceAll("\\n", "");
-			javadoc = javadoc.trim();
+			javadoc = javadoc.replaceAll("[\r\n]+", "").trim();
 		}
 		return ("".equals(javadoc) ? null : javadoc);
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -222,7 +222,7 @@ public class ConfigurationMetadataAnnotationProcessorTests {
 		assertThat(metadata).has(Metadata
 				.withProperty("description.multi-line", String.class)
 				.fromSource(DescriptionProperties.class).withDescription(
-						"This is a lengthy description that spans across multiple lines to showcase that the carriage return is cleaned automatically."));
+						"This is a lengthy description that spans across multiple lines to showcase that the line separators are cleaned automatically."));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/DescriptionProperties.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/DescriptionProperties.java
@@ -33,7 +33,7 @@ public class DescriptionProperties {
 
 	/**
 	 * This is a lengthy description that spans across multiple lines to showcase that the
-	 * carriage return is cleaned automatically.
+	 * line separators are cleaned automatically.
 	 */
 	private String multiLine;
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR changes to use system-dependent line separator in `TypeUtils.getJavaDoc()`.