### PR TITLE
Add Health details using maps

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Health.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Health.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import org.springframework.util.Assert;
  *
  * @author Christian Dupuis
  * @author Phillip Webb
+ * @author Michael Pratt
  * @since 1.1.0
  */
 @JsonInclude(Include.NON_EMPTY)
@@ -226,6 +227,18 @@ public final class Health {
 			Assert.notNull(key, "Key must not be null");
 			Assert.notNull(value, "Value must not be null");
 			this.details.put(key, value);
+			return this;
+		}
+
+		/**
+		 * Add details from the given {@code details} map into existing details. Keys from
+		 * the given map will replace any existing keys if there are duplicates.
+		 * @param details map of details
+		 * @return this {@link Builder} instance
+		 */
+		public Builder withDetails(Map<String, Object> details) {
+			Assert.notNull(details, "Details must not be null");
+			this.details.putAll(details);
 			return this;
 		}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Health.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Health.java
@@ -236,7 +236,7 @@ public final class Health {
 		 * @param details map of details
 		 * @return this {@link Builder} instance
 		 */
-		public Builder withDetails(Map<String, Object> details) {
+		public Builder withDetails(Map<String, ?> details) {
 			Assert.notNull(details, "Details must not be null");
 			this.details.putAll(details);
 			return this;

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthTests.java
@@ -141,6 +141,18 @@ public class HealthTests {
 	}
 
 	@Test
+	public void mixWithDetailsUsage() {
+		Map<String, Object> details = new LinkedHashMap<>();
+		details.put("a", "b");
+
+		Health.Builder builder = Health.up().withDetails(details).withDetail("c", "d");
+
+		Health health = builder.build();
+		assertThat(health.getDetails().get("a")).isEqualTo("b");
+		assertThat(health.getDetails().get("c")).isEqualTo("d");
+	}
+
+	@Test
 	public void unknownWithDetails() {
 		Health health = new Health.Builder().unknown().withDetail("a", "b").build();
 		assertThat(health.getStatus()).isEqualTo(Status.UNKNOWN);

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.boot.actuate.health;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link Health}.
  *
  * @author Phillip Webb
+ * @author Michael Pratt
  */
 public class HealthTests {
 
@@ -85,6 +88,20 @@ public class HealthTests {
 	public void withDetails() {
 		Health health = new Health.Builder(Status.UP, Collections.singletonMap("a", "b"))
 				.withDetail("c", "d").build();
+		assertThat(health.getDetails().get("a")).isEqualTo("b");
+		assertThat(health.getDetails().get("c")).isEqualTo("d");
+	}
+
+	@Test
+	public void withDetailsMap() {
+		Map<String, Object> details = new LinkedHashMap<>();
+		details.put("a", "b");
+		details.put("c", "d");
+
+		Health.Builder builder = Health.up();
+		builder.withDetails(details);
+
+		Health health = builder.build();
 		assertThat(health.getDetails().get("a")).isEqualTo("b");
 		assertThat(health.getDetails().get("c")).isEqualTo("d");
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthTests.java
@@ -107,6 +107,40 @@ public class HealthTests {
 	}
 
 	@Test
+	public void withDetailsMapDuplicateKeys() {
+		Map<String, Object> details = new LinkedHashMap<>();
+		details.put("a", "b");
+		details.put("c", "d");
+		details.put("a", "e");
+
+		Health.Builder builder = Health.up();
+		builder.withDetails(details);
+
+		Health health = builder.build();
+		assertThat(health.getDetails().get("a")).isEqualTo("e");
+		assertThat(health.getDetails().get("c")).isEqualTo("d");
+	}
+
+	@Test
+	public void withMultipleDetailsMaps() {
+		Map<String, Object> details1 = new LinkedHashMap<>();
+		details1.put("a", "b");
+		details1.put("c", "d");
+
+		Map<String, Object> details2 = new LinkedHashMap<>();
+		details2.put("1", "2");
+
+		Health.Builder builder = Health.up();
+		builder.withDetails(details1);
+		builder.withDetails(details2);
+
+		Health health = builder.build();
+		assertThat(health.getDetails().get("a")).isEqualTo("b");
+		assertThat(health.getDetails().get("c")).isEqualTo("d");
+		assertThat(health.getDetails().get("1")).isEqualTo("2");
+	}
+
+	@Test
 	public void unknownWithDetails() {
 		Health health = new Health.Builder().unknown().withDetail("a", "b").build();
 		assertThat(health.getStatus()).isEqualTo(Status.UNKNOWN);


### PR DESCRIPTION
Added `Health.Builder.withDetails(Map<String, ?>)` to allow adding entire maps at once instead of calling `withDetails(String, Object)` for each entry. Also includes new unit tests.

See issue #14299