### PR TITLE
Rename logging.file to logging.file.name

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfiguration.java
@@ -63,24 +63,25 @@ public class LogFileWebEndpointAutoConfiguration {
 				AnnotatedTypeMetadata metadata) {
 			Environment environment = context.getEnvironment();
 			String config = environment
-					.resolvePlaceholders("${" + LogFile.FILE_PROPERTY + ":}");
+					.resolvePlaceholders("${" + LogFile.FILE_NAME_PROPERTY + ":}");
 			if (!StringUtils.hasText(config)) {
-				config = environment.resolvePlaceholders(
-						"${" + LogFile.DEPRECATED_FILE_PROPERTY + ":}");
+				config = environment
+						.resolvePlaceholders("${" + LogFile.FILE_PROPERTY + ":}");
 			}
 			ConditionMessage.Builder message = ConditionMessage.forCondition("Log File");
 			if (StringUtils.hasText(config)) {
 				return ConditionOutcome
-						.match(message.found(LogFile.FILE_PROPERTY).items(config));
+						.match(message.found(LogFile.FILE_NAME_PROPERTY).items(config));
 			}
-			config = environment.resolvePlaceholders("${" + LogFile.PATH_PROPERTY + ":}");
+			config = environment
+					.resolvePlaceholders("${" + LogFile.FILE_PATH_PROPERTY + ":}");
 			if (!StringUtils.hasText(config)) {
-				config = environment.resolvePlaceholders(
-						"${" + LogFile.DEPRECATED_PATH_PROPERTY + ":}");
+				config = environment
+						.resolvePlaceholders("${" + LogFile.PATH_PROPERTY + ":}");
 			}
 			if (StringUtils.hasText(config)) {
 				return ConditionOutcome
-						.match(message.found(LogFile.PATH_PROPERTY).items(config));
+						.match(message.found(LogFile.FILE_PATH_PROPERTY).items(config));
 			}
 			config = environment.getProperty("management.endpoint.logfile.external-file");
 			if (StringUtils.hasText(config)) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfiguration.java
@@ -60,11 +60,11 @@ public class LogFileWebEndpointAutoConfiguration {
 		public ConditionOutcome getMatchOutcome(ConditionContext context,
 				AnnotatedTypeMetadata metadata) {
 			Environment environment = context.getEnvironment();
-			String config = environment.resolvePlaceholders("${logging.file:}");
+			String config = environment.resolvePlaceholders("${logging.file.name:}");
 			ConditionMessage.Builder message = ConditionMessage.forCondition("Log File");
 			if (StringUtils.hasText(config)) {
 				return ConditionOutcome
-						.match(message.found("logging.file").items(config));
+						.match(message.found("logging.file.name").items(config));
 			}
 			config = environment.resolvePlaceholders("${logging.path:}");
 			if (StringUtils.hasText(config)) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfiguration.java
@@ -66,10 +66,10 @@ public class LogFileWebEndpointAutoConfiguration {
 				return ConditionOutcome
 						.match(message.found("logging.file.name").items(config));
 			}
-			config = environment.resolvePlaceholders("${logging.path:}");
+			config = environment.resolvePlaceholders("${logging.file.path:}");
 			if (StringUtils.hasText(config)) {
 				return ConditionOutcome
-						.match(message.found("logging.path").items(config));
+						.match(message.found("logging.file.path").items(config));
 			}
 			config = environment.getProperty("management.endpoint.logfile.external-file");
 			if (StringUtils.hasText(config)) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.logging.LogFile;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
@@ -35,6 +36,7 @@ import org.springframework.util.StringUtils;
  * {@link EnableAutoConfiguration Auto-configuration} for {@link LogFileWebEndpoint}.
  *
  * @author Andy Wilkinson
+ * @author Christian Carriere-Tisseur
  * @since 2.0.0
  */
 @Configuration
@@ -60,16 +62,25 @@ public class LogFileWebEndpointAutoConfiguration {
 		public ConditionOutcome getMatchOutcome(ConditionContext context,
 				AnnotatedTypeMetadata metadata) {
 			Environment environment = context.getEnvironment();
-			String config = environment.resolvePlaceholders("${logging.file.name:}");
+			String config = environment
+					.resolvePlaceholders("${" + LogFile.FILE_PROPERTY + ":}");
+			if (!StringUtils.hasText(config)) {
+				config = environment.resolvePlaceholders(
+						"${" + LogFile.DEPRECATED_FILE_PROPERTY + ":}");
+			}
 			ConditionMessage.Builder message = ConditionMessage.forCondition("Log File");
 			if (StringUtils.hasText(config)) {
 				return ConditionOutcome
-						.match(message.found("logging.file.name").items(config));
+						.match(message.found(LogFile.FILE_PROPERTY).items(config));
 			}
-			config = environment.resolvePlaceholders("${logging.file.path:}");
+			config = environment.resolvePlaceholders("${" + LogFile.PATH_PROPERTY + ":}");
+			if (!StringUtils.hasText(config)) {
+				config = environment.resolvePlaceholders(
+						"${" + LogFile.DEPRECATED_PATH_PROPERTY + ":}");
+			}
 			if (StringUtils.hasText(config)) {
 				return ConditionOutcome
-						.match(message.found("logging.file.path").items(config));
+						.match(message.found(LogFile.PATH_PROPERTY).items(config));
 			}
 			config = environment.getProperty("management.endpoint.logfile.external-file");
 			if (StringUtils.hasText(config)) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/LogFileWebEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/LogFileWebEndpointDocumentationTests.java
@@ -34,7 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Andy Wilkinson
  */
-@TestPropertySource(properties = "logging.file=src/test/resources/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/sample.log")
+@TestPropertySource(properties = "logging.file.name=src/test/resources/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/sample.log")
 public class LogFileWebEndpointDocumentationTests
 		extends MockMvcEndpointDocumentationTests {
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfigurationTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Christian Carriere-Tisseur
  */
 public class LogFileWebEndpointAutoConfigurationTests {
 
@@ -54,8 +55,22 @@ public class LogFileWebEndpointAutoConfigurationTests {
 	}
 
 	@Test
+	@Deprecated
+	public void logFileWebEndpointIsAutoConfiguredWhenLoggingFileIsSetWithDeprecatedProperty() {
+		this.contextRunner.withPropertyValues("logging.file:test.log").run(
+				(context) -> assertThat(context).hasSingleBean(LogFileWebEndpoint.class));
+	}
+
+	@Test
 	public void logFileWebEndpointIsAutoConfiguredWhenLoggingPathIsSet() {
 		this.contextRunner.withPropertyValues("logging.file.path:test/logs").run(
+				(context) -> assertThat(context).hasSingleBean(LogFileWebEndpoint.class));
+	}
+
+	@Test
+	@Deprecated
+	public void logFileWebEndpointIsAutoConfiguredWhenLoggingPathIsSetWithDeprecatedProperty() {
+		this.contextRunner.withPropertyValues("logging.path:test/logs").run(
 				(context) -> assertThat(context).hasSingleBean(LogFileWebEndpoint.class));
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfigurationTests.java
@@ -55,7 +55,7 @@ public class LogFileWebEndpointAutoConfigurationTests {
 
 	@Test
 	public void logFileWebEndpointIsAutoConfiguredWhenLoggingPathIsSet() {
-		this.contextRunner.withPropertyValues("logging.path:test/logs").run(
+		this.contextRunner.withPropertyValues("logging.file.path:test/logs").run(
 				(context) -> assertThat(context).hasSingleBean(LogFileWebEndpoint.class));
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfigurationTests.java
@@ -49,7 +49,7 @@ public class LogFileWebEndpointAutoConfigurationTests {
 
 	@Test
 	public void logFileWebEndpointIsAutoConfiguredWhenLoggingFileIsSet() {
-		this.contextRunner.withPropertyValues("logging.file:test.log").run(
+		this.contextRunner.withPropertyValues("logging.file.name:test.log").run(
 				(context) -> assertThat(context).hasSingleBean(LogFileWebEndpoint.class));
 	}
 
@@ -71,7 +71,7 @@ public class LogFileWebEndpointAutoConfigurationTests {
 	@Test
 	public void logFileWebEndpointCanBeDisabled() {
 		this.contextRunner
-				.withPropertyValues("logging.file:test.log",
+				.withPropertyValues("logging.file.name:test.log",
 						"management.endpoint.logfile.enabled:false")
 				.run((context) -> assertThat(context)
 						.hasSingleBean(LogFileWebEndpoint.class));

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/logging/LogFileWebEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/logging/LogFileWebEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ public class LogFileWebEndpoint {
 		}
 		LogFile logFile = LogFile.get(this.environment);
 		if (logFile == null) {
-			logger.debug("Missing 'logging.file.name' or 'logging.path' properties");
+			logger.debug("Missing 'logging.file.name' or 'logging.file.path' properties");
 			return null;
 		}
 		return new FileSystemResource(logFile.toString());

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/logging/LogFileWebEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/logging/LogFileWebEndpoint.java
@@ -70,7 +70,7 @@ public class LogFileWebEndpoint {
 		}
 		LogFile logFile = LogFile.get(this.environment);
 		if (logFile == null) {
-			logger.debug("Missing 'logging.file' or 'logging.path' properties");
+			logger.debug("Missing 'logging.file.name' or 'logging.path' properties");
 			return null;
 		}
 		return new FileSystemResource(logFile.toString());

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/logging/LogFileWebEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/logging/LogFileWebEndpointTests.java
@@ -77,6 +77,16 @@ public class LogFileWebEndpointTests {
 	}
 
 	@Test
+	@Deprecated
+	public void resourceResponseWithLogFileAndDeprecatedProperty() throws Exception {
+		this.environment.setProperty("logging.file", this.logFile.getAbsolutePath());
+		Resource resource = this.endpoint.logFile();
+		assertThat(resource).isNotNull();
+		assertThat(StreamUtils.copyToString(resource.getInputStream(),
+				StandardCharsets.UTF_8)).isEqualTo("--TEST--");
+	}
+
+	@Test
 	public void resourceResponseWithExternalLogFile() throws Exception {
 		LogFileWebEndpoint endpoint = new LogFileWebEndpoint(this.environment,
 				this.logFile);

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/logging/LogFileWebEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/logging/LogFileWebEndpointTests.java
@@ -63,13 +63,13 @@ public class LogFileWebEndpointTests {
 
 	@Test
 	public void nullResponseWithMissingLogFile() {
-		this.environment.setProperty("logging.file", "no_test.log");
+		this.environment.setProperty("logging.file.name", "no_test.log");
 		assertThat(this.endpoint.logFile()).isNull();
 	}
 
 	@Test
 	public void resourceResponseWithLogFile() throws Exception {
-		this.environment.setProperty("logging.file", this.logFile.getAbsolutePath());
+		this.environment.setProperty("logging.file.name", this.logFile.getAbsolutePath());
 		Resource resource = this.endpoint.logFile();
 		assertThat(resource).isNotNull();
 		assertThat(StreamUtils.copyToString(resource.getInputStream(),

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/logging/LogFileWebEndpointWebIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/logging/LogFileWebEndpointWebIntegrationTests.java
@@ -65,7 +65,7 @@ public class LogFileWebEndpointWebIntegrationTests {
 
 	@Test
 	public void getRequestProducesResponseWithLogFile() {
-		TestPropertyValues.of("logging.file:" + this.logFile.getAbsolutePath())
+		TestPropertyValues.of("logging.file.name:" + this.logFile.getAbsolutePath())
 				.applyTo(context);
 		client.get().uri("/actuator/logfile").exchange().expectStatus().isOk()
 				.expectBody(String.class).isEqualTo("--TEST--");

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -37,7 +37,7 @@ content into your application. Rather, pick only the properties that you need.
 	# LOGGING
 	logging.config= # Location of the logging configuration file. For instance, `classpath:logback.xml` for Logback.
 	logging.exception-conversion-word=%wEx # Conversion word used when logging exceptions.
-	logging.file= # Log file name (for instance, `myapp.log`). Names can be an exact location or relative to the current directory.
+	logging.file.name= # Log file name (for instance, `myapp.log`). Names can be an exact location or relative to the current directory.
 	logging.file.max-history=0 # Maximum of archive log files to keep. Only supported with the default logback setup.
 	logging.file.max-size=10MB # Maximum log file size. Only supported with the default logback setup.
 	logging.group.*= # Log groups to quickly change multiple loggers at the same time. For instance, `logging.level.db=org.hibernate,org.springframework.jdbc`.

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -42,7 +42,7 @@ content into your application. Rather, pick only the properties that you need.
 	logging.file.max-size=10MB # Maximum log file size. Only supported with the default logback setup.
 	logging.group.*= # Log groups to quickly change multiple loggers at the same time. For instance, `logging.level.db=org.hibernate,org.springframework.jdbc`.
 	logging.level.*= # Log levels severity mapping. For instance, `logging.level.org.springframework=DEBUG`.
-	logging.path= # Location of the log file. For instance, `/var/log`.
+	logging.file.path= # Location of the log file. For instance, `/var/log`.
 	logging.pattern.console= # Appender pattern for output to the console. Supported only with the default Logback setup.
 	logging.pattern.dateformat=yyyy-MM-dd HH:mm:ss.SSS # Appender pattern for log date format. Supported only with the default Logback setup.
 	logging.pattern.file= # Appender pattern for output to a file. Supported only with the default Logback setup.

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -1531,7 +1531,7 @@ in the following example:
 ----
 
 You can also set the location of a file to which to write the log (in addition to the
-console) by using "logging.file".
+console) by using "logging.file.name".
 
 To configure the more fine-grained settings of a logging system, you need to use the native
 configuration format supported by the `LoggingSystem` in question. By default, Spring Boot
@@ -1561,7 +1561,7 @@ If you look at `base.xml` in the spring-boot jar, you can see that it uses
 some useful System properties that the `LoggingSystem` takes care of creating for you:
 
 * `${PID}`: The current process ID.
-* `${LOG_FILE}`: Whether `logging.file` was set in Boot's external configuration.
+* `${LOG_FILE}`: Whether `logging.file.name` was set in Boot's external configuration.
 * `${LOG_PATH}`: Whether `logging.path` (representing a directory for
    log files to live in) was set in Boot's external configuration.
 * `${LOG_EXCEPTION_CONVERSION_WORD}`: Whether `logging.exception-conversion-word` was set
@@ -1595,12 +1595,12 @@ shown in the following example:
 	</configuration>
 ----
 
-You also need to add `logging.file` to your `application.properties`, as shown in the
+You also need to add `logging.file.name` to your `application.properties`, as shown in the
 following example:
 
 [source,properties,indent=0,subs="verbatim,quotes,attributes"]
 ----
-	logging.file=myapplication.log
+	logging.file.name=myapplication.log
 ----
 
 

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/howto.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/howto.adoc
@@ -1562,7 +1562,7 @@ some useful System properties that the `LoggingSystem` takes care of creating fo
 
 * `${PID}`: The current process ID.
 * `${LOG_FILE}`: Whether `logging.file.name` was set in Boot's external configuration.
-* `${LOG_PATH}`: Whether `logging.path` (representing a directory for
+* `${LOG_PATH}`: Whether `logging.file.path` (representing a directory for
    log files to live in) was set in Boot's external configuration.
 * `${LOG_EXCEPTION_CONVERSION_WORD}`: Whether `logging.exception-conversion-word` was set
    in Boot's external configuration.

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -164,7 +164,7 @@ use the following additional endpoints:
 |Yes
 
 |`logfile`
-|Returns the contents of the logfile (if `logging.file.name` or `logging.path` properties have
+|Returns the contents of the logfile (if `logging.file.name` or `logging.file.path` properties have
 been set). Supports the use of the HTTP `Range` header to retrieve part of the log file's
 content.
 |Yes

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -164,7 +164,7 @@ use the following additional endpoints:
 |Yes
 
 |`logfile`
-|Returns the contents of the logfile (if `logging.file` or `logging.path` properties have
+|Returns the contents of the logfile (if `logging.file.name` or `logging.path` properties have
 been set). Supports the use of the HTTP `Range` header to retrieve part of the log file's
 content.
 |Yes

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -1686,7 +1686,7 @@ The following colors and styles are supported:
 === File Output
 By default, Spring Boot logs only to the console and does not write log files. If you
 want to write log files in addition to the console output, you need to set a
-`logging.file` or `logging.path` property (for example, in your
+`logging.file.name` or `logging.path` property (for example, in your
 `application.properties`).
 
 The following table shows how the `logging.*` properties can be used together:
@@ -1694,7 +1694,7 @@ The following table shows how the `logging.*` properties can be used together:
 .Logging properties
 [cols="1,1,1,4"]
 |===
-|`logging.file` |`logging.path` |Example |Description
+|`logging.file.name` |`logging.path` |Example |Description
 
 |_(none)_
 |_(none)_
@@ -1835,7 +1835,7 @@ To help with the customization, some other properties are transferred from the S
 |`LOG_EXCEPTION_CONVERSION_WORD`
 |The conversion word used when logging exceptions.
 
-|`logging.file`
+|`logging.file.name`
 |`LOG_FILE`
 |If defined, it is used in the default log configuration.
 

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -1686,7 +1686,7 @@ The following colors and styles are supported:
 === File Output
 By default, Spring Boot logs only to the console and does not write log files. If you
 want to write log files in addition to the console output, you need to set a
-`logging.file.name` or `logging.path` property (for example, in your
+`logging.file.name` or `logging.file.path` property (for example, in your
 `application.properties`).
 
 The following table shows how the `logging.*` properties can be used together:
@@ -1694,7 +1694,7 @@ The following table shows how the `logging.*` properties can be used together:
 .Logging properties
 [cols="1,1,1,4"]
 |===
-|`logging.file.name` |`logging.path` |Example |Description
+|`logging.file.name` |`logging.file.path` |Example |Description
 
 |_(none)_
 |_(none)_
@@ -1849,7 +1849,7 @@ setup.)
 |Maximum number of archive log files to keep (if LOG_FILE enabled). (Only supported with
 the default Logback setup.)
 
-|`logging.path`
+|`logging.file.path`
 |`LOG_PATH`
 |If defined, it is used in the default log configuration.
 

--- a/spring-boot-project/spring-boot-properties-migrator/src/main/java/org/springframework/boot/context/properties/migrator/PropertiesMigrationReporter.java
+++ b/spring-boot-project/spring-boot-properties-migrator/src/main/java/org/springframework/boot/context/properties/migrator/PropertiesMigrationReporter.java
@@ -88,7 +88,6 @@ class PropertiesMigrationReporter {
 		properties.forEach((property) -> (isRenamed(property) ? renamed : unsupported)
 				.add(property));
 		report.add(name, renamed, unsupported);
-		System.out.println("name="+name+"; renamed="+renamed);
 		if (renamed.isEmpty()) {
 			return null;
 		}

--- a/spring-boot-project/spring-boot-properties-migrator/src/main/java/org/springframework/boot/context/properties/migrator/PropertiesMigrationReporter.java
+++ b/spring-boot-project/spring-boot-properties-migrator/src/main/java/org/springframework/boot/context/properties/migrator/PropertiesMigrationReporter.java
@@ -88,6 +88,7 @@ class PropertiesMigrationReporter {
 		properties.forEach((property) -> (isRenamed(property) ? renamed : unsupported)
 				.add(property));
 		report.add(name, renamed, unsupported);
+		System.out.println("name="+name+"; renamed="+renamed);
 		if (renamed.isEmpty()) {
 			return null;
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
@@ -69,7 +69,7 @@ import org.springframework.util.StringUtils;
  * properties you can set {@link #setParseArgs(boolean) parseArgs} to {@code false}.
  * <p>
  * By default, log output is only written to the console. If a log file is required the
- * {@code logging.path} and {@code logging.file} properties can be used.
+ * {@code logging.path} and {@code logging.file.name} properties can be used.
  * <p>
  * Some system properties may be set as side effects, and these can be useful if the
  * logging configuration supports placeholders (i.e. log4j or logback):

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
@@ -68,8 +68,8 @@ import org.springframework.util.StringUtils;
  * {@literal java -jar myapp.jar [--debug | --trace]}). If you prefer to ignore these
  * properties you can set {@link #setParseArgs(boolean) parseArgs} to {@code false}.
  * <p>
- * By default, log output is only written to the console. If a log file is required the
- * {@code logging.path} and {@code logging.file.name} properties can be used.
+ * By default, log output is only written to the console. If a log file is required, the
+ * {@code logging.file.path} and {@code logging.file.name} properties can be used.
  * <p>
  * Some system properties may be set as side effects, and these can be useful if the
  * logging configuration supports placeholders (i.e. log4j or logback):

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogFile.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogFile.java
@@ -97,7 +97,6 @@ public class LogFile {
 	 * @param properties the properties to apply to
 	 */
 	public void applyTo(Properties properties) {
-		System.out.println("[LogFile][applyTo]");
 		put(properties, LoggingSystemProperties.LOG_PATH, this.path);
 		put(properties, LoggingSystemProperties.LOG_FILE, toString());
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogFile.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogFile.java
@@ -25,8 +25,8 @@ import org.springframework.util.StringUtils;
 
 /**
  * A reference to a log output file. Log output files are specified using
- * {@code logging.file} or {@code logging.path} {@link Environment} properties. If the
- * {@code logging.file} property is not specified {@code "spring.log"} will be written in
+ * {@code logging.file.name} or {@code logging.path} {@link Environment} properties. If the
+ * {@code logging.file.name} property is not specified {@code "spring.log"} will be written in
  * the {@code logging.path} directory.
  *
  * @author Phillip Webb
@@ -39,7 +39,7 @@ public class LogFile {
 	 * The name of the Spring property that contains the name of the log file. Names can
 	 * be an exact location or relative to the current directory.
 	 */
-	public static final String FILE_PROPERTY = "logging.file";
+	public static final String FILE_PROPERTY = "logging.file.name";
 
 	/**
 	 * The name of the Spring property that contains the directory where log files are

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogFile.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogFile.java
@@ -30,6 +30,7 @@ import org.springframework.util.StringUtils;
  * written in the {@code logging.file.path} directory.
  *
  * @author Phillip Webb
+ * @author Christian Carriere-Tisseur
  * @since 1.2.1
  * @see #get(PropertyResolver)
  */

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogFile.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogFile.java
@@ -25,9 +25,9 @@ import org.springframework.util.StringUtils;
 
 /**
  * A reference to a log output file. Log output files are specified using
- * {@code logging.file.name} or {@code logging.path} {@link Environment} properties. If
- * the {@code logging.file.name} property is not specified {@code "spring.log"} will be
- * written in the {@code logging.path} directory.
+ * {@code logging.file.name} or {@code logging.file.path} {@link Environment} properties.
+ * If the {@code logging.file.name} property is not specified {@code "spring.log"} will be
+ * written in the {@code logging.file.path} directory.
  *
  * @author Phillip Webb
  * @since 1.2.1
@@ -45,7 +45,7 @@ public class LogFile {
 	 * The name of the Spring property that contains the directory where log files are
 	 * written.
 	 */
-	public static final String PATH_PROPERTY = "logging.path";
+	public static final String PATH_PROPERTY = "logging.file.path";
 
 	private final String file;
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogFile.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogFile.java
@@ -47,6 +47,20 @@ public class LogFile {
 	 */
 	public static final String PATH_PROPERTY = "logging.file.path";
 
+	/**
+	 * The name of the Spring property that contains the name of the log file. Names can
+	 * be an exact location or relative to the current directory.
+	 */
+	@Deprecated
+	public static final String DEPRECATED_FILE_PROPERTY = "logging.file";
+
+	/**
+	 * The name of the Spring property that contains the directory where log files are
+	 * written.
+	 */
+	@Deprecated
+	public static final String DEPRECATED_PATH_PROPERTY = "logging.path";
+
 	private final String file;
 
 	private final String path;
@@ -83,6 +97,7 @@ public class LogFile {
 	 * @param properties the properties to apply to
 	 */
 	public void applyTo(Properties properties) {
+		System.out.println("[LogFile][applyTo]");
 		put(properties, LoggingSystemProperties.LOG_PATH, this.path);
 		put(properties, LoggingSystemProperties.LOG_FILE, toString());
 	}
@@ -115,6 +130,12 @@ public class LogFile {
 	public static LogFile get(PropertyResolver propertyResolver) {
 		String file = propertyResolver.getProperty(FILE_PROPERTY);
 		String path = propertyResolver.getProperty(PATH_PROPERTY);
+		if (file == null) {
+			file = propertyResolver.getProperty(DEPRECATED_FILE_PROPERTY);
+		}
+		if (path == null) {
+			path = propertyResolver.getProperty(DEPRECATED_PATH_PROPERTY);
+		}
 		if (StringUtils.hasLength(file) || StringUtils.hasLength(path)) {
 			return new LogFile(file, path);
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogFile.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogFile.java
@@ -25,9 +25,9 @@ import org.springframework.util.StringUtils;
 
 /**
  * A reference to a log output file. Log output files are specified using
- * {@code logging.file.name} or {@code logging.path} {@link Environment} properties. If the
- * {@code logging.file.name} property is not specified {@code "spring.log"} will be written in
- * the {@code logging.path} directory.
+ * {@code logging.file.name} or {@code logging.path} {@link Environment} properties. If
+ * the {@code logging.file.name} property is not specified {@code "spring.log"} will be
+ * written in the {@code logging.path} directory.
  *
  * @author Phillip Webb
  * @since 1.2.1

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogFile.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogFile.java
@@ -39,28 +39,32 @@ public class LogFile {
 	/**
 	 * The name of the Spring property that contains the name of the log file. Names can
 	 * be an exact location or relative to the current directory.
+	 * @deprecated since 2.2.0 in favor of {@link #FILE_NAME_PROPERTY}
 	 */
-	public static final String FILE_PROPERTY = "logging.file.name";
+	@Deprecated
+	public static final String FILE_PROPERTY = "logging.file";
 
 	/**
 	 * The name of the Spring property that contains the directory where log files are
 	 * written.
+	 * @deprecated since 2.2.0 in favor of {@link #FILE_PATH_PROPERTY}
 	 */
-	public static final String PATH_PROPERTY = "logging.file.path";
+	@Deprecated
+	public static final String PATH_PROPERTY = "logging.path";
 
 	/**
 	 * The name of the Spring property that contains the name of the log file. Names can
 	 * be an exact location or relative to the current directory.
+	 * @since 2.2.0
 	 */
-	@Deprecated
-	public static final String DEPRECATED_FILE_PROPERTY = "logging.file";
+	public static final String FILE_NAME_PROPERTY = "logging.file.name";
 
 	/**
 	 * The name of the Spring property that contains the directory where log files are
 	 * written.
+	 * @since 2.2.0
 	 */
-	@Deprecated
-	public static final String DEPRECATED_PATH_PROPERTY = "logging.path";
+	public static final String FILE_PATH_PROPERTY = "logging.file.path";
 
 	private final String file;
 
@@ -128,13 +132,13 @@ public class LogFile {
 	 * suitable properties
 	 */
 	public static LogFile get(PropertyResolver propertyResolver) {
-		String file = propertyResolver.getProperty(FILE_PROPERTY);
-		String path = propertyResolver.getProperty(PATH_PROPERTY);
+		String file = propertyResolver.getProperty(FILE_NAME_PROPERTY);
+		String path = propertyResolver.getProperty(FILE_PATH_PROPERTY);
 		if (file == null) {
-			file = propertyResolver.getProperty(DEPRECATED_FILE_PROPERTY);
+			file = propertyResolver.getProperty(FILE_PROPERTY);
 		}
 		if (path == null) {
-			path = propertyResolver.getProperty(DEPRECATED_PATH_PROPERTY);
+			path = propertyResolver.getProperty(PATH_PROPERTY);
 		}
 		if (StringUtils.hasLength(file) || StringUtils.hasLength(path)) {
 			return new LogFile(file, path);

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -84,6 +84,21 @@
       }
     },
     {
+      "name": "logging.file.path",
+      "type": "java.lang.String",
+      "description": "Location of the log file. For instance, `/var/log`.",
+      "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener"
+    },
+    {
+      "name": "logging.path",
+      "type": "java.lang.String",
+      "description": "Location of the log file. For instance, `/var/log`.",
+      "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener",
+      "deprecation": {
+        "replacement": "logging.file.path"
+      }
+    },
+    {
       "name": "logging.file.max-size",
       "type": "java.lang.String",
       "description": "Maximum log file size. Only supported with the default logback setup.",
@@ -107,12 +122,6 @@
       "name": "logging.level",
       "type": "java.util.Map<java.lang.String,java.lang.String>",
       "description": "Log levels severity mapping. For instance, `logging.level.org.springframework=DEBUG`.",
-      "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener"
-    },
-    {
-      "name": "logging.path",
-      "type": "java.lang.String",
-      "description": "Location of the log file. For instance, `/var/log`.",
       "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener"
     },
     {

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -332,8 +332,8 @@
       "type": "java.lang.Integer",
       "description": "Application index.",
       "deprecation": {
-        "level": "error",
-        "reason": "Application context ids are now unique by default."
+        "reason": "Application context ids are now unique by default.",
+        "level": "error"
       }
     },
     {

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -74,28 +74,10 @@
       "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener"
     },
     {
-      "name": "logging.file",
-      "type": "java.lang.String",
-      "description": "Log file name (for instance, `myapp.log`). Names can be an exact location or relative to the current directory.",
-      "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener",
-      "deprecation": {
-        "replacement": "logging.file.name"
-      }
-    },
-    {
       "name": "logging.file.path",
       "type": "java.lang.String",
       "description": "Location of the log file. For instance, `/var/log`.",
       "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener"
-    },
-    {
-      "name": "logging.path",
-      "type": "java.lang.String",
-      "description": "Location of the log file. For instance, `/var/log`.",
-      "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener",
-      "deprecation": {
-        "replacement": "logging.file.path"
-      }
     },
     {
       "name": "logging.file.max-size",
@@ -353,7 +335,25 @@
         "level": "error",
         "reason": "Application context ids are now unique by default."
       }
-    }
+    },
+    {
+      "name": "logging.file",
+      "type": "java.lang.String",
+      "description": "Log file name (for instance, `myapp.log`). Names can be an exact location or relative to the current directory.",
+      "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener",
+      "deprecation": {
+        "replacement": "logging.file.name"
+      }
+    },
+    {
+      "name": "logging.path",
+      "type": "java.lang.String",
+      "description": "Location of the log file. For instance, `/var/log`.",
+      "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener",
+      "deprecation": {
+        "replacement": "logging.file.path"
+      }
+    },
   ],
   "hints": [
     {

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -342,7 +342,8 @@
       "description": "Log file name (for instance, `myapp.log`). Names can be an exact location or relative to the current directory.",
       "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener",
       "deprecation": {
-        "replacement": "logging.file.name"
+        "replacement": "logging.file.name",
+        "level": "error"
       }
     },
     {
@@ -351,7 +352,8 @@
       "description": "Location of the log file. For instance, `/var/log`.",
       "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener",
       "deprecation": {
-        "replacement": "logging.file.path"
+        "replacement": "logging.file.path",
+        "level": "error"
       }
     }
   ],

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -74,6 +74,16 @@
       "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener"
     },
     {
+      "name": "logging.file",
+      "type": "java.lang.String",
+      "description": "Log file name (for instance, `myapp.log`). Names can be an exact location or relative to the current directory.",
+      "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener",
+      "deprecation": {
+        "replacement": "logging.file.name",
+        "level": "error"
+      }
+    },
+    {
       "name": "logging.file.max-size",
       "type": "java.lang.String",
       "description": "Maximum log file size. Only supported with the default logback setup.",

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -68,7 +68,7 @@
       "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener"
     },
     {
-      "name": "logging.file",
+      "name": "logging.file.name",
       "type": "java.lang.String",
       "description": "Log file name (for instance, `myapp.log`). Names can be an exact location or relative to the current directory.",
       "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener"

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -353,7 +353,7 @@
       "deprecation": {
         "replacement": "logging.file.path"
       }
-    },
+    }
   ],
   "hints": [
     {
@@ -364,7 +364,6 @@
           "parameters": {
             "group": false
           }
-
         }
       ]
     },

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -79,8 +79,7 @@
       "description": "Log file name (for instance, `myapp.log`). Names can be an exact location or relative to the current directory.",
       "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener",
       "deprecation": {
-        "replacement": "logging.file.name",
-        "level": "error"
+        "replacement": "logging.file.name"
       }
     },
     {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/builder/SpringApplicationBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/builder/SpringApplicationBuilderTests.java
@@ -100,13 +100,13 @@ public class SpringApplicationBuilderTests {
 	public void propertiesWithRepeatSeparator() {
 		SpringApplicationBuilder application = new SpringApplicationBuilder()
 				.sources(ExampleConfig.class).contextClass(StaticApplicationContext.class)
-				.properties("one=c:\\logging.file", "two=a:b", "three:c:\\logging.file",
+				.properties("one=c:\\logging.file.name", "two=a:b", "three:c:\\logging.file.name",
 						"four:a:b");
 		this.context = application.run();
 		ConfigurableEnvironment environment = this.context.getEnvironment();
-		assertThat(environment.getProperty("one")).isEqualTo("c:\\logging.file");
+		assertThat(environment.getProperty("one")).isEqualTo("c:\\logging.file.name");
 		assertThat(environment.getProperty("two")).isEqualTo("a:b");
-		assertThat(environment.getProperty("three")).isEqualTo("c:\\logging.file");
+		assertThat(environment.getProperty("three")).isEqualTo("c:\\logging.file.name");
 		assertThat(environment.getProperty("four")).isEqualTo("a:b");
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/builder/SpringApplicationBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/builder/SpringApplicationBuilderTests.java
@@ -100,8 +100,8 @@ public class SpringApplicationBuilderTests {
 	public void propertiesWithRepeatSeparator() {
 		SpringApplicationBuilder application = new SpringApplicationBuilder()
 				.sources(ExampleConfig.class).contextClass(StaticApplicationContext.class)
-				.properties("one=c:\\logging.file.name", "two=a:b", "three:c:\\logging.file.name",
-						"four:a:b");
+				.properties("one=c:\\logging.file.name", "two=a:b",
+						"three:c:\\logging.file.name", "four:a:b");
 		this.context = application.run();
 		ConfigurableEnvironment environment = this.context.getEnvironment();
 		assertThat(environment.getProperty("one")).isEqualTo("c:\\logging.file.name");

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
@@ -501,6 +501,30 @@ public class LoggingApplicationListenerTests {
 	}
 
 	@Test
+	@Deprecated
+	public void systemPropertiesAreSetForLoggingConfigurationWithDeprecatedProperties() {
+		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context,
+				"logging.exception-conversion-word=conversion", "logging.file=target/log",
+				"logging.path=path", "logging.pattern.console=console",
+				"logging.pattern.file=file", "logging.pattern.level=level");
+		this.initializer.initialize(this.context.getEnvironment(),
+				this.context.getClassLoader());
+		assertThat(System.getProperty(LoggingSystemProperties.CONSOLE_LOG_PATTERN))
+				.isEqualTo("console");
+		assertThat(System.getProperty(LoggingSystemProperties.FILE_LOG_PATTERN))
+				.isEqualTo("file");
+		assertThat(System.getProperty(LoggingSystemProperties.EXCEPTION_CONVERSION_WORD))
+				.isEqualTo("conversion");
+		assertThat(System.getProperty(LoggingSystemProperties.LOG_FILE))
+				.isEqualTo("target/log");
+		assertThat(System.getProperty(LoggingSystemProperties.LOG_LEVEL_PATTERN))
+				.isEqualTo("level");
+		assertThat(System.getProperty(LoggingSystemProperties.LOG_PATH))
+				.isEqualTo("path");
+		assertThat(System.getProperty(LoggingSystemProperties.PID_KEY)).isNotNull();
+	}
+
+	@Test
 	public void environmentPropertiesIgnoreUnresolvablePlaceholders() {
 		// gh-7719
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context,

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
@@ -213,7 +213,7 @@ public class LoggingApplicationListenerTests {
 	public void addLogFileProperty() {
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context,
 				"logging.config=classpath:logback-nondefault.xml",
-				"logging.file=target/foo.log");
+				"logging.file.name=target/foo.log");
 		this.initializer.initialize(this.context.getEnvironment(),
 				this.context.getClassLoader());
 		Log logger = LogFactory.getLog(LoggingApplicationListenerTests.class);
@@ -228,7 +228,7 @@ public class LoggingApplicationListenerTests {
 	public void addLogFilePropertyWithDefault() {
 		assertThat(new File("target/foo.log").exists()).isFalse();
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context,
-				"logging.file=target/foo.log");
+				"logging.file.name=target/foo.log");
 		this.initializer.initialize(this.context.getEnvironment(),
 				this.context.getClassLoader());
 		Log logger = LogFactory.getLog(LoggingApplicationListenerTests.class);
@@ -479,7 +479,7 @@ public class LoggingApplicationListenerTests {
 	@Test
 	public void systemPropertiesAreSetForLoggingConfiguration() {
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context,
-				"logging.exception-conversion-word=conversion", "logging.file=target/log",
+				"logging.exception-conversion-word=conversion", "logging.file.name=target/log",
 				"logging.path=path", "logging.pattern.console=console",
 				"logging.pattern.file=file", "logging.pattern.level=level");
 		this.initializer.initialize(this.context.getEnvironment(),
@@ -524,7 +524,7 @@ public class LoggingApplicationListenerTests {
 	@Test
 	public void logFilePropertiesCanReferenceSystemProperties() {
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context,
-				"logging.file=target/${PID}.log");
+				"logging.file.name=target/${PID}.log");
 		this.initializer.initialize(this.context.getEnvironment(),
 				this.context.getClassLoader());
 		assertThat(System.getProperty(LoggingSystemProperties.LOG_FILE))

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
@@ -240,7 +240,7 @@ public class LoggingApplicationListenerTests {
 	public void addLogPathProperty() {
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context,
 				"logging.config=classpath:logback-nondefault.xml",
-				"logging.path=target/foo/");
+				"logging.file.path=target/foo/");
 		this.initializer.initialize(this.context.getEnvironment(),
 				this.context.getClassLoader());
 		Log logger = LogFactory.getLog(LoggingApplicationListenerTests.class);
@@ -480,7 +480,7 @@ public class LoggingApplicationListenerTests {
 	public void systemPropertiesAreSetForLoggingConfiguration() {
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context,
 				"logging.exception-conversion-word=conversion",
-				"logging.file.name=target/log", "logging.path=path",
+				"logging.file.name=target/log", "logging.file.path=path",
 				"logging.pattern.console=console", "logging.pattern.file=file",
 				"logging.pattern.level=level");
 		this.initializer.initialize(this.context.getEnvironment(),

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
@@ -479,9 +479,10 @@ public class LoggingApplicationListenerTests {
 	@Test
 	public void systemPropertiesAreSetForLoggingConfiguration() {
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context,
-				"logging.exception-conversion-word=conversion", "logging.file.name=target/log",
-				"logging.path=path", "logging.pattern.console=console",
-				"logging.pattern.file=file", "logging.pattern.level=level");
+				"logging.exception-conversion-word=conversion",
+				"logging.file.name=target/log", "logging.path=path",
+				"logging.pattern.console=console", "logging.pattern.file=file",
+				"logging.pattern.level=level");
 		this.initializer.initialize(this.context.getEnvironment(),
 				this.context.getClassLoader());
 		assertThat(System.getProperty(LoggingSystemProperties.CONSOLE_LOG_PATTERN))

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LogFileTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LogFileTests.java
@@ -84,7 +84,7 @@ public class LogFileTests {
 
 	private PropertyResolver getPropertyResolver(String file, String path) {
 		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("logging.file", file);
+		properties.put("logging.file.name", file);
 		properties.put("logging.path", path);
 		PropertySource<?> propertySource = new MapPropertySource("properties",
 				properties);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LogFileTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LogFileTests.java
@@ -43,9 +43,9 @@ public class LogFileTests {
 		LogFile logFile = LogFile.get(resolver);
 		assertThat(logFile).isNull();
 	}
-	
+
 	@Test
-	public void deprecatedLoggingFile() {
+	public void loggingFile() {
 		PropertyResolver resolver = getPropertyResolver("log.file", null);
 		LogFile logFile = LogFile.get(resolver);
 		Properties properties = new Properties();
@@ -57,8 +57,10 @@ public class LogFileTests {
 	}
 
 	@Test
-	public void loggingFile() {
-		PropertyResolver resolver = getPropertyResolver("log.file", null);
+	@Deprecated
+	public void loggingFileWithDeprecatedProperties() {
+		PropertyResolver resolver = getPropertyResolverWithDeprecatedProperties(
+				"log.file", null);
 		LogFile logFile = LogFile.get(resolver);
 		Properties properties = new Properties();
 		logFile.applyTo(properties);
@@ -82,8 +84,38 @@ public class LogFileTests {
 	}
 
 	@Test
+	@Deprecated
+	public void loggingPathWithDeprecatedProperties() {
+		PropertyResolver resolver = getPropertyResolverWithDeprecatedProperties(null,
+				"logpath");
+		LogFile logFile = LogFile.get(resolver);
+		Properties properties = new Properties();
+		logFile.applyTo(properties);
+		assertThat(logFile.toString()).isEqualTo("logpath/spring.log");
+		assertThat(properties.getProperty(LoggingSystemProperties.LOG_FILE))
+				.isEqualTo("logpath/spring.log");
+		assertThat(properties.getProperty(LoggingSystemProperties.LOG_PATH))
+				.isEqualTo("logpath");
+	}
+
+	@Test
 	public void loggingFileAndPath() {
 		PropertyResolver resolver = getPropertyResolver("log.file", "logpath");
+		LogFile logFile = LogFile.get(resolver);
+		Properties properties = new Properties();
+		logFile.applyTo(properties);
+		assertThat(logFile.toString()).isEqualTo("log.file");
+		assertThat(properties.getProperty(LoggingSystemProperties.LOG_FILE))
+				.isEqualTo("log.file");
+		assertThat(properties.getProperty(LoggingSystemProperties.LOG_PATH))
+				.isEqualTo("logpath");
+	}
+
+	@Test
+	@Deprecated
+	public void loggingFileAndPathWithDeprecatedProperties() {
+		PropertyResolver resolver = getPropertyResolverWithDeprecatedProperties(
+				"log.file", "logpath");
 		LogFile logFile = LogFile.get(resolver);
 		Properties properties = new Properties();
 		logFile.applyTo(properties);
@@ -98,6 +130,19 @@ public class LogFileTests {
 		Map<String, Object> properties = new LinkedHashMap<>();
 		properties.put("logging.file.name", file);
 		properties.put("logging.file.path", path);
+		PropertySource<?> propertySource = new MapPropertySource("properties",
+				properties);
+		MutablePropertySources propertySources = new MutablePropertySources();
+		propertySources.addFirst(propertySource);
+		return new PropertySourcesPropertyResolver(propertySources);
+	}
+
+	@Deprecated
+	private PropertyResolver getPropertyResolverWithDeprecatedProperties(String file,
+			String path) {
+		Map<String, Object> properties = new LinkedHashMap<>();
+		properties.put("logging.file", file);
+		properties.put("logging.path", path);
 		PropertySource<?> propertySource = new MapPropertySource("properties",
 				properties);
 		MutablePropertySources propertySources = new MutablePropertySources();

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LogFileTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LogFileTests.java
@@ -43,6 +43,18 @@ public class LogFileTests {
 		LogFile logFile = LogFile.get(resolver);
 		assertThat(logFile).isNull();
 	}
+	
+	@Test
+	public void deprecatedLoggingFile() {
+		PropertyResolver resolver = getPropertyResolver("log.file", null);
+		LogFile logFile = LogFile.get(resolver);
+		Properties properties = new Properties();
+		logFile.applyTo(properties);
+		assertThat(logFile.toString()).isEqualTo("log.file");
+		assertThat(properties.getProperty(LoggingSystemProperties.LOG_FILE))
+				.isEqualTo("log.file");
+		assertThat(properties.getProperty(LoggingSystemProperties.LOG_PATH)).isNull();
+	}
 
 	@Test
 	public void loggingFile() {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LogFileTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LogFileTests.java
@@ -85,7 +85,7 @@ public class LogFileTests {
 	private PropertyResolver getPropertyResolver(String file, String path) {
 		Map<String, Object> properties = new LinkedHashMap<>();
 		properties.put("logging.file.name", file);
-		properties.put("logging.path", path);
+		properties.put("logging.file.path", path);
 		PropertySource<?> propertySource = new MapPropertySource("properties",
 				properties);
 		MutablePropertySources propertySources = new MutablePropertySources();

--- a/spring-boot-samples/spring-boot-sample-actuator/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-actuator/src/main/resources/application.properties
@@ -3,7 +3,7 @@ service.name=Phil
 spring.security.user.name=user
 spring.security.user.password=password
 
-# logging.file=/tmp/logs/app.log
+# logging.file.name=/tmp/logs/app.log
 # logging.level.org.springframework.security=DEBUG
 management.server.address=127.0.0.1
 


### PR DESCRIPTION
As discussed in #12510 with @philwebb:

-------------------
Using `properties` configuration we can use this:
```properties
logging.file=logs/app.log
logging.file.max-history=20
logging.file.max-size=50MB
```
However, using YAML, we cannot set those at the same time without using the following workaround:  
```yaml
logging.file: logs/app.log
logging:
  file:
    max-history: 20
    max-size: 50MB 
```
----------------------

Thus, to prevent this specific issue from happening with `logging.file`, I suggest `logging.file` should be renamed to `logging.file.name`.



Furthermore, I modified `additional-spring-configuration-metadata.json` accordingly:

The new property entry:
```json
    {
      "name": "logging.file.name",
      "type": "java.lang.String",
      "description": "Log file name (for instance, `myapp.log`). Names can be an exact location or relative to the current directory.",
      "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener"
    }
```

And to notify users of the breaking change:
```json
    {
      "name": "logging.file",
      "type": "java.lang.String",
      "description": "Log file name (for instance, `myapp.log`). Names can be an exact location or relative to the current directory.",
      "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener",
      "deprecation": {
        "replacement": "logging.file.name",
        "level": "error"
      }
    }
```

This (partially) fixes #12510 