### PR TITLE
URL's retryWrites query parameter is ignored when auto-configuring a reactive Mongo client

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactory.java
@@ -159,6 +159,7 @@ public class ReactiveMongoClientFactory {
 		if (connection.getApplicationName() != null) {
 			builder.applicationName(connection.getApplicationName());
 		}
+		builder.retryWrites(connection.getRetryWrites());
 		return builder;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactoryTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactoryTests.java
@@ -113,6 +113,14 @@ public class ReactiveMongoClientFactoryTests {
 	}
 
 	@Test
+	public void retryWritesIsPropagatedFromUri() {
+		MongoProperties properties = new MongoProperties();
+		properties.setUri("mongodb://localhost/test?retryWrites=true");
+		MongoClient client = createMongoClient(properties);
+		assertThat(client.getSettings().getRetryWrites()).isTrue();
+	}
+
+	@Test
 	public void uriCannotBeSetWithCredentials() {
 		MongoProperties properties = new MongoProperties();
 		properties.setUri("mongodb://127.0.0.1:1234/mydb");


### PR DESCRIPTION
Add `retryWrites` flag to set of flags propagated from `connectionString`
to `ReactiveMongoClient`.

Regular `MongoClientFactory` relies of `MongoClientURI` class that
propagates all flags in its `getOptions()` method.