### PR TITLE
Use the first "?" for a query part in Handler.setFile()

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/Handler.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/Handler.java
@@ -213,7 +213,7 @@ public class Handler extends URLStreamHandler {
 	private void setFile(URL context, String file) {
 		String path = normalize(file);
 		String query = null;
-		int queryIndex = path.lastIndexOf('?');
+		int queryIndex = path.indexOf('?');
 		if (queryIndex != -1) {
 			query = path.substring(queryIndex + 1);
 			path = path.substring(0, queryIndex);


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR changes to use the first "?" for a query part in `Handler.setFile()` as the first "?" is the starting character for a query part in a URL.