### PR TITLE
Cookie http-only setting has no effect when using Spring Session

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
@@ -39,10 +39,12 @@ import org.springframework.session.config.annotation.web.http.EnableSpringHttpSe
 import org.springframework.session.web.http.CookieHttpSessionIdResolver;
 import org.springframework.session.web.http.DefaultCookieSerializer;
 import org.springframework.session.web.http.HeaderHttpSessionIdResolver;
+import org.springframework.session.web.http.HttpSessionIdResolver;
 import org.springframework.session.web.http.SessionRepositoryFilter;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link SessionAutoConfiguration}.
@@ -245,6 +247,15 @@ public class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurat
 						context.getBeansOfType(DefaultCookieSerializer.class)).isEmpty());
 	}
 
+	@Test
+	public void userProvidedCustomHttpSessionStrategyConfiguration() {
+		this.contextRunner
+				.withUserConfiguration(
+						UserProvidedCustomHttpSessionStrategyConfiguration.class)
+				.run((context) -> assertThat(
+						context.getBeansOfType(DefaultCookieSerializer.class)).isEmpty());
+	}
+
 	@Configuration
 	@EnableSpringHttpSession
 	static class SessionRepositoryConfiguration {
@@ -293,6 +304,18 @@ public class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurat
 		@Bean
 		public HeaderHttpSessionIdResolver httpSessionStrategy() {
 			return HeaderHttpSessionIdResolver.xAuthToken();
+		}
+
+	}
+
+	@Configuration
+	@EnableSpringHttpSession
+	static class UserProvidedCustomHttpSessionStrategyConfiguration
+			extends SessionRepositoryConfiguration {
+
+		@Bean
+		public HttpSessionIdResolver httpSessionStrategy() {
+			return mock(HttpSessionIdResolver.class);
 		}
 
 	}


### PR DESCRIPTION
This PR enhances the existing Spring Session auto-configuration with `DefaultCookieSerializer` configuration. This `DefaultCookieSerializer` is configurable using `ServerProperties` i.e. `server.servlet.session.cookie.*` configuration properties.

By doing this, users are able to fully configure `DefaultCookieSerializer` off `server.servlet.session.cookie.*` which removes the limitation of Spring Session's native configuration that is unable to reliably set `httpOnly` and `secure` attributes.

This resolves #15139 - note that even though that issue is assigned to `2.0.x` I've targeted this at `master` branch as it feels like a big change to have so late in the 2.0 lifecycle. The changes here take basically the same approach as in #10440.