### PR TITLE
Add null guards for getBeanDefinition() in BeanTypeRegistry

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/BeanTypeRegistry.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/BeanTypeRegistry.java
@@ -155,7 +155,10 @@ final class BeanTypeRegistry implements SmartInitializingSingleton {
 	}
 
 	private void addBeanTypeForNonAliasDefinition(String name) {
-		addBeanTypeForNonAliasDefinition(name, getBeanDefinition(name));
+		RootBeanDefinition beanDefinition = getBeanDefinition(name);
+		if (beanDefinition != null) {
+			addBeanTypeForNonAliasDefinition(name, beanDefinition);
+		}
 	}
 
 	private RootBeanDefinition getBeanDefinition(String name) {
@@ -215,11 +218,13 @@ final class BeanTypeRegistry implements SmartInitializingSingleton {
 				if (!this.beanFactory.isAlias(name)
 						&& !this.beanFactory.containsSingleton(name)) {
 					RootBeanDefinition beanDefinition = getBeanDefinition(name);
-					RootBeanDefinition existingDefinition = this.beanDefinitions.put(name,
-							beanDefinition);
-					if (existingDefinition != null
-							&& !beanDefinition.equals(existingDefinition)) {
-						addBeanTypeForNonAliasDefinition(name, beanDefinition);
+					if (beanDefinition != null) {
+						RootBeanDefinition existingDefinition = this.beanDefinitions
+								.put(name, beanDefinition);
+						if (existingDefinition != null
+								&& !beanDefinition.equals(existingDefinition)) {
+							addBeanTypeForNonAliasDefinition(name, beanDefinition);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR adds `null` guards for `getBeanDefinition()` in `BeanTypeRegistry` as it could cause NPEs. It looks missed in 6dc14af92dbfa7b5281072d9fdde241ce0da3679.