### PR TITLE
clientSecret property is not required

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2ClientProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2ClientProperties.java
@@ -30,6 +30,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Madhura Bhave
  * @author Phillip Webb
+ * @author Artsiom Yudovin
  */
 @ConfigurationProperties(prefix = "spring.security.oauth2.client")
 public class OAuth2ClientProperties {
@@ -60,9 +61,6 @@ public class OAuth2ClientProperties {
 	private void validateRegistration(Registration registration) {
 		if (!StringUtils.hasText(registration.getClientId())) {
 			throw new IllegalStateException("Client id must not be empty.");
-		}
-		if (!StringUtils.hasText(registration.getClientSecret())) {
-			throw new IllegalStateException("Client secret must not be empty.");
 		}
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2ClientPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2ClientPropertiesTests.java
@@ -24,6 +24,7 @@ import org.junit.rules.ExpectedException;
  * Tests for {@link OAuth2ClientProperties}.
  *
  * @author Madhura Bhave
+ * @author Artsiom Yudovin
  */
 public class OAuth2ClientPropertiesTests {
 
@@ -44,13 +45,11 @@ public class OAuth2ClientPropertiesTests {
 	}
 
 	@Test
-	public void clientSecretAbsentThrowsException() {
+	public void clientSecretAbsentNotThrowsException() {
 		OAuth2ClientProperties.Registration registration = new OAuth2ClientProperties.Registration();
 		registration.setClientId("foo");
 		registration.setProvider("google");
 		this.properties.getRegistration().put("foo", registration);
-		this.thrown.expect(IllegalStateException.class);
-		this.thrown.expectMessage("Client secret must not be empty.");
 		this.properties.validate();
 	}
 


### PR DESCRIPTION
Remove the validation from Boot for the client secret.
this [bug](https://github.com/spring-projects/spring-boot/issues/14151) 