### PR TITLE
Avoid unnecessary usage of ReflectionTestUtils

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfigurationTests.java
@@ -23,12 +23,10 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.ldap.core.ContextSource;
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.ldap.pool2.factory.PoolConfig;
 import org.springframework.ldap.pool2.factory.PooledContextSource;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -58,7 +56,7 @@ public class LdapAutoConfigurationTests {
 	public void contextSourceWithSingleUrl() {
 		this.contextRunner.withPropertyValues("spring.ldap.urls:ldap://localhost:123")
 				.run((context) -> {
-					ContextSource contextSource = context
+					LdapContextSource contextSource = context
 							.getBean(LdapContextSource.class);
 					String[] urls = getUrls(contextSource);
 					assertThat(urls).containsExactly("ldap://localhost:123");
@@ -71,7 +69,7 @@ public class LdapAutoConfigurationTests {
 				.withPropertyValues(
 						"spring.ldap.urls:ldap://localhost:123,ldap://mycompany:123")
 				.run((context) -> {
-					ContextSource contextSource = context
+					LdapContextSource contextSource = context
 							.getBean(LdapContextSource.class);
 					LdapProperties ldapProperties = context.getBean(LdapProperties.class);
 					String[] urls = getUrls(contextSource);
@@ -120,8 +118,8 @@ public class LdapAutoConfigurationTests {
 				});
 	}
 
-	private String[] getUrls(ContextSource contextSource) {
-		return (String[]) ReflectionTestUtils.getField(contextSource, "urls");
+	private String[] getUrls(LdapContextSource contextSource) {
+		return contextSource.getUrls();
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoPropertiesTests.java
@@ -21,15 +21,12 @@ import java.util.List;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.ServerAddress;
-import com.mongodb.connection.Cluster;
-import com.mongodb.connection.ClusterSettings;
 import org.junit.Test;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -120,7 +117,7 @@ public class MongoPropertiesTests {
 		properties.setUri("mongodb://mongo1.example.com:12345");
 		MongoClient client = new MongoClientFactory(properties, null)
 				.createMongoClient(null);
-		List<ServerAddress> allAddresses = extractServerAddresses(client);
+		List<ServerAddress> allAddresses = client.getAllAddress();
 		assertThat(allAddresses).hasSize(1);
 		assertServerAddress(allAddresses.get(0), "mongo1.example.com", 12345);
 	}
@@ -132,7 +129,7 @@ public class MongoPropertiesTests {
 		properties.setPort(27017);
 		MongoClient client = new MongoClientFactory(properties, null)
 				.createMongoClient(null);
-		List<ServerAddress> allAddresses = extractServerAddresses(client);
+		List<ServerAddress> allAddresses = client.getAllAddress();
 		assertThat(allAddresses).hasSize(1);
 		assertServerAddress(allAddresses.get(0), "localhost", 27017);
 	}
@@ -143,7 +140,7 @@ public class MongoPropertiesTests {
 		properties.setUri("mongodb://mongo1.example.com:12345");
 		MongoClient client = new MongoClientFactory(properties, null)
 				.createMongoClient(null);
-		List<ServerAddress> allAddresses = extractServerAddresses(client);
+		List<ServerAddress> allAddresses = client.getAllAddress();
 		assertThat(allAddresses).hasSize(1);
 		assertServerAddress(allAddresses.get(0), "mongo1.example.com", 12345);
 	}
@@ -153,17 +150,9 @@ public class MongoPropertiesTests {
 		MongoProperties properties = new MongoProperties();
 		MongoClient client = new MongoClientFactory(properties, null)
 				.createMongoClient(null);
-		List<ServerAddress> allAddresses = extractServerAddresses(client);
+		List<ServerAddress> allAddresses = client.getAllAddress();
 		assertThat(allAddresses).hasSize(1);
 		assertServerAddress(allAddresses.get(0), "localhost", 27017);
-	}
-
-	private List<ServerAddress> extractServerAddresses(MongoClient client) {
-		Cluster cluster = (Cluster) ReflectionTestUtils
-				.getField(ReflectionTestUtils.getField(client, "delegate"), "cluster");
-		ClusterSettings clusterSettings = (ClusterSettings) ReflectionTestUtils
-				.getField(cluster, "settings");
-		return clusterSettings.getHosts();
 	}
 
 	private void assertServerAddress(ServerAddress serverAddress, String expectedHost,

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/client/servlet/OAuth2WebSecurityConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/client/servlet/OAuth2WebSecurityConfigurationTests.java
@@ -165,14 +165,12 @@ public class OAuth2WebSecurityConfigurationTests {
 				});
 	}
 
-	@SuppressWarnings("unchecked")
 	private List<Filter> getFilters(AssertableApplicationContext context,
 			Class<? extends Filter> filter) {
 		FilterChainProxy filterChain = (FilterChainProxy) context
 				.getBean(BeanIds.SPRING_SECURITY_FILTER_CHAIN);
 		List<SecurityFilterChain> filterChains = filterChain.getFilterChains();
-		List<Filter> filters = (List<Filter>) ReflectionTestUtils
-				.getField(filterChains.get(0), "filters");
+		List<Filter> filters = filterChains.get(0).getFilters();
 		return filters.stream().filter(filter::isInstance).collect(Collectors.toList());
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
@@ -18,8 +18,8 @@ package org.springframework.boot.autoconfigure.security.oauth2.resource.reactive
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -175,14 +175,12 @@ public class ReactiveOAuth2ResourceServerAutoConfigurationTests {
 				});
 	}
 
-	@SuppressWarnings("unchecked")
 	private void assertFilterConfiguredWithJwtAuthenticationManager(
 			AssertableReactiveWebApplicationContext context) {
 		MatcherSecurityWebFilterChain filterChain = (MatcherSecurityWebFilterChain) context
 				.getBean(BeanIds.SPRING_SECURITY_FILTER_CHAIN);
-		List<WebFilter> filters = (List<WebFilter>) ReflectionTestUtils
-				.getField(filterChain, "filters");
-		AuthenticationWebFilter webFilter = (AuthenticationWebFilter) filters.stream()
+		Stream<WebFilter> filters = filterChain.getWebFilters().toStream();
+		AuthenticationWebFilter webFilter = (AuthenticationWebFilter) filters
 				.filter((f) -> f instanceof AuthenticationWebFilter).findFirst()
 				.orElse(null);
 		ReactiveAuthenticationManager authenticationManager = (ReactiveAuthenticationManager) ReflectionTestUtils

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
@@ -47,7 +47,6 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -183,13 +182,11 @@ public class OAuth2ResourceServerAutoConfigurationTests {
 				.run((context) -> assertThat(getBearerTokenFilter(context)).isNull());
 	}
 
-	@SuppressWarnings("unchecked")
 	private Filter getBearerTokenFilter(AssertableWebApplicationContext context) {
 		FilterChainProxy filterChain = (FilterChainProxy) context
 				.getBean(BeanIds.SPRING_SECURITY_FILTER_CHAIN);
 		List<SecurityFilterChain> filterChains = filterChain.getFilterChains();
-		List<Filter> filters = (List<Filter>) ReflectionTestUtils
-				.getField(filterChains.get(0), "filters");
+		List<Filter> filters = filterChains.get(0).getFilters();
 		return filters.stream()
 				.filter((f) -> f instanceof BearerTokenAuthenticationFilter).findFirst()
 				.orElse(null);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
@@ -40,7 +40,6 @@ import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
 import org.springframework.boot.web.embedded.jetty.JettyWebServer;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.context.support.TestPropertySourceUtils;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -172,8 +171,10 @@ public class JettyWebServerFactoryCustomizerTests {
 
 	private List<Integer> getRequestHeaderSizes(JettyWebServer server) {
 		List<Integer> requestHeaderSizes = new ArrayList<>();
-		Connector[] connectors = (Connector[]) ReflectionTestUtils.getField(server,
-				"connectors");
+		// Start (and directly stop) server to have connectors available
+		server.start();
+		server.stop();
+		Connector[] connectors = server.getServer().getConnectors();
 		for (Connector connector : connectors) {
 			connector.getConnectionFactories().stream()
 					.filter((factory) -> factory instanceof ConnectionFactory)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizerTests.java
@@ -16,17 +16,14 @@
 
 package org.springframework.boot.autoconfigure.web.embedded;
 
-import java.util.Map;
 import java.util.function.Consumer;
 
 import org.apache.catalina.Context;
 import org.apache.catalina.Valve;
-import org.apache.catalina.mapper.Mapper;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.catalina.valves.AccessLogValve;
 import org.apache.catalina.valves.ErrorReportValve;
 import org.apache.catalina.valves.RemoteIpValve;
-import org.apache.catalina.webresources.StandardRoot;
 import org.apache.coyote.AbstractProtocol;
 import org.apache.coyote.http11.AbstractHttp11Protocol;
 import org.junit.Before;
@@ -40,7 +37,6 @@ import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactor
 import org.springframework.boot.web.embedded.tomcat.TomcatWebServer;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.context.support.TestPropertySourceUtils;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.unit.DataSize;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -186,18 +182,13 @@ public class TomcatWebServerFactoryCustomizerTests {
 		assertThat(remoteIpValve.getInternalProxies()).isEqualTo("192.168.0.1");
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void customStaticResourceAllowCaching() {
 		bind("server.tomcat.resource.allow-caching=false");
 		customizeAndRunServer((server) -> {
-			Mapper mapper = server.getTomcat().getService().getMapper();
-			Object contextObjectToContextVersionMap = ReflectionTestUtils.getField(mapper,
-					"contextObjectToContextVersionMap");
-			Object tomcatEmbeddedContext = ((Map<Context, Object>) contextObjectToContextVersionMap)
-					.values().toArray()[0];
-			assertThat(((StandardRoot) ReflectionTestUtils.getField(tomcatEmbeddedContext,
-					"resources")).isCachingAllowed()).isFalse();
+			Tomcat tomcat = server.getTomcat();
+			Context context = (Context) tomcat.getHost().findChildren()[0];
+			assertThat(context.getResources().isCachingAllowed()).isFalse();
 		});
 	}
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/servlet/mockmvc/WebMvcTestWebDriverIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/servlet/mockmvc/WebMvcTestWebDriverIntegrationTests.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -64,7 +63,7 @@ public class WebMvcTestWebDriverIntegrationTests {
 		WebElement element = this.webDriver.findElement(By.tagName("body"));
 		assertThat(element.getText()).isEqualTo("Hello");
 		try {
-			ReflectionTestUtils.invokeMethod(previousWebDriver, "getCurrentWindow");
+			previousWebDriver.getWindowHandle();
 			fail("Did not call quit()");
 		}
 		catch (NoSuchWindowException ex) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactoryTests.java
@@ -32,9 +32,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 
+import io.undertow.Undertow;
 import io.undertow.Undertow.Builder;
 import io.undertow.servlet.api.DeploymentInfo;
-import io.undertow.servlet.api.DeploymentManager;
 import io.undertow.servlet.api.ServletContainer;
 import org.apache.jasper.servlet.JspServlet;
 import org.junit.Test;
@@ -263,8 +263,7 @@ public class UndertowServletWebServerFactoryTests
 		UndertowServletWebServer container = (UndertowServletWebServer) getFactory()
 				.getWebServer();
 		try {
-			return ((DeploymentManager) ReflectionTestUtils.getField(container,
-					"manager")).getDeployment().getServletContainer();
+			return container.getDeploymentManager().getDeployment().getServletContainer();
 		}
 		finally {
 			container.stop();
@@ -273,8 +272,8 @@ public class UndertowServletWebServerFactoryTests
 
 	@Override
 	protected Map<String, String> getActualMimeMappings() {
-		return ((DeploymentManager) ReflectionTestUtils.getField(this.webServer,
-				"manager")).getDeployment().getMimeExtensionMappings();
+		return ((UndertowServletWebServer) this.webServer).getDeploymentManager()
+				.getDeployment().getMimeExtensionMappings();
 	}
 
 	@Override
@@ -288,8 +287,8 @@ public class UndertowServletWebServerFactoryTests
 
 	@Override
 	protected Charset getCharset(Locale locale) {
-		DeploymentInfo info = ((DeploymentManager) ReflectionTestUtils
-				.getField(this.webServer, "manager")).getDeployment().getDeploymentInfo();
+		DeploymentInfo info = ((UndertowServletWebServer) this.webServer)
+				.getDeploymentManager().getDeployment().getDeploymentInfo();
 		String charsetName = info.getLocaleCharsetMapping().get(locale.toString());
 		return (charsetName != null) ? Charset.forName(charsetName) : null;
 	}
@@ -299,9 +298,9 @@ public class UndertowServletWebServerFactoryTests
 			int blockedPort) {
 		assertThat(ex).isInstanceOf(PortInUseException.class);
 		assertThat(((PortInUseException) ex).getPort()).isEqualTo(blockedPort);
-		Object undertow = ReflectionTestUtils.getField(this.webServer, "undertow");
-		Object worker = ReflectionTestUtils.getField(undertow, "worker");
-		assertThat(worker).isNull();
+		Undertow undertow = (Undertow) ReflectionTestUtils.getField(this.webServer,
+				"undertow");
+		assertThat(undertow.getWorker()).isNull();
 	}
 
 }


### PR DESCRIPTION
Hi,

I found some places in the tests that make use of `ReflectionTestUtils`, while there are methods available to achieve the same result without reflection.

Let me know what you think.
Cheers,
Christoph