### PR TITLE
Allow easy customization of EmbeddedMongo DownloadConfig

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoDownloadConfigBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoDownloadConfigBuilderCustomizer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.mongo.embedded;
+
+import de.flapdoodle.embed.mongo.config.DownloadConfigBuilder;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize the
+ * EmbeddedMongo {@link DownloadConfigBuilder} outcome whilst retaining default
+ * auto-configuration.
+ *
+ * @author Michael Gmeiner
+ * @since 2.2.0
+ */
+@FunctionalInterface
+public interface EmbeddedMongoDownloadConfigBuilderCustomizer {
+
+	/**
+	 * Customize the {@link DownloadConfigBuilder}.
+	 * @param downloadConfigBuilder the {@link DownloadConfigBuilder} to customize
+	 */
+	void customize(DownloadConfigBuilder downloadConfigBuilder);
+
+}


### PR DESCRIPTION
This PR introduces 2 new configuration properties to allow easy customization of the DownloadPath of a mongodb. 

- `spring.mongodb.embedded.download.path` = custom download url
- `spring.mongodb.embedded.download.user-agent` = custom User-Agent HTTP-Header for the download request

We need this due to some special security rules in our company which prevents us from downloading the binaries directly from mongodb. With this PR it is possible to easy override the default download-path and point it to our own server. 
Also it is now possible to easy create a completely custom DownloadConfig by simply providing a bean which implements `IDownloadConfig`


