### PR TITLE
Fix NPE when pool is not initialized

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/metadata/HikariDataSourcePoolMetadata.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/metadata/HikariDataSourcePoolMetadata.java
@@ -39,7 +39,12 @@ public class HikariDataSourcePoolMetadata
 	@Override
 	public Integer getActive() {
 		try {
-			return getHikariPool().getActiveConnections();
+			HikariPool pool = getHikariPool();
+			if (pool != null) {
+				return pool.getActiveConnections();
+			} else {
+				return null;
+			}
 		}
 		catch (Exception ex) {
 			return null;


### PR DESCRIPTION
NPE happens on start-up when pool field is set to null