### PR TITLE
DigitalAmount, DigitalUnit,  DigitalAmountStyle (gh-13974)

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DigitalAmount.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DigitalAmount.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -35,10 +36,13 @@ import org.springframework.util.Assert;
  */
 public final class DigitalAmount implements Comparable<DigitalAmount>, Serializable {
 
-	private final long bytes;
+	/**
+	 * amount in terms of bytes.
+	 */
+	private final long amount;
 
-	private DigitalAmount(long bytes) {
-		this.bytes = bytes;
+	private DigitalAmount(long amount) {
+		this.amount = amount;
 	}
 
 	/**
@@ -46,7 +50,7 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @return the total amount of the bytes.
 	 */
 	public long toBytes() {
-		return this.bytes;
+		return this.amount;
 	}
 
 	/**
@@ -54,7 +58,7 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @return the total amount of the kilobytes.
 	 */
 	public long toKilobytes() {
-		return DigitalUnit.BYTES.toKilobytes(this.bytes);
+		return DigitalUnit.BYTES.toKilobytes(this.amount);
 	}
 
 	/**
@@ -62,7 +66,7 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @return the total amount of the megabytes.
 	 */
 	public long toMegabytes() {
-		return DigitalUnit.BYTES.toMegabytes(this.bytes);
+		return DigitalUnit.BYTES.toMegabytes(this.amount);
 	}
 
 	/**
@@ -70,7 +74,7 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @return the total amount of the gigabytes.
 	 */
 	public long toGigabytes() {
-		return DigitalUnit.BYTES.toGigabytes(this.bytes);
+		return DigitalUnit.BYTES.toGigabytes(this.amount);
 	}
 
 	/**
@@ -78,7 +82,7 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @return the total amount of the terabytes.
 	 */
 	public long toTerabytes() {
-		return DigitalUnit.BYTES.toTerabytes(this.bytes);
+		return DigitalUnit.BYTES.toTerabytes(this.amount);
 	}
 
 	/**
@@ -86,7 +90,7 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @return true if this {@code DigitalAmount} has a total amount less than zero
 	 */
 	public boolean isNegative() {
-		return this.bytes < 0;
+		return this.amount < 0;
 	}
 
 	/**
@@ -94,7 +98,7 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @return true if this {@code DigitalAmount} has a total amount greater than zero
 	 */
 	public boolean isPositive() {
-		return this.bytes > 0;
+		return this.amount > 0;
 	}
 
 	/**
@@ -102,7 +106,7 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @return true if this {@code DigitalAmount} has a total amount equal to zero
 	 */
 	public boolean isZero() {
-		return this.bytes == 0;
+		return this.amount == 0;
 	}
 
 	/**
@@ -112,7 +116,8 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @return an {@code Optional} describing the value if a value matches the given
 	 * predicate, otherwise an empty {@code Optional}
 	 */
-	public Optional<DigitalAmount> filter(Predicate<? super DigitalAmount> predicate) {
+	public Optional<DigitalAmount> filter(
+			@NonNull Predicate<? super DigitalAmount> predicate) {
 		Assert.notNull(predicate, () -> "Predicate must not be null");
 		if (predicate.test(this)) {
 			return Optional.of(this);
@@ -126,7 +131,7 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @param mapper a mapping function to apply to the value.
 	 * @return the result of applying a mapping function
 	 */
-	public <T> T map(Function<? super DigitalAmount, ? extends T> mapper) {
+	public <T> T map(@NonNull Function<? super DigitalAmount, ? extends T> mapper) {
 		Assert.notNull(mapper, () -> "Mapper must not be null");
 		return mapper.apply(this);
 	}
@@ -138,7 +143,7 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @param unit {@code DigitalUnit} of this amount.
 	 * @return {@code this + other}
 	 */
-	public DigitalAmount add(long amount, DigitalUnit unit) {
+	public DigitalAmount add(long amount, @NonNull DigitalUnit unit) {
 		return add(fromUnit(amount, unit));
 	}
 
@@ -149,7 +154,7 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @param unit {@code DigitalUnit} of this amount.
 	 * @return {@code this - other}
 	 */
-	public DigitalAmount subtract(long amount, DigitalUnit unit) {
+	public DigitalAmount subtract(long amount, @NonNull DigitalUnit unit) {
 		return subtract(fromUnit(amount, unit));
 	}
 
@@ -159,9 +164,9 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @param other value to be added to this {@code DigitalAmount}.
 	 * @return {@code this + other}
 	 */
-	public DigitalAmount add(DigitalAmount other) {
+	public DigitalAmount add(@NonNull DigitalAmount other) {
 		Assert.notNull(other, () -> "Digital Amount must not be null");
-		return new DigitalAmount(Math.addExact(this.bytes, other.bytes));
+		return new DigitalAmount(Math.addExact(this.amount, other.amount));
 	}
 
 	/**
@@ -170,15 +175,15 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @param other value to be subtracted from this {@code DigitalAmount}.
 	 * @return {@code this - other}
 	 */
-	public DigitalAmount subtract(DigitalAmount other) {
+	public DigitalAmount subtract(@NonNull DigitalAmount other) {
 		Assert.notNull(other, () -> "Digital Amount must not be null");
-		return new DigitalAmount(Math.subtractExact(this.bytes, other.bytes));
+		return new DigitalAmount(Math.subtractExact(this.amount, other.amount));
 	}
 
 	@Override
 	public int compareTo(@NonNull DigitalAmount other) {
 		Assert.notNull(other, () -> "Digital Amount must not be null");
-		return Long.compare(this.bytes, other.bytes);
+		return Long.compare(this.amount, other.amount);
 	}
 
 	@Override
@@ -190,12 +195,12 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 			return false;
 		}
 		DigitalAmount that = (DigitalAmount) o;
-		return this.bytes == that.bytes;
+		return this.amount == that.amount;
 	}
 
 	@Override
 	public int hashCode() {
-		return Long.hashCode(this.bytes);
+		return Long.hashCode(this.amount);
 	}
 
 	/**
@@ -205,7 +210,7 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @return the printed result
 	 * @see DigitalAmountStyle
 	 */
-	public String print(DigitalUnit unit) {
+	public String print(@Nullable DigitalUnit unit) {
 		return DigitalAmountStyle.SIMPLE.print(this, unit);
 	}
 
@@ -219,8 +224,9 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * {@link DigitalAmountStyle#SIMPLE}.
 	 * @param value the value to parse
 	 * @return a {@code DigitalAmount}
+	 * @see #parse(CharSequence, DigitalUnit)
 	 */
-	public static DigitalAmount parse(CharSequence value) {
+	public static DigitalAmount parse(@NonNull CharSequence value) {
 		return parse(value, DigitalUnit.BYTES);
 	}
 
@@ -232,7 +238,8 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * {@link DigitalUnit#BYTES}
 	 * @return a {@code DigitalAmount}
 	 */
-	public static DigitalAmount parse(CharSequence value, DigitalUnit unit) {
+	public static DigitalAmount parse(@NonNull CharSequence value,
+			@Nullable DigitalUnit unit) {
 		return DigitalAmountStyle.SIMPLE.parse(value, unit);
 	}
 
@@ -292,7 +299,7 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @return a {@code DigitalAmount}
 	 * @throws ArithmeticException if the result overflows a long
 	 */
-	public static DigitalAmount fromUnit(long amount, DigitalUnit unit) {
+	public static DigitalAmount fromUnit(long amount, @NonNull DigitalUnit unit) {
 		Assert.notNull(unit, () -> "Digital Unit must not be null");
 		return new DigitalAmount(unit.toBytes(amount));
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DigitalAmount.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DigitalAmount.java
@@ -112,7 +112,7 @@ public final class DigitalAmount implements Comparable<DigitalAmount>, Serializa
 	 * @return an {@code Optional} describing the value if a value matches the given
 	 * predicate, otherwise an empty {@code Optional}
 	 */
-	public Optional<DigitalAmount> filter(Predicate<DigitalAmount> predicate) {
+	public Optional<DigitalAmount> filter(Predicate<? super DigitalAmount> predicate) {
 		Assert.notNull(predicate, () -> "Predicate must not be null");
 		if (predicate.test(this)) {
 			return Optional.of(this);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DigitalAmount.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DigitalAmount.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot;
+
+import java.io.Serializable;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.springframework.lang.NonNull;
+import org.springframework.util.Assert;
+
+/**
+ * This class models a quantity or amount of digital information in terms of bytes. This
+ * class is immutable and thread-safe.
+ *
+ * @author Dmytro Nosan
+ * @since 2.1.0
+ * @see DigitalAmountStyle
+ * @see DigitalUnit
+ */
+public final class DigitalAmount implements Comparable<DigitalAmount>, Serializable {
+
+	private final long bytes;
+
+	private DigitalAmount(long bytes) {
+		this.bytes = bytes;
+	}
+
+	/**
+	 * Converts this {@code DigitalAmount} to the bytes.
+	 * @return the total amount of the bytes.
+	 */
+	public long toBytes() {
+		return this.bytes;
+	}
+
+	/**
+	 * Converts this {@code DigitalAmount} to the kilobytes.
+	 * @return the total amount of the kilobytes.
+	 */
+	public long toKilobytes() {
+		return DigitalUnit.BYTES.toKilobytes(this.bytes);
+	}
+
+	/**
+	 * Converts this {@code DigitalAmount} to the megabytes.
+	 * @return the total amount of the megabytes.
+	 */
+	public long toMegabytes() {
+		return DigitalUnit.BYTES.toMegabytes(this.bytes);
+	}
+
+	/**
+	 * Converts this {@code DigitalAmount} to the gigabytes.
+	 * @return the total amount of the gigabytes.
+	 */
+	public long toGigabytes() {
+		return DigitalUnit.BYTES.toGigabytes(this.bytes);
+	}
+
+	/**
+	 * Converts this {@code DigitalAmount} to the terabytes.
+	 * @return the total amount of the terabytes.
+	 */
+	public long toTerabytes() {
+		return DigitalUnit.BYTES.toTerabytes(this.bytes);
+	}
+
+	/**
+	 * Checks if this duration is {@code DigitalAmount} negative, excluding zero.
+	 * @return true if this {@code DigitalAmount} has a total amount less than zero
+	 */
+	public boolean isNegative() {
+		return this.bytes < 0;
+	}
+
+	/**
+	 * Checks if this duration is {@code DigitalAmount} positive, excluding zero.
+	 * @return true if this {@code DigitalAmount} has a total amount greater than zero
+	 */
+	public boolean isPositive() {
+		return this.bytes > 0;
+	}
+
+	/**
+	 * Checks if this {@code DigitalAmount} is zero.
+	 * @return true if this {@code DigitalAmount} has a total amount equal to zero
+	 */
+	public boolean isZero() {
+		return this.bytes == 0;
+	}
+
+	/**
+	 * If the value matches the given predicate, return an {@code Optional} describing the
+	 * value, otherwise return an empty {@code Optional}.
+	 * @param predicate a predicate to apply to the value.
+	 * @return an {@code Optional} describing the value if a value matches the given
+	 * predicate, otherwise an empty {@code Optional}
+	 */
+	public Optional<DigitalAmount> filter(Predicate<DigitalAmount> predicate) {
+		Assert.notNull(predicate, () -> "Predicate must not be null");
+		if (predicate.test(this)) {
+			return Optional.of(this);
+		}
+		return Optional.empty();
+	}
+
+	/**
+	 * Apply the provided mapping function to this.
+	 * @param <T> the type of the result of the mapping function
+	 * @param mapper a mapping function to apply to the value.
+	 * @return the result of applying a mapping function
+	 */
+	public <T> T map(Function<? super DigitalAmount, ? extends T> mapper) {
+		Assert.notNull(mapper, () -> "Mapper must not be null");
+		return mapper.apply(this);
+	}
+
+	/**
+	 * Returns a {@code DigitalAmount} whose value is {@code (this +
+	 * other)}.
+	 * @param amount value to be added to this {@code DigitalAmount}.
+	 * @param unit {@code DigitalUnit} of this amount.
+	 * @return {@code this + other}
+	 */
+	public DigitalAmount add(long amount, DigitalUnit unit) {
+		return add(fromUnit(amount, unit));
+	}
+
+	/**
+	 * Returns a {@code DigitalAmount} whose value is {@code (this -
+	 * other)}.
+	 * @param amount value to be subtracted to this {@code DigitalAmount}.
+	 * @param unit {@code DigitalUnit} of this amount.
+	 * @return {@code this - other}
+	 */
+	public DigitalAmount subtract(long amount, DigitalUnit unit) {
+		return subtract(fromUnit(amount, unit));
+	}
+
+	/**
+	 * Returns a new {@code DigitalAmount} whose value is {@code (this +
+	 * other)}.
+	 * @param other value to be added to this {@code DigitalAmount}.
+	 * @return {@code this + other}
+	 */
+	public DigitalAmount add(DigitalAmount other) {
+		Assert.notNull(other, () -> "Digital Amount must not be null");
+		return new DigitalAmount(Math.addExact(this.bytes, other.bytes));
+	}
+
+	/**
+	 * Returns a new {@code DigitalAmount} whose value is {@code (this -
+	 * other)}.
+	 * @param other value to be subtracted from this {@code DigitalAmount}.
+	 * @return {@code this - other}
+	 */
+	public DigitalAmount subtract(DigitalAmount other) {
+		Assert.notNull(other, () -> "Digital Amount must not be null");
+		return new DigitalAmount(Math.subtractExact(this.bytes, other.bytes));
+	}
+
+	@Override
+	public int compareTo(@NonNull DigitalAmount other) {
+		Assert.notNull(other, () -> "Digital Amount must not be null");
+		return Long.compare(this.bytes, other.bytes);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		DigitalAmount that = (DigitalAmount) o;
+		return this.bytes == that.bytes;
+	}
+
+	@Override
+	public int hashCode() {
+		return Long.hashCode(this.bytes);
+	}
+
+	/**
+	 * Print this {@code DigitalAmount} using the given unit.
+	 * @param unit the {@code DigitalUnit} to use if the value doesn't specify,
+	 * {@link DigitalUnit#BYTES} will be used
+	 * @return the printed result
+	 * @see DigitalAmountStyle
+	 */
+	public String print(DigitalUnit unit) {
+		return DigitalAmountStyle.SIMPLE.print(this, unit);
+	}
+
+	@Override
+	public String toString() {
+		return print(DigitalUnit.BYTES);
+	}
+
+	/**
+	 * Parse the given value to a {@code DigitalAmount} using
+	 * {@link DigitalAmountStyle#SIMPLE}.
+	 * @param value the value to parse
+	 * @return a {@code DigitalAmount}
+	 */
+	public static DigitalAmount parse(CharSequence value) {
+		return parse(value, DigitalUnit.BYTES);
+	}
+
+	/**
+	 * Parse the given value to a {@code DigitalAmount} using
+	 * {@link DigitalAmountStyle#SIMPLE}.
+	 * @param value the value to parse
+	 * @param unit {@code DigitalUnit} to use if one is not specified, default value is
+	 * {@link DigitalUnit#BYTES}
+	 * @return a {@code DigitalAmount}
+	 */
+	public static DigitalAmount parse(CharSequence value, DigitalUnit unit) {
+		return DigitalAmountStyle.SIMPLE.parse(value, unit);
+	}
+
+	/**
+	 * Creates a new {@code DigitalAmount} from the bytes.
+	 * @param amount amount of the bytes
+	 * @return a {@code DigitalAmount}
+	 */
+	public static DigitalAmount fromBytes(long amount) {
+		return new DigitalAmount(amount);
+	}
+
+	/**
+	 * Creates a new {@code DigitalAmount} from the kilobytes.
+	 * @param amount amount of the kilobytes
+	 * @return a {@code DigitalAmount}
+	 * @throws ArithmeticException if the result overflows a long
+	 */
+	public static DigitalAmount fromKilobytes(long amount) {
+		return new DigitalAmount(DigitalUnit.KILOBYTES.toBytes(amount));
+	}
+
+	/**
+	 * Creates a new {@code DigitalAmount} from the megabytes.
+	 * @param amount amount of the megabytes
+	 * @return a {@code DigitalAmount}
+	 * @throws ArithmeticException if the result overflows a long
+	 */
+	public static DigitalAmount fromMegabytes(long amount) {
+		return new DigitalAmount(DigitalUnit.MEGABYTES.toBytes(amount));
+	}
+
+	/**
+	 * Creates a new {@code DigitalAmount} from the gigabytes.
+	 * @param amount amount of the gigabytes
+	 * @return a {@code DigitalAmount}
+	 * @throws ArithmeticException if the result overflows a long
+	 */
+	public static DigitalAmount fromGigabytes(long amount) {
+		return new DigitalAmount(DigitalUnit.GIGABYTES.toBytes(amount));
+	}
+
+	/**
+	 * Creates a new {@code DigitalAmount} from the terabytes.
+	 * @param amount amount of the terabytes
+	 * @return a {@code DigitalAmount}
+	 * @throws ArithmeticException if the result overflows a long
+	 */
+	public static DigitalAmount fromTerabytes(long amount) {
+		return new DigitalAmount(DigitalUnit.TERABYTES.toBytes(amount));
+	}
+
+	/**
+	 * Creates a new {@code DigitalAmount} from the given amount and unit.
+	 * @param amount amount of the unit
+	 * @param unit unit of the amount
+	 * @return a {@code DigitalAmount}
+	 * @throws ArithmeticException if the result overflows a long
+	 */
+	public static DigitalAmount fromUnit(long amount, DigitalUnit unit) {
+		Assert.notNull(unit, () -> "Digital Unit must not be null");
+		return new DigitalAmount(unit.toBytes(amount));
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DigitalAmountStyle.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DigitalAmountStyle.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.util.Assert;
+import org.springframework.util.NumberUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@code DigitalAmount} format styles.
+ *
+ * @author Dmytro Nosan
+ * @since 2.1.0
+ */
+public enum DigitalAmountStyle {
+
+	/**
+	 * Simple formatting, for example '1GB', '1MB', '1B', etc...
+	 */
+	SIMPLE("^\\s*([\\+\\-]?\\d+)\\s*([a-zA-Z]{0,2})\\s*$") {
+		@Override
+		public DigitalAmount parse(CharSequence value, DigitalUnit unit) {
+			Assert.notNull(value, () -> "Digital Amount pattern must not be null");
+			try {
+				Matcher matcher = matcher(value);
+				Assert.state(matcher.matches(),
+						"Does not match simple Digital Amount " + "pattern");
+				long amount = NumberUtils
+						.parseNumber(matcher.group(1).toLowerCase(Locale.US), Long.class);
+				String abbreviation = matcher.group(2);
+				if (StringUtils.hasText(abbreviation)) {
+					unit = DigitalUnit.fromAbbreviation(abbreviation);
+				}
+				return DigitalAmount.fromUnit(amount,
+						Optional.ofNullable(unit).orElse(DigitalUnit.BYTES));
+			}
+			catch (Exception ex) {
+				throw new IllegalArgumentException(
+						"'" + value + "' is not a valid simple digital amount", ex);
+			}
+		}
+
+		@Override
+		public String print(DigitalAmount value, DigitalUnit unit) {
+			Assert.notNull(value, () -> "Digital Amount must not be null");
+			if (unit == null) {
+				unit = DigitalUnit.BYTES;
+			}
+			long amount = unit.fromUnit(value.toBytes(), DigitalUnit.BYTES);
+			return String.format("%d%s", amount, unit.getAbbreviation());
+		}
+
+	};
+
+	private final Pattern pattern;
+
+	DigitalAmountStyle(String pattern) {
+		this.pattern = Pattern.compile(pattern);
+	}
+
+	protected final boolean matches(CharSequence value) {
+		return this.pattern.matcher(value).matches();
+	}
+
+	protected final Matcher matcher(CharSequence value) {
+		return this.pattern.matcher(value);
+	}
+
+	/**
+	 * Parse the given value to a {@code DigitalAmount}.
+	 * @param value the value to parse
+	 * @return a {@code DigitalAmount}
+	 */
+	public final DigitalAmount parse(CharSequence value) {
+		return parse(value, null);
+	}
+
+	/**
+	 * Parse the given value to a {@code DigitalAmount}.
+	 * @param value the value to parse
+	 * @param unit {@code DigitalUnit} to use if one is not specified, default value is
+	 * {@link DigitalUnit#BYTES}
+	 * @return a {@code DigitalAmount}
+	 */
+	public abstract DigitalAmount parse(CharSequence value, DigitalUnit unit);
+
+	/**
+	 * Print the specified {@code DigitalAmount}.
+	 * @param value the value to print
+	 * @return the printed result
+	 */
+	public final String print(DigitalAmount value) {
+		return print(value, null);
+	}
+
+	/**
+	 * Print the specified {@code DigitalAmount} using the given unit.
+	 * @param value the value to print
+	 * @param unit the {@code DigitalUnit} to use, if {@code null} then
+	 * {@link DigitalUnit#BYTES} will be used.
+	 * @return the printed result
+	 */
+	public abstract String print(DigitalAmount value, DigitalUnit unit);
+
+	/**
+	 * Detect the style from the given source value.
+	 * @param value the source value
+	 * @return the digital amount style
+	 * @throws IllegalStateException if the value is not a known style
+	 */
+	public static DigitalAmountStyle detect(CharSequence value) {
+		Assert.notNull(value, "Digital Amount pattern must not be null");
+		for (DigitalAmountStyle candidate : values()) {
+			if (candidate.matches(value)) {
+				return candidate;
+			}
+		}
+		throw new IllegalArgumentException(
+				"'" + value + "' is not a valid digital " + "amount");
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DigitalAmountStyle.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DigitalAmountStyle.java
@@ -16,11 +16,12 @@
 
 package org.springframework.boot;
 
-import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.NumberUtils;
 import org.springframework.util.StringUtils;
@@ -38,14 +39,14 @@ public enum DigitalAmountStyle {
 	 */
 	SIMPLE("^\\s*([\\+\\-]?\\d+)\\s*([a-zA-Z]{0,2})\\s*$") {
 		@Override
-		public DigitalAmount parse(CharSequence value, DigitalUnit unit) {
+		public DigitalAmount parse(@NonNull CharSequence value,
+				@Nullable DigitalUnit unit) {
 			Assert.notNull(value, () -> "Digital Amount pattern must not be null");
 			try {
 				Matcher matcher = matcher(value);
 				Assert.state(matcher.matches(),
-						"Does not match simple Digital Amount " + "pattern");
-				long amount = NumberUtils
-						.parseNumber(matcher.group(1).toLowerCase(Locale.US), Long.class);
+						"Does not match simple Digital Amount pattern");
+				long amount = NumberUtils.parseNumber(matcher.group(1), Long.class);
 				String abbreviation = matcher.group(2);
 				if (StringUtils.hasText(abbreviation)) {
 					unit = DigitalUnit.fromAbbreviation(abbreviation);
@@ -60,7 +61,7 @@ public enum DigitalAmountStyle {
 		}
 
 		@Override
-		public String print(DigitalAmount value, DigitalUnit unit) {
+		public String print(@NonNull DigitalAmount value, @Nullable DigitalUnit unit) {
 			Assert.notNull(value, () -> "Digital Amount must not be null");
 			if (unit == null) {
 				unit = DigitalUnit.BYTES;
@@ -90,7 +91,7 @@ public enum DigitalAmountStyle {
 	 * @param value the value to parse
 	 * @return a {@code DigitalAmount}
 	 */
-	public final DigitalAmount parse(CharSequence value) {
+	public final DigitalAmount parse(@NonNull CharSequence value) {
 		return parse(value, null);
 	}
 
@@ -101,14 +102,15 @@ public enum DigitalAmountStyle {
 	 * {@link DigitalUnit#BYTES}
 	 * @return a {@code DigitalAmount}
 	 */
-	public abstract DigitalAmount parse(CharSequence value, DigitalUnit unit);
+	public abstract DigitalAmount parse(@NonNull CharSequence value,
+			@Nullable DigitalUnit unit);
 
 	/**
 	 * Print the specified {@code DigitalAmount}.
 	 * @param value the value to print
 	 * @return the printed result
 	 */
-	public final String print(DigitalAmount value) {
+	public final String print(@NonNull DigitalAmount value) {
 		return print(value, null);
 	}
 
@@ -119,7 +121,8 @@ public enum DigitalAmountStyle {
 	 * {@link DigitalUnit#BYTES} will be used.
 	 * @return the printed result
 	 */
-	public abstract String print(DigitalAmount value, DigitalUnit unit);
+	public abstract String print(@NonNull DigitalAmount value,
+			@Nullable DigitalUnit unit);
 
 	/**
 	 * Detect the style from the given source value.
@@ -127,7 +130,7 @@ public enum DigitalAmountStyle {
 	 * @return the digital amount style
 	 * @throws IllegalStateException if the value is not a known style
 	 */
-	public static DigitalAmountStyle detect(CharSequence value) {
+	public static DigitalAmountStyle detect(@NonNull CharSequence value) {
 		Assert.notNull(value, "Digital Amount pattern must not be null");
 		for (DigitalAmountStyle candidate : values()) {
 			if (candidate.matches(value)) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DigitalUnit.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DigitalUnit.java
@@ -1,0 +1,491 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot;
+
+import org.springframework.util.Assert;
+
+/**
+ * A {@code DigitalUnit} represents digital amount at a given unit of granularity and
+ * provides utility methods to convert across units.
+ *
+ * @author Dmytro Nosan
+ * @since 2.1.0
+ */
+public enum DigitalUnit {
+
+	/**
+	 * A unit that represents the concept of a byte.
+	 */
+	BYTES("Bytes", "B") {
+		@Override
+		public long fromBytes(long amount) {
+			return amount;
+		}
+
+		@Override
+		public long fromKilobytes(long amount) {
+			return KILOBYTES.toBytes(amount);
+		}
+
+		@Override
+		public long fromMegabytes(long amount) {
+			return MEGABYTES.toBytes(amount);
+		}
+
+		@Override
+		public long fromGigabytes(long amount) {
+			return GIGABYTES.toBytes(amount);
+		}
+
+		@Override
+		public long fromTerabytes(long amount) {
+			return TERABYTES.toBytes(amount);
+		}
+
+		@Override
+		public long toBytes(long amount) {
+			return amount;
+		}
+
+		@Override
+		public long toKilobytes(long amount) {
+			return amount / KB;
+		}
+
+		@Override
+		public long toMegabytes(long amount) {
+			return amount / MB;
+
+		}
+
+		@Override
+		public long toGigabytes(long amount) {
+			return amount / GB;
+
+		}
+
+		@Override
+		public long toTerabytes(long amount) {
+			return amount / TB;
+
+		}
+
+	},
+	/**
+	 * A unit that represents the concept of a kilobyte.
+	 */
+	KILOBYTES("Kilobytes", "KB") {
+		@Override
+		public long fromBytes(long amount) {
+			return BYTES.toKilobytes(amount);
+		}
+
+		@Override
+		public long fromKilobytes(long amount) {
+			return amount;
+		}
+
+		@Override
+		public long fromMegabytes(long amount) {
+			return MEGABYTES.toKilobytes(amount);
+		}
+
+		@Override
+		public long fromGigabytes(long amount) {
+			return GIGABYTES.toKilobytes(amount);
+		}
+
+		@Override
+		public long fromTerabytes(long amount) {
+			return TERABYTES.toKilobytes(amount);
+		}
+
+		@Override
+		public long toBytes(long amount) {
+			return Math.multiplyExact(amount, KB);
+		}
+
+		@Override
+		public long toKilobytes(long amount) {
+			return amount;
+		}
+
+		@Override
+		public long toMegabytes(long amount) {
+			return amount / (MB / KB);
+
+		}
+
+		@Override
+		public long toGigabytes(long amount) {
+			return amount / (GB / KB);
+
+		}
+
+		@Override
+		public long toTerabytes(long amount) {
+			return amount / (TB / KB);
+		}
+	},
+	/**
+	 * A unit that represents the concept of megabyte.
+	 */
+	MEGABYTES("Megabytes", "MB") {
+		@Override
+		public long fromBytes(long amount) {
+			return BYTES.toMegabytes(amount);
+		}
+
+		@Override
+		public long fromKilobytes(long amount) {
+			return KILOBYTES.toMegabytes(amount);
+		}
+
+		@Override
+		public long fromMegabytes(long amount) {
+			return amount;
+		}
+
+		@Override
+		public long fromGigabytes(long amount) {
+			return GIGABYTES.toMegabytes(amount);
+		}
+
+		@Override
+		public long fromTerabytes(long amount) {
+			return TERABYTES.toMegabytes(amount);
+		}
+
+		@Override
+		public long toBytes(long amount) {
+			return Math.multiplyExact(amount, MB);
+		}
+
+		@Override
+		public long toKilobytes(long amount) {
+			return Math.multiplyExact(amount, KB);
+		}
+
+		@Override
+		public long toMegabytes(long amount) {
+			return amount;
+
+		}
+
+		@Override
+		public long toGigabytes(long amount) {
+			return amount / (GB / MB);
+
+		}
+
+		@Override
+		public long toTerabytes(long amount) {
+			return amount / (TB / MB);
+		}
+	},
+	/**
+	 * A unit that represents the concept of gigabyte.
+	 */
+	GIGABYTES("Gigabytes", "GB") {
+		@Override
+		public long fromBytes(long amount) {
+			return BYTES.toGigabytes(amount);
+		}
+
+		@Override
+		public long fromKilobytes(long amount) {
+			return KILOBYTES.toGigabytes(amount);
+		}
+
+		@Override
+		public long fromMegabytes(long amount) {
+			return MEGABYTES.toGigabytes(amount);
+		}
+
+		@Override
+		public long fromGigabytes(long amount) {
+			return amount;
+		}
+
+		@Override
+		public long fromTerabytes(long amount) {
+			return TERABYTES.toGigabytes(amount);
+		}
+
+		@Override
+		public long toBytes(long amount) {
+			return Math.multiplyExact(amount, GB);
+		}
+
+		@Override
+		public long toKilobytes(long amount) {
+			return Math.multiplyExact(amount, MB);
+		}
+
+		@Override
+		public long toMegabytes(long amount) {
+			return Math.multiplyExact(amount, KB);
+		}
+
+		@Override
+		public long toGigabytes(long amount) {
+			return amount;
+
+		}
+
+		@Override
+		public long toTerabytes(long amount) {
+			return amount / (TB / GB);
+		}
+	},
+	/**
+	 * A unit that represents the concept of terabyte.
+	 */
+	TERABYTES("Terabytes", "TB") {
+		@Override
+		public long fromBytes(long amount) {
+			return BYTES.toTerabytes(amount);
+		}
+
+		@Override
+		public long fromKilobytes(long amount) {
+			return KILOBYTES.toTerabytes(amount);
+		}
+
+		@Override
+		public long fromMegabytes(long amount) {
+			return MEGABYTES.toTerabytes(amount);
+		}
+
+		@Override
+		public long fromGigabytes(long amount) {
+			return GIGABYTES.toTerabytes(amount);
+		}
+
+		@Override
+		public long fromTerabytes(long amount) {
+			return amount;
+		}
+
+		@Override
+		public long toBytes(long amount) {
+			return Math.multiplyExact(amount, TB);
+		}
+
+		@Override
+		public long toKilobytes(long amount) {
+			return Math.multiplyExact(amount, GB);
+		}
+
+		@Override
+		public long toMegabytes(long amount) {
+			return Math.multiplyExact(amount, MB);
+		}
+
+		@Override
+		public long toGigabytes(long amount) {
+			return Math.multiplyExact(amount, KB);
+		}
+
+		@Override
+		public long toTerabytes(long amount) {
+			return amount;
+		}
+	};
+
+	private static final long KB = 1024;
+
+	private static final long MB = KB * 1024;
+
+	private static final long GB = MB * 1024;
+
+	private static final long TB = GB * 1024;
+
+	private final String name;
+
+	private final String abbreviation;
+
+	DigitalUnit(String name, String abbreviation) {
+		this.name = name;
+		this.abbreviation = abbreviation;
+	}
+
+	public final String getName() {
+		return this.name;
+	}
+
+	public final String getAbbreviation() {
+		return this.abbreviation;
+	}
+
+	/**
+	 * Converts the given amount of the given unit to this unit.
+	 * @param amount the amount to convert
+	 * @param unit the unit of the amount
+	 * @return converted amount.
+	 */
+	public final long toUnit(long amount, DigitalUnit unit) {
+		Assert.notNull(unit, "Digital Unit must not be null");
+		switch (unit) {
+		case BYTES:
+			return toBytes(amount);
+		case KILOBYTES:
+			return toKilobytes(amount);
+		case MEGABYTES:
+			return toMegabytes(amount);
+		case GIGABYTES:
+			return toGigabytes(amount);
+		case TERABYTES:
+			return toTerabytes(amount);
+		}
+		throw new IllegalArgumentException("Unknown Digital Unit '" + unit + "'");
+	}
+
+	/**
+	 * Converts the given amount of this unit to bytes.
+	 * @param amount the amount to convert
+	 * @return converted amount.
+	 */
+	public abstract long toBytes(long amount);
+
+	/**
+	 * Converts the given amount of this unit to kilobytes.
+	 * @param amount the amount to convert
+	 * @return converted amount.
+	 */
+	public abstract long toKilobytes(long amount);
+
+	/**
+	 * Converts the given amount of this unit to megabytes.
+	 * @param amount the amount to convert
+	 * @return converted amount.
+	 */
+	public abstract long toMegabytes(long amount);
+
+	/**
+	 * Converts the given amount of this unit to gigabytes.
+	 * @param amount the amount to convert
+	 * @return converted amount.
+	 */
+	public abstract long toGigabytes(long amount);
+
+	/**
+	 * Converts the given amount of this unit to terabytes.
+	 * @param amount the amount to convert
+	 * @return converted amount.
+	 */
+	public abstract long toTerabytes(long amount);
+
+	/**
+	 * Converts the given amount of the given unit to this unit.
+	 * @param amount the amount to convert
+	 * @param unit the unit of the amount
+	 * @return converted amount.
+	 * @throws ArithmeticException if the result overflows a long
+	 */
+	public final long fromUnit(long amount, DigitalUnit unit) {
+		Assert.notNull(unit, "Digital Unit must not be null");
+		switch (unit) {
+		case BYTES:
+			return fromBytes(amount);
+		case KILOBYTES:
+			return fromKilobytes(amount);
+		case MEGABYTES:
+			return fromMegabytes(amount);
+		case GIGABYTES:
+			return fromGigabytes(amount);
+		case TERABYTES:
+			return fromTerabytes(amount);
+		}
+		throw new IllegalArgumentException("Unknown unit '" + unit + "'");
+	}
+
+	/**
+	 * Converts the given amount of bytes to this unit.
+	 * @param amount the amount to convert
+	 * @return converted amount.
+	 */
+	public abstract long fromBytes(long amount);
+
+	/**
+	 * Converts the given amount of kilobytes to this unit.
+	 * @param amount the amount to convert
+	 * @return converted amount.
+	 * @throws ArithmeticException if the result overflows a long
+	 */
+	public abstract long fromKilobytes(long amount);
+
+	/**
+	 * Converts the given amount of megabytes to this unit.
+	 * @param amount the amount to convert
+	 * @return converted amount.
+	 * @throws ArithmeticException if the result overflows a long
+	 */
+	public abstract long fromMegabytes(long amount);
+
+	/**
+	 * Converts the given amount of gigabytes to this unit.
+	 * @param amount the amount to convert
+	 * @return converted amount.
+	 * @throws ArithmeticException if the result overflows a long
+	 */
+	public abstract long fromGigabytes(long amount);
+
+	/**
+	 * Converts the given amount of terabytes to this unit.
+	 * @param amount the amount to convert
+	 * @return converted amount.
+	 * @throws ArithmeticException if the result overflows a long
+	 */
+	public abstract long fromTerabytes(long amount);
+
+	/**
+	 * Detect the {@code DigitalUnit} from the given abbreviation value.
+	 * @param value the abbreviation value
+	 * @return the {@code DigitalUnit}
+	 * @throws IllegalStateException if the value is not a known abbreviation
+	 */
+	public static DigitalUnit fromAbbreviation(String value) {
+		for (DigitalUnit unit : values()) {
+			if (value != null && unit.abbreviation.equalsIgnoreCase(value.trim())) {
+				return unit;
+			}
+		}
+		throw new IllegalArgumentException("Unknown abbreviation '" + value + "'");
+	}
+
+	/**
+	 * Detect the {@code DigitalUnit} from the given name value.
+	 * @param value the name value
+	 * @return the {@code DigitalUnit}
+	 * @throws IllegalStateException if the value is not a known name
+	 */
+	public static DigitalUnit fromName(String value) {
+		for (DigitalUnit unit : values()) {
+			if (value != null && unit.name.equalsIgnoreCase(value.trim())) {
+				return unit;
+			}
+		}
+		throw new IllegalArgumentException("Unknown name '" + value + "'");
+	}
+
+	@Override
+	public String toString() {
+		return this.name;
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DigitalUnit.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DigitalUnit.java
@@ -16,7 +16,10 @@
 
 package org.springframework.boot;
 
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * A {@code DigitalUnit} represents digital amount at a given unit of granularity and
@@ -338,7 +341,7 @@ public enum DigitalUnit {
 	 * @param unit the unit of the amount
 	 * @return converted amount.
 	 */
-	public final long toUnit(long amount, DigitalUnit unit) {
+	public final long toUnit(long amount, @NonNull DigitalUnit unit) {
 		Assert.notNull(unit, "Digital Unit must not be null");
 		switch (unit) {
 		case BYTES:
@@ -397,7 +400,7 @@ public enum DigitalUnit {
 	 * @return converted amount.
 	 * @throws ArithmeticException if the result overflows a long
 	 */
-	public final long fromUnit(long amount, DigitalUnit unit) {
+	public final long fromUnit(long amount, @NonNull DigitalUnit unit) {
 		Assert.notNull(unit, "Digital Unit must not be null");
 		switch (unit) {
 		case BYTES:
@@ -459,10 +462,12 @@ public enum DigitalUnit {
 	 * @return the {@code DigitalUnit}
 	 * @throws IllegalStateException if the value is not a known abbreviation
 	 */
-	public static DigitalUnit fromAbbreviation(String value) {
-		for (DigitalUnit unit : values()) {
-			if (value != null && unit.abbreviation.equalsIgnoreCase(value.trim())) {
-				return unit;
+	public static DigitalUnit fromAbbreviation(@Nullable String value) {
+		if (StringUtils.hasText(value)) {
+			for (DigitalUnit unit : values()) {
+				if (unit.abbreviation.equalsIgnoreCase(value.trim())) {
+					return unit;
+				}
 			}
 		}
 		throw new IllegalArgumentException("Unknown abbreviation '" + value + "'");
@@ -474,10 +479,12 @@ public enum DigitalUnit {
 	 * @return the {@code DigitalUnit}
 	 * @throws IllegalStateException if the value is not a known name
 	 */
-	public static DigitalUnit fromName(String value) {
-		for (DigitalUnit unit : values()) {
-			if (value != null && unit.name.equalsIgnoreCase(value.trim())) {
-				return unit;
+	public static DigitalUnit fromName(@Nullable String value) {
+		if (StringUtils.hasText(value)) {
+			for (DigitalUnit unit : values()) {
+				if (unit.name.equalsIgnoreCase(value.trim())) {
+					return unit;
+				}
 			}
 		}
 		throw new IllegalArgumentException("Unknown name '" + value + "'");

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/ApplicationConversionService.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/ApplicationConversionService.java
@@ -99,6 +99,10 @@ public class ApplicationConversionService extends FormattingConversionService {
 		registry.addConverter(new DurationToStringConverter());
 		registry.addConverter(new NumberToDurationConverter());
 		registry.addConverter(new DurationToNumberConverter());
+		registry.addConverter(new StringToDigitalAmountConverter());
+		registry.addConverter(new DigitalAmountToStringConverter());
+		registry.addConverter(new NumberToDigitalAmountConverter());
+		registry.addConverter(new DigitalAmountToNumberConverter());
 		registry.addConverterFactory(new StringToEnumIgnoringCaseConverterFactory());
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DigitalAmountFormat.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DigitalAmountFormat.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.convert;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.DigitalAmountStyle;
+
+/**
+ * Annotation that can be used to indicate the format to use when converting a
+ * {@link org.springframework.boot.DigitalAmount}.
+ *
+ * @author Dmytro Nosan
+ * @since 2.1.0
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface DigitalAmountFormat {
+
+	/**
+	 * The {@code DigitalAmount} format style.
+	 * @return the {@code DigitalAmount} format style.
+	 */
+	DigitalAmountStyle value();
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DigitalAmountToNumberConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DigitalAmountToNumberConverter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.convert;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.springframework.boot.DigitalAmount;
+import org.springframework.boot.DigitalUnit;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.GenericConverter;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * {@link Converter} to convert from a {@link DigitalAmount} to a {@link Number}.
+ *
+ * @author Dmytro Nosan
+ * @since 2.1.0
+ * @see DigitalAmountFormat
+ * @see DigitalAmountUnit
+ */
+final class DigitalAmountToNumberConverter implements GenericConverter {
+
+	@Override
+	public Set<ConvertiblePair> getConvertibleTypes() {
+		return Collections
+				.singleton(new ConvertiblePair(DigitalAmount.class, Number.class));
+	}
+
+	@Override
+	public Object convert(Object source, TypeDescriptor sourceType,
+			TypeDescriptor targetType) {
+		if (source == null) {
+			return null;
+		}
+		return convert((DigitalAmount) source, getUnit(sourceType),
+				targetType.getObjectType());
+	}
+
+	private DigitalUnit getUnit(TypeDescriptor sourceType) {
+		DigitalAmountUnit annotation = sourceType.getAnnotation(DigitalAmountUnit.class);
+		return (annotation != null) ? annotation.value() : null;
+	}
+
+	private Object convert(DigitalAmount source, DigitalUnit unit, Class<?> type) {
+		try {
+			if (unit == null) {
+				unit = DigitalUnit.BYTES;
+			}
+			return type.getConstructor(String.class).newInstance(
+					String.valueOf(unit.fromUnit(source.toBytes(), DigitalUnit.BYTES)));
+		}
+		catch (Exception ex) {
+			ReflectionUtils.rethrowRuntimeException(ex);
+			throw new IllegalStateException(ex);
+		}
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DigitalAmountToStringConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DigitalAmountToStringConverter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.convert;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.springframework.boot.DigitalAmount;
+import org.springframework.boot.DigitalAmountStyle;
+import org.springframework.boot.DigitalUnit;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.GenericConverter;
+
+/**
+ * {@link Converter} to convert from a {@link org.springframework.boot.DigitalAmount} to a
+ * {@link String}.
+ *
+ * @author Dmytro Nosan
+ * @since 2.1.0
+ * @see DigitalAmountFormat
+ * @see DigitalAmountUnit
+ */
+final class DigitalAmountToStringConverter implements GenericConverter {
+
+	@Override
+	public Set<ConvertiblePair> getConvertibleTypes() {
+		return Collections
+				.singleton(new ConvertiblePair(DigitalAmount.class, String.class));
+	}
+
+	@Override
+	public Object convert(Object source, TypeDescriptor sourceType,
+			TypeDescriptor targetType) {
+		if (source == null) {
+			return null;
+		}
+		return convert((DigitalAmount) source, getStyle(sourceType), getUnit(sourceType));
+	}
+
+	private DigitalUnit getUnit(TypeDescriptor sourceType) {
+		DigitalAmountUnit annotation = sourceType.getAnnotation(DigitalAmountUnit.class);
+		return (annotation != null) ? annotation.value() : null;
+	}
+
+	private DigitalAmountStyle getStyle(TypeDescriptor sourceType) {
+		DigitalAmountFormat annotation = sourceType
+				.getAnnotation(DigitalAmountFormat.class);
+		return (annotation != null) ? annotation.value() : null;
+	}
+
+	private String convert(DigitalAmount source, DigitalAmountStyle style,
+			DigitalUnit unit) {
+		style = (style != null) ? style : DigitalAmountStyle.SIMPLE;
+		return style.print(source, unit);
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DigitalAmountUnit.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DigitalAmountUnit.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.convert;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.DigitalUnit;
+
+/**
+ * Annotation that can be used to change the default unit used when converting a
+ * {@link org.springframework.boot.DigitalAmount}.
+ *
+ * @author Dmytro Nosan
+ * @since 2.1.0
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface DigitalAmountUnit {
+
+	/**
+	 * The {@code DigitalUnit} to use if one is not specified.
+	 * @return the {@code DigitalUnit}
+	 */
+	DigitalUnit value();
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/NumberToDigitalAmountConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/NumberToDigitalAmountConverter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.convert;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.springframework.boot.DigitalAmount;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.GenericConverter;
+
+/**
+ * {@link Converter} to convert from a {@link Number} to a
+ * {@link org.springframework.boot.DigitalAmount}.
+ *
+ * @author Dmytro Nosan
+ * @since 2.1.0
+ * @see DigitalAmountFormat
+ * @see DigitalAmountUnit
+ */
+final class NumberToDigitalAmountConverter implements GenericConverter {
+
+	private final StringToDigitalAmountConverter delegate = new StringToDigitalAmountConverter();
+
+	@Override
+	public Set<ConvertiblePair> getConvertibleTypes() {
+		return Collections
+				.singleton(new ConvertiblePair(Number.class, DigitalAmount.class));
+	}
+
+	@Override
+	public Object convert(Object source, TypeDescriptor sourceType,
+			TypeDescriptor targetType) {
+		return this.delegate.convert((source != null) ? source.toString() : null,
+				TypeDescriptor.valueOf(String.class), targetType);
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/StringToDigitalAmountConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/StringToDigitalAmountConverter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.convert;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.springframework.boot.DigitalAmount;
+import org.springframework.boot.DigitalAmountStyle;
+import org.springframework.boot.DigitalUnit;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.GenericConverter;
+import org.springframework.util.ObjectUtils;
+
+/**
+ * {@link Converter} to convert from a {@link String} to a
+ * {@link org.springframework.boot.DigitalAmount}.
+ *
+ * @author Dmytro Nosan
+ * @since 2.1.0
+ * @see DigitalAmountFormat
+ * @see DigitalAmountUnit
+ */
+final class StringToDigitalAmountConverter implements GenericConverter {
+
+	@Override
+	public Set<ConvertiblePair> getConvertibleTypes() {
+		return Collections
+				.singleton(new ConvertiblePair(String.class, DigitalAmount.class));
+	}
+
+	@Override
+	public Object convert(Object source, TypeDescriptor sourceType,
+			TypeDescriptor targetType) {
+		if (ObjectUtils.isEmpty(source)) {
+			return null;
+		}
+		return convert(source.toString(), getStyle(targetType), getUnit(targetType));
+	}
+
+	private DigitalUnit getUnit(TypeDescriptor sourceType) {
+		DigitalAmountUnit annotation = sourceType.getAnnotation(DigitalAmountUnit.class);
+		return (annotation != null) ? annotation.value() : null;
+	}
+
+	private DigitalAmountStyle getStyle(TypeDescriptor sourceType) {
+		DigitalAmountFormat annotation = sourceType
+				.getAnnotation(DigitalAmountFormat.class);
+		return (annotation != null) ? annotation.value() : null;
+	}
+
+	private DigitalAmount convert(String source, DigitalAmountStyle style,
+			DigitalUnit unit) {
+		style = (style != null) ? style : DigitalAmountStyle.detect(source);
+		return style.parse(source, unit);
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/DigitalAmountStyleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/DigitalAmountStyleTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link DigitalAmountStyle}.
+ *
+ * @author Dmytro Nosan
+ */
+public class DigitalAmountStyleTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void detectAndParseWhenValueIsNullShouldThrowException() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Digital Amount pattern must not be null");
+		detectAndParse(null, null);
+	}
+
+	@Test
+	public void detectAndParseWhenSimpleBytesDigitalAmount() {
+		assertThat(detectAndParse("10b")).isEqualTo(DigitalAmount.fromBytes(10));
+		assertThat(detectAndParse("10B")).isEqualTo(DigitalAmount.fromBytes(10));
+		assertThat(detectAndParse("+10 B")).isEqualTo(DigitalAmount.fromBytes(10));
+		assertThat(detectAndParse("-10 b")).isEqualTo(DigitalAmount.fromBytes(-10));
+	}
+
+	@Test
+	public void detectAndParseWhenSimpleKilobytesShouldReturnDigitalAmount() {
+		assertThat(detectAndParse("10kb")).isEqualTo(DigitalAmount.fromKilobytes(10));
+		assertThat(detectAndParse("10KB")).isEqualTo(DigitalAmount.fromKilobytes(10));
+		assertThat(detectAndParse("+10 KB")).isEqualTo(DigitalAmount.fromKilobytes(10));
+		assertThat(detectAndParse("-10 kb")).isEqualTo(DigitalAmount.fromKilobytes(-10));
+	}
+
+	@Test
+	public void detectAndParseWhenSimpleMegabytesShouldReturnDigitalAmount() {
+		assertThat(detectAndParse("10mb")).isEqualTo(DigitalAmount.fromMegabytes(10));
+		assertThat(detectAndParse("10MB")).isEqualTo(DigitalAmount.fromMegabytes(10));
+		assertThat(detectAndParse("+10 MB")).isEqualTo(DigitalAmount.fromMegabytes(10));
+		assertThat(detectAndParse("-10 mb")).isEqualTo(DigitalAmount.fromMegabytes(-10));
+	}
+
+	@Test
+	public void detectAndParseWhenSimpleGigabytesShouldReturnDigitalAmount() {
+		assertThat(detectAndParse("10gb")).isEqualTo(DigitalAmount.fromGigabytes(10));
+		assertThat(detectAndParse("10GB")).isEqualTo(DigitalAmount.fromGigabytes(10));
+		assertThat(detectAndParse("+10 gb")).isEqualTo(DigitalAmount.fromGigabytes(10));
+		assertThat(detectAndParse("-10 GB")).isEqualTo(DigitalAmount.fromGigabytes(-10));
+	}
+
+	@Test
+	public void detectAndParseWhenSimpleTerabytesShouldReturnDigitalAmount() {
+		assertThat(detectAndParse("10tb")).isEqualTo(DigitalAmount.fromTerabytes(10));
+		assertThat(detectAndParse("10TB")).isEqualTo(DigitalAmount.fromTerabytes(10));
+		assertThat(detectAndParse("+10 tb")).isEqualTo(DigitalAmount.fromTerabytes(10));
+		assertThat(detectAndParse("-10 TB")).isEqualTo(DigitalAmount.fromTerabytes(-10));
+	}
+
+	@Test
+	public void detectAndParseWhenSimpleWithoutSuffixShouldReturnDigitalAmount() {
+		assertThat(detectAndParse("10")).isEqualTo(DigitalAmount.fromBytes(10));
+		assertThat(detectAndParse("+10")).isEqualTo(DigitalAmount.fromBytes(10));
+		assertThat(detectAndParse("-10")).isEqualTo(DigitalAmount.fromBytes(-10));
+	}
+
+	@Test
+	public void detectAndParseWhenSimpleWithoutSuffixButWithDigitalUnitShouldReturnDigitalAmount() {
+		assertThat(detectAndParse("10", DigitalUnit.MEGABYTES))
+				.isEqualTo(DigitalAmount.fromMegabytes(10));
+		assertThat(detectAndParse("+10", DigitalUnit.MEGABYTES))
+				.isEqualTo(DigitalAmount.fromMegabytes(10));
+		assertThat(detectAndParse("-10", DigitalUnit.MEGABYTES))
+				.isEqualTo(DigitalAmount.fromMegabytes(-10));
+	}
+
+	@Test
+	public void detectAndParseWhenBadFormatShouldThrowException() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("'10foo' is not a valid digital amount");
+		detectAndParse("10foo");
+	}
+
+	@Test
+	public void detectWhenUnknownShouldThrowException() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("'bad' is not a valid digital amount");
+		DigitalAmountStyle.detect("bad");
+	}
+
+	@Test
+	public void parseSimpleShouldParse() {
+		assertThat(DigitalAmountStyle.SIMPLE.parse("10mb"))
+				.isEqualTo(DigitalAmount.fromMegabytes(10));
+	}
+
+	@Test
+	public void parseSimpleWithUnitShouldUseUnitAsFallback() {
+		assertThat(DigitalAmountStyle.SIMPLE.parse("10mb", DigitalUnit.KILOBYTES))
+				.isEqualTo(DigitalAmount.fromMegabytes(10));
+		assertThat(DigitalAmountStyle.SIMPLE.parse("10", DigitalUnit.KILOBYTES))
+				.isEqualTo(DigitalAmount.fromKilobytes(10));
+	}
+
+	@Test
+	public void parseSimpleWhenUnknownUnitShouldThrowException() {
+		try {
+			DigitalAmountStyle.SIMPLE.parse("10EB");
+			fail("Did not throw");
+		}
+		catch (IllegalArgumentException ex) {
+			assertThat(ex.getCause().getMessage()).isEqualTo("Unknown abbreviation 'EB'");
+		}
+	}
+
+	@Test
+	public void printSimpleWithoutUnitShouldPrintInBytes() {
+		assertThat(DigitalAmountStyle.SIMPLE.print(DigitalAmount.fromKilobytes(1)))
+				.isEqualTo("1024B");
+	}
+
+	@Test
+	public void printSimpleWithUnitShouldPrintInUnit() {
+		assertThat(DigitalAmountStyle.SIMPLE.print(DigitalAmount.fromBytes(1024),
+				DigitalUnit.KILOBYTES)).isEqualTo("1KB");
+	}
+
+	private static DigitalAmount detectAndParse(CharSequence value, DigitalUnit unit) {
+		return DigitalAmountStyle.detect(value).parse(value, unit);
+	}
+
+	private static DigitalAmount detectAndParse(CharSequence value) {
+		return detectAndParse(value, null);
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/DigitalAmountTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/DigitalAmountTests.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DigitalAmount}.
+ *
+ * @author Dmytro Nosan
+ */
+public class DigitalAmountTests {
+
+	@Test
+	public void isNegative() {
+		DigitalAmount digitalAmount = DigitalAmount.fromMegabytes(-10);
+		assertThat(digitalAmount.isZero()).isFalse();
+		assertThat(digitalAmount.isNegative()).isTrue();
+		assertThat(digitalAmount.isPositive()).isFalse();
+	}
+
+	@Test
+	public void isPositive() {
+		DigitalAmount digitalAmount = DigitalAmount.fromMegabytes(10);
+		assertThat(digitalAmount.isZero()).isFalse();
+		assertThat(digitalAmount.isNegative()).isFalse();
+		assertThat(digitalAmount.isPositive()).isTrue();
+	}
+
+	@Test
+	public void isZero() {
+		DigitalAmount digitalAmount = DigitalAmount.fromMegabytes(0);
+		assertThat(digitalAmount.isZero()).isTrue();
+		assertThat(digitalAmount.isNegative()).isFalse();
+		assertThat(digitalAmount.isPositive()).isFalse();
+	}
+
+	@Test
+	public void filter() {
+		assertThat(
+				DigitalAmount.fromMegabytes(0).filter(DigitalAmount::isZero).isPresent())
+						.isTrue();
+
+		assertThat(DigitalAmount.fromMegabytes(0).filter(DigitalAmount::isPositive)
+				.isPresent()).isFalse();
+	}
+
+	@Test
+	public void map() {
+		assertThat(DigitalAmount.fromMegabytes(1).map(DigitalAmount::toKilobytes))
+				.isEqualTo(1024);
+	}
+
+	@Test
+	public void amountHashCode() {
+		assertThat(DigitalAmount.fromGigabytes(1024).hashCode())
+				.isEqualTo(DigitalAmount.fromTerabytes(1).hashCode());
+	}
+
+	@Test
+	public void compareTo() {
+		assertThat(DigitalAmount.fromMegabytes(1)
+				.compareTo(DigitalAmount.fromKilobytes(1024))).isZero();
+
+		assertThat(
+				DigitalAmount.fromMegabytes(1).compareTo(DigitalAmount.fromBytes(1024)))
+						.isGreaterThan(0);
+
+		assertThat(
+				DigitalAmount.fromMegabytes(1).compareTo(DigitalAmount.fromGigabytes(1)))
+						.isLessThan(0);
+	}
+
+	@Test
+	public void equalsAmount() {
+
+		assertThat(
+				DigitalAmount.fromMegabytes(1).equals(DigitalAmount.fromKilobytes(1024)))
+						.isTrue();
+
+		assertThat(DigitalAmount.fromMegabytes(1).equals(DigitalAmount.fromMegabytes(1)))
+				.isTrue();
+
+		assertThat(DigitalAmount.fromMegabytes(1).equals(DigitalAmount.fromGigabytes(1)))
+				.isFalse();
+	}
+
+	@Test
+	public void toStringAmount() {
+		assertThat(DigitalAmount.fromMegabytes(10).toString()).isEqualTo("10485760B");
+	}
+
+	@Test
+	public void print() {
+		assertThat(DigitalAmount.fromBytes(10).print(DigitalUnit.BYTES)).isEqualTo("10B");
+
+		assertThat(DigitalAmount.fromKilobytes(10).print(DigitalUnit.BYTES))
+				.isEqualTo("10240B");
+
+		assertThat(DigitalAmount.fromMegabytes(10).print(DigitalUnit.KILOBYTES))
+				.isEqualTo("10240KB");
+	}
+
+	@Test
+	public void parse() {
+		assertThat(DigitalAmount.parse("10")).isEqualTo(DigitalAmount.fromBytes(10));
+		assertThat(DigitalAmount.parse("10 B")).isEqualTo(DigitalAmount.fromBytes(10));
+		assertThat(DigitalAmount.parse("10 KB"))
+				.isEqualTo(DigitalAmount.fromKilobytes(10));
+		assertThat(DigitalAmount.parse("10 MB"))
+				.isEqualTo(DigitalAmount.fromMegabytes(10));
+		assertThat(DigitalAmount.parse("10 GB"))
+				.isEqualTo(DigitalAmount.fromGigabytes(10));
+		assertThat(DigitalAmount.parse("-10 TB"))
+				.isEqualTo(DigitalAmount.fromTerabytes(-10));
+	}
+
+	@Test
+	public void toBytes() {
+		assertThat(DigitalAmount.fromTerabytes(1).toBytes())
+				.isEqualTo(1024L * 1024 * 1024 * 1024);
+		assertThat(DigitalAmount.fromGigabytes(1).toBytes())
+				.isEqualTo(1024 * 1024 * 1024);
+		assertThat(DigitalAmount.fromMegabytes(1).toBytes()).isEqualTo(1024 * 1024);
+		assertThat(DigitalAmount.fromKilobytes(1).toBytes()).isEqualTo(1024);
+		assertThat(DigitalAmount.fromBytes(1).toBytes()).isEqualTo(1);
+	}
+
+	@Test
+	public void toKilobytes() {
+		assertThat(DigitalAmount.fromTerabytes(1).toKilobytes())
+				.isEqualTo(1024L * 1024 * 1024);
+		assertThat(DigitalAmount.fromGigabytes(1).toKilobytes()).isEqualTo(1024 * 1024);
+		assertThat(DigitalAmount.fromMegabytes(1).toKilobytes()).isEqualTo(1024);
+		assertThat(DigitalAmount.fromKilobytes(1).toKilobytes()).isEqualTo(1);
+		assertThat(DigitalAmount.fromBytes(1).toKilobytes()).isEqualTo(0);
+	}
+
+	@Test
+	public void toMegabytes() {
+
+		assertThat(DigitalAmount.fromTerabytes(1).toMegabytes()).isEqualTo(1024L * 1024);
+		assertThat(DigitalAmount.fromGigabytes(1).toMegabytes()).isEqualTo(1024);
+		assertThat(DigitalAmount.fromMegabytes(1).toMegabytes()).isEqualTo(1);
+		assertThat(DigitalAmount.fromKilobytes(1).toMegabytes()).isEqualTo(0);
+		assertThat(DigitalAmount.fromBytes(1).toMegabytes()).isEqualTo(0);
+	}
+
+	@Test
+	public void toGigabytes() {
+
+		assertThat(DigitalAmount.fromTerabytes(1).toGigabytes()).isEqualTo(1024);
+		assertThat(DigitalAmount.fromGigabytes(1).toGigabytes()).isEqualTo(1);
+		assertThat(DigitalAmount.fromMegabytes(1).toGigabytes()).isEqualTo(0);
+		assertThat(DigitalAmount.fromKilobytes(1).toGigabytes()).isEqualTo(0);
+		assertThat(DigitalAmount.fromBytes(1).toGigabytes()).isEqualTo(0);
+	}
+
+	@Test
+	public void toTerabytes() {
+		assertThat(DigitalAmount.fromTerabytes(1).toTerabytes()).isEqualTo(1);
+		assertThat(DigitalAmount.fromGigabytes(1).toTerabytes()).isEqualTo(0);
+		assertThat(DigitalAmount.fromMegabytes(1).toTerabytes()).isEqualTo(0);
+		assertThat(DigitalAmount.fromKilobytes(1).toTerabytes()).isEqualTo(0);
+		assertThat(DigitalAmount.fromBytes(1).toTerabytes()).isEqualTo(0);
+	}
+
+	@Test
+	public void fromBytes() {
+		assertThat(DigitalAmount.fromBytes(1024L * 1024 * 1024 * 1024).toTerabytes())
+				.isEqualTo(1);
+		assertThat(DigitalAmount.fromBytes(1024L * 1024 * 1024 * 1024).toGigabytes())
+				.isEqualTo(1024);
+		assertThat(DigitalAmount.fromBytes(1024L * 1024 * 1024 * 1024).toMegabytes())
+				.isEqualTo(1024 * 1024);
+		assertThat(DigitalAmount.fromBytes(1024L * 1024 * 1024 * 1024).toKilobytes())
+				.isEqualTo(1024 * 1024 * 1024);
+		assertThat(DigitalAmount.fromBytes(1024L * 1024 * 1024 * 1024).toBytes())
+				.isEqualTo(1024L * 1024 * 1024 * 1024);
+	}
+
+	@Test
+	public void fromKilobytes() {
+		assertThat(DigitalAmount.fromKilobytes(1024L * 1024 * 1024 * 1024).toTerabytes())
+				.isEqualTo(1024);
+		assertThat(DigitalAmount.fromKilobytes(1024L * 1024 * 1024 * 1024).toGigabytes())
+				.isEqualTo(1024 * 1024);
+		assertThat(DigitalAmount.fromKilobytes(1024L * 1024 * 1024 * 1024).toMegabytes())
+				.isEqualTo(1024 * 1024 * 1024);
+		assertThat(DigitalAmount.fromKilobytes(1024L * 1024 * 1024 * 1024).toKilobytes())
+				.isEqualTo(1024L * 1024 * 1024 * 1024);
+		assertThat(DigitalAmount.fromKilobytes(1024L * 1024 * 1024 * 1024).toBytes())
+				.isEqualTo(1024L * 1024 * 1024 * 1024 * 1024);
+	}
+
+	@Test
+	public void fromMegabytes() {
+		assertThat(DigitalAmount.fromMegabytes(1024L * 1024 * 1024 * 1024).toTerabytes())
+				.isEqualTo(1024 * 1024);
+		assertThat(DigitalAmount.fromMegabytes(1024L * 1024 * 1024 * 1024).toGigabytes())
+				.isEqualTo(1024 * 1024 * 1024);
+		assertThat(DigitalAmount.fromMegabytes(1024L * 1024 * 1024 * 1024).toMegabytes())
+				.isEqualTo(1024L * 1024 * 1024 * 1024);
+		assertThat(DigitalAmount.fromMegabytes(1024L * 1024 * 1024 * 1024).toKilobytes())
+				.isEqualTo(1024L * 1024 * 1024 * 1024 * 1024);
+		assertThat(DigitalAmount.fromMegabytes(1024L * 1024 * 1024 * 1024).toBytes())
+				.isEqualTo(1024L * 1024 * 1024 * 1024 * 1024 * 1024);
+	}
+
+	@Test
+	public void fromGigabytes() {
+		assertThat(DigitalAmount.fromGigabytes(1024L).toTerabytes()).isEqualTo(1);
+		assertThat(DigitalAmount.fromGigabytes(1024L).toGigabytes()).isEqualTo(1024);
+		assertThat(DigitalAmount.fromGigabytes(1024L).toMegabytes())
+				.isEqualTo(1024 * 1024);
+		assertThat(DigitalAmount.fromGigabytes(1024L).toKilobytes())
+				.isEqualTo(1024 * 1024 * 1024);
+		assertThat(DigitalAmount.fromGigabytes(1024L).toBytes())
+				.isEqualTo(1024L * 1024 * 1024 * 1024);
+	}
+
+	@Test
+	public void fromTerabytes() {
+		assertThat(DigitalAmount.fromTerabytes(1).toTerabytes()).isEqualTo(1);
+		assertThat(DigitalAmount.fromTerabytes(1).toGigabytes()).isEqualTo(1024);
+		assertThat(DigitalAmount.fromTerabytes(1).toMegabytes()).isEqualTo(1024 * 1024);
+		assertThat(DigitalAmount.fromTerabytes(1).toKilobytes())
+				.isEqualTo(1024 * 1024 * 1024);
+		assertThat(DigitalAmount.fromTerabytes(1).toBytes())
+				.isEqualTo(1024L * 1024 * 1024 * 1024);
+	}
+
+	@Test
+	public void fromUnit() {
+		assertThat(DigitalAmount.fromUnit(1, DigitalUnit.BYTES))
+				.isEqualTo(DigitalAmount.fromBytes(1));
+		assertThat(DigitalAmount.fromUnit(1, DigitalUnit.KILOBYTES))
+				.isEqualTo(DigitalAmount.fromKilobytes(1));
+		assertThat(DigitalAmount.fromUnit(1, DigitalUnit.MEGABYTES))
+				.isEqualTo(DigitalAmount.fromMegabytes(1));
+		assertThat(DigitalAmount.fromUnit(1, DigitalUnit.GIGABYTES))
+				.isEqualTo(DigitalAmount.fromGigabytes(1));
+		assertThat(DigitalAmount.fromUnit(1, DigitalUnit.TERABYTES))
+				.isEqualTo(DigitalAmount.fromTerabytes(1));
+	}
+
+	@Test
+	public void add() {
+		assertThat(DigitalAmount.fromTerabytes(1).add(DigitalAmount.fromGigabytes(1))
+				.add(DigitalAmount.fromMegabytes(10))
+				.add(DigitalAmount.fromKilobytes(10).add(DigitalAmount.fromBytes(10))))
+						.isEqualTo(DigitalAmount.fromBytes(1100595865610L));
+	}
+
+	@Test
+	public void addUnit() {
+		assertThat(DigitalAmount.fromUnit(1, DigitalUnit.TERABYTES)
+				.add(1, DigitalUnit.GIGABYTES).add(10, DigitalUnit.MEGABYTES)
+				.add(10, DigitalUnit.KILOBYTES).add(10, DigitalUnit.BYTES))
+						.isEqualTo(DigitalAmount.fromBytes(1100595865610L));
+	}
+
+	@Test
+	public void subtract() {
+
+		assertThat(DigitalAmount.fromTerabytes(1).subtract(DigitalAmount.fromGigabytes(1))
+				.subtract(DigitalAmount.fromMegabytes(10))
+				.subtract(DigitalAmount.fromKilobytes(10)
+						.subtract(DigitalAmount.fromBytes(10))))
+								.isEqualTo(DigitalAmount.fromBytes(1098427389962L));
+	}
+
+	@Test
+	public void subtractUnit() {
+		assertThat(DigitalAmount.fromUnit(1, DigitalUnit.TERABYTES)
+				.subtract(1, DigitalUnit.GIGABYTES).subtract(10, DigitalUnit.MEGABYTES)
+				.subtract(10, DigitalUnit.KILOBYTES).subtract(10, DigitalUnit.BYTES))
+						.isEqualTo(DigitalAmount.fromBytes(1098427389942L));
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/DigitalAmountTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/DigitalAmountTests.java
@@ -278,7 +278,6 @@ public class DigitalAmountTests {
 
 	@Test
 	public void subtract() {
-
 		assertThat(DigitalAmount.fromTerabytes(1).subtract(DigitalAmount.fromGigabytes(1))
 				.subtract(DigitalAmount.fromMegabytes(10))
 				.subtract(DigitalAmount.fromKilobytes(10)

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/DigitalUnitTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/DigitalUnitTests.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DigitalUnit}.
+ *
+ * @author Dmytro Nosan
+ */
+public class DigitalUnitTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void bytesUnit() {
+		assertBytesToUnit();
+		assertFromUnitToBytes();
+		assertCompareBytes();
+	}
+
+	@Test
+	public void kilobytesUnit() {
+		assertKilobytesToUnit();
+		assertFromUnitToKilobytes();
+		assertCompareKilobytes();
+
+	}
+
+	@Test
+	public void megabytesUnit() {
+		assertMegabytesToUnit();
+		assertFromUnitToMegabytes();
+		assertCompareMegabytes();
+	}
+
+	@Test
+	public void gigabytesUnit() {
+		assertGigabytesToUnit();
+		assertUnitToGigabytes();
+		assertCompareGigabytes();
+
+	}
+
+	@Test
+	public void terabytesUnit() {
+		assertTerabytesToUnit();
+		assertUnitToTerabytes();
+		assertCompareTerabytes();
+
+	}
+
+	@Test
+	public void fromNameUnknown() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Unknown name 'TTT'");
+		DigitalUnit.fromName("TTT");
+	}
+
+	@Test
+	public void fromName() {
+		assertThat(DigitalUnit.fromName("Bytes")).isEqualTo(DigitalUnit.BYTES);
+		assertThat(DigitalUnit.fromName("Kilobytes")).isEqualTo(DigitalUnit.KILOBYTES);
+		assertThat(DigitalUnit.fromName("Megabytes")).isEqualTo(DigitalUnit.MEGABYTES);
+		assertThat(DigitalUnit.fromName("Gigabytes")).isEqualTo(DigitalUnit.GIGABYTES);
+		assertThat(DigitalUnit.fromName("Terabytes")).isEqualTo(DigitalUnit.TERABYTES);
+	}
+
+	@Test
+	public void fromAbbreviation() {
+		assertThat(DigitalUnit.fromAbbreviation("B")).isEqualTo(DigitalUnit.BYTES);
+		assertThat(DigitalUnit.fromAbbreviation("KB")).isEqualTo(DigitalUnit.KILOBYTES);
+		assertThat(DigitalUnit.fromAbbreviation("MB")).isEqualTo(DigitalUnit.MEGABYTES);
+		assertThat(DigitalUnit.fromAbbreviation("GB")).isEqualTo(DigitalUnit.GIGABYTES);
+		assertThat(DigitalUnit.fromAbbreviation("TB")).isEqualTo(DigitalUnit.TERABYTES);
+	}
+
+	@Test
+	public void fromNameAbbreviation() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Unknown abbreviation 'TTT'");
+		DigitalUnit.fromAbbreviation("TTT");
+	}
+
+	private static void assertBytesToUnit() {
+		assertThat(DigitalUnit.BYTES.toBytes(1024)).isEqualTo(1024);
+		assertThat(DigitalUnit.BYTES.toKilobytes(1024)).isEqualTo(1);
+		assertThat(DigitalUnit.BYTES.toMegabytes(1024 * 1024)).isEqualTo(1);
+		assertThat(DigitalUnit.BYTES.toGigabytes(1024 * 1024 * 1024)).isEqualTo(1);
+		assertThat(DigitalUnit.BYTES.toTerabytes(1024L * 1024 * 1024 * 1024))
+				.isEqualTo(1);
+
+		assertThat(DigitalUnit.BYTES.toUnit(1024, DigitalUnit.BYTES)).isEqualTo(1024);
+		assertThat(DigitalUnit.BYTES.toUnit(1024, DigitalUnit.KILOBYTES)).isEqualTo(1);
+		assertThat(DigitalUnit.BYTES.toUnit(1024 * 1024, DigitalUnit.MEGABYTES))
+				.isEqualTo(1);
+		assertThat(DigitalUnit.BYTES.toUnit(1024 * 1024 * 1024, DigitalUnit.GIGABYTES))
+				.isEqualTo(1);
+		assertThat(DigitalUnit.BYTES.toUnit(1024L * 1024 * 1024 * 1024,
+				DigitalUnit.TERABYTES)).isEqualTo(1);
+	}
+
+	private static void assertFromUnitToBytes() {
+		assertThat(DigitalUnit.BYTES.fromBytes(1024)).isEqualTo(1024);
+		assertThat(DigitalUnit.BYTES.fromKilobytes(1)).isEqualTo(1024);
+		assertThat(DigitalUnit.BYTES.fromMegabytes(1)).isEqualTo(1024 * 1024);
+		assertThat(DigitalUnit.BYTES.fromGigabytes(1)).isEqualTo(1024 * 1024 * 1024);
+		assertThat(DigitalUnit.BYTES.fromTerabytes(1))
+				.isEqualTo(1024L * 1024 * 1024 * 1024);
+
+		assertThat(DigitalUnit.BYTES.fromUnit(1024, DigitalUnit.BYTES)).isEqualTo(1024);
+		assertThat(DigitalUnit.BYTES.fromUnit(1, DigitalUnit.KILOBYTES)).isEqualTo(1024);
+		assertThat(DigitalUnit.BYTES.fromUnit(1, DigitalUnit.MEGABYTES))
+				.isEqualTo(1024 * 1024);
+		assertThat(DigitalUnit.BYTES.fromUnit(1, DigitalUnit.GIGABYTES))
+				.isEqualTo(1024 * 1024 * 1024);
+		assertThat(DigitalUnit.BYTES.fromUnit(1, DigitalUnit.TERABYTES))
+				.isEqualTo(1024L * 1024 * 1024 * 1024);
+	}
+
+	private static void assertCompareBytes() {
+		assertThat(DigitalUnit.BYTES.compareTo(DigitalUnit.BYTES)).isZero();
+		assertThat(DigitalUnit.BYTES.compareTo(DigitalUnit.KILOBYTES)).isLessThan(0);
+		assertThat(DigitalUnit.BYTES.compareTo(DigitalUnit.MEGABYTES)).isLessThan(0);
+		assertThat(DigitalUnit.BYTES.compareTo(DigitalUnit.GIGABYTES)).isLessThan(0);
+		assertThat(DigitalUnit.BYTES.compareTo(DigitalUnit.TERABYTES)).isLessThan(0);
+
+	}
+
+	private static void assertFromUnitToKilobytes() {
+		assertThat(DigitalUnit.KILOBYTES.fromBytes(1024)).isEqualTo(1);
+		assertThat(DigitalUnit.KILOBYTES.fromKilobytes(1024)).isEqualTo(1024);
+		assertThat(DigitalUnit.KILOBYTES.fromMegabytes(1)).isEqualTo(1024);
+		assertThat(DigitalUnit.KILOBYTES.fromGigabytes(1)).isEqualTo(1024 * 1024);
+		assertThat(DigitalUnit.KILOBYTES.fromTerabytes(1)).isEqualTo(1024 * 1024 * 1024);
+
+		assertThat(DigitalUnit.KILOBYTES.fromUnit(1024, DigitalUnit.BYTES)).isEqualTo(1);
+		assertThat(DigitalUnit.KILOBYTES.fromUnit(1024, DigitalUnit.KILOBYTES))
+				.isEqualTo(1024);
+		assertThat(DigitalUnit.KILOBYTES.fromUnit(1, DigitalUnit.MEGABYTES))
+				.isEqualTo(1024);
+		assertThat(DigitalUnit.KILOBYTES.fromUnit(1, DigitalUnit.GIGABYTES))
+				.isEqualTo(1024 * 1024);
+		assertThat(DigitalUnit.KILOBYTES.fromUnit(1, DigitalUnit.TERABYTES))
+				.isEqualTo(1024 * 1024 * 1024);
+	}
+
+	private static void assertKilobytesToUnit() {
+		assertThat(DigitalUnit.KILOBYTES.toBytes(1)).isEqualTo(1024);
+		assertThat(DigitalUnit.KILOBYTES.toKilobytes(1024)).isEqualTo(1024);
+		assertThat(DigitalUnit.KILOBYTES.toMegabytes(1024)).isEqualTo(1);
+		assertThat(DigitalUnit.KILOBYTES.toGigabytes(1024 * 1024)).isEqualTo(1);
+		assertThat(DigitalUnit.KILOBYTES.toTerabytes(1024 * 1024 * 1024)).isEqualTo(1);
+
+		assertThat(DigitalUnit.KILOBYTES.toUnit(1, DigitalUnit.BYTES)).isEqualTo(1024);
+		assertThat(DigitalUnit.KILOBYTES.toUnit(1024, DigitalUnit.KILOBYTES))
+				.isEqualTo(1024);
+		assertThat(DigitalUnit.KILOBYTES.toUnit(1024, DigitalUnit.MEGABYTES))
+				.isEqualTo(1);
+		assertThat(DigitalUnit.KILOBYTES.toUnit(1024 * 1024, DigitalUnit.GIGABYTES))
+				.isEqualTo(1);
+		assertThat(
+				DigitalUnit.KILOBYTES.toUnit(1024 * 1024 * 1024, DigitalUnit.TERABYTES))
+						.isEqualTo(1);
+	}
+
+	private static void assertCompareKilobytes() {
+		assertThat(DigitalUnit.KILOBYTES.compareTo(DigitalUnit.BYTES)).isGreaterThan(0);
+		assertThat(DigitalUnit.KILOBYTES.compareTo(DigitalUnit.KILOBYTES)).isZero();
+		assertThat(DigitalUnit.KILOBYTES.compareTo(DigitalUnit.MEGABYTES)).isLessThan(0);
+		assertThat(DigitalUnit.KILOBYTES.compareTo(DigitalUnit.GIGABYTES)).isLessThan(0);
+		assertThat(DigitalUnit.KILOBYTES.compareTo(DigitalUnit.TERABYTES)).isLessThan(0);
+	}
+
+	private void assertFromUnitToMegabytes() {
+		assertThat(DigitalUnit.MEGABYTES.fromBytes(1024 * 1024)).isEqualTo(1);
+		assertThat(DigitalUnit.MEGABYTES.fromKilobytes(1024)).isEqualTo(1);
+		assertThat(DigitalUnit.MEGABYTES.fromMegabytes(1024)).isEqualTo(1024);
+		assertThat(DigitalUnit.MEGABYTES.fromGigabytes(1)).isEqualTo(1024);
+		assertThat(DigitalUnit.MEGABYTES.fromTerabytes(1)).isEqualTo(1024 * 1024);
+
+		assertThat(DigitalUnit.MEGABYTES.fromUnit(1024 * 1024, DigitalUnit.BYTES))
+				.isEqualTo(1);
+		assertThat(DigitalUnit.MEGABYTES.fromUnit(1024, DigitalUnit.KILOBYTES))
+				.isEqualTo(1);
+		assertThat(DigitalUnit.MEGABYTES.fromUnit(1024, DigitalUnit.MEGABYTES))
+				.isEqualTo(1024);
+		assertThat(DigitalUnit.MEGABYTES.fromUnit(1, DigitalUnit.GIGABYTES))
+				.isEqualTo(1024);
+		assertThat(DigitalUnit.MEGABYTES.fromUnit(1, DigitalUnit.TERABYTES))
+				.isEqualTo(1024 * 1024);
+	}
+
+	private static void assertMegabytesToUnit() {
+		assertThat(DigitalUnit.MEGABYTES.toBytes(1)).isEqualTo(1024 * 1024);
+		assertThat(DigitalUnit.MEGABYTES.toKilobytes(1)).isEqualTo(1024);
+		assertThat(DigitalUnit.MEGABYTES.toMegabytes(1024)).isEqualTo(1024);
+		assertThat(DigitalUnit.MEGABYTES.toGigabytes(1024)).isEqualTo(1);
+		assertThat(DigitalUnit.MEGABYTES.toTerabytes(1024 * 1024)).isEqualTo(1);
+
+		assertThat(DigitalUnit.MEGABYTES.toUnit(1, DigitalUnit.BYTES))
+				.isEqualTo(1024 * 1024);
+		assertThat(DigitalUnit.MEGABYTES.toUnit(1, DigitalUnit.KILOBYTES))
+				.isEqualTo(1024);
+		assertThat(DigitalUnit.MEGABYTES.toUnit(1024, DigitalUnit.MEGABYTES))
+				.isEqualTo(1024);
+		assertThat(DigitalUnit.MEGABYTES.toUnit(1024, DigitalUnit.GIGABYTES))
+				.isEqualTo(1);
+		assertThat(DigitalUnit.MEGABYTES.toUnit(1024 * 1024, DigitalUnit.TERABYTES))
+				.isEqualTo(1);
+	}
+
+	private static void assertCompareMegabytes() {
+		assertThat(DigitalUnit.MEGABYTES.compareTo(DigitalUnit.BYTES)).isGreaterThan(0);
+		assertThat(DigitalUnit.MEGABYTES.compareTo(DigitalUnit.KILOBYTES))
+				.isGreaterThan(0);
+		assertThat(DigitalUnit.MEGABYTES.compareTo(DigitalUnit.MEGABYTES)).isZero();
+		assertThat(DigitalUnit.MEGABYTES.compareTo(DigitalUnit.GIGABYTES)).isLessThan(0);
+		assertThat(DigitalUnit.MEGABYTES.compareTo(DigitalUnit.TERABYTES)).isLessThan(0);
+	}
+
+	private static void assertUnitToGigabytes() {
+		assertThat(DigitalUnit.GIGABYTES.fromBytes(1024 * 1024 * 1024)).isEqualTo(1);
+		assertThat(DigitalUnit.GIGABYTES.fromKilobytes(1024 * 1024)).isEqualTo(1);
+		assertThat(DigitalUnit.GIGABYTES.fromMegabytes(1024)).isEqualTo(1);
+		assertThat(DigitalUnit.GIGABYTES.fromGigabytes(1024)).isEqualTo(1024);
+		assertThat(DigitalUnit.GIGABYTES.fromTerabytes(1)).isEqualTo(1024);
+
+		assertThat(DigitalUnit.GIGABYTES.fromUnit(1024 * 1024 * 1024, DigitalUnit.BYTES))
+				.isEqualTo(1);
+		assertThat(DigitalUnit.GIGABYTES.fromUnit(1024 * 1024, DigitalUnit.KILOBYTES))
+				.isEqualTo(1);
+		assertThat(DigitalUnit.GIGABYTES.fromUnit(1024, DigitalUnit.MEGABYTES))
+				.isEqualTo(1);
+		assertThat(DigitalUnit.GIGABYTES.fromUnit(1024, DigitalUnit.GIGABYTES))
+				.isEqualTo(1024);
+		assertThat(DigitalUnit.GIGABYTES.fromUnit(1, DigitalUnit.TERABYTES))
+				.isEqualTo(1024);
+	}
+
+	private static void assertGigabytesToUnit() {
+		assertThat(DigitalUnit.GIGABYTES.toBytes(1)).isEqualTo(1024 * 1024 * 1024);
+		assertThat(DigitalUnit.GIGABYTES.toKilobytes(1)).isEqualTo(1024 * 1024);
+		assertThat(DigitalUnit.GIGABYTES.toMegabytes(1)).isEqualTo(1024);
+		assertThat(DigitalUnit.GIGABYTES.toGigabytes(1024)).isEqualTo(1024);
+		assertThat(DigitalUnit.GIGABYTES.toTerabytes(1024)).isEqualTo(1);
+
+		assertThat(DigitalUnit.GIGABYTES.toUnit(1, DigitalUnit.BYTES))
+				.isEqualTo(1024 * 1024 * 1024);
+		assertThat(DigitalUnit.GIGABYTES.toUnit(1, DigitalUnit.KILOBYTES))
+				.isEqualTo(1024 * 1024);
+		assertThat(DigitalUnit.GIGABYTES.toUnit(1, DigitalUnit.MEGABYTES))
+				.isEqualTo(1024);
+		assertThat(DigitalUnit.GIGABYTES.toUnit(1024, DigitalUnit.GIGABYTES))
+				.isEqualTo(1024);
+		assertThat(DigitalUnit.GIGABYTES.toUnit(1024, DigitalUnit.TERABYTES))
+				.isEqualTo(1);
+	}
+
+	private static void assertCompareGigabytes() {
+		assertThat(DigitalUnit.GIGABYTES.compareTo(DigitalUnit.BYTES)).isGreaterThan(0);
+		assertThat(DigitalUnit.GIGABYTES.compareTo(DigitalUnit.KILOBYTES))
+				.isGreaterThan(0);
+		assertThat(DigitalUnit.GIGABYTES.compareTo(DigitalUnit.MEGABYTES))
+				.isGreaterThan(0);
+		assertThat(DigitalUnit.GIGABYTES.compareTo(DigitalUnit.GIGABYTES)).isZero();
+		assertThat(DigitalUnit.GIGABYTES.compareTo(DigitalUnit.TERABYTES)).isLessThan(0);
+	}
+
+	private static void assertUnitToTerabytes() {
+		assertThat(DigitalUnit.TERABYTES.fromBytes(1024L * 1024 * 1024 * 1024))
+				.isEqualTo(1);
+		assertThat(DigitalUnit.TERABYTES.fromKilobytes(1024 * 1024 * 1024)).isEqualTo(1);
+		assertThat(DigitalUnit.TERABYTES.fromMegabytes(1024 * 1024)).isEqualTo(1);
+		assertThat(DigitalUnit.TERABYTES.fromGigabytes(1024)).isEqualTo(1);
+		assertThat(DigitalUnit.TERABYTES.fromTerabytes(1024)).isEqualTo(1024);
+
+		assertThat(DigitalUnit.TERABYTES.fromUnit(1024L * 1024 * 1024 * 1024,
+				DigitalUnit.BYTES)).isEqualTo(1);
+		assertThat(
+				DigitalUnit.TERABYTES.fromUnit(1024 * 1024 * 1024, DigitalUnit.KILOBYTES))
+						.isEqualTo(1);
+		assertThat(DigitalUnit.TERABYTES.fromUnit(1024 * 1024, DigitalUnit.MEGABYTES))
+				.isEqualTo(1);
+		assertThat(DigitalUnit.TERABYTES.fromUnit(1024, DigitalUnit.GIGABYTES))
+				.isEqualTo(1);
+		assertThat(DigitalUnit.TERABYTES.fromUnit(1024, DigitalUnit.TERABYTES))
+				.isEqualTo(1024);
+	}
+
+	private static void assertTerabytesToUnit() {
+		assertThat(DigitalUnit.TERABYTES.toBytes(1))
+				.isEqualTo(1024L * 1024 * 1024 * 1024);
+		assertThat(DigitalUnit.TERABYTES.toKilobytes(1)).isEqualTo(1024 * 1024 * 1024);
+		assertThat(DigitalUnit.TERABYTES.toMegabytes(1)).isEqualTo(1024 * 1024);
+		assertThat(DigitalUnit.TERABYTES.toGigabytes(1)).isEqualTo(1024);
+		assertThat(DigitalUnit.TERABYTES.toTerabytes(1024)).isEqualTo(1024);
+
+		assertThat(DigitalUnit.TERABYTES.toUnit(1, DigitalUnit.BYTES))
+				.isEqualTo(1024L * 1024 * 1024 * 1024);
+		assertThat(DigitalUnit.TERABYTES.toUnit(1, DigitalUnit.KILOBYTES))
+				.isEqualTo(1024 * 1024 * 1024);
+		assertThat(DigitalUnit.TERABYTES.toUnit(1, DigitalUnit.MEGABYTES))
+				.isEqualTo(1024 * 1024);
+		assertThat(DigitalUnit.TERABYTES.toUnit(1, DigitalUnit.GIGABYTES))
+				.isEqualTo(1024);
+		assertThat(DigitalUnit.TERABYTES.toUnit(1024, DigitalUnit.TERABYTES))
+				.isEqualTo(1024);
+	}
+
+	private static void assertCompareTerabytes() {
+		assertThat(DigitalUnit.TERABYTES.compareTo(DigitalUnit.BYTES)).isGreaterThan(0);
+		assertThat(DigitalUnit.TERABYTES.compareTo(DigitalUnit.KILOBYTES))
+				.isGreaterThan(0);
+		assertThat(DigitalUnit.TERABYTES.compareTo(DigitalUnit.MEGABYTES))
+				.isGreaterThan(0);
+		assertThat(DigitalUnit.TERABYTES.compareTo(DigitalUnit.GIGABYTES))
+				.isGreaterThan(0);
+		assertThat(DigitalUnit.TERABYTES.compareTo(DigitalUnit.TERABYTES)).isZero();
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/DigitalAmountToNumberConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/DigitalAmountToNumberConverterTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.convert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.springframework.boot.DigitalAmount;
+import org.springframework.boot.DigitalUnit;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DigitalAmountToNumberConverter}.
+ *
+ * @author Dmytro Nosan
+ */
+@RunWith(Parameterized.class)
+public class DigitalAmountToNumberConverterTests {
+
+	private final ConversionService conversionService;
+
+	public DigitalAmountToNumberConverterTests(String name,
+			ConversionService conversionService) {
+		this.conversionService = conversionService;
+	}
+
+	@Test
+	public void convertWithoutStyleShouldReturnBytes() {
+		Long converted = this.conversionService.convert(DigitalAmount.fromKilobytes(1),
+				Long.class);
+		assertThat(converted).isEqualTo(1024L);
+	}
+
+	@Test
+	public void convertWithFormatAndUnitShouldUseFormatAndUnit() {
+		Integer converted = (Integer) this.conversionService.convert(
+				DigitalAmount.fromMegabytes(1),
+				MockDigitalAmountTypeDescriptor.get(DigitalUnit.KILOBYTES, null),
+				TypeDescriptor.valueOf(Integer.class));
+		assertThat(converted).isEqualTo(1024);
+	}
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Iterable<Object[]> conversionServices() {
+		return new ConversionServiceParameters(new DigitalAmountToNumberConverter());
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/DigitalAmountToStringConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/DigitalAmountToStringConverterTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.convert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.springframework.boot.DigitalAmount;
+import org.springframework.boot.DigitalAmountStyle;
+import org.springframework.boot.DigitalUnit;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DigitalAmountToStringConverter}.
+ *
+ * @author Dmytro Nosan
+ */
+@RunWith(Parameterized.class)
+public class DigitalAmountToStringConverterTests {
+
+	private final ConversionService conversionService;
+
+	public DigitalAmountToStringConverterTests(String name,
+			ConversionService conversionService) {
+		this.conversionService = conversionService;
+	}
+
+	@Test
+	public void convertWithFormatShouldUseFormatAndBytes() {
+		String converted = (String) this.conversionService.convert(
+				DigitalAmount.fromMegabytes(1),
+				MockDigitalAmountTypeDescriptor.get(null, DigitalAmountStyle.SIMPLE),
+				TypeDescriptor.valueOf(String.class));
+		assertThat(converted).isEqualTo("1048576B");
+	}
+
+	@Test
+	public void convertWithFormatAndUnitShouldUseFormatAndUnit() {
+		String converted = (String) this.conversionService.convert(
+				DigitalAmount.fromMegabytes(1), MockDigitalAmountTypeDescriptor
+						.get(DigitalUnit.KILOBYTES, DigitalAmountStyle.SIMPLE),
+				TypeDescriptor.valueOf(String.class));
+		assertThat(converted).isEqualTo("1024KB");
+	}
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Iterable<Object[]> conversionServices() {
+		return new ConversionServiceParameters(new DigitalAmountToStringConverter());
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/MockDigitalAmountTypeDescriptor.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/MockDigitalAmountTypeDescriptor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.convert;
+
+import java.util.Collections;
+
+import org.springframework.boot.DigitalAmount;
+import org.springframework.boot.DigitalAmountStyle;
+import org.springframework.boot.DigitalUnit;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.convert.TypeDescriptor;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Create a mock {@link TypeDescriptor} with optional {@link DigitalAmountUnit} and
+ * {@link DigitalAmountFormat} annotations.
+ *
+ * @author Dmytro Nosan
+ */
+public final class MockDigitalAmountTypeDescriptor {
+
+	private MockDigitalAmountTypeDescriptor() {
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public static TypeDescriptor get(DigitalUnit unit, DigitalAmountStyle style) {
+		TypeDescriptor descriptor = mock(TypeDescriptor.class);
+		if (unit != null) {
+			DigitalAmountUnit unitAnnotation = AnnotationUtils.synthesizeAnnotation(
+					Collections.singletonMap("value", unit), DigitalAmountUnit.class,
+					null);
+			given(descriptor.getAnnotation(DigitalAmountUnit.class))
+					.willReturn(unitAnnotation);
+		}
+		if (style != null) {
+			DigitalAmountFormat formatAnnotation = AnnotationUtils.synthesizeAnnotation(
+					Collections.singletonMap("value", style), DigitalAmountFormat.class,
+					null);
+			given(descriptor.getAnnotation(DigitalAmountFormat.class))
+					.willReturn(formatAnnotation);
+		}
+		given(descriptor.getType()).willReturn((Class) DigitalAmount.class);
+		given(descriptor.getObjectType()).willReturn((Class) DigitalAmount.class);
+		return descriptor;
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/NumberToDigitalAmountConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/NumberToDigitalAmountConverterTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.convert;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.springframework.boot.DigitalAmount;
+import org.springframework.boot.DigitalUnit;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link NumberToDigitalAmountConverter}.
+ *
+ * @author Dmytro Nosan
+ */
+@RunWith(Parameterized.class)
+public class NumberToDigitalAmountConverterTests {
+
+	private final ConversionService conversionService;
+
+	public NumberToDigitalAmountConverterTests(String name,
+			ConversionService conversionService) {
+		this.conversionService = conversionService;
+	}
+
+	@Test
+	public void convertWhenSimpleWithoutSuffixShouldReturnDigitalAmount() {
+		assertThat(convert(10)).isEqualTo(DigitalAmount.fromBytes(10));
+		assertThat(convert(+10)).isEqualTo(DigitalAmount.fromBytes(10));
+		assertThat(convert(-10)).isEqualTo(DigitalAmount.fromBytes(-10));
+	}
+
+	@Test
+	public void convertWhenSimpleWithoutSuffixButWithAnnotationShouldReturnDigitalAmount() {
+		assertThat(convert(10, DigitalUnit.MEGABYTES))
+				.isEqualTo(DigitalAmount.fromMegabytes(10));
+		assertThat(convert(+10, DigitalUnit.MEGABYTES))
+				.isEqualTo(DigitalAmount.fromMegabytes(10));
+		assertThat(convert(-10, DigitalUnit.MEGABYTES))
+				.isEqualTo(DigitalAmount.fromMegabytes(-10));
+	}
+
+	private DigitalAmount convert(Integer source) {
+		return this.conversionService.convert(source, DigitalAmount.class);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private DigitalAmount convert(Integer source, DigitalUnit defaultUnit) {
+		TypeDescriptor targetType = mock(TypeDescriptor.class);
+		if (defaultUnit != null) {
+			DigitalAmountUnit unitAnnotation = AnnotationUtils.synthesizeAnnotation(
+					Collections.singletonMap("value", defaultUnit),
+					DigitalAmountUnit.class, null);
+			given(targetType.getAnnotation(DigitalAmountUnit.class))
+					.willReturn(unitAnnotation);
+		}
+		given(targetType.getType()).willReturn((Class) DigitalAmount.class);
+		return (DigitalAmount) this.conversionService.convert(source,
+				TypeDescriptor.forObject(source), targetType);
+	}
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Iterable<Object[]> conversionServices() {
+		return new ConversionServiceParameters(new NumberToDigitalAmountConverter());
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/StringToDigitalAmountConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/StringToDigitalAmountConverterTests.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.convert;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.springframework.boot.DigitalAmount;
+import org.springframework.boot.DigitalAmountStyle;
+import org.springframework.boot.DigitalUnit;
+import org.springframework.core.convert.ConversionFailedException;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link StringToDigitalAmountConverter}.
+ *
+ * @author Dmytro Nosan
+ */
+@RunWith(Parameterized.class)
+public class StringToDigitalAmountConverterTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private final ConversionService conversionService;
+
+	public StringToDigitalAmountConverterTests(String name,
+			ConversionService conversionService) {
+		this.conversionService = conversionService;
+	}
+
+	@Test
+	public void convertWhenSimpleBytesShouldReturnDigitalAmount() {
+		assertThat(convert("10b")).isEqualTo(DigitalAmount.fromBytes(10));
+		assertThat(convert("10B")).isEqualTo(DigitalAmount.fromBytes(10));
+		assertThat(convert("+10 B")).isEqualTo(DigitalAmount.fromBytes(10));
+		assertThat(convert("-10 b")).isEqualTo(DigitalAmount.fromBytes(-10));
+	}
+
+	@Test
+	public void convertWhenSimpleKilobytesShouldReturnDigitalAmount() {
+		assertThat(convert("10kb")).isEqualTo(DigitalAmount.fromKilobytes(10));
+		assertThat(convert("10Kb")).isEqualTo(DigitalAmount.fromKilobytes(10));
+		assertThat(convert("+10KB")).isEqualTo(DigitalAmount.fromKilobytes(10));
+		assertThat(convert("-10 kb")).isEqualTo(DigitalAmount.fromKilobytes(-10));
+	}
+
+	@Test
+	public void convertWhenSimpleMegabytesShouldReturnDigitalAmount() {
+		assertThat(convert("10MB")).isEqualTo(DigitalAmount.fromMegabytes(10));
+		assertThat(convert("10 mb")).isEqualTo(DigitalAmount.fromMegabytes(10));
+		assertThat(convert("+10 Mb")).isEqualTo(DigitalAmount.fromMegabytes(10));
+		assertThat(convert("-10 mB")).isEqualTo(DigitalAmount.fromMegabytes(-10));
+	}
+
+	@Test
+	public void convertWhenSimpleGigabytesShouldReturnDigitalAmount() {
+		assertThat(convert("10GB")).isEqualTo(DigitalAmount.fromGigabytes(10));
+		assertThat(convert("10 gb")).isEqualTo(DigitalAmount.fromGigabytes(10));
+		assertThat(convert("+10 Gb")).isEqualTo(DigitalAmount.fromGigabytes(10));
+		assertThat(convert("-10 gB")).isEqualTo(DigitalAmount.fromGigabytes(-10));
+	}
+
+	@Test
+	public void convertWhenSimpleTerabytesShouldReturnDigitalAmount() {
+		assertThat(convert("10TB")).isEqualTo(DigitalAmount.fromTerabytes(10));
+		assertThat(convert("10 tb")).isEqualTo(DigitalAmount.fromTerabytes(10));
+		assertThat(convert("+10 Tb")).isEqualTo(DigitalAmount.fromTerabytes(10));
+		assertThat(convert("-10 tB")).isEqualTo(DigitalAmount.fromTerabytes(-10));
+	}
+
+	@Test
+	public void convertWhenSimpleWithoutSuffixShouldReturnDigitalAmount() {
+		assertThat(convert("10")).isEqualTo(DigitalAmount.fromBytes(10));
+		assertThat(convert("+10")).isEqualTo(DigitalAmount.fromBytes(10));
+		assertThat(convert("-10")).isEqualTo(DigitalAmount.fromBytes(-10));
+	}
+
+	@Test
+	public void convertWhenSimpleWithoutSuffixButWithAnnotationShouldReturnDigitalAmount() {
+		assertThat(convert("10", DigitalUnit.MEGABYTES, null))
+				.isEqualTo(DigitalAmount.fromMegabytes(10));
+		assertThat(convert("+10", DigitalUnit.MEGABYTES, null))
+				.isEqualTo(DigitalAmount.fromMegabytes(10));
+		assertThat(convert("-10", DigitalUnit.MEGABYTES, null))
+				.isEqualTo(DigitalAmount.fromMegabytes(-10));
+	}
+
+	@Test
+	public void convertWhenBadFormatShouldThrowException() {
+		this.thrown.expect(ConversionFailedException.class);
+		this.thrown.expectMessage("'10foo' is not a valid digital");
+		convert("10foo");
+	}
+
+	@Test
+	public void convertWhenStyleMismatchShouldThrowException() {
+		this.thrown.expect(ConversionFailedException.class);
+		convert("10000qeq ", null, DigitalAmountStyle.SIMPLE);
+	}
+
+	@Test
+	public void convertWhenEmptyShouldReturnNull() {
+		assertThat(convert("")).isNull();
+	}
+
+	private DigitalAmount convert(String source) {
+		return this.conversionService.convert(source, DigitalAmount.class);
+	}
+
+	private DigitalAmount convert(String source, DigitalUnit unit,
+			DigitalAmountStyle style) {
+		return (DigitalAmount) this.conversionService.convert(source,
+				TypeDescriptor.forObject(source),
+				MockDigitalAmountTypeDescriptor.get(unit, style));
+	}
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Iterable<Object[]> conversionServices() {
+		return new ConversionServiceParameters(new StringToDigitalAmountConverter());
+	}
+
+}


### PR DESCRIPTION
see [gh-13974](https://github.com/spring-projects/spring-boot/issues/13974)
`DigitalAmount` -  class models a quantity or amount of digital information in terms of bytes. This class is immutable and thread-safe.
`DigitalUnit` - represents digital amount at a given unit of granularity and provides utility methods to convert across units.
`DigitalAmountStyle` -  format styles