### PR TITLE
deprecate EntityManagerFactoryBuilder.EntityManagerFactoryBeanCallback

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/orm/jpa/EntityManagerFactoryBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/orm/jpa/EntityManagerFactoryBuilder.java
@@ -43,6 +43,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Phillip Webb
  * @author Stephane Nicoll
+ * @author Artsiom Yudovin
  * @since 1.3.0
  */
 public class EntityManagerFactoryBuilder {
@@ -98,6 +99,7 @@ public class EntityManagerFactoryBuilder {
 	 * An optional callback for new entity manager factory beans.
 	 * @param callback the entity manager factory bean callback
 	 */
+	@Deprecated
 	public void setCallback(EntityManagerFactoryBeanCallback callback) {
 		this.callback = callback;
 	}
@@ -241,7 +243,9 @@ public class EntityManagerFactoryBuilder {
 
 	/**
 	 * A callback for new entity manager factory beans created by a Builder.
+	 * {@link EntityManagerFactoryBeanCallback} will be removed in 2.1.0
 	 */
+	@Deprecated
 	@FunctionalInterface
 	public interface EntityManagerFactoryBeanCallback {
 


### PR DESCRIPTION
Deprecate
org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder.EntityManagerFactoryBeanCallback
this [enhancement](https://github.com/spring-projects/spring-boot/issues/14083) 