### PR TITLE
Remove redundancy from actuator documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -473,25 +473,6 @@ disabled to prevent the possibility of a clash with other mappings.
 
 
 
-[[production-ready-endpoints-custom-mapping]]
-=== Actuator Web Endpoint Paths
-By default, endpoints are exposed over HTTP under the `/actuator` path by using the ID of
-the endpoint. For example, the `beans` endpoint is exposed under `/actuator/beans`. If you
-want to map endpoints to a different path, you can use the
-`management.endpoints.web.path-mapping` property. Also, if you want change the base path,
-you can use `management.endpoints.web.base-path`.
-
-The following example remaps `/actuator/health` to `/healthcheck`:
-
-.application.properties
-[source,properties,indent=0]
-----
-	management.endpoints.web.base-path=/
-	management.endpoints.web.path-mapping.health=healthcheck
-----
-
-
-
 [[production-ready-endpoints-cors]]
 === CORS Support
 https://en.wikipedia.org/wiki/Cross-origin_resource_sharing[Cross-origin resource sharing]
@@ -1068,20 +1049,11 @@ additional entry:
 
 
 
-[[production-ready-monitoring]]
-== Monitoring and Management over HTTP
-If you are developing a web application, Spring Boot Actuator auto-configures all
-enabled endpoints to be exposed over HTTP. The default convention is to use the `id` of
-the endpoint with a prefix of `/actuator` as the URL path. For example, `health` is
-exposed as `/actuator/health`.
-
-TIP: Actuator is supported natively with Spring MVC, Spring WebFlux, and Jersey.
-
-
-
 [[production-ready-customizing-management-server-context-path]]
 === Customizing the Management Endpoint Paths
-Sometimes, it is useful to customize the prefix for the management endpoints. For
+Sometimes, it is useful to customize the prefix for the management endpoints. By default,
+endpoints are exposed over HTTP under the `/actuator` path by using the ID of
+the endpoint. For
 example, your application might already use `/actuator` for another purpose. You can
 use the `management.endpoints.web.base-path` property to change the prefix for your
 management endpoint, as shown in the following example:
@@ -1101,7 +1073,17 @@ different HTTP port>>, `management.endpoints.web.base-path` is relative to
 `management.endpoints.web.base-path` is relative to
 `management.server.servlet.context-path`.
 
+If you want to map endpoints to a different path, you can use the
+`management.endpoints.web.path-mapping` property.
 
+The following example remaps `/actuator/health` to `/healthcheck`:
+
+.application.properties
+[source,properties,indent=0]
+----
+	management.endpoints.web.base-path=/
+	management.endpoints.web.path-mapping.health=healthcheck
+----
 
 [[production-ready-customizing-management-server-port]]
 === Customizing the Management Server Port
@@ -1184,7 +1166,26 @@ If you do not want to expose endpoints over HTTP, you can set the management por
 	management.server.port=-1
 ----
 
+Above can be achieved using the property `management.endpoints.web.exposure.exclude` as well, as shown in
+following example:
 
+[source,properties,indent=0]
+----
+	management.endpoints.web.exposure.exclude=*
+----
+
+`*` can be used to select all endpoints.
+
+If you want to disable HTTP endpoints selectively, configure the list of endpoints IDs to be disabled in
+`management.endpoints.web.exposure.exclude` property
+as shown in following example:
+
+[source,properties,indent=0]
+----
+	management.endpoints.web.exposure.exclude=env,beans
+----
+
+`env` and `beans` endpoints will not be exposed over HTTP.
 
 [[production-ready-jmx]]
 == Monitoring and Management over JMX


### PR DESCRIPTION
This is to remove redundancy from actuator documentation.
Fixes #13905 