### PR TITLE
Align max HTTP header size configuration across all supported containers 

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -53,6 +53,7 @@ import org.springframework.util.unit.DataSize;
  * @author Aurélien Leboulanger
  * @author Brian Clozel
  * @author Olivier Lamy
+ * @author Chentao Qu
  */
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = true)
 public class ServerProperties {
@@ -81,9 +82,9 @@ public class ServerProperties {
 	private String serverHeader;
 
 	/**
-	 * Maximum size, in bytes, of the HTTP message header.
+	 * Maximum size of the HTTP message header.
 	 */
-	private int maxHttpHeaderSize = 8192;
+	private DataSize maxHttpHeaderSize = DataSize.ofKiloBytes(8L);
 
 	/**
 	 * Time that connectors wait for another HTTP request before closing the connection.
@@ -141,11 +142,11 @@ public class ServerProperties {
 		this.serverHeader = serverHeader;
 	}
 
-	public int getMaxHttpHeaderSize() {
+	public DataSize getMaxHttpHeaderSize() {
 		return this.maxHttpHeaderSize;
 	}
 
-	public void setMaxHttpHeaderSize(int maxHttpHeaderSize) {
+	public void setMaxHttpHeaderSize(DataSize maxHttpHeaderSize) {
 		this.maxHttpHeaderSize = maxHttpHeaderSize;
 	}
 
@@ -327,7 +328,9 @@ public class ServerProperties {
 
 		/**
 		 * Maximum size, in bytes, of the HTTP message header.
+		 * @deprecated since 2.1.0 in favor of {@link ServerProperties#maxHttpHeaderSize}
 		 */
+		@Deprecated
 		private int maxHttpHeaderSize = 0;
 
 		/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -729,11 +729,6 @@ public class ServerProperties {
 		 */
 		private Integer selectors;
 
-		/**
-		 * Maximum size, in bytes, of the HTTP response header.
-		 */
-		private int maxHttpResponseHeaderSize;
-
 		public Accesslog getAccesslog() {
 			return this.accesslog;
 		}
@@ -760,14 +755,6 @@ public class ServerProperties {
 
 		public void setSelectors(Integer selectors) {
 			this.selectors = selectors;
-		}
-
-		public int getMaxHttpResponseHeaderSize() {
-			return this.maxHttpResponseHeaderSize;
-		}
-
-		public void setMaxHttpResponseHeaderSize(int maxHttpResponseHeaderSize) {
-			this.maxHttpResponseHeaderSize = maxHttpResponseHeaderSize;
 		}
 
 		/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -83,7 +83,7 @@ public class ServerProperties {
 	/**
 	 * Maximum size, in bytes, of the HTTP message header.
 	 */
-	private int maxHttpHeaderSize = 0; // bytes
+	private int maxHttpHeaderSize = 8192;
 
 	/**
 	 * Time that connectors wait for another HTTP request before closing the connection.
@@ -729,6 +729,11 @@ public class ServerProperties {
 		 */
 		private Integer selectors;
 
+		/**
+		 * Maximum size, in bytes, of the HTTP response header.
+		 */
+		private int maxHttpResponseHeaderSize;
+
 		public Accesslog getAccesslog() {
 			return this.accesslog;
 		}
@@ -755,6 +760,14 @@ public class ServerProperties {
 
 		public void setSelectors(Integer selectors) {
 			this.selectors = selectors;
+		}
+
+		public int getMaxHttpResponseHeaderSize() {
+			return this.maxHttpResponseHeaderSize;
+		}
+
+		public void setMaxHttpResponseHeaderSize(int maxHttpResponseHeaderSize) {
+			this.maxHttpResponseHeaderSize = maxHttpResponseHeaderSize;
 		}
 
 		/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
@@ -73,13 +73,9 @@ public class JettyWebServerFactoryCustomizer implements
 				.to(factory::setAcceptors);
 		propertyMapper.from(jettyProperties::getSelectors).whenNonNull()
 				.to(factory::setSelectors);
-		propertyMapper.from(properties::getMaxHttpHeaderSize).when(this::isPositive).to(
-				(maxHttpRequestHeaderSize) -> customizeMaxHttpRequestHeaderSize(factory,
-						maxHttpRequestHeaderSize));
-		propertyMapper.from(jettyProperties::getMaxHttpResponseHeaderSize)
-				.when(this::isPositive)
-				.to((maxHttpResponseHeaderSize) -> customizeMaxHttpResponseHeaderSize(
-						factory, maxHttpResponseHeaderSize));
+		propertyMapper.from(properties::getMaxHttpHeaderSize).when(this::isPositive)
+				.to((maxHttpHeaderSize) -> customizeMaxHttpHeaderSize(factory,
+						maxHttpHeaderSize));
 		propertyMapper.from(jettyProperties::getMaxHttpPostSize).when(this::isPositive)
 				.to((maxHttpPostSize) -> customizeMaxHttpPostSize(factory,
 						maxHttpPostSize));
@@ -116,8 +112,8 @@ public class JettyWebServerFactoryCustomizer implements
 		});
 	}
 
-	private void customizeMaxHttpRequestHeaderSize(
-			ConfigurableJettyWebServerFactory factory, int maxHttpRequestHeaderSize) {
+	private void customizeMaxHttpHeaderSize(ConfigurableJettyWebServerFactory factory,
+			int maxHttpHeaderSize) {
 		factory.addServerCustomizers(new JettyServerCustomizer() {
 
 			@Override
@@ -136,34 +132,7 @@ public class JettyWebServerFactoryCustomizer implements
 
 			private void customize(HttpConfiguration.ConnectionFactory factory) {
 				HttpConfiguration configuration = factory.getHttpConfiguration();
-				configuration.setRequestHeaderSize(maxHttpRequestHeaderSize);
-			}
-
-		});
-	}
-
-	private void customizeMaxHttpResponseHeaderSize(
-			ConfigurableJettyWebServerFactory factory,
-			Integer maxHttpResponseHeaderSize) {
-		factory.addServerCustomizers(new JettyServerCustomizer() {
-
-			@Override
-			public void customize(Server server) {
-				for (org.eclipse.jetty.server.Connector connector : server
-						.getConnectors()) {
-					for (ConnectionFactory connectionFactory : connector
-							.getConnectionFactories()) {
-						if (connectionFactory instanceof HttpConfiguration.ConnectionFactory) {
-							customize(
-									(HttpConfiguration.ConnectionFactory) connectionFactory);
-						}
-					}
-				}
-			}
-
-			private void customize(HttpConfiguration.ConnectionFactory factory) {
-				HttpConfiguration configuration = factory.getHttpConfiguration();
-				configuration.setResponseHeaderSize(maxHttpResponseHeaderSize);
+				configuration.setRequestHeaderSize(maxHttpHeaderSize);
 			}
 
 		});

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
@@ -36,6 +36,7 @@ import org.springframework.boot.web.embedded.jetty.JettyServerCustomizer;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.Environment;
+import org.springframework.util.unit.DataSize;
 
 /**
  * Customization for Jetty-specific features common for both Servlet and Reactive servers.
@@ -73,7 +74,8 @@ public class JettyWebServerFactoryCustomizer implements
 				.to(factory::setAcceptors);
 		propertyMapper.from(jettyProperties::getSelectors).whenNonNull()
 				.to(factory::setSelectors);
-		propertyMapper.from(properties::getMaxHttpHeaderSize).when(this::isPositive)
+		propertyMapper.from(properties::getMaxHttpHeaderSize).whenNonNull()
+				.asInt(DataSize::toBytes)
 				.to((maxHttpHeaderSize) -> customizeMaxHttpHeaderSize(factory,
 						maxHttpHeaderSize));
 		propertyMapper.from(jettyProperties::getMaxHttpPostSize).when(this::isPositive)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizer.java
@@ -24,11 +24,13 @@ import org.springframework.boot.web.embedded.netty.NettyServerCustomizer;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.Environment;
+import org.springframework.util.unit.DataSize;
 
 /**
  * Customization for Netty-specific features.
  *
  * @author Brian Clozel
+ * @author Chentao Qu
  * @since 2.1.0
  */
 public class NettyWebServerFactoryCustomizer
@@ -54,8 +56,8 @@ public class NettyWebServerFactoryCustomizer
 		factory.setUseForwardHeaders(
 				getOrDeduceUseForwardHeaders(this.serverProperties, this.environment));
 		PropertyMapper propertyMapper = PropertyMapper.get();
-		propertyMapper.from(this.serverProperties::getMaxHttpHeaderSize)
-				.when(this::isPositive)
+		propertyMapper.from(this.serverProperties::getMaxHttpHeaderSize).whenNonNull()
+				.asInt(DataSize::toBytes)
 				.to((maxHttpRequestHeaderSize) -> customizeMaxHttpHeaderSize(factory,
 						maxHttpRequestHeaderSize));
 	}
@@ -74,10 +76,6 @@ public class NettyWebServerFactoryCustomizer
 		factory.addServerCustomizers((NettyServerCustomizer) (httpServer) -> httpServer
 				.httpRequestDecoder((httpRequestDecoderSpec) -> httpRequestDecoderSpec
 						.maxHeaderSize(maxHttpHeaderSize)));
-	}
-
-	private boolean isPositive(Integer value) {
-		return value > 0;
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
@@ -48,6 +48,7 @@ import org.springframework.util.unit.DataSize;
  * @author Stephane Nicoll
  * @author Phillip Webb
  * @author Artsiom Yudovin
+ * @author Chentao Qu
  * @since 2.0.0
  */
 public class TomcatWebServerFactoryCustomizer implements
@@ -84,7 +85,8 @@ public class TomcatWebServerFactoryCustomizer implements
 						tomcatProperties.getMaxThreads()));
 		propertyMapper.from(tomcatProperties::getMinSpareThreads).when(this::isPositive)
 				.to((minSpareThreads) -> customizeMinThreads(factory, minSpareThreads));
-		propertyMapper.from(this::determineMaxHttpHeaderSize).when(this::isPositive)
+		propertyMapper.from(this::determineMaxHttpHeaderSize).whenNonNull()
+				.asInt(DataSize::toBytes)
 				.to((maxHttpHeaderSize) -> customizeMaxHttpHeaderSize(factory,
 						maxHttpHeaderSize));
 		propertyMapper.from(tomcatProperties::getMaxSwallowSize).whenNonNull()
@@ -114,10 +116,11 @@ public class TomcatWebServerFactoryCustomizer implements
 		return value > 0;
 	}
 
-	private int determineMaxHttpHeaderSize() {
-		return (this.serverProperties.getMaxHttpHeaderSize() > 0)
-				? this.serverProperties.getMaxHttpHeaderSize()
-				: this.serverProperties.getTomcat().getMaxHttpHeaderSize();
+	private DataSize determineMaxHttpHeaderSize() {
+		return isPositive(this.serverProperties.getTomcat().getMaxHttpHeaderSize())
+				? DataSize
+						.ofBytes(this.serverProperties.getTomcat().getMaxHttpHeaderSize())
+				: this.serverProperties.getMaxHttpHeaderSize();
 	}
 
 	private void customizeAcceptCount(ConfigurableTomcatWebServerFactory factory,

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/UndertowWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/UndertowWebServerFactoryCustomizer.java
@@ -27,6 +27,7 @@ import org.springframework.boot.web.embedded.undertow.ConfigurableUndertowWebSer
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.Environment;
+import org.springframework.util.unit.DataSize;
 
 /**
  * Customization for Undertow-specific features common for both Servlet and Reactive
@@ -83,7 +84,8 @@ public class UndertowWebServerFactoryCustomizer implements
 				.to(factory::setAccessLogRotate);
 		propertyMapper.from(this::getOrDeduceUseForwardHeaders)
 				.to(factory::setUseForwardHeaders);
-		propertyMapper.from(properties::getMaxHttpHeaderSize).when(this::isPositive)
+		propertyMapper.from(properties::getMaxHttpHeaderSize).whenNonNull()
+				.asInt(DataSize::toBytes)
 				.to((maxHttpHeaderSize) -> customizeMaxHttpHeaderSize(factory,
 						maxHttpHeaderSize));
 		propertyMapper.from(undertowProperties::getMaxHttpPostSize).when(this::isPositive)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -29,6 +29,7 @@ import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+import org.springframework.util.unit.DataSize;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -136,7 +137,8 @@ public class ServerPropertiesTests {
 	@Test
 	public void testCustomizeHeaderSize() {
 		bind("server.max-http-header-size", "9999");
-		assertThat(this.properties.getMaxHttpHeaderSize()).isEqualTo(9999);
+		assertThat(this.properties.getMaxHttpHeaderSize())
+				.isEqualTo(DataSize.ofBytes(9999));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -168,13 +168,6 @@ public class ServerPropertiesTests {
 		assertThat(jetty.getAccesslog().isAppend()).isTrue();
 	}
 
-	@Test
-	public void customizeMaxHttpResponseHeaderSize() {
-		bind("server.jetty.max-http-response-header-size", "2048");
-		ServerProperties.Jetty jetty = this.properties.getJetty();
-		assertThat(jetty.getMaxHttpResponseHeaderSize()).isEqualTo(2048);
-	}
-
 	private void bind(String name, String value) {
 		bind(Collections.singletonMap(name, value));
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -168,6 +168,13 @@ public class ServerPropertiesTests {
 		assertThat(jetty.getAccesslog().isAppend()).isTrue();
 	}
 
+	@Test
+	public void customizeMaxHttpResponseHeaderSize() {
+		bind("server.jetty.max-http-response-header-size", "2048");
+		ServerProperties.Jetty jetty = this.properties.getJetty();
+		assertThat(jetty.getMaxHttpResponseHeaderSize()).isEqualTo(2048);
+	}
+
 	private void bind(String name, String value) {
 		bind(Collections.singletonMap(name, value));
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
@@ -144,8 +144,8 @@ public class JettyWebServerFactoryCustomizerTests {
 	}
 
 	@Test
-	public void customizeMaxHttpResponseHeaderSize() {
-		bind("server.jetty.max-http-response-header-size=2048");
+	public void customizeMaxHttpHeaderSize() {
+		bind("server.max-http-header-size=2048");
 		JettyWebServer server = customizeAndGetServer();
 		for (Connector connector : server.getServer().getConnectors()) {
 			connector.getConnectionFactories().stream()
@@ -153,7 +153,7 @@ public class JettyWebServerFactoryCustomizerTests {
 					.forEach((cf) -> {
 						ConnectionFactory factory = (ConnectionFactory) cf;
 						HttpConfiguration configuration = factory.getHttpConfiguration();
-						assertThat(configuration.getResponseHeaderSize()).isEqualTo(2048);
+						assertThat(configuration.getRequestHeaderSize()).isEqualTo(2048);
 					});
 		}
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConfiguration.ConnectionFactory;
 import org.eclipse.jetty.server.NCSARequestLog;
 import org.eclipse.jetty.server.RequestLog;
 import org.junit.Before;
@@ -138,6 +141,21 @@ public class JettyWebServerFactoryCustomizerTests {
 				ConfigurableJettyWebServerFactory.class);
 		this.customizer.customize(factory);
 		verify(factory).setUseForwardHeaders(true);
+	}
+
+	@Test
+	public void customizeMaxHttpResponseHeaderSize() {
+		bind("server.jetty.max-http-response-header-size=2048");
+		JettyWebServer server = customizeAndGetServer();
+		for (Connector connector : server.getServer().getConnectors()) {
+			connector.getConnectionFactories().stream()
+					.filter((factory) -> factory instanceof ConnectionFactory)
+					.forEach((cf) -> {
+						ConnectionFactory factory = (ConnectionFactory) cf;
+						HttpConfiguration configuration = factory.getHttpConfiguration();
+						assertThat(configuration.getResponseHeaderSize()).isEqualTo(2048);
+					});
+		}
 	}
 
 	private void bind(String... inlinedProperties) {

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -207,7 +207,7 @@ content into your application. Rather, pick only the properties that you need.
 	server.jetty.accesslog.time-zone=GMT # Timezone of the request log.
 	server.jetty.max-http-post-size=0 # Maximum size, in bytes, of the HTTP post or put content.
 	server.jetty.selectors= # Number of selector threads to use.
-	server.max-http-header-size=0 # Maximum size, in bytes, of the HTTP message header.
+	server.max-http-header-size=8KB # Maximum size of the HTTP message header.
 	server.port=8080 # Server HTTP port.
 	server.server-header= # Value to use for the Server response header (if empty, no header is sent).
 	server.use-forward-headers= # Whether X-Forwarded-* headers should be applied to the HttpRequest.
@@ -265,7 +265,7 @@ content into your application. Rather, pick only the properties that you need.
 			172\\.2[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|\\
 			172\\.3[0-1]{1}\\.\\d{1,3}\\.\\d{1,3} # Regular expression matching trusted IP addresses.
 	server.tomcat.max-connections=0 # Maximum number of connections that the server accepts and processes at any given time.
-	server.tomcat.max-http-header-size=0 # Maximum size, in bytes, of the HTTP message header.
+	server.tomcat.max-http-header-size=0 # Maximum size, in bytes, of the HTTP message header. Deprecated, use server.max-http-header-size instead.
 	server.tomcat.max-http-post-size=0 # Maximum size, in bytes, of the HTTP post content.
 	server.tomcat.max-swallow-size=2MB # Maximum amount of request body to swallow.
 	server.tomcat.max-threads=0 # Maximum number of worker threads.


### PR DESCRIPTION
Align max HTTP header size configuration across all supported containers

Fix: #13831 

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->