### PR TITLE
Use assertJ to generate AssertionError and filter its stacktrace

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/JsonContentAssert.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/JsonContentAssert.java
@@ -45,6 +45,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Camille Vienot
  * @since 1.4.0
  */
 public class JsonContentAssert extends AbstractAssert<JsonContentAssert, CharSequence> {
@@ -96,7 +97,8 @@ public class JsonContentAssert extends AbstractAssert<JsonContentAssert, CharSeq
 		if (expected instanceof Resource) {
 			return isEqualToJson((Resource) expected);
 		}
-		throw new AssertionError("Unsupport type for JSON assert " + expected.getClass());
+		failWithMessage("Unsupport type for JSON assert {}", expected.getClass());
+		return null;
 	}
 
 	/**
@@ -432,7 +434,8 @@ public class JsonContentAssert extends AbstractAssert<JsonContentAssert, CharSeq
 		if (expected instanceof Resource) {
 			return isNotEqualToJson((Resource) expected);
 		}
-		throw new AssertionError("Unsupport type for JSON assert " + expected.getClass());
+		failWithMessage("Unsupport type for JSON assert {]", expected.getClass());
+		return null;
 	}
 
 	/**
@@ -1031,14 +1034,14 @@ public class JsonContentAssert extends AbstractAssert<JsonContentAssert, CharSeq
 
 	private JsonContentAssert assertNotFailed(JSONCompareResult result) {
 		if (result.failed()) {
-			throw new AssertionError("JSON Comparison failure: " + result.getMessage());
+			failWithMessage("JSON Comparison failure: {}", result.getMessage());
 		}
 		return this;
 	}
 
 	private JsonContentAssert assertNotPassed(JSONCompareResult result) {
 		if (result.passed()) {
-			throw new AssertionError("JSON Comparison failure: " + result.getMessage());
+			failWithMessage("JSON Comparison failure: {}", result.getMessage());
 		}
 		return this;
 	}
@@ -1064,24 +1067,24 @@ public class JsonContentAssert extends AbstractAssert<JsonContentAssert, CharSeq
 			if (ObjectUtils.isEmpty(getValue(false)) || isIndefiniteAndEmpty()) {
 				return;
 			}
-			throw new AssertionError(getExpectedValueMessage("an empty value"));
+			failWithMessage(getExpectedValueMessage("an empty value"));
 		}
 
 		public void assertDoesNotHaveEmptyValue() {
 			if (!ObjectUtils.isEmpty(getValue(false))) {
 				return;
 			}
-			throw new AssertionError(getExpectedValueMessage("a non-empty value"));
+			failWithMessage(getExpectedValueMessage("a non-empty value"));
 
 		}
 
 		public void assertHasValue(Class<?> type, String expectedDescription) {
 			Object value = getValue(true);
 			if (value == null || isIndefiniteAndEmpty()) {
-				throw new AssertionError(getNoValueMessage());
+				failWithMessage(getNoValueMessage());
 			}
 			if (type != null && !type.isInstance(value)) {
-				throw new AssertionError(getExpectedValueMessage(expectedDescription));
+				failWithMessage(getExpectedValueMessage(expectedDescription));
 			}
 		}
 
@@ -1089,7 +1092,7 @@ public class JsonContentAssert extends AbstractAssert<JsonContentAssert, CharSeq
 			if (getValue(false) == null || isIndefiniteAndEmpty()) {
 				return;
 			}
-			throw new AssertionError(getExpectedValueMessage("no value"));
+			failWithMessage(getExpectedValueMessage("no value"));
 		}
 
 		private boolean isIndefiniteAndEmpty() {
@@ -1110,10 +1113,10 @@ public class JsonContentAssert extends AbstractAssert<JsonContentAssert, CharSeq
 				return this.jsonPath.read((json != null) ? json.toString() : null);
 			}
 			catch (Exception ex) {
-				if (!required) {
-					return null;
+				if (required) {
+					failWithMessage("{}. {}", getNoValueMessage(), ex.getMessage());
 				}
-				throw new AssertionError(getNoValueMessage() + ". " + ex.getMessage());
+				return null;
 			}
 		}
 


### PR DESCRIPTION
Closes gh-9776

Rely on AssertJ to generate and throw AssertionError, taking advantage of stacktrace filtering.