### PR TITLE
Add validation query to DataSourceHealthIndicator details

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicator.java
@@ -115,6 +115,7 @@ public class DataSourceHealthIndicator extends AbstractHealthIndicator
 					new SingleColumnRowMapper());
 			Object result = DataAccessUtils.requiredSingleResult(results);
 			builder.withDetail("hello", result);
+			builder.withDetail("validationQuery", validationQuery);
 		}
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicator.java
@@ -114,8 +114,9 @@ public class DataSourceHealthIndicator extends AbstractHealthIndicator
 			List<Object> results = this.jdbcTemplate.query(validationQuery,
 					new SingleColumnRowMapper());
 			Object result = DataAccessUtils.requiredSingleResult(results);
-			builder.withDetail("hello", result);
-			builder.withDetail("validationQuery", validationQuery);
+            builder.withDetail("hello", result);
+            builder.withDetail("result", result);
+            builder.withDetail("validationQuery", validationQuery);
 		}
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicator.java
@@ -114,9 +114,9 @@ public class DataSourceHealthIndicator extends AbstractHealthIndicator
 			List<Object> results = this.jdbcTemplate.query(validationQuery,
 					new SingleColumnRowMapper());
 			Object result = DataAccessUtils.requiredSingleResult(results);
-            builder.withDetail("hello", result);
-            builder.withDetail("result", result);
-            builder.withDetail("validationQuery", validationQuery);
+			builder.withDetail("hello", result);
+			builder.withDetail("result", result);
+			builder.withDetail("validationQuery", validationQuery);
 		}
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicatorTests.java
@@ -80,9 +80,9 @@ public class DataSourceHealthIndicatorTests {
 		System.err.println(health);
 		assertThat(health.getDetails().get("database")).isNotNull();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-        assertThat(health.getDetails().get("hello")).isNotNull();
-        assertThat(health.getDetails().get("result")).isNotNull();
-        assertThat(health.getDetails().get("validationQuery")).isEqualTo("SELECT COUNT(*) from FOO");
+		assertThat(health.getDetails().get("hello")).isNotNull();
+		assertThat(health.getDetails().get("result")).isNotNull();
+		assertThat(health.getDetails().get("validationQuery")).isEqualTo("SELECT COUNT(*) from FOO");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicatorTests.java
@@ -80,7 +80,9 @@ public class DataSourceHealthIndicatorTests {
 		System.err.println(health);
 		assertThat(health.getDetails().get("database")).isNotNull();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails().get("hello")).isNotNull();
+        assertThat(health.getDetails().get("hello")).isNotNull();
+        assertThat(health.getDetails().get("result")).isNotNull();
+        assertThat(health.getDetails().get("validationQuery")).isEqualTo("SELECT COUNT(*) from FOO");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicatorTests.java
@@ -82,7 +82,8 @@ public class DataSourceHealthIndicatorTests {
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
 		assertThat(health.getDetails().get("hello")).isNotNull();
 		assertThat(health.getDetails().get("result")).isNotNull();
-		assertThat(health.getDetails().get("validationQuery")).isEqualTo("SELECT COUNT(*) from FOO");
+		assertThat(health.getDetails().get("validationQuery"))
+				.isEqualTo("SELECT COUNT(*) from FOO");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicatorTests.java
@@ -82,8 +82,7 @@ public class DataSourceHealthIndicatorTests {
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
 		assertThat(health.getDetails().get("hello")).isNotNull();
 		assertThat(health.getDetails().get("result")).isNotNull();
-		assertThat(health.getDetails().get("validationQuery"))
-				.isEqualTo("SELECT COUNT(*) from FOO");
+		assertThat(health.getDetails().get("validationQuery")).isEqualTo("SELECT COUNT(*) from FOO");
 	}
 
 	@Test


### PR DESCRIPTION
When the default validation Query is overwritten it would be nice to show the query in the actuator health endpoint.
