### PR TITLE
Add Ordered to SharedMetadataReaderFactoryContextInitializer

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/SharedMetadataReaderFactoryContextInitializer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/SharedMetadataReaderFactoryContextInitializer.java
@@ -46,8 +46,8 @@ import org.springframework.core.type.classreading.MetadataReaderFactory;
  * @author Phillip Webb
  * @since 1.4.0
  */
-class SharedMetadataReaderFactoryContextInitializer
-		implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+class SharedMetadataReaderFactoryContextInitializer implements
+		ApplicationContextInitializer<ConfigurableApplicationContext>, Ordered {
 
 	public static final String BEAN_NAME = "org.springframework.boot.autoconfigure."
 			+ "internalCachingMetadataReaderFactory";
@@ -56,6 +56,12 @@ class SharedMetadataReaderFactoryContextInitializer
 	public void initialize(ConfigurableApplicationContext applicationContext) {
 		applicationContext.addBeanFactoryPostProcessor(
 				new CachingMetadataReaderFactoryPostProcessor());
+	}
+
+	@Override
+	public int getOrder() {
+		// Should happen before other BeanDefinitionRegistryPostProcessors are added
+		return 0;
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/BeanTypeRegistry.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/BeanTypeRegistry.java
@@ -98,7 +98,7 @@ final class BeanTypeRegistry implements SmartInitializingSingleton {
 					.genericBeanDefinition(BeanTypeRegistry.class,
 							() -> new BeanTypeRegistry(
 									(DefaultListableBeanFactory) beanFactory))
-					.getBeanDefinition();
+					.setRole(BeanDefinition.ROLE_INFRASTRUCTURE).getBeanDefinition();
 			listableBeanFactory.registerBeanDefinition(BEAN_NAME, bd);
 
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/SharedMetadataReaderFactoryContextInitializerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/SharedMetadataReaderFactoryContextInitializerTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class SharedMetadataReaderFactoryContextInitializerTests {
+
+	@Test
+	public void checkOrderOfInitializer() {
+		SpringApplication application = new SpringApplication(TestConfig.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+		@SuppressWarnings("unchecked")
+		List<ApplicationContextInitializer<?>> initializers = (List<ApplicationContextInitializer<?>>) ReflectionTestUtils
+				.getField(application, "initializers");
+		// Simulate what would happen if an initializer was added using spring.factories
+		// and happened to be loaded first
+		initializers.add(0, new Initializer());
+		GenericApplicationContext context = (GenericApplicationContext) application.run();
+		BeanDefinition definition = context.getBeanDefinition(
+				SharedMetadataReaderFactoryContextInitializer.BEAN_NAME);
+		assertThat(definition.getAttribute("seen")).isEqualTo(true);
+	}
+
+	protected static class TestConfig {
+
+	}
+
+	static class Initializer
+			implements ApplicationContextInitializer<GenericApplicationContext> {
+
+		@Override
+		public void initialize(GenericApplicationContext applicationContext) {
+			applicationContext.addBeanFactoryPostProcessor(new PostProcessor());
+		}
+
+	}
+
+	static class PostProcessor implements BeanDefinitionRegistryPostProcessor {
+
+		@Override
+		public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory)
+				throws BeansException {
+		}
+
+		@Override
+		public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry)
+				throws BeansException {
+			for (String name : registry.getBeanDefinitionNames()) {
+				BeanDefinition definition = registry.getBeanDefinition(name);
+				definition.setAttribute("seen", true);
+			}
+		}
+
+	}
+
+}


### PR DESCRIPTION
An initializer that adds a BeanDefinitionRegistryPostProcessor which
in turn adds bean definitions has to be very careful to run early
(so at the very least implementing `Ordered`). Otherwise other
initializers that want to influence the bean definitions added never
get a chance.