### PR TITLE
Add 100.64.0.0/10 to internal-proxies

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -56,6 +56,7 @@ import org.springframework.util.unit.DataSize;
  * @author Brian Clozel
  * @author Olivier Lamy
  * @author Chentao Qu
+ * @author Andras Tornai
  */
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = true)
 public class ServerProperties {
@@ -273,6 +274,13 @@ public class ServerProperties {
 		 * Regular expression matching trusted IP addresses.
 		 */
 		private String internalProxies = "10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|" // 10/8
+				+ "100\\.6[4-9]{1}\\.\\d{1,3}\\.\\d{1,3}|" // 100.64/10
+				+ "100\\.7[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|"
+				+ "100\\.8[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|"
+				+ "100\\.9[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|"
+				+ "100\\.10[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|"
+				+ "100\\.11[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|"
+				+ "100\\.12[0-7]{1}\\.\\d{1,3}\\.\\d{1,3}|"
 				+ "192\\.168\\.\\d{1,3}\\.\\d{1,3}|" // 192.168/16
 				+ "169\\.254\\.\\d{1,3}\\.\\d{1,3}|" // 169.254/16
 				+ "127\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|" // 127/8

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -258,6 +258,13 @@ content into your application. Rather, pick only the properties that you need.
 	server.tomcat.background-processor-delay=10 # Delay in seconds between the invocation of backgroundProcess methods.
 	server.tomcat.basedir= # Tomcat base directory. If not specified, a temporary directory is used.
 	server.tomcat.internal-proxies=10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|\\
+			100\\.6[4-9]{1}\\.\\d{1,3}\\.\\d{1,3}|\\
+			100\\.7[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|\\
+			100\\.8[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|\\
+			100\\.9[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|\\
+			100\\.10[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|\\
+			100\\.11[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|\\
+			100\\.12[0-7]{1}\\.\\d{1,3}\\.\\d{1,3}|\\
 			192\\.168\\.\\d{1,3}\\.\\d{1,3}|\\
 			169\\.254\\.\\d{1,3}\\.\\d{1,3}|\\
 			127\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|\\

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -988,7 +988,7 @@ carry "`forwarded`" information, as shown in the following example:
 ----
 
 Tomcat is also configured with a default regular expression that matches internal
-proxies that are to be trusted. By default, IP addresses in `10/8`, `192.168/16`,
+proxies that are to be trusted. By default, IP addresses in `10/8`, `100.64/10`, `192.168/16`,
 `169.254/16` and `127/8` are trusted. You can customize the valve's configuration by
 adding an entry to `application.properties`, as shown in the following example:
 


### PR DESCRIPTION
Motivation: Swisscom (telecom provider) uses this ip address range in its proxies/load-balancers (Cloud Foundry) and anyway this range is reserved.

More to read:
https://en.wikipedia.org/wiki/Reserved_IP_addresses
https://en.wikipedia.org/wiki/IPv4_shared_address_space