### PR TITLE
Allow to disable SSL client authentication on the management port

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -303,7 +303,7 @@
     },
     {
       "name": "management.server.ssl.client-auth",
-      "description": "Whether client authentication is wanted (\"want\") or needed (\"need\"). Requires a trust store."
+      "description": "Whether client authentication is not wanted (\"none\"), wanted (\"want\") or needed (\"need\"). Requires a trust store."
     },
     {
       "name": "management.server.ssl.enabled",

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -136,7 +136,7 @@
     },
     {
       "name": "server.ssl.client-auth",
-      "description": "Whether client authentication is wanted (\"want\") or needed (\"need\"). Requires a trust store."
+      "description": "Whether client authentication is not wanted (\"none\"), wanted (\"want\") or needed (\"need\"). Requires a trust store."
     },
     {
       "name": "server.ssl.enabled",

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -234,7 +234,7 @@ content into your application. Rather, pick only the properties that you need.
 	server.servlet.session.timeout=30m # Session timeout. If a duration suffix is not specified, seconds will be used.
 	server.servlet.session.tracking-modes= # Session tracking modes.
 	server.ssl.ciphers= # Supported SSL ciphers.
-	server.ssl.client-auth= # Whether client authentication is wanted ("want") or needed ("need"). Requires a trust store.
+	server.ssl.client-auth= # Whether client authentication is not wanted ("none"), wanted ("want") or needed ("need"). Requires a trust store.
 	server.ssl.enabled=true # Whether to enable SSL support.
 	server.ssl.enabled-protocols= # Enabled SSL protocols.
 	server.ssl.key-alias= # Alias that identifies the key in the key store.
@@ -1206,7 +1206,7 @@ content into your application. Rather, pick only the properties that you need.
 	management.server.port= # Management endpoint HTTP port (uses the same port as the application by default). Configure a different port to use management-specific SSL.
 	management.server.servlet.context-path= # Management endpoint context-path (for instance, `/management`). Requires a custom management.server.port.
 	management.server.ssl.ciphers= # Supported SSL ciphers.
-	management.server.ssl.client-auth= # Whether client authentication is wanted ("want") or needed ("need"). Requires a trust store.
+	management.server.ssl.client-auth= # Whether client authentication is not wanted ("none"), wanted ("want") or needed ("need"). Requires a trust store.
 	management.server.ssl.enabled=true # Whether to enable SSL support.
 	management.server.ssl.enabled-protocols= # Enabled SSL protocols.
 	management.server.ssl.key-alias= # Alias that identifies the key in the key store.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/Ssl.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/Ssl.java
@@ -28,7 +28,7 @@ public class Ssl {
 
 	private boolean enabled = true;
 
-	private ClientAuth clientAuth;
+	private ClientAuth clientAuth = ClientAuth.NONE;
 
 	private String[] ciphers;
 
@@ -69,8 +69,8 @@ public class Ssl {
 	}
 
 	/**
-	 * Return Whether client authentication is wanted ("want") or needed ("need").
-	 * Requires a trust store.
+	 * Return Whether client authentication is not wanted ("none"), wanted ("want") or
+	 * needed ("need"). Requires a trust store.
 	 * @return the {@link ClientAuth} to use
 	 */
 	public ClientAuth getClientAuth() {
@@ -78,7 +78,12 @@ public class Ssl {
 	}
 
 	public void setClientAuth(ClientAuth clientAuth) {
-		this.clientAuth = clientAuth;
+		if (clientAuth == null) {
+			this.clientAuth = ClientAuth.NONE;
+		}
+		else {
+			this.clientAuth = clientAuth;
+		}
 	}
 
 	/**
@@ -242,6 +247,11 @@ public class Ssl {
 	 * Client authentication types.
 	 */
 	public enum ClientAuth {
+
+		/**
+		 * Client authentication is not wanted.
+		 */
+		NONE,
 
 		/**
 		 * Client authentication is wanted but not mandatory.


### PR DESCRIPTION
When server and management are at different ports, and when server requires
TLS client authentication, then there is no simple method to disable TLS
client authentication for management port.

Adding ssl.client-auth=none enables this.

Example:

    server.port=8080
    server.ssl.enabled=true
    server.ssl.client-auth=need
    management.server.port=8081
    management.server.ssl.enabled=true
    management.server.ssl.client-auth=none

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
