### PR TITLE
Expose [a few] devtools classes as public classes

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/ConditionEvaluationDeltaLoggingListener.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/ConditionEvaluationDeltaLoggingListener.java
@@ -30,7 +30,7 @@ import org.springframework.context.ApplicationListener;
  *
  * @author Andy Wilkinson
  */
-class ConditionEvaluationDeltaLoggingListener
+public class ConditionEvaluationDeltaLoggingListener
 		implements ApplicationListener<ApplicationReadyEvent> {
 
 	private final Log logger = LogFactory.getLog(getClass());

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/FileWatchingFailureHandler.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/FileWatchingFailureHandler.java
@@ -32,7 +32,7 @@ import org.springframework.boot.devtools.restart.Restarter;
  *
  * @author Phillip Webb
  */
-class FileWatchingFailureHandler implements FailureHandler {
+public class FileWatchingFailureHandler implements FailureHandler {
 
 	private final FileSystemWatcherFactory fileSystemWatcherFactory;
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/HateoasObjenesisCacheDisabler.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/HateoasObjenesisCacheDisabler.java
@@ -34,7 +34,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Andy Wilkinson
  * @since 1.3.0
  */
-class HateoasObjenesisCacheDisabler implements InitializingBean {
+public class HateoasObjenesisCacheDisabler implements InitializingBean {
 
 	private static final Log logger = LogFactory
 			.getLog(HateoasObjenesisCacheDisabler.class);

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/ChangeableUrls.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/ChangeableUrls.java
@@ -44,7 +44,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @author Andy Wilkinson
  */
-final class ChangeableUrls implements Iterable<URL> {
+public final class ChangeableUrls implements Iterable<URL> {
 
 	private static final Log logger = LogFactory.getLog(ChangeableUrls.class);
 


### PR DESCRIPTION
I am working on a custom configuration of devtools, supplying my own configuration and beans to experiment with restart behavior. In doing so, I learned that a number of classes, needed for the custom configuration of devtools, presently employed by `LocalDevToolsAutoConfiguration` are kept as package-private. This pull request proposes to open up these classes so as to improve code-reuse.

Spring Boot 2.0.3.RELEASE, JDK 10, embedded Tomcat 9.0.10. 

