### PR TITLE
Remove unused static methods in tests

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/HikariDataSourceConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/HikariDataSourceConfigurationTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.boot.autoconfigure.jdbc;
 
-import java.lang.reflect.Field;
-
 import javax.sql.DataSource;
 
 import com.zaxxer.hikari.HikariDataSource;
@@ -25,7 +23,6 @@ import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -103,13 +100,6 @@ public class HikariDataSourceConfigurationTests {
 					HikariDataSource ds = context.getBean(HikariDataSource.class);
 					assertThat(ds.getPoolName()).isEqualTo("myHikariDS");
 				});
-	}
-
-	@SuppressWarnings("unchecked")
-	public static <T> T getField(Class<?> target, String name) {
-		Field field = ReflectionUtils.findField(target, name, null);
-		ReflectionUtils.makeAccessible(field);
-		return (T) ReflectionUtils.getField(field, target);
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/TomcatDataSourceConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/TomcatDataSourceConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  */
 
 package org.springframework.boot.autoconfigure.jdbc;
-
-import java.lang.reflect.Field;
 
 import javax.sql.DataSource;
 
@@ -34,7 +32,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableMBeanExport;
-import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -113,13 +110,6 @@ public class TomcatDataSourceConfigurationTests {
 		assertThat(ds.getMinEvictableIdleTimeMillis()).isEqualTo(60000);
 		assertThat(ds.getMaxWait()).isEqualTo(30000);
 		assertThat(ds.getValidationInterval()).isEqualTo(3000L);
-	}
-
-	@SuppressWarnings("unchecked")
-	public static <T> T getField(Class<?> target, String name) {
-		Field field = ReflectionUtils.findField(target, name, null);
-		ReflectionUtils.makeAccessible(field);
-		return (T) ReflectionUtils.getField(field, target);
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContextTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContextTests.java
@@ -475,13 +475,6 @@ public class ServletWebServerApplicationContextTests {
 		return beanDefinition;
 	}
 
-	public static <T> T getBean(T object) {
-		if (object instanceof RuntimeException) {
-			throw (RuntimeException) object;
-		}
-		return object;
-	}
-
 	public static class MockListener
 			implements ApplicationListener<ServletWebServerInitializedEvent> {
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContextTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContextTests.java
@@ -475,6 +475,13 @@ public class ServletWebServerApplicationContextTests {
 		return beanDefinition;
 	}
 
+	public static <T> T getBean(T object) {
+		if (object instanceof RuntimeException) {
+			throw (RuntimeException) object;
+		}
+		return object;
+	}
+
 	public static class MockListener
 			implements ApplicationListener<ServletWebServerInitializedEvent> {
 


### PR DESCRIPTION
Hi,

this trivial PR removes some unused static methods in tests.

Cheers,
Christoph