### PR TITLE
Add global support for JMX unique names

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfiguration.java
@@ -93,6 +93,11 @@ public class JmxAutoConfiguration implements EnvironmentAware, BeanFactoryAware 
 		if (StringUtils.hasLength(defaultDomain)) {
 			namingStrategy.setDefaultDomain(defaultDomain);
 		}
+
+		boolean uniqueName = this.environment.getProperty("spring.jmx.unique-names",
+				Boolean.class, false);
+		namingStrategy.setEnsureUniqueRuntimeObjectNames(uniqueName);
+
 		return namingStrategy;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfiguration.java
@@ -49,6 +49,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Christian Dupuis
  * @author Madhura Bhave
+ * @author Artsiom Yudovin
  */
 @Configuration
 @ConditionalOnClass({ MBeanExporter.class })

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -293,8 +293,8 @@
     {
       "name": "spring.jmx.unique-names",
       "type": "java.lang.Boolean",
-      "description": "Wether if unique runtime object names should be ensured.",
-      "defaultValue": true
+      "description": "Whether to ensure that ObjectNames are modified in case of conflict.",
+      "defaultValue": false
     },
     {
       "name": "spring.jpa.open-in-view",

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -291,6 +291,12 @@
       "defaultValue": "mbeanServer"
     },
     {
+      "name": "spring.jmx.unique-names",
+      "type": "java.lang.Boolean",
+      "description": "Wether if unique runtime object names should be ensured.",
+      "defaultValue": true
+    },
+    {
       "name": "spring.jpa.open-in-view",
       "defaultValue": true
     },

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfigurationTests.java
@@ -42,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link JmxAutoConfiguration}.
  *
  * @author Christian Dupuis
+ * @author Artsiom Yudovin
  */
 public class JmxAutoConfigurationTests {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfigurationTests.java
@@ -92,6 +92,7 @@ public class JmxAutoConfigurationTests {
 		MockEnvironment env = new MockEnvironment();
 		env.setProperty("spring.jmx.enabled", "true");
 		env.setProperty("spring.jmx.default-domain", "my-test-domain");
+		env.setProperty("spring.jmx.unique-names", "true");
 		this.context = new AnnotationConfigApplicationContext();
 		this.context.setEnvironment(env);
 		this.context.register(TestConfiguration.class, JmxAutoConfiguration.class);
@@ -102,6 +103,8 @@ public class JmxAutoConfigurationTests {
 				.getField(mBeanExporter, "namingStrategy");
 		assertThat(ReflectionTestUtils.getField(naming, "defaultDomain"))
 				.isEqualTo("my-test-domain");
+		assertThat(ReflectionTestUtils.getField(naming, "ensureUniqueRuntimeObjectNames"))
+				.isEqualTo(true);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -100,6 +100,7 @@ content into your application. Rather, pick only the properties that you need.
 	spring.jmx.default-domain= # JMX domain name.
 	spring.jmx.enabled=true # Expose management beans to the JMX domain.
 	spring.jmx.server=mbeanServer # MBeanServer bean name.
+    spring.jmx.jmx.unique-names=true # Set if unique runtime object names should be ensured.
 
 	# Email ({sc-spring-boot-autoconfigure}/mail/MailProperties.{sc-ext}[MailProperties])
 	spring.mail.default-encoding=UTF-8 # Default MimeMessage encoding.

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -100,7 +100,7 @@ content into your application. Rather, pick only the properties that you need.
 	spring.jmx.default-domain= # JMX domain name.
 	spring.jmx.enabled=true # Expose management beans to the JMX domain.
 	spring.jmx.server=mbeanServer # MBeanServer bean name.
-    spring.jmx.jmx.unique-names=true # Set if unique runtime object names should be ensured.
+	spring.jmx.jmx.unique-names=true # Set if unique runtime object names should be ensured.
 
 	# Email ({sc-spring-boot-autoconfigure}/mail/MailProperties.{sc-ext}[MailProperties])
 	spring.mail.default-encoding=UTF-8 # Default MimeMessage encoding.

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -100,7 +100,7 @@ content into your application. Rather, pick only the properties that you need.
 	spring.jmx.default-domain= # JMX domain name.
 	spring.jmx.enabled=true # Expose management beans to the JMX domain.
 	spring.jmx.server=mbeanServer # MBeanServer bean name.
-	spring.jmx.jmx.unique-names=true # Set if unique runtime object names should be ensured.
+	spring.jmx.unique-names=false # Set if unique runtime object names should be ensured.
 
 	# Email ({sc-spring-boot-autoconfigure}/mail/MailProperties.{sc-ext}[MailProperties])
 	spring.mail.default-encoding=UTF-8 # Default MimeMessage encoding.


### PR DESCRIPTION
Support ensureUniqueRuntimeObjectNames globally rather than only on Actuator endpoints
this [enhancement](https://github.com/spring-projects/spring-boot/issues/13959) 