### PR TITLE
MetricsRun could be run not only with ApplicationContextRunner

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/amqp/RabbitMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/amqp/RabbitMetricsAutoConfigurationTests.java
@@ -34,8 +34,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RabbitMetricsAutoConfigurationTests {
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.with(MetricsRun.simple())
-			.withConfiguration(AutoConfigurations.of(RabbitAutoConfiguration.class));
+			.with(MetricsRun.simple()).withConfiguration(AutoConfigurations.of(
+					RabbitAutoConfiguration.class, RabbitMetricsAutoConfiguration.class));
 
 	@Test
 	public void autoConfiguredConnectionFactoryIsInstrumented() {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/cache/CacheMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/cache/CacheMetricsAutoConfigurationTests.java
@@ -37,7 +37,8 @@ public class CacheMetricsAutoConfigurationTests {
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.with(MetricsRun.simple()).withUserConfiguration(CachingConfiguration.class)
-			.withConfiguration(AutoConfigurations.of(CacheAutoConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(CacheAutoConfiguration.class,
+					CacheMetricsAutoConfiguration.class));
 
 	@Test
 	public void autoConfiguredCacheManagerIsInstrumented() {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/test/MetricsRun.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/test/MetricsRun.java
@@ -23,8 +23,6 @@ import java.util.function.Function;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.metrics.amqp.RabbitMetricsAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.metrics.cache.CacheMetricsAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.atlas.AtlasMetricsExportAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.datadog.DatadogMetricsExportAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.ganglia.GangliaMetricsExportAutoConfiguration;
@@ -36,12 +34,8 @@ import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.
 import org.springframework.boot.actuate.autoconfigure.metrics.export.signalfx.SignalFxMetricsExportAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.statsd.StatsdMetricsExportAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.metrics.jdbc.DataSourcePoolMetricsAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.metrics.orm.jpa.HibernateMetricsAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.metrics.web.client.HttpClientMetricsAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.metrics.web.reactive.WebFluxMetricsAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvcMetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.AbstractApplicationContextRunner;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.util.Assert;
 
@@ -73,12 +67,8 @@ public final class MetricsRun {
 	}
 
 	private static final AutoConfigurations AUTO_CONFIGURATIONS = AutoConfigurations.of(
-			MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class,
-			RabbitMetricsAutoConfiguration.class, CacheMetricsAutoConfiguration.class,
-			DataSourcePoolMetricsAutoConfiguration.class,
-			HibernateMetricsAutoConfiguration.class,
-			HttpClientMetricsAutoConfiguration.class,
-			WebFluxMetricsAutoConfiguration.class, WebMvcMetricsAutoConfiguration.class);
+			MetricsAutoConfiguration.class,
+			CompositeMeterRegistryAutoConfiguration.class);
 
 	private MetricsRun() {
 	}
@@ -88,7 +78,7 @@ public final class MetricsRun {
 	 * implementation.
 	 * @return the function to apply
 	 */
-	public static Function<ApplicationContextRunner, ApplicationContextRunner> simple() {
+	public static <SELF extends AbstractApplicationContextRunner<SELF, ?, ?>> Function<SELF, SELF> simple() {
 		return limitedTo(SimpleMetricsExportAutoConfiguration.class);
 	}
 
@@ -98,13 +88,14 @@ public final class MetricsRun {
 	 * @param exportAutoConfigurations the export auto-configurations to include
 	 * @return the function to apply
 	 */
-	public static Function<ApplicationContextRunner, ApplicationContextRunner> limitedTo(
+	public static <SELF extends AbstractApplicationContextRunner<SELF, ?, ?>> Function<SELF, SELF> limitedTo(
 			Class<?>... exportAutoConfigurations) {
 		return (contextRunner) -> apply(contextRunner, exportAutoConfigurations);
 	}
 
-	private static ApplicationContextRunner apply(ApplicationContextRunner contextRunner,
-			Class<?>[] exportAutoConfigurations) {
+	@SuppressWarnings("unchecked")
+	private static <SELF extends AbstractApplicationContextRunner<SELF, ?, ?>> SELF apply(
+			SELF contextRunner, Class<?>[] exportAutoConfigurations) {
 		for (Class<?> configuration : exportAutoConfigurations) {
 			Assert.state(EXPORT_AUTO_CONFIGURATIONS.contains(configuration),
 					() -> "Unknown export auto-configuration " + configuration.getName());

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsConfigurationTests.java
@@ -45,8 +45,9 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 public class RestTemplateMetricsConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.with(MetricsRun.simple()).withConfiguration(
-					AutoConfigurations.of(RestTemplateAutoConfiguration.class));
+			.with(MetricsRun.simple())
+			.withConfiguration(AutoConfigurations.of(RestTemplateAutoConfiguration.class,
+					HttpClientMetricsAutoConfiguration.class));
 
 	@Rule
 	public OutputCapture out = new OutputCapture();

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/WebClientMetricsConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/WebClientMetricsConfigurationTests.java
@@ -50,7 +50,8 @@ public class WebClientMetricsConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.with(MetricsRun.simple())
-			.withConfiguration(AutoConfigurations.of(WebClientAutoConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(WebClientAutoConfiguration.class,
+					HttpClientMetricsAutoConfiguration.class));
 
 	@Rule
 	public OutputCapture out = new OutputCapture();

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/reactive/WebFluxMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/reactive/WebFluxMetricsAutoConfigurationTests.java
@@ -20,8 +20,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.test.MetricsRun;
 import org.springframework.boot.actuate.autoconfigure.metrics.web.TestController;
 import org.springframework.boot.actuate.metrics.web.reactive.server.DefaultWebFluxTagsProvider;
 import org.springframework.boot.actuate.metrics.web.reactive.server.MetricsWebFilter;
@@ -47,9 +46,9 @@ import static org.mockito.Mockito.mock;
 public class WebFluxMetricsAutoConfigurationTests {
 
 	private ReactiveWebApplicationContextRunner contextRunner = new ReactiveWebApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class,
-					SimpleMetricsExportAutoConfiguration.class,
-					WebFluxMetricsAutoConfiguration.class));
+			.with(MetricsRun.simple()).withConfiguration(
+					AutoConfigurations.of(WebFluxMetricsAutoConfiguration.class,
+							WebFluxAutoConfiguration.class));
 
 	@Rule
 	public OutputCapture output = new OutputCapture();
@@ -71,9 +70,7 @@ public class WebFluxMetricsAutoConfigurationTests {
 
 	@Test
 	public void afterMaxUrisReachedFurtherUrisAreDenied() {
-		this.contextRunner
-				.withConfiguration(AutoConfigurations.of(WebFluxAutoConfiguration.class))
-				.withUserConfiguration(TestController.class)
+		this.contextRunner.withUserConfiguration(TestController.class)
 				.withPropertyValues("management.metrics.web.server.max-uri-tags=2")
 				.run((context) -> {
 					MeterRegistry registry = getInitializedMeterRegistry(context);
@@ -86,9 +83,7 @@ public class WebFluxMetricsAutoConfigurationTests {
 
 	@Test
 	public void shouldNotDenyNorLogIfMaxUrisIsNotReached() {
-		this.contextRunner
-				.withConfiguration(AutoConfigurations.of(WebFluxAutoConfiguration.class))
-				.withUserConfiguration(TestController.class)
+		this.contextRunner.withUserConfiguration(TestController.class)
 				.withPropertyValues("management.metrics.web.server.max-uri-tags=5")
 				.run((context) -> {
 					MeterRegistry registry = getInitializedMeterRegistry(context);

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsAutoConfigurationTests.java
@@ -26,11 +26,10 @@ import javax.servlet.http.HttpServletResponse;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.test.MetricsRun;
 import org.springframework.boot.actuate.autoconfigure.metrics.web.TestController;
 import org.springframework.boot.actuate.metrics.web.servlet.DefaultWebMvcTagsProvider;
 import org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter;
@@ -60,33 +59,26 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class WebMvcMetricsAutoConfigurationTests {
 
 	private WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
-			.withConfiguration(
-					AutoConfigurations.of(WebMvcMetricsAutoConfiguration.class));
+			.with(MetricsRun.simple()).withConfiguration(AutoConfigurations.of(
+					WebMvcAutoConfiguration.class, WebMvcMetricsAutoConfiguration.class));
 
 	@Rule
 	public OutputCapture output = new OutputCapture();
 
 	@Test
-	public void backsOffWhenMeterRegistryIsMissing() {
-		this.contextRunner.run((context) -> assertThat(context)
-				.doesNotHaveBean(WebMvcMetricsAutoConfiguration.class));
-	}
-
-	@Test
 	public void definesTagsProviderAndFilterWhenMeterRegistryIsPresent() {
-		this.contextRunner.withUserConfiguration(MeterRegistryConfiguration.class)
-				.run((context) -> {
-					assertThat(context).hasSingleBean(DefaultWebMvcTagsProvider.class);
-					assertThat(context).hasSingleBean(FilterRegistrationBean.class);
-					assertThat(context.getBean(FilterRegistrationBean.class).getFilter())
-							.isInstanceOf(WebMvcMetricsFilter.class);
-				});
+		this.contextRunner.run((context) -> {
+			assertThat(context).hasSingleBean(DefaultWebMvcTagsProvider.class);
+			assertThat(context).hasSingleBean(FilterRegistrationBean.class);
+			assertThat(context.getBean(FilterRegistrationBean.class).getFilter())
+					.isInstanceOf(WebMvcMetricsFilter.class);
+		});
 	}
 
 	@Test
 	public void tagsProviderBacksOff() {
-		this.contextRunner.withUserConfiguration(MeterRegistryConfiguration.class,
-				TagsProviderConfiguration.class).run((context) -> {
+		this.contextRunner.withUserConfiguration(TagsProviderConfiguration.class)
+				.run((context) -> {
 					assertThat(context).doesNotHaveBean(DefaultWebMvcTagsProvider.class);
 					assertThat(context).hasSingleBean(TestWebMvcTagsProvider.class);
 				});
@@ -94,25 +86,18 @@ public class WebMvcMetricsAutoConfigurationTests {
 
 	@Test
 	public void filterRegistrationHasExpectedDispatcherTypesAndOrder() {
-		this.contextRunner.withUserConfiguration(MeterRegistryConfiguration.class)
-				.run((context) -> {
-					FilterRegistrationBean<?> registration = context
-							.getBean(FilterRegistrationBean.class);
-					assertThat(registration).hasFieldOrPropertyWithValue(
-							"dispatcherTypes",
-							EnumSet.of(DispatcherType.REQUEST, DispatcherType.ASYNC));
-					assertThat(registration.getOrder())
-							.isEqualTo(Ordered.HIGHEST_PRECEDENCE + 1);
-				});
+		this.contextRunner.run((context) -> {
+			FilterRegistrationBean<?> registration = context
+					.getBean(FilterRegistrationBean.class);
+			assertThat(registration).hasFieldOrPropertyWithValue("dispatcherTypes",
+					EnumSet.of(DispatcherType.REQUEST, DispatcherType.ASYNC));
+			assertThat(registration.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE + 1);
+		});
 	}
 
 	@Test
 	public void afterMaxUrisReachedFurtherUrisAreDenied() {
-		this.contextRunner
-				.withUserConfiguration(TestController.class,
-						MeterRegistryConfiguration.class)
-				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class,
-						WebMvcAutoConfiguration.class))
+		this.contextRunner.withUserConfiguration(TestController.class)
 				.withPropertyValues("management.metrics.web.server.max-uri-tags=2")
 				.run((context) -> {
 					MeterRegistry registry = getInitializedMeterRegistry(context);
@@ -125,11 +110,7 @@ public class WebMvcMetricsAutoConfigurationTests {
 
 	@Test
 	public void shouldNotDenyNorLogIfMaxUrisIsNotReached() {
-		this.contextRunner
-				.withUserConfiguration(TestController.class,
-						MeterRegistryConfiguration.class)
-				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class,
-						WebMvcAutoConfiguration.class))
+		this.contextRunner.withUserConfiguration(TestController.class)
 				.withPropertyValues("management.metrics.web.server.max-uri-tags=5")
 				.run((context) -> {
 					MeterRegistry registry = getInitializedMeterRegistry(context);
@@ -152,16 +133,6 @@ public class WebMvcMetricsAutoConfigurationTests {
 					.andExpect(status().isOk());
 		}
 		return context.getBean(MeterRegistry.class);
-	}
-
-	@Configuration
-	static class MeterRegistryConfiguration {
-
-		@Bean
-		public MeterRegistry meterRegistry() {
-			return new SimpleMeterRegistry();
-		}
-
 	}
 
 	@Configuration


### PR DESCRIPTION
`MetricsRun` could be run not only with `ApplicationContextRunner` but with any of `AbstractApplicationContextRunner's` implementation. 