### PR TITLE
Allow the ability to set shareNativeConnection to false for LettuceConnectionFactory

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.data.redis;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.resource.ClientResources;
@@ -45,6 +46,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Paluch
  * @author Andy Wilkinson
+ * @author Artsiom Yudovin
  */
 @Configuration
 @ConditionalOnClass(RedisClient.class)
@@ -76,7 +78,15 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 			ClientResources clientResources) throws UnknownHostException {
 		LettuceClientConfiguration clientConfig = getLettuceClientConfiguration(
 				clientResources, this.properties.getLettuce().getPool());
-		return createLettuceConnectionFactory(clientConfig);
+		LettuceConnectionFactory lettuceConnectionFactory = createLettuceConnectionFactory(
+				clientConfig);
+
+		if (Objects.nonNull(this.properties.getLettuce().getShareNativeConnection())) {
+			lettuceConnectionFactory.setShareNativeConnection(
+					this.properties.getLettuce().getShareNativeConnection());
+		}
+
+		return lettuceConnectionFactory;
 	}
 
 	private LettuceConnectionFactory createLettuceConnectionFactory(

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -30,6 +30,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Marco Aust
  * @author Mark Paluch
  * @author Stephane Nicoll
+ * @author Artsiom Yudovin
  */
 @ConfigurationProperties(prefix = "spring.redis")
 public class RedisProperties {
@@ -325,6 +326,14 @@ public class RedisProperties {
 		 */
 		private Pool pool;
 
+		/**
+		 * If shareNativeConnection is true, the pool will be used to select a connection
+		 * for blocking and tx operations only, which should not share a connection. If
+		 * native connection sharing is false, the selected connection will be used for
+		 * all operations
+		 */
+		private Boolean shareNativeConnection;
+
 		public Duration getShutdownTimeout() {
 			return this.shutdownTimeout;
 		}
@@ -339,6 +348,14 @@ public class RedisProperties {
 
 		public void setPool(Pool pool) {
 			this.pool = pool;
+		}
+
+		public Boolean getShareNativeConnection() {
+			return this.shareNativeConnection;
+		}
+
+		public void setShareNativeConnection(Boolean shareNativeConnection) {
+			this.shareNativeConnection = shareNativeConnection;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -327,7 +327,7 @@ public class RedisProperties {
 		private Pool pool;
 
 		/**
-		 * Whether to enable share native connection
+		 * Whether to enable share native connection.
 		 */
 		private Boolean shareNativeConnection;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -327,10 +327,7 @@ public class RedisProperties {
 		private Pool pool;
 
 		/**
-		 * If shareNativeConnection is true, the pool will be used to select a connection
-		 * for blocking and tx operations only, which should not share a connection. If
-		 * native connection sharing is false, the selected connection will be used for
-		 * all operations
+		 * Whether to enable share native connection
 		 */
 		private Boolean shareNativeConnection;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -51,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Paluch
  * @author Stephane Nicoll
  * @author Alen Turkovic
+ * @author Artsiom Yudovin
  */
 public class RedisAutoConfigurationTests {
 
@@ -150,12 +151,15 @@ public class RedisAutoConfigurationTests {
 
 	@Test
 	public void testRedisConfigurationWithPool() {
-		this.contextRunner.withPropertyValues("spring.redis.host:foo",
-				"spring.redis.lettuce.pool.min-idle:1",
-				"spring.redis.lettuce.pool.max-idle:4",
-				"spring.redis.lettuce.pool.max-active:16",
-				"spring.redis.lettuce.pool.max-wait:2000",
-				"spring.redis.lettuce.shutdown-timeout:1000").run((context) -> {
+		this.contextRunner
+				.withPropertyValues("spring.redis.host:foo",
+						"spring.redis.lettuce.pool.min-idle:1",
+						"spring.redis.lettuce.pool.max-idle:4",
+						"spring.redis.lettuce.pool.max-active:16",
+						"spring.redis.lettuce.pool.max-wait:2000",
+						"spring.redis.lettuce.shutdown-timeout:1000",
+						"spring.redis.lettuce.share-native-connection:false")
+				.run((context) -> {
 					LettuceConnectionFactory cf = context
 							.getBean(LettuceConnectionFactory.class);
 					assertThat(cf.getHostName()).isEqualTo("foo");
@@ -166,6 +170,7 @@ public class RedisAutoConfigurationTests {
 					assertThat(poolConfig.getMaxTotal()).isEqualTo(16);
 					assertThat(poolConfig.getMaxWaitMillis()).isEqualTo(2000);
 					assertThat(cf.getShutdownTimeout()).isEqualTo(1000);
+					assertThat(cf.getShareNativeConnection()).isFalse();
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -151,15 +151,13 @@ public class RedisAutoConfigurationTests {
 
 	@Test
 	public void testRedisConfigurationWithPool() {
-		this.contextRunner
-				.withPropertyValues("spring.redis.host:foo",
-						"spring.redis.lettuce.pool.min-idle:1",
-						"spring.redis.lettuce.pool.max-idle:4",
-						"spring.redis.lettuce.pool.max-active:16",
-						"spring.redis.lettuce.pool.max-wait:2000",
-						"spring.redis.lettuce.shutdown-timeout:1000",
-						"spring.redis.lettuce.share-native-connection:false")
-				.run((context) -> {
+		this.contextRunner.withPropertyValues("spring.redis.host:foo",
+				"spring.redis.lettuce.pool.min-idle:1",
+				"spring.redis.lettuce.pool.max-idle:4",
+				"spring.redis.lettuce.pool.max-active:16",
+				"spring.redis.lettuce.pool.max-wait:2000",
+				"spring.redis.lettuce.shutdown-timeout:1000",
+				"spring.redis.lettuce.share-native-connection:false").run((context) -> {
 					LettuceConnectionFactory cf = context
 							.getBean(LettuceConnectionFactory.class);
 					assertThat(cf.getHostName()).isEqualTo("foo");


### PR DESCRIPTION
Allow the ability to set shareNativeConnection for LettuceConnectionFactory
this [enhancement](https://github.com/spring-projects/spring-boot/issues/14196) 