### PR TITLE
Fix NPE when tomcat customizer accesses resources

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
@@ -184,9 +184,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	protected void prepareContext(Host host, ServletContextInitializer[] initializers) {
 		File documentRoot = getValidDocumentRoot();
 		TomcatEmbeddedContext context = new TomcatEmbeddedContext();
-		if (documentRoot != null) {
-			context.setResources(new LoaderHidingResourceRoot(context));
-		}
+		context.setResources(new LoaderHidingResourceRoot(context));
 		context.setName(getContextPath());
 		context.setDisplayName(getDisplayName());
 		context.setPath(getContextPath());


### PR DESCRIPTION
Absence of validDocumentRoot prevents setting resources that leads to NPE in customizer, that tries to load additional resources.
validDocumentRoot can't be resolved if webapp runs as executable Jar without webapp/staic/public directories.
That leads to resources being null. And TomcatContextCustomizer can't load additional resources.
TomcatContextCustomizer can set resources to new StandardRoot instance, but that will lead to disclosure of spring files, fixed in [gh 5550](https://github.com/spring-projects/spring-boot/issues/5550)