### PR TITLE
14561: Reduce Jar Handler GC pressure cause by URL.toString()

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/Handler.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/Handler.java
@@ -93,7 +93,7 @@ public class Handler extends URLStreamHandler {
 	@Override
 	protected URLConnection openConnection(URL url) throws IOException {
 		if (this.jarFile != null
-				&& url.toString().startsWith(this.jarFile.getUrl().toString())) {
+				&& url.getPath().startsWith(this.jarFile.getUrl().getPath())) {
 			return JarURLConnection.get(url, this.jarFile);
 		}
 		try {


### PR DESCRIPTION
This PR reflects the issues described in #14561.