### PR TITLE
add an authentication method 's field to the OAuth2ClientProperties's provider

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2ClientProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2ClientProperties.java
@@ -204,6 +204,11 @@ public class OAuth2ClientProperties {
 		private String userNameAttribute;
 
 		/**
+		 * Authentication method for the provider
+		 */
+		private String authenticationMethod;
+
+		/**
 		 * JWK set URI for the provider.
 		 */
 		private String jwkSetUri;
@@ -238,6 +243,14 @@ public class OAuth2ClientProperties {
 
 		public void setUserNameAttribute(String userNameAttribute) {
 			this.userNameAttribute = userNameAttribute;
+		}
+
+		public String getAuthenticationMethod() {
+			return authenticationMethod;
+		}
+
+		public void setAuthenticationMethod(String authenticationMethod) {
+			this.authenticationMethod = authenticationMethod;
 		}
 
 		public String getJwkSetUri() {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
spring-security-oauth2-client-5.1.0.RC1
org.springframework.security.oauth2.client.registration.ClientRegistration
userinfoendpoint have a new field authenticationMethod. but it can read the value from the application.yml