### PR TITLE
DecodingException should be wrapped into HTTP 400 as per its doc

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributes.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributes.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.codec.DecodingException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.ObjectError;
@@ -93,6 +94,9 @@ public class DefaultErrorAttributes implements ErrorAttributes {
 	private HttpStatus determineHttpStatus(Throwable error) {
 		if (error instanceof ResponseStatusException) {
 			return ((ResponseStatusException) error).getStatus();
+		}
+		if (error instanceof DecodingException) {
+			return HttpStatus.BAD_REQUEST;
 		}
 		ResponseStatus responseStatus = AnnotatedElementUtils
 				.findMergedAnnotation(error.getClass(), ResponseStatus.class);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributesTests.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import org.springframework.core.MethodParameter;
+import org.springframework.core.codec.DecodingException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.codec.HttpMessageReader;
 import org.springframework.http.codec.ServerCodecConfigurer;
@@ -119,6 +120,17 @@ public class DefaultErrorAttributesTests {
 		assertThat(attributes.get("error"))
 				.isEqualTo(HttpStatus.NOT_FOUND.getReasonPhrase());
 		assertThat(attributes.get("status")).isEqualTo(404);
+	}
+
+	@Test
+	public void returnRequestErrorWhenDecodingException() {
+		DecodingException error = new DecodingException("Decoding error");
+		MockServerHttpRequest request = MockServerHttpRequest.get("/test").build();
+		Map<String, Object> attributes = this.errorAttributes
+				.getErrorAttributes(buildServerRequest(request, error), false);
+		assertThat(attributes.get("error"))
+				.isEqualTo(HttpStatus.BAD_REQUEST.getReasonPhrase());
+		assertThat(attributes.get("status")).isEqualTo(400);
 	}
 
 	@Test


### PR DESCRIPTION
As stated in DecodingException javadoc:

> For example in server web application, a DecodingException would
> translate to a response with a 400 (bad input) status while
>  CodecException would translate to 500 (server error) status.

Which was not the case for reactive. As a result, all Jackson exceptions, which are not covered by @ResponseStatus handlers, were mapped to HTTP 500. It's definitely undesirable for most services, because, apart from being confusing, it can draw a misleading picture for analytics, etc., with regard to your service's health/behaviour.  


<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
