### PR TITLE
WebClient and RestTemplate 'uri' tag filter.

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/WebMetricsClientFiltersAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/WebMetricsClientFiltersAutoConfiguration.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.web;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties;
+import org.springframework.boot.actuate.autoconfigure.metrics.OnlyOnceLoggingDenyMeterFilter;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
+ * Auto-configuration} for register {@link RestTemplate} or {@link WebClient} metrics
+ * filters.
+ *
+ * @author Dmytro Nosan
+ * @since 2.0.5
+ */
+@Configuration
+@AutoConfigureAfter({ MetricsAutoConfiguration.class,
+		SimpleMetricsExportAutoConfiguration.class })
+@ConditionalOnBean(MeterRegistry.class)
+@Conditional(WebMetricsClientFiltersAutoConfiguration.AnyWebMetricsClientAvailableCondition.class)
+public class WebMetricsClientFiltersAutoConfiguration {
+
+	private final MetricsProperties properties;
+
+	public WebMetricsClientFiltersAutoConfiguration(MetricsProperties properties) {
+		this.properties = properties;
+	}
+
+	@Bean
+	@Order(0)
+	public MeterFilter webMetricsClientUriTagFilter() {
+		MetricsProperties.Web.Client client = this.properties.getWeb().getClient();
+		String metricName = client.getRequestsMetricName();
+		MeterFilter denyFilter = new OnlyOnceLoggingDenyMeterFilter(
+				() -> String.format(
+						"Reached the maximum number of URI tags for '%s'. Are you using "
+								+ "'uriVariables' on RestTemplate/WebClient calls?",
+						metricName));
+		return MeterFilter.maximumAllowableTags(metricName, "uri", client.getMaxUriTags(),
+				denyFilter);
+	}
+
+	/**
+	 * Check if either a {@link RestTemplate} or {@link WebClient} class is available.
+	 */
+	static class AnyWebMetricsClientAvailableCondition extends AnyNestedCondition {
+
+		AnyWebMetricsClientAvailableCondition() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@ConditionalOnClass(RestTemplate.class)
+		static class RestTemplateAvailable {
+
+		}
+
+		@ConditionalOnClass(WebClient.class)
+		static class WebClientAvailable {
+
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsAutoConfiguration.java
@@ -17,11 +17,9 @@
 package org.springframework.boot.actuate.autoconfigure.metrics.web.client;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.config.MeterFilter;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties;
-import org.springframework.boot.actuate.autoconfigure.metrics.OnlyOnceLoggingDenyMeterFilter;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
 import org.springframework.boot.actuate.metrics.web.client.DefaultRestTemplateExchangeTagsProvider;
 import org.springframework.boot.actuate.metrics.web.client.MetricsRestTemplateCustomizer;
@@ -34,7 +32,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -70,17 +67,6 @@ public class RestTemplateMetricsAutoConfiguration {
 			RestTemplateExchangeTagsProvider restTemplateTagConfigurer) {
 		return new MetricsRestTemplateCustomizer(meterRegistry, restTemplateTagConfigurer,
 				this.properties.getWeb().getClient().getRequestsMetricName());
-	}
-
-	@Bean
-	@Order(0)
-	public MeterFilter metricsHttpClientUriTagFilter() {
-		String metricName = this.properties.getWeb().getClient().getRequestsMetricName();
-		MeterFilter denyFilter = new OnlyOnceLoggingDenyMeterFilter(() -> String
-				.format("Reached the maximum number of URI tags for '%s'. Are you using "
-						+ "'uriVariables' on RestTemplate calls?", metricName));
-		return MeterFilter.maximumAllowableTags(metricName, "uri",
-				this.properties.getWeb().getClient().getMaxUriTags(), denyFilter);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -71,7 +71,8 @@ org.springframework.boot.actuate.autoconfigure.trace.http.HttpTraceEndpointAutoC
 org.springframework.boot.actuate.autoconfigure.web.mappings.MappingsEndpointAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.web.reactive.ReactiveManagementContextAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration,\
-org.springframework.boot.actuate.autoconfigure.web.servlet.ServletManagementContextAutoConfiguration
+org.springframework.boot.actuate.autoconfigure.web.servlet.ServletManagementContextAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.metrics.web.WebMetricsClientFiltersAutoConfiguration
 org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration=\
 org.springframework.boot.actuate.autoconfigure.endpoint.web.ServletEndpointManagementContextConfiguration,\
 org.springframework.boot.actuate.autoconfigure.endpoint.web.reactive.WebFluxEndpointManagementContextConfiguration,\

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/WebMetricsClientFiltersAutoConfigurationRestTemplateTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/WebMetricsClientFiltersAutoConfigurationRestTemplateTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.web;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.web.client.RestTemplateMetricsAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+/**
+ * Tests for {@link WebMetricsClientFiltersAutoConfiguration}.
+ *
+ * @author Stephane Nicoll
+ * @author Dmytro Nosan
+ */
+public class WebMetricsClientFiltersAutoConfigurationRestTemplateTests {
+
+	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class,
+					RestTemplateMetricsAutoConfiguration.class,
+					SimpleMetricsExportAutoConfiguration.class,
+					RestTemplateAutoConfiguration.class,
+					WebMetricsClientFiltersAutoConfiguration.class));
+
+	@Rule
+	public OutputCapture out = new OutputCapture();
+
+	@Test
+	public void afterMaxUrisReachedFurtherUrisAreDenied() {
+		this.contextRunner
+				.withPropertyValues("management.metrics.web.client.max-uri-tags=2")
+				.run((context) -> {
+					MeterRegistry registry = getInitializedMeterRegistry(context);
+					assertThat(registry.get("http.client.requests").meters()).hasSize(2);
+					assertThat(this.out.toString()).contains(
+							"Reached the maximum number of URI tags for 'http.client.requests'.");
+					assertThat(this.out.toString()).contains(
+							"Are you using 'uriVariables' on RestTemplate/WebClient "
+									+ "calls?");
+				});
+	}
+
+	@Test
+	public void shouldNotDenyNorLogIfMaxUrisIsNotReached() {
+		this.contextRunner
+				.withPropertyValues("management.metrics.web.client.max-uri-tags=5")
+				.run((context) -> {
+					MeterRegistry registry = getInitializedMeterRegistry(context);
+					assertThat(registry.get("http.client.requests").meters()).hasSize(3);
+					assertThat(this.out.toString()).doesNotContain(
+							"Reached the maximum number of URI tags for 'http.client.requests'.");
+					assertThat(this.out.toString()).doesNotContain(
+							"Are you using 'uriVariables' on RestTemplate/WebClient "
+									+ "calls?");
+				});
+	}
+
+	private MeterRegistry getInitializedMeterRegistry(
+			AssertableApplicationContext context) {
+		MeterRegistry registry = context.getBean(MeterRegistry.class);
+		RestTemplate restTemplate = context.getBean(RestTemplateBuilder.class).build();
+		MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
+		for (int i = 0; i < 3; i++) {
+			server.expect(requestTo("/test/" + i)).andRespond(withStatus(HttpStatus.OK));
+		}
+		for (int i = 0; i < 3; i++) {
+			restTemplate.getForObject("/test/" + i, String.class);
+		}
+		return registry;
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/WebMetricsClientFiltersAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/WebMetricsClientFiltersAutoConfigurationTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.web;
+
+import io.micrometer.core.instrument.config.MeterFilter;
+import org.junit.Test;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.web.client.RestTemplateMetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.web.reactive.WebClientMetricsAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link WebMetricsClientFiltersAutoConfiguration}.
+ *
+ * @author Dmytro Nosan
+ */
+public class WebMetricsClientFiltersAutoConfigurationTests {
+
+	private static final String FILTER_NAME = "webMetricsClientUriTagFilter";
+
+	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class,
+					SimpleMetricsExportAutoConfiguration.class,
+					RestTemplateAutoConfiguration.class, WebClientAutoConfiguration.class,
+					RestTemplateMetricsAutoConfiguration.class,
+					WebClientMetricsAutoConfiguration.class,
+					WebMetricsClientFiltersAutoConfiguration.class));
+
+	@Test
+	public void filterShouldNotBeRegisteredIfWebClientAndRestTemplateAreNotAvailable() {
+		FilteredClassLoader classLoader = new FilteredClassLoader(WebClient.class,
+				RestTemplate.class);
+		this.contextRunner.withClassLoader(classLoader).run(
+				(context) -> assertThat(context.getBeanNamesForType(MeterFilter.class))
+						.doesNotContain(FILTER_NAME));
+	}
+
+	@Test
+	public void filterShouldBeRegisteredIfRestTemplateIsAvailable() {
+		FilteredClassLoader classLoader = new FilteredClassLoader(WebClient.class);
+		this.contextRunner.withClassLoader(classLoader).run(
+				(context) -> assertThat(context.getBeanNamesForType(MeterFilter.class))
+						.contains(FILTER_NAME));
+	}
+
+	@Test
+	public void filterShouldBeRegisteredIfWebClientIsAvailable() {
+		FilteredClassLoader classLoader = new FilteredClassLoader(RestTemplate.class);
+		this.contextRunner.withClassLoader(classLoader).run(
+				(context) -> assertThat(context.getBeanNamesForType(MeterFilter.class))
+						.contains(FILTER_NAME));
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsAutoConfigurationTests.java
@@ -17,16 +17,13 @@
 package org.springframework.boot.actuate.autoconfigure.metrics.web.client;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.test.MetricsRun;
 import org.springframework.boot.actuate.metrics.web.client.MetricsRestTemplateCustomizer;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.boot.test.rule.OutputCapture;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -48,9 +45,6 @@ public class RestTemplateMetricsAutoConfigurationTests {
 			.with(MetricsRun.simple()).withConfiguration(
 					AutoConfigurations.of(RestTemplateAutoConfiguration.class));
 
-	@Rule
-	public OutputCapture out = new OutputCapture();
-
 	@Test
 	public void restTemplateCreatedWithBuilderIsInstrumented() {
 		this.contextRunner.run((context) -> {
@@ -71,48 +65,6 @@ public class RestTemplateMetricsAutoConfigurationTests {
 			MeterRegistry registry = context.getBean(MeterRegistry.class);
 			validateRestTemplate(restTemplate, registry);
 		});
-	}
-
-	@Test
-	public void afterMaxUrisReachedFurtherUrisAreDenied() {
-		this.contextRunner
-				.withPropertyValues("management.metrics.web.client.max-uri-tags=2")
-				.run((context) -> {
-					MeterRegistry registry = getInitializedMeterRegistry(context);
-					assertThat(registry.get("http.client.requests").meters()).hasSize(2);
-					assertThat(this.out.toString()).contains(
-							"Reached the maximum number of URI tags for 'http.client.requests'.");
-					assertThat(this.out.toString()).contains(
-							"Are you using 'uriVariables' on RestTemplate calls?");
-				});
-	}
-
-	@Test
-	public void shouldNotDenyNorLogIfMaxUrisIsNotReached() {
-		this.contextRunner
-				.withPropertyValues("management.metrics.web.client.max-uri-tags=5")
-				.run((context) -> {
-					MeterRegistry registry = getInitializedMeterRegistry(context);
-					assertThat(registry.get("http.client.requests").meters()).hasSize(3);
-					assertThat(this.out.toString()).doesNotContain(
-							"Reached the maximum number of URI tags for 'http.client.requests'.");
-					assertThat(this.out.toString()).doesNotContain(
-							"Are you using 'uriVariables' on RestTemplate calls?");
-				});
-	}
-
-	private MeterRegistry getInitializedMeterRegistry(
-			AssertableApplicationContext context) {
-		MeterRegistry registry = context.getBean(MeterRegistry.class);
-		RestTemplate restTemplate = context.getBean(RestTemplateBuilder.class).build();
-		MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
-		for (int i = 0; i < 3; i++) {
-			server.expect(requestTo("/test/" + i)).andRespond(withStatus(HttpStatus.OK));
-		}
-		for (int i = 0; i < 3; i++) {
-			restTemplate.getForObject("/test/" + i, String.class);
-		}
-		return registry;
 	}
 
 	private void validateRestTemplate(RestTemplate restTemplate, MeterRegistry registry) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/reactive/WebFluxMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/reactive/WebFluxMetricsAutoConfigurationTests.java
@@ -42,7 +42,6 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link WebFluxMetricsAutoConfiguration}
  *
  * @author Brian Clozel
- * @author Dmytro Nosan
  */
 public class WebFluxMetricsAutoConfigurationTests {
 


### PR DESCRIPTION
Currently, `WebClient` using `URI` tag filter which was provided by `ResTemplateMetricsAutoConfiguration`, hence if `RestTemplateMetricsAutoConfiguration` is excluded or `RestTemplate` class is not available in the classpath then `URI` tag filter will not be registered (this affects on` WebClient`).

This commit provides a new class `WebMetricsClientFiltersAutoConfiguration` for register `URI` tag filter if either `RestTemplate` or `WebClient` is available.

