### PR TITLE
Find DataSourceProxy even when it is wrapped or proxied 

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceJmxConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceJmxConfiguration.java
@@ -26,6 +26,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.tomcat.jdbc.pool.DataSourceProxy;
 
+import org.springframework.aop.framework.AopProxyUtils;
+import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -33,12 +35,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DelegatingDataSource;
 import org.springframework.jmx.export.MBeanExporter;
 
 /**
  * Configures DataSource related MBeans.
  *
  * @author Stephane Nicoll
+ * @author Tadaya Tsuyukubo
  */
 @Configuration
 @ConditionalOnProperty(prefix = "spring.jmx", name = "enabled", havingValue = "true", matchIfMissing = true)
@@ -89,14 +93,45 @@ class DataSourceJmxConfiguration {
 		@Bean
 		@ConditionalOnMissingBean(name = "dataSourceMBean")
 		public Object dataSourceMBean(DataSource dataSource) {
-			if (dataSource instanceof DataSourceProxy) {
+			DataSourceProxy dataSourceProxy = extractDataSourceProxy(dataSource);
+			if (dataSourceProxy != null) {
 				try {
-					return ((DataSourceProxy) dataSource).createPool().getJmxPool();
+					return dataSourceProxy.createPool().getJmxPool();
 				}
 				catch (SQLException ex) {
 					logger.warn("Cannot expose DataSource to JMX (could not connect)");
 				}
 			}
+			return null;
+		}
+
+		/**
+		 * Perform best effort to retrieve tomcat's {@link DataSourceProxy}.
+		 *
+		 * Since {@link DataSourceProxy#unwrap(Class)} always return {@code null}, it
+		 * cannot directly retrieve {@link DataSourceProxy}. This method tries best effort
+		 * to find {@link DataSourceProxy} if the given {@link DataSource} is wrapped or
+		 * proxied by spring.
+		 * @param dataSource candidate datasource
+		 * @return found DataSourceProxy or null
+		 */
+		private DataSourceProxy extractDataSourceProxy(DataSource dataSource) {
+			if (dataSource instanceof DataSourceProxy) {
+				return (DataSourceProxy) dataSource; // found
+			}
+			else if (dataSource instanceof DelegatingDataSource) {
+				// check delegating target
+				return extractDataSourceProxy(
+						((DelegatingDataSource) dataSource).getTargetDataSource());
+			}
+			else if (AopUtils.isAopProxy(dataSource)) {
+				// for proxy by spring, try target(advised) instance
+				Object target = AopProxyUtils.getSingletonTarget(dataSource);
+				if (target instanceof DataSource) {
+					return extractDataSourceProxy((DataSource) target);
+				}
+			}
+
 			return null;
 		}
 


### PR DESCRIPTION
In `DataSourceJmxConfiguration` with tomcat `DataSource`, it can only find `DataSourceProxy` if given `DataSource` is a direct child of it.

The check logic uses `instanceof`. When target `DataSource` is wrapped(delegated) or proxied, it cannot find `DataSourceProxy`.

Since `DataSourceProxy#unwrap()` always returns null, here cannot use this method to directly obtain `DataSourceProxy`.


In this PR, updated the check logic to perform the best effort to retrieve `DataSourceProxy`. If given `DataSource` is wrapped or proxied *by spring*, tries to unwrap or get target datasource recursively.
