### PR TITLE
Fix unchecked assignment in AutoConfigurationImportSelector

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelector.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelector.java
@@ -489,8 +489,8 @@ public class AutoConfigurationImportSelector
 		private final Set<String> exclusions;
 
 		private AutoConfigurationEntry() {
-			this.configurations = Collections.EMPTY_LIST;
-			this.exclusions = Collections.EMPTY_SET;
+			this.configurations = Collections.emptyList();
+			this.exclusions = Collections.emptySet();
 		}
 
 		/**


### PR DESCRIPTION
Hi,

this trivial PR replaces the usage of `Collections.EMPTY_(SET|LIST)` with `Collections.empty(Set|List)()` in AutoConfigurationImportSelector and therefore gets rid of some unchecked assignment warnings.

Cheers,
Christoph