### PR TITLE
make RabbitTemplate default receive queue configurable

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -190,6 +190,7 @@ public class RabbitAutoConfiguration {
 					.to(template::setReplyTimeout);
 			map.from(properties::getExchange).to(template::setExchange);
 			map.from(properties::getRoutingKey).to(template::setRoutingKey);
+			map.from(properties::getQueue).whenNonNull().to(template::setQueue);
 			return template;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -79,6 +79,7 @@ import org.springframework.context.annotation.Import;
  * @author Stephane Nicoll
  * @author Gary Russell
  * @author Phillip Webb
+ * @author Artsiom Yudovin
  */
 @Configuration
 @ConditionalOnClass({ RabbitTemplate.class, Channel.class })

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -713,6 +713,11 @@ public class RabbitProperties {
 		 */
 		private String routingKey = "";
 
+		/**
+		 * The default queue name that will be used for synchronous receives.
+		 */
+		private String queue;
+
 		public Retry getRetry() {
 			return this.retry;
 		}
@@ -757,6 +762,13 @@ public class RabbitProperties {
 			this.routingKey = routingKey;
 		}
 
+		public String getQueue() {
+			return queue;
+		}
+
+		public void setQueue(String queue) {
+			this.queue = queue;
+		}
 	}
 
 	public static class Retry {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -770,6 +770,7 @@ public class RabbitProperties {
 		public void setQueue(String queue) {
 			this.queue = queue;
 		}
+
 	}
 
 	public static class Retry {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -764,7 +764,7 @@ public class RabbitProperties {
 		}
 
 		public String getQueue() {
-			return queue;
+			return this.queue;
 		}
 
 		public void setQueue(String queue) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
  * @author Andy Wilkinson
  * @author Josh Thornhill
  * @author Gary Russell
+ * @author Artsiom Yudovin
  */
 @ConfigurationProperties(prefix = "spring.rabbitmq")
 public class RabbitProperties {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -714,7 +714,7 @@ public class RabbitProperties {
 		private String routingKey = "";
 
 		/**
-		 * The default queue name that will be used for synchronous receives.
+		 * Default queue name that will be used for synchronous receives.
 		 */
 		private String queue;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -62,6 +62,7 @@ import org.springframework.retry.interceptor.MethodInvocationRecoverer;
 import org.springframework.retry.policy.NeverRetryPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -316,6 +317,17 @@ public class RabbitAutoConfigurationTests {
 					assertThat(rabbitTemplate.getExchange()).isEqualTo("my-exchange");
 					assertThat(rabbitTemplate.getRoutingKey())
 							.isEqualTo("my-routing-key");
+				});
+	}
+
+	@Test
+	public void testRabbitTemplateDefaultQueue() {
+		this.contextRunner.withUserConfiguration(TestConfiguration.class)
+				.withPropertyValues("spring.rabbitmq.template.queue:default-queue")
+				.run((context) -> {
+					RabbitTemplate rabbitTemplate = context.getBean(RabbitTemplate.class);
+					assertThat(ReflectionTestUtils.getField(rabbitTemplate, "queue"))
+							.isEqualTo("default-queue");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -1166,6 +1166,7 @@ content into your application. Rather, pick only the properties that you need.
 	spring.rabbitmq.template.retry.max-interval=10000ms # Maximum duration between attempts.
 	spring.rabbitmq.template.retry.multiplier=1 # Multiplier to apply to the previous retry interval.
 	spring.rabbitmq.template.routing-key= # Value of a default routing key to use for send operations.
+	spring.rabbitmq.template.queue= # Value of a default queue name that will be used for synchronous receives.
 	spring.rabbitmq.username=guest # Login user to authenticate to the broker.
 	spring.rabbitmq.virtual-host= # Virtual host to use when connecting to the broker.
 


### PR DESCRIPTION
Make RabbitTemplate default receive queue configurable. 
this [enhancement](https://github.com/spring-projects/spring-boot/issues/11820)