### PR TITLE
Avoid unwanted logging by making auto-configured applicationTaskExecutor bean lazy

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/task/TaskExecutionAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/task/TaskExecutionAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.task.TaskExecutorBuilder;
 import org.springframework.boot.task.TaskExecutorCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.task.TaskDecorator;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -77,6 +78,7 @@ public class TaskExecutionAutoConfiguration {
 		return builder;
 	}
 
+	@Lazy
 	@Bean(name = APPLICATION_TASK_EXECUTOR_BEAN_NAME)
 	@ConditionalOnMissingBean(Executor.class)
 	public ThreadPoolTaskExecutor applicationTaskExecutor(TaskExecutorBuilder builder) {


### PR DESCRIPTION
this [enhancement](https://github.com/spring-projects/spring-boot/issues/14904) 