### PR TITLE
Use non-reflective APIs to inject converters

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinding.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinding.java
@@ -30,10 +30,15 @@ import org.springframework.beans.factory.annotation.Qualifier;
  *
  * @author Dave Syer
  */
-@Qualifier
+@Qualifier(ConfigurationPropertiesBinding.VALUE)
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface ConfigurationPropertiesBinding {
+
+	/**
+	 * Concrete value for the <code>@Qualifier</code>.
+	 */
+	String VALUE = "org.springframework.boot.context.properties.ConfigurationPropertiesBinding";
 
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConversionServiceDeducer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConversionServiceDeducer.java
@@ -23,15 +23,12 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.config.DependencyDescriptor;
 import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.converter.GenericConverter;
-import org.springframework.util.ReflectionUtils;
 
 /**
  * Utility to deduce the {@link ConversionService} to use for configuration properties
@@ -61,9 +58,6 @@ class ConversionServiceDeducer {
 
 	private static class Factory {
 
-		private static DependencyDescriptor DUMMY = new DependencyDescriptor(
-				ReflectionUtils.findField(Factory.class, "genericConverters"), false);
-
 		/**
 		 * A list of custom converters (in addition to the defaults) to use when
 		 * converting properties for binding.
@@ -91,13 +85,6 @@ class ConversionServiceDeducer {
 				return list;
 			}
 			ListableBeanFactory listable = (ListableBeanFactory) beanFactory;
-			if (listable instanceof ConfigurableListableBeanFactory) {
-				for (String name : listable.getBeanNamesForType(type)) {
-					// Force bean definition to resolve its factory method
-					((ConfigurableListableBeanFactory) listable).isAutowireCandidate(name,
-							DUMMY);
-				}
-			}
 			list.addAll(BeanFactoryAnnotationUtils
 					.qualifiedBeansOfType(listable, type, qualifier).values());
 			return list;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConversionServiceDeducer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConversionServiceDeducer.java
@@ -23,12 +23,15 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.config.DependencyDescriptor;
 import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.converter.GenericConverter;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * Utility to deduce the {@link ConversionService} to use for configuration properties
@@ -58,6 +61,9 @@ class ConversionServiceDeducer {
 
 	private static class Factory {
 
+		private static DependencyDescriptor DUMMY = new DependencyDescriptor(
+				ReflectionUtils.findField(Factory.class, "genericConverters"), false);
+
 		/**
 		 * A list of custom converters (in addition to the defaults) to use when
 		 * converting properties for binding.
@@ -85,6 +91,13 @@ class ConversionServiceDeducer {
 				return list;
 			}
 			ListableBeanFactory listable = (ListableBeanFactory) beanFactory;
+			if (listable instanceof ConfigurableListableBeanFactory) {
+				for (String name : listable.getBeanNamesForType(type)) {
+					// Force bean definition to resolve its factory method
+					((ConfigurableListableBeanFactory) listable).isAutowireCandidate(name,
+							DUMMY);
+				}
+			}
 			list.addAll(BeanFactoryAnnotationUtils
 					.qualifiedBeansOfType(listable, type, qualifier).values());
 			return list;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConversionServiceDeducer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConversionServiceDeducer.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.context.properties;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,15 +23,12 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
-import org.springframework.beans.factory.config.DependencyDescriptor;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.converter.GenericConverter;
-import org.springframework.util.ReflectionUtils;
 
 /**
  * Utility to deduce the {@link ConversionService} to use for configuration properties
@@ -89,21 +85,9 @@ class ConversionServiceDeducer {
 				return list;
 			}
 			ListableBeanFactory listable = (ListableBeanFactory) beanFactory;
-			for (String name : listable.getBeanNamesForType(type)) {
-				if (listable instanceof DefaultListableBeanFactory) {
-					// Force bean definition to resolve its factory method
-					Field dummy = ReflectionUtils.findField(Factory.class,
-							"genericConverters");
-					((DefaultListableBeanFactory) listable).isAutowireCandidate(name,
-							new DependencyDescriptor(dummy, false));
-				}
-				if (BeanFactoryAnnotationUtils.isQualifierMatch(
-						(value) -> qualifier.equals(value), name, listable)) {
-					list.add(listable.getBean(name, type));
-				}
-			}
+			list.addAll(BeanFactoryAnnotationUtils
+					.qualifiedBeansOfType(listable, type, qualifier).values());
 			return list;
-
 		}
 
 		public ConversionService create() {


### PR DESCRIPTION
The `@Qualifier` APIs are a bit limited in Spring still, so we might
want to use this to pursue additional convenience methods before
merging. See [SPR-8891](https://jira.spring.io/browse/SPR-8891).