### PR TITLE
Support for capping archived log files

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-application-properties.adoc
@@ -40,6 +40,8 @@ content into your application. Rather, pick only the properties that you need.
 	logging.file= # Log file name (for instance, `myapp.log`). Names can be an exact location or relative to the current directory.
 	logging.file.max-history=0 # Maximum of archive log files to keep. Only supported with the default logback setup.
 	logging.file.max-size=10MB # Maximum log file size. Only supported with the default logback setup.
+	logging.file.total-size-cap=0 # Places a cap on the total size of log backups. Only supported with the default logback setup.
+	logging.file.clean-history-on-start=false # Whether to clean the archive log files on startup. Only supported with the default logback setup.
 	logging.group.*= # Log groups to quickly change multiple loggers at the same time. For instance, `logging.level.db=org.hibernate,org.springframework.jdbc`.
 	logging.level.*= # Log levels severity mapping. For instance, `logging.level.org.springframework=DEBUG`.
 	logging.path= # Location of the log file. For instance, `/var/log`.

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -1717,7 +1717,10 @@ relative to the current directory.
 Log files rotate when they reach 10 MB and, as with console output, `ERROR`-level,
 `WARN`-level, and `INFO`-level messages are logged by default. Size limits can be changed
 using the `logging.file.max-size` property. Previously rotated files are archived
-indefinitely unless the `logging.file.max-history` property has been set.
+indefinitely unless the `logging.file.max-history` property has been set. The total size
+of log archives can be capped using `logging.file.total-size-cap`. When the total size of
+log archives exceeds that threshold, backups will be deleted. To force log archive cleanup
+on application startup, use the `logging.file.clean-history-on-start` property.
 
 NOTE: The logging system is initialized early in the application lifecycle. Consequently,
 logging properties are not found in property files loaded through `@PropertySource`
@@ -1847,6 +1850,16 @@ setup.)
 |`logging.file.max-history`
 |`LOG_FILE_MAX_HISTORY`
 |Maximum number of archive log files to keep (if LOG_FILE enabled). (Only supported with
+the default Logback setup.)
+
+|`logging.file.total-size-cap`
+|`LOG_FILE_TOTAL_SIZE_CAP`
+|The total size of log backups to be kept (if LOG_FILE enabled). (Only supported with
+the default Logback setup.)
+
+|`logging.file.clean-history-on-start`
+|`LOG_FILE_CLEAN_HISTORY_ON_START`
+|Whether to clean the archive log files on startup (if LOG_FILE enabled). (Only supported with
 the default Logback setup.)
 
 |`logging.path`

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
@@ -30,6 +30,7 @@ import org.springframework.util.Assert;
  * @author Phillip Webb
  * @author Madhura Bhave
  * @author Vedran Pavic
+ * @author Robert Thornton
  * @since 2.0.0
  */
 public class LoggingSystemProperties {
@@ -75,6 +76,16 @@ public class LoggingSystemProperties {
 	public static final String FILE_MAX_SIZE = "LOG_FILE_MAX_SIZE";
 
 	/**
+	 * The name of the System property that contains the file total size cap.
+	 */
+	public static final String FILE_TOTAL_SIZE_CAP = "LOG_FILE_TOTAL_SIZE_CAP";
+
+	/**
+	 * The name of the System property that contains the clean history on start flag.
+	 */
+	public static final String FILE_CLEAN_HISTORY_ON_START = "LOG_FILE_CLEAN_HISTORY_ON_START";
+
+	/**
 	 * The name of the System property that contains the log level pattern.
 	 */
 	public static final String LOG_LEVEL_PATTERN = "LOG_LEVEL_PATTERN";
@@ -108,6 +119,9 @@ public class LoggingSystemProperties {
 		setSystemProperty(resolver, FILE_LOG_PATTERN, "pattern.file");
 		setSystemProperty(resolver, FILE_MAX_HISTORY, "file.max-history");
 		setSystemProperty(resolver, FILE_MAX_SIZE, "file.max-size");
+		setSystemProperty(resolver, FILE_TOTAL_SIZE_CAP, "file.total-size-cap");
+		setSystemProperty(resolver, FILE_CLEAN_HISTORY_ON_START,
+				"file.clean-history-on-start");
 		setSystemProperty(resolver, LOG_LEVEL_PATTERN, "pattern.level");
 		setSystemProperty(resolver, LOG_DATEFORMAT_PATTERN, "pattern.dateformat");
 		if (logFile != null) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
@@ -45,6 +45,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Phillip Webb
  * @author Madhura Bhave
  * @author Vedran Pavic
+ * @author Robert Thornton
  * @since 1.1.2
  */
 class DefaultLogbackConfiguration {
@@ -145,6 +146,11 @@ class DefaultLogbackConfiguration {
 				this.patterns.getProperty("logging.file.max-size", MAX_FILE_SIZE));
 		rollingPolicy.setMaxHistory(this.patterns.getProperty("logging.file.max-history",
 				Integer.class, CoreConstants.UNBOUND_HISTORY));
+		rollingPolicy.setTotalSizeCap(
+				FileSize.valueOf(this.patterns.getProperty("logging.file.total-size-cap",
+						"" + CoreConstants.UNBOUNDED_TOTAL_SIZE_CAP)));
+		rollingPolicy.setCleanHistoryOnStart(Boolean.parseBoolean(this.patterns
+				.getProperty("logging.file.clean-history-on-start", "false")));
 		appender.setRollingPolicy(rollingPolicy);
 		rollingPolicy.setParent(appender);
 		config.start(rollingPolicy);

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -88,6 +88,20 @@
       "defaultValue": 0
     },
     {
+      "name": "logging.file.total-size-cap",
+      "type": "java.lang.String",
+      "description": "Total size of log backups to be kept. Only supported with the default logback setup.",
+      "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener",
+      "defaultValue": 0
+    },
+    {
+      "name": "logging.file.clean-history-on-start",
+      "type": "java.lang.Boolean",
+      "description": "Whether to clean log backups on start. Only supported with the default logback setup.",
+      "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener",
+      "defaultValue": false
+    },
+    {
       "name": "logging.group",
       "type": "java.util.Map<java.lang.String,java.util.List<java.lang.String>>",
       "description": "Log groups to quickly change multiple loggers at the same time. For instance, `logging.level.db=org.hibernate,org.springframework.jdbc`.",

--- a/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/file-appender.xml
+++ b/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/file-appender.xml
@@ -16,6 +16,8 @@ initialization performed by Boot
 			<fileNamePattern>${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
 			<maxFileSize>${LOG_FILE_MAX_SIZE:-10MB}</maxFileSize>
 			<maxHistory>${LOG_FILE_MAX_HISTORY:-0}</maxHistory>
+			<totalSizeCap>${LOG_FILE_TOTAL_SIZE_CAP:-0}</totalSizeCap>
+			<cleanHistoryOnStart>${LOG_FILE_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
 		</rollingPolicy>
 	</appender>
 </included>

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -76,6 +76,7 @@ import static org.mockito.Mockito.verify;
  * @author Ben Hale
  * @author Madhura Bhave
  * @author Vedran Pavic
+ * @author Robert Thornton
  */
 @RunWith(ModifiedClassPathRunner.class)
 @ClassPathExclusions("log4j-*.jar")
@@ -413,6 +414,68 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.logger.info("Hello world");
 		assertThat(getLineWithText(file, "Hello world")).contains("INFO");
 		assertThat(getRollingPolicy().getMaxHistory()).isEqualTo(30);
+	}
+
+	@Test
+	public void testTotalSizeCapProperty() throws Exception {
+		String expectedSize = "101 MB";
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("logging.file.total-size-cap", expectedSize);
+		LoggingInitializationContext loggingInitializationContext = new LoggingInitializationContext(
+				environment);
+		File file = new File(tmpDir(), "logback-test.log");
+		LogFile logFile = getLogFile(file.getPath(), null);
+		this.loggingSystem.initialize(loggingInitializationContext, null, logFile);
+		this.logger.info("Hello world");
+		assertThat(getLineWithText(file, "Hello world")).contains("INFO");
+		assertThat(ReflectionTestUtils.getField(getRollingPolicy(), "totalSizeCap")
+				.toString()).isEqualTo(expectedSize);
+	}
+
+	@Test
+	public void testTotalSizeCapPropertyWithXmlConfiguration() throws Exception {
+		String expectedSize = "101 MB";
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("logging.file.total-size-cap", expectedSize);
+		LoggingInitializationContext loggingInitializationContext = new LoggingInitializationContext(
+				environment);
+		File file = new File(tmpDir(), "logback-test.log");
+		LogFile logFile = getLogFile(file.getPath(), null);
+		this.loggingSystem.initialize(loggingInitializationContext,
+				"classpath:logback-include-base.xml", logFile);
+		this.logger.info("Hello world");
+		assertThat(getLineWithText(file, "Hello world")).contains("INFO");
+		assertThat(ReflectionTestUtils.getField(getRollingPolicy(), "totalSizeCap")
+				.toString()).isEqualTo(expectedSize);
+	}
+
+	@Test
+	public void testCleanHistoryOnStartProperty() throws Exception {
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("logging.file.clean-history-on-start", "true");
+		LoggingInitializationContext loggingInitializationContext = new LoggingInitializationContext(
+				environment);
+		File file = new File(tmpDir(), "logback-test.log");
+		LogFile logFile = getLogFile(file.getPath(), null);
+		this.loggingSystem.initialize(loggingInitializationContext, null, logFile);
+		this.logger.info("Hello world");
+		assertThat(getLineWithText(file, "Hello world")).contains("INFO");
+		assertThat(getRollingPolicy().isCleanHistoryOnStart()).isTrue();
+	}
+
+	@Test
+	public void testCleanHistoryOnStartPropertyWithXmlConfiguration() throws Exception {
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("logging.file.clean-history-on-start", "true");
+		LoggingInitializationContext loggingInitializationContext = new LoggingInitializationContext(
+				environment);
+		File file = new File(tmpDir(), "logback-test.log");
+		LogFile logFile = getLogFile(file.getPath(), null);
+		this.loggingSystem.initialize(loggingInitializationContext,
+				"classpath:logback-include-base.xml", logFile);
+		this.logger.info("Hello world");
+		assertThat(getLineWithText(file, "Hello world")).contains("INFO");
+		assertThat(getRollingPolicy().isCleanHistoryOnStart()).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
This pull request provides support for setting the `total-size-cap` and `clean-history-on-start` properties on the SizeAndTimeBasedRollingPolicy. This makes it possible to limit the total size of the archived log files in order to avoid overuse of an application's disk space quota.