### PR TITLE
Fix Freemarker documentation link

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -2243,7 +2243,7 @@ integrations.
 
 Spring Boot includes auto-configuration support for the following templating engines:
 
- * https://freemarker.org/docs/[FreeMarker]
+ * https://freemarker.apache.org/docs/[FreeMarker]
  * http://docs.groovy-lang.org/docs/next/html/documentation/template-engines.html#_the_markuptemplateengine[Groovy]
  * http://www.thymeleaf.org[Thymeleaf]
  * https://mustache.github.io/[Mustache]
@@ -2674,7 +2674,7 @@ Thymeleaf, FreeMarker, and Mustache.
 
 Spring Boot includes auto-configuration support for the following templating engines:
 
- * http://freemarker.org/docs/[FreeMarker]
+ * http://freemarker.apache.org/docs/[FreeMarker]
  * http://www.thymeleaf.org[Thymeleaf]
  * http://mustache.github.io/[Mustache]
 


### PR DESCRIPTION
Documentation of the Freemarker template engine has moved to the new project page at freemarker.apache.org. This just updates the links in the spring-boot documentation