### PR TITLE
Add "With an Immediate Pull Request"

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,9 +2,16 @@
 Thanks for raising a Spring Boot issue. Please take the time to review the following
 categories as some of them do not apply here.
 
-❓Question
+🙅 "Please DO NOT Raise an Issue" Cases
+- Question
 STOP!! Please ask questions about how to use something, or to understand why something isn't
 working as you expect it to, on Stack Overflow using the spring-boot tag.
+- Security Vulnerability
+STOP!! Please don't raise security vulnerabilities here. Head over to https://pivotal.io/security to learn how to disclose them responsibly.
+- Managed Dependency Upgrade
+You DO NOT need to raise an issue for a managed dependency version upgrade as there's a semi-automatic process for checking managed dependencies for new versions before a release. BUT pull requests for upgrades that are more involved than just a version property change are still most welcome.
+- With an Immediate Pull Request
+An issue will be closed as a duplicate of the immediate pull request, so you don't have to raise an issue if you plan to create a pull request immediately.
 
 🐞 Bug report
 Please provide details of the problem, including the version of Spring Boot that you
@@ -12,13 +19,7 @@ are using. If possible, please provide a test case or sample application that re
 the problem. This makes it much easier for us to diagnose the problem and to verify that
 we have fixed it.
 
-🚨 Security Vulnerability
-STOP!! Please don't raise security vulnerabilities here. Head over to https://pivotal.io/security to learn how to disclose them responsibly.
-
 🎁 Enhancement
 Please start by describing the problem that you are trying to solve. There may already
 be a solution, or there may be a way to solve it that you hadn't considered.
-
-🙅 Managed dependency upgrade
-You DO NOT need to raise an issue for a managed dependency version upgrade as there's a semi-automatic process for checking managed dependencies for new versions before a release. But pull requests for upgrades that are more involved than just a version property change are still most welcome.
 -->


### PR DESCRIPTION
I have seen many "an issue with an immediate pull request" patterns like [this one](https://github.com/spring-projects/spring-boot/issues/13981#issuecomment-409913552) but the pattern is considered as a duplicate in the Spring Boot repository, so I added "With an Immediate Pull Request" note to the issue template.

This PR also reorganises with "Please DO NOT Raise an Issue" Cases.