### PR TITLE
Use message source in Web UI sample

### DIFF
--- a/spring-boot-samples/spring-boot-sample-web-ui/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-web-ui/pom.xml
@@ -24,6 +24,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+		</dependency>
 		<!-- Test -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-boot-samples/spring-boot-sample-web-ui/src/main/java/sample/web/ui/mvc/MessageController.java
+++ b/spring-boot-samples/spring-boot-sample-web-ui/src/main/java/sample/web/ui/mvc/MessageController.java
@@ -64,7 +64,7 @@ public class MessageController {
 			return new ModelAndView("messages/form", "formErrors", result.getAllErrors());
 		}
 		message = this.messageRepository.save(message);
-		redirect.addFlashAttribute("globalMessage", "Successfully created a new message");
+		redirect.addFlashAttribute("globalMessage", "view.success");
 		return new ModelAndView("redirect:/{message.id}", "message.id", message.getId());
 	}
 

--- a/spring-boot-samples/spring-boot-sample-web-ui/src/main/resources/messages.properties
+++ b/spring-boot-samples/spring-boot-sample-web-ui/src/main/resources/messages.properties
@@ -1,0 +1,21 @@
+form.message=Message
+form.messages=Messages
+form.submit=Submit
+form.summary=Summary
+form.title=Messages : Create
+
+list.create=Create Message
+list.table.created=Created
+list.table.empty=No messages
+list.table.id=Id
+list.table.summary=Summary
+list.title=Messages : View all
+
+navbar.messages=Messages
+navbar.thymeleaf=Thymeleaf
+
+view.delete=delete
+view.messages=Messages
+view.modify=modify
+view.success=Successfully created a new message
+view.title=Messages : View

--- a/spring-boot-samples/spring-boot-sample-web-ui/src/main/resources/templates/fragments.html
+++ b/spring-boot-samples/spring-boot-sample-web-ui/src/main/resources/templates/fragments.html
@@ -8,9 +8,9 @@
 	<body>
 		<div class="container">
 			<nav th:fragment="navbar" class="navbar navbar-dark bg-primary">
-				<a class="navbar-brand" href="http://thymeleaf.org">Thymeleaf</a>
+				<a class="navbar-brand" href="http://thymeleaf.org" th:text="#{navbar.thymeleaf}">Thymeleaf</a>
 				<ul class="navbar-nav mr-auto mt-2 mt-lg-0">
-					<li class="nav-item"><a class="nav-link" th:href="@{/}" href="messages.html">Messages</a></li>
+					<li class="nav-item"><a class="nav-link" th:href="@{/}" href="messages.html" th:text="#{navbar.messages}">Messages</a></li>
 				</ul>
 			</nav>
 		</div>

--- a/spring-boot-samples/spring-boot-sample-web-ui/src/main/resources/templates/messages/form.html
+++ b/spring-boot-samples/spring-boot-sample-web-ui/src/main/resources/templates/messages/form.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 	<head th:replace="fragments :: head(title=~{::title/text()})">
-		<title>Messages : Create</title>
+		<title th:text="#{form.title}">Messages : Create</title>
 	</head>
 	<body>
 		<div class="container">
 			<div th:replace="fragments :: navbar"></div>
 			<div class="float-right mt-2">
-				<a class="btn btn-primary btn-sm" th:href="@{/}" href="messages.html"> Messages </a>
+				<a class="btn btn-primary btn-sm" th:href="@{/}" href="messages.html" th:text="#{form.messages}"> Messages </a>
 			</div>
-			<h4 class="float-left mt-2">Messages : Create</h4>
+			<h4 class="float-left mt-2" th:text="#{form.title}">Messages : Create</h4>
 			<div class="clearfix"></div>
 			<form id="messageForm" th:action="@{/(form)}" th:object="${message}" action="#" method="post">
 				<div th:if="${#fields.hasErrors('*')}" class="alert alert-danger" role="alert">
@@ -17,14 +17,14 @@
 				</div>
 				<input type="hidden" th:field="*{id}" th:class="${'form-control' + (#fields.hasErrors('id') ? ' is-invalid' : '')}"/>
 				<div class="form-group">
-					<label for="summary">Summary</label>
+					<label for="summary" th:text="#{form.summary}">Summary</label>
 					<input type="text" th:field="*{summary}" th:class="${'form-control' + (#fields.hasErrors('summary') ? ' is-invalid' : '')}">
 				</div>
 				<div class="form-group">
-					<label for="text">Message</label>
+					<label for="text" th:text="#{form.message}">Message</label>
 					<textarea th:field="*{text}" th:class="${'form-control' + (#fields.hasErrors('text') ? ' is-invalid' : '')}"></textarea>
 				</div>
-				<button type="submit" class="btn btn-primary">Submit</button>
+				<button type="submit" class="btn btn-primary" th:text="#{form.submit}">Submit</button>
 			</form>
 		</div>
 	</body>

--- a/spring-boot-samples/spring-boot-sample-web-ui/src/main/resources/templates/messages/list.html
+++ b/spring-boot-samples/spring-boot-sample-web-ui/src/main/resources/templates/messages/list.html
@@ -1,26 +1,26 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 	<head th:replace="fragments :: head(title=~{::title/text()})">
-		<title>Messages : View all</title>
+		<title th:text="#{list.title}">Messages : View all</title>
 	</head>
 	<body>
 		<div class="container">
 			<div th:replace="fragments :: navbar"></div>
 			<div class="float-right mt-2">
-				<a class="btn btn-primary btn-sm" href="form.html" th:href="@{/(form)}">Create Message</a>
+				<a class="btn btn-primary btn-sm" href="form.html" th:href="@{/(form)}" th:text="#{list.create}">Create Message</a>
 			</div>
-			<h4 class="float-left mt-2">Messages : View all</h4>
+			<h4 class="float-left mt-2" th:text="#{list.title}">Messages : View all</h4>
 			<table class="table table-bordered table-striped">
 				<thead>
 					<tr>
-						<th>ID</th>
-						<th>Created</th>
-						<th>Summary</th>
+						<th th:text="#{list.table.id}">ID</th>
+						<th th:text="#{list.table.created}">Created</th>
+						<th th:text="#{list.table.summary}">Summary</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr th:if="${messages.empty}">
-						<td colspan="3">No messages</td>
+						<td colspan="3" th:text="#{list.table.empty}">No messages</td>
 					</tr>
 					<tr th:each="message : ${messages}">
 						<td th:text="${message.id}">1</td>

--- a/spring-boot-samples/spring-boot-sample-web-ui/src/main/resources/templates/messages/view.html
+++ b/spring-boot-samples/spring-boot-sample-web-ui/src/main/resources/templates/messages/view.html
@@ -1,25 +1,25 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 	<head th:replace="fragments :: head(title=~{::title/text()})">
-		<title>Messages : View</title>
+		<title th:text="#{view.title}">Messages : View</title>
 	</head>
 	<body>
 		<div class="container">
 			<div th:replace="fragments :: navbar"></div>
 			<div class="float-right mt-2">
-				<a class="btn btn-primary btn-sm" href="list.html" th:href="@{/}">Messages</a>
+				<a class="btn btn-primary btn-sm" href="list.html" th:href="@{/}" th:text="#{view.messages}">Messages</a>
 			</div>
-			<h4 class="float-left mt-2">Messages : View</h4>
+			<h4 class="float-left mt-2" th:text="#{view.title}">Messages : View</h4>
 			<div class="clearfix"></div>
-			<div class="alert alert-success" th:if="${globalMessage}" th:text="${globalMessage}">Some Success message
+			<div class="alert alert-success" th:if="${globalMessage}" th:text="#{${globalMessage}}">Some Success message
 			</div>
 			<div class="card">
 				<div class="card-body">
 					<h4 class="card-title" th:text="${message.id + ': ' + message.summary}">123 - A short summary...</h4>
 					<h6 class="card-subtitle mb-2 text-muted" th:text="${#calendars.format(message.created)}">July 11, 2012 2:17:16 PM CDT</h6>
 					<p class="card-text" th:text="${message.text}">A detailed message that is longer than the summary.</p>
-					<a class="card-link" href="messages" th:href="@{'/delete/' + ${message.id}}">delete</a>
-					<a class="card-link" href="form.html" th:href="@{'/modify/' + ${message.id}}"> modify</a>
+					<a class="card-link" href="messages" th:href="@{'/delete/' + ${message.id}}" th:text="#{view.delete}">delete</a>
+					<a class="card-link" href="form.html" th:href="@{'/modify/' + ${message.id}}" th:text="#{view.modify}"> modify</a>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
This makes it possible to reproduce #14882 using a sample app.

I also haven't found any of the sample apps to be using message source, and found `spring-boot-sample-web-ui` to be most fitting for such thing.