### PR TITLE
Use MeterRegistry.isClosed() for tests

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/appoptics/AppOpticsMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/appoptics/AppOpticsMetricsExportAutoConfigurationTests.java
@@ -16,24 +16,18 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.appoptics;
 
-import java.util.Map;
-
 import io.micrometer.appoptics.AppOpticsConfig;
 import io.micrometer.appoptics.AppOpticsMeterRegistry;
 import io.micrometer.core.instrument.Clock;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link AppOpticsMetricsExportAutoConfiguration}.
@@ -89,25 +83,12 @@ public class AppOpticsMetricsExportAutoConfigurationTests {
 	public void stopsMeterRegistryWhenContextIsClosed() {
 		this.contextRunner.withUserConfiguration(BaseConfiguration.class)
 				.run((context) -> {
-					AppOpticsMeterRegistry registry = spyOnDisposableBean(
-							AppOpticsMeterRegistry.class, context);
+					AppOpticsMeterRegistry registry = context
+							.getBean(AppOpticsMeterRegistry.class);
+					assertThat(registry.isClosed()).isFalse();
 					context.close();
-					verify(registry).stop();
+					assertThat(registry.isClosed()).isTrue();
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T> T spyOnDisposableBean(Class<T> type,
-			AssertableApplicationContext context) {
-		String[] names = context.getBeanNamesForType(type);
-		assertThat(names).hasSize(1);
-		String registryBeanName = names[0];
-		Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-				.getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-		Object registryAdapter = disposableBeans.get(registryBeanName);
-		T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-		ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-		return registry;
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/atlas/AtlasMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/atlas/AtlasMetricsExportAutoConfigurationTests.java
@@ -16,24 +16,18 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.atlas;
 
-import java.util.Map;
-
 import com.netflix.spectator.atlas.AtlasConfig;
 import io.micrometer.atlas.AtlasMeterRegistry;
 import io.micrometer.core.instrument.Clock;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link AtlasMetricsExportAutoConfiguration}.
@@ -89,25 +83,12 @@ public class AtlasMetricsExportAutoConfigurationTests {
 	public void stopsMeterRegistryWhenContextIsClosed() {
 		this.contextRunner.withUserConfiguration(BaseConfiguration.class)
 				.run((context) -> {
-					AtlasMeterRegistry registry = spyOnDisposableBean(
-							AtlasMeterRegistry.class, context);
+					AtlasMeterRegistry registry = context
+							.getBean(AtlasMeterRegistry.class);
+					assertThat(registry.isClosed()).isFalse();
 					context.close();
-					verify(registry).stop();
+					assertThat(registry.isClosed()).isTrue();
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T> T spyOnDisposableBean(Class<T> type,
-			AssertableApplicationContext context) {
-		String[] names = context.getBeanNamesForType(type);
-		assertThat(names).hasSize(1);
-		String registryBeanName = names[0];
-		Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-				.getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-		Object registryAdapter = disposableBeans.get(registryBeanName);
-		T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-		ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-		return registry;
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogMetricsExportAutoConfigurationTests.java
@@ -16,24 +16,18 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.datadog;
 
-import java.util.Map;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.datadog.DatadogConfig;
 import io.micrometer.datadog.DatadogMeterRegistry;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link DatadogMetricsExportAutoConfiguration}.
@@ -98,25 +92,12 @@ public class DatadogMetricsExportAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(BaseConfiguration.class)
 				.withPropertyValues("management.metrics.export.datadog.api-key=abcde")
 				.run((context) -> {
-					DatadogMeterRegistry registry = spyOnDisposableBean(
-							DatadogMeterRegistry.class, context);
+					DatadogMeterRegistry registry = context
+							.getBean(DatadogMeterRegistry.class);
+					assertThat(registry.isClosed()).isFalse();
 					context.close();
-					verify(registry).stop();
+					assertThat(registry.isClosed()).isTrue();
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T> T spyOnDisposableBean(Class<T> type,
-			AssertableApplicationContext context) {
-		String[] names = context.getBeanNamesForType(type);
-		assertThat(names).hasSize(1);
-		String registryBeanName = names[0];
-		Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-				.getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-		Object registryAdapter = disposableBeans.get(registryBeanName);
-		T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-		ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-		return registry;
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/elastic/ElasticMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/elastic/ElasticMetricsExportAutoConfigurationTests.java
@@ -16,24 +16,18 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.elastic;
 
-import java.util.Map;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.elastic.ElasticConfig;
 import io.micrometer.elastic.ElasticMeterRegistry;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link ElasticMetricsExportAutoConfiguration}.
@@ -90,25 +84,12 @@ public class ElasticMetricsExportAutoConfigurationTests {
 	public void stopsMeterRegistryWhenContextIsClosed() {
 		this.contextRunner.withUserConfiguration(BaseConfiguration.class)
 				.run((context) -> {
-					ElasticMeterRegistry registry = spyOnDisposableBean(
-							ElasticMeterRegistry.class, context);
+					ElasticMeterRegistry registry = context
+							.getBean(ElasticMeterRegistry.class);
+					assertThat(registry.isClosed()).isFalse();
 					context.close();
-					verify(registry).stop();
+					assertThat(registry.isClosed()).isTrue();
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T> T spyOnDisposableBean(Class<T> type,
-			AssertableApplicationContext context) {
-		String[] names = context.getBeanNamesForType(type);
-		assertThat(names).hasSize(1);
-		String registryBeanName = names[0];
-		Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-				.getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-		Object registryAdapter = disposableBeans.get(registryBeanName);
-		T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-		ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-		return registry;
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/ganglia/GangliaMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/ganglia/GangliaMetricsExportAutoConfigurationTests.java
@@ -16,24 +16,18 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.ganglia;
 
-import java.util.Map;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.ganglia.GangliaConfig;
 import io.micrometer.ganglia.GangliaMeterRegistry;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link GangliaMetricsExportAutoConfiguration}.
@@ -89,25 +83,12 @@ public class GangliaMetricsExportAutoConfigurationTests {
 	public void stopsMeterRegistryWhenContextIsClosed() {
 		this.contextRunner.withUserConfiguration(BaseConfiguration.class)
 				.run((context) -> {
-					GangliaMeterRegistry registry = spyOnDisposableBean(
-							GangliaMeterRegistry.class, context);
+					GangliaMeterRegistry registry = context
+							.getBean(GangliaMeterRegistry.class);
+					assertThat(registry.isClosed()).isFalse();
 					context.close();
-					verify(registry).stop();
+					assertThat(registry.isClosed()).isTrue();
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T> T spyOnDisposableBean(Class<T> type,
-			AssertableApplicationContext context) {
-		String[] names = context.getBeanNamesForType(type);
-		assertThat(names).hasSize(1);
-		String registryBeanName = names[0];
-		Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-				.getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-		Object registryAdapter = disposableBeans.get(registryBeanName);
-		T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-		ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-		return registry;
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphiteMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphiteMetricsExportAutoConfigurationTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.graphite;
 
-import java.util.Map;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.graphite.GraphiteConfig;
@@ -25,16 +23,12 @@ import io.micrometer.graphite.GraphiteMeterRegistry;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link GraphiteMetricsExportAutoConfiguration}.
@@ -106,25 +100,12 @@ public class GraphiteMetricsExportAutoConfigurationTests {
 	public void stopsMeterRegistryWhenContextIsClosed() {
 		this.contextRunner.withUserConfiguration(BaseConfiguration.class)
 				.run((context) -> {
-					GraphiteMeterRegistry registry = spyOnDisposableBean(
-							GraphiteMeterRegistry.class, context);
+					GraphiteMeterRegistry registry = context
+							.getBean(GraphiteMeterRegistry.class);
+					assertThat(registry.isClosed()).isFalse();
 					context.close();
-					verify(registry).stop();
+					assertThat(registry.isClosed()).isTrue();
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T> T spyOnDisposableBean(Class<T> type,
-			AssertableApplicationContext context) {
-		String[] names = context.getBeanNamesForType(type);
-		assertThat(names).hasSize(1);
-		String registryBeanName = names[0];
-		Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-				.getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-		Object registryAdapter = disposableBeans.get(registryBeanName);
-		T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-		ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-		return registry;
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/humio/HumioMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/humio/HumioMetricsExportAutoConfigurationTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.humio;
 
-import java.util.Map;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.humio.HumioConfig;
@@ -25,16 +23,12 @@ import io.micrometer.humio.HumioMeterRegistry;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link HumioMetricsExportAutoConfiguration}.
@@ -90,26 +84,13 @@ public class HumioMetricsExportAutoConfigurationTests {
 	public void stopsMeterRegistryWhenContextIsClosed() {
 		this.contextRunner.withUserConfiguration(BaseConfiguration.class)
 				.run((context) -> {
-					HumioMeterRegistry registry = spyOnDisposableBean(
-							HumioMeterRegistry.class, context);
+					HumioMeterRegistry registry = context
+							.getBean(HumioMeterRegistry.class);
 					new JvmMemoryMetrics().bindTo(registry);
+					assertThat(registry.isClosed()).isFalse();
 					context.close();
-					verify(registry).stop();
+					assertThat(registry.isClosed()).isTrue();
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T> T spyOnDisposableBean(Class<T> type,
-			AssertableApplicationContext context) {
-		String[] names = context.getBeanNamesForType(type);
-		assertThat(names).hasSize(1);
-		String registryBeanName = names[0];
-		Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-				.getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-		Object registryAdapter = disposableBeans.get(registryBeanName);
-		T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-		ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-		return registry;
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxMetricsExportAutoConfigurationTests.java
@@ -16,24 +16,18 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.influx;
 
-import java.util.Map;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.influx.InfluxConfig;
 import io.micrometer.influx.InfluxMeterRegistry;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link InfluxMetricsExportAutoConfiguration}.
@@ -89,25 +83,12 @@ public class InfluxMetricsExportAutoConfigurationTests {
 	public void stopsMeterRegistryWhenContextIsClosed() {
 		this.contextRunner.withUserConfiguration(BaseConfiguration.class)
 				.run((context) -> {
-					InfluxMeterRegistry registry = spyOnDisposableBean(
-							InfluxMeterRegistry.class, context);
+					InfluxMeterRegistry registry = context
+							.getBean(InfluxMeterRegistry.class);
+					assertThat(registry.isClosed()).isFalse();
 					context.close();
-					verify(registry).stop();
+					assertThat(registry.isClosed()).isTrue();
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T> T spyOnDisposableBean(Class<T> type,
-			AssertableApplicationContext context) {
-		String[] names = context.getBeanNamesForType(type);
-		assertThat(names).hasSize(1);
-		String registryBeanName = names[0];
-		Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-				.getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-		Object registryAdapter = disposableBeans.get(registryBeanName);
-		T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-		ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-		return registry;
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxMetricsExportAutoConfigurationTests.java
@@ -16,24 +16,18 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.jmx;
 
-import java.util.Map;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.jmx.JmxConfig;
 import io.micrometer.jmx.JmxMeterRegistry;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link JmxMetricsExportAutoConfiguration}.
@@ -89,25 +83,11 @@ public class JmxMetricsExportAutoConfigurationTests {
 	public void stopsMeterRegistryWhenContextIsClosed() {
 		this.contextRunner.withUserConfiguration(BaseConfiguration.class)
 				.run((context) -> {
-					JmxMeterRegistry registry = spyOnDisposableBean(
-							JmxMeterRegistry.class, context);
+					JmxMeterRegistry registry = context.getBean(JmxMeterRegistry.class);
+					assertThat(registry.isClosed()).isFalse();
 					context.close();
-					verify(registry).stop();
+					assertThat(registry.isClosed()).isTrue();
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T> T spyOnDisposableBean(Class<T> type,
-			AssertableApplicationContext context) {
-		String[] names = context.getBeanNamesForType(type);
-		assertThat(names).hasSize(1);
-		String registryBeanName = names[0];
-		Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-				.getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-		Object registryAdapter = disposableBeans.get(registryBeanName);
-		T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-		ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-		return registry;
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/kairos/KairosMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/kairos/KairosMetricsExportAutoConfigurationTests.java
@@ -16,24 +16,18 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.kairos;
 
-import java.util.Map;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.kairos.KairosConfig;
 import io.micrometer.kairos.KairosMeterRegistry;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link KairosMetricsExportAutoConfiguration}.
@@ -89,25 +83,12 @@ public class KairosMetricsExportAutoConfigurationTests {
 	public void stopsMeterRegistryWhenContextIsClosed() {
 		this.contextRunner.withUserConfiguration(BaseConfiguration.class)
 				.run((context) -> {
-					KairosMeterRegistry registry = spyOnDisposableBean(
-							KairosMeterRegistry.class, context);
+					KairosMeterRegistry registry = context
+							.getBean(KairosMeterRegistry.class);
+					assertThat(registry.isClosed()).isFalse();
 					context.close();
-					verify(registry).stop();
+					assertThat(registry.isClosed()).isTrue();
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T> T spyOnDisposableBean(Class<T> type,
-			AssertableApplicationContext context) {
-		String[] names = context.getBeanNamesForType(type);
-		assertThat(names).hasSize(1);
-		String registryBeanName = names[0];
-		Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-				.getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-		Object registryAdapter = disposableBeans.get(registryBeanName);
-		T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-		ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-		return registry;
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/newrelic/NewRelicMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/newrelic/NewRelicMetricsExportAutoConfigurationTests.java
@@ -16,24 +16,18 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.newrelic;
 
-import java.util.Map;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.newrelic.NewRelicConfig;
 import io.micrometer.newrelic.NewRelicMeterRegistry;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  *
@@ -111,25 +105,12 @@ public class NewRelicMetricsExportAutoConfigurationTests {
 				.withPropertyValues("management.metrics.export.newrelic.api-key=abcde",
 						"management.metrics.export.newrelic.account-id=abcde")
 				.withUserConfiguration(BaseConfiguration.class).run((context) -> {
-					NewRelicMeterRegistry registry = spyOnDisposableBean(
-							NewRelicMeterRegistry.class, context);
+					NewRelicMeterRegistry registry = context
+							.getBean(NewRelicMeterRegistry.class);
+					assertThat(registry.isClosed()).isFalse();
 					context.close();
-					verify(registry).stop();
+					assertThat(registry.isClosed()).isTrue();
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T> T spyOnDisposableBean(Class<T> type,
-			AssertableApplicationContext context) {
-		String[] names = context.getBeanNamesForType(type);
-		assertThat(names).hasSize(1);
-		String registryBeanName = names[0];
-		Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-				.getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-		Object registryAdapter = disposableBeans.get(registryBeanName);
-		T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-		ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-		return registry;
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/signalfx/SignalFxMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/signalfx/SignalFxMetricsExportAutoConfigurationTests.java
@@ -16,24 +16,18 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.signalfx;
 
-import java.util.Map;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.signalfx.SignalFxConfig;
 import io.micrometer.signalfx.SignalFxMeterRegistry;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link SignalFxMetricsExportAutoConfiguration}.
@@ -106,25 +100,12 @@ public class SignalFxMetricsExportAutoConfigurationTests {
 				.withPropertyValues(
 						"management.metrics.export.signalfx.access-token=abcde")
 				.withUserConfiguration(BaseConfiguration.class).run((context) -> {
-					SignalFxMeterRegistry registry = spyOnDisposableBean(
-							SignalFxMeterRegistry.class, context);
+					SignalFxMeterRegistry registry = context
+							.getBean(SignalFxMeterRegistry.class);
+					assertThat(registry.isClosed()).isFalse();
 					context.close();
-					verify(registry).stop();
+					assertThat(registry.isClosed()).isTrue();
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T> T spyOnDisposableBean(Class<T> type,
-			AssertableApplicationContext context) {
-		String[] names = context.getBeanNamesForType(type);
-		assertThat(names).hasSize(1);
-		String registryBeanName = names[0];
-		Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-				.getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-		Object registryAdapter = disposableBeans.get(registryBeanName);
-		T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-		ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-		return registry;
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdMetricsExportAutoConfigurationTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.statsd;
 
-import java.util.Map;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.statsd.StatsdConfig;
 import io.micrometer.statsd.StatsdMeterRegistry;
@@ -25,16 +23,12 @@ import io.micrometer.statsd.StatsdMetrics;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link StatsdMetricsExportAutoConfiguration}.
@@ -91,25 +85,12 @@ public class StatsdMetricsExportAutoConfigurationTests {
 	public void stopsMeterRegistryWhenContextIsClosed() {
 		this.contextRunner.withUserConfiguration(BaseConfiguration.class)
 				.run((context) -> {
-					StatsdMeterRegistry registry = spyOnDisposableBean(
-							StatsdMeterRegistry.class, context);
+					StatsdMeterRegistry registry = context
+							.getBean(StatsdMeterRegistry.class);
+					assertThat(registry.isClosed()).isFalse();
 					context.close();
-					verify(registry).stop();
+					assertThat(registry.isClosed()).isTrue();
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T> T spyOnDisposableBean(Class<T> type,
-			AssertableApplicationContext context) {
-		String[] names = context.getBeanNamesForType(type);
-		assertThat(names).hasSize(1);
-		String registryBeanName = names[0];
-		Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-				.getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-		Object registryAdapter = disposableBeans.get(registryBeanName);
-		T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-		ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-		return registry;
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfigurationTests.java
@@ -16,24 +16,18 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.wavefront;
 
-import java.util.Map;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.wavefront.WavefrontConfig;
 import io.micrometer.wavefront.WavefrontMeterRegistry;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link WavefrontMetricsExportAutoConfiguration}.
@@ -90,25 +84,12 @@ public class WavefrontMetricsExportAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(BaseConfiguration.class)
 				.withPropertyValues("management.metrics.export.wavefront.api-token=abcde")
 				.run((context) -> {
-					WavefrontMeterRegistry registry = spyOnDisposableBean(
-							WavefrontMeterRegistry.class, context);
+					WavefrontMeterRegistry registry = context
+							.getBean(WavefrontMeterRegistry.class);
+					assertThat(registry.isClosed()).isFalse();
 					context.close();
-					verify(registry).stop();
+					assertThat(registry.isClosed()).isTrue();
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T> T spyOnDisposableBean(Class<T> type,
-			AssertableApplicationContext context) {
-		String[] names = context.getBeanNamesForType(type);
-		assertThat(names).hasSize(1);
-		String registryBeanName = names[0];
-		Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-				.getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-		Object registryAdapter = disposableBeans.get(registryBeanName);
-		T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-		ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-		return registry;
 	}
 
 	@Configuration


### PR DESCRIPTION
Hi,

while working on #14972 I noticed that in quite some tests in this package we have a method called `spyOnDisposableBean` that gets duplicated and seems rather complicated - at least for the purpose of just being able to verify that `stop()` is called on MeterRegistry instances.

My initial thought here was to extract this into some utility class to at least get rid of the duplication. The problem here was to find an appropriate place and name for the class. And of course, the complexity of the method remained.

So after giving this a bit more thought, I found a solution that doesn't need reflection and spying at all. We could simply check for `MeterRegistry.isClosed()`, which is slightly different to `stop()`, but still gets the job done if you ask me. The destroyMethod of the underlying bean seems to point to `close()` anyway, so we should be safe here.

Let me know what you think.
Cheers,
Christoph 