### PR TITLE
Provide an option to use Neo4j-OGM native types.

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Eric Spiegelberg
  * @author Stephane Nicoll
+ * @author Michael Simons
  */
 public class Neo4jHealthIndicatorTests {
 
@@ -77,9 +78,8 @@ public class Neo4jHealthIndicatorTests {
 
 	@Test
 	public void neo4jDown() {
-		CypherException cypherException = new CypherException("Error executing Cypher",
-				"Neo.ClientError.Statement.SyntaxError",
-				"Unable to execute invalid Cypher");
+		CypherException cypherException = new CypherException(
+				"Neo.ClientError.Statement.SyntaxError", "Error executing Cypher");
 		given(this.session.query(Neo4jHealthIndicator.CYPHER, Collections.emptyMap()))
 				.willThrow(cypherException);
 		Health health = this.neo4jHealthIndicator.health();

--- a/spring-boot-project/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/pom.xml
@@ -782,12 +782,17 @@
 		</dependency>
 		<dependency>
 			<groupId>org.neo4j</groupId>
-			<artifactId>neo4j-ogm-http-driver</artifactId>
+			<artifactId>neo4j-ogm-bolt-native-types</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-ogm-embedded-driver</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.neo4j</groupId>
+			<artifactId>neo4j-ogm-http-driver</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,10 +33,13 @@ import org.springframework.util.ClassUtils;
  * @author Michael Hunger
  * @author Vince Bickers
  * @author Aurélien Leboulanger
+ * @author Michael Simons
  * @since 1.4.0
  */
-@ConfigurationProperties(prefix = "spring.data.neo4j")
+@ConfigurationProperties(prefix = Neo4jProperties.CONFIGURATION_PREFIX)
 public class Neo4jProperties implements ApplicationContextAware {
+
+	static final String CONFIGURATION_PREFIX = "spring.data.neo4j";
 
 	static final String EMBEDDED_DRIVER = "org.neo4j.ogm.drivers.embedded.driver.EmbeddedDriver";
 
@@ -71,6 +74,12 @@ public class Neo4jProperties implements ApplicationContextAware {
 	 * entire processing of the request.",
 	 */
 	private Boolean openInView;
+
+	/**
+	 * Disables the conversion of java.time.* and spatial types in Neo4j-OGM entities and
+	 * uses Neo4j native types wherever possible.
+	 */
+	private boolean useNativeTypes = false;
 
 	private final Embedded embedded = new Embedded();
 
@@ -116,6 +125,14 @@ public class Neo4jProperties implements ApplicationContextAware {
 		this.openInView = openInView;
 	}
 
+	public boolean isUseNativeTypes() {
+		return this.useNativeTypes;
+	}
+
+	public void setUseNativeTypes(boolean useNativeTypes) {
+		this.useNativeTypes = useNativeTypes;
+	}
+
 	public Embedded getEmbedded() {
 		return this.embedded;
 	}
@@ -146,6 +163,9 @@ public class Neo4jProperties implements ApplicationContextAware {
 			builder.credentials(this.username, this.password);
 		}
 		builder.autoIndex(this.getAutoIndex().getName());
+		if (this.useNativeTypes) {
+			builder.useNativeTypes();
+		}
 	}
 
 	private void configureUriWithDefaults(Builder builder) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link Neo4jProperties}.
  *
  * @author Stephane Nicoll
+ * @author Michael Simons
  */
 public class Neo4jPropertiesTests {
 
@@ -145,6 +146,21 @@ public class Neo4jPropertiesTests {
 		Configuration configuration = properties.createConfiguration();
 		assertDriver(configuration, Neo4jProperties.EMBEDDED_DRIVER,
 				"file:relative/path/to/my.db");
+	}
+
+	@Test
+	public void nativeTypesAreSetToFalseByDefault() {
+		Neo4jProperties properties = load(true);
+		Configuration configuration = properties.createConfiguration();
+		assertThat(configuration.getUseNativeTypes()).isFalse();
+	}
+
+	@Test
+	public void nativeTypesCanBeConfigured() {
+		Neo4jProperties properties = load(true,
+				"spring.data.neo4j.use-native-types=true");
+		Configuration configuration = properties.createConfiguration();
+		assertThat(configuration.getUseNativeTypes()).isTrue();
 	}
 
 	private static void assertDriver(Configuration actual, String driver, String uri) {

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -138,7 +138,7 @@
 		<mssql-jdbc.version>6.4.0.jre8</mssql-jdbc.version>
 		<mysql.version>8.0.15</mysql.version>
 		<nekohtml.version>1.9.22</nekohtml.version>
-		<neo4j-ogm.version>3.1.7</neo4j-ogm.version>
+		<neo4j-ogm.version>3.2.0-alpha04</neo4j-ogm.version>
 		<netty.version>4.1.33.Final</netty.version>
 		<netty-tcnative.version>2.0.20.Final</netty-tcnative.version>
 		<nio-multipart-parser.version>1.1.0</nio-multipart-parser.version>

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -2529,12 +2529,22 @@
 			</dependency>
 			<dependency>
 				<groupId>org.neo4j</groupId>
+				<artifactId>neo4j-ogm-bolt-native-types</artifactId>
+				<version>${neo4j-ogm.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.neo4j</groupId>
 				<artifactId>neo4j-ogm-core</artifactId>
 				<version>${neo4j-ogm.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.neo4j</groupId>
 				<artifactId>neo4j-ogm-embedded-driver</artifactId>
+				<version>${neo4j-ogm.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.neo4j</groupId>
+				<artifactId>neo4j-ogm-embedded-native-types</artifactId>
 				<version>${neo4j-ogm.version}</version>
 			</dependency>
 			<dependency>

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -4440,6 +4440,25 @@ in your configuration, e.g. `spring.data.neo4j.uri=file://var/tmp/graph.db`.
 
 
 
+[[boot-features-neo4j-ogm-native-types]]
+==== Using native types
+Neo4j-OGM can map some types, like `java.time.*` to `String` based properties or
+use one of the various native types that Neo4j provides.
+For backwards compatibility reasons the default for Neo4j-OGM is using a `String` based representation.
+To change that behaviour, please add one of `org.neo4j:neo4j-ogm-bolt-native-types` or `org.neo4j:neo4j-ogm-embedded-native-types`
+to the dependencies of your application
+and use the following property in your Spring Boot configuration:
+
+[source,properties,indent=0]
+----
+	spring.data.neo4j.use-native-types=true
+----
+
+Please refer to the Neo4j-OGM reference for more information about
+https://neo4j.com/docs/ogm-manual/current/reference/#reference:native-property-types[native property types].
+
+
+
 [[boot-features-neo4j-ogm-session]]
 ==== Neo4jSession
 By default, if you are running a web application, the session is bound to the thread for


### PR DESCRIPTION
In the upcoming next release of Neo4j-OGM we provide means to use Neo4j native types (Spatial, Time ec.) in Neo4j-OGM. This native types allow the user to use `java.time.*`and others in entities without OGM converting them to Strings or longs.

These types are available for Bolt and Embedded modes and a feature requested by our users.

This PR contains the following:
* Added the modules containing the native type system for Bolt and Embedded Neo4j-OGM to the dependency management
* A new configuration property to enable them (They are an opt-in feature)
* A failure analyser when they are enabled but the dependencies aren't on the class path

The dependency of OGM has been set to a released alpha version to be able to discuss this PR.

Neo4j-OGM 3.2 will be the version Spring Data Moore (5.2) requires. It is however not compatible with Spring Data Lovelace (5.1) and as such, this PR should not make it into a Spring Boot version that uses Spring Data Lovelace or before.
