### PR TITLE
Polish some joining collectors

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/annotation/DiscoveredWebOperation.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/annotation/DiscoveredWebOperation.java
@@ -61,8 +61,8 @@ class DiscoveredWebOperation extends AbstractDiscoveredOperation implements WebO
 	}
 
 	private String getId(String endpointId, Method method) {
-		return endpointId + Stream.of(method.getParameters()).filter(this::hasSelector)
-				.map(this::dashName).collect(Collectors.joining());
+		return Stream.of(method.getParameters()).filter(this::hasSelector)
+				.map(this::dashName).collect(Collectors.joining("", endpointId, ""));
 	}
 
 	private boolean hasSelector(Parameter parameter) {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/annotation/RequestPredicateFactory.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/annotation/RequestPredicateFactory.java
@@ -62,8 +62,8 @@ class RequestPredicateFactory {
 	}
 
 	private String getPath(String rootPath, Method method) {
-		return rootPath + Stream.of(method.getParameters()).filter(this::hasSelector)
-				.map(this::slashName).collect(Collectors.joining());
+		return Stream.of(method.getParameters()).filter(this::hasSelector)
+				.map(this::slashName).collect(Collectors.joining("", rootPath, ""));
 	}
 
 	private boolean hasSelector(Parameter parameter) {


### PR DESCRIPTION
Hi,

this PR polishes two occurences where the result of `Collectors.joining()` is concatenated with another String. These could be rewritten to include the specific String as a prefix in the joining Collector, which saves some allocations.

Let me know what you think.
Cheers,
Christoph