### PR TITLE
Configure MessageSource if no "messageSource" bean defined

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/MessageSourceAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/MessageSourceAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.core.Ordered;
 import org.springframework.core.io.Resource;
@@ -49,7 +50,7 @@ import org.springframework.util.StringUtils;
  * @author Eddú Meléndez
  */
 @Configuration
-@ConditionalOnMissingBean(value = MessageSource.class, search = SearchStrategy.CURRENT)
+@ConditionalOnMissingBean(name = AbstractApplicationContext.MESSAGE_SOURCE_BEAN_NAME, search = SearchStrategy.CURRENT)
 @AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE)
 @Conditional(ResourceBundleCondition.class)
 @EnableConfigurationProperties

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/context/MessageSourceAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/context/MessageSourceAutoConfigurationTests.java
@@ -220,6 +220,48 @@ public class MessageSourceAutoConfigurationTests {
 								.isEqualTo("bar")));
 	}
 
+	@Test
+	public void messageSourceDeclaredWithNonStandardNameDoesNotBreakAutoConfig() {
+		this.contextRunner.withPropertyValues("spring.messages.basename:test/messages")
+				.withUserConfiguration(ConfigWithNonStandardMessageSourceBeanName.class)
+				.run((context) -> {
+					assertThat(context.getMessage("foo", null, Locale.US))
+							.isEqualTo("bar");
+				});
+	}
+
+	private static class CodeReturningMessageSource implements MessageSource {
+
+		@Override
+		public String getMessage(String code, Object[] args, String defaultMessage,
+				Locale locale) {
+			return code;
+		}
+
+		@Override
+		public String getMessage(String code, Object[] args, Locale locale)
+				throws NoSuchMessageException {
+			return code;
+		}
+
+		@Override
+		public String getMessage(MessageSourceResolvable resolvable, Locale locale)
+				throws NoSuchMessageException {
+			return resolvable.getCodes()[0];
+		}
+
+	}
+
+	@Configuration
+	protected static class ConfigWithNonStandardMessageSourceBeanName {
+
+		@Bean
+		public MessageSource codeReturningMessageSource() {
+			return new CodeReturningMessageSource();
+		}
+
+	}
+
 	@Configuration
 	@PropertySource("classpath:/switch-messages.properties")
 	protected static class Config {
@@ -231,27 +273,7 @@ public class MessageSourceAutoConfigurationTests {
 
 		@Bean
 		public MessageSource messageSource() {
-			return new MessageSource() {
-
-				@Override
-				public String getMessage(String code, Object[] args,
-						String defaultMessage, Locale locale) {
-					return code;
-				}
-
-				@Override
-				public String getMessage(String code, Object[] args, Locale locale)
-						throws NoSuchMessageException {
-					return code;
-				}
-
-				@Override
-				public String getMessage(MessageSourceResolvable resolvable,
-						Locale locale) throws NoSuchMessageException {
-					return resolvable.getCodes()[0];
-				}
-
-			};
+			return new CodeReturningMessageSource();
 		}
 
 	}


### PR DESCRIPTION
Hello.

This PR fixes an issue with `MessageSourceAutoConfiguration` when a `MessageSource` bean with non standard name defined.

In particular `ApplicationContext` expects a `MessageSource` bean defined only with `"messageSource"` name, but `MessageSourceAutoConfiguration` does not convey the same policy.

So when a `MessageSource` is defined with non-standard name `MessageSourceAutoConfiguration` does not expose a `MessageSource` named `"messageSource"` and at the same time `ApplicationContext` does not use defined `MessageSource` and message resolution process fails.

See [`AbstractApplicationContext.initMessageSource()`](https://github.com/spring-projects/spring-framework/blob/afa38f5f97b0101f4b0f11768ca0c512c0dab45a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java#L714).
It is also stated in the [reference documentation](https://docs.spring.io/spring/docs/5.1.2.RELEASE/spring-framework-reference/core.html#context-functionality-messagesource):

> When an ApplicationContext is loaded, it automatically searches for a MessageSource bean defined in the context. **The bean must have the name messageSource.** If such a bean is found, all calls to the preceding methods are delegated to the message source. If no message source is found, the ApplicationContext attempts to find a parent containing a bean with the same name. If it does, it uses that bean as the MessageSource. If the ApplicationContext cannot find any source for messages, an empty DelegatingMessageSource is instantiated in order to be able to accept calls to the methods defined above.


[Project](https://github.com/cac03/spring-boot-messagesource-issue) reproducing the issue.
See created tests. In particular: 
* [MessageSourceWithNonStandardNameTests](https://github.com/cac03/spring-boot-messagesource-issue/blob/master/src/test/java/com/caco3/messagesource/MessageSourceWithNonStandardNameTests.java) demonstrates expected behaviour.
* [MessageSourceWithStandardNameTests](https://github.com/cac03/spring-boot-messagesource-issue/blob/master/src/test/java/com/caco3/messagesource/MessageSourceWithStandardNameTests.java) demonstrates behaviour  when `MessageSource` is defined with `"messagesSource"` name.
* [NotMessageSourceMessageSourceTests](https://github.com/cac03/spring-boot-messagesource-issue/blob/master/src/test/java/com/caco3/messagesource/NotMessageSourceMessageSourceTests.java) demonstrates that a bean named `"messageSource"` must actually be `MessageSource`



<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
