### PR TITLE
Skip actuator security autoconfig if resource server autoconfig is active

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
@@ -557,6 +557,16 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-oauth2-resource-server</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-oauth2-jose</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
 			<scope>test</scope>

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/reactive/ReactiveManagementWebSecurityAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/reactive/ReactiveManagementWebSecurityAutoConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.security.oauth2.client.reactive.ReactiveOAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.reactive.ReactiveOAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -51,7 +52,8 @@ import org.springframework.security.web.server.WebFilterChainProxy;
 @AutoConfigureBefore(ReactiveSecurityAutoConfiguration.class)
 @AutoConfigureAfter({ HealthEndpointAutoConfiguration.class,
 		InfoEndpointAutoConfiguration.class, WebEndpointAutoConfiguration.class,
-		ReactiveOAuth2ClientAutoConfiguration.class })
+		ReactiveOAuth2ClientAutoConfiguration.class,
+		ReactiveOAuth2ResourceServerAutoConfiguration.class })
 public class ReactiveManagementWebSecurityAutoConfiguration {
 
 	@Bean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/ManagementWebSecurityAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/ManagementWebSecurityAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.WebSecurityEnablerConfiguration;
 import org.springframework.context.annotation.Configuration;
@@ -47,7 +48,8 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 @AutoConfigureBefore(SecurityAutoConfiguration.class)
 @AutoConfigureAfter({ HealthEndpointAutoConfiguration.class,
 		InfoEndpointAutoConfiguration.class, WebEndpointAutoConfiguration.class,
-		OAuth2ClientAutoConfiguration.class })
+		OAuth2ClientAutoConfiguration.class,
+		OAuth2ResourceServerAutoConfiguration.class })
 @Import({ ManagementWebSecurityConfigurerAdapter.class,
 		WebSecurityEnablerConfiguration.class })
 public class ManagementWebSecurityAutoConfiguration {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/reactive/ReactiveManagementWebSecurityAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/reactive/ReactiveManagementWebSecurityAutoConfigurationTests.java
@@ -31,6 +31,7 @@ import org.springframework.boot.actuate.autoconfigure.health.HealthEndpointAutoC
 import org.springframework.boot.actuate.autoconfigure.health.HealthIndicatorAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.info.InfoEndpointAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.reactive.ReactiveOAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.reactive.ReactiveUserDetailsServiceAutoConfiguration;
 import org.springframework.boot.test.context.assertj.AssertableReactiveWebApplicationContext;
@@ -114,6 +115,22 @@ public class ReactiveManagementWebSecurityAutoConfigurationTests {
 					assertThat(getLocationHeader(context, "/actuator/health").toString())
 							.contains("/login");
 					assertThat(getLocationHeader(context, "/foo")).isNull();
+				});
+	}
+
+	@Test
+	public void backsOffIfReactiveOAuth2ResourceServerAutoConfigurationSecurityIsAdded() {
+		this.contextRunner
+				.withConfiguration(AutoConfigurations
+						.of(ReactiveOAuth2ResourceServerAutoConfiguration.class))
+				.withPropertyValues(
+						"spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://authserver")
+				.run((context) -> {
+					assertThat(
+							getAuthenticateHeader(context, "/actuator/health").toString())
+									.contains("Bearer");
+					assertThat(getAuthenticateHeader(context, "/anything").toString())
+							.contains("Bearer");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/reactive/ReactiveManagementWebSecurityAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/reactive/ReactiveManagementWebSecurityAutoConfigurationTests.java
@@ -126,11 +126,9 @@ public class ReactiveManagementWebSecurityAutoConfigurationTests {
 				.withPropertyValues(
 						"spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://authserver")
 				.run((context) -> {
-					assertThat(
-							getAuthenticateHeader(context, "/actuator/health").toString())
-									.contains("Bearer");
-					assertThat(getAuthenticateHeader(context, "/anything").toString())
-							.contains("Bearer");
+					assertThat(context.getBeanNamesForType(
+							ReactiveManagementWebSecurityAutoConfiguration.class))
+									.isEmpty();
 				});
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/ManagementWebSecurityAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/ManagementWebSecurityAutoConfigurationTests.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.actuate.autoconfigure.security.servlet;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.junit.Test;
 
@@ -33,7 +32,6 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.boot.test.context.assertj.AssertableWebApplicationContext;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -117,27 +115,12 @@ public class ManagementWebSecurityAutoConfigurationTests {
 				.withPropertyValues(
 						"spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://authserver")
 				.run((context) -> {
-					assertThat(
-							getAuthenticateHeader(context, "/actuator/info").toString())
-									.contains("Bearer");
-					assertThat(getAuthenticateHeader(context, "/anything").toString())
-							.contains("Bearer");
+					assertThat(context.getBeanNamesForType(
+							ManagementWebSecurityConfigurerAdapter.class)).isEmpty();
 				});
 	}
 
-	private List<String> getAuthenticateHeader(AssertableWebApplicationContext context,
-			String path) throws IOException, javax.servlet.ServletException {
-		MockHttpServletResponse response = getResponse(context, path);
-		return response.getHeaders(HttpHeaders.WWW_AUTHENTICATE);
-	}
-
 	private HttpStatus getResponseStatus(AssertableWebApplicationContext context,
-			String path) throws IOException, javax.servlet.ServletException {
-		MockHttpServletResponse response = getResponse(context, path);
-		return HttpStatus.valueOf(response.getStatus());
-	}
-
-	private MockHttpServletResponse getResponse(AssertableWebApplicationContext context,
 			String path) throws IOException, javax.servlet.ServletException {
 		FilterChainProxy filterChainProxy = context.getBean(FilterChainProxy.class);
 		MockServletContext servletContext = new MockServletContext();
@@ -148,7 +131,7 @@ public class ManagementWebSecurityAutoConfigurationTests {
 		request.setServletPath(path);
 		request.setMethod("GET");
 		filterChainProxy.doFilter(request, response, new MockFilterChain());
-		return response;
+		return HttpStatus.valueOf(response.getStatus());
 	}
 
 	@Configuration


### PR DESCRIPTION
I had a working Spring Boot 2.1.0 OAuth2 resource server application (with autoconfig based on https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-security-oauth2-server) but wanted to add the actuator. What happened was that the actuator security configuration autoconfiguration occurred before the OAuth2ResourceServerAutoconfiguration resulting in my endpoints becoming Basic-protected rather than OAuth2-protected.

I noticed that actuator security configuration was skipped if OAuth2 client autoconfiguration exists and figured that since resource server was new in 2.1.x that adding detection for its security configuration was missed (didn't see any tests for that level of detail...nor the right way to add tests for these "composed starter" cases).  

I realize that this OAuth2-protects ALL the actuator endpoints (including the normally open health and info endpoints) but, without autoconfiguration detecting and creating a hybrid security config, this seemed to be this simplest logical solution and was more in line with the docs:

> If Spring Security is on the classpath and no other WebSecurityConfigurerAdapter is present, all actuators other than /health and /info are secured by Spring Boot auto-configuration. If you define a custom WebSecurityConfigurerAdapter, Spring Boot auto-configuration will back off and you will be in full control of actuator access rules.

https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-security-actuator
