### PR TITLE
Allow for additional customization in spring-boot-loader and spring-boot-loader-tools

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Repackager.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Repackager.java
@@ -314,7 +314,11 @@ public class Repackager {
 		if (StringUtils.hasLength(lib)) {
 			manifest.getMainAttributes().putValue(BOOT_LIB_ATTRIBUTE, lib);
 		}
+		customizeManifest(manifest);
 		return manifest;
+	}
+
+	protected void customizeManifest(Manifest manifest) {
 	}
 
 	private String findMainMethodWithTimeoutWarning(JarFile source) throws IOException {

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/archive/JarFileArchive.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/archive/JarFileArchive.java
@@ -134,7 +134,7 @@ public class JarFileArchive implements Archive {
 		while (attempts++ < 1000) {
 			String fileName = new File(this.jarFile.getName()).getName();
 			File unpackFolder = new File(parent,
-					fileName + "-spring-boot-libs-" + UUID.randomUUID());
+					getUniqueUnpackFolderFileName(fileName));
 			if (unpackFolder.mkdirs()) {
 				return unpackFolder;
 			}
@@ -153,6 +153,10 @@ public class JarFileArchive implements Archive {
 			}
 			outputStream.flush();
 		}
+	}
+
+	protected String getUniqueUnpackFolderFileName(String folderName) {
+		return folderName + "-spring-boot-libs-" + UUID.randomUUID();
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/archive/JarFileArchiveTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/archive/JarFileArchiveTests.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.zip.CRC32;
@@ -162,6 +163,17 @@ public class JarFileArchiveTests {
 				.getNestedArchive(getEntriesMap(jarFileArchive).get("nested/zip64.jar"));
 	}
 
+	@Test
+	public void getNestedArchiveFromCustomizedUnpackFolder() throws Exception {
+		this.rootJarFile = this.temporaryFolder.newFile();
+		this.rootJarFileUrl = this.rootJarFile.toURI().toString();
+		TestJarCreator.createTestJar(this.rootJarFile, true);
+		this.archive = new CustomizedUnpackFolderJarFileArchive(this.rootJarFile);
+		Entry entry = getEntriesMap(this.archive).get("nested.jar");
+		Archive nested = this.archive.getNestedArchive(entry);
+		assertThat(nested.getUrl().toString()).contains("-unique-folder-name-");
+	}
+
 	private byte[] writeZip64Jar() throws IOException {
 		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
 		JarOutputStream jarOutput = new JarOutputStream(bytes);
@@ -179,6 +191,20 @@ public class JarFileArchiveTests {
 			entries.put(entry.getName(), entry);
 		}
 		return entries;
+	}
+
+	private static final class CustomizedUnpackFolderJarFileArchive
+			extends JarFileArchive {
+
+		private CustomizedUnpackFolderJarFileArchive(File file) throws IOException {
+			super(file);
+		}
+
+		@Override
+		protected String getUniqueUnpackFolderFileName(String folderName) {
+			return folderName + "-unique-folder-name-" + UUID.randomUUID();
+		}
+
 	}
 
 }


### PR DESCRIPTION
I'm working on an executable JAR format that utilizes spring-boot-loader-tools for creation and spring-boot-loader for initialization.  The built-in customization has allowed me to move move around libraries, create a custom runtime classloader, etc. but there are still two pieces of customization that I'd like to propose:

1. Allow for customization of the manifest before it is written.  There are some attributes I need to remove/add/etc. and today I have to let `Repackager.repackage` run and then crack open the JAR and rewrite the manifest to accomplish this.  The first commit in this PR simply adds a method called `Repackager.customizeManifest` which is run before the manifest is written and defaults to a no-op.
2. When unpacking nested archives, `JarFileArchive` creates a unique folder name of the form `<originalName>-spring-boot-libs-<UUID>`.  I'd like to have a way to customize this folder name, and to that end I've created a method called `JarFileArchive.getUniqueUnpackFolderFileName` that defaults to the current behavior.