### PR TITLE
Add outcome tag to web mvc servlet and reactive metrics. Fixes gh-13801.

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/DefaultWebFluxTagsProvider.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/DefaultWebFluxTagsProvider.java
@@ -35,7 +35,8 @@ public class DefaultWebFluxTagsProvider implements WebFluxTagsProvider {
 	public Iterable<Tag> httpRequestTags(ServerWebExchange exchange,
 			Throwable exception) {
 		return Arrays.asList(WebFluxTags.method(exchange), WebFluxTags.uri(exchange),
-				WebFluxTags.exception(exception), WebFluxTags.status(exchange));
+				WebFluxTags.exception(exception), WebFluxTags.status(exchange),
+				WebFluxTags.outcome(exchange));
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTags.java
@@ -30,6 +30,7 @@ import org.springframework.web.util.pattern.PathPattern;
  *
  * @author Jon Schneider
  * @author Andy Wilkinson
+ * @author Michael McFadyen
  * @since 2.0.0
  */
 public final class WebFluxTags {
@@ -43,6 +44,14 @@ public final class WebFluxTags {
 	private static final Tag URI_UNKNOWN = Tag.of("uri", "UNKNOWN");
 
 	private static final Tag EXCEPTION_NONE = Tag.of("exception", "None");
+
+	private static final Tag OUTCOME_UNKNOWN = Tag.of("outcome", "UNKNOWN");
+
+	private static final Tag OUTCOME_SUCCESS = Tag.of("outcome", "SUCCESS");
+
+	private static final Tag OUTCOME_CLIENT_ERROR = Tag.of("outcome", "CLIENT_ERROR");
+
+	private static final Tag OUTCOME_SERVER_ERROR = Tag.of("outcome", "SERVER_ERROR");
 
 	private WebFluxTags() {
 	}
@@ -60,7 +69,7 @@ public final class WebFluxTags {
 	}
 
 	/**
-	 * Creates a {@code method} tag based on the response status of the given
+	 * Creates a {@code status} tag based on the response status of the given
 	 * {@code exchange}.
 	 * @param exchange the exchange
 	 * @return the "status" tag derived from the response status
@@ -115,6 +124,31 @@ public final class WebFluxTags {
 					: exception.getClass().getName());
 		}
 		return EXCEPTION_NONE;
+	}
+
+	/**
+	 * Creates a {@code outcome} tag based on the response status of the given
+	 * {@code exchange}.
+	 * @param exchange the exchange
+	 * @return the "outcome" tag derived from the response status
+	 */
+	public static Tag outcome(ServerWebExchange exchange) {
+		if (exchange != null && exchange.getResponse().getStatusCode() != null) {
+			HttpStatus status = exchange.getResponse().getStatusCode();
+			if (status.is1xxInformational() || status.is2xxSuccessful()
+					|| status.is3xxRedirection()) {
+				return OUTCOME_SUCCESS;
+			}
+			else if (status.is4xxClientError()) {
+				return OUTCOME_CLIENT_ERROR;
+			}
+			else {
+				return OUTCOME_SERVER_ERROR;
+			}
+		}
+		else {
+			return OUTCOME_UNKNOWN;
+		}
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/DefaultWebMvcTagsProvider.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/DefaultWebMvcTagsProvider.java
@@ -34,7 +34,8 @@ public class DefaultWebMvcTagsProvider implements WebMvcTagsProvider {
 	public Iterable<Tag> getTags(HttpServletRequest request, HttpServletResponse response,
 			Object handler, Throwable exception) {
 		return Tags.of(WebMvcTags.method(request), WebMvcTags.uri(request, response),
-				WebMvcTags.exception(exception), WebMvcTags.status(response));
+				WebMvcTags.exception(exception), WebMvcTags.status(response),
+				WebMvcTags.outcome(response));
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcTags.java
@@ -32,6 +32,7 @@ import org.springframework.web.servlet.HandlerMapping;
  * @author Jon Schneider
  * @author Andy Wilkinson
  * @author Brian Clozel
+ * @author Michael McFadyen
  * @since 2.0.0
  */
 public final class WebMvcTags {
@@ -47,6 +48,14 @@ public final class WebMvcTags {
 	private static final Tag EXCEPTION_NONE = Tag.of("exception", "None");
 
 	private static final Tag STATUS_UNKNOWN = Tag.of("status", "UNKNOWN");
+
+	private static final Tag OUTCOME_UNKNOWN = Tag.of("outcome", "UNKNOWN");
+
+	private static final Tag OUTCOME_SUCCESS = Tag.of("outcome", "SUCCESS");
+
+	private static final Tag OUTCOME_CLIENT_ERROR = Tag.of("outcome", "CLIENT_ERROR");
+
+	private static final Tag OUTCOME_SERVER_ERROR = Tag.of("outcome", "SERVER_ERROR");
 
 	private static final Tag METHOD_UNKNOWN = Tag.of("method", "UNKNOWN");
 
@@ -64,7 +73,7 @@ public final class WebMvcTags {
 	}
 
 	/**
-	 * Creates a {@code method} tag based on the status of the given {@code response}.
+	 * Creates a {@code status} tag based on the status of the given {@code response}.
 	 * @param response the HTTP response
 	 * @return the status tag derived from the status of the response
 	 */
@@ -140,6 +149,29 @@ public final class WebMvcTags {
 					: exception.getClass().getName());
 		}
 		return EXCEPTION_NONE;
+	}
+
+	/**
+	 * Creates a {@code outcome} tag based on the status of the given {@code response}.
+	 * @param response the HTTP response
+	 * @return the outcome tag derived from the status of the response
+	 */
+	public static Tag outcome(HttpServletResponse response) {
+		if (response != null) {
+			int status = response.getStatus();
+			if (status < 400) {
+				return OUTCOME_SUCCESS;
+			}
+			else if (status < 500) {
+				return OUTCOME_CLIENT_ERROR;
+			}
+			else {
+				return OUTCOME_SERVER_ERROR;
+			}
+		}
+		else {
+			return OUTCOME_UNKNOWN;
+		}
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcTagsTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcTagsTests.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Andy Wilkinson
  * @author Brian Clozel
+ * @author Michael McFadyen
  */
 public class WebMvcTagsTests {
 
@@ -89,6 +90,33 @@ public class WebMvcTagsTests {
 	public void uriTagIsUnknownWhenRequestIsNull() {
 		Tag tag = WebMvcTags.uri(null, null);
 		assertThat(tag.getValue()).isEqualTo("UNKNOWN");
+	}
+
+	@Test
+	public void outcomeTagIsUnknownWhenResponseIsNull() {
+		Tag tag = WebMvcTags.outcome(null);
+		assertThat(tag.getValue()).isEqualTo("UNKNOWN");
+	}
+
+	@Test
+	public void outcomeTagIsSuccessWhenResponseIs2XX() {
+		this.response.setStatus(200);
+		Tag tag = WebMvcTags.outcome(this.response);
+		assertThat(tag.getValue()).isEqualTo("SUCCESS");
+	}
+
+	@Test
+	public void outcomeTagIsClientErrorWhenResponseIs4XX() {
+		this.response.setStatus(400);
+		Tag tag = WebMvcTags.outcome(this.response);
+		assertThat(tag.getValue()).isEqualTo("CLIENT_ERROR");
+	}
+
+	@Test
+	public void outcomeTagIsServerErrorWhenResponseIs5XX() {
+		this.response.setStatus(500);
+		Tag tag = WebMvcTags.outcome(this.response);
+		assertThat(tag.getValue()).isEqualTo("SERVER_ERROR");
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTagsTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTagsTests.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link WebFluxTags}.
  *
  * @author Brian Clozel
+ * @author Michael McFadyen
  */
 public class WebFluxTagsTests {
 
@@ -92,6 +93,40 @@ public class WebFluxTagsTests {
 		given(request.getMethodValue()).willReturn("CUSTOM");
 		Tag tag = WebFluxTags.method(exchange);
 		assertThat(tag.getValue()).isEqualTo("CUSTOM");
+	}
+
+	@Test
+	public void outcomeTagIsUnknownWhenResponseIsNull() {
+		Tag tag = WebFluxTags.outcome(null);
+		assertThat(tag.getValue()).isEqualTo("UNKNOWN");
+	}
+
+	@Test
+	public void outcomeTagIsUnknownWhenResponseStatusIsNull() {
+		this.exchange.getResponse().setStatusCode(null);
+		Tag tag = WebFluxTags.outcome(this.exchange);
+		assertThat(tag.getValue()).isEqualTo("UNKNOWN");
+	}
+
+	@Test
+	public void outcomeTagIsSuccessWhenResponseIs2XX() {
+		this.exchange.getResponse().setStatusCode(HttpStatus.OK);
+		Tag tag = WebFluxTags.outcome(this.exchange);
+		assertThat(tag.getValue()).isEqualTo("SUCCESS");
+	}
+
+	@Test
+	public void outcomeTagIsClientErrorWhenResponseIs4XX() {
+		this.exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
+		Tag tag = WebFluxTags.outcome(this.exchange);
+		assertThat(tag.getValue()).isEqualTo("CLIENT_ERROR");
+	}
+
+	@Test
+	public void outcomeTagIsServerErrorWhenResponseIs5XX() {
+		this.exchange.getResponse().setStatusCode(HttpStatus.BAD_GATEWAY);
+		Tag tag = WebFluxTags.outcome(this.exchange);
+		assertThat(tag.getValue()).isEqualTo("SERVER_ERROR");
 	}
 
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Add a new tag "outcome" to web mvc metrics for both servlet and reactive models. The outcome tag can have 4 possible values based on the http status code of the response.

1xx, 2xx, 3xx -> SUCCESS
4xx -> CLIENT_ERROR
5xx -> SERVER_ERROR
no status code -> UNKNOWN

Related Issue: #13801 