### PR TITLE
Failing test for gh-13945

### DIFF
--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanWithAopProxyTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanWithAopProxyTests.java
@@ -18,6 +18,7 @@ package org.springframework.boot.test.mock.mockito;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,6 +65,16 @@ public class SpyBeanWithAopProxyTests {
 		verify(this.dateService, times(1)).getDate(matchesAnyBoolean());
 	}
 
+	@Test
+	public void verifyShouldUseProxyTargetWithMethodArguments() throws Exception {
+		Long d1 = this.dateService.getRandomDate(1234L);
+		Thread.sleep(200);
+		Long d2 = this.dateService.getRandomDate(1234L);
+		assertThat(d1).isEqualTo(d2);
+		verify(this.dateService, times(1)).getRandomDate(1234L);
+	}
+
+
 	private boolean matchesFalse() {
 		if (isTestingMockito1()) {
 			Method method = ReflectionUtils.findMethod(
@@ -103,7 +114,7 @@ public class SpyBeanWithAopProxyTests {
 		@Bean
 		public ConcurrentMapCacheManager cacheManager() {
 			ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager();
-			cacheManager.setCacheNames(Arrays.asList("test"));
+			cacheManager.setCacheNames(Arrays.asList("test", "test2"));
 			return cacheManager;
 		}
 
@@ -115,6 +126,11 @@ public class SpyBeanWithAopProxyTests {
 		@Cacheable(cacheNames = "test")
 		public Long getDate(boolean arg) {
 			return System.nanoTime();
+		}
+
+		@Cacheable(cacheNames = "test2", key = "#seed")
+		public Long getRandomDate(Long seed) {
+			return ThreadLocalRandom.current().nextLong(seed);
 		}
 
 	}


### PR DESCRIPTION
Failing testcase to show the issue. When Spring AOP need method
arguments to build a cache key (but probably also on other annotations
that require method arguments) the AOP part will fail.

Creating a Mockito mock results in the loss of the debug information
needed to read the correct method parameter.

issue: gh-13945

When running the test (locally) it fails with the following exception.

```
java.lang.IllegalArgumentException: Null key returned for cache operation (maybe you are using named params on classes without debug info?) Builder[public java.lang.Long org.springframework.boot.test.mock.mockito.SpyBeanWithAopProxyTests$DateService$MockitoMock$842880437.getRandomDate(java.lang.Long)] caches=[test2] | key='#seed' | keyGenerator='' | cacheManager='' | cacheResolver='' | condition='' | unless='' | sync='false'

	at org.springframework.cache.interceptor.CacheAspectSupport.generateKey(CacheAspectSupport.java:578)
	at org.springframework.cache.interceptor.CacheAspectSupport.findCachedItem(CacheAspectSupport.java:518)
	at org.springframework.cache.interceptor.CacheAspectSupport.execute(CacheAspectSupport.java:401)
	at org.springframework.cache.interceptor.CacheAspectSupport.execute(CacheAspectSupport.java:345)
	at org.springframework.cache.interceptor.CacheInterceptor.invoke(CacheInterceptor.java:61)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:688)
	at org.springframework.boot.test.mock.mockito.SpyBeanWithAopProxyTests$DateService$MockitoMock$842880437$$EnhancerBySpringCGLIB$$82557bd3.getRandomDate(<generated>)
	at org.springframework.boot.test.mock.mockito.SpyBeanWithAopProxyTests.verifyShouldUseProxyTargetWithMethodArguments(SpyBeanWithAopProxyTests.java:70)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.springframework.test.context.junit4.statements.RunBeforeTestExecutionCallbacks.evaluate(RunBeforeTestExecutionCallbacks.java:74)
	at org.springframework.test.context.junit4.statements.RunAfterTestExecutionCallbacks.evaluate(RunAfterTestExecutionCallbacks.java:84)
	at org.springframework.test.context.junit4.statements.RunBeforeTestMethodCallbacks.evaluate(RunBeforeTestMethodCallbacks.java:75)
	at org.springframework.test.context.junit4.statements.RunAfterTestMethodCallbacks.evaluate(RunAfterTestMethodCallbacks.java:86)
	at org.springframework.test.context.junit4.statements.SpringRepeat.evaluate(SpringRepeat.java:84)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:251)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:97)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.springframework.test.context.junit4.statements.RunBeforeTestClassCallbacks.evaluate(RunBeforeTestClassCallbacks.java:61)
	at org.springframework.test.context.junit4.statements.RunAfterTestClassCallbacks.evaluate(RunAfterTestClassCallbacks.java:70)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.run(SpringJUnit4ClassRunner.java:190)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)

```