### PR TITLE
Upgrade to Micrometer 1.0.6

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxProperties.java
@@ -58,6 +58,21 @@ public class InfluxProperties extends StepRegistryProperties {
 	private String retentionPolicy;
 
 	/**
+	 * Time period for which influx should retain data in the current database (e.g. 2h, 52w)
+	 */
+	private String retentionDuration;
+
+	/**
+	 * How many copies of the data are stored in the cluster. Must be 1 for a single node instance.
+	 */
+	private Integer retentionReplicationFactor;
+
+	/**
+	 * The time range covered by a shard group (e.g. 2h, 52w).
+	 */
+	private String retentionShardDuration;
+
+	/**
 	 * URI of the Influx server.
 	 */
 	private String uri = "http://localhost:8086";
@@ -137,4 +152,27 @@ public class InfluxProperties extends StepRegistryProperties {
 		this.autoCreateDb = autoCreateDb;
 	}
 
+	public String getRetentionDuration() {
+		return retentionDuration;
+	}
+
+	public void setRetentionDuration(String retentionDuration) {
+		this.retentionDuration = retentionDuration;
+	}
+
+	public Integer getRetentionReplicationFactor() {
+		return retentionReplicationFactor;
+	}
+
+	public void setRetentionReplicationFactor(Integer retentionReplicationFactor) {
+		this.retentionReplicationFactor = retentionReplicationFactor;
+	}
+
+	public String getRetentionShardDuration() {
+		return retentionShardDuration;
+	}
+
+	public void setRetentionShardDuration(String retentionShardDuration) {
+		this.retentionShardDuration = retentionShardDuration;
+	}
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxPropertiesConfigAdapter.java
@@ -61,6 +61,24 @@ class InfluxPropertiesConfigAdapter extends
 	}
 
 	@Override
+	public Integer retentionReplicationFactor() {
+		return get(InfluxProperties::getRetentionReplicationFactor,
+				InfluxConfig.super::retentionReplicationFactor);
+	}
+
+	@Override
+	public String retentionDuration() {
+		return get(InfluxProperties::getRetentionDuration,
+				InfluxConfig.super::retentionDuration);
+	}
+
+	@Override
+	public String retentionShardDuration() {
+		return get(InfluxProperties::getRetentionShardDuration,
+				InfluxConfig.super::retentionShardDuration);
+	}
+
+	@Override
 	public String uri() {
 		return get(InfluxProperties::getUri, InfluxConfig.super::uri);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/signalfx/SignalFxPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/signalfx/SignalFxPropertiesConfigAdapter.java
@@ -32,6 +32,7 @@ public class SignalFxPropertiesConfigAdapter
 
 	public SignalFxPropertiesConfigAdapter(SignalFxProperties properties) {
 		super(properties);
+		accessToken(); // validate that an access token is set
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -122,7 +122,7 @@
 		<logback.version>1.2.3</logback.version>
 		<lombok.version>1.16.22</lombok.version>
 		<mariadb.version>2.2.5</mariadb.version>
-		<micrometer.version>1.0.5</micrometer.version>
+		<micrometer.version>1.0.6</micrometer.version>
 		<mockito.version>2.15.0</mockito.version>
 		<mongo-driver-reactivestreams.version>1.7.1</mongo-driver-reactivestreams.version>
 		<mongodb.version>3.6.4</mongodb.version>


### PR DESCRIPTION
Resolves #13746.

A couple notes:

1. Authorization key access has shifted to be lazily evaluated on each publish internally in push-based registries that require them. The purpose of this was to allow users to rotate keys at runtime.

2. This PR contains two commits, the second of which adds 3 new properties to the configuration of InfluxDB. While I'd typically reserve additions like this for a minor release, I think that these properties were an "error of omission" earlier. We've gotten feedback that retention policy is a critical thing to configure on any production Influx database. If you decide not to allow this in 2.0.4, please cherry pick to the master branch or I can open a separate PR.