### PR TITLE
Use Errors.hasErrors() in DefaultErrorAttributes

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributes.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributes.java
@@ -141,7 +141,7 @@ public class DefaultErrorAttributes implements ErrorAttributes {
 		}
 		if (error instanceof BindingResult) {
 			BindingResult result = (BindingResult) error;
-			if (result.getErrorCount() > 0) {
+			if (result.hasErrors()) {
 				errorAttributes.put("errors", result.getAllErrors());
 			}
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/error/DefaultErrorAttributes.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/error/DefaultErrorAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,7 +159,7 @@ public class DefaultErrorAttributes
 			errorAttributes.put("message", error.getMessage());
 			return;
 		}
-		if (result.getErrorCount() > 0) {
+		if (result.hasErrors()) {
 			errorAttributes.put("errors", result.getAllErrors());
 			errorAttributes.put("message",
 					"Validation failed for object='" + result.getObjectName()


### PR DESCRIPTION
Hi,

this PR replaces occurences of `result.getErrorCount() > 0` with `result.hasErrors()` where applicable.

Cheers,
Christoph