### PR TITLE
Polish

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootContextLoader.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootContextLoader.java
@@ -80,15 +80,6 @@ import org.springframework.web.context.support.GenericWebApplicationContext;
  */
 public class SpringBootContextLoader extends AbstractContextLoader {
 
-	private static final Set<String> INTEGRATION_TEST_ANNOTATIONS;
-
-	static {
-		Set<String> annotations = new LinkedHashSet<>();
-		annotations.add("org.springframework.boot.test.IntegrationTest");
-		annotations.add("org.springframework.boot.test.WebIntegrationTest");
-		INTEGRATION_TEST_ANNOTATIONS = Collections.unmodifiableSet(annotations);
-	}
-
 	@Override
 	public ApplicationContext loadContext(MergedContextConfiguration config)
 			throws Exception {
@@ -222,11 +213,6 @@ public class SpringBootContextLoader extends AbstractContextLoader {
 	}
 
 	private boolean isEmbeddedWebEnvironment(MergedContextConfiguration config) {
-		for (String annotation : INTEGRATION_TEST_ANNOTATIONS) {
-			if (AnnotatedElementUtils.isAnnotated(config.getTestClass(), annotation)) {
-				return true;
-			}
-		}
 		SpringBootTest annotation = AnnotatedElementUtils
 				.findMergedAnnotation(config.getTestClass(), SpringBootTest.class);
 		if (annotation != null && annotation.webEnvironment().isEmbedded()) {


### PR DESCRIPTION
The SpringBootContextLoader still checked if tests were
annotated with @IntegrationTest or @WebIntegrationTest.
Those classes have been removed in Spring Boot 1.5 and
been deprecated since 1.4.

Removed the check on the annotations as well as the
static list of names.