### PR TITLE
Add netty request decoder customizer

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -53,6 +53,7 @@ import org.springframework.util.unit.DataSize;
  * @author Aurélien Leboulanger
  * @author Brian Clozel
  * @author Olivier Lamy
+ * @author Samuel Ko
  */
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = true)
 public class ServerProperties {
@@ -108,6 +109,8 @@ public class ServerProperties {
 	private final Jetty jetty = new Jetty();
 
 	private final Undertow undertow = new Undertow();
+
+	private final Netty netty = new Netty();
 
 	public Integer getPort() {
 		return this.port;
@@ -191,6 +194,10 @@ public class ServerProperties {
 
 	public Undertow getUndertow() {
 		return this.undertow;
+	}
+
+	public Netty getNetty() {
+		return this.netty;
 	}
 
 	/**
@@ -1094,6 +1101,78 @@ public class ServerProperties {
 				this.rotate = rotate;
 			}
 
+		}
+
+	}
+
+	/**
+	 * Netty properties.
+	 */
+	public static class Netty {
+
+		/**
+		 * Maximum initial line length, in bytes.
+		 */
+		private int maxInitialLineLength = 0;
+
+		/**
+		 * Maximum header size for a request, in bytes.
+		 */
+		private int maxHeaderSize = 0;
+
+		/**
+		 * Maximum chunk size for a request, in bytes.
+		 */
+		private int maxChunkSize = 0;
+
+		/**
+		 * Whether to validate headers for illegal characters and character sequences.
+		 */
+		private boolean validateHeaders;
+
+		/**
+		 * Initial buffer size for a request, in bytes.
+		 */
+		private int initialBufferSize;
+
+		public int getMaxInitialLineLength() {
+			return this.maxInitialLineLength;
+		}
+
+		public void setMaxInitialLineLength(int maxInitialLineLength) {
+			this.maxInitialLineLength = maxInitialLineLength;
+		}
+
+		public int getMaxHeaderSize() {
+			return this.maxHeaderSize;
+		}
+
+		public void setMaxHeaderSize(int maxHeaderSize) {
+			this.maxHeaderSize = maxHeaderSize;
+		}
+
+		public int getMaxChunkSize() {
+			return this.maxChunkSize;
+		}
+
+		public void setMaxChunkSize(int maxChunkSize) {
+			this.maxChunkSize = maxChunkSize;
+		}
+
+		public boolean getValidateHeaders() {
+			return this.validateHeaders;
+		}
+
+		public void setValidateHeaders(boolean validateHeaders) {
+			this.validateHeaders = validateHeaders;
+		}
+
+		public int getInitialBufferSize() {
+			return this.initialBufferSize;
+		}
+
+		public void setInitialBufferSize(int initialBufferSize) {
+			this.initialBufferSize = initialBufferSize;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -1128,7 +1128,7 @@ public class ServerProperties {
 		/**
 		 * Whether to validate headers for illegal characters and character sequences.
 		 */
-		private boolean validateHeaders;
+		private boolean validateHeaders = true;
 
 		/**
 		 * Initial buffer size for a request, in bytes.

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizer.java
@@ -38,8 +38,6 @@ import org.springframework.core.env.Environment;
 public class NettyWebServerFactoryCustomizer
 		implements WebServerFactoryCustomizer<NettyReactiveWebServerFactory>, Ordered {
 
-	private static final Predicate<Integer> isStrictlyPositive = (n) -> n > 0;
-
 	private final Environment environment;
 
 	private final ServerProperties serverProperties;
@@ -77,7 +75,7 @@ public class NettyWebServerFactoryCustomizer
 	}
 
 	private boolean isStrictlyPositive(int n) {
-		return isStrictlyPositive.test(n);
+		return n > 0;
 	}
 
 	private int determineMaxHeaderSize() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizer.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.autoconfigure.web.embedded;
 
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import reactor.netty.http.server.HttpRequestDecoderSpec;
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

When making the jump from Tomcat to Netty, I noticed that my `-Dserver.max-http-header-size` configuration was not being honored. This PR allows users to configure the netty `HttpRequestDecoderSpec` using ServerProperties.

#### Notes on implementation
* (`serverProperties` max-http-header-size of <= 0 will defer to `serverProperties.netty` maxHeaderSize)
