### PR TITLE
Add factory method to RestTemplateBuilder

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RequestFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RequestFactoryCustomizer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.client;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+import org.springframework.http.client.ClientHttpRequestFactory;
+
+/**
+ * A customizer to set properties on passed-in {@link ClientHttpRequestFactory} instances
+ * as used by {@link RestTemplateBuilder}.
+ *
+ * @author Brian Deacon
+ * @since 2.1.0
+ */
+public interface RequestFactoryCustomizer extends Consumer<ClientHttpRequestFactory> {
+
+	/**
+	 * Specifies the read timeout that will be set on customized
+	 * {@link ClientHttpRequestFactory} instances.
+	 * @param readTimeout the read timeout
+	 * @return the configured instance of the customizer
+	 */
+	RequestFactoryCustomizer readTimeout(Duration readTimeout);
+
+	/**
+	 * Specifies the connection timeout that will be set on customized
+	 * {@link ClientHttpRequestFactory} instances.
+	 * @param connectTimeout the connect timeout
+	 * @return the configured instance of the customizer
+	 */
+	RequestFactoryCustomizer connectTimeout(Duration connectTimeout);
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RestTemplateBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RestTemplateBuilder.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.springframework.beans.BeanUtils;
@@ -58,6 +57,7 @@ import org.springframework.web.util.UriTemplateHandler;
  * @author Phillip Webb
  * @author Andy Wilkinson
  * @author Brian Clozel
+ * @author Brian Deacon
  * @since 1.4.0
  */
 public class RestTemplateBuilder {
@@ -98,7 +98,7 @@ public class RestTemplateBuilder {
 		this.basicAuthorization = null;
 		this.restTemplateCustomizers = Collections
 				.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(customizers)));
-		this.requestFactoryCustomizer = new RequestFactoryCustomizer();
+		this.requestFactoryCustomizer = new DefaultRequestFactoryCustomizer();
 		this.interceptors = Collections.emptySet();
 	}
 
@@ -122,6 +122,20 @@ public class RestTemplateBuilder {
 		this.interceptors = interceptors;
 	}
 
+	protected RestTemplateBuilder newInstance(boolean detectRequestFactory,
+			String rootUri, Set<HttpMessageConverter<?>> messageConverters,
+			Supplier<ClientHttpRequestFactory> requestFactorySupplier,
+			UriTemplateHandler uriTemplateHandler, ResponseErrorHandler errorHandler,
+			BasicAuthorizationInterceptor basicAuthorization,
+			Set<RestTemplateCustomizer> restTemplateCustomizers,
+			RequestFactoryCustomizer requestFactoryCustomizer,
+			Set<ClientHttpRequestInterceptor> interceptors) {
+		return new RestTemplateBuilder(detectRequestFactory, rootUri, messageConverters,
+				requestFactorySupplier, uriTemplateHandler, errorHandler,
+				basicAuthorization, restTemplateCustomizers, requestFactoryCustomizer,
+				interceptors);
+	}
+
 	/**
 	 * Set if the {@link ClientHttpRequestFactory} should be detected based on the
 	 * classpath. Default if {@code true}.
@@ -130,11 +144,10 @@ public class RestTemplateBuilder {
 	 * @return a new builder instance
 	 */
 	public RestTemplateBuilder detectRequestFactory(boolean detectRequestFactory) {
-		return new RestTemplateBuilder(detectRequestFactory, this.rootUri,
-				this.messageConverters, this.requestFactorySupplier,
-				this.uriTemplateHandler, this.errorHandler, this.basicAuthorization,
-				this.restTemplateCustomizers, this.requestFactoryCustomizer,
-				this.interceptors);
+		return newInstance(detectRequestFactory, this.rootUri, this.messageConverters,
+				this.requestFactorySupplier, this.uriTemplateHandler, this.errorHandler,
+				this.basicAuthorization, this.restTemplateCustomizers,
+				this.requestFactoryCustomizer, this.interceptors);
 	}
 
 	/**
@@ -144,11 +157,10 @@ public class RestTemplateBuilder {
 	 * @return a new builder instance
 	 */
 	public RestTemplateBuilder rootUri(String rootUri) {
-		return new RestTemplateBuilder(this.detectRequestFactory, rootUri,
-				this.messageConverters, this.requestFactorySupplier,
-				this.uriTemplateHandler, this.errorHandler, this.basicAuthorization,
-				this.restTemplateCustomizers, this.requestFactoryCustomizer,
-				this.interceptors);
+		return newInstance(this.detectRequestFactory, rootUri, this.messageConverters,
+				this.requestFactorySupplier, this.uriTemplateHandler, this.errorHandler,
+				this.basicAuthorization, this.restTemplateCustomizers,
+				this.requestFactoryCustomizer, this.interceptors);
 	}
 
 	/**
@@ -176,7 +188,7 @@ public class RestTemplateBuilder {
 	public RestTemplateBuilder messageConverters(
 			Collection<? extends HttpMessageConverter<?>> messageConverters) {
 		Assert.notNull(messageConverters, "MessageConverters must not be null");
-		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
+		return newInstance(this.detectRequestFactory, this.rootUri,
 				Collections.unmodifiableSet(
 						new LinkedHashSet<HttpMessageConverter<?>>(messageConverters)),
 				this.requestFactorySupplier, this.uriTemplateHandler, this.errorHandler,
@@ -207,7 +219,7 @@ public class RestTemplateBuilder {
 	public RestTemplateBuilder additionalMessageConverters(
 			Collection<? extends HttpMessageConverter<?>> messageConverters) {
 		Assert.notNull(messageConverters, "MessageConverters must not be null");
-		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
+		return newInstance(this.detectRequestFactory, this.rootUri,
 				append(this.messageConverters, messageConverters),
 				this.requestFactorySupplier, this.uriTemplateHandler, this.errorHandler,
 				this.basicAuthorization, this.restTemplateCustomizers,
@@ -222,7 +234,7 @@ public class RestTemplateBuilder {
 	 * @see #messageConverters(HttpMessageConverter...)
 	 */
 	public RestTemplateBuilder defaultMessageConverters() {
-		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
+		return newInstance(this.detectRequestFactory, this.rootUri,
 				Collections.unmodifiableSet(
 						new LinkedHashSet<>(new RestTemplate().getMessageConverters())),
 				this.requestFactorySupplier, this.uriTemplateHandler, this.errorHandler,
@@ -257,7 +269,7 @@ public class RestTemplateBuilder {
 	public RestTemplateBuilder interceptors(
 			Collection<ClientHttpRequestInterceptor> interceptors) {
 		Assert.notNull(interceptors, "interceptors must not be null");
-		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
+		return newInstance(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactorySupplier,
 				this.uriTemplateHandler, this.errorHandler, this.basicAuthorization,
 				this.restTemplateCustomizers, this.requestFactoryCustomizer,
@@ -289,7 +301,7 @@ public class RestTemplateBuilder {
 	public RestTemplateBuilder additionalInterceptors(
 			Collection<? extends ClientHttpRequestInterceptor> interceptors) {
 		Assert.notNull(interceptors, "interceptors must not be null");
-		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
+		return newInstance(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactorySupplier,
 				this.uriTemplateHandler, this.errorHandler, this.basicAuthorization,
 				this.restTemplateCustomizers, this.requestFactoryCustomizer,
@@ -331,7 +343,7 @@ public class RestTemplateBuilder {
 			Supplier<ClientHttpRequestFactory> requestFactorySupplier) {
 		Assert.notNull(requestFactorySupplier,
 				"RequestFactory Supplier must not be null");
-		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
+		return newInstance(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, requestFactorySupplier, this.uriTemplateHandler,
 				this.errorHandler, this.basicAuthorization, this.restTemplateCustomizers,
 				this.requestFactoryCustomizer, this.interceptors);
@@ -345,7 +357,7 @@ public class RestTemplateBuilder {
 	 */
 	public RestTemplateBuilder uriTemplateHandler(UriTemplateHandler uriTemplateHandler) {
 		Assert.notNull(uriTemplateHandler, "UriTemplateHandler must not be null");
-		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
+		return newInstance(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactorySupplier, uriTemplateHandler,
 				this.errorHandler, this.basicAuthorization, this.restTemplateCustomizers,
 				this.requestFactoryCustomizer, this.interceptors);
@@ -359,7 +371,7 @@ public class RestTemplateBuilder {
 	 */
 	public RestTemplateBuilder errorHandler(ResponseErrorHandler errorHandler) {
 		Assert.notNull(errorHandler, "ErrorHandler must not be null");
-		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
+		return newInstance(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactorySupplier,
 				this.uriTemplateHandler, errorHandler, this.basicAuthorization,
 				this.restTemplateCustomizers, this.requestFactoryCustomizer,
@@ -374,7 +386,7 @@ public class RestTemplateBuilder {
 	 * @return a new builder instance
 	 */
 	public RestTemplateBuilder basicAuthorization(String username, String password) {
-		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
+		return newInstance(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactorySupplier,
 				this.uriTemplateHandler, this.errorHandler,
 				new BasicAuthorizationInterceptor(username, password),
@@ -411,7 +423,7 @@ public class RestTemplateBuilder {
 			Collection<? extends RestTemplateCustomizer> restTemplateCustomizers) {
 		Assert.notNull(restTemplateCustomizers,
 				"RestTemplateCustomizers must not be null");
-		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
+		return newInstance(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactorySupplier,
 				this.uriTemplateHandler, this.errorHandler, this.basicAuthorization,
 				Collections.unmodifiableSet(new LinkedHashSet<RestTemplateCustomizer>(
@@ -445,7 +457,7 @@ public class RestTemplateBuilder {
 	public RestTemplateBuilder additionalCustomizers(
 			Collection<? extends RestTemplateCustomizer> customizers) {
 		Assert.notNull(customizers, "RestTemplateCustomizers must not be null");
-		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
+		return newInstance(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactorySupplier,
 				this.uriTemplateHandler, this.errorHandler, this.basicAuthorization,
 				append(this.restTemplateCustomizers, customizers),
@@ -459,7 +471,7 @@ public class RestTemplateBuilder {
 	 * @since 2.1.0
 	 */
 	public RestTemplateBuilder setConnectTimeout(Duration connectTimeout) {
-		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
+		return newInstance(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactorySupplier,
 				this.uriTemplateHandler, this.errorHandler, this.basicAuthorization,
 				this.restTemplateCustomizers,
@@ -486,7 +498,7 @@ public class RestTemplateBuilder {
 	 * @since 2.1.0
 	 */
 	public RestTemplateBuilder setReadTimeout(Duration readTimeout) {
-		return new RestTemplateBuilder(this.detectRequestFactory, this.rootUri,
+		return newInstance(this.detectRequestFactory, this.rootUri,
 				this.messageConverters, this.requestFactorySupplier,
 				this.uriTemplateHandler, this.errorHandler, this.basicAuthorization,
 				this.restTemplateCustomizers,
@@ -586,28 +598,33 @@ public class RestTemplateBuilder {
 		return Collections.unmodifiableSet(result);
 	}
 
-	private static class RequestFactoryCustomizer
-			implements Consumer<ClientHttpRequestFactory> {
+	/**
+	 * Default implementation of RequestFactoryCustomizer.
+	 */
+	protected static class DefaultRequestFactoryCustomizer
+			implements RequestFactoryCustomizer {
 
 		private final Duration connectTimeout;
 
 		private final Duration readTimeout;
 
-		RequestFactoryCustomizer() {
+		DefaultRequestFactoryCustomizer() {
 			this(null, null);
 		}
 
-		private RequestFactoryCustomizer(Duration connectTimeout, Duration readTimeout) {
+		private DefaultRequestFactoryCustomizer(Duration connectTimeout,
+				Duration readTimeout) {
 			this.connectTimeout = connectTimeout;
 			this.readTimeout = readTimeout;
 		}
 
-		public RequestFactoryCustomizer connectTimeout(Duration connectTimeout) {
-			return new RequestFactoryCustomizer(connectTimeout, this.readTimeout);
+		public DefaultRequestFactoryCustomizer connectTimeout(Duration connectTimeout) {
+			return new DefaultRequestFactoryCustomizer(connectTimeout, this.readTimeout);
 		}
 
+		@Override
 		public RequestFactoryCustomizer readTimeout(Duration readTimeout) {
-			return new RequestFactoryCustomizer(this.connectTimeout, readTimeout);
+			return new DefaultRequestFactoryCustomizer(this.connectTimeout, readTimeout);
 		}
 
 		@Override

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/RestTemplateBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/RestTemplateBuilderTests.java
@@ -429,6 +429,34 @@ public class RestTemplateBuilderTests {
 	}
 
 	@Test
+	public void subclassBuilderMethodsShouldReturnCustomizableInstance() {
+		RestTemplateBuilder builder = new RestTemplateBuilderSubclass();
+		assertThat(builder.defaultMessageConverters()).isSameAs(builder);
+		assertThat(builder.detectRequestFactory(true)).isSameAs(builder);
+		assertThat(builder.interceptors(mock(ClientHttpRequestInterceptor.class)))
+				.isSameAs(builder);
+		assertThat(builder.requestFactory(ClientHttpRequestFactory.class))
+				.isSameAs(builder);
+		assertThat(builder.additionalCustomizers(mock(RestTemplateCustomizer.class)))
+				.isSameAs(builder);
+		assertThat(
+				builder.additionalInterceptors(mock(ClientHttpRequestInterceptor.class)))
+						.isSameAs(builder);
+		assertThat(builder.additionalMessageConverters(mock(HttpMessageConverter.class)))
+				.isSameAs(builder);
+		assertThat(builder.basicAuthorization("", "")).isSameAs(builder);
+		assertThat(builder.customizers(mock(RestTemplateCustomizer.class)))
+				.isSameAs(builder);
+		assertThat(builder.errorHandler(mock(ResponseErrorHandler.class)))
+				.isSameAs(builder);
+		assertThat(builder.rootUri("")).isSameAs(builder);
+		assertThat(builder.setConnectTimeout(Duration.ofSeconds(1))).isSameAs(builder);
+		assertThat(builder.setReadTimeout(Duration.ofSeconds(1))).isSameAs(builder);
+		assertThat(builder.uriTemplateHandler(mock(UriTemplateHandler.class)))
+				.isSameAs(builder);
+	}
+
+	@Test
 	public void configureShouldApply() {
 		RestTemplate template = new RestTemplate();
 		this.builder.configure(template);
@@ -568,6 +596,27 @@ public class RestTemplateBuilderTests {
 	}
 
 	static class TestClientHttpRequestFactory extends SimpleClientHttpRequestFactory {
+
+	}
+
+	public static class RestTemplateBuilderSubclass extends RestTemplateBuilder {
+
+		public RestTemplateBuilderSubclass() {
+			super(((restTemplate) -> {
+			}));
+		}
+
+		@Override
+		protected RestTemplateBuilder newInstance(boolean detectRequestFactory,
+				String rootUri, Set<HttpMessageConverter<?>> messageConverters,
+				Supplier<ClientHttpRequestFactory> requestFactorySupplier,
+				UriTemplateHandler uriTemplateHandler, ResponseErrorHandler errorHandler,
+				BasicAuthorizationInterceptor basicAuthorization,
+				Set<RestTemplateCustomizer> restTemplateCustomizers,
+				RequestFactoryCustomizer requestFactoryCustomizer,
+				Set<ClientHttpRequestInterceptor> interceptors) {
+			return this;
+		}
 
 	}
 


### PR DESCRIPTION
Changed builder methods in RestTemplateBuilder to use an overridable factory method to facilitate creation of subclasses.
Previously, a subclass of RestTemplateBuilder would no longer be used if a non-overriden builder method was used.

i.e. aSubclassedBuilder.defaultMessageConverters().build() would not call build() on the subclass instance. Now that subclass
could get that behavior by overriding the new "newInstance" method.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
