### PR TITLE
Log error before emitting application failed event

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -821,6 +821,9 @@ public class SpringApplication {
 			Throwable exception,
 			Collection<SpringBootExceptionReporter> exceptionReporters,
 			SpringApplicationRunListeners listeners) {
+		if (logger.isErrorEnabled()) {
+			logger.error("Application run failed", exception);
+		}
 		try {
 			try {
 				handleExitCode(context, exception);
@@ -855,7 +858,6 @@ public class SpringApplication {
 			// Continue with normal handling of the original failure
 		}
 		if (logger.isErrorEnabled()) {
-			logger.error("Application run failed", failure);
 			registerLoggedException(failure);
 		}
 	}


### PR DESCRIPTION
This is simplest possible solution.

With the previous implementation, the error never gets logged, because the `SLF4JBridgeHandler` is removed from the root logger as a response to the `ApplicationFailedEvent`

Some details about it:
spring-projects#14979

Obvious Fix