### PR TITLE
Embedded Mongo may be shut down while being used during application context close processing

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
@@ -212,7 +212,7 @@ public class EmbeddedMongoAutoConfiguration {
 							"[console>]", Processors.logTo(logger, Slf4jLevel.DEBUG)));
 			return new RuntimeConfigBuilder().defaultsWithLogger(Command.MongoD, logger)
 					.processOutput(processOutput).artifactStore(getArtifactStore(logger))
-					.build();
+					.daemonProcess(false).build();
 		}
 
 		private ArtifactStoreBuilder getArtifactStore(Logger logger) {


### PR DESCRIPTION
Fix bug when embedded mongo stopped and closed before all beans that relies on MongoDB stuff not closed.
During Spring context closing process beans can send requests to the mongo, but since `daemonProcess` by default is `true` - this enables shutdown hook:
```
		if (runtimeConfig.isDaemonProcess()) {
			ProcessControl.addShutdownHook(new JobKiller());
			registeredJobKiller = true;
		}
```
in tests this shutdown hook is called before all dependent beans is closed.

Code for shutdown hook here:
```
/de/flapdoodle/embed/de.flapdoodle.embed.process/2.0.5/de.flapdoodle.embed.process-2.0.5-sources.jar!/de/flapdoodle/embed/process/runtime/Executable.java:58
```
