### PR TITLE
Update docs to Spock 1.2

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -7731,9 +7731,9 @@ can specify a source for your test, which disables the behavior of finding a def
 ==== Using Spock to Test Spring Boot Applications
 If you wish to use Spock to test a Spring Boot application, you should add a dependency
 on Spock's `spock-spring` module to your application's build. `spock-spring` integrates
-Spring's test framework into Spock. It is recommended that you use Spock 1.1 or later to
+Spring's test framework into Spock. It is recommended that you use Spock 1.2 or later to
 benefit from a number of improvements to Spock's Spring Framework and Spring Boot
-integration. See http://spockframework.org/spock/docs/1.1/modules.html[the documentation
+integration. See http://spockframework.org/spock/docs/1.2/modules.html#_spring_module[the documentation
 for Spock's Spring module] for further details.
 
 


### PR DESCRIPTION
Spock 1.2 has added new `@SpringBean`, `@SpringSpy`, and `@UnwrapAopProxy` annotations that make testing Spring apps much easier. This is just an update to the docs to reference using Spock 1.2 http://spockframework.org/spock/docs/1.2/modules.html#_spring_module