### PR TITLE
Remove unnecessary parameters for String.substring

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/PropertiesLauncher.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/PropertiesLauncher.java
@@ -521,7 +521,7 @@ public class PropertiesLauncher extends Launcher {
 				file = new File(root.substring("jar:file:".length(), index));
 			}
 			parent = new JarFileArchive(file);
-			root = root.substring(index + 1, root.length());
+			root = root.substring(index + 1);
 			while (root.startsWith("/")) {
 				root = root.substring(1);
 			}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
@@ -1075,7 +1075,7 @@ public class ConfigurationPropertiesTests {
 		@Override
 		public Resource resolve(String location, ResourceLoader resourceLoader) {
 			if (location.startsWith(PREFIX)) {
-				String path = location.substring(PREFIX.length(), location.length());
+				String path = location.substring(PREFIX.length());
 				return new ClassPathResource(path);
 			}
 			return null;


### PR DESCRIPTION
Hi,

this trivial PR removes some unnecessary length parameters when using String.substring.

Cheers,
Christoph