### PR TITLE
Remove need for zt-zip dependency

### DIFF
--- a/spring-boot-project/spring-boot-parent/pom.xml
+++ b/spring-boot-project/spring-boot-parent/pom.xml
@@ -242,11 +242,6 @@
 				<artifactId>spock-spring</artifactId>
 				<version>${spock.version}</version>
 			</dependency>
-			<dependency>
-				<groupId>org.zeroturnaround</groupId>
-				<artifactId>zt-zip</artifactId>
-				<version>1.13</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/pom.xml
@@ -33,12 +33,6 @@
 			<artifactId>logback-classic</artifactId>
 			<scope>provided</scope>
 		</dependency>
-		<!-- Test -->
-		<dependency>
-			<groupId>org.zeroturnaround</groupId>
-			<artifactId>zt-zip</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/JarWriter.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/JarWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,6 +167,22 @@ public class JarWriter implements LoaderClassesWriter, AutoCloseable {
 	@Override
 	public void writeEntry(String entryName, InputStream inputStream) throws IOException {
 		JarArchiveEntry entry = new JarArchiveEntry(entryName);
+		writeEntry(entry, new InputStreamEntryWriter(inputStream, true));
+	}
+
+	/**
+	 * Writes an entry with the specified modification time. The {@code inputStream} is
+	 * closed once the entry has been written.
+	 * @param entryName the name of the entry
+	 * @param inputStream the stream from which the entry's data can be read
+	 * @param time the modification time of the entry
+	 * @throws IOException if the write fails
+	 */
+	@Override
+	public void writeEntry(String entryName, InputStream inputStream, long time)
+			throws IOException {
+		JarArchiveEntry entry = new JarArchiveEntry(entryName);
+		entry.setTime(time);
 		writeEntry(entry, new InputStreamEntryWriter(inputStream, true));
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/LoaderClassesWriter.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/LoaderClassesWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,5 +49,14 @@ public interface LoaderClassesWriter {
 	 * @throws IOException if the entry cannot be written
 	 */
 	void writeEntry(String name, InputStream inputStream) throws IOException;
+
+	/**
+	 * Write a single entry to the JAR with a specified modification time.
+	 * @param name the name of the entry
+	 * @param inputStream the input stream content
+	 * @param time the modification time of the entry
+	 * @throws IOException if the entry cannot be written
+	 */
+	void writeEntry(String name, InputStream inputStream, long time) throws IOException;
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/RepackagerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/RepackagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.zeroturnaround.zip.ZipUtil;
 
 import org.springframework.boot.loader.tools.sample.ClassWithMainMethod;
 import org.springframework.boot.loader.tools.sample.ClassWithoutMainMethod;
@@ -498,8 +497,8 @@ public class RepackagerTests {
 		repackager.repackage((callback) -> {
 			nestedFile.delete();
 			File toZip = RepackagerTests.this.temporaryFolder.newFile();
-			ZipUtil.packEntry(toZip, nestedFile);
-			callback.library(new Library(nestedFile, LibraryScope.COMPILE));
+			nested.addFile(toZip.getName(), toZip);
+			callback.library(new Library(nested.getFile(), LibraryScope.COMPILE));
 		});
 		try (JarFile jarFile = new JarFile(file)) {
 			assertThat(jarFile.getEntry("BOOT-INF/lib/" + nestedFile.getName()).getSize())


### PR DESCRIPTION
Hi,

while looking through the code I noticed that we have a test-dependency on `zt-zip` that we could get rid of by relatively little code.
There are no strong reasons though to remove the dependency to be entirely honest. It might be just the security issue that was still in my brain and forced me into the PR (I think it was a directory traversal fixed in 1.13). Feel free to close this PR in case you want to keep the dependency.

Cheers,
Christoph