### PR TITLE
Sync requiment of maven version with enforce rule, add a table

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/getting-started.adoc
@@ -39,8 +39,20 @@ configuration).
 [[getting-started-system-requirements]]
 == System Requirements
 Spring Boot {spring-boot-version} requires https://www.java.com[Java 8 or 9] and
-{spring-reference}[Spring Framework {spring-version}] or above. Explicit build support is
-provided for Maven 3.2+ and Gradle 4.
+{spring-reference}[Spring Framework {spring-version}] or above.
+
+Explicit build support is provided for Maven 3.5+ and Gradle 4.
+
+|===
+|Build Tool |Version
+
+|Maven
+|3.5+
+
+|Gradle
+|4+
+
+|===
 
 
 


### PR DESCRIPTION
it's a correction to b75e58b70f416bd5e7cea4f26349bd2e43f2d20b, sync docs with enforce rule, and add a table.