### PR TITLE
Add missing tests and fix potential NPE

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/tomcat/TomcatMetricsBinder.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/tomcat/TomcatMetricsBinder.java
@@ -64,10 +64,12 @@ public class TomcatMetricsBinder implements ApplicationListener<ApplicationStart
 		if (applicationContext instanceof WebServerApplicationContext) {
 			WebServer webServer = ((WebServerApplicationContext) applicationContext)
 					.getWebServer();
-			if (webServer instanceof TomcatWebServer) {
-				Context context = findContext((TomcatWebServer) webServer);
-				return context.getManager();
-			}
+            if (webServer instanceof TomcatWebServer) {
+                Context context = findContext((TomcatWebServer) webServer);
+                if (context != null) {
+                    return context.getManager();
+                }
+            }
 		}
 		return null;
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/TestServlet.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/TestServlet.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.actuate;
+
+import javax.servlet.GenericServlet;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+@SuppressWarnings("serial")
+public class TestServlet extends GenericServlet {
+
+    @Override
+    public void service(ServletRequest req, ServletResponse res) {
+    }
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/cassandra/CassandraHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/cassandra/CassandraHealthIndicatorTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.cassandra;
+
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.querybuilder.Select;
+
+import org.junit.Test;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.data.cassandra.core.CassandraOperations;
+import org.springframework.data.cassandra.core.cql.CqlOperations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link CassandraHealthIndicator}.
+ *
+ * @author Oleksii Bondar
+ */
+
+public class CassandraHealthIndicatorTests {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsExceptionOnNullCassandraOperations() {
+        new CassandraHealthIndicator(null);
+    }
+    
+    @Test
+    public void verifyHealthStatusWhenExhausted() {
+        CassandraOperations cassandraOperations = mock(CassandraOperations.class);
+        CqlOperations cqlOperations = mock(CqlOperations.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        CassandraHealthIndicator healthIndicator = new CassandraHealthIndicator(cassandraOperations);
+        given(cassandraOperations.getCqlOperations()).willReturn(cqlOperations);
+        given(cqlOperations.queryForResultSet(any(Select.class))).willReturn(resultSet);
+        given(resultSet.isExhausted()).willReturn(true);
+        
+        Health health = healthIndicator.health();
+        
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+    }
+    
+    @Test
+    public void verifyHealthStatusWithVersion() {
+        CassandraOperations cassandraOperations = mock(CassandraOperations.class);
+        CqlOperations cqlOperations = mock(CqlOperations.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        Row row = mock(Row.class);
+        CassandraHealthIndicator healthIndicator = new CassandraHealthIndicator(cassandraOperations);
+        given(cassandraOperations.getCqlOperations()).willReturn(cqlOperations);
+        given(cqlOperations.queryForResultSet(any(Select.class))).willReturn(resultSet);
+        given(resultSet.isExhausted()).willReturn(false);
+        given(resultSet.one()).willReturn(row);
+        String expectedVersion = "1.0.0";
+        given(row.getString(0)).willReturn(expectedVersion);
+
+        Health health = healthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails().get("version")).isEqualTo(expectedVersion);
+    }
+            
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/elasticsearch/ElasticsearchJestHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/elasticsearch/ElasticsearchJestHealthIndicatorTests.java
@@ -61,7 +61,8 @@ public class ElasticsearchJestHealthIndicatorTests {
 		assertHealthDetailsWithStatus(health.getDetails(), "green");
 	}
 
-	@Test
+	@SuppressWarnings("unchecked")
+    @Test
 	public void elasticsearchWithYellowStatusIsUp() throws IOException {
 		given(this.jestClient.execute(any(Action.class)))
 				.willReturn(createJestResult(200, true, "yellow"));

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/EndpointServletTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/EndpointServletTests.java
@@ -132,7 +132,8 @@ public class EndpointServletTests {
 
 	}
 
-	private static class TestServlet extends GenericServlet {
+	@SuppressWarnings("serial")
+    private static class TestServlet extends GenericServlet {
 
 		@Override
 		public void service(ServletRequest req, ServletResponse res)

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/EndpointServletTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/EndpointServletTests.java
@@ -16,18 +16,14 @@
 
 package org.springframework.boot.actuate.endpoint.web;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import javax.servlet.GenericServlet;
 import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 
 import org.junit.Test;
+import org.springframework.boot.actuate.TestServlet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -129,16 +125,6 @@ public class EndpointServletTests {
 		extra.put("e", "f");
 		assertThat(endpointServlet.withInitParameters(extra).getInitParameters())
 				.containsExactly(entry("a", "b1"), entry("c", "d"), entry("e", "f"));
-
-	}
-
-	@SuppressWarnings("serial")
-    private static class TestServlet extends GenericServlet {
-
-		@Override
-		public void service(ServletRequest req, ServletResponse res)
-				throws ServletException, IOException {
-		}
 
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/ServletEndpointRegistrarTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/ServletEndpointRegistrarTests.java
@@ -18,13 +18,10 @@ package org.springframework.boot.actuate.endpoint.web;
 
 import java.util.Collections;
 
-import javax.servlet.GenericServlet;
 import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRegistration.Dynamic;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -32,7 +29,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
+import org.springframework.boot.actuate.TestServlet;
 import org.springframework.boot.actuate.endpoint.EndpointId;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -126,15 +123,6 @@ public class ServletEndpointRegistrarTests {
 		given(endpoint.getEndpointServlet()).willReturn(endpointServlet);
 		given(endpoint.getRootPath()).willReturn("test");
 		return endpoint;
-	}
-
-	@SuppressWarnings("serial")
-    public static class TestServlet extends GenericServlet {
-
-		@Override
-		public void service(ServletRequest req, ServletResponse res) {
-		}
-
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/ServletEndpointRegistrarTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/ServletEndpointRegistrarTests.java
@@ -128,7 +128,8 @@ public class ServletEndpointRegistrarTests {
 		return endpoint;
 	}
 
-	public static class TestServlet extends GenericServlet {
+	@SuppressWarnings("serial")
+    public static class TestServlet extends GenericServlet {
 
 		@Override
 		public void service(ServletRequest req, ServletResponse res) {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/annotation/ServletEndpointDiscovererTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/annotation/ServletEndpointDiscovererTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.actuate.endpoint.web.annotation;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -24,13 +23,8 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import javax.servlet.GenericServlet;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-
 import org.junit.Test;
-
+import org.springframework.boot.actuate.TestServlet;
 import org.springframework.boot.actuate.endpoint.EndpointId;
 import org.springframework.boot.actuate.endpoint.ExposableEndpoint;
 import org.springframework.boot.actuate.endpoint.annotation.DiscoveredEndpoint;
@@ -204,15 +198,6 @@ public class ServletEndpointDiscovererTests {
 		@ReadOperation
 		public String read() {
 			return "error";
-		}
-
-	}
-
-	private static class TestServlet extends GenericServlet {
-
-		@Override
-		public void service(ServletRequest req, ServletResponse res)
-				throws ServletException, IOException {
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/MetricsWebFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/MetricsWebFilterTests.java
@@ -82,7 +82,8 @@ public class MetricsWebFilterTests {
 		assertMetricsContainsTag("exception", "IllegalStateException");
 	}
 
-	@Test
+	@SuppressWarnings("serial")
+    @Test
 	public void filterAddsNonEmptyTagsToRegistryForAnonymousExceptions() {
 		final Exception anonymous = new Exception("test error") {
 		};

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilterTests.java
@@ -437,7 +437,8 @@ public class WebMvcMetricsFilterTests {
 			throw new IllegalStateException("Boom on " + id + "!");
 		}
 
-		@Timed
+		@SuppressWarnings("serial")
+        @Timed
 		@GetMapping("/anonymousError/{id}")
 		public String alwaysThrowsAnonymousException(@PathVariable Long id)
 				throws Exception {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsIntegrationTests.java
@@ -138,11 +138,13 @@ public class WebMvcMetricsIntegrationTests {
 
 	}
 
-	static class Exception1 extends RuntimeException {
+	@SuppressWarnings("serial")
+    static class Exception1 extends RuntimeException {
 
 	}
 
-	static class Exception2 extends RuntimeException {
+	@SuppressWarnings("serial")
+    static class Exception2 extends RuntimeException {
 
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/tomcat/TomcatMetricsBinderTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/tomcat/TomcatMetricsBinderTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.metrics.web.tomcat;
+
+import org.apache.catalina.Container;
+import org.apache.catalina.Context;
+import org.apache.catalina.Engine;
+import org.apache.catalina.Host;
+import org.apache.catalina.Manager;
+import org.apache.catalina.startup.Tomcat;
+import org.junit.Test;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.boot.web.embedded.jetty.JettyWebServer;
+import org.springframework.boot.web.embedded.tomcat.TomcatWebServer;
+import org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+public class TomcatMetricsBinderTests {
+
+    @Test
+    public void reportExpectedMetrics() {
+        ApplicationStartedEvent event = mock(ApplicationStartedEvent.class);
+        AnnotationConfigServletWebServerApplicationContext context = mock(
+                AnnotationConfigServletWebServerApplicationContext.class);
+        given(event.getApplicationContext()).willReturn(context);
+        TomcatWebServer webServer = mock(TomcatWebServer.class);
+        given(context.getWebServer()).willReturn(webServer);
+        Tomcat tomcat = mock(Tomcat.class);
+        given(webServer.getTomcat()).willReturn(tomcat);
+        Host host = mock(Host.class);
+        given(tomcat.getHost()).willReturn(host);
+        Context container = mock(Context.class);
+        given(host.findChildren()).willReturn(new Container[] {container});
+        Manager manager = mock(Manager.class);
+        given(container.getManager()).willReturn(manager);
+
+        MeterRegistry meterRegistry = bindToMeterRegistry(event);
+
+        meterRegistry.get("tomcat.sessions.active.max").gauge();
+    }
+
+    @Test(expected = MeterNotFoundException.class)
+    public void doNotReportMetricsForNonWebServerApplicationContext() {
+        ApplicationStartedEvent event = mock(ApplicationStartedEvent.class);
+        GenericApplicationContext context = mock(GenericApplicationContext.class);
+        given(event.getApplicationContext()).willReturn(context);
+
+        MeterRegistry meterRegistry = bindToMeterRegistry(event);
+
+        meterRegistry.get("tomcat.sessions.active.max").gauge();
+    }
+
+    @Test(expected = MeterNotFoundException.class)
+    public void doNotReportMetricsForNonTomcatWebServer() {
+        ApplicationStartedEvent event = mock(ApplicationStartedEvent.class);
+        AnnotationConfigServletWebServerApplicationContext context = mock(
+                AnnotationConfigServletWebServerApplicationContext.class);
+        given(event.getApplicationContext()).willReturn(context);
+        JettyWebServer webServer = mock(JettyWebServer.class);
+        given(context.getWebServer()).willReturn(webServer);
+
+        MeterRegistry meterRegistry = bindToMeterRegistry(event);
+
+        meterRegistry.get("tomcat.sessions.active.max").gauge();
+    }
+
+    @Test(expected = MeterNotFoundException.class)
+    public void doNotReportMetricsForEmptyTomcatContainer() {
+        ApplicationStartedEvent event = mock(ApplicationStartedEvent.class);
+        AnnotationConfigServletWebServerApplicationContext context = mock(
+                AnnotationConfigServletWebServerApplicationContext.class);
+        given(event.getApplicationContext()).willReturn(context);
+        TomcatWebServer webServer = mock(TomcatWebServer.class);
+        given(context.getWebServer()).willReturn(webServer);
+        Tomcat tomcat = mock(Tomcat.class);
+        given(webServer.getTomcat()).willReturn(tomcat);
+        Host host = mock(Host.class);
+        given(tomcat.getHost()).willReturn(host);
+        given(host.findChildren()).willReturn(new Container[0]);
+
+        MeterRegistry meterRegistry = bindToMeterRegistry(event);
+
+        meterRegistry.get("tomcat.sessions.active.max").gauge();
+    }
+
+    @Test(expected = MeterNotFoundException.class)
+    public void doNotReportMetricsForNonCatalinaContext() {
+        ApplicationStartedEvent event = mock(ApplicationStartedEvent.class);
+        AnnotationConfigServletWebServerApplicationContext context = mock(
+                AnnotationConfigServletWebServerApplicationContext.class);
+        given(event.getApplicationContext()).willReturn(context);
+        TomcatWebServer webServer = mock(TomcatWebServer.class);
+        given(context.getWebServer()).willReturn(webServer);
+        Tomcat tomcat = mock(Tomcat.class);
+        given(webServer.getTomcat()).willReturn(tomcat);
+        Host host = mock(Host.class);
+        given(tomcat.getHost()).willReturn(host);
+        Engine engine = mock(Engine.class);
+        given(host.findChildren()).willReturn(new Container[] {engine});
+
+        MeterRegistry meterRegistry = bindToMeterRegistry(event);
+
+        meterRegistry.get("tomcat.sessions.active.max").gauge();
+    }
+
+    private MeterRegistry bindToMeterRegistry(ApplicationStartedEvent event) {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        TomcatMetricsBinder metricsBinder = new TomcatMetricsBinder(meterRegistry);
+        metricsBinder.onApplicationEvent(event);
+        return meterRegistry;
+    }
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/http/servlet/HttpTraceFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/http/servlet/HttpTraceFilterTests.java
@@ -69,7 +69,8 @@ public class HttpTraceFilterTests {
 		assertThat(this.repository.findAll()).hasSize(1);
 	}
 
-	@Test
+	@SuppressWarnings("serial")
+    @Test
 	public void filterCapturesSessionId() throws ServletException, IOException {
 		this.filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(),
 				new MockFilterChain(new HttpServlet() {
@@ -103,7 +104,8 @@ public class HttpTraceFilterTests {
 		assertThat(tracedPrincipal.getName()).isEqualTo("alice");
 	}
 
-	@Test
+	@SuppressWarnings("serial")
+    @Test
 	public void statusIsAssumedToBe500WhenChainFails()
 			throws ServletException, IOException {
 		try {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2ClientPropertiesRegistrationAdapterTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2ClientPropertiesRegistrationAdapterTests.java
@@ -345,13 +345,6 @@ public class OAuth2ClientPropertiesRegistrationAdapterTests {
 						org.springframework.security.oauth2.core.AuthenticationMethod.HEADER);
 	}
 
-	private String cleanIssuerPath(String issuer) {
-		if (issuer.endsWith("/")) {
-			return issuer.substring(0, issuer.length() - 1);
-		}
-		return issuer;
-	}
-
 	private void setupMockResponse(String issuer) throws Exception {
 		MockResponse mockResponse = new MockResponse()
 				.setResponseCode(HttpStatus.OK.value())


### PR DESCRIPTION
This PR contains following changes:
 - fix potential NPE in TomcatMetricsBinder;
 - add missing unit tests for TomcatMetricsBinder and CassandraHealthIndicator;
 - @SuppressWarning where needed;
 - remove unused method in tests;
 - extract common class to address code duplication.

