### PR TITLE
Use hasFieldOrPropertyWithValue where possible

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/rest/RestClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/rest/RestClientAutoConfigurationTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.autoconfigure.elasticsearch.rest;
 
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,7 +32,6 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.testsupport.testcontainers.ElasticsearchContainer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -71,11 +69,8 @@ public class RestClientAutoConfigurationTests {
 				.run((context) -> {
 					assertThat(context).hasSingleBean(RestClient.class);
 					RestClient restClient = context.getBean(RestClient.class);
-					Field field = ReflectionUtils.findField(RestClient.class,
-							"maxRetryTimeoutMillis");
-					ReflectionUtils.makeAccessible(field);
-					assertThat(ReflectionUtils.getField(field, restClient))
-							.isEqualTo(42L);
+					assertThat(restClient)
+							.hasFieldOrPropertyWithValue("maxRetryTimeoutMillis", 42L);
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfigurationTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.autoconfigure.gson;
 
-import java.lang.reflect.Field;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -180,15 +179,7 @@ public class GsonAutoConfigurationTests {
 	public void withoutLenient() {
 		this.contextRunner.run((context) -> {
 			Gson gson = context.getBean(Gson.class);
-			/*
-			 * It seems that lenient setting not work in version 2.8.2. We get access to
-			 * it via reflection
-			 */
-			Field lenientField = gson.getClass().getDeclaredField("lenient");
-			lenientField.setAccessible(true);
-			boolean lenient = lenientField.getBoolean(gson);
-
-			assertThat(lenient).isFalse();
+			assertThat(gson).hasFieldOrPropertyWithValue("lenient", false);
 		});
 	}
 
@@ -197,15 +188,7 @@ public class GsonAutoConfigurationTests {
 		this.contextRunner.withPropertyValues("spring.gson.lenient:true")
 				.run((context) -> {
 					Gson gson = context.getBean(Gson.class);
-					/*
-					 * It seems that lenient setting not work in version 2.8.2. We get
-					 * access to it via reflection
-					 */
-					Field lenientField = gson.getClass().getDeclaredField("lenient");
-					lenientField.setAccessible(true);
-					boolean lenient = lenientField.getBoolean(gson);
-
-					assertThat(lenient).isTrue();
+					assertThat(gson).hasFieldOrPropertyWithValue("lenient", true);
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/AbstractJpaAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/AbstractJpaAutoConfigurationTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.autoconfigure.orm.jpa;
 
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -232,11 +231,9 @@ public abstract class AbstractJpaAutoConfigurationTests {
 				.run((context) -> {
 					LocalContainerEntityManagerFactoryBean entityManagerFactoryBean = context
 							.getBean(LocalContainerEntityManagerFactoryBean.class);
-					Field field = LocalContainerEntityManagerFactoryBean.class
-							.getDeclaredField("persistenceUnitManager");
-					field.setAccessible(true);
-					assertThat(field.get(entityManagerFactoryBean))
-							.isEqualTo(context.getBean(PersistenceUnitManager.class));
+					assertThat(entityManagerFactoryBean).hasFieldOrPropertyWithValue(
+							"persistenceUnitManager",
+							context.getBean(PersistenceUnitManager.class));
 				});
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot;
 
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -96,7 +95,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.test.context.support.TestPropertySourceUtils;
-import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.ConfigurableWebEnvironment;
 import org.springframework.web.context.WebApplicationContext;
@@ -285,24 +283,22 @@ public class SpringApplicationTests {
 	}
 
 	@Test
-	public void triggersConfigFileApplicationListenerBeforeBinding() throws Exception {
+	public void triggersConfigFileApplicationListenerBeforeBinding() {
 		SpringApplication application = new SpringApplication(ExampleConfig.class);
 		application.setWebApplicationType(WebApplicationType.NONE);
 		this.context = application.run("--spring.config.name=bindtoapplication");
-		Field field = ReflectionUtils.findField(SpringApplication.class, "bannerMode");
-		field.setAccessible(true);
-		assertThat((Banner.Mode) field.get(application)).isEqualTo(Banner.Mode.OFF);
+		assertThat(application).hasFieldOrPropertyWithValue("bannerMode",
+				Banner.Mode.OFF);
 	}
 
 	@Test
-	public void bindsSystemPropertyToSpringApplication() throws Exception {
+	public void bindsSystemPropertyToSpringApplication() {
 		System.setProperty("spring.main.banner-mode", "off");
 		SpringApplication application = new SpringApplication(ExampleConfig.class);
 		application.setWebApplicationType(WebApplicationType.NONE);
 		this.context = application.run();
-		Field field = ReflectionUtils.findField(SpringApplication.class, "bannerMode");
-		field.setAccessible(true);
-		assertThat((Banner.Mode) field.get(application)).isEqualTo(Banner.Mode.OFF);
+		assertThat(application).hasFieldOrPropertyWithValue("bannerMode",
+				Banner.Mode.OFF);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContextTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContextTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.web.servlet.context;
 
-import java.lang.reflect.Field;
 import java.util.EnumSet;
 import java.util.Properties;
 
@@ -55,7 +54,6 @@ import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.boot.web.servlet.server.MockServletWebServerFactory;
 import org.springframework.context.ApplicationContextException;
 import org.springframework.context.ApplicationListener;
-import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -129,17 +127,13 @@ public class ServletWebServerApplicationContextTests {
 	}
 
 	@Test
-	public void doesNotRegistersShutdownHook() throws Exception {
+	public void doesNotRegistersShutdownHook() {
 		// See gh-314 for background. We no longer register the shutdown hook
 		// since it is really the callers responsibility. The shutdown hook could
 		// also be problematic in a classic WAR deployment.
 		addWebServerFactoryBean();
 		this.context.refresh();
-		Field shutdownHookField = AbstractApplicationContext.class
-				.getDeclaredField("shutdownHook");
-		shutdownHookField.setAccessible(true);
-		Object shutdownHook = shutdownHookField.get(this.context);
-		assertThat(shutdownHook).isNull();
+		assertThat(this.context).hasFieldOrPropertyWithValue("shutdownHook", null);
 	}
 
 	@Test


### PR DESCRIPTION
Hi,

this PR replaces some direct reflection usages with AssertJ's `hasFieldOrPropertyWithValue` functionality.

As this is probably my last PR this year, I also want to take the opportunity to wish you a great start into 2019.
Cheers,
Christoph