### PR TITLE
Ensure checking customizer ordering

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/RestTemplateBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/RestTemplateBuilderTests.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 import org.apache.http.client.config.RequestConfig;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -47,6 +48,7 @@ import org.springframework.web.util.UriTemplateHandler;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -401,8 +403,9 @@ public class RestTemplateBuilderTests {
 		RestTemplateCustomizer customizer2 = mock(RestTemplateCustomizer.class);
 		RestTemplate template = this.builder.customizers(customizer1)
 				.additionalCustomizers(customizer2).build();
-		verify(customizer1).customize(template);
-		verify(customizer2).customize(template);
+		InOrder inOrder = inOrder(customizer1, customizer2);
+		inOrder.verify(customizer1).customize(template);
+		inOrder.verify(customizer2).customize(template);
 	}
 
 	@Test


### PR DESCRIPTION
Updated `RestTemplateBuilderTests#additionalCustomizersShouldAddToExisting()` to ensure verifying the order of customizer calls.
