### PR TITLE
Expose InfoContributor information via the metrics endpoint

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfiguration.java
@@ -30,6 +30,9 @@ import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.info.ApplicationInfoMetrics;
+import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -46,6 +49,9 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Micrometer-based metrics.
@@ -140,6 +146,13 @@ public class MetricsAutoConfiguration {
 		@ConditionalOnMissingBean
 		public FileDescriptorMetrics fileDescriptorMetrics() {
 			return new FileDescriptorMetrics();
+		}
+
+		@Bean
+		@ConditionalOnProperty(name = "management.metrics.binders.info.enabled", matchIfMissing = true)
+		@ConditionalOnMissingBean
+		public ApplicationInfoMetrics applicationInfoMetrics(ObjectProvider<List<InfoContributor>> infoContributors) {
+			return new ApplicationInfoMetrics(infoContributors.getIfAvailable(Collections::emptyList));
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
@@ -380,4 +380,24 @@ public class MetricsAutoConfigurationTests {
 
 	}
 
+	@Configuration
+	static class CustomApplicationInfoMetricsConfiguration {
+
+		@Bean
+		ApplicationInfoMetrics customApplicationInfoMetrics() {
+			return new ApplicationInfoMetrics(Collections.singletonList(mock(InfoContributor.class)));
+		}
+
+	}
+
+	@Configuration
+	static class CustomApplicationInfoMetricsConfiguration {
+
+		@Bean
+		ApplicationInfoMetrics customApplicationInfoMetrics() {
+			return new ApplicationInfoMetrics(Collections.singletonList(mock(InfoContributor.class)));
+		}
+
+	}
+
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics;
 
+import java.util.Collections;
 import java.util.List;
 
 import io.micrometer.core.instrument.Clock;
@@ -33,6 +34,8 @@ import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
 
+import org.springframework.boot.actuate.info.ApplicationInfoMetrics;
+import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -232,6 +235,29 @@ public class MetricsAutoConfigurationTests {
 						.hasBean("customFileDescriptorMetrics"));
 	}
 
+	@Test
+	public void autoConfiguresApplicationInfoMetrics() {
+		this.contextRunner.run((context) -> assertThat(context)
+				.hasSingleBean(ApplicationInfoMetrics.class));
+	}
+
+	@Test
+	public void allowsApplicationInfoMetricsToBeDisabled() {
+		this.contextRunner
+				.withPropertyValues("management.metrics.binders.info.enabled=false")
+				.run((context) -> assertThat(context)
+						.doesNotHaveBean(ApplicationInfoMetrics.class));
+	}
+
+	@Test
+	public void allowsCustomApplicationInfoMetricsToBeUsed() {
+		this.contextRunner
+				.withUserConfiguration(CustomApplicationInfoMetricsConfiguration.class)
+				.run((context) -> assertThat(context)
+						.hasSingleBean(ApplicationInfoMetrics.class)
+						.hasBean("customApplicationInfoMetrics"));
+	}
+
 	@Configuration
 	static class CustomClockConfiguration {
 
@@ -340,6 +366,16 @@ public class MetricsAutoConfigurationTests {
 		@Bean
 		FileDescriptorMetrics customFileDescriptorMetrics() {
 			return new FileDescriptorMetrics();
+		}
+
+	}
+
+	@Configuration
+	static class CustomApplicationInfoMetricsConfiguration {
+
+		@Bean
+		ApplicationInfoMetrics customApplicationInfoMetrics() {
+			return new ApplicationInfoMetrics(Collections.singletonList(mock(InfoContributor.class)));
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/ApplicationInfoMetrics.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/ApplicationInfoMetrics.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.info;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import org.springframework.util.Assert;
+
+
+/**
+ * Makes the data from all InfoContributors available as a metric.
+ *
+ * @author Tiago Bilou, Florian Stumpf
+ * @since 2.0.0
+ */
+public class ApplicationInfoMetrics implements MeterBinder {
+
+	private final List<InfoContributor> infoContributors;
+	private final AtomicInteger value = new AtomicInteger(1);
+
+	public ApplicationInfoMetrics(List<InfoContributor> infoContributors) {
+		Assert.notNull(infoContributors, "Info contributors must not be null");
+		this.infoContributors = infoContributors;
+	}
+
+	@Override
+	public void bindTo(MeterRegistry registry) {
+		Gauge.builder("application.info", this.value, AtomicInteger::get).tags(info()).register(registry);
+	}
+
+	private List<Tag> info() {
+		Info.Builder builder = new Info.Builder();
+		for (InfoContributor contributor : this.infoContributors) {
+			contributor.contribute(builder);
+		}
+		Info build = builder.build();
+
+		final Map<String, Object> details = build.getDetails();
+		final List<Tag> tags = new ArrayList<>(details.size());
+		for (Map.Entry<String, Object> entry : details.entrySet()) {
+			tags.add(Tag.of(entry.getKey(), (String) entry.getValue()));
+		}
+
+		return tags;
+	}
+}


### PR DESCRIPTION
Hi,

this PR exposes InfoContributor information via the metrics endpoint (see https://github.com/spring-projects/spring-boot/issues/12348)

Need some feedback regarding the flattenKeys recursive implementation. This is a problem that has been solved many times, but I was unable to find an existing method I could re-purpose for this case. Maybe someone can point out an existing implementation in spring boot