### PR TITLE
Fix parameters handling on a restart of a Spring Batch job

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
@@ -56,6 +56,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Eddú Meléndez
  * @author Kazuki Shimizu
+ * @author Mahmoud Ben Hassine
  */
 @Configuration
 @ConditionalOnClass({ JobLauncher.class, DataSource.class, JdbcOperations.class })
@@ -88,9 +89,10 @@ public class BatchAutoConfiguration {
 	@ConditionalOnMissingBean
 	@ConditionalOnProperty(prefix = "spring.batch.job", name = "enabled", havingValue = "true", matchIfMissing = true)
 	public JobLauncherCommandLineRunner jobLauncherCommandLineRunner(
-			JobLauncher jobLauncher, JobExplorer jobExplorer) {
+			JobLauncher jobLauncher, JobExplorer jobExplorer,
+			JobRepository jobRepository) {
 		JobLauncherCommandLineRunner runner = new JobLauncherCommandLineRunner(
-				jobLauncher, jobExplorer);
+				jobLauncher, jobExplorer, jobRepository);
 		String jobNames = this.properties.getJob().getNames();
 		if (StringUtils.hasText(jobNames)) {
 			runner.setJobNames(jobNames);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/JobLauncherCommandLineRunnerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/JobLauncherCommandLineRunnerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.Step;
@@ -34,6 +36,7 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.launch.support.SimpleJobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.JobRestartException;
 import org.springframework.batch.core.repository.support.MapJobRepositoryFactoryBean;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
@@ -43,12 +46,14 @@ import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Tests for {@link JobLauncherCommandLineRunner}.
  *
  * @author Dave Syer
  * @author Jean-Pierre Bergamin
+ * @author Mahmoud Ben Hassine
  */
 public class JobLauncherCommandLineRunnerTests {
 
@@ -80,7 +85,8 @@ public class JobLauncherCommandLineRunnerTests {
 		this.step = this.steps.get("step").tasklet(tasklet).build();
 		this.job = this.jobs.get("job").start(this.step).build();
 		this.jobExplorer = this.context.getBean(JobExplorer.class);
-		this.runner = new JobLauncherCommandLineRunner(jobLauncher, this.jobExplorer);
+		this.runner = new JobLauncherCommandLineRunner(jobLauncher, this.jobExplorer,
+				jobRepository);
 		this.context.getBean(BatchConfiguration.class).clear();
 	}
 
@@ -113,8 +119,25 @@ public class JobLauncherCommandLineRunnerTests {
 				.start(this.steps.get("step").tasklet(throwingTasklet()).build())
 				.incrementer(new RunIdIncrementer()).build();
 		this.runner.execute(this.job, new JobParameters());
-		this.runner.execute(this.job, new JobParameters());
+		this.runner.execute(this.job,
+				new JobParametersBuilder().addLong("run.id", 1L).toJobParameters());
 		assertThat(this.jobExplorer.getJobInstances("job", 0, 100)).hasSize(1);
+	}
+
+	@Test
+	public void runDifferentInstances() throws Exception {
+		this.job = this.jobs.get("job")
+				.start(this.steps.get("step").tasklet(throwingTasklet()).build()).build();
+		// start a job instance
+		JobParameters jobParameters = new JobParametersBuilder().addString("name", "foo")
+				.toJobParameters();
+		this.runner.execute(this.job, jobParameters);
+		assertThat(this.jobExplorer.getJobInstances("job", 0, 100)).hasSize(1);
+		// start a different job instance
+		JobParameters otherJobParameters = new JobParametersBuilder()
+				.addString("name", "bar").toJobParameters();
+		this.runner.execute(this.job, otherJobParameters);
+		assertThat(this.jobExplorer.getJobInstances("job", 0, 100)).hasSize(2);
 	}
 
 	@Test
@@ -127,6 +150,17 @@ public class JobLauncherCommandLineRunnerTests {
 		// A failed job that is not restartable does not re-use the job params of
 		// the last execution, but creates a new job instance when running it again.
 		assertThat(this.jobExplorer.getJobInstances("job", 0, 100)).hasSize(2);
+		try {
+			// try to re-run a failed execution
+			this.runner.execute(this.job,
+					new JobParametersBuilder().addLong("run.id", 1L).toJobParameters());
+			fail("expected JobRestartException");
+		}
+		catch (JobRestartException ex) {
+			assertThat(ex.getMessage())
+					.isEqualTo("JobInstance already exists and is not restartable");
+			// expected
+		}
 	}
 
 	@Test
@@ -137,8 +171,43 @@ public class JobLauncherCommandLineRunnerTests {
 		JobParameters jobParameters = new JobParametersBuilder().addLong("id", 1L, false)
 				.addLong("foo", 2L, false).toJobParameters();
 		this.runner.execute(this.job, jobParameters);
+		assertThat(this.jobExplorer.getJobInstances("job", 0, 100)).hasSize(1);
+		// try to re-run a failed execution with non identifying parameters
+		this.runner.execute(this.job, new JobParametersBuilder(jobParameters)
+				.addLong("run.id", 1L).toJobParameters());
+		assertThat(this.jobExplorer.getJobInstances("job", 0, 100)).hasSize(1);
+	}
+
+	@Test
+	public void retryFailedExecutionWithDifferentNonIdentifyingParametersFromPreviousExecution()
+			throws Exception {
+		this.job = this.jobs.get("job")
+				.start(this.steps.get("step").tasklet(throwingTasklet()).build())
+				.incrementer(new RunIdIncrementer()).build();
+		JobParameters jobParameters = new JobParametersBuilder().addLong("id", 1L, false)
+				.addLong("foo", 2L, false).toJobParameters();
 		this.runner.execute(this.job, jobParameters);
 		assertThat(this.jobExplorer.getJobInstances("job", 0, 100)).hasSize(1);
+		// try to re-run a failed execution with non identifying parameters
+		this.runner.execute(this.job, new JobParametersBuilder().addLong("run.id", 1L)
+				.addLong("id", 2L, false).addLong("foo", 3L, false).toJobParameters());
+		assertThat(this.jobExplorer.getJobInstances("job", 0, 100)).hasSize(1);
+		JobInstance jobInstance = this.jobExplorer.getJobInstance(0L);
+		assertThat(this.jobExplorer.getJobExecutions(jobInstance)).hasSize(2);
+		// first execution
+		JobExecution firstJobExecution = this.jobExplorer.getJobExecution(0L);
+		JobParameters parameters = firstJobExecution.getJobParameters();
+		assertThat(parameters.getLong("run.id")).isEqualTo(1L);
+		assertThat(parameters.getLong("id")).isEqualTo(1L);
+		assertThat(parameters.getLong("foo")).isEqualTo(2L);
+		// second execution
+		JobExecution secondJobExecution = this.jobExplorer.getJobExecution(1L);
+		parameters = secondJobExecution.getJobParameters();
+		// identifying parameters should be the same as previous execution
+		assertThat(parameters.getLong("run.id")).isEqualTo(1L);
+		// non-identifying parameters should be the newly specified ones
+		assertThat(parameters.getLong("id")).isEqualTo(2L);
+		assertThat(parameters.getLong("foo")).isEqualTo(3L);
 	}
 
 	private Tasklet throwingTasklet() {


### PR DESCRIPTION
This PR resolves gh-14484.

Before this commit, Spring Boot was calling the `JobParametersBuilder#getNextJobParameters`
method from batch. This method was getting the previous parameters of the wrong job instance in a restart scenario.

This commit fixes the issue by first getting the right job instance with the provided parameters, then restarting it if necessary.

To correctly fix the issue reported in gh-14484, a fix needs to be applied on both sides (batch and boot). This PR is coupled with the one opened against batch: https://github.com/spring-projects/spring-batch/pull/660.