### PR TITLE
Make HierarchicalNameMapper injectable for GraphiteMeterRegistry

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphiteMetricsExportAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphiteMetricsExportAutoConfiguration.java
@@ -59,8 +59,9 @@ public class GraphiteMetricsExportAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean
-	public HierarchicalNameMapper graphiteHierarchicalNameMapper(GraphiteConfig config) {
+	@ConditionalOnMissingBean(HierarchicalNameMapper.class)
+	public GraphiteHierarchicalNameMapper graphiteHierarchicalNameMapper(
+			GraphiteConfig config) {
 		return new GraphiteHierarchicalNameMapper(config.tagsAsPrefix());
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphiteMetricsExportAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphiteMetricsExportAutoConfiguration.java
@@ -17,7 +17,9 @@
 package org.springframework.boot.actuate.autoconfigure.metrics.export.graphite;
 
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.util.HierarchicalNameMapper;
 import io.micrometer.graphite.GraphiteConfig;
+import io.micrometer.graphite.GraphiteHierarchicalNameMapper;
 import io.micrometer.graphite.GraphiteMeterRegistry;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
@@ -58,9 +60,15 @@ public class GraphiteMetricsExportAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public GraphiteMeterRegistry graphiteMeterRegistry(GraphiteConfig graphiteConfig,
-			Clock clock) {
-		return new GraphiteMeterRegistry(graphiteConfig, clock);
+	public HierarchicalNameMapper graphiteHierarchicalNameMapper(GraphiteConfig config) {
+		return new GraphiteHierarchicalNameMapper(config.tagsAsPrefix());
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public GraphiteMeterRegistry graphiteMeterRegistry(GraphiteConfig config, Clock clock,
+			HierarchicalNameMapper nameMapper) {
+		return new GraphiteMeterRegistry(config, clock, nameMapper);
 	}
 
 }


### PR DESCRIPTION
This PR changes to make `HierarchicalNameMapper` injectable for `GraphiteMeterRegistry`.

See https://github.com/micrometer-metrics/micrometer/issues/638

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
