### PR TITLE
Align server.tomcat.max-swallow-size with Tomcat's default value

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -332,7 +332,7 @@ public class ServerProperties {
 		/**
 		 * Maximum amount of request body bytes to swallow.
 		 */
-		private int maxSwallowSize = 4096;
+		private int maxSwallowSize = 2097152;
 
 		/**
 		 * Whether requests to the context root should be redirected by appending a / to

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -260,7 +260,7 @@ content into your application. Rather, pick only the properties that you need.
 	server.tomcat.max-connections=0 # Maximum number of connections that the server accepts and processes at any given time.
 	server.tomcat.max-http-header-size=0 # Maximum size, in bytes, of the HTTP message header.
 	server.tomcat.max-http-post-size=0 # Maximum size, in bytes, of the HTTP post content.
-	server.tomcat.max-swallow-size=4096 # Maximum amount of request body bytes to swallow.
+	server.tomcat.max-swallow-size=2097152 # Maximum amount of request body bytes to swallow.
 	server.tomcat.max-threads=0 # Maximum number of worker threads.
 	server.tomcat.min-spare-threads=0 # Minimum number of worker threads.
 	server.tomcat.port-header=X-Forwarded-Port # Name of the HTTP header used to override the original port value.


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR makes `server.tomcat.max-swallow-size` align with Tomcat's default value as I couldn't find any good reason to diverge from Tomcat's default value in the related issue (#6669), PR (#13966) and commits (0d40c5aeccacb3123d3d5b4eb4391031cddb4adf, a8b9718073ec997e3cd4f0a696ed65a4af33364a). If there's any good reason to diverge which I missed, feel free to close this PR.

See https://tomcat.apache.org/tomcat-9.0-doc/config/http.html