### PR TITLE
Use Collections.list() where possible

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/trace/servlet/TraceableHttpServletRequest.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/trace/servlet/TraceableHttpServletRequest.java
@@ -19,7 +19,7 @@ package org.springframework.boot.actuate.web.trace.servlet;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -85,17 +85,9 @@ final class TraceableHttpServletRequest implements TraceableRequest {
 		Enumeration<String> names = this.request.getHeaderNames();
 		while (names.hasMoreElements()) {
 			String name = names.nextElement();
-			headers.put(name, toList(this.request.getHeaders(name)));
+			headers.put(name, Collections.list(this.request.getHeaders(name)));
 		}
 		return headers;
-	}
-
-	private List<String> toList(Enumeration<String> enumeration) {
-		List<String> list = new ArrayList<>();
-		while (enumeration.hasMoreElements()) {
-			list.add(enumeration.nextElement());
-		}
-		return list;
 	}
 
 }

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/classloader/RestartClassLoaderTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/classloader/RestartClassLoaderTests.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.JarOutputStream;
@@ -212,13 +212,10 @@ public class RestartClassLoaderTests {
 	}
 
 	private <T> List<T> toList(Enumeration<T> enumeration) {
-		List<T> list = new ArrayList<>();
 		if (enumeration != null) {
-			while (enumeration.hasMoreElements()) {
-				list.add(enumeration.nextElement());
-			}
+			return Collections.list(enumeration);
 		}
-		return list;
+		return Collections.emptyList();
 	}
 
 }


### PR DESCRIPTION
Hi,

this PR replaces a few loops over enumerations with `Collections.list()` where possible.

Cheers,
Christoph