### PR TITLE
Invoke Inflater.end() in ZipInflaterInputStream.close()

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/ZipInflaterInputStream.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/ZipInflaterInputStream.java
@@ -30,12 +30,19 @@ import java.util.zip.InflaterInputStream;
  */
 class ZipInflaterInputStream extends InflaterInputStream {
 
+	private final Inflater inflater;
+
 	private boolean extraBytesWritten;
 
 	private int available;
 
 	ZipInflaterInputStream(InputStream inputStream, int size) {
-		super(inputStream, new Inflater(true), getInflaterBufferSize(size));
+		this(inputStream, new Inflater(true), size);
+	}
+
+	private ZipInflaterInputStream(InputStream inputStream, Inflater inflater, int size) {
+		super(inputStream, inflater, getInflaterBufferSize(size));
+		this.inflater = inflater;
 		this.available = size;
 	}
 
@@ -54,6 +61,12 @@ class ZipInflaterInputStream extends InflaterInputStream {
 			this.available -= result;
 		}
 		return result;
+	}
+
+	@Override
+	public void close() throws IOException {
+		super.close();
+		this.inflater.end();
 	}
 
 	@Override


### PR DESCRIPTION
This PR changes to invoke `Inflater.end()` in `ZipInflaterInputStream.close()` as it looks reasonable to do so likewise `InflaterInputStream.close()` as follows:

```java
    public void close() throws IOException {
        if (!closed) {
            if (usesDefaultInflater)
                inf.end();
            in.close();
            closed = true;
        }
    }
```

Closes gh-13935