### PR TITLE
Disable background preinitializer when only one processor is available

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/BackgroundPreinitializer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/BackgroundPreinitializer.java
@@ -69,9 +69,10 @@ public class BackgroundPreinitializer
 
 	@Override
 	public void onApplicationEvent(SpringApplicationEvent event) {
-		if (!Boolean.getBoolean(IGNORE_BACKGROUNDPREINITIALIZER_PROPERTY_NAME)
+		if ((!Boolean.getBoolean(IGNORE_BACKGROUNDPREINITIALIZER_PROPERTY_NAME)
 				&& event instanceof ApplicationStartingEvent
-				&& preinitializationStarted.compareAndSet(false, true)) {
+				&& preinitializationStarted.compareAndSet(false, true))
+				|| isOneProcessor()) {
 			performPreinitialization();
 		}
 		if ((event instanceof ApplicationReadyEvent
@@ -84,6 +85,10 @@ public class BackgroundPreinitializer
 				Thread.currentThread().interrupt();
 			}
 		}
+	}
+
+	private boolean isOneProcessor() {
+		return Runtime.getRuntime().availableProcessors() == 1;
 	}
 
 	private void performPreinitialization() {


### PR DESCRIPTION
this [enhancement](https://github.com/spring-projects/spring-boot/issues/15722) 