### PR TITLE
Make StaticResourceRequest methods static. Fixes gh-15050

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/reactive/StaticResourceRequest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/reactive/StaticResourceRequest.java
@@ -57,7 +57,7 @@ public final class StaticResourceRequest {
 	 * </pre>
 	 * @return the configured {@link ServerWebExchangeMatcher}
 	 */
-	public StaticResourceServerWebExchange atCommonLocations() {
+	public static StaticResourceServerWebExchange atCommonLocations() {
 		return at(EnumSet.allOf(StaticResourceLocation.class));
 	}
 
@@ -70,7 +70,7 @@ public final class StaticResourceRequest {
 	 * @param rest additional locations to include
 	 * @return the configured {@link ServerWebExchangeMatcher}
 	 */
-	public StaticResourceServerWebExchange at(StaticResourceLocation first,
+	public static StaticResourceServerWebExchange at(StaticResourceLocation first,
 			StaticResourceLocation... rest) {
 		return at(EnumSet.of(first, rest));
 	}
@@ -83,7 +83,8 @@ public final class StaticResourceRequest {
 	 * @param locations the locations to include
 	 * @return the configured {@link ServerWebExchangeMatcher}
 	 */
-	public StaticResourceServerWebExchange at(Set<StaticResourceLocation> locations) {
+	public static StaticResourceServerWebExchange at(
+			Set<StaticResourceLocation> locations) {
 		Assert.notNull(locations, "Locations must not be null");
 		return new StaticResourceServerWebExchange(new LinkedHashSet<>(locations));
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/StaticResourceRequest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/StaticResourceRequest.java
@@ -60,7 +60,7 @@ public final class StaticResourceRequest {
 	 * </pre>
 	 * @return the configured {@link RequestMatcher}
 	 */
-	public StaticResourceRequestMatcher atCommonLocations() {
+	public static StaticResourceRequestMatcher atCommonLocations() {
 		return at(EnumSet.allOf(StaticResourceLocation.class));
 	}
 
@@ -73,7 +73,7 @@ public final class StaticResourceRequest {
 	 * @param rest additional locations to include
 	 * @return the configured {@link RequestMatcher}
 	 */
-	public StaticResourceRequestMatcher at(StaticResourceLocation first,
+	public static StaticResourceRequestMatcher at(StaticResourceLocation first,
 			StaticResourceLocation... rest) {
 		return at(EnumSet.of(first, rest));
 	}
@@ -86,7 +86,7 @@ public final class StaticResourceRequest {
 	 * @param locations the locations to include
 	 * @return the configured {@link RequestMatcher}
 	 */
-	public StaticResourceRequestMatcher at(Set<StaticResourceLocation> locations) {
+	public static StaticResourceRequestMatcher at(Set<StaticResourceLocation> locations) {
 		Assert.notNull(locations, "Locations must not be null");
 		return new StaticResourceRequestMatcher(new LinkedHashSet<>(locations));
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/reactive/StaticResourceRequestTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/reactive/StaticResourceRequestTests.java
@@ -47,7 +47,7 @@ public class StaticResourceRequestTests {
 
 	@Test
 	public void atCommonLocationsShouldMatchCommonLocations() {
-		ServerWebExchangeMatcher matcher = this.resourceRequest.atCommonLocations();
+		ServerWebExchangeMatcher matcher = StaticResourceRequest.atCommonLocations();
 		assertMatcher(matcher).matches("/css/file.css");
 		assertMatcher(matcher).matches("/js/file.js");
 		assertMatcher(matcher).matches("/images/file.css");
@@ -58,7 +58,7 @@ public class StaticResourceRequestTests {
 
 	@Test
 	public void atCommonLocationsWithExcludeShouldNotMatchExcluded() {
-		ServerWebExchangeMatcher matcher = this.resourceRequest.atCommonLocations()
+		ServerWebExchangeMatcher matcher = StaticResourceRequest.atCommonLocations()
 				.excluding(StaticResourceLocation.CSS);
 		assertMatcher(matcher).doesNotMatch("/css/file.css");
 		assertMatcher(matcher).matches("/js/file.js");
@@ -66,7 +66,7 @@ public class StaticResourceRequestTests {
 
 	@Test
 	public void atLocationShouldMatchLocation() {
-		ServerWebExchangeMatcher matcher = this.resourceRequest
+		ServerWebExchangeMatcher matcher = StaticResourceRequest
 				.at(StaticResourceLocation.CSS);
 		assertMatcher(matcher).matches("/css/file.css");
 		assertMatcher(matcher).doesNotMatch("/js/file.js");
@@ -75,7 +75,7 @@ public class StaticResourceRequestTests {
 	@Test
 	public void atLocationsFromSetWhenSetIsNullShouldThrowException() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> this.resourceRequest.at(null))
+				.isThrownBy(() -> StaticResourceRequest.at(null))
 				.withMessageContaining("Locations must not be null");
 	}
 
@@ -83,7 +83,7 @@ public class StaticResourceRequestTests {
 	public void excludeFromSetWhenSetIsNullShouldThrowException() {
 		assertThatIllegalArgumentException()
 				.isThrownBy(
-						() -> this.resourceRequest.atCommonLocations().excluding(null))
+						() -> StaticResourceRequest.atCommonLocations().excluding(null))
 				.withMessageContaining("Locations must not be null");
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/servlet/StaticResourceRequestTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/servlet/StaticResourceRequestTests.java
@@ -40,11 +40,9 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  */
 public class StaticResourceRequestTests {
 
-	private StaticResourceRequest resourceRequest = StaticResourceRequest.INSTANCE;
-
 	@Test
 	public void atCommonLocationsShouldMatchCommonLocations() {
-		RequestMatcher matcher = this.resourceRequest.atCommonLocations();
+		RequestMatcher matcher = StaticResourceRequest.atCommonLocations();
 		assertMatcher(matcher).matches("/css/file.css");
 		assertMatcher(matcher).matches("/js/file.js");
 		assertMatcher(matcher).matches("/images/file.css");
@@ -55,7 +53,7 @@ public class StaticResourceRequestTests {
 
 	@Test
 	public void atCommonLocationsWithExcludeShouldNotMatchExcluded() {
-		RequestMatcher matcher = this.resourceRequest.atCommonLocations()
+		RequestMatcher matcher = StaticResourceRequest.atCommonLocations()
 				.excluding(StaticResourceLocation.CSS);
 		assertMatcher(matcher).doesNotMatch("/css/file.css");
 		assertMatcher(matcher).matches("/js/file.js");
@@ -63,14 +61,14 @@ public class StaticResourceRequestTests {
 
 	@Test
 	public void atLocationShouldMatchLocation() {
-		RequestMatcher matcher = this.resourceRequest.at(StaticResourceLocation.CSS);
+		RequestMatcher matcher = StaticResourceRequest.at(StaticResourceLocation.CSS);
 		assertMatcher(matcher).matches("/css/file.css");
 		assertMatcher(matcher).doesNotMatch("/js/file.js");
 	}
 
 	@Test
 	public void atLocationWhenHasServletPathShouldMatchLocation() {
-		RequestMatcher matcher = this.resourceRequest.at(StaticResourceLocation.CSS);
+		RequestMatcher matcher = StaticResourceRequest.at(StaticResourceLocation.CSS);
 		assertMatcher(matcher, "/foo").matches("/foo", "/css/file.css");
 		assertMatcher(matcher, "/foo").doesNotMatch("/foo", "/js/file.js");
 	}
@@ -78,7 +76,7 @@ public class StaticResourceRequestTests {
 	@Test
 	public void atLocationsFromSetWhenSetIsNullShouldThrowException() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> this.resourceRequest.at(null))
+				.isThrownBy(() -> StaticResourceRequest.at(null))
 				.withMessageContaining("Locations must not be null");
 	}
 
@@ -86,7 +84,7 @@ public class StaticResourceRequestTests {
 	public void excludeFromSetWhenSetIsNullShouldThrowException() {
 		assertThatIllegalArgumentException()
 				.isThrownBy(
-						() -> this.resourceRequest.atCommonLocations().excluding(null))
+						() -> StaticResourceRequest.atCommonLocations().excluding(null))
 				.withMessageContaining("Locations must not be null");
 	}
 


### PR DESCRIPTION
Fixes #15050, where StaticResourceRequest.at*() methods were unusable
because of not being static, according to the javadoc.