### PR TITLE
Include @ in javadoc links for annotations

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelector.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelector.java
@@ -104,7 +104,7 @@ public class AutoConfigurationImportSelector
 
 	/**
 	 * Return the {@link AutoConfigurationEntry} based on the {@link AnnotationMetadata}
-	 * of the importing @{@link Configuration} class.
+	 * of the importing {@link Configuration @Configuration} class.
 	 * @param autoConfigurationMetadata the auto-configuration metadata
 	 * @param annotationMetadata the annotation metadata of the configuration class
 	 * @return the auto-configurations that should be imported

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/EnvironmentPostProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/EnvironmentPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.springframework.core.env.Environment;
  * <p>
  * {@code EnvironmentPostProcessor} processors are encouraged to detect whether Spring's
  * {@link org.springframework.core.Ordered Ordered} interface has been implemented or if
- * the @{@link org.springframework.core.annotation.Order Order} annotation is present and
+ * the {@link org.springframework.core.annotation.Order @Order} annotation is present and
  * to sort instances accordingly if so prior to invocation.
  *
  * @author Andy Wilkinson


### PR DESCRIPTION
Hi,

I decided to provide a first part of #13920 that at least fixes @link declarations like the following: 

- `@{@link ExampleAnnotation}`

They simply look a bit broken in the actual Javadocs and are probably worth fixing even before we harmonize everything.

Let me know what you think.
Cheers,
Christoph