### PR TITLE
Anonymous exception leads to empty exception tags in WebMvc/WebFlux metrics

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTags.java
@@ -109,7 +109,8 @@ public final class WebFluxTags {
 	 */
 	public static Tag exception(Throwable exception) {
 		if (exception != null) {
-			return Tag.of("exception", exception.getClass().getSimpleName());
+			String simpleName = exception.getClass().getSimpleName();
+			return Tag.of("exception", simpleName.isEmpty() ? exception.getClass().getName() : simpleName);
 		}
 		return EXCEPTION_NONE;
 	}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcTags.java
@@ -134,9 +134,11 @@ public final class WebMvcTags {
 	 * @return the exception tag derived from the exception
 	 */
 	public static Tag exception(Throwable exception) {
-		return (exception != null
-				? Tag.of("exception", exception.getClass().getSimpleName())
-				: EXCEPTION_NONE);
+		if (exception != null) {
+			String simpleName = exception.getClass().getSimpleName();
+			return Tag.of("exception", simpleName.isEmpty() ? exception.getClass().getName() : simpleName);
+		}
+		return EXCEPTION_NONE;
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/MetricsWebFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/MetricsWebFilterTests.java
@@ -77,6 +77,26 @@ public class MetricsWebFilterTests {
 				}).block();
 		assertMetricsContainsTag("uri", "/projects/{project}");
 		assertMetricsContainsTag("status", "500");
+		assertMetricsContainsTag("exception", "IllegalStateException");
+	}
+
+	@Test
+	public void filterAddsNonEmptyTagsToRegistryForAnonymousExceptions() {
+		final Exception anonymous = new Exception("test error") {};
+
+		MockServerWebExchange exchange = createExchange("/projects/spring-boot",
+				"/projects/{project}");
+		this.webFilter
+				.filter(exchange,
+						(serverWebExchange) -> Mono
+								.error(anonymous))
+				.onErrorResume((t) -> {
+					exchange.getResponse().setStatusCodeValue(500);
+					return exchange.getResponse().setComplete();
+				}).block();
+		assertMetricsContainsTag("uri", "/projects/{project}");
+		assertMetricsContainsTag("status", "500");
+		assertMetricsContainsTag("exception", anonymous.getClass().getName());
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilterTests.java
@@ -189,6 +189,18 @@ public class WebMvcMetricsFilterTests {
 	}
 
 	@Test
+	public void anonymousError() throws Exception {
+		try {
+			mvc.perform(get("/api/c1/anonymousError/10"));
+		} catch(Throwable ignore) {
+		}
+
+		assertThat(this.registry.get("http.server.requests").tag("uri", "/api/c1/anonymousError/{id}").timer().getId()
+				.getTag("exception"))
+				.endsWith("$1");
+	}
+
+	@Test
 	public void asyncCallableRequest() throws Exception {
 		AtomicReference<MvcResult> result = new AtomicReference<>();
 		Thread backgroundRequest = new Thread(() -> {
@@ -438,6 +450,12 @@ public class WebMvcMetricsFilterTests {
 		@GetMapping("/error/{id}")
 		public String alwaysThrowsException(@PathVariable Long id) {
 			throw new IllegalStateException("Boom on " + id + "!");
+		}
+
+		@Timed
+		@GetMapping("/anonymousError/{id}")
+		public String alwaysThrowsAnonymousException(@PathVariable Long id) throws Exception {
+			throw new Exception("this exception won't have a simple class name") {};
 		}
 
 		@Timed


### PR DESCRIPTION
Empty tag values are rejected by some monitoring systems.

See https://github.com/micrometer-metrics/micrometer/issues/680.