### PR TITLE
Add dependency management for Neo4J OGM embedded driver

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -2397,6 +2397,11 @@
 				<version>${neo4j-ogm.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.neo4j</groupId>
+				<artifactId>neo4j-ogm-embedded-driver</artifactId>
+				<version>${neo4j-ogm.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
 				<version>${postgresql.version}</version>


### PR DESCRIPTION
At the moment one has to specify the version of the embedded driver for OGM in contrast to Bolt and HTTP driver. This PR adds the embedded driver with the same version as Bolt and Http as a managed dependency.