### PR TITLE
Fix String concatenation in a loop

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
@@ -317,11 +317,11 @@ public final class EndpointRequest {
 
 		public RequestMatcher antPath(RequestMatcherProvider matcherProvider,
 				String... parts) {
-			String pattern = this.prefix;
+			StringBuffer pattern = new StringBuffer(this.prefix);
 			for (String part : parts) {
-				pattern += part;
+				pattern.append(part);
 			}
-			return matcherProvider.getRequestMatcher(pattern);
+			return matcherProvider.getRequestMatcher(pattern.toString());
 		}
 
 	}


### PR DESCRIPTION
This PR fixes an SBSC_USE_STRINGBUFFER_CONCATENATION warning reported by FindBugs-3.0.1 ([http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)):
```
M P SBSC: org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest$RequestMatcherFactory.antPath(RequestMatcherProvider, String[]) concatenates strings using + in a loop At EndpointRequest.java:[line 322]
```
The description of the bug is as follows:
> **SBSC: Method concatenates strings using + in a loop (SBSC_USE_STRINGBUFFER_CONCATENATION)**
> The method seems to be building a String using concatenation in a loop. In each iteration, the String is converted to a StringBuffer/StringBuilder, appended to, and converted back to a String. This can lead to a cost quadratic in the number of iterations, as the growing string is recopied in each iteration.
> Better performance can be obtained by using a StringBuffer (or StringBuilder in Java 1.5) explicitly.
> For example:
> ```
>  // This is bad
>  String s = "";
>  for (int i = 0; i < field.length; ++i) {
>    s = s + field[i];
>  }
>
>  // This is better
>  StringBuffer buf = new StringBuffer();
>  for (int i = 0; i < field.length; ++i) {
>    buf.append(field[i]);
>  }
>  String s = buf.toString();
>```
> [http://findbugs.sourceforge.net/bugDescriptions.html#SBSC_USE_STRINGBUFFER_CONCATENATION](http://findbugs.sourceforge.net/bugDescriptions.html#SBSC_USE_STRINGBUFFER_CONCATENATION)