### PR TITLE
Avoid instantiation of BeanPropertyBinder in Binder

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java
@@ -333,12 +333,12 @@ public class Binder {
 				|| isUnbindableBean(name, target, context)) {
 			return null;
 		}
-		BeanPropertyBinder propertyBinder = (propertyName, propertyTarget) -> bind(
-				name.append(propertyName), propertyTarget, handler, context, false);
 		Class<?> type = target.getType().resolve(Object.class);
 		if (!allowRecursiveBinding && context.hasBoundBean(type)) {
 			return null;
 		}
+		BeanPropertyBinder propertyBinder = (propertyName, propertyTarget) -> bind(
+				name.append(propertyName), propertyTarget, handler, context, false);
 		return context.withBean(type, () -> {
 			Stream<?> boundBeans = BEAN_BINDERS.stream()
 					.map((b) -> b.bind(name, target, context, propertyBinder));


### PR DESCRIPTION
Hi,

this PR moves an instantiation of `BeanPropertyBinder` in `Binder.bindBean` and therefore avoids unnecessary calls and allocations in case of early returns.

I'm not sure yet if this is side-effect free, though. Tests seem to run, but maybe there is a reason for it being done even though the BeanPropertyBinder is not used eventually. (In which case you can happily decline this PR).

Let me know what you think.
Cheers,
Christoph