### PR TITLE
Fail fast if nested condition uses a phase inappropriate for its memers

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/AbstractNestedCondition.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/AbstractNestedCondition.java
@@ -58,10 +58,11 @@ abstract class AbstractNestedCondition extends SpringBootCondition
 	}
 
 	@Override
-	public ConditionOutcome getMatchOutcome(ConditionContext context,
+	public final ConditionOutcome getMatchOutcome(ConditionContext context,
 			AnnotatedTypeMetadata metadata) {
 		String className = getClass().getName();
-		MemberConditions memberConditions = new MemberConditions(context, className);
+		MemberConditions memberConditions = new MemberConditions(context,
+				this.configurationPhase, className);
 		MemberMatchOutcomes memberOutcomes = new MemberMatchOutcomes(memberConditions);
 		return getFinalMatchOutcome(memberOutcomes);
 	}
@@ -108,12 +109,18 @@ abstract class AbstractNestedCondition extends SpringBootCondition
 
 		private final MetadataReaderFactory readerFactory;
 
+		private final ConfigurationPhase nestedPhase;
+
+		private final String nestedClassName;
+
 		private final Map<AnnotationMetadata, List<Condition>> memberConditions;
 
-		MemberConditions(ConditionContext context, String className) {
+		MemberConditions(ConditionContext context, ConfigurationPhase nestedPhase, String className) {
 			this.context = context;
 			this.readerFactory = new SimpleMetadataReaderFactory(
 					context.getResourceLoader());
+			this.nestedPhase = nestedPhase;
+			this.nestedClassName = className;
 			String[] members = getMetadata(className).getMemberClassNames();
 			this.memberConditions = getMemberConditions(members);
 		}
@@ -126,11 +133,23 @@ abstract class AbstractNestedCondition extends SpringBootCondition
 				for (String[] conditionClasses : getConditionClasses(metadata)) {
 					for (String conditionClass : conditionClasses) {
 						Condition condition = getCondition(conditionClass);
+						validateMemberCondition(condition);
 						memberConditions.add(metadata, condition);
 					}
 				}
 			}
 			return Collections.unmodifiableMap(memberConditions);
+		}
+
+		private void validateMemberCondition(Condition condition) {
+			if (this.nestedPhase == ConfigurationPhase.PARSE_CONFIGURATION
+					&& condition instanceof ConfigurationCondition) {
+				ConfigurationPhase memberPhase = ((ConfigurationCondition) condition).getConfigurationPhase();
+				if (memberPhase == ConfigurationPhase.REGISTER_BEAN) {
+					throw new IllegalStateException("Nested condition " + this.nestedClassName + " uses a configuration"
+							+ " phase that is inappropriate for " + condition.getClass());
+				}
+			}
 		}
 
 		private AnnotationMetadata getMetadata(String className) {

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/AbstractNestedConditionTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/AbstractNestedConditionTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.condition;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.Assert.assertThat;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
+
+/**
+ * Tests for {@link AbstractNestedCondition}.
+ *
+ * @author Razib Shahriar
+ */
+public class AbstractNestedConditionTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void validMemberPhaseEvaluatesCorrectly() {
+		AnnotationConfigApplicationContext context = load(ValidConfig.class);
+		assertThat(context.containsBean("myBean"), equalTo(true));
+		context.close();
+	}
+
+	@Test
+	public void invalidMemberPhaseThrowsIllegalState() {
+		this.thrown.expectCause(isA(IllegalStateException.class));
+		this.thrown.expectCause(hasMessage(
+				equalTo("Nested condition " + InvalidNestedCondition.class.getName()
+						+ " uses a configuration phase that is inappropriate for class "
+						+ OnBeanCondition.class.getName())));
+		AnnotationConfigApplicationContext context = load(InvalidConfig.class);
+	}
+
+	@Test
+	public void invalidNestedMemberPhaseThrowsIllegalState() {
+		this.thrown.expectCause(isA(IllegalStateException.class));
+		this.thrown.expectCause(hasMessage(
+				equalTo("Nested condition " + DoubleNestedCondition.class.getName()
+						+ " uses a configuration phase that is inappropriate for class "
+						+ ValidNestedCondition.class.getName())));
+		AnnotationConfigApplicationContext context = load(DoubleNestedConfig.class);
+	}
+
+	private AnnotationConfigApplicationContext load(Class<?> config, String... env) {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(context, env);
+		context.register(config);
+		context.refresh();
+		return context;
+	}
+
+	@Configuration
+	@Conditional(ValidNestedCondition.class)
+	public static class ValidConfig {
+
+		@Bean
+		public String myBean() {
+			return "myBean";
+		}
+
+	}
+
+	static class ValidNestedCondition extends AbstractNestedCondition {
+
+		ValidNestedCondition() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@Override
+		protected ConditionOutcome getFinalMatchOutcome(
+				MemberMatchOutcomes memberOutcomes) {
+			return ConditionOutcome.match();
+		}
+
+		@ConditionalOnMissingBean(name = "myBean")
+		static class MissingMyBean {
+
+		}
+
+	}
+
+	@Configuration
+	@Conditional(InvalidNestedCondition.class)
+	public static class InvalidConfig {
+
+		@Bean
+		public String myBean() {
+			return "myBean";
+		}
+
+	}
+
+	static class InvalidNestedCondition extends AbstractNestedCondition {
+
+		InvalidNestedCondition() {
+			super(ConfigurationPhase.PARSE_CONFIGURATION);
+		}
+
+		@Override
+		protected ConditionOutcome getFinalMatchOutcome(
+				MemberMatchOutcomes memberOutcomes) {
+			return ConditionOutcome.match();
+		}
+
+		@ConditionalOnMissingBean(name = "myBean")
+		static class MissingMyBean {
+
+		}
+
+	}
+
+	@Configuration
+	@Conditional(DoubleNestedCondition.class)
+	public static class DoubleNestedConfig {
+
+	}
+
+	static class DoubleNestedCondition extends AbstractNestedCondition {
+
+		DoubleNestedCondition() {
+			super(ConfigurationPhase.PARSE_CONFIGURATION);
+		}
+
+		@Override
+		protected ConditionOutcome getFinalMatchOutcome(
+				MemberMatchOutcomes memberOutcomes) {
+			return ConditionOutcome.match();
+		}
+
+		@Conditional(ValidNestedCondition.class)
+		static class NestedConditionThatIsValid {
+
+		}
+
+	}
+
+}


### PR DESCRIPTION
Addresses gh-10347 by ensuring a nested condition doesn't use a `PARSE_CONFIGURATION` phase when any of it member conditions have a `REGISTER_BEAN` phase. This contract is enforced in `AbstractNestedCondition`, such that all subclasses (e.g. `AllNestedCondition`) also enforce it. The change is applied as the conditions are loaded, to minimize performance overhead.
