### PR TITLE
Fix use of java11 in springci/spring-boot-jdk11-ci-image

### DIFF
--- a/ci/images/setup.sh
+++ b/ci/images/setup.sh
@@ -26,7 +26,7 @@ case "$1" in
 	java10)
 		 JDK_URL=https://github.com/AdoptOpenJDK/openjdk10-releases/releases/download/jdk-10.0.2%2B13/OpenJDK10_x64_Linux_jdk-10.0.2.13.tar.gz
 	;;
-	jav11)
+	java11)
 		 JDK_URL=https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz
 	;;
 	*)

--- a/ci/images/spring-boot-jdk11-ci-image/Dockerfile
+++ b/ci/images/spring-boot-jdk11-ci-image/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic-20181018
 
 ADD setup.sh /setup.sh
-RUN ./setup.sh java10
+RUN ./setup.sh java11
 
 ENV JAVA_HOME /opt/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH


### PR DESCRIPTION
This commit reverts to use Java 11 in `springci/spring-boot-jdk11-ci-image` image that is now accidentally using java10 by https://github.com/spring-projects/spring-boot/commit/e9232288f41800583447753b4340ae33b5db7631 