### PR TITLE
Add Log Output when DevTools restart is disabled

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/RestartApplicationListener.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/RestartApplicationListener.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.devtools.restart;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.boot.context.event.ApplicationFailedEvent;
 import org.springframework.boot.context.event.ApplicationPreparedEvent;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -35,9 +38,11 @@ import org.springframework.core.Ordered;
 public class RestartApplicationListener
 		implements ApplicationListener<ApplicationEvent>, Ordered {
 
-	private int order = HIGHEST_PRECEDENCE;
-
 	private static final String ENABLED_PROPERTY = "spring.devtools.restart.enabled";
+
+	private static final Log logger = LogFactory.getLog(RestartApplicationListener.class);
+
+	private int order = HIGHEST_PRECEDENCE;
 
 	@Override
 	public void onApplicationEvent(ApplicationEvent event) {
@@ -63,10 +68,17 @@ public class RestartApplicationListener
 		if (enabled == null || Boolean.parseBoolean(enabled)) {
 			String[] args = event.getArgs();
 			DefaultRestartInitializer initializer = new DefaultRestartInitializer();
-			boolean restartOnInitialize = !AgentReloader.isActive();
+			boolean restartOnInitialize = true;
+			if (AgentReloader.isActive()) {
+				logger.info(
+						"Restart disabled due to an agent-based reloader being active");
+				restartOnInitialize = false;
+			}
 			Restarter.initialize(args, false, initializer, restartOnInitialize);
 		}
 		else {
+			logger.info("Restart disabled due to System property '" + ENABLED_PROPERTY
+					+ "' set to false");
 			Restarter.disable();
 		}
 	}


### PR DESCRIPTION
This covers the cases when:
* An Java agent based reloader (e.g. JRebel) is being used
* The reloader was disabled by using a system property

See gh-14492

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
