### PR TITLE
Trim whitespace from configured value for a log level

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
@@ -361,7 +361,7 @@ public class LoggingApplicationListener implements GenericApplicationListener {
 	private void setLogLevel(LoggingSystem system, String name, String level) {
 		try {
 			name = name.equalsIgnoreCase(LoggingSystem.ROOT_LOGGER_NAME) ? null : name;
-			system.setLogLevel(name, coerceLogLevel(level));
+			system.setLogLevel(name, coerceLogLevel(level.trim()));
 		}
 		catch (RuntimeException ex) {
 			this.logger.error("Cannot set level: " + level + " for '" + name + "'");


### PR DESCRIPTION
This is to remove unwanted spaces in the configuration file for log level.