### PR TITLE
Thymeleaf 3.0.10 configuration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
@@ -198,6 +198,8 @@ public class ThymeleafAutoConfiguration {
 				resolver.setContentType(
 						appendCharset(this.properties.getServlet().getContentType(),
 								resolver.getCharacterEncoding()));
+				resolver.setProducePartialOutputWhileProcessing(
+						this.properties.getServlet().isProducePartialOutputWhileProcessing());
 				resolver.setExcludedViewNames(this.properties.getExcludedViewNames());
 				resolver.setViewNames(this.properties.getViewNames());
 				// This resolver acts as a fallback resolver (e.g. like a

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
@@ -154,6 +154,8 @@ public class ThymeleafAutoConfiguration {
 		public SpringTemplateEngine templateEngine() {
 			SpringTemplateEngine engine = new SpringTemplateEngine();
 			engine.setEnableSpringELCompiler(this.properties.isEnableSpringElCompiler());
+			engine.setRenderHiddenMarkersBeforeCheckboxes(
+					this.properties.isRenderHiddenMarkersBeforeCheckboxes());
 			this.templateResolvers.forEach(engine::addTemplateResolver);
 			this.dialects.orderedStream().forEach(engine::addDialect);
 			return engine;
@@ -247,6 +249,8 @@ public class ThymeleafAutoConfiguration {
 		public SpringWebFluxTemplateEngine templateEngine() {
 			SpringWebFluxTemplateEngine engine = new SpringWebFluxTemplateEngine();
 			engine.setEnableSpringELCompiler(this.properties.isEnableSpringElCompiler());
+			engine.setRenderHiddenMarkersBeforeCheckboxes(
+					this.properties.isRenderHiddenMarkersBeforeCheckboxes());
 			this.templateResolvers.forEach(engine::addTemplateResolver);
 			this.dialects.orderedStream().forEach(engine::addDialect);
 			return engine;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafProperties.java
@@ -102,6 +102,14 @@ public class ThymeleafProperties {
 	private boolean enableSpringElCompiler;
 
 	/**
+	 * Whether hidden form inputs acting as markers for checkboxes (which are
+	 * omitted from form submission when unchecked) should be rendered before or after
+	 * the rendered checkbox element itself for better integration with some CSS
+	 * frameworks. Default is "false" (hiddens will be rendered after checkboxes).
+	 */
+	private boolean renderHiddenMarkersBeforeCheckboxes;
+
+	/**
 	 * Whether to enable Thymeleaf view resolution for Web frameworks.
 	 */
 	private boolean enabled = true;
@@ -204,6 +212,14 @@ public class ThymeleafProperties {
 
 	public void setEnableSpringElCompiler(boolean enableSpringElCompiler) {
 		this.enableSpringElCompiler = enableSpringElCompiler;
+	}
+
+	public boolean isRenderHiddenMarkersBeforeCheckboxes() {
+		return renderHiddenMarkersBeforeCheckboxes;
+	}
+
+	public void setRenderHiddenMarkersBeforeCheckboxes(boolean renderHiddenMarkersBeforeCheckboxes) {
+		this.renderHiddenMarkersBeforeCheckboxes = renderHiddenMarkersBeforeCheckboxes;
 	}
 
 	public Reactive getReactive() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafProperties.java
@@ -221,6 +221,14 @@ public class ThymeleafProperties {
 		 */
 		private MimeType contentType = MimeType.valueOf("text/html");
 
+		/**
+		 * Whether Thymeleaf should start sending partial output to the server's output
+		 * buffers as soon as it becomes available (default), or instead wait until
+		 * template processing is finished, keeping all rendered results in memory until
+		 * that moment and sending them to the server's output buffers in a single call.
+		 */
+		private boolean producePartialOutputWhileProcessing = true;
+
 		public MimeType getContentType() {
 			return this.contentType;
 		}
@@ -229,6 +237,13 @@ public class ThymeleafProperties {
 			this.contentType = contentType;
 		}
 
+		public boolean isProducePartialOutputWhileProcessing() {
+			return producePartialOutputWhileProcessing;
+		}
+
+		public void setProducePartialOutputWhileProcessing(boolean producePartialOutputWhileProcessing) {
+			this.producePartialOutputWhileProcessing = producePartialOutputWhileProcessing;
+		}
 	}
 
 	public static class Reactive {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafReactiveAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafReactiveAutoConfigurationTests.java
@@ -163,6 +163,20 @@ public class ThymeleafReactiveAutoConfigurationTests {
 	}
 
 	@Test
+	public void overrideRenderHiddenMarkersBeforeCheckboxes() {
+		load(BaseConfiguration.class, "spring.thymeleaf.render-hidden-markers-before-checkboxes:true");
+		assertThat(this.context.getBean(SpringWebFluxTemplateEngine.class)
+				.getRenderHiddenMarkersBeforeCheckboxes()).isTrue();
+	}
+
+	@Test
+	public void enableRenderHiddenMarkersBeforeCheckboxesIsDisabledByDefault() {
+		load(BaseConfiguration.class);
+		assertThat(this.context.getBean(SpringWebFluxTemplateEngine.class)
+				.getRenderHiddenMarkersBeforeCheckboxes()).isFalse();
+	}
+
+	@Test
 	public void templateLocationDoesNotExist() {
 		load(BaseConfiguration.class,
 				"spring.thymeleaf.prefix:classpath:/no-such-directory/");

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafServletAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafServletAutoConfigurationTests.java
@@ -108,6 +108,20 @@ public class ThymeleafServletAutoConfigurationTests {
 	}
 
 	@Test
+	public void overrideDisableProducePartialOutputWhileProcessing() {
+		load(BaseConfiguration.class, "spring.thymeleaf.servlet.produce-partial-output-while-processing:false");
+		assertThat(this.context.getBean(ThymeleafViewResolver.class)
+				.getProducePartialOutputWhileProcessing()).isFalse();
+	}
+
+	@Test
+	public void disableProducePartialOutputWhileProcessingIsEnabledByDefault() {
+		load(BaseConfiguration.class);
+		assertThat(this.context.getBean(ThymeleafViewResolver.class)
+				.getProducePartialOutputWhileProcessing()).isTrue();
+	}
+
+	@Test
 	public void overrideTemplateResolverOrder() {
 		load(BaseConfiguration.class, "spring.thymeleaf.templateResolverOrder:25");
 		ITemplateResolver resolver = this.context.getBean(ITemplateResolver.class);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafServletAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafServletAutoConfigurationTests.java
@@ -150,6 +150,20 @@ public class ThymeleafServletAutoConfigurationTests {
 	}
 
 	@Test
+	public void overrideRenderHiddenMarkersBeforeCheckboxes() {
+		load(BaseConfiguration.class, "spring.thymeleaf.render-hidden-markers-before-checkboxes:true");
+		assertThat(this.context.getBean(SpringTemplateEngine.class)
+				.getRenderHiddenMarkersBeforeCheckboxes()).isTrue();
+	}
+
+	@Test
+	public void enableRenderHiddenMarkersBeforeCheckboxesIsDisabledByDefault() {
+		load(BaseConfiguration.class);
+		assertThat(this.context.getBean(SpringTemplateEngine.class)
+				.getRenderHiddenMarkersBeforeCheckboxes()).isFalse();
+	}
+
+	@Test
 	public void templateLocationDoesNotExist() {
 		load(BaseConfiguration.class,
 				"spring.thymeleaf.prefix:classpath:/no-such-directory/");


### PR DESCRIPTION
Thymeleaf 3.0.10 added two new configuration parameters that could be configured in Spring Boot:

   * `spring.thymeleaf.render-hidden-markers-before-checkboxes` will determine whether the hidden elements rendered in forms to mark checkboxes should be rendered before or after (default) the checkbox elements themselves. This is for better integration with some CSS frameworks.
   * `spring.thymeleaf.servlet.produce-partial-output-while-processing` (only for Spring MVC environments) will determine whether partial output should be sent to the server's output buffers as soon as it becomes available (default) or instead the engine should wait until the whole template is processed, keeping results in memory until processing is finished, and then send everything to the output buffers in one call.

This PR adds support for configuring both new flags, and their corresponding test cases.