### PR TITLE
Polish some Map operations

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthStatusHttpMapper.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthStatusHttpMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,9 +102,9 @@ public class HealthStatusHttpMapper {
 	public int mapStatus(Status status) {
 		String code = getUniformValue(status.getCode());
 		if (code != null) {
-			return this.statusMapping.keySet().stream()
-					.filter((key) -> code.equals(getUniformValue(key)))
-					.map(this.statusMapping::get).findFirst()
+			return this.statusMapping.entrySet().stream()
+					.filter((entry) -> code.equals(getUniformValue(entry.getKey())))
+					.map(Map.Entry::getValue).findFirst()
 					.orElse(WebEndpointResponse.STATUS_OK);
 		}
 		return WebEndpointResponse.STATUS_OK;

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/session/SessionsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/session/SessionsEndpoint.java
@@ -79,8 +79,7 @@ public class SessionsEndpoint {
 		private final List<SessionDescriptor> sessions;
 
 		public SessionsReport(Map<String, ? extends Session> sessions) {
-			this.sessions = sessions.entrySet().stream()
-					.map((s) -> new SessionDescriptor(s.getValue()))
+			this.sessions = sessions.values().stream().map(SessionDescriptor::new)
 					.collect(Collectors.toList());
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/dao/PersistenceExceptionTranslationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/dao/PersistenceExceptionTranslationAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ public class PersistenceExceptionTranslationAutoConfigurationTests {
 		this.context.refresh();
 		Map<String, PersistenceExceptionTranslationPostProcessor> beans = this.context
 				.getBeansOfType(PersistenceExceptionTranslationPostProcessor.class);
-		assertThat(beans.entrySet()).isEmpty();
+		assertThat(beans).isEmpty();
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/JavaBeanBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/JavaBeanBinder.java
@@ -68,8 +68,8 @@ class JavaBeanBinder implements BeanBinder {
 	private <T> boolean bind(BeanPropertyBinder propertyBinder, Bean<T> bean,
 			BeanSupplier<T> beanSupplier) {
 		boolean bound = false;
-		for (Map.Entry<String, BeanProperty> entry : bean.getProperties().entrySet()) {
-			bound |= bind(beanSupplier, propertyBinder, entry.getValue());
+		for (BeanProperty beanProperty : bean.getProperties().values()) {
+			bound |= bind(beanSupplier, propertyBinder, beanProperty);
 		}
 		return bound;
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/MapBinderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/MapBinderTests.java
@@ -620,7 +620,7 @@ public class MapBinderTests {
 								.withExistingValue(Collections.singletonMap("a", "b")))
 				.get();
 		assertThat(result).hasSize(3);
-		assertThat(result.entrySet()).containsExactly(entry("a", "b"), entry("c", "d"),
+		assertThat(result).containsExactly(entry("a", "b"), entry("c", "d"),
 				entry("e", "f"));
 	}
 


### PR DESCRIPTION
Hi,

this PR polishes some Map operations. E.g. replacing `entrySet()` with `values()/keySet()` where only the values/keys of the map are used or vice versa.

Cheers,
Christoph