### PR TITLE
Remove Mockito 1 leftover

### DIFF
--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanWithAopProxyTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanWithAopProxyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,10 @@
 
 package org.springframework.boot.test.mock.mockito;
 
-import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatchers;
 
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
@@ -34,10 +32,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.util.ClassUtils;
-import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -60,32 +58,8 @@ public class SpyBeanWithAopProxyTests {
 		Long d2 = this.dateService.getDate(false);
 		assertThat(d1).isEqualTo(d2);
 		verify(this.dateService, times(1)).getDate(false);
-		verify(this.dateService, times(1)).getDate(matchesFalse());
-		verify(this.dateService, times(1)).getDate(matchesAnyBoolean());
-	}
-
-	private boolean matchesFalse() {
-		if (isTestingMockito1()) {
-			Method method = ReflectionUtils.findMethod(
-					ClassUtils.resolveClassName("org.mockito.Matchers", null), "eq",
-					Boolean.TYPE);
-			return (boolean) ReflectionUtils.invokeMethod(method, null, false);
-		}
-		return ArgumentMatchers.eq(false);
-	}
-
-	private boolean matchesAnyBoolean() {
-		if (isTestingMockito1()) {
-			Method method = ReflectionUtils.findMethod(
-					ClassUtils.resolveClassName("org.mockito.Matchers", null),
-					"anyBoolean");
-			return (boolean) ReflectionUtils.invokeMethod(method, null);
-		}
-		return ArgumentMatchers.anyBoolean();
-	}
-
-	private boolean isTestingMockito1() {
-		return ClassUtils.isPresent("org.mockito.ReturnValues", null);
+		verify(this.dateService, times(1)).getDate(eq(false));
+		verify(this.dateService, times(1)).getDate(anyBoolean());
 	}
 
 	@Configuration


### PR DESCRIPTION
Hi,

while looking through some code that uses reflection, I noticed that in `SpyBeanWithAopProxyTests` there is still a reference to Mockito 1, which isn't supported anymore. This PR removes that leftover.

Have yourself a nice weekend,
Christoph