### PR TITLE
fix spring cli use windows style path in msys2 environment 

### DIFF
--- a/spring-boot-project/spring-boot-cli/src/main/executablecontent/bin/spring
+++ b/spring-boot-project/spring-boot-cli/src/main/executablecontent/bin/spring
@@ -108,8 +108,8 @@ for f in "${SPRING_HOME}"/lib/*; do
 done
 
 if $cygwin; then
-	SPRING_HOME=$(cygpath --path --mixed "$SPRING_HOME")
-	CLASSPATH=$(cygpath --path --mixed "$CLASSPATH")
+	SPRING_HOME=$(cygpath --path --unix "$SPRING_HOME")
+	CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
 fi
 
 IFS=" " read -r -a javaOpts <<< "$JAVA_OPTS"


### PR DESCRIPTION
in msys2 environment execute `spring` command will cause 


`'/c/Program Files/Java/jdk1.8.0_172/bin/java' -cp '.;C:/spring-2.0.4.RELEASE/bin;C:/spring-2.0.4.RELEASE/lib/spring-boot-cli-2.0.4.RELEASE.jar' org.springframework.boot.loader.JarLauncher`


![image](https://user-images.githubusercontent.com/16847935/48001976-24ba9200-e145-11e8-8537-7a64431409c4.png)

this path style can not be recognized for bash/msys2