### PR TITLE
Customize compression only when it is enabled

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -211,7 +211,7 @@ public class ServerProperties
 		if (getJspServlet() != null) {
 			container.setJspServlet(getJspServlet());
 		}
-		if (getCompression() != null) {
+		if (getCompression() != null && getCompression().getEnabled()) {
 			container.setCompression(getCompression());
 		}
 		container.setServerHeader(getServerHeader());

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -92,6 +92,7 @@ import org.springframework.util.StringUtils;
  * @author Quinten De Swaef
  * @author Venil Noronha
  * @author Aurélien Leboulanger
+ * @author Wenjie Zhang
  */
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = true)
 public class ServerProperties

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -57,6 +57,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.boot.bind.RelaxedDataBinder;
 import org.springframework.boot.context.embedded.AbstractEmbeddedServletContainerFactory;
+import org.springframework.boot.context.embedded.Compression;
 import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
 import org.springframework.boot.context.embedded.EmbeddedServletContainer;
 import org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainer;
@@ -76,6 +77,8 @@ import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -763,6 +766,30 @@ public class ServerPropertiesTests {
 		StandardContext context = (StandardContext) tomcat.getHost().findChildren()[0];
 		assertThat(context.getUseHttpOnly()).isFalse();
 		container.stop();
+	}
+	
+	@Test
+	public void customTomcatCompressionProgramtically() throws Exception {
+		Compression mockCompression = mock(Compression.class);
+		
+		TomcatEmbeddedServletContainerFactory factory = new TomcatEmbeddedServletContainerFactory();
+		factory.setCompression(mockCompression);
+		this.properties.customize(factory);
+		assertEquals(mockCompression, factory.getCompression());
+	}
+	
+	@Test
+	public void customTomcatCompressionWithServerProperties() throws Exception {
+
+		Map<String, String> map = new HashMap<String, String>();
+		map.put("server.compression.enable", "true");
+		bindProperties(map);
+		Compression mockCompression = mock(Compression.class);
+		
+		TomcatEmbeddedServletContainerFactory factory = new TomcatEmbeddedServletContainerFactory();
+		factory.setCompression(mockCompression);
+		this.properties.customize(factory);
+		assertNotEquals(mockCompression, factory.getCompression());
 	}
 
 	@Test


### PR DESCRIPTION
When the user defines the compression strategy in EmbeddedServletContainerFactory, the compression strategy should only be overridden when there is any enabled compression configuration in the application.properties

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
