### PR TITLE
Depending on Elasticsearch rest client pulls in commons-logging

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -1800,6 +1800,16 @@
 				<groupId>org.elasticsearch.client</groupId>
 				<artifactId>elasticsearch-rest-high-level-client</artifactId>
 				<version>${elasticsearch.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.apache.logging.log4j</groupId>
+						<artifactId>log4j-core</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.firebirdsql.jdbc</groupId>


### PR DESCRIPTION
We have a `maven-enforcer-plugin` definition to make sure there are no other logging systems installed except logback and sfl4j and I had to override the elasticsearch client definition to this.

You have it excluded in other definitions too so I hope this is correct. But maybe, it's gonna be required in other elasticsearch definitions.. I'm using only this one, so I'm not sure, but I wanted to contribute at least a bit, and not only open an issue :) 