### PR TITLE
Avoid annotation attribute lookup in OnBeanCondition

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnBeanCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnBeanCondition.java
@@ -365,8 +365,7 @@ class OnBeanCondition extends SpringBootCondition implements ConfigurationCondit
 			collect(attributes, "annotation", this.annotations);
 			collect(attributes, "ignored", this.ignoredTypes);
 			collect(attributes, "ignoredType", this.ignoredTypes);
-			this.strategy = (SearchStrategy) metadata
-					.getAnnotationAttributes(annotationType.getName()).get("search");
+			this.strategy = (SearchStrategy) attributes.getFirst("search");
 			BeanTypeDeductionException deductionException = null;
 			try {
 				if (this.types.isEmpty() && this.names.isEmpty()) {


### PR DESCRIPTION
Hi,

this PR avoids an annotation attribute lookup in `OnBeanCondition` in order to retrieve the `SearchStrategy` that seems superfluous - given that all attributes are already fetched a few lines earlier and the search strategy isn't affected by the class-to-string conversion parameter. I wonder if I miss something, so please feel free to close this PR if it turns out to be bogus.

Let me know what you think.
Cheers,
Christoph