### PR TITLE
Use InvalidEndpointRequestException for MetricsEndpoint.metric()

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/MetricsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/MetricsEndpoint.java
@@ -34,11 +34,11 @@ import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
+import org.springframework.boot.actuate.endpoint.InvalidEndpointRequestException;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
 import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
 
 /**
  * An {@link Endpoint} for exposing the metrics held by a {@link MeterRegistry}.
@@ -80,8 +80,6 @@ public class MetricsEndpoint {
 	@ReadOperation
 	public MetricResponse metric(@Selector String requiredMetricName,
 			@Nullable List<String> tag) {
-		Assert.isTrue(tag == null || tag.stream().allMatch((t) -> t.contains(":")),
-				"Each tag parameter must be in the form key:value");
 		List<Tag> tags = parseTags(tag);
 		List<Meter> meters = new ArrayList<>();
 		collectMeters(meters, this.registry, requiredMetricName, tags);
@@ -106,6 +104,11 @@ public class MetricsEndpoint {
 
 	private Tag parseTag(String tag) {
 		String[] parts = tag.split(":", 2);
+		if (parts.length != 2) {
+			throw new InvalidEndpointRequestException(
+					"Each tag parameter must be in the form 'key:value' but was: " + tag,
+					"Each tag parameter must be in the form 'key:value'");
+		}
 		return Tag.of(parts[0], parts[1]);
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/MetricsEndpointTests.java
@@ -27,7 +27,11 @@ import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.boot.actuate.endpoint.InvalidEndpointRequestException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,6 +42,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Jon Schneider
  */
 public class MetricsEndpointTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
 
 	private final MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT,
 			new MockClock());
@@ -107,6 +114,12 @@ public class MetricsEndpointTests {
 		assertThat(response.getName()).isEqualTo("counter");
 		assertThat(availableTagKeys(response)).isEmpty();
 		assertThat(getCount(response)).hasValue(2.0);
+	}
+
+	@Test
+	public void metricWithInvalidTag() {
+		this.thrown.expect(InvalidEndpointRequestException.class);
+		this.endpoint.metric("counter", Collections.singletonList("key"));
 	}
 
 	@Test


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR changes to use `InvalidEndpointRequestException` for `MetricsEndpoint.metric()` instead of `Assert` as the `Assert` will end up with responding with 500 for invalid requests, not 400.