### PR TITLE
Allow ClassPathResources to be filtered by FilteredClassLoader

### DIFF
--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/FilteredClassLoaderTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/FilteredClassLoaderTests.java
@@ -16,9 +16,13 @@
 
 package org.springframework.boot.test.context;
 
+import java.net.URL;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import org.springframework.core.io.ClassPathResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,8 +30,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link FilteredClassLoader}.
  *
  * @author Phillip Webb
+ * @author Roy Jacobs
  */
 public class FilteredClassLoaderTests {
+
+	private static ClassPathResource TEST_RESOURCE = new ClassPathResource(
+			"org/springframework/boot/test/context/FilteredClassLoaderTestsResource.txt");
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
@@ -57,6 +65,24 @@ public class FilteredClassLoaderTests {
 		Class<?> loaded = classLoader.loadClass(getClass().getName());
 		assertThat(loaded.getName()).isEqualTo(getClass().getName());
 		classLoader.close();
+	}
+
+	@Test
+	public void loadResourceWhenFilteredOnResourceShouldReturnNotFound()
+			throws Exception {
+		try (FilteredClassLoader classLoader = new FilteredClassLoader(TEST_RESOURCE)) {
+			final URL loaded = classLoader.getResource(TEST_RESOURCE.getPath());
+			assertThat(loaded).isNull();
+		}
+	}
+
+	@Test
+	public void loadResourceWhenNotFilteredShouldLoadResource() throws Exception {
+		try (FilteredClassLoader classLoader = new FilteredClassLoader(
+				(resourceName) -> false)) {
+			final URL loaded = classLoader.getResource(TEST_RESOURCE.getPath());
+			assertThat(loaded).isNotNull();
+		}
 	}
 
 }

--- a/spring-boot-project/spring-boot-test/src/test/resources/org/springframework/boot/test/context/FilteredClassLoaderTestsResource.txt
+++ b/spring-boot-project/spring-boot-test/src/test/resources/org/springframework/boot/test/context/FilteredClassLoaderTestsResource.txt
@@ -1,0 +1,1 @@
+Used by FilteredClassLoaderTests.java


### PR DESCRIPTION
Hi! Based on a brief discussion on Gitter with @snicoll I've added support for filtering resources in 
`FilteredClassLoader`. This can be used when testing things like `@ConditionalOnResource`.

The current class is a bit tricky to augment since it relies on varargs lists of `Predicate<String>`. This is why I've chosen to follow the same approach and allow filtering `ClassPathResources`, but this means it's not possible to filter both classes *and* resources simultaneously. If this is desired the loader should probably be refactored to use a builder or something, but I didn't want to make this a breaking change.

I've based the pull request on the `2.0.x` branch because the `master` branch doesn't build right now.
