### PR TITLE
Unlike Jetty and Tomcat, Reactor Netty and Undertow do not cause a startup failure when SSL is enabled but no key store is configured

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/netty/SslServerCustomizerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/netty/SslServerCustomizerTests.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.fail;
  * Tests for {@link SslServerCustomizer}.
  *
  * @author Andy Wilkinson
+ * @author Raheela Aslam
  */
 public class SslServerCustomizerTests {
 
@@ -65,6 +66,22 @@ public class SslServerCustomizerTests {
 			Throwable cause = ex.getCause();
 			assertThat(cause).isInstanceOf(NoSuchProviderException.class);
 			assertThat(cause).hasMessageContaining("com.example.TrustStoreProvider");
+		}
+	}
+
+	@Test
+	public void keyStoreProviderIsUsedWhenKeyStoreNotContaining() throws Exception {
+		Ssl ssl = new Ssl();
+		ssl.setKeyPassword("password");
+		SslServerCustomizer customizer = new SslServerCustomizer(ssl, null, null);
+		try {
+			customizer.getKeyManagerFactory(ssl, null);
+			fail();
+		}
+		catch (IllegalStateException ex) {
+			Throwable cause = ex.getCause();
+			assertThat(cause).isInstanceOf(IllegalArgumentException.class);
+			assertThat(cause).hasMessageContaining("Resource location must not be null");
 		}
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/undertow/SslBuilderCustomizerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/undertow/SslBuilderCustomizerTests.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.fail;
  * Tests for {@link SslBuilderCustomizer}
  *
  * @author Brian Clozel
+ * @author Raheela Aslam
  */
 public class SslBuilderCustomizerTests {
 
@@ -85,6 +86,26 @@ public class SslBuilderCustomizerTests {
 			Throwable cause = ex.getCause();
 			assertThat(cause).isInstanceOf(NoSuchProviderException.class);
 			assertThat(cause).hasMessageContaining("com.example.TrustStoreProvider");
+		}
+	}
+
+	@Test
+	public void getKeyManagersWhenKeyStoreIsNotProvided() throws Exception {
+		Ssl ssl = new Ssl();
+		ssl.setKeyPassword("password");
+		SslBuilderCustomizer customizer = new SslBuilderCustomizer(8080,
+				InetAddress.getLocalHost(), ssl, null);
+		try {
+			KeyManager[] keyManagers = ReflectionTestUtils.invokeMethod(customizer,
+					"getKeyManagers", ssl, null);
+			Class<?> name = Class.forName("org.springframework.boot.web.embedded.undertow"
+					+ ".SslBuilderCustomizer$ConfigurableAliasKeyManager");
+			assertThat(keyManagers[0]).isNotInstanceOf(name);
+		}
+		catch (IllegalStateException ex) {
+			Throwable cause = ex.getCause();
+			assertThat(cause).isInstanceOf(IllegalArgumentException.class);
+			assertThat(cause).hasMessageContaining("Resource location must not be null");
 		}
 	}
 


### PR DESCRIPTION
…artup failure when SSL is enabled but no key store is configured issue fixed.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
