### PR TITLE
Use meaningful name for MockServerConfigurer bean

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/reactive/WebTestClientSecurityConfiguration.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/reactive/WebTestClientSecurityConfiguration.java
@@ -33,7 +33,7 @@ import org.springframework.test.web.reactive.server.MockServerConfigurer;
 class WebTestClientSecurityConfiguration {
 
 	@Bean
-	public MockServerConfigurer get() {
+	public MockServerConfigurer mockServerConfigurer() {
 		return SecurityMockServerConfigurers.springSecurity();
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
It looks accidentally named as `get()`, so this PR renames it to `mockServerConfigurer()`.