### PR TITLE
Remove duplicate -l option for init command

### DIFF
--- a/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/InitCommand.java
+++ b/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/InitCommand.java
@@ -127,7 +127,7 @@ public class InitCommand extends OptionParsingCommand {
 			this.target = option(Arrays.asList("target"), "URL of the service to use")
 					.withRequiredArg()
 					.defaultsTo(ProjectGenerationRequest.DEFAULT_SERVICE_URL);
-			this.listCapabilities = option(Arrays.asList("list", "l"),
+			this.listCapabilities = option(Arrays.asList("list"),
 					"List the capabilities of the service. Use it to discover the "
 							+ "dependencies and the types that are available");
 			projectGenerationOptions();


### PR DESCRIPTION
`--list` option should be displayed by default out-of-the-box. But `InitCommand` had 2 options with `-l` key: `-l` for `--language` and `-l` for `--list`. In that case, when `OptionHelpFormatter.format(...)` pushing options into TreeSet, the `--list` option disappears.