### PR TITLE
Fix OAuth2WebSecurityConfigurationTests

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/client/servlet/OAuth2WebSecurityConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/client/servlet/OAuth2WebSecurityConfigurationTests.java
@@ -85,12 +85,7 @@ public class OAuth2WebSecurityConfigurationTests {
 	public void configurationRegistersAuthorizedClientServiceBean() {
 		this.contextRunner.withUserConfiguration(ClientRepositoryConfiguration.class,
 				OAuth2WebSecurityConfiguration.class).run((context) -> {
-					OAuth2AuthorizedClientService bean = context
-							.getBean(OAuth2AuthorizedClientService.class);
-					OAuth2AuthorizedClientService authorizedClientService = (OAuth2AuthorizedClientService) ReflectionTestUtils
-							.getField(getAuthCodeFilters(context).get(0),
-									"authorizedClientService");
-					assertThat(authorizedClientService).isEqualTo(bean);
+					assertThat(context).hasSingleBean(OAuth2AuthorizedClientService.class);
 				});
 	}
 
@@ -110,12 +105,9 @@ public class OAuth2WebSecurityConfigurationTests {
 				.withUserConfiguration(OAuth2AuthorizedClientServiceConfiguration.class,
 						OAuth2WebSecurityConfiguration.class)
 				.run((context) -> {
-					OAuth2AuthorizedClientService bean = context
-							.getBean(OAuth2AuthorizedClientService.class);
-					OAuth2AuthorizedClientService authorizedClientService = (OAuth2AuthorizedClientService) ReflectionTestUtils
-							.getField(getAuthCodeFilters(context).get(0),
-									"authorizedClientService");
-					assertThat(authorizedClientService).isEqualTo(bean);
+					assertThat(context)
+							.hasSingleBean(OAuth2AuthorizedClientService.class);
+					assertThat(context).hasBean("testAuthorizedClientService");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/client/servlet/OAuth2WebSecurityConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/client/servlet/OAuth2WebSecurityConfigurationTests.java
@@ -85,7 +85,8 @@ public class OAuth2WebSecurityConfigurationTests {
 	public void configurationRegistersAuthorizedClientServiceBean() {
 		this.contextRunner.withUserConfiguration(ClientRepositoryConfiguration.class,
 				OAuth2WebSecurityConfiguration.class).run((context) -> {
-					assertThat(context).hasSingleBean(OAuth2AuthorizedClientService.class);
+					assertThat(context)
+							.hasSingleBean(OAuth2AuthorizedClientService.class);
 				});
 	}
 


### PR DESCRIPTION
Hi,

this PR attempts to fix the currently failing OAuth2WebSecurityConfigurationTests that are broken due to the changes in https://github.com/spring-projects/spring-security/commit/9a144d742eca681e83b2a70be2654c501dab7313

I aligned the tests to their ReactiveOAuth2WebSecurityConfigurationTests counterparts that don't rely on reflection and specific fields.

Let me know what you think.
Cheers,
Christoph