### PR TITLE
@ResponseStatus does not work when using WebFlux

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributes.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributes.java
@@ -22,9 +22,11 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.server.ResponseStatusException;
@@ -46,6 +48,7 @@ import org.springframework.web.server.ServerWebExchange;
  *
  * @author Brian Clozel
  * @author Stephane Nicoll
+ * @author Michele Mancioppi
  * @since 2.0.0
  * @see ErrorAttributes
  */
@@ -91,6 +94,14 @@ public class DefaultErrorAttributes implements ErrorAttributes {
 		if (error instanceof ResponseStatusException) {
 			return ((ResponseStatusException) error).getStatus();
 		}
+
+		ResponseStatus responseStatus = AnnotatedElementUtils
+				.findMergedAnnotation(error.getClass(), ResponseStatus.class);
+
+		if (responseStatus != null) {
+			return responseStatus.code();
+		}
+
 		return HttpStatus.INTERNAL_SERVER_ERROR;
 	}
 
@@ -98,9 +109,18 @@ public class DefaultErrorAttributes implements ErrorAttributes {
 		if (error instanceof WebExchangeBindException) {
 			return error.getMessage();
 		}
+
 		if (error instanceof ResponseStatusException) {
 			return ((ResponseStatusException) error).getReason();
 		}
+
+		ResponseStatus responseStatus = AnnotatedElementUtils
+				.findMergedAnnotation(error.getClass(), ResponseStatus.class);
+
+		if (responseStatus != null) {
+			return responseStatus.reason();
+		}
+
 		return error.getMessage();
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributesTests.java
@@ -33,6 +33,7 @@ import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.MapBindingResult;
 import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.server.ResponseStatusException;
@@ -85,6 +86,29 @@ public class DefaultErrorAttributesTests {
 		assertThat(attributes.get("error"))
 				.isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase());
 		assertThat(attributes.get("status")).isEqualTo(500);
+	}
+
+	@Test
+	public void annotatedResponseStatusCode() {
+		Exception error = new CustomException();
+		MockServerHttpRequest request = MockServerHttpRequest.get("/test").build();
+		Map<String, Object> attributes = this.errorAttributes
+				.getErrorAttributes(buildServerRequest(request, error), false);
+		assertThat(attributes.get("error"))
+				.isEqualTo(HttpStatus.I_AM_A_TEAPOT.getReasonPhrase());
+		assertThat(attributes.get("status")).isEqualTo(HttpStatus.I_AM_A_TEAPOT.value());
+	}
+
+	@Test
+	public void annotatedResponseStatusCodeWithCustomReasonPhrase() {
+		Exception error = new Custom2Exception();
+		MockServerHttpRequest request = MockServerHttpRequest.get("/test").build();
+		Map<String, Object> attributes = this.errorAttributes
+				.getErrorAttributes(buildServerRequest(request, error), false);
+		assertThat(attributes.get("error"))
+				.isEqualTo(HttpStatus.I_AM_A_TEAPOT.getReasonPhrase());
+		assertThat(attributes.get("status")).isEqualTo(HttpStatus.I_AM_A_TEAPOT.value());
+		assertThat(attributes.get("message")).isEqualTo("Nope!");
 	}
 
 	@Test
@@ -209,6 +233,16 @@ public class DefaultErrorAttributesTests {
 
 	public int method(String firstParam) {
 		return 42;
+	}
+
+	@ResponseStatus(HttpStatus.I_AM_A_TEAPOT)
+	private static class CustomException extends RuntimeException {
+
+	}
+
+	@ResponseStatus(value = HttpStatus.I_AM_A_TEAPOT, reason = "Nope!")
+	private static class Custom2Exception extends RuntimeException {
+
 	}
 
 }


### PR DESCRIPTION
This commit adds support for @ResponseStatus in DefaultErrorAttributes
mimicking the semantics of @ResponseStatus in SpringMVC.

Throwables annotated with @ResponseStatus handled by
DefaultErrorAttributes will result in the following error attributes:
* 'status' set as the return value of the HttpStatus#value()
  defined as @ResponseStatus#value()
* 'error' set to the default reason phrase of the HttpStatus
  defined as @ResponseStatus#value()
* 'message' defined as the value of @ResponseStatus#reason(),
  or the default HttpStatus's reason phrase if left unspecified

Fixes #14742

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
