### PR TITLE
Fix use of deprecated Mongo API

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoClientSettingsBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoClientSettingsBuilderCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 package org.springframework.boot.autoconfigure.mongo;
 
-import com.mongodb.async.client.MongoClientSettings.Builder;
+import com.mongodb.MongoClientSettings.Builder;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link com.mongodb.async.client.MongoClientSettings} via a {@link Builder
+ * {@link com.mongodb.MongoClientSettings} via a {@link Builder
  * MongoClientSettings.Builder} whilst retaining default auto-configuration.
  *
  * @author Mark Paluch

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveAutoConfiguration.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import javax.annotation.PreDestroy;
 
-import com.mongodb.async.client.MongoClientSettings;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.connection.netty.NettyStreamFactoryFactory;
 import com.mongodb.reactivestreams.client.MongoClient;
 import io.netty.channel.socket.SocketChannel;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactory.java
@@ -20,15 +20,10 @@ import java.util.Collections;
 import java.util.List;
 
 import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoClientSettings.Builder;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
-import com.mongodb.async.client.MongoClientSettings;
-import com.mongodb.async.client.MongoClientSettings.Builder;
-import com.mongodb.connection.ClusterSettings;
-import com.mongodb.connection.ConnectionPoolSettings;
-import com.mongodb.connection.ServerSettings;
-import com.mongodb.connection.SocketSettings;
-import com.mongodb.connection.SslSettings;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
 
@@ -88,9 +83,8 @@ public class ReactiveMongoClientFactory {
 		Builder builder = builder(settings);
 		String host = (this.properties.getHost() != null) ? this.properties.getHost()
 				: "localhost";
-		ClusterSettings clusterSettings = ClusterSettings.builder()
-				.hosts(Collections.singletonList(new ServerAddress(host, port))).build();
-		builder.clusterSettings(clusterSettings);
+		builder.applyToClusterSettings(cluster -> cluster
+				.hosts(Collections.singletonList(new ServerAddress(host, port))));
 		return createMongoClient(builder);
 	}
 
@@ -113,8 +107,8 @@ public class ReactiveMongoClientFactory {
 		String host = getOrDefault(this.properties.getHost(), "localhost");
 		int port = getOrDefault(this.properties.getPort(), MongoProperties.DEFAULT_PORT);
 		ServerAddress serverAddress = new ServerAddress(host, port);
-		builder.clusterSettings(ClusterSettings.builder()
-				.hosts(Collections.singletonList(serverAddress)).build());
+		builder.applyToClusterSettings(
+				cluster -> cluster.hosts(Collections.singletonList(serverAddress)));
 		return createMongoClient(builder);
 	}
 
@@ -124,7 +118,6 @@ public class ReactiveMongoClientFactory {
 				: this.properties.getMongoClientDatabase();
 		builder.credential((MongoCredential.createCredential(
 				this.properties.getUsername(), database, this.properties.getPassword())));
-
 	}
 
 	private <T> T getOrDefault(T value, T defaultValue) {
@@ -138,50 +131,7 @@ public class ReactiveMongoClientFactory {
 
 	private Builder createBuilder(MongoClientSettings settings,
 			ConnectionString connection) {
-		Builder builder = builder(settings);
-		builder.clusterSettings(getClusterSettings(connection));
-		builder.connectionPoolSettings(getConnectionPoolSettings(connection));
-		builder.serverSettings(getServerSettings(connection));
-		if (connection.getCredential() != null) {
-			builder.credential(connection.getCredential());
-		}
-		builder.sslSettings(getSslSettings(connection));
-		builder.socketSettings(getSocketSettings(connection));
-		if (connection.getReadPreference() != null) {
-			builder.readPreference(connection.getReadPreference());
-		}
-		if (connection.getReadConcern() != null) {
-			builder.readConcern(connection.getReadConcern());
-		}
-		if (connection.getWriteConcern() != null) {
-			builder.writeConcern(connection.getWriteConcern());
-		}
-		if (connection.getApplicationName() != null) {
-			builder.applicationName(connection.getApplicationName());
-		}
-		builder.retryWrites(connection.getRetryWrites());
-		return builder;
-	}
-
-	private ClusterSettings getClusterSettings(ConnectionString connection) {
-		return ClusterSettings.builder().applyConnectionString(connection).build();
-	}
-
-	private ConnectionPoolSettings getConnectionPoolSettings(
-			ConnectionString connection) {
-		return ConnectionPoolSettings.builder().applyConnectionString(connection).build();
-	}
-
-	private ServerSettings getServerSettings(ConnectionString connection) {
-		return ServerSettings.builder().applyConnectionString(connection).build();
-	}
-
-	private SslSettings getSslSettings(ConnectionString connection) {
-		return SslSettings.builder().applyConnectionString(connection).build();
-	}
-
-	private SocketSettings getSocketSettings(ConnectionString connection) {
-		return SocketSettings.builder().applyConnectionString(connection).build();
+		return builder(settings).applyConnectionString(connection);
 	}
 
 	private void customize(MongoClientSettings.Builder builder) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveAutoConfigurationTests.java
@@ -18,10 +18,9 @@ package org.springframework.boot.autoconfigure.mongo;
 
 import java.util.concurrent.TimeUnit;
 
+import com.mongodb.MongoClientSettings;
 import com.mongodb.ReadPreference;
-import com.mongodb.async.client.MongoClientSettings;
 import com.mongodb.connection.AsynchronousSocketChannelStreamFactoryFactory;
-import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.StreamFactory;
 import com.mongodb.connection.StreamFactoryFactory;
 import com.mongodb.connection.netty.NettyStreamFactoryFactory;
@@ -83,7 +82,8 @@ public class MongoReactiveAutoConfigurationTests {
 				.withUserConfiguration(SslOptionsConfig.class).run((context) -> {
 					assertThat(context).hasSingleBean(MongoClient.class);
 					MongoClient mongo = context.getBean(MongoClient.class);
-					MongoClientSettings settings = mongo.getSettings();
+					com.mongodb.async.client.MongoClientSettings settings = mongo
+							.getSettings();
 					assertThat(settings.getApplicationName()).isEqualTo("test-config");
 					assertThat(settings.getStreamFactoryFactory())
 							.isSameAs(context.getBean("myStreamFactoryFactory"));
@@ -120,8 +120,8 @@ public class MongoReactiveAutoConfigurationTests {
 		@Bean
 		public MongoClientSettings mongoClientSettings() {
 			return MongoClientSettings.builder().readPreference(ReadPreference.nearest())
-					.socketSettings(SocketSettings.builder()
-							.readTimeout(300, TimeUnit.SECONDS).build())
+					.applyToSocketSettings(
+							socket -> socket.readTimeout(300, TimeUnit.SECONDS))
 					.build();
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactoryTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/ReactiveMongoClientFactoryTests.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
-import com.mongodb.async.client.MongoClientSettings;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.connection.ClusterSettings;
 import com.mongodb.reactivestreams.client.MongoClient;
 import org.junit.Rule;
@@ -196,13 +196,13 @@ public class ReactiveMongoClientFactoryTests {
 	}
 
 	private List<ServerAddress> extractServerAddresses(MongoClient client) {
-		MongoClientSettings settings = client.getSettings();
+		com.mongodb.async.client.MongoClientSettings settings = client.getSettings();
 		ClusterSettings clusterSettings = settings.getClusterSettings();
 		return clusterSettings.getHosts();
 	}
 
 	private MongoCredential extractMongoCredentials(MongoClient client) {
-		MongoClientSettings settings = client.getSettings();
+		com.mongodb.async.client.MongoClientSettings settings = client.getSettings();
 		return settings.getCredential();
 	}
 


### PR DESCRIPTION
We now use `com.mongodb.MongoClientSettings` to configure the reactive MongoDB driver. This is a breaking change as `MongoClientSettingsBuilderCustomizer` and user-provided `MongoClientSettings` beans referenced the package the settings type from `com.mongodb.async.client`.

`MongoClient.getSettings()` is deprecated and still in use within tests until a replacement is available.

---

Related to this change and #14176, we should provide a `com.mongodb.MongoClientSettings` factory as soon as we consider migrating to `com.mongodb.client.MongoClient` as the default client implementation (currently: `com.mongodb.MongoClient`) to provide the same configuration to the reactive and synchronous drivers. `com.mongodb.MongoClient` provides still access to the legacy DBObject API whereas `com.mongodb.client.MongoClient` does not expose the DBObject API.
