### PR TITLE
Upgrade to Neo4j Ogm 3.1.3

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -134,7 +134,7 @@
 		<mssql-jdbc.version>6.4.0.jre8</mssql-jdbc.version>
 		<mysql.version>8.0.12</mysql.version>
 		<nekohtml.version>1.9.22</nekohtml.version>
-		<neo4j-ogm.version>3.1.2</neo4j-ogm.version>
+		<neo4j-ogm.version>3.1.3</neo4j-ogm.version>
 		<netty.version>4.1.29.Final</netty.version>
 		<netty-tcnative.version>2.0.15.Final</netty-tcnative.version>
 		<nio-multipart-parser.version>1.1.0</nio-multipart-parser.version>


### PR DESCRIPTION
Neo4j OGM 3.1.3 will be the version of OGM used by Spring Data Neo4j Lovelace. See #14510.