### PR TITLE
Fix StringSequence.equals() for different lengths

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/StringSequence.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/StringSequence.java
@@ -126,7 +126,7 @@ final class StringSequence implements CharSequence {
 			}
 			return true;
 		}
-		return true;
+		return false;
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/StringSequenceTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/StringSequenceTests.java
@@ -163,6 +163,13 @@ public class StringSequenceTests {
 	}
 
 	@Test
+	public void notEqualsWhenSequencesOfDifferentLength() {
+		StringSequence a = new StringSequence("abcd");
+		StringSequence b = new StringSequence("ef");
+		assertThat(a).isNotEqualTo(b);
+	}
+
+	@Test
 	public void startsWithWhenExactMatch() {
 		assertThat(new StringSequence("abc").startsWith("abc")).isTrue();
 	}


### PR DESCRIPTION
Hi,

while working on an optimization in `StringSequence.subSequence()` I noticed that `StringSequence.equals()` returns `true` for sequences with different lengths. In order to be able to easily cherry-pick that here is the isolated PR just for the fix without the optimization (on which I'd ask for feedback later in a separate PR).

Cheers,
Christoph