### PR TITLE
Make tags providers extend TagsProvider

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/client/RestTemplateExchangeTagsProvider.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/client/RestTemplateExchangeTagsProvider.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.actuate.metrics.web.client;
 
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.TagsProvider;
 
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
@@ -30,7 +31,7 @@ import org.springframework.web.client.RestTemplate;
  * @since 2.0.0
  */
 @FunctionalInterface
-public interface RestTemplateExchangeTagsProvider {
+public interface RestTemplateExchangeTagsProvider extends TagsProvider {
 
 	/**
 	 * Provides the tags to be associated with metrics that are recorded for the given

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/client/WebClientExchangeTagsProvider.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/client/WebClientExchangeTagsProvider.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.actuate.metrics.web.reactive.client;
 
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.TagsProvider;
 
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
@@ -29,7 +30,7 @@ import org.springframework.web.reactive.function.client.ClientResponse;
  * @since 2.1.0
  */
 @FunctionalInterface
-public interface WebClientExchangeTagsProvider {
+public interface WebClientExchangeTagsProvider extends TagsProvider {
 
 	/**
 	 * Provide tags to be associated with metrics for the client exchange.

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTagsProvider.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTagsProvider.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.actuate.metrics.web.reactive.server;
 
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.TagsProvider;
 
 import org.springframework.web.server.ServerWebExchange;
 
@@ -28,7 +29,7 @@ import org.springframework.web.server.ServerWebExchange;
  * @since 2.0.0
  */
 @FunctionalInterface
-public interface WebFluxTagsProvider {
+public interface WebFluxTagsProvider extends TagsProvider {
 
 	/**
 	 * Provides tags to be associated with metrics for the given {@code exchange}.

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcTagsProvider.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcTagsProvider.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.TagsProvider;
 
 /**
  * Provides {@link Tag Tags} for Spring MVC-based request handling.
@@ -29,7 +30,7 @@ import io.micrometer.core.instrument.Tag;
  * @author Andy Wilkinson
  * @since 2.0.0
  */
-public interface WebMvcTagsProvider {
+public interface WebMvcTagsProvider extends TagsProvider {
 
 	/**
 	 * Provides tags to be associated with metrics for the given {@code request} and


### PR DESCRIPTION
This PR makes tags providers extend `TagsProvider`.

See https://github.com/micrometer-metrics/micrometer/issues/542

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
