### PR TITLE
Use Commons Logging for OnlyOnceLoggingDenyMeterFilter

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/OnlyOnceLoggingDenyMeterFilter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/OnlyOnceLoggingDenyMeterFilter.java
@@ -23,8 +23,8 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Meter.Id;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.MeterFilterReply;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.util.Assert;
 
@@ -38,8 +38,8 @@ import org.springframework.util.Assert;
  */
 public final class OnlyOnceLoggingDenyMeterFilter implements MeterFilter {
 
-	private final Logger logger = LoggerFactory
-			.getLogger(OnlyOnceLoggingDenyMeterFilter.class);
+	private static final Log logger = LogFactory
+			.getLog(OnlyOnceLoggingDenyMeterFilter.class);
 
 	private final AtomicBoolean alreadyWarned = new AtomicBoolean(false);
 
@@ -52,9 +52,8 @@ public final class OnlyOnceLoggingDenyMeterFilter implements MeterFilter {
 
 	@Override
 	public MeterFilterReply accept(Id id) {
-		if (this.logger.isWarnEnabled()
-				&& this.alreadyWarned.compareAndSet(false, true)) {
-			this.logger.warn(this.message.get());
+		if (logger.isWarnEnabled() && this.alreadyWarned.compareAndSet(false, true)) {
+			logger.warn(this.message.get());
 		}
 		return MeterFilterReply.DENY;
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR changes to use Commons Logging for `OnlyOnceLoggingDenyMeterFilter` as it seems that SLF4J is used accidentally.