### PR TITLE
add switch to create RabbitAutoConfiguration bean

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -83,6 +83,7 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration
 @ConditionalOnClass({ RabbitTemplate.class, Channel.class })
+@ConditionalOnProperty(value = "spring.rabbitmq.enabled", matchIfMissing = true)
 @EnableConfigurationProperties(RabbitProperties.class)
 @Import(RabbitAnnotationDrivenConfiguration.class)
 public class RabbitAutoConfiguration {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -706,6 +706,12 @@
       "defaultValue": "simple"
     },
     {
+      "name": "spring.rabbitmq.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to create the org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration bean.",
+      "defaultValue": true
+    },
+    {
       "name": "spring.security.filter.dispatcher-types",
       "defaultValue": [
         "async",


### PR DESCRIPTION
When I use RabbitMQ in springboot application, I want some profile enable RabbitAutoConfiguration and others disabled. So, I need a switch to control it.
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
