### PR TITLE
Auto-configure jOOQ to use an ExecutorProvider bean if available

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfiguration.java
@@ -21,6 +21,7 @@ import javax.sql.DataSource;
 import org.jooq.ConnectionProvider;
 import org.jooq.DSLContext;
 import org.jooq.ExecuteListenerProvider;
+import org.jooq.ExecutorProvider;
 import org.jooq.RecordListenerProvider;
 import org.jooq.RecordMapperProvider;
 import org.jooq.RecordUnmapperProvider;
@@ -32,7 +33,6 @@ import org.jooq.impl.DataSourceConnectionProvider;
 import org.jooq.impl.DefaultConfiguration;
 import org.jooq.impl.DefaultDSLContext;
 import org.jooq.impl.DefaultExecuteListenerProvider;
-
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -109,6 +109,8 @@ public class JooqAutoConfiguration {
 
 		private final TransactionListenerProvider[] transactionListenerProviders;
 
+		private final ExecutorProvider executorProvider;
+
 		public DslContextConfiguration(JooqProperties properties,
 				ConnectionProvider connectionProvider, DataSource dataSource,
 				ObjectProvider<TransactionProvider> transactionProvider,
@@ -118,7 +120,8 @@ public class JooqAutoConfiguration {
 				ObjectProvider<RecordListenerProvider[]> recordListenerProviders,
 				ExecuteListenerProvider[] executeListenerProviders,
 				ObjectProvider<VisitListenerProvider[]> visitListenerProviders,
-				ObjectProvider<TransactionListenerProvider[]> transactionListenerProviders) {
+				ObjectProvider<TransactionListenerProvider[]> transactionListenerProviders,
+				ObjectProvider<ExecutorProvider> executorProvider) {
 			this.properties = properties;
 			this.connection = connectionProvider;
 			this.dataSource = dataSource;
@@ -131,6 +134,7 @@ public class JooqAutoConfiguration {
 			this.visitListenerProviders = visitListenerProviders.getIfAvailable();
 			this.transactionListenerProviders = transactionListenerProviders
 					.getIfAvailable();
+			this.executorProvider = executorProvider.getIfAvailable();
 		}
 
 		@Bean
@@ -155,6 +159,9 @@ public class JooqAutoConfiguration {
 			}
 			if (this.settings != null) {
 				configuration.set(this.settings);
+			}
+			if (this.executorProvider != null) {
+				configuration.set(this.executorProvider);
 			}
 			configuration.set(this.recordListenerProviders);
 			configuration.set(this.executeListenerProviders);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfigurationTests.java
@@ -17,10 +17,12 @@
 package org.springframework.boot.autoconfigure.jooq;
 
 import javax.sql.DataSource;
+import java.util.concurrent.Executor;
 
 import org.jooq.DSLContext;
 import org.jooq.ExecuteListener;
 import org.jooq.ExecuteListenerProvider;
+import org.jooq.ExecutorProvider;
 import org.jooq.Record;
 import org.jooq.RecordListener;
 import org.jooq.RecordListenerProvider;
@@ -141,12 +143,14 @@ public class JooqAutoConfigurationTests {
 				TxManagerConfiguration.class, TestRecordMapperProvider.class,
 				TestRecordUnmapperProvider.class, TestRecordListenerProvider.class,
 				TestExecuteListenerProvider.class, TestVisitListenerProvider.class,
-				TestTransactionListenerProvider.class).run((context) -> {
+				TestTransactionListenerProvider.class, TestExecutorProvider.class).run((context) -> {
 					DSLContext dsl = context.getBean(DSLContext.class);
 					assertThat(dsl.configuration().recordMapperProvider().getClass())
 							.isEqualTo(TestRecordMapperProvider.class);
 					assertThat(dsl.configuration().recordUnmapperProvider().getClass())
 							.isEqualTo(TestRecordUnmapperProvider.class);
+					assertThat(dsl.configuration().executorProvider().getClass())
+							.isEqualTo(TestExecutorProvider.class);
 					assertThat(dsl.configuration().recordListenerProviders().length)
 							.isEqualTo(1);
 					assertThat(dsl.configuration().executeListenerProviders().length)
@@ -283,6 +287,15 @@ public class JooqAutoConfigurationTests {
 
 		@Override
 		public TransactionListener provide() {
+			return null;
+		}
+
+	}
+
+	protected static class TestExecutorProvider implements ExecutorProvider {
+
+		@Override
+		public Executor provide() {
 			return null;
 		}
 


### PR DESCRIPTION
This improvement allow to define a custom Executor for Jooq. To provide it, you have to wrap it under a `org.jooq.ExecutorProvider`. This is useful in multiple case, especially for testing in my case when I want to run my `@Sql()` test inside a transaction with `fetchAsync` which wasn't compatible. Thanks to this, we can in our test use the `SyncTaskExecutor` to use the `main` thread for all our tests.

BTW, I've made some code modification in another commit (not in this PR) to simplify (from my point of view) the configuration system (using the `ObjectProvider` instead of relying on null). Do you think I can make a PR of this (https://github.com/davinkevin/spring-boot/commit/bf4e36c0d077664d6ae8832ff06974ad91ab559e) ?

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->