### PR TITLE
Remove unnecessary cast in LoggingSystemProperties

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
@@ -117,10 +117,9 @@ public class LoggingSystemProperties {
 
 	private PropertyResolver getPropertyResolver() {
 		if (this.environment instanceof ConfigurableEnvironment) {
-			PropertyResolver resolver = new PropertySourcesPropertyResolver(
+			PropertySourcesPropertyResolver resolver = new PropertySourcesPropertyResolver(
 					((ConfigurableEnvironment) this.environment).getPropertySources());
-			((PropertySourcesPropertyResolver) resolver)
-					.setIgnoreUnresolvableNestedPlaceholders(true);
+			resolver.setIgnoreUnresolvableNestedPlaceholders(true);
 			return resolver;
 		}
 		return this.environment;


### PR DESCRIPTION
Hi,

this PR removes a cast in LoggingSystemProperties that seems unnecessary.

Cheers,
Christoph