### PR TITLE
Expose preferProxiedForAddress Jetty access log property.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -56,6 +56,7 @@ import org.springframework.util.unit.DataSize;
  * @author Brian Clozel
  * @author Olivier Lamy
  * @author Chentao Qu
+ * @author Marvin S. Addison
  */
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = true)
 public class ServerProperties {
@@ -831,6 +832,11 @@ public class ServerProperties {
 			 */
 			private boolean logLatency;
 
+			/**
+			 * Prefer IP address specified in X-Forwarded-For header.
+			 */
+			private boolean preferProxiedForAddress;
+
 			public boolean isEnabled() {
 				return this.enabled;
 			}
@@ -925,6 +931,14 @@ public class ServerProperties {
 
 			public void setLogLatency(boolean logLatency) {
 				this.logLatency = logLatency;
+			}
+
+			public boolean isPreferProxiedForAddress() {
+				return this.preferProxiedForAddress;
+			}
+
+			public void setPreferProxiedForAddress(boolean preferProxiedForAddress) {
+				this.preferProxiedForAddress = preferProxiedForAddress;
 			}
 
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
@@ -43,6 +43,7 @@ import org.springframework.util.unit.DataSize;
  *
  * @author Brian Clozel
  * @author Phillip Webb
+ * @author Marvin S. Addison
  * @since 2.0.0
  */
 public class JettyWebServerFactoryCustomizer implements
@@ -195,6 +196,7 @@ public class JettyWebServerFactoryCustomizer implements
 			log.setLogCookies(properties.isLogCookies());
 			log.setLogServer(properties.isLogServer());
 			log.setLogLatency(properties.isLogLatency());
+			log.setPreferProxiedForAddress(properties.isPreferProxiedForAddress());
 			server.setRequestLog(log);
 		});
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -73,6 +73,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Eddú Meléndez
  * @author Quinten De Swaef
  * @author Venil Noronha
+ * @author Marvin S. Addison
  */
 public class ServerPropertiesTests {
 
@@ -339,6 +340,13 @@ public class ServerPropertiesTests {
 		finally {
 			jetty.stop();
 		}
+	}
+
+	@Test
+	public void jettyPreferProxiedForAddress() {
+		bind("server.jetty.accesslog.prefer-proxied-for-address", "true");
+		assertThat(this.properties.getJetty().getAccesslog().isPreferProxiedForAddress())
+				.isEqualTo(true);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.verify;
  *
  * @author Brian Clozel
  * @author Phillip Webb
+ * @author Marvin S. Addison
  */
 public class JettyWebServerFactoryCustomizerTests {
 
@@ -99,7 +100,8 @@ public class JettyWebServerFactoryCustomizerTests {
 				"server.jetty.accesslog.time-zone=" + timezone,
 				"server.jetty.accesslog.log-cookies=true",
 				"server.jetty.accesslog.log-server=true",
-				"server.jetty.accesslog.log-latency=true");
+				"server.jetty.accesslog.log-latency=true",
+				"server.jetty.accesslog.prefer-proxied-for-address=true");
 		JettyWebServer server = customizeAndGetServer();
 		NCSARequestLog requestLog = getNCSARequestLog(server);
 		assertThat(requestLog.getFilename()).isEqualTo(logFile.getAbsolutePath());
@@ -113,6 +115,7 @@ public class JettyWebServerFactoryCustomizerTests {
 		assertThat(requestLog.getLogCookies()).isTrue();
 		assertThat(requestLog.getLogServer()).isTrue();
 		assertThat(requestLog.getLogLatency()).isTrue();
+		assertThat(requestLog.getPreferProxiedForAddress()).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
Provides the Spring boot property `server.jetty.accesslog.prefer-proxied-for-address` to control Jetty access log behavior to prefer `X-Forwarded-For` header if present for logging IP address in HTTP access logs. Closes #14608.