### PR TITLE
Optimize StringSequence

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/StringSequence.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/StringSequence.java
@@ -66,6 +66,9 @@ final class StringSequence implements CharSequence {
 		if (subSequenceEnd > this.end) {
 			throw new StringIndexOutOfBoundsException(end);
 		}
+		if (start == 0 && subSequenceEnd == this.end) {
+			return this;
+		}
 		return new StringSequence(this.source, subSequenceStart, subSequenceEnd);
 	}
 
@@ -100,10 +103,18 @@ final class StringSequence implements CharSequence {
 	}
 
 	public boolean startsWith(CharSequence prefix, int offset) {
-		if (length() - prefix.length() - offset < 0) {
+		int prefixLength = prefix.length();
+		if (length() - prefixLength - offset < 0) {
 			return false;
 		}
-		return subSequence(offset, offset + prefix.length()).equals(prefix);
+		int prefixOffset = 0;
+		int sourceOffset = offset;
+		while (prefixLength-- != 0) {
+			if (charAt(sourceOffset++) != prefix.charAt(prefixOffset++)) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
Hi,

as mentioned earlier today in #15465 this is the PR for some optimizations of `StringSequence`. More specifically for `StringSequence.subSequence()` in cases where the starting offset is 0 (much like in `String.substring()`). Additionally, for `StringSequence.startsWith()` by avoiding potential allocations of `subSequence()` - even though there is a good chance escape analysis avoids them.

See the following results with the patch:
```
Benchmark                                                         Mode  Cnt          Score          Error   Units
MyBenchmark.testStartsWith                                    thrpt   10   67431840,006 ±   791645,524   ops/s
MyBenchmark.testStartsWith:·gc.alloc.rate                     thrpt   10          0,001 ±        0,001  MB/sec
MyBenchmark.testStartsWith:·gc.alloc.rate.norm                thrpt   10         ? 10??                   B/op
MyBenchmark.testStartsWith:·gc.count                          thrpt   10            ? 0                 counts
MyBenchmark.testSubsequence                                   thrpt   10  316711796,197 ± 10992166,059   ops/s
MyBenchmark.testSubsequence:·gc.alloc.rate                    thrpt   10          0,001 ±        0,001  MB/sec
MyBenchmark.testSubsequence:·gc.alloc.rate.norm               thrpt   10         ? 10??                   B/op
MyBenchmark.testSubsequence:·gc.count                         thrpt   10            ? 0                 counts
```
vs. the old code:
```
Benchmark                                                         Mode  Cnt          Score          Error   Units
MyBenchmark.testStartsWith                                    thrpt   10   63029809,023 ±  1172502,340   ops/s
MyBenchmark.testStartsWith:·gc.alloc.rate                     thrpt   10          0,001 ±        0,001  MB/sec
MyBenchmark.testStartsWith:·gc.alloc.rate.norm                thrpt   10         ? 10??                   B/op
MyBenchmark.testStartsWith:·gc.count                          thrpt   10            ? 0                 counts
MyBenchmark.testSubsequence                                   thrpt   10  123833544,662 ±  9933577,230   ops/s
MyBenchmark.testSubsequence:·gc.alloc.rate                    thrpt   10       3777,956 ±      302,934  MB/sec
MyBenchmark.testSubsequence:·gc.alloc.rate.norm               thrpt   10         32,000 ±        0,001    B/op
MyBenchmark.testSubsequence:·gc.churn.PS_Eden_Space           thrpt   10       3769,693 ±      330,836  MB/sec
MyBenchmark.testSubsequence:·gc.churn.PS_Eden_Space.norm      thrpt   10         31,948 ±        2,016    B/op
MyBenchmark.testSubsequence:·gc.churn.PS_Survivor_Space       thrpt   10          0,187 ±        0,074  MB/sec
MyBenchmark.testSubsequence:·gc.churn.PS_Survivor_Space.norm  thrpt   10          0,002 ±        0,001    B/op
MyBenchmark.testSubsequence:·gc.count                         thrpt   10        141,000                 counts
MyBenchmark.testSubsequence:·gc.time                          thrpt   10         93,000                     ms
```

For completeness reasons here is the benchmark for the old `startsWith` without escape analysis kicking in (by disabling it via `-XX:-DoEscapeAnalysis`):
```
MyBenchmark.testStartsWith                                    thrpt   10   53268054,305 ± 3264411,681   ops/s
MyBenchmark.testStartsWith:·gc.alloc.rate                     thrpt   10       1625,151 ±      99,597  MB/sec
MyBenchmark.testStartsWith:·gc.alloc.rate.norm                thrpt   10         32,000 ±       0,001    B/op
MyBenchmark.testStartsWith:·gc.churn.PS_Eden_Space            thrpt   10       1678,723 ±     156,577  MB/sec
MyBenchmark.testStartsWith:·gc.churn.PS_Eden_Space.norm       thrpt   10         33,066 ±       2,719    B/op
MyBenchmark.testStartsWith:·gc.churn.PS_Survivor_Space        thrpt   10          0,131 ±       0,077  MB/sec
MyBenchmark.testStartsWith:·gc.churn.PS_Survivor_Space.norm   thrpt   10          0,003 ±       0,001    B/op
MyBenchmark.testStartsWith:·gc.count                          thrpt   10         81,000                counts
MyBenchmark.testStartsWith:·gc.time                           thrpt   10         58,000                    ms
```

Let me know what you think.
Cheers,
Christoph