### PR TITLE
Update @since tag

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cloud/CloudServiceConnectorsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cloud/CloudServiceConnectorsAutoConfiguration.java
@@ -41,7 +41,7 @@ import org.springframework.core.Ordered;
  * {@link ApplicationInstanceInfo}.
  *
  * @author Ramnivas Laddad
- * @since 1.2.0
+ * @since 2.1.0
  */
 @Configuration
 @Profile("cloud")


### PR DESCRIPTION
This PR updates `@since` tag in `CloudServiceConnectorsAutoConfiguration` as it has been renamed in cfd0ab7646fcb8a5ea27fa573cc1429ad5734ef3.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->