### PR TITLE
Make standard JSON builder customiser classes package-private

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfiguration.java
@@ -62,7 +62,7 @@ public class GsonAutoConfiguration {
 		return new StandardGsonBuilderCustomizer(gsonProperties);
 	}
 
-	private static final class StandardGsonBuilderCustomizer
+	static final class StandardGsonBuilderCustomizer
 			implements GsonBuilderCustomizer, Ordered {
 
 		private final GsonProperties properties;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
@@ -213,7 +213,7 @@ public class JacksonAutoConfiguration {
 					jacksonProperties);
 		}
 
-		private static final class StandardJackson2ObjectMapperBuilderCustomizer
+		static final class StandardJackson2ObjectMapperBuilderCustomizer
 				implements Jackson2ObjectMapperBuilderCustomizer, Ordered {
 
 			private final ApplicationContext applicationContext;


### PR DESCRIPTION
As a follow-up of e1ebbcd720df38960a9d3ea938b38860afc633eb and as part of #13490, I would need `StandardGsonBuilderCustomizer` and `StandardJackson2ObjectMapperBuilderCustomizer` to be package private instead of private in order to be able to leverage Boot auto-configuration via functional bean registration.