### PR TITLE
Make SpringBootConfigurationFinder public and usable with other annot…

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
@@ -33,7 +33,7 @@ import org.springframework.util.ClassUtils;
  *  Utility class to scan for a {@link SpringBootConfiguration} or custom annotation.
  *
  * @author Phillip Webb
- * @since 2.0.0
+ * @since 2.1.0
  */
 public final class SpringBootConfigurationFinder {
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
@@ -33,7 +33,7 @@ import org.springframework.util.ClassUtils;
  *  Utility class to scan for a {@link SpringBootConfiguration} or custom annotation.
  *
  * @author Phillip Webb
- * @author Artsiom Yudovin 
+ * @author Artsiom Yudovin
  * @since 2.1.0
  */
 public final class SpringBootConfigurationFinder {

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.test.context;
 
+import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -33,17 +34,24 @@ import org.springframework.util.ClassUtils;
  *
  * @author Phillip Webb
  */
-final class SpringBootConfigurationFinder {
+public final class SpringBootConfigurationFinder {
 
 	private static final Map<String, Class<?>> cache = Collections
 			.synchronizedMap(new Cache(40));
 
 	private final ClassPathScanningCandidateComponentProvider scanner;
 
-	SpringBootConfigurationFinder() {
+	public SpringBootConfigurationFinder() {
 		this.scanner = new ClassPathScanningCandidateComponentProvider(false);
 		this.scanner.addIncludeFilter(
 				new AnnotationTypeFilter(SpringBootConfiguration.class));
+		this.scanner.setResourcePattern("*.class");
+	}
+
+	public SpringBootConfigurationFinder(Class<? extends Annotation> annotationType) {
+		this.scanner = new ClassPathScanningCandidateComponentProvider(false);
+		this.scanner.addIncludeFilter(
+				new AnnotationTypeFilter(annotationType));
 		this.scanner.setResourcePattern("*.class");
 	}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
@@ -33,6 +33,7 @@ import org.springframework.util.ClassUtils;
  *  Utility class to scan for a {@link SpringBootConfiguration} or custom annotation.
  *
  * @author Phillip Webb
+ * @author Artsiom Yudovin 
  * @since 2.1.0
  */
 public final class SpringBootConfigurationFinder {

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
@@ -30,7 +30,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
 /**
- *  Utility class to scan for a {@link SpringBootConfiguration} or your custom annotation.
+ *  Utility class to scan for a {@link SpringBootConfiguration} or custom annotation.
  *
  * @author Phillip Webb
  * @since 2.0.0

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootConfigurationFinder.java
@@ -30,9 +30,10 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
 /**
- * Internal utility class to scan for a {@link SpringBootConfiguration} class.
+ *  Utility class to scan for a {@link SpringBootConfiguration} or your custom annotation.
  *
  * @author Phillip Webb
+ * @since 2.0.0
  */
 public final class SpringBootConfigurationFinder {
 
@@ -41,13 +42,17 @@ public final class SpringBootConfigurationFinder {
 
 	private final ClassPathScanningCandidateComponentProvider scanner;
 
+	/**
+	 * Default constructor initializing finder to scan for a {@link SpringBootConfiguration} annotation.
+	 */
 	public SpringBootConfigurationFinder() {
-		this.scanner = new ClassPathScanningCandidateComponentProvider(false);
-		this.scanner.addIncludeFilter(
-				new AnnotationTypeFilter(SpringBootConfiguration.class));
-		this.scanner.setResourcePattern("*.class");
+		this(SpringBootConfiguration.class);
 	}
 
+	/**
+	 * Customiable constructor allow to provide the custom annotation to scan for.
+	 * @param annotationType Annotation to scan for.
+	 */
 	public SpringBootConfigurationFinder(Class<? extends Annotation> annotationType) {
 		this.scanner = new ClassPathScanningCandidateComponentProvider(false);
 		this.scanner.addIncludeFilter(


### PR DESCRIPTION
Make SpringBootConfigurationFinder public and usable with other annotations. I hope that I understand the goal of this [enhancement](https://github.com/spring-projects/spring-boot/issues/13713) right. 
