### PR TITLE
Allow using jacoco with Spring Boot modules, inherited from "spring-boot-parent"

### DIFF
--- a/spring-boot-project/spring-boot-parent/pom.xml
+++ b/spring-boot-project/spring-boot-parent/pom.xml
@@ -23,6 +23,7 @@
 		<java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<argLine>-Xmx1024m</argLine>
 		<maven.version>3.5.4</maven.version>
 		<maven-resolver.version>1.1.1</maven-resolver.version>
 		<spock.version>1.0-groovy-2.4</spock.version>
@@ -631,7 +632,6 @@
 						<java.security.egd>file:/dev/./urandom</java.security.egd>
 						<java.awt.headless>true</java.awt.headless>
 					</systemPropertyVariables>
-					<argLine>-Xmx1024m</argLine>
 					<trimStackTrace>false</trimStackTrace>
 					<redirectTestOutputToFile>true</redirectTestOutputToFile>
 					<runOrder>alphabetical</runOrder>


### PR DESCRIPTION
Hello,

I have a "[pet project](https://github.com/stepio/spring-actuator-kafka)", which inherits `spring-boot-parent` module, mostly to get your great dependency management and follow most of the building approach.

Recently I decided to configure a couple of code analyzers for it, including [SonarCloud](https://sonarcloud.io/dashboard?id=stepio_spring-actuator-kafka) check.

Everything was fine there except of test code coverage - although I had a fair number of tests, I could not make [jacoco](https://www.jacoco.org) work properly - file `jacoco.exec` simply was not generated. After studying the relevant documentation, stackoverflow and experimenting with my other projects I found that root cause was usage of `spring-boot-parent`.

The problem is that `maven-surefire-plugin` overrides value of `argLine` property, so jacoco cannot pass location of agent for surefire. That's a well-known issue and possible solutions are explained [in their docs](https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html).

I'm not sure if you aware of this issue or care about this particular case, but I decided to share my finding with you just to save your time if you encounter the same case.

P.S.: For some reason I cannot build latest `spring-boot` on my mac - same error before my changes and after them, so hope I did not mess it up.