### PR TITLE
Align WebFluxTags#uri() with WebMvcTags#uri()

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,8 @@ public final class WebFluxTags {
 	private static final Tag URI_REDIRECTION = Tag.of("uri", "REDIRECTION");
 
 	private static final Tag URI_ROOT = Tag.of("uri", "root");
+
+	private static final Tag URI_UNKNOWN = Tag.of("uri", "UNKNOWN");
 
 	private static final Tag EXCEPTION_NONE = Tag.of("exception", "None");
 
@@ -86,7 +88,10 @@ public final class WebFluxTags {
 
 	/**
 	 * Creates a {@code uri} tag based on the URI of the given {@code exchange}. Uses the
-	 * {@link HandlerMapping#BEST_MATCHING_PATTERN_ATTRIBUTE} best matching pattern.
+	 * {@link HandlerMapping#BEST_MATCHING_PATTERN_ATTRIBUTE} best matching pattern if
+	 * available. Falling back to {@code REDIRECTION} for 3xx responses, {@code NOT_FOUND}
+	 * for 404 responses, {@code root} for requests with no path info, and {@code UNKNOWN}
+	 * for all other requests.
 	 * @param exchange the exchange
 	 * @return the uri tag derived from the exchange
 	 */
@@ -105,11 +110,17 @@ public final class WebFluxTags {
 				return URI_NOT_FOUND;
 			}
 		}
-		String path = exchange.getRequest().getPath().value();
+		String path = getPathInfo(exchange);
 		if (path.isEmpty()) {
 			return URI_ROOT;
 		}
-		return Tag.of("uri", path);
+		return URI_UNKNOWN;
+	}
+
+	private static String getPathInfo(ServerWebExchange exchange) {
+		String path = exchange.getRequest().getPath().value();
+		String uri = StringUtils.hasText(path) ? path : "/";
+		return uri.replaceAll("//+", "/").replaceAll("/$", "");
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTagsTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTagsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,28 @@ public class WebFluxTagsTests {
 		this.exchange.getResponse().setStatusCodeValue(601);
 		Tag tag = WebFluxTags.uri(this.exchange);
 		assertThat(tag.getValue()).isEqualTo("root");
+	}
+
+	@Test
+	public void uriTagValueIsRootWhenRequestHasNoPatternOrPathInfo() {
+		Tag tag = WebFluxTags.uri(this.exchange);
+		assertThat(tag.getValue()).isEqualTo("root");
+	}
+
+	@Test
+	public void uriTagValueIsRootWhenRequestHasNoPatternAndSlashPathInfo() {
+		MockServerHttpRequest request = MockServerHttpRequest.get("/").build();
+		ServerWebExchange exchange = MockServerWebExchange.from(request);
+		Tag tag = WebFluxTags.uri(exchange);
+		assertThat(tag.getValue()).isEqualTo("root");
+	}
+
+	@Test
+	public void uriTagValueIsUnknownWhenRequestHasNoPatternAndNonRootPathInfo() {
+		MockServerHttpRequest request = MockServerHttpRequest.get("/example").build();
+		ServerWebExchange exchange = MockServerWebExchange.from(request);
+		Tag tag = WebFluxTags.uri(exchange);
+		assertThat(tag.getValue()).isEqualTo("UNKNOWN");
 	}
 
 	@Test


### PR DESCRIPTION
Hi,

this PR is an attempt to fix #15608 by aligning `WebFluxTags#uri()` with `WebMvcTags#uri()`.

Let me know what you think.
Cheers,
Christoph