### PR TITLE
Return null immediately when sla is null in convertSla()

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/PropertiesMeterFilter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/PropertiesMeterFilter.java
@@ -43,8 +43,6 @@ import org.springframework.util.StringUtils;
  */
 public class PropertiesMeterFilter implements MeterFilter {
 
-	private static final ServiceLevelAgreementBoundary[] EMPTY_SLA = {};
-
 	private final MetricsProperties properties;
 
 	private final MeterFilter mapFilter;
@@ -90,7 +88,10 @@ public class PropertiesMeterFilter implements MeterFilter {
 	}
 
 	private long[] convertSla(Meter.Type meterType, ServiceLevelAgreementBoundary[] sla) {
-		long[] converted = Arrays.stream((sla != null) ? sla : EMPTY_SLA)
+		if (sla == null) {
+			return null;
+		}
+		long[] converted = Arrays.stream(sla)
 				.map((candidate) -> candidate.getValue(meterType))
 				.filter(Objects::nonNull).mapToLong(Long::longValue).toArray();
 		return (converted.length != 0) ? converted : null;


### PR DESCRIPTION
This PR changes to return `null` immediately when `sla` is `null` in `PropertiesMeterFilter.convertSla()` as passing through the stream pipeline isn't necessary.

See https://github.com/micrometer-metrics/micrometer/pull/746 for the same change in Micrometer Spring Boot 1.5.x support.