### PR TITLE
Documentation update for default compressible MIME types

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -668,6 +668,10 @@ following:
 * `text/xml`
 * `text/plain`
 * `text/css`
+* `text/javascript`
+* `application/javascript`
+* `application/json`
+* `application/xml`
 
 You can configure this behavior by setting the `server.compression.mime-types` property.
 


### PR DESCRIPTION
Currently Spring Boot documentation states that -

> By default, responses are compressed only if their content type is one of the following:
> 
> * `text/html`
> * `text/xml`
> * `text/plain`
> * `text/css`

Commits fff2804 and 70dabdb added few more MIME types to the list. This PR aligns the documentation with the changes in those commits.
