### PR TITLE
Add HANA to the lookup of well-known databases

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/DatabaseLookup.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/DatabaseLookup.java
@@ -53,6 +53,7 @@ final class DatabaseLookup {
 		map.put(DatabaseDriver.SQLSERVER, Database.SQL_SERVER);
 		map.put(DatabaseDriver.DB2, Database.DB2);
 		map.put(DatabaseDriver.INFORMIX, Database.INFORMIX);
+		map.put(DatabaseDriver.HANA, Database.HANA);
 		LOOKUP = Collections.unmodifiableMap(map);
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/DatabaseLookupTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/DatabaseLookupTests.java
@@ -91,6 +91,10 @@ public class DatabaseLookupTests {
 	public void getDatabaseWhenInformixShouldReturnInformix() throws Exception {
 		testGetDatabase("jdbc:informix-sqli:", Database.INFORMIX);
 	}
+	@Test
+	public void getDatabaseWhenSapShouldReturnHana() throws Exception {
+		testGetDatabase("jdbc:sap:", Database.HANA);
+	}
 
 	private void testGetDatabase(String url, Database expected) throws Exception {
 		DataSource dataSource = mock(DataSource.class);


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

HANA has been added to the `DatabaseDriver` enum with PR #14513, but it is still missing in the `DatabaseLookup` utility class.