### PR TITLE
#14075 Custom Exit Code on Job Execution Exit Status FAILED

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
@@ -57,6 +57,7 @@ import org.springframework.util.StringUtils;
  * @author Eddú Meléndez
  * @author Kazuki Shimizu
  * @author Mahmoud Ben Hassine
+ * @author Dimitrios Liapis
  */
 @Configuration
 @ConditionalOnClass({ JobLauncher.class, DataSource.class, JdbcOperations.class })
@@ -103,7 +104,10 @@ public class BatchAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(ExitCodeGenerator.class)
 	public JobExecutionExitCodeGenerator jobExecutionExitCodeGenerator() {
-		return new JobExecutionExitCodeGenerator();
+		JobExecutionExitCodeGenerator jobExecutionExitCodeGenerator = new JobExecutionExitCodeGenerator();
+		jobExecutionExitCodeGenerator.setExitCodeEnabled(this.properties.getExitCode().isEnabled());
+		jobExecutionExitCodeGenerator.setExitCode(this.properties.getExitCode().getValue());
+		return jobExecutionExitCodeGenerator;
 	}
 
 	@Bean

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
@@ -105,8 +105,10 @@ public class BatchAutoConfiguration {
 	@ConditionalOnMissingBean(ExitCodeGenerator.class)
 	public JobExecutionExitCodeGenerator jobExecutionExitCodeGenerator() {
 		JobExecutionExitCodeGenerator jobExecutionExitCodeGenerator = new JobExecutionExitCodeGenerator();
-		jobExecutionExitCodeGenerator.setExitCodeEnabled(this.properties.getExitCode().isEnabled());
-		jobExecutionExitCodeGenerator.setExitCode(this.properties.getExitCode().getValue());
+		jobExecutionExitCodeGenerator
+				.setExitCodeEnabled(this.properties.getExitCode().isEnabled());
+		jobExecutionExitCodeGenerator
+				.setExitCode(this.properties.getExitCode().getValue());
 		return jobExecutionExitCodeGenerator;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
@@ -124,7 +124,7 @@ public class BatchProperties {
 		public void setValue(int value) {
 			this.value = value;
 		}
-	}
 
+	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
@@ -82,7 +82,7 @@ public class BatchProperties {
 	}
 
 	public ExitCode getExitCode() {
-		return exitCode;
+		return this.exitCode;
 	}
 
 	public static class Job {
@@ -110,7 +110,7 @@ public class BatchProperties {
 		private int value = -1;
 
 		public boolean isEnabled() {
-			return enabled;
+			return this.enabled;
 		}
 
 		public void setEnabled(boolean enabled) {
@@ -118,7 +118,7 @@ public class BatchProperties {
 		}
 
 		public int getValue() {
-			return value;
+			return this.value;
 		}
 
 		public void setValue(int value) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
@@ -25,6 +25,7 @@ import org.springframework.boot.jdbc.DataSourceInitializationMode;
  * @author Stephane Nicoll
  * @author Eddú Meléndez
  * @author Vedran Pavic
+ * @author Dimitrios Liapis
  * @since 1.2.0
  */
 @ConfigurationProperties(prefix = "spring.batch")
@@ -49,6 +50,8 @@ public class BatchProperties {
 	private DataSourceInitializationMode initializeSchema = DataSourceInitializationMode.EMBEDDED;
 
 	private final Job job = new Job();
+
+	private final ExitCode exitCode = new ExitCode();
 
 	public String getSchema() {
 		return this.schema;
@@ -78,6 +81,10 @@ public class BatchProperties {
 		return this.job;
 	}
 
+	public ExitCode getExitCode() {
+		return exitCode;
+	}
+
 	public static class Job {
 
 		/**
@@ -95,5 +102,29 @@ public class BatchProperties {
 		}
 
 	}
+
+	public static class ExitCode {
+
+		private boolean enabled = false;
+
+		private int value = -1;
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public int getValue() {
+			return value;
+		}
+
+		public void setValue(int value) {
+			this.value = value;
+		}
+	}
+
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobExecutionExitCodeGenerator.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobExecutionExitCodeGenerator.java
@@ -36,6 +36,7 @@ public class JobExecutionExitCodeGenerator
 	private final List<JobExecution> executions = new ArrayList<>();
 
 	private boolean exitCodeEnabled;
+
 	private int exitCode;
 
 	@Override
@@ -46,7 +47,8 @@ public class JobExecutionExitCodeGenerator
 	@Override
 	public int getExitCode() {
 		for (JobExecution execution : this.executions) {
-			if (this.exitCodeEnabled && ExitStatus.FAILED.getExitCode().equals(execution.getExitStatus().getExitCode())) {
+			if (this.exitCodeEnabled && ExitStatus.FAILED.getExitCode()
+					.equals(execution.getExitStatus().getExitCode())) {
 				return this.exitCode;
 			}
 			else if (execution.getStatus().ordinal() > 0) {
@@ -63,4 +65,5 @@ public class JobExecutionExitCodeGenerator
 	public void setExitCode(int exitCode) {
 		this.exitCode = exitCode;
 	}
+
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobExecutionExitCodeGenerator.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobExecutionExitCodeGenerator.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.batch;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.context.ApplicationListener;
@@ -27,11 +28,15 @@ import org.springframework.context.ApplicationListener;
  * {@link ExitCodeGenerator} for {@link JobExecutionEvent}s.
  *
  * @author Dave Syer
+ * @author Dimitrios Liapis
  */
 public class JobExecutionExitCodeGenerator
 		implements ApplicationListener<JobExecutionEvent>, ExitCodeGenerator {
 
 	private final List<JobExecution> executions = new ArrayList<>();
+
+	private boolean exitCodeEnabled;
+	private int exitCode;
 
 	@Override
 	public void onApplicationEvent(JobExecutionEvent event) {
@@ -41,11 +46,20 @@ public class JobExecutionExitCodeGenerator
 	@Override
 	public int getExitCode() {
 		for (JobExecution execution : this.executions) {
-			if (execution.getStatus().ordinal() > 0) {
+			if (exitCodeEnabled && ExitStatus.FAILED.getExitCode().equals(execution.getExitStatus().getExitCode())) {
+				return exitCode;
+			} else if (execution.getStatus().ordinal() > 0) {
 				return execution.getStatus().ordinal();
 			}
 		}
 		return 0;
 	}
 
+	public void setExitCodeEnabled(boolean exitCodeEnabled) {
+		this.exitCodeEnabled = exitCodeEnabled;
+	}
+
+	public void setExitCode(int exitCode) {
+		this.exitCode = exitCode;
+	}
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobExecutionExitCodeGenerator.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobExecutionExitCodeGenerator.java
@@ -46,9 +46,10 @@ public class JobExecutionExitCodeGenerator
 	@Override
 	public int getExitCode() {
 		for (JobExecution execution : this.executions) {
-			if (exitCodeEnabled && ExitStatus.FAILED.getExitCode().equals(execution.getExitStatus().getExitCode())) {
-				return exitCode;
-			} else if (execution.getStatus().ordinal() > 0) {
+			if (this.exitCodeEnabled && ExitStatus.FAILED.getExitCode().equals(execution.getExitStatus().getExitCode())) {
+				return this.exitCode;
+			}
+			else if (execution.getStatus().ordinal() > 0) {
 				return execution.getStatus().ordinal();
 			}
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfigurationTests.java
@@ -262,70 +262,80 @@ public class BatchAutoConfigurationTests {
 
 	@Test
 	public void testExitCodeDisabledImplicit() {
-		this.contextRunner
-				.withUserConfiguration(JobConfiguration.class, EmbeddedDataSourceConfiguration.class).run((context) -> {
-			assertThat(SpringApplication.exit(context)).isEqualTo(0);
-		});
+		this.contextRunner.withUserConfiguration(JobConfiguration.class,
+				EmbeddedDataSourceConfiguration.class).run((context) -> {
+					assertThat(SpringApplication.exit(context)).isEqualTo(0);
+				});
 	}
 
 	@Test
 	public void testExitCodeDisabledExplicit() {
 		this.contextRunner
-				.withUserConfiguration(JobConfiguration.class, EmbeddedDataSourceConfiguration.class)
-				.withPropertyValues("spring.batch.exit-code.enabled:false").run((context) -> {
-			assertThat(SpringApplication.exit(context)).isEqualTo(0);
-		});
+				.withUserConfiguration(JobConfiguration.class,
+						EmbeddedDataSourceConfiguration.class)
+				.withPropertyValues("spring.batch.exit-code.enabled:false")
+				.run((context) -> {
+					assertThat(SpringApplication.exit(context)).isEqualTo(0);
+				});
 	}
 
 	@Test
 	public void testExitCodeEnabledWithoutValueBatchExitCodeCompleted() {
 		this.contextRunner
-				.withUserConfiguration(JobConfiguration.class, EmbeddedDataSourceConfiguration.class)
-				.withPropertyValues("spring.batch.exit-code.enabled:true").run((context) -> {
-			context.getBean(JobLauncherCommandLineRunner.class).run();
-			assertThat(SpringApplication.exit(context)).isEqualTo(0);
-		});
+				.withUserConfiguration(JobConfiguration.class,
+						EmbeddedDataSourceConfiguration.class)
+				.withPropertyValues("spring.batch.exit-code.enabled:true")
+				.run((context) -> {
+					context.getBean(JobLauncherCommandLineRunner.class).run();
+					assertThat(SpringApplication.exit(context)).isEqualTo(0);
+				});
 	}
 
 	@Test
 	public void testExitCodeEnabledWithoutValueBatchExitCodeFailed() {
 		this.contextRunner
-				.withUserConfiguration(FailedJobConfiguration.class, EmbeddedDataSourceConfiguration.class)
-				.withPropertyValues("spring.batch.exit-code.enabled:true").run((context) -> {
-			context.getBean(JobLauncherCommandLineRunner.class).run();
-			JobExecution jobExecution = context.getBean(JobRepository.class)
-					.getLastJobExecution("job", new JobParameters());
+				.withUserConfiguration(FailedJobConfiguration.class,
+						EmbeddedDataSourceConfiguration.class)
+				.withPropertyValues("spring.batch.exit-code.enabled:true")
+				.run((context) -> {
+					context.getBean(JobLauncherCommandLineRunner.class).run();
+					JobExecution jobExecution = context.getBean(JobRepository.class)
+							.getLastJobExecution("job", new JobParameters());
 
-			assertThat(SpringApplication.exit(context)).isEqualTo(-1);
-		});
+					assertThat(SpringApplication.exit(context)).isEqualTo(-1);
+				});
 	}
 
 	@Test
 	public void testExitCodeEnabledWithValueBatchExitCodeCompleted() {
 		this.contextRunner
-				.withUserConfiguration(JobConfiguration.class, EmbeddedDataSourceConfiguration.class)
+				.withUserConfiguration(JobConfiguration.class,
+						EmbeddedDataSourceConfiguration.class)
 				.withPropertyValues("spring.batch.exit-code.enabled:true",
-									"spring.batch.exit-code.value:-11").run((context) -> {
-			context.getBean(JobLauncherCommandLineRunner.class).run();
-			JobExecution jobExecution = context.getBean(JobRepository.class)
-					.getLastJobExecution("job", new JobParameters());
+						"spring.batch.exit-code.value:-11")
+				.run((context) -> {
+					context.getBean(JobLauncherCommandLineRunner.class).run();
+					JobExecution jobExecution = context.getBean(JobRepository.class)
+							.getLastJobExecution("job", new JobParameters());
 
-			assertThat(SpringApplication.exit(context)).isEqualTo(0);
-		});
+					assertThat(SpringApplication.exit(context)).isEqualTo(0);
+				});
 	}
 
 	@Test
 	public void testExitCodeEnabledWithValueBatchExitCodeFailed() {
 		this.contextRunner
-				.withUserConfiguration(FailedJobConfiguration.class, EmbeddedDataSourceConfiguration.class)
+				.withUserConfiguration(FailedJobConfiguration.class,
+						EmbeddedDataSourceConfiguration.class)
 				.withPropertyValues("spring.batch.exit-code.enabled:true",
-									"spring.batch.exit-code.value:-11").run((context) -> {
-			context.getBean(JobLauncherCommandLineRunner.class).run();
-			JobExecution jobExecution = context.getBean(JobRepository.class)
-					.getLastJobExecution("job", new JobParameters());
+						"spring.batch.exit-code.value:-11")
+				.run((context) -> {
+					context.getBean(JobLauncherCommandLineRunner.class).run();
+					JobExecution jobExecution = context.getBean(JobRepository.class)
+							.getLastJobExecution("job", new JobParameters());
 
-			assertThat(SpringApplication.exit(context)).isEqualTo(-11);
-		});
+					assertThat(SpringApplication.exit(context)).isEqualTo(-11);
+				});
 	}
 
 	@Configuration
@@ -480,7 +490,6 @@ public class BatchAutoConfigurationTests {
 		}
 
 	}
-
 
 	@EnableBatchProcessing
 	protected static class FailedJobConfiguration {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/JobExecutionExitCodeGeneratorTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/JobExecutionExitCodeGeneratorTests.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.batch;
 import org.junit.Test;
 
 import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,19 +28,20 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link JobExecutionExitCodeGenerator}.
  *
  * @author Dave Syer
+ * @author Dimitrios Liapis
  */
 public class JobExecutionExitCodeGeneratorTests {
 
 	private final JobExecutionExitCodeGenerator generator = new JobExecutionExitCodeGenerator();
 
 	@Test
-	public void testExitCodeForRunning() {
+	public void testExitCodeForRunningNoCustomExitCodeEnabled() {
 		this.generator.onApplicationEvent(new JobExecutionEvent(new JobExecution(0L)));
 		assertThat(this.generator.getExitCode()).isEqualTo(1);
 	}
 
 	@Test
-	public void testExitCodeForCompleted() {
+	public void testExitCodeForCompletedNoCustomExitCodeEnabled() {
 		JobExecution execution = new JobExecution(0L);
 		execution.setStatus(BatchStatus.COMPLETED);
 		this.generator.onApplicationEvent(new JobExecutionEvent(execution));
@@ -47,11 +49,31 @@ public class JobExecutionExitCodeGeneratorTests {
 	}
 
 	@Test
-	public void testExitCodeForFailed() {
+	public void testExitCodeForFailedNoCustomExitCodeEnabled() {
 		JobExecution execution = new JobExecution(0L);
 		execution.setStatus(BatchStatus.FAILED);
 		this.generator.onApplicationEvent(new JobExecutionEvent(execution));
 		assertThat(this.generator.getExitCode()).isEqualTo(5);
+	}
+
+	@Test
+	public void testExitCodeForFailedWithCustomExitCodeEnabled() {
+		this.generator.setExitCodeEnabled(true);
+		this.generator.setExitCode(-11);
+		JobExecution execution = new JobExecution(0L);
+		execution.setExitStatus(ExitStatus.FAILED);
+		this.generator.onApplicationEvent(new JobExecutionEvent(execution));
+		assertThat(this.generator.getExitCode()).isEqualTo(-11);
+	}
+
+	@Test
+	public void testExitCodeForCompletedWithCustomExitCodeEnabled() {
+		this.generator.setExitCodeEnabled(true);
+		this.generator.setExitCode(-11);
+		JobExecution execution = new JobExecution(0L);
+		execution.setStatus(BatchStatus.COMPLETED);
+		this.generator.onApplicationEvent(new JobExecutionEvent(execution));
+		assertThat(this.generator.getExitCode()).isEqualTo(0);
 	}
 
 }

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -1005,6 +1005,8 @@ content into your application. Rather, pick only the properties that you need.
 	spring.batch.initialize-schema=embedded # Database schema initialization mode.
 	spring.batch.job.enabled=true # Execute all Spring Batch jobs in the context on startup.
 	spring.batch.job.names= # Comma-separated list of job names to execute on startup (for instance, `job1,job2`). By default, all Jobs found in the context are executed.
+	spring.batch.exit-code.enabled=false # Whether to consider a provided Exit Code. By default it's disabled and the ordinal of the Batch Status is returned.
+	spring.batch.exit-code.value=-1 # In case the spring.batch.exit-code.enabled is true then only this property gets considered. It defines the Exit Code returned in case a Job Execution has ExitStatus FAILED.
 	spring.batch.schema=classpath:org/springframework/batch/core/schema-@@platform@@.sql # Path to the SQL file to use to initialize the database schema.
 	spring.batch.table-prefix= # Table prefix for all the batch meta-data tables.
 


### PR DESCRIPTION
1. Adding new property to enable the functionality to provide custom
Exit Code on Job Execution Exit Status FAILED. By default it's false
and no change to the previous functionality which was an Exit Code
according to the Status ordinal.

2. Adding new property with user specific value of Exit Code in case
the functionality via flag (1) is enabled.

3. Loading both these properties into the JobExecutionExitCodeGenerator
and amending the logic there regarding the Exit Code returned.

4. Adding tests.

5. Adding properties documentation.