### PR TITLE
Add log messages to lines only when the destination isn't set

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/DeferredLog.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/DeferredLog.java
@@ -142,7 +142,9 @@ public class DeferredLog implements Log {
 			if (this.destination != null) {
 				logTo(this.destination, level, message, t);
 			}
-			this.lines.add(new Line(level, message, t));
+			else {
+				this.lines.add(new Line(level, message, t));
+			}
 		}
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/DeferredLogTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/DeferredLogTests.java
@@ -16,8 +16,12 @@
 
 package org.springframework.boot.logging;
 
+import java.util.List;
+
 import org.apache.commons.logging.Log;
 import org.junit.Test;
+
+import org.springframework.beans.DirectFieldAccessor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -169,9 +173,21 @@ public class DeferredLogTests {
 
 	@Test
 	public void switchTo() {
+		DirectFieldAccessor deferredLogFieldAccessor = new DirectFieldAccessor(
+				this.deferredLog);
+		List<String> lines = (List<String>) deferredLogFieldAccessor
+				.getPropertyValue("lines");
+		assertThat(lines).isEmpty();
+
 		this.deferredLog.error(this.message, this.throwable);
+		assertThat(lines).hasSize(1);
+
 		this.deferredLog.switchTo(this.log);
+		assertThat(lines).isEmpty();
+
 		this.deferredLog.info("Message2");
+		assertThat(lines).isEmpty();
+
 		verify(this.log).error(this.message, this.throwable);
 		verify(this.log).info("Message2", null);
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR adds log messages to `this.lines` in `DeferredLog.log()` only when the `this.destination` isn't set as it doesn't seem to be intentional unless I'm missing something.