### PR TITLE
Upgrade classmate version to 1.4.0

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -44,7 +44,7 @@
 		<byte-buddy.version>1.8.13</byte-buddy.version>
 		<caffeine.version>2.6.2</caffeine.version>
 		<cassandra-driver.version>3.5.1</cassandra-driver.version>
-		<classmate.version>1.3.4</classmate.version>
+		<classmate.version>1.4.0</classmate.version>
 		<commons-codec.version>1.11</commons-codec.version>
 		<commons-dbcp2.version>2.5.0</commons-dbcp2.version>
 		<commons-lang3.version>3.7</commons-lang3.version>


### PR DESCRIPTION
The classmate dependency version was not reflected for a long time (1.3.4 -> 1.4.0) so I updated it.

I tried contribution for the first time, but please point out any mistakes.