### PR TITLE
Upgrade to Neo4j Ogm 3.1.1

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -131,7 +131,7 @@
 		<mssql-jdbc.version>6.4.0.jre8</mssql-jdbc.version>
 		<mysql.version>8.0.12</mysql.version>
 		<nekohtml.version>1.9.22</nekohtml.version>
-		<neo4j-ogm.version>3.1.0</neo4j-ogm.version>
+		<neo4j-ogm.version>3.1.1</neo4j-ogm.version>
 		<netty.version>4.1.28.Final</netty.version>
 		<netty-tcnative.version>2.0.13.Final</netty-tcnative.version>
 		<nio-multipart-parser.version>1.1.0</nio-multipart-parser.version>


### PR DESCRIPTION
The Spring Data Neo4j version (Kay) used in this version
of Spring Boot (2.0.x) does expect Neo4j-OGM 3.0.x to work with.
Because Spring Boot defines a 3.1.x version and a downgrade
does not feel right, Neo4j-OGM 3.1.1 brings back the compatibility for SDN Kay. 
Fixes #13999 