### PR TITLE
Fix MetricsAutoConfigurationTests

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
@@ -95,8 +95,7 @@ public class MetricsAutoConfigurationTests {
 
 		@Bean
 		MeterRegistry meterRegistry() {
-			SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-			return meterRegistry;
+			return new SimpleMeterRegistry();
 		}
 
 		@Bean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics;
 
-import java.util.List;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -36,7 +34,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -68,13 +65,13 @@ public class MetricsAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(MeterRegistryConfiguration.class)
 				.run((context) -> {
 					MeterRegistry meterRegistry = context.getBean(MeterRegistry.class);
-					List<MeterFilter> filters = (List<MeterFilter>) ReflectionTestUtils
+					MeterFilter[] filters = (MeterFilter[]) ReflectionTestUtils
 							.getField(meterRegistry, "filters");
 					assertThat(filters).hasSize(3);
-					assertThat(filters.get(0).accept((Meter.Id) null))
+					assertThat(filters[0].accept((Meter.Id) null))
 							.isEqualTo(MeterFilterReply.DENY);
-					assertThat(filters.get(1)).isInstanceOf(PropertiesMeterFilter.class);
-					assertThat(filters.get(2).accept((Meter.Id) null))
+					assertThat(filters[1]).isInstanceOf(PropertiesMeterFilter.class);
+					assertThat(filters[2].accept((Meter.Id) null))
 							.isEqualTo(MeterFilterReply.ACCEPT);
 					verify((MeterBinder) context.getBean("meterBinder"))
 							.bindTo(meterRegistry);
@@ -99,7 +96,7 @@ public class MetricsAutoConfigurationTests {
 		@Bean
 		MeterRegistry meterRegistry() {
 			SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-			return spy(meterRegistry);
+			return meterRegistry;
 		}
 
 		@Bean


### PR DESCRIPTION
Hi,

while working on another PR I stumbled upon a test failure in MetricsAutoConfigurationTests caused by changes in [micrometer](https://github.com/micrometer-metrics/micrometer/commit/b7bbea3d6935aaf794d538cf5f6da5155c9bb93f#diff-f4ae48de52fffce2dfe4b359fb28ea39R691).

In theory, this should work without the removal of the spy() call (although it's not needed here anyway if you ask me), but it doesn't. With the spy() call the array is empty, without it it's filled. I wonder why, but maybe you can enlighten me. Maybe because the field is volatile now?

Let me know what you think.
Cheers,
Christoph