### PR TITLE
Introduce support for passing env props in fully-executable jars

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -57,6 +57,9 @@ configfile="$(basename "${jarfile%.*}.conf")"
 # shellcheck source=/dev/null
 [[ -r "${CONF_FOLDER}/${configfile}" ]] && source "${CONF_FOLDER}/${configfile}"
 
+# Initialize ENVIRONMENT_PROPERTIES value if not provided by the config file
+[[ -z "$ENVIRONMENT_PROPERTIES" ]] && ENVIRONMENT_PROPERTIES="{{environmentProperties:}}"
+
 # Initialize PID/LOG locations if they weren't provided by the config file
 [[ -z "$PID_FOLDER" ]] && PID_FOLDER="{{pidFolder:/var/run}}"
 [[ -z "$LOG_FOLDER" ]] && LOG_FOLDER="{{logFolder:/var/log}}"
@@ -143,6 +146,7 @@ else
     exit 1
 fi
 
+environment_properties=($ENVIRONMENT_PROPERTIES)
 arguments=(-Dsun.misc.URLClassPath.disableJarChecking=true $JAVA_OPTS -jar "$jarfile" $RUN_ARGS "$@")
 
 # Action functions
@@ -172,23 +176,42 @@ do_start() {
   if [[ -n "$run_user" ]]; then
     checkPermissions || return $?
     if [ $USE_START_STOP_DAEMON = true ] && type start-stop-daemon > /dev/null 2>&1; then
+      cmd_line="$javaexe ${arguments[@]}"
+
+      if (( ${#environment_properties[@]} )); then
+        cmd_line="${environment_properties[@]} ${cmd_line}"
+      fi
+
       start-stop-daemon --start --quiet \
         --chuid "$run_user" \
         --name "$identity" \
         --make-pidfile --pidfile "$pid_file" \
         --background --no-close \
-        --startas "$javaexe" \
         --chdir "$working_dir" \
-        -- "${arguments[@]}" \
+        --startas "$env_exe" \
+        -- $cmd_line \
         >> "$log_file" 2>&1
       await_file "$pid_file"
     else
-      su -s /bin/sh -c "$javaexe $(printf "\"%s\" " "${arguments[@]}") >> \"$log_file\" 2>&1 & echo \$!" "$run_user" > "$pid_file"
+      env_cmd_line="$env_exe"
+
+      if (( ${#environment_properties[@]} )); then
+        env_cmd_line="$env_cmd_line ${environment_properties[@]}"
+      fi
+
+      su -s /bin/sh -c "$env_cmd_line $javaexe $(printf "\"%s\" " "${arguments[@]}") >> \"$log_file\" 2>&1 & echo \$!" "$run_user" > "$pid_file"
     fi
     pid=$(cat "$pid_file")
   else
     checkPermissions || return $?
-    "$javaexe" "${arguments[@]}" >> "$log_file" 2>&1 &
+
+    cmd_line="$javaexe ${arguments[@]}"
+
+    if (( ${#environment_properties[@]} )); then
+      cmd_line="$env_exe ${environment_properties[@]} ${cmd_line}"
+    fi
+
+    $cmd_line >> "$log_file" 2>&1 &
     pid=$!
     disown $pid
     echo "$pid" > "$pid_file"
@@ -262,7 +285,7 @@ status() {
 
 run() {
   pushd "$(dirname "$jarfile")" > /dev/null
-  "$javaexe" "${arguments[@]}"
+  "$env_exe" "${environment_properties[@]}" "$javaexe" "${arguments[@]}"
   result=$?
   popd > /dev/null
   return "$result"

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/DefaultLaunchScriptTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/DefaultLaunchScriptTests.java
@@ -129,6 +129,11 @@ public class DefaultLaunchScriptTests {
 	}
 
 	@Test
+	public void environmentProperties() throws Exception {
+		assertThatPlaceholderCanBeReplaced("environmentProperties");
+	}
+
+	@Test
 	public void inlinedConfScriptFileLoad() throws IOException {
 		DefaultLaunchScript script = new DefaultLaunchScript(null,
 				createProperties("inlinedConfScript:src/test/resources/example.script"));
@@ -155,6 +160,13 @@ public class DefaultLaunchScriptTests {
 		DefaultLaunchScript script = new DefaultLaunchScript(null, null);
 		String content = new String(script.toByteArray());
 		assertThat(content).contains("STOP_WAIT_TIME=\"60\"");
+	}
+
+	@Test
+	public void defaultForEnvironmentPropertiesIsEmptyString() throws Exception {
+		DefaultLaunchScript script = new DefaultLaunchScript(null, null);
+		String content = new String(script.toByteArray());
+		assertThat(content).contains("ENVIRONMENT_PROPERTIES=\"\"");
 	}
 
 	@Test


### PR DESCRIPTION
This commit patches the default launch script for fully executable jars to allow the specification of a configuration property called `environmentProperties` and its matching environment property
`ENVIRONMENT_PROPERTIES` that allows to specify environment variables (as in `java.lang.System#getenv()`) to be passed to the process spawned by running the fully-executable jar.

The environment variables to be passed to the process need to be specified as a list of <key>=<value> pairs, e.g.:

environmentProperties=A=B C=D
ENVIRONMENT_PROPERTIES='A=B C=D'

Fixes #14662

I developed and tested this on a Devuan based on Debian Jesse (I am told that is the pickiest `init.d` system around). Please try it on other distros, especially more recent ones.

P.S. I almost lost my sanity over the intricacies of `start-stop-daemon`. I am fairly certain that at some point, in the throws of desperation, I started chanting `Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn`.