### PR TITLE
Use null check on groovyReader instead of class loading

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/BeanDefinitionLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/BeanDefinitionLoader.java
@@ -147,7 +147,7 @@ class BeanDefinitionLoader {
 	}
 
 	private int load(Class<?> source) {
-		if (isGroovyPresent()
+		if (this.groovyReader != null
 				&& GroovyBeanDefinitionSource.class.isAssignableFrom(source)) {
 			// Any GroovyLoaders added in beans{} DSL can contribute beans here
 			GroovyBeanDefinitionSource loader = BeanUtils.instantiateClass(source,


### PR DESCRIPTION
To detect Groovy we can use the null value of the reader as a test
equivalently outside the constructor.

Alternative to #13711