### PR TITLE
Take aliases into consideration when checking  descendants

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/AliasedConfigurationPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/AliasedConfigurationPropertySource.java
@@ -62,7 +62,7 @@ class AliasedConfigurationPropertySource implements ConfigurationPropertySource 
 		}
 		Set<ConfigurationPropertyName> aliasNames = getAliases().getAllNames();
 		for (ConfigurationPropertyName configurationPropertyName : aliasNames) {
-			boolean descendantPresentInAlias = aliases
+			boolean descendantPresentInAlias = this.aliases
 					.getAliases(configurationPropertyName).stream()
 					.filter(name::isAncestorOf).findFirst().isPresent();
 			if (descendantPresentInAlias) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/AliasedConfigurationPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/AliasedConfigurationPropertySource.java
@@ -60,7 +60,7 @@ class AliasedConfigurationPropertySource implements ConfigurationPropertySource 
 		if (result != ConfigurationPropertyState.ABSENT) {
 			return result;
 		}
-		Set<ConfigurationPropertyName> aliasNames = getAliases().getAllNames();
+		Set<ConfigurationPropertyName> aliasNames = this.aliases.getAllNames();
 		for (ConfigurationPropertyName configurationPropertyName : aliasNames) {
 			boolean descendantPresentInAlias = this.aliases
 					.getAliases(configurationPropertyName).stream()

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/AliasedConfigurationPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/AliasedConfigurationPropertySource.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.context.properties.source;
 
+import java.util.Set;
+
 import org.springframework.util.Assert;
 
 /**
@@ -58,11 +60,17 @@ class AliasedConfigurationPropertySource implements ConfigurationPropertySource 
 		if (result != ConfigurationPropertyState.ABSENT) {
 			return result;
 		}
-		for (ConfigurationPropertyName alias : getAliases().getAliases(name)) {
-			ConfigurationPropertyState aliasResult = this.source
-					.containsDescendantOf(alias);
-			if (aliasResult != ConfigurationPropertyState.ABSENT) {
-				return aliasResult;
+		Set<ConfigurationPropertyName> aliasNames = getAliases().getAllNames();
+		for (ConfigurationPropertyName configurationPropertyName : aliasNames) {
+			boolean descendantPresentInAlias = aliases
+					.getAliases(configurationPropertyName).stream()
+					.filter(name::isAncestorOf).findFirst().isPresent();
+			if (descendantPresentInAlias) {
+				ConfigurationProperty configurationProperty = this.getSource()
+						.getConfigurationProperty(configurationPropertyName);
+				if (configurationProperty != null) {
+					return ConfigurationPropertyState.PRESENT;
+				}
 			}
 		}
 		return ConfigurationPropertyState.ABSENT;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyNameAliases.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyNameAliases.java
@@ -76,7 +76,7 @@ public final class ConfigurationPropertyNameAliases {
 	}
 
 	public Set<ConfigurationPropertyName> getAllNames() {
-		return aliases.keySet();
+		return this.aliases.keySet();
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyNameAliases.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyNameAliases.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
@@ -72,6 +73,10 @@ public final class ConfigurationPropertyNameAliases {
 		return this.aliases.entrySet().stream()
 				.filter((e) -> e.getValue().contains(alias)).map(Map.Entry::getKey)
 				.findFirst().orElse(null);
+	}
+
+	public Set<ConfigurationPropertyName> getAllNames() {
+		return aliases.keySet();
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/AliasedConfigurationPropertySourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/AliasedConfigurationPropertySourceTests.java
@@ -107,8 +107,11 @@ public class AliasedConfigurationPropertySourceTests {
 				.willReturn(ConfigurationPropertyState.ABSENT);
 		given(source.containsDescendantOf(ConfigurationPropertyName.of("bar")))
 				.willReturn(ConfigurationPropertyState.PRESENT);
+		ConfigurationPropertyName barBar = ConfigurationPropertyName.of("bar.bar");
+		given(source.getConfigurationProperty(barBar)).willReturn(
+				new ConfigurationProperty(barBar, "barBarValue", mock(Origin.class)));
 		ConfigurationPropertySource aliased = source
-				.withAliases(new ConfigurationPropertyNameAliases("foo", "bar"));
+				.withAliases(new ConfigurationPropertyNameAliases("bar.bar", "foo.foo"));
 		assertThat(aliased.containsDescendantOf(name))
 				.isEqualTo(ConfigurationPropertyState.PRESENT);
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/AliasedConfigurationPropertySourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/AliasedConfigurationPropertySourceTests.java
@@ -16,13 +16,14 @@
 
 package org.springframework.boot.context.properties.source;
 
-import org.junit.Test;
-import org.mockito.Answers;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
+
+import org.junit.Test;
+import org.mockito.Answers;
+import org.springframework.boot.origin.Origin;
 
 /**
  * Tests for {@link AliasedConfigurationPropertySource}.
@@ -107,6 +108,25 @@ public class AliasedConfigurationPropertySourceTests {
 				.willReturn(ConfigurationPropertyState.PRESENT);
 		ConfigurationPropertySource aliased = source
 				.withAliases(new ConfigurationPropertyNameAliases("foo", "bar"));
+		assertThat(aliased.containsDescendantOf(name))
+				.isEqualTo(ConfigurationPropertyState.PRESENT);
+	}
+
+	@Test
+	public void containsDescendantOfWhenPresentInAliasShouldReturnPresent() {
+		ConfigurationPropertyName name = ConfigurationPropertyName.of("baz");
+		ConfigurationPropertySource source = mock(ConfigurationPropertySource.class,
+				withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS));
+		given(source.containsDescendantOf(name))
+				.willReturn(ConfigurationPropertyState.ABSENT);
+
+		ConfigurationPropertyName barFoo = ConfigurationPropertyName.of("bar.foo");
+
+		given(source.getConfigurationProperty(barFoo)).willReturn(
+				new ConfigurationProperty(barFoo, "barFooValue", mock(Origin.class)));
+
+		ConfigurationPropertySource aliased = source
+				.withAliases(new ConfigurationPropertyNameAliases("bar.foo", "baz.foo"));
 		assertThat(aliased.containsDescendantOf(name))
 				.isEqualTo(ConfigurationPropertyState.PRESENT);
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/AliasedConfigurationPropertySourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/AliasedConfigurationPropertySourceTests.java
@@ -16,14 +16,15 @@
 
 package org.springframework.boot.context.properties.source;
 
+import org.junit.Test;
+import org.mockito.Answers;
+
+import org.springframework.boot.origin.Origin;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
-
-import org.junit.Test;
-import org.mockito.Answers;
-import org.springframework.boot.origin.Origin;
 
 /**
  * Tests for {@link AliasedConfigurationPropertySource}.


### PR DESCRIPTION
`AliasedConfigurationPropertySource` class does not properly treat aliases in `containsDescendantOf method`.
For example, in the following case,  `containsDescendantOf("baz")` should return `true` , but currently `false` is returned.
 

- source property:
 bar.foo = barValue

- alias:
 bar.foo -> baz.foo

This PR fixes this issue.
