### PR TITLE
@WebMvcTest does not include applicationTaskExecutor

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -165,7 +165,7 @@
 		<spring-framework.version>${spring.version}</spring-framework.version>
 		<spring-hateoas.version>0.25.0.RELEASE</spring-hateoas.version>
 		<spring-integration.version>5.1.0.M2</spring-integration.version>
-		<spring-kafka.version>2.2.0.BUILD-SNAPSHOT</spring-kafka.version>
+		<spring-kafka.version>2.2.0.M3</spring-kafka.version>
 		<spring-ldap.version>2.3.2.RELEASE</spring-ldap.version>
 		<spring-plugin.version>1.2.0.RELEASE</spring-plugin.version>
 		<spring-restdocs.version>2.0.2.RELEASE</spring-restdocs.version>

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -128,6 +128,7 @@ org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfigurati
 org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration,\
 org.springframework.boot.autoconfigure.jsonb.JsonbAutoConfiguration,\
 org.springframework.boot.autoconfigure.mustache.MustacheAutoConfiguration,\
+org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration,\
 org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration,\
 org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration,\
 org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration,\

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTestAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTestAutoConfigurationIntegrationTests.java
@@ -16,19 +16,22 @@
 
 package org.springframework.boot.test.autoconfigure.web.servlet;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.autoconfigure.AutoConfigurationImportedCondition.importedAutoConfiguration;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration;
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration;
 import org.springframework.boot.autoconfigure.mustache.MustacheAutoConfiguration;
+import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
 import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.autoconfigure.AutoConfigurationImportedCondition.importedAutoConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
 /**
  * Tests for the auto-configuration imported by {@link WebMvcTest}.
@@ -66,4 +69,20 @@ public class WebMvcTestAutoConfigurationIntegrationTests {
 				.has(importedAutoConfiguration(ThymeleafAutoConfiguration.class));
 	}
 
+	@Test
+	public void taskExecutionAutoConfigurationWasImported() {
+		assertThat(this.applicationContext)
+				.has(importedAutoConfiguration(TaskExecutionAutoConfiguration.class));
+
+	}
+
+	@Test
+	public void asyncTaskExecutorWithApplicationTaskExecutor() {
+		assertThat(this.applicationContext.getBeansOfType(AsyncTaskExecutor.class))
+				.hasSize(1);
+		assertThat(ReflectionTestUtils.getField(
+				this.applicationContext.getBean(RequestMappingHandlerAdapter.class),
+				"taskExecutor"))
+				.isSameAs(applicationContext.getBean("applicationTaskExecutor"));
+	}
 }

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTestAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTestAutoConfigurationIntegrationTests.java
@@ -19,8 +19,9 @@ package org.springframework.boot.test.autoconfigure.web.servlet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.autoconfigure.AutoConfigurationImportedCondition.importedAutoConfiguration;
 
-import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration;
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration;
@@ -37,6 +38,7 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  * Tests for the auto-configuration imported by {@link WebMvcTest}.
  *
  * @author Andy Wilkinson
+ * @author Levi Puot Paul
  */
 @RunWith(SpringRunner.class)
 @WebMvcTest
@@ -73,7 +75,6 @@ public class WebMvcTestAutoConfigurationIntegrationTests {
 	public void taskExecutionAutoConfigurationWasImported() {
 		assertThat(this.applicationContext)
 				.has(importedAutoConfiguration(TaskExecutionAutoConfiguration.class));
-
 	}
 
 	@Test
@@ -83,6 +84,6 @@ public class WebMvcTestAutoConfigurationIntegrationTests {
 		assertThat(ReflectionTestUtils.getField(
 				this.applicationContext.getBean(RequestMappingHandlerAdapter.class),
 				"taskExecutor"))
-				.isSameAs(applicationContext.getBean("applicationTaskExecutor"));
+				.isSameAs(this.applicationContext.getBean("applicationTaskExecutor"));
 	}
 }


### PR DESCRIPTION
Added TaskExecutionAutoConfiguration to the list of auto-configurations for AutoConfigureWebMvc so that an applicationTaskExecutor is auto-configured when @WebMvcTest is used.