### PR TITLE
Polish ItemMetadata.buildName()

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/ItemMetadata.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/ItemMetadata.java
@@ -58,14 +58,17 @@ public final class ItemMetadata implements Comparable<ItemMetadata> {
 	}
 
 	private String buildName(String prefix, String name) {
-		while (prefix != null && prefix.endsWith(".")) {
-			prefix = prefix.substring(0, prefix.length() - 1);
-		}
-		StringBuilder fullName = new StringBuilder((prefix != null) ? prefix : "");
-		if (fullName.length() > 0 && name != null) {
-			fullName.append('.');
+		StringBuilder fullName = new StringBuilder();
+		if (prefix != null) {
+			if (prefix.endsWith(".")) {
+				prefix = prefix.substring(0, prefix.length() - 1);
+			}
+			fullName.append(prefix);
 		}
 		if (name != null) {
+			if (fullName.length() > 0) {
+				fullName.append('.');
+			}
 			fullName.append(ConfigurationMetadata.toDashedCase(name));
 		}
 		return fullName.toString();


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR polishes `ItemMetadata.buildName()`.

Along the way, I noticed the current `prefix` handling which removes all trailing dots looks unusual, so I changed it to remove the last one only. I just judged it's not intentional by passing all tests but if it's intentional, please let me know. I'll revert it.