### PR TITLE
Update to Infinispan 9.4.0.Final

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -78,7 +78,7 @@
 		<httpasyncclient.version>4.1.4</httpasyncclient.version>
 		<httpclient.version>4.5.6</httpclient.version>
 		<httpcore.version>4.4.10</httpcore.version>
-		<infinispan.version>9.3.3.Final</infinispan.version>
+		<infinispan.version>9.4.0.Final</infinispan.version>
 		<influxdb-java.version>2.13</influxdb-java.version>
 		<jackson.version>2.9.7</jackson.version>
 		<janino.version>3.0.10</janino.version>


### PR DESCRIPTION
Upgrade master (2.1.x) to Infinispan 9.4.0.Final. This is highly recommended for Hibernate 5.3 users.