### PR TITLE
add a warning message if PID/LOG location uses fallback

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -57,6 +57,11 @@ configfile="$(basename "${jarfile%.*}.conf")"
 # shellcheck source=/dev/null
 [[ -r "${CONF_FOLDER}/${configfile}" ]] && source "${CONF_FOLDER}/${configfile}"
 
+# ANSI Colors
+echoRed() { echo $'\e[0;31m'"$1"$'\e[0m'; }
+echoGreen() { echo $'\e[0;32m'"$1"$'\e[0m'; }
+echoYellow() { echo $'\e[0;33m'"$1"$'\e[0m'; }
+
 # Initialize PID/LOG locations if they weren't provided by the config file
 [[ -z "$PID_FOLDER" ]] && PID_FOLDER="{{pidFolder:/var/run}}"
 [[ -z "$LOG_FOLDER" ]] && LOG_FOLDER="{{logFolder:/var/log}}"
@@ -83,11 +88,6 @@ fi
 
 # Initialize stop wait time if not provided by the config file
 [[ -z "$STOP_WAIT_TIME" ]] && STOP_WAIT_TIME="{{stopWaitTime:60}}"
-
-# ANSI Colors
-echoRed() { echo $'\e[0;31m'"$1"$'\e[0m'; }
-echoGreen() { echo $'\e[0;32m'"$1"$'\e[0m'; }
-echoYellow() { echo $'\e[0;33m'"$1"$'\e[0m'; }
 
 # Utility functions
 checkPermissions() {

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -67,8 +67,8 @@ echoYellow() { echo $'\e[0;33m'"$1"$'\e[0m'; }
 [[ -z "$LOG_FOLDER" ]] && LOG_FOLDER="{{logFolder:/var/log}}"
 ! [[ "$PID_FOLDER" == /* ]] && PID_FOLDER="$(dirname "$jarfile")"/"$PID_FOLDER"
 ! [[ "$LOG_FOLDER" == /* ]] && LOG_FOLDER="$(dirname "$jarfile")"/"$LOG_FOLDER"
-! [[ -x "$PID_FOLDER" ]] && PID_FOLDER="/tmp"
-! [[ -x "$LOG_FOLDER" ]] && LOG_FOLDER="/tmp"
+! [[ -x "$PID_FOLDER" ]] && echoYellow "Warning: PID_FOLDER=$PID_FOLDER does not exists fallback to /tmp" && PID_FOLDER="/tmp"
+! [[ -x "$LOG_FOLDER" ]] && echoYellow "Warning: LOG_FOLDER=$LOG_FOLDER does not exists fallback to /tmp" && LOG_FOLDER="/tmp"
 
 # Set up defaults
 [[ -z "$MODE" ]] && MODE="{{mode:auto}}" # modes are "auto", "service" or "run"


### PR DESCRIPTION
If the content of `PID_FOLDER` is not valid it falls back to `/tmp` without any
notification. This holds for `LOG_FOLDER` too. Added a warning message to notify
the user in such a case.