### PR TITLE
Drop a constant from Servlet package in OrderedHiddenHttpMethodFilter

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/filter/OrderedHiddenHttpMethodFilter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/filter/OrderedHiddenHttpMethodFilter.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.web.reactive.filter;
 
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.core.Ordered;
 import org.springframework.web.filter.reactive.HiddenHttpMethodFilter;
 
@@ -32,8 +31,7 @@ public class OrderedHiddenHttpMethodFilter extends HiddenHttpMethodFilter
 	/**
 	 * The default order is high to ensure the filter is applied before Spring Security.
 	 */
-	public static final int DEFAULT_ORDER = FilterRegistrationBean.REQUEST_WRAPPER_FILTER_MAX_ORDER
-			- 10000;
+	public static final int DEFAULT_ORDER = -10000;
 
 	private int order = DEFAULT_ORDER;
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
The constant comes from Servlet package and has a value of `0`, so this PR simply drops the constant.