### PR TITLE
Async configuration ignores `applicationTaskExecutor` when `EnableScheduling` is enabled 

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/task/TaskExecutionAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/task/TaskExecutionAutoConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  * {@link EnableAutoConfiguration Auto-configuration} for {@link TaskExecutor}.
  *
  * @author Stephane Nicoll
+ * @author Camille Vienot
  * @since 2.1.0
  */
 @ConditionalOnClass(ThreadPoolTaskExecutor.class)
@@ -47,6 +48,8 @@ public class TaskExecutionAutoConfiguration {
 	 * Bean name of the application {@link TaskExecutor}.
 	 */
 	public static final String APPLICATION_TASK_EXECUTOR_BEAN_NAME = "applicationTaskExecutor";
+
+	public static final String ASYNC_TASK_EXECUTOR_BEAN_NAME = "taskExecutor";
 
 	private final TaskExecutionProperties properties;
 
@@ -79,7 +82,7 @@ public class TaskExecutionAutoConfiguration {
 	}
 
 	@Lazy
-	@Bean(name = APPLICATION_TASK_EXECUTOR_BEAN_NAME)
+	@Bean(name = { APPLICATION_TASK_EXECUTOR_BEAN_NAME, ASYNC_TASK_EXECUTOR_BEAN_NAME })
 	@ConditionalOnMissingBean(Executor.class)
 	public ThreadPoolTaskExecutor applicationTaskExecutor(TaskExecutorBuilder builder) {
 		return builder.build();

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/task/TaskExecutionAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/task/TaskExecutionAutoConfigurationTests.java
@@ -38,6 +38,7 @@ import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -49,6 +50,7 @@ import static org.mockito.Mockito.verify;
  * Tests for {@link TaskExecutionAutoConfiguration}.
  *
  * @author Stephane Nicoll
+ * @author Camille Vienot
  */
 public class TaskExecutionAutoConfigurationTests {
 
@@ -151,6 +153,21 @@ public class TaskExecutionAutoConfigurationTests {
 				});
 	}
 
+	@Test
+	public void enableAsyncUsesAutoConfiguredOneByDefaultEvenThoughSchedulingIsConfigured() {
+		this.contextRunner
+				.withPropertyValues("spring.task.execution.thread-name-prefix=task-test-")
+				.withConfiguration(
+						AutoConfigurations.of(TaskSchedulingAutoConfiguration.class))
+				.withUserConfiguration(AsyncConfiguration.class,
+						SchedulingConfiguration.class, TestBean.class)
+				.run((context) -> {
+					TestBean bean = context.getBean(TestBean.class);
+					String text = bean.echo("something").get();
+					assertThat(text).contains("task-test-").contains("something");
+				});
+	}
+
 	private ContextConsumer<AssertableApplicationContext> assertTaskExecutor(
 			Consumer<ThreadPoolTaskExecutor> taskExecutor) {
 		return (context) -> {
@@ -205,6 +222,12 @@ public class TaskExecutionAutoConfigurationTests {
 	@Configuration
 	@EnableAsync
 	static class AsyncConfiguration {
+
+	}
+
+	@Configuration
+	@EnableScheduling
+	static class SchedulingConfiguration {
 
 	}
 


### PR DESCRIPTION
Use alias for autoconfigured task executor, enabling async configuration to pick it, even though multiple task executors are injected

Fixes gh-15729


