### PR TITLE
Add missing @Deprecated annotation

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RestTemplateBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RestTemplateBuilder.java
@@ -379,6 +379,7 @@ public class RestTemplateBuilder {
 	 * @deprecated since 2.1.0 in favor of
 	 * {@link #basicAuthentication(String username, String password)}
 	 */
+	@Deprecated
 	public RestTemplateBuilder basicAuthorization(String username, String password) {
 		return basicAuthentication(username, password);
 	}


### PR DESCRIPTION
Hi,

this PR adds a missing `@Deprecated` annotation to `RestTemplateBuilder.basicAuthorization()`.

Cheers,
Christoph