### PR TITLE
Fix actuator endpoint tables in docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -228,6 +228,10 @@ endpoints:
 |Yes
 |No
 
+|`caches`
+|Yes
+|No
+
 |`conditions`
 |Yes
 |No
@@ -262,7 +266,7 @@ endpoints:
 
 |`integrationgraph`
 |Yes
-|Yes
+|No
 
 |`jolokia`
 |N/A


### PR DESCRIPTION
Hi,

this PR fixes a missing entry for the `caches` endpoint in the [production-ready-endpoints-exposing-endpoints](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#production-ready-endpoints-exposing-endpoints) section.

While doing that, I noticed that the `integrationgraph` endpoint is documented to be available via Web by default, which doesn't seem to be the case. Maybe I'm missing something here though (in which case I'm happy to revert that particular change).

Let me know what you think.

Cheers,
Christoph