### PR TITLE
Polish CommandCompleter

### DIFF
--- a/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/shell/CommandCompleter.java
+++ b/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/shell/CommandCompleter.java
@@ -127,12 +127,7 @@ public class CommandCompleter extends StringsCompleter {
 		private final String usage;
 
 		OptionHelpLine(OptionHelp optionHelp) {
-			StringBuilder options = new StringBuilder();
-			for (String option : optionHelp.getOptions()) {
-				options.append((options.length() != 0) ? ", " : "");
-				options.append(option);
-			}
-			this.options = options.toString();
+			this.options = String.join(", ", optionHelp.getOptions());
 			this.usage = optionHelp.getUsageHelp();
 		}
 


### PR DESCRIPTION
Hi,

this trivial PR polishes CommandCompleter by using `String.join()`.

Cheers,
Christoph