### PR TITLE
Temporarily make @Bean methods in Spring Data JDBC public

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.autoconfigure.data.jdbc;
 
+import java.util.Optional;
+
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -25,9 +27,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.jdbc.core.convert.JdbcCustomConversions;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 import org.springframework.data.jdbc.repository.config.JdbcConfiguration;
 import org.springframework.data.jdbc.repository.config.JdbcRepositoryConfigExtension;
+import org.springframework.data.relational.core.conversion.RelationalConverter;
+import org.springframework.data.relational.core.mapping.NamingStrategy;
+import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 
 /**
@@ -58,6 +64,25 @@ public class JdbcRepositoriesAutoConfiguration {
 	@Configuration
 	@ConditionalOnMissingBean(JdbcConfiguration.class)
 	static class SpringBootJdbcConfiguration extends JdbcConfiguration {
+
+		// Remove these public methods when they are made
+		// public in Spring Data
+		@Override
+		public JdbcCustomConversions jdbcCustomConversions() {
+			return super.jdbcCustomConversions();
+		}
+
+		@Override
+		public RelationalMappingContext jdbcMappingContext(
+				Optional<NamingStrategy> namingStrategy) {
+			return super.jdbcMappingContext(namingStrategy);
+		}
+
+		@Override
+		public RelationalConverter relationalConverter(
+				RelationalMappingContext mappingContext) {
+			return super.relationalConverter(mappingContext);
+		}
 
 	}
 


### PR DESCRIPTION
`@Bean` methods are usually public, but there is one class in Spring
Data that breaks this convention, and Spring Boot happens to 
extend it. The normal reflective use of `@Configuration` isn't affected
but if you wanted to build a functional bean registration from the
Spring Boot code you couldn't without the public accessor.

See https://github.com/spring-projects/spring-data-jdbc/pull/100 for
a change in Spring Data that makes this redundant, but might not be
available till after Lovelace.