### PR TITLE
Refactor String#replaceAll

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/WebOperationRequestPredicate.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/WebOperationRequestPredicate.java
@@ -18,6 +18,7 @@ package org.springframework.boot.actuate.endpoint.web;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.regex.Pattern;
 
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -29,6 +30,8 @@ import org.springframework.util.StringUtils;
  * @since 2.0.0
  */
 public final class WebOperationRequestPredicate {
+
+	private static final Pattern PATH_VAR_PATTERN = Pattern.compile("\\{.*?}");
 
 	private final String path;
 
@@ -50,7 +53,7 @@ public final class WebOperationRequestPredicate {
 	public WebOperationRequestPredicate(String path, WebEndpointHttpMethod httpMethod,
 			Collection<String> consumes, Collection<String> produces) {
 		this.path = path;
-		this.canonicalPath = path.replaceAll("\\{.*?}", "{*}");
+		this.canonicalPath = PATH_VAR_PATTERN.matcher(path).replaceAll("{*}");
 		this.httpMethod = httpMethod;
 		this.consumes = consumes;
 		this.produces = produces;

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/client/RestTemplateExchangeTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/client/RestTemplateExchangeTags.java
@@ -18,6 +18,7 @@ package org.springframework.boot.actuate.metrics.web.client;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.regex.Pattern;
 
 import io.micrometer.core.instrument.Tag;
 
@@ -35,6 +36,8 @@ import org.springframework.web.client.RestTemplate;
  * @since 2.0.0
  */
 public final class RestTemplateExchangeTags {
+
+	private static final Pattern STRIP_URI_PATTERN = Pattern.compile("^https?://[^/]+/");
 
 	private RestTemplateExchangeTags() {
 	}
@@ -69,7 +72,7 @@ public final class RestTemplateExchangeTags {
 	}
 
 	private static String stripUri(String uri) {
-		return uri.replaceAll("^https?://[^/]+/", "");
+		return STRIP_URI_PATTERN.matcher(uri).replaceAll("");
 	}
 
 	private static String ensureLeadingSlash(String url) {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcTags.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.actuate.metrics.web.servlet;
 
+import java.util.regex.Pattern;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -49,6 +51,10 @@ public final class WebMvcTags {
 	private static final Tag STATUS_UNKNOWN = Tag.of("status", "UNKNOWN");
 
 	private static final Tag METHOD_UNKNOWN = Tag.of("method", "UNKNOWN");
+
+	private static final Pattern TRAILING_SLASH_PATTERN = Pattern.compile("/$");
+
+	private static final Pattern MULTIPLE_SLASH_PATTERN = Pattern.compile("//+");
 
 	private WebMvcTags() {
 	}
@@ -124,7 +130,8 @@ public final class WebMvcTags {
 	private static String getPathInfo(HttpServletRequest request) {
 		String pathInfo = request.getPathInfo();
 		String uri = StringUtils.hasText(pathInfo) ? pathInfo : "/";
-		return uri.replaceAll("//+", "/").replaceAll("/$", "");
+		uri = MULTIPLE_SLASH_PATTERN.matcher(uri).replaceAll("/");
+		return TRAILING_SLASH_PATTERN.matcher(uri).replaceAll("");
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -60,6 +61,8 @@ class TypeUtils {
 	}
 
 	private static final Map<String, TypeKind> WRAPPER_TO_PRIMITIVE;
+
+	private static final Pattern NEW_LINE_PATTERN = Pattern.compile("[\r\n]+");
 
 	static {
 		Map<String, TypeKind> primitives = new HashMap<>();
@@ -131,7 +134,7 @@ class TypeUtils {
 		String javadoc = (element != null)
 				? this.env.getElementUtils().getDocComment(element) : null;
 		if (javadoc != null) {
-			javadoc = javadoc.replaceAll("[\r\n]+", "").trim();
+			javadoc = NEW_LINE_PATTERN.matcher(javadoc).replaceAll("").trim();
 		}
 		return "".equals(javadoc) ? null : javadoc;
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/LaunchScriptConfiguration.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/LaunchScriptConfiguration.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.gradle.api.Project;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
@@ -35,6 +36,10 @@ import org.springframework.boot.loader.tools.FileUtils;
  */
 @SuppressWarnings("serial")
 public class LaunchScriptConfiguration implements Serializable {
+
+	private static final Pattern WHITE_SPACE_PATTERN = Pattern.compile("\\s+");
+
+	private static final Pattern LINE_FEED_PATTERN = Pattern.compile("\n");
 
 	private final Map<String, String> properties = new HashMap<>();
 
@@ -134,11 +139,13 @@ public class LaunchScriptConfiguration implements Serializable {
 	}
 
 	private String removeLineBreaks(String string) {
-		return (string != null) ? string.replaceAll("\\s+", " ") : null;
+		return (string != null) ? WHITE_SPACE_PATTERN.matcher(string).replaceAll(" ")
+				: null;
 	}
 
 	private String augmentLineBreaks(String string) {
-		return (string != null) ? string.replaceAll("\n", "\n#  ") : null;
+		return (string != null) ? LINE_FEED_PATTERN.matcher(string).replaceAll("\n#  ")
+				: null;
 	}
 
 	private void putIfMissing(Map<String, String> properties, String key,

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/testkit/GradleBuild.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/testkit/GradleBuild.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpression;
@@ -49,6 +50,9 @@ import org.springframework.util.FileCopyUtils;
  * @author Andy Wilkinson
  */
 public class GradleBuild implements TestRule {
+
+	private static final Pattern GRADLE_VERSION_PATTERN = Pattern
+			.compile("\\[Gradle .+\\]");
 
 	private final TemporaryFolder temp = new TemporaryFolder();
 
@@ -95,7 +99,7 @@ public class GradleBuild implements TestRule {
 	}
 
 	private String removeGradleVersion(String methodName) {
-		return methodName.replaceAll("\\[Gradle .+\\]", "").trim();
+		return GRADLE_VERSION_PATTERN.matcher(methodName).replaceAll("").trim();
 	}
 
 	private URL getScriptForTestClass(Class<?> testClass) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Dependency;
@@ -61,6 +62,8 @@ import org.springframework.boot.loader.tools.Repackager.MainClassTimeoutWarningL
  */
 @Mojo(name = "repackage", defaultPhase = LifecyclePhase.PACKAGE, requiresProject = true, threadSafe = true, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class RepackageMojo extends AbstractDependencyFilterMojo {
+
+	private static final Pattern WHITE_SPACE_PATTERN = Pattern.compile("\\s+");
 
 	/**
 	 * The Maven project.
@@ -312,7 +315,8 @@ public class RepackageMojo extends AbstractDependencyFilterMojo {
 	}
 
 	private String removeLineBreaks(String description) {
-		return (description != null) ? description.replaceAll("\\s+", " ") : null;
+		return (description != null)
+				? WHITE_SPACE_PATTERN.matcher(description).replaceAll(" ") : null;
 	}
 
 	private void putIfMissing(Properties properties, String key,

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-devtools-tests/src/test/java/org/springframework/boot/devtools/tests/JvmLauncher.java
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-devtools-tests/src/test/java/org/springframework/boot/devtools/tests/JvmLauncher.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -36,12 +37,14 @@ import org.springframework.util.StringUtils;
  */
 class JvmLauncher implements TestRule {
 
+	private static final Pattern NON_ALPHABET_PATTERN = Pattern.compile("[^A-Za-z]+");
+
 	private File outputDirectory;
 
 	@Override
 	public Statement apply(Statement base, Description description) {
-		this.outputDirectory = new File("target/output/"
-				+ description.getMethodName().replaceAll("[^A-Za-z]+", ""));
+		this.outputDirectory = new File("target/output/" + NON_ALPHABET_PATTERN
+				.matcher(description.getMethodName()).replaceAll(""));
 		this.outputDirectory.mkdirs();
 		return base;
 	}


### PR DESCRIPTION
If we repeatedly call String#replaceAll, we internally repeatedly call the regular expression pattern compilation every time as following:

```java
    public String replaceAll(String regex, String replacement) {
        return Pattern.compile(regex).matcher(this).replaceAll(replacement);
    }
```
The modifications are to keep the compiled pattern.
Therefore, compiling a relatively expensive regular expression pattern does not have to be done every time.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->