### PR TITLE
Rename ElasticSearchJestHealthIndicatorAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticsearchJestHealthIndicatorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticsearchJestHealthIndicatorAutoConfiguration.java
@@ -50,12 +50,12 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureBefore(HealthIndicatorAutoConfiguration.class)
 @AutoConfigureAfter({ JestAutoConfiguration.class,
 		ElasticSearchClientHealthIndicatorAutoConfiguration.class })
-public class ElasticSearchJestHealthIndicatorAutoConfiguration extends
+public class ElasticsearchJestHealthIndicatorAutoConfiguration extends
 		CompositeHealthIndicatorConfiguration<ElasticsearchJestHealthIndicator, JestClient> {
 
 	private final Map<String, JestClient> clients;
 
-	public ElasticSearchJestHealthIndicatorAutoConfiguration(
+	public ElasticsearchJestHealthIndicatorAutoConfiguration(
 			Map<String, JestClient> clients) {
 		this.clients = clients;
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -14,7 +14,7 @@ org.springframework.boot.actuate.autoconfigure.context.ShutdownEndpointAutoConfi
 org.springframework.boot.actuate.autoconfigure.couchbase.CouchbaseHealthIndicatorAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.couchbase.CouchbaseReactiveHealthIndicatorAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.elasticsearch.ElasticSearchClientHealthIndicatorAutoConfiguration,\
-org.springframework.boot.actuate.autoconfigure.elasticsearch.ElasticSearchJestHealthIndicatorAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.elasticsearch.ElasticsearchJestHealthIndicatorAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.elasticsearch.ElasticSearchRestHealthIndicatorAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.endpoint.jmx.JmxEndpointAutoConfiguration,\

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticsearchHealthIndicatorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticsearchHealthIndicatorAutoConfigurationTests.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link ElasticSearchClientHealthIndicatorAutoConfiguration} and
- * {@link ElasticSearchJestHealthIndicatorAutoConfiguration}.
+ * {@link ElasticsearchJestHealthIndicatorAutoConfiguration}.
  *
  * @author Phillip Webb
  */
@@ -45,7 +45,7 @@ public class ElasticsearchHealthIndicatorAutoConfigurationTests {
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(ElasticsearchAutoConfiguration.class,
 					ElasticSearchClientHealthIndicatorAutoConfiguration.class,
-					ElasticSearchJestHealthIndicatorAutoConfiguration.class,
+					ElasticsearchJestHealthIndicatorAutoConfiguration.class,
 					HealthIndicatorAutoConfiguration.class));
 
 	@Test


### PR DESCRIPTION
Rename `ElasticSearchJestHealthIndicatorAutoConfiguration` to `ElasticsearchJestHealthIndicatorAutoConfiguration`
this [task](https://github.com/spring-projects/spring-boot/issues/15705) 