### PR TITLE
Added a starter for the Stripe Payment Gateway

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/pom.xml
@@ -98,6 +98,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.technochord.stripe</groupId>
+			<artifactId>stripe-service</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>de.flapdoodle.embed</groupId>
 			<artifactId>de.flapdoodle.embed.mongo</artifactId>
 			<optional>true</optional>

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/stripe/StripeProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/stripe/StripeProperties.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.stripe;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for {@link com.technochord.stripe.service.StripeService}.
+ *
+ * @author Pankaj Tandon
+ * @since 2.1.0
+ */
+@ConfigurationProperties(prefix = "spring.stripe")
+public class StripeProperties {
+
+	private boolean enabled;
+
+	private String apiKey;
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public void setApiKey(String apiKey) {
+		this.apiKey = apiKey;
+	}
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public String getApiKey() {
+		return this.apiKey;
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/stripe/StripeServiceAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/stripe/StripeServiceAutoConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.stripe;
+
+import com.stripe.Stripe;
+import com.technochord.stripe.service.StripeService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for {@link Stripe}.
+ *
+ * @author Pankaj Tandon
+ * @since 2.1.0
+ */
+@ConditionalOnClass(Stripe.class)
+@Configuration
+@EnableConfigurationProperties(StripeProperties.class)
+@ConditionalOnProperty(prefix = "spring.stripe", name = "enabled", havingValue = "true")
+public class StripeServiceAutoConfiguration {
+
+	@Autowired
+	private StripeProperties stripeProperties;
+
+	@Bean
+	@ConditionalOnMissingBean
+	public StripeService stripeService() {
+		return new StripeService(this.stripeProperties.getApiKey());
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/stripe/package-info.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/stripe/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for task execution and scheduling.
+ */
+package org.springframework.boot.autoconfigure.stripe;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -110,6 +110,7 @@ org.springframework.boot.autoconfigure.security.oauth2.client.reactive.ReactiveO
 org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration,\
 org.springframework.boot.autoconfigure.security.oauth2.resource.reactive.ReactiveOAuth2ResourceServerAutoConfiguration,\
 org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration,\
+org.springframework.boot.autoconfigure.stripe.StripeServiceAutoConfiguration,\
 org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration,\
 org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration,\
 org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration,\

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/stripe/StripeServiceAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/stripe/StripeServiceAutoConfigurationTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.stripe;
+
+import com.technochord.stripe.service.StripeService;
+import org.junit.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class for {@link StripeServiceAutoConfiguration}.
+ *
+ * @author Pankaj Tandon
+ */
+public class StripeServiceAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(
+					AutoConfigurations.of(StripeServiceAutoConfiguration.class));
+
+	@Test
+	public void testAutoConfigurationIsLoadedWhenEnabled() {
+		this.contextRunner.withPropertyValues("spring.stripe.enabled=true",
+				"spring.stripe.apiKey=dummy").run((context) -> {
+					assertThat(context).hasSingleBean(StripeService.class);
+				});
+	}
+
+	@Test
+	public void testAutoConfigurationIsNotLoadedWhenDisabled() {
+		this.contextRunner.withPropertyValues("spring.stripe.enabled=false",
+				"spring.stripe.apiKey=dummy").run((context) -> {
+					assertThat(context).doesNotHaveBean(StripeService.class);
+				});
+	}
+
+	@Test
+	public void testAutoConfigurationIsNotLoadedAndDoesNotThrowExceptionWhenDisabledAndNoKeyPassed() {
+		this.contextRunner.withPropertyValues("spring.stripe.enabled=false",
+				"spring.stripe.apiKey=").run((context) -> {
+					assertThat(context).doesNotHaveBean(StripeService.class);
+				});
+	}
+
+	@Test
+	public void testAutoConfigurationIsNotLoadedWhenDisabledAndZeroLengthKeyPassed() {
+		this.contextRunner.withPropertyValues("spring.stripe.enabled=false")
+				.run((context) -> {
+					assertThat(context).doesNotHaveBean(StripeService.class);
+				});
+	}
+
+	@Test(expected = AssertionError.class)
+	public void testAutoConfigurationThrowsExceptionWhenEnabledAndNoKeyPassed() {
+		this.contextRunner.withPropertyValues("spring.stripe.enabled=true")
+				.run((context) -> {
+					assertThat(context).doesNotHaveBean(StripeService.class);
+				});
+	}
+
+	@Test(expected = AssertionError.class)
+	public void testAutoConfigurationThrowsExceptionWhenEnabledAndZeroLengthKeyPassed() {
+		this.contextRunner
+				.withPropertyValues("spring.stripe.enabled=true", "spring.stripe.apiKey=")
+				.run((context) -> {
+					assertThat(context).doesNotHaveBean(StripeService.class);
+				});
+	}
+
+}

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -170,6 +170,7 @@
 		<spring-ws.version>3.0.3.RELEASE</spring-ws.version>
 		<sqlite-jdbc.version>3.23.1</sqlite-jdbc.version>
 		<statsd-client.version>3.1.0</statsd-client.version>
+		<stripe-service.version>1.0.1</stripe-service.version>
 		<sun-mail.version>${javax-mail.version}</sun-mail.version>
 		<saaj-impl.version>1.4.0</saaj-impl.version>
 		<thymeleaf.version>3.0.9.RELEASE</thymeleaf.version>
@@ -718,6 +719,11 @@
 				<groupId>com.sun.xml.messaging.saaj</groupId>
 				<artifactId>saaj-impl</artifactId>
 				<version>${saaj-impl.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.technochord.stripe</groupId>
+				<artifactId>stripe-service</artifactId>
+				<version>${stripe-service.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.timgroup</groupId>

--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -133,6 +133,9 @@ do as they were designed before this was clarified.
 | SSH Daemon
 | https://github.com/anand1st/sshd-shell-spring-boot
 
+| https://github.com/pankajtandon/StripeService[StripeService]
+| https://github.com/pankajtandon/StripeService
+
 | https://github.com/StripesFramework/stripes[Stripes]
 | https://github.com/juanpablo-santos/stripes-spring-boot
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This branch adds a spring-boot-starter project to easily integrate a [StripeService](https://github.com/pankajtandon/StripeService) as a Spring managed bean. [This service](https://github.com/pankajtandon/StripeService) facades the rich API offered by [Stripe.com (Payment Gateway)](https://stripe.com/docs/api/java#intro).

The [API exposed by Stripe](https://stripe.com/docs/api/java#intro) is rich and open-ended. This effort exposes a limited set of functionality (as described [here](https://github.com/pankajtandon/StripeService#common-use-cases)) that is used most commonly.

Minimal configuration exists currently via Spring Boot's property management in the client app:
1. The user can enable/disable the starter
2. The user can specify the Stripe API Key.

More configuration will follow representing more complex use-cases.



