### PR TITLE
Auto-configure Neo4J BookmarkManager when possible

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jBookmarkManagementConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jBookmarkManagementConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.neo4j;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnNotWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.data.neo4j.bookmark.BeanFactoryBookmarkOperationAdvisor;
+import org.springframework.data.neo4j.bookmark.BookmarkInterceptor;
+import org.springframework.data.neo4j.bookmark.BookmarkManager;
+import org.springframework.data.neo4j.bookmark.CaffeineBookmarkManager;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Provides a {@link BookmarkManager} for Neo4j's bookmark support based on Caffeine if
+ * available. Depending on the applications kind (web or not) the bookmark manager will be
+ * bound to the application or the request, as recommend by Spring Data Neo4j.
+ *
+ * @author Michael Simons
+ * @since 2.1
+ */
+@Configuration
+@ConditionalOnClass({ Caffeine.class, CaffeineCacheManager.class })
+@ConditionalOnMissingBean(BookmarkManager.class)
+@ConditionalOnBean({ BeanFactoryBookmarkOperationAdvisor.class,
+		BookmarkInterceptor.class })
+class Neo4jBookmarkManagementConfiguration {
+
+	static final String BOOKMARK_MANAGER_BEAN_NAME = "bookmarkManager";
+
+	@Bean(BOOKMARK_MANAGER_BEAN_NAME)
+	@Scope(value = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.INTERFACES)
+	@ConditionalOnWebApplication
+	public BookmarkManager requestScopedBookmarkManager() {
+		return new CaffeineBookmarkManager();
+	}
+
+	@Bean(BOOKMARK_MANAGER_BEAN_NAME)
+	@Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
+	@ConditionalOnNotWebApplication
+	public BookmarkManager singletonScopedBookmarkManager() {
+		return new CaffeineBookmarkManager();
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.neo4j.transaction.Neo4jTransactionManager;
 import org.springframework.data.neo4j.web.support.OpenSessionInViewInterceptor;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -52,6 +53,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * @author Vince Bickers
  * @author Stephane Nicoll
  * @author Kazuki Shimizu
+ * @author Michael Simons
  * @since 1.4.0
  */
 @Configuration
@@ -59,6 +61,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 		PlatformTransactionManager.class })
 @ConditionalOnMissingBean(SessionFactory.class)
 @EnableConfigurationProperties(Neo4jProperties.class)
+@Import(Neo4jBookmarkManagementConfiguration.class)
 public class Neo4jDataAutoConfiguration {
 
 	@Bean


### PR DESCRIPTION
This adds `Neo4jBookmarkManagementConfiguration` which provides an instance of `BookmarkManager` if necessary and Caffeine cache is on the classpath.
Depending on the kind of application, the `BookmarkManager` will be request scoped or singleton, as recommended by Spring Data Neo4j.

This change would provide a better getting started experience for people who want to use Neo4js bookmark support given they have all the needed dependencies (i.e. Caffeine) declared.

It's not a critical feature and especially not time relevant, given the S1P around the corner,  but it would be nice to have and less error prone for the user than what there is now.