### PR TITLE
 Align SessionsEndpoint with Spring Session API improvements

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/SessionsEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/SessionsEndpointDocumentationTests.java
@@ -89,9 +89,7 @@ public class SessionsEndpointDocumentationTests
 		sessions.put(sessionOne.getId(), sessionOne);
 		sessions.put(sessionTwo.getId(), sessionTwo);
 		sessions.put(sessionThree.getId(), sessionThree);
-		given(this.sessionRepository.findByIndexNameAndIndexValue(
-				FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, "alice"))
-						.willReturn(sessions);
+		given(this.sessionRepository.findByPrincipalName("alice")).willReturn(sessions);
 		this.mockMvc.perform(get("/actuator/sessions").param("username", "alice"))
 				.andExpect(status().isOk())
 				.andDo(document("sessions/username",

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/session/SessionsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/session/SessionsEndpoint.java
@@ -52,9 +52,7 @@ public class SessionsEndpoint {
 	@ReadOperation
 	public SessionsReport sessionsForUsername(String username) {
 		Map<String, ? extends Session> sessions = this.sessionRepository
-				.findByIndexNameAndIndexValue(
-						FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME,
-						username);
+				.findByPrincipalName(username);
 		return new SessionsReport(sessions);
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/session/SessionsEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/session/SessionsEndpointTests.java
@@ -48,9 +48,8 @@ public class SessionsEndpointTests {
 
 	@Test
 	public void sessionsForUsername() {
-		given(this.repository.findByIndexNameAndIndexValue(
-				FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, "user"))
-						.willReturn(Collections.singletonMap(session.getId(), session));
+		given(this.repository.findByPrincipalName("user"))
+				.willReturn(Collections.singletonMap(session.getId(), session));
 		List<SessionDescriptor> result = this.endpoint.sessionsForUsername("user")
 				.getSessions();
 		assertThat(result).hasSize(1);

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/session/SessionsEndpointWebIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/session/SessionsEndpointWebIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,9 +58,7 @@ public class SessionsEndpointWebIntegrationTests {
 
 	@Test
 	public void sessionsForUsernameNoResults() {
-		given(repository.findByIndexNameAndIndexValue(
-				FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, "user"))
-						.willReturn(Collections.emptyMap());
+		given(repository.findByPrincipalName("user")).willReturn(Collections.emptyMap());
 		client.get()
 				.uri((builder) -> builder.path("/actuator/sessions")
 						.queryParam("username", "user").build())
@@ -70,9 +68,8 @@ public class SessionsEndpointWebIntegrationTests {
 
 	@Test
 	public void sessionsForUsernameFound() {
-		given(repository.findByIndexNameAndIndexValue(
-				FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, "user"))
-						.willReturn(Collections.singletonMap(session.getId(), session));
+		given(repository.findByPrincipalName("user"))
+				.willReturn(Collections.singletonMap(session.getId(), session));
 		client.get()
 				.uri((builder) -> builder.path("/actuator/sessions")
 						.queryParam("username", "user").build())

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -166,7 +166,7 @@
 		<spring-restdocs.version>2.0.2.RELEASE</spring-restdocs.version>
 		<spring-retry.version>1.2.2.RELEASE</spring-retry.version>
 		<spring-security.version>5.1.0.BUILD-SNAPSHOT</spring-security.version>
-		<spring-session-bom.version>Bean-M1</spring-session-bom.version>
+		<spring-session-bom.version>Bean-BUILD-SNAPSHOT</spring-session-bom.version>
 		<spring-ws.version>3.0.3.RELEASE</spring-ws.version>
 		<sqlite-jdbc.version>3.23.1</sqlite-jdbc.version>
 		<statsd-client.version>3.1.0</statsd-client.version>


### PR DESCRIPTION
This PR aligns `SessionsEndpoint` with `FindByIndexNameSessionRepository` API improvements that simplifies retrieval of sessions by principal name.