### PR TITLE
Optimize some StringBuilder.append() calls

### DIFF
--- a/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/archive/ArchiveCommand.java
+++ b/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/archive/ArchiveCommand.java
@@ -230,7 +230,9 @@ abstract class ArchiveCommand extends OptionParsingCommand {
 		private String commaDelimitedClassNames(Class<?>[] classes) {
 			StringBuilder builder = new StringBuilder();
 			for (int i = 0; i < classes.length; i++) {
-				builder.append((i != 0) ? "," : "");
+				if (i != 0) {
+					builder.append(',');
+				}
 				builder.append(classes[i].getName());
 			}
 			return builder.toString();

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/properties/PropertyMappingContextCustomizer.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/properties/PropertyMappingContextCustomizer.java
@@ -115,8 +115,11 @@ class PropertyMappingContextCustomizer implements ContextCustomizer {
 		private String getAnnotationsDescription(Set<Class<?>> annotations) {
 			StringBuilder result = new StringBuilder();
 			for (Class<?> annotation : annotations) {
-				result.append((result.length() != 0) ? ", " : "");
-				result.append("@" + ClassUtils.getShortName(annotation));
+				if (result.length() != 0) {
+					result.append(", ");
+				}
+				result.append('@');
+				result.append(ClassUtils.getShortName(annotation));
 			}
 			result.insert(0, (annotations.size() != 1) ? "annotations " : "annotation ");
 			return result.toString();

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/properties/PropertyMappingContextCustomizer.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/properties/PropertyMappingContextCustomizer.java
@@ -118,8 +118,7 @@ class PropertyMappingContextCustomizer implements ContextCustomizer {
 				if (result.length() != 0) {
 					result.append(", ");
 				}
-				result.append('@');
-				result.append(ClassUtils.getShortName(annotation));
+				result.append('@').append(ClassUtils.getShortName(annotation));
 			}
 			result.insert(0, (annotations.size() != 1) ? "annotations " : "annotation ");
 			return result.toString();

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/ItemMetadata.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/ItemMetadata.java
@@ -63,9 +63,11 @@ public final class ItemMetadata implements Comparable<ItemMetadata> {
 		}
 		StringBuilder fullName = new StringBuilder((prefix != null) ? prefix : "");
 		if (fullName.length() > 0 && name != null) {
-			fullName.append(".");
+			fullName.append('.');
 		}
-		fullName.append((name != null) ? ConfigurationMetadata.toDashedCase(name) : "");
+		if (name != null) {
+			fullName.append(ConfigurationMetadata.toDashedCase(name));
+		}
 		return fullName.toString();
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractRunMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractRunMojo.java
@@ -391,9 +391,10 @@ public abstract class AbstractRunMojo extends AbstractDependencyFilterMojo {
 		try {
 			StringBuilder classpath = new StringBuilder();
 			for (URL ele : getClassPathUrls()) {
-				classpath = classpath
-						.append(((classpath.length() > 0) ? File.pathSeparator : "")
-								+ new File(ele.toURI()));
+				if (classpath.length() > 0) {
+					classpath.append(File.pathSeparator);
+				}
+				classpath.append(new File(ele.toURI()));
 			}
 			if (getLog().isDebugEnabled()) {
 				getLog().debug("Classpath for forked process: " + classpath);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
@@ -214,7 +214,9 @@ class MapBinder extends AggregateBinder<Map<Object, Object>> {
 			StringBuilder result = new StringBuilder();
 			for (int i = this.root.getNumberOfElements(); i < name
 					.getNumberOfElements(); i++) {
-				result.append((result.length() != 0) ? "." : "");
+				if (result.length() != 0) {
+					result.append('.');
+				}
 				result.append(name.getElement(i, Form.ORIGINAL));
 			}
 			return result.toString();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -394,7 +394,7 @@ public final class ConfigurationPropertyName
 		for (CharSequence element : elements) {
 			boolean indexed = isIndexed(element);
 			if (result.length() > 0 && !indexed) {
-				result.append(".");
+				result.append('.');
 			}
 			if (indexed) {
 				result.append(element);
@@ -402,7 +402,9 @@ public final class ConfigurationPropertyName
 			else {
 				for (int i = 0; i < element.length(); i++) {
 					char ch = Character.toLowerCase(element.charAt(i));
-					result.append((ch != '_') ? ch : "");
+					if (ch != '_') {
+						result.append(ch);
+					}
 				}
 			}
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
@@ -172,8 +172,11 @@ public class JettyWebServer implements WebServer {
 	private String getActualPortsDescription() {
 		StringBuilder ports = new StringBuilder();
 		for (Connector connector : this.server.getConnectors()) {
-			ports.append((ports.length() != 0) ? ", " : "");
-			ports.append(getLocalPort(connector) + getProtocols(connector));
+			if (ports.length() != 0) {
+				ports.append(", ");
+			}
+			ports.append(getLocalPort(connector));
+			ports.append(getProtocols(connector));
 		}
 		return ports.toString();
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
@@ -175,8 +175,7 @@ public class JettyWebServer implements WebServer {
 			if (ports.length() != 0) {
 				ports.append(", ");
 			}
-			ports.append(getLocalPort(connector));
-			ports.append(getProtocols(connector));
+			ports.append(getLocalPort(connector)).append(getProtocols(connector));
 		}
 		return ports.toString();
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
@@ -323,10 +323,7 @@ public class TomcatWebServer implements WebServer {
 				ports.append(' ');
 			}
 			int port = localPort ? connector.getLocalPort() : connector.getPort();
-			ports.append(port);
-			ports.append(" (");
-			ports.append(connector.getScheme());
-			ports.append(')');
+			ports.append(port).append(" (").append(connector.getScheme()).append(')');
 		}
 		return ports.toString();
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
@@ -319,9 +319,14 @@ public class TomcatWebServer implements WebServer {
 	private String getPortsDescription(boolean localPort) {
 		StringBuilder ports = new StringBuilder();
 		for (Connector connector : this.tomcat.getService().findConnectors()) {
-			ports.append((ports.length() != 0) ? " " : "");
+			if (ports.length() != 0) {
+				ports.append(' ');
+			}
 			int port = localPort ? connector.getLocalPort() : connector.getPort();
-			ports.append(port + " (" + connector.getScheme() + ")");
+			ports.append(port);
+			ports.append(" (");
+			ports.append(connector.getScheme());
+			ports.append(')');
 		}
 		return ports.toString();
 	}


### PR DESCRIPTION
Hi,

I noticed that sometimes we do `StringBuilder.append((i != 0) ? "," : "");` . This will still call `System.arrayCopy()` eventually and therefore is slower than simply omitting the call to `StringBuilder.append()` at all.

E.g. testing `ConfigurationPropertyName.toString()` shows the following results:
```
MyBenchmark.testNew                                                  thrpt   50  4331037,115 ± 40253,270   ops/s
MyBenchmark.testNew:·gc.alloc.rate                                   thrpt   50     1056,753 ±     9,813  MB/sec
MyBenchmark.testNew:·gc.alloc.rate.norm                              thrpt   50      256,000 ±     0,001    B/op
MyBenchmark.testNew:·gc.count                                        thrpt   50      346,000              counts
MyBenchmark.testNew:·gc.time                                         thrpt   50      244,000                  ms
MyBenchmark.testOld                                                  thrpt   50  1943977,722 ± 38335,644   ops/s
MyBenchmark.testOld:·gc.alloc.rate                                   thrpt   50     3408,980 ±    67,227  MB/sec
MyBenchmark.testOld:·gc.alloc.rate.norm                              thrpt   50     1840,001 ±     0,001    B/op
MyBenchmark.testOld:·gc.count                                        thrpt   50      504,000              counts
MyBenchmark.testOld:·gc.time                                         thrpt   50      469,000                  ms
```

This PR optimizes those places. Where applicable, this PR touches the surrounding code in order to avoid string concatenations inside `StringBuilder.append()` calls that are somewhat wasteful themselves.

Let me know what you think.
Cheers,
Christoph