### PR TITLE
Add the capability to set the default Console appender to write logs in JSON when using Logback

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
@@ -44,6 +44,16 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-json-classic</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-jackson</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-xml</artifactId>
 			<optional>true</optional>

--- a/spring-boot-project/spring-boot-actuator/pom.xml
+++ b/spring-boot-project/spring-boot-actuator/pom.xml
@@ -299,6 +299,16 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-json-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-jackson</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
 			<scope>test</scope>

--- a/spring-boot-project/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/pom.xml
@@ -721,6 +721,16 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-json-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-jackson</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
 			<scope>test</scope>

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -573,6 +573,16 @@
 				<version>${logback.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>ch.qos.logback.contrib</groupId>
+				<artifactId>logback-json-classic</artifactId>
+				<version>${logback-contrib.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>ch.qos.logback.contrib</groupId>
+				<artifactId>logback-jackson</artifactId>
+				<version>${logback-contrib.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-core</artifactId>
 				<version>${logback.version}</version>

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -128,6 +128,7 @@
 		<liquibase.version>3.6.2</liquibase.version>
 		<log4j2.version>2.11.1</log4j2.version>
 		<logback.version>1.2.3</logback.version>
+		<logback-contrib.version>0.1.5</logback-contrib.version>
 		<lombok.version>1.18.4</lombok.version>
 		<mariadb.version>2.3.0</mariadb.version>
 		<micrometer.version>1.1.2</micrometer.version>

--- a/spring-boot-project/spring-boot-devtools/pom.xml
+++ b/spring-boot-project/spring-boot-devtools/pom.xml
@@ -97,6 +97,16 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-json-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-jackson</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>test</scope>

--- a/spring-boot-project/spring-boot-docs/pom.xml
+++ b/spring-boot-project/spring-boot-docs/pom.xml
@@ -78,6 +78,16 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-json-classic</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-jackson</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>com.atomikos</groupId>
 			<artifactId>transactions-jms</artifactId>
 			<optional>true</optional>

--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-logging/pom.xml
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-logging/pom.xml
@@ -19,6 +19,14 @@
 			<artifactId>logback-classic</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-json-classic</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-jackson</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-to-slf4j</artifactId>
 		</dependency>

--- a/spring-boot-project/spring-boot-test-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-test-autoconfigure/pom.xml
@@ -190,6 +190,16 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-json-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-jackson</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-module-parameter-names</artifactId>
 			<scope>test</scope>

--- a/spring-boot-project/spring-boot-test/pom.xml
+++ b/spring-boot-project/spring-boot-test/pom.xml
@@ -147,6 +147,16 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-json-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-jackson</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.tomcat.embed</groupId>
 			<artifactId>tomcat-embed-core</artifactId>
 			<scope>test</scope>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/pom.xml
@@ -33,6 +33,17 @@
 			<artifactId>logback-classic</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-json-classic</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-jackson</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- Test -->
 		<dependency>
 			<groupId>org.zeroturnaround</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/pom.xml
@@ -27,6 +27,16 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-json-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-jackson</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
 			<scope>test</scope>

--- a/spring-boot-project/spring-boot/pom.xml
+++ b/spring-boot-project/spring-boot/pom.xml
@@ -32,6 +32,16 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-json-classic</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-jackson</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>com.atomikos</groupId>
 			<artifactId>transactions-jdbc</artifactId>
 			<optional>true</optional>

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
@@ -124,8 +124,8 @@ class DefaultLogbackConfiguration {
 	private Appender<ILoggingEvent> consoleAppender(LogbackConfigurator config) {
 		ConsoleAppender<ILoggingEvent> appender = new ConsoleAppender<>();
 		String format = this.patterns.getProperty("logging.format", TEXT);
-		String timestampFormat = this.patterns
-				.getProperty("logging.timestampFormat", ISO_8601_TIMESTAMP_FORMAT);
+		String timestampFormat = this.patterns.getProperty("logging.timestampFormat",
+				ISO_8601_TIMESTAMP_FORMAT);
 		boolean appendLineSeparator = this.patterns
 				.getProperty("logging.appendLineSeparator", Boolean.class, Boolean.TRUE);
 		Encoder<ILoggingEvent> encoder;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
@@ -123,23 +123,23 @@ class DefaultLogbackConfiguration {
 
 	private Appender<ILoggingEvent> consoleAppender(LogbackConfigurator config) {
 		ConsoleAppender<ILoggingEvent> appender = new ConsoleAppender<>();
-		final String format = this.patterns.getProperty("logging.format", TEXT);
-		final String timestampFormat = this.patterns
+		String format = this.patterns.getProperty("logging.format", TEXT);
+		String timestampFormat = this.patterns
 				.getProperty("logging.timestampFormat", ISO_8601_TIMESTAMP_FORMAT);
-		final boolean appendLineSeparator = this.patterns
+		boolean appendLineSeparator = this.patterns
 				.getProperty("logging.appendLineSeparator", Boolean.class, Boolean.TRUE);
-		final Encoder<ILoggingEvent> encoder;
+		Encoder<ILoggingEvent> encoder;
 		if (JSON.equalsIgnoreCase(format)) {
-			final JacksonJsonFormatter jacksonJsonFormatter = new JacksonJsonFormatter();
+			JacksonJsonFormatter jacksonJsonFormatter = new JacksonJsonFormatter();
 			jacksonJsonFormatter.setPrettyPrint(true);
 
-			final JsonLayout jsonLayout = new JsonLayout();
+			JsonLayout jsonLayout = new JsonLayout();
 			jsonLayout.setJsonFormatter(jacksonJsonFormatter);
 			jsonLayout.setTimestampFormat(timestampFormat);
 			jsonLayout
 					.setAppendLineSeparator(BooleanUtils.toBoolean(appendLineSeparator));
 
-			final LayoutWrappingEncoder<ILoggingEvent> layoutWrappingEncoder = new LayoutWrappingEncoder<>();
+			LayoutWrappingEncoder<ILoggingEvent> layoutWrappingEncoder = new LayoutWrappingEncoder<>();
 			layoutWrappingEncoder.setLayout(jsonLayout);
 
 			config.start(layoutWrappingEncoder);
@@ -148,8 +148,8 @@ class DefaultLogbackConfiguration {
 			encoder = layoutWrappingEncoder;
 		}
 		else {
-			final PatternLayoutEncoder patternLayoutEncoder = new PatternLayoutEncoder();
-			final String logPattern = this.patterns.getProperty("logging.pattern.console",
+			PatternLayoutEncoder patternLayoutEncoder = new PatternLayoutEncoder();
+			String logPattern = this.patterns.getProperty("logging.pattern.console",
 					CONSOLE_LOG_PATTERN);
 			patternLayoutEncoder
 					.setPattern(OptionHelper.substVars(logPattern, config.getContext()));

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
@@ -32,6 +32,7 @@ import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
 import ch.qos.logback.core.util.FileSize;
 import ch.qos.logback.core.util.OptionHelper;
+import org.apache.commons.lang3.BooleanUtils;
 
 import org.springframework.boot.logging.LogFile;
 import org.springframework.boot.logging.LoggingInitializationContext;
@@ -66,6 +67,8 @@ class DefaultLogbackConfiguration {
 	private static final String JSON = "json";
 
 	private static final String TEXT = "text";
+
+	private static final String ISO_8601_TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm'Z'";
 
 	private final PropertyResolver patterns;
 
@@ -121,6 +124,10 @@ class DefaultLogbackConfiguration {
 	private Appender<ILoggingEvent> consoleAppender(LogbackConfigurator config) {
 		ConsoleAppender<ILoggingEvent> appender = new ConsoleAppender<>();
 		final String format = this.patterns.getProperty("logging.format", TEXT);
+		final String timestampFormat = this.patterns
+				.getProperty("logging.timestampFormat", ISO_8601_TIMESTAMP_FORMAT);
+		final boolean appendLineSeparator = this.patterns
+				.getProperty("logging.appendLineSeparator", Boolean.class, Boolean.TRUE);
 		final Encoder<ILoggingEvent> encoder;
 		if (JSON.equalsIgnoreCase(format)) {
 			final JacksonJsonFormatter jacksonJsonFormatter = new JacksonJsonFormatter();
@@ -128,8 +135,9 @@ class DefaultLogbackConfiguration {
 
 			final JsonLayout jsonLayout = new JsonLayout();
 			jsonLayout.setJsonFormatter(jacksonJsonFormatter);
-			jsonLayout.setTimestampFormat("yyyy-MM-dd' 'HH:mm:ss.SSS");
-			jsonLayout.setAppendLineSeparator(true);
+			jsonLayout.setTimestampFormat(timestampFormat);
+			jsonLayout
+					.setAppendLineSeparator(BooleanUtils.toBoolean(appendLineSeparator));
 
 			final LayoutWrappingEncoder<ILoggingEvent> layoutWrappingEncoder = new LayoutWrappingEncoder<>();
 			layoutWrappingEncoder.setLayout(jsonLayout);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -509,7 +509,8 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.loggingSystem.initialize(loggingInitializationContext, null, null);
 		this.logger.info("Hello Json!");
 
-		Map<String, Object> result = new ObjectMapper().readValue(this.output.toString(), HashMap.class);
+		Map<String, Object> result = new ObjectMapper().readValue(this.output.toString(),
+				HashMap.class);
 
 		assertThat(this.output.toString().charAt(this.output.toString().length() - 1))
 				.isEqualTo('\n');
@@ -534,7 +535,8 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.loggingSystem.initialize(loggingInitializationContext, null, null);
 		this.logger.info("Hello Json!");
 
-		Map<String, Object> result = new ObjectMapper().readValue(this.output.toString(), HashMap.class);
+		Map<String, Object> result = new ObjectMapper().readValue(this.output.toString(),
+				HashMap.class);
 
 		assertThat(this.output.toString().charAt(this.output.toString().length() - 1))
 				.isEqualTo('}');

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -509,8 +509,7 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.loggingSystem.initialize(loggingInitializationContext, null, null);
 		this.logger.info("Hello Json!");
 
-		final Map<String, Object> result = new ObjectMapper()
-				.readValue(this.output.toString(), HashMap.class);
+		Map<String, Object> result = new ObjectMapper().readValue(this.output.toString(), HashMap.class);
 
 		assertThat(this.output.toString().charAt(this.output.toString().length() - 1))
 				.isEqualTo('\n');
@@ -535,8 +534,7 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.loggingSystem.initialize(loggingInitializationContext, null, null);
 		this.logger.info("Hello Json!");
 
-		final Map<String, Object> result = new ObjectMapper()
-				.readValue(this.output.toString(), HashMap.class);
+		Map<String, Object> result = new ObjectMapper().readValue(this.output.toString(), HashMap.class);
 
 		assertThat(this.output.toString().charAt(this.output.toString().length() - 1))
 				.isEqualTo('}');


### PR DESCRIPTION
This pull request gives developers the capability to set the default Console appender output when using Logback to be in JSON or plain text in the default configuration file (application properties/yml). This was suggested by a colleague and after some discussions we found it useful to be able to easily set the format of the logs, in our case to JSON to be consumed by a logging application e.g. Splunk without defining a separate configuration file. 

To use the feature, one just has to define in the application properties/yml file the ff:

    logging:
        format: json
        
Further more timestamp & adding line separators can also be set

    logging:
        format: json
        timestampFormat: yyyy-MM-dd' 'HH:mm:ss.SSS
        appendLineSeparator: 'false'

Default for timestampFormat is ISO_8601 and the default for appendLineSeparator is 'true'

Please note that we wanted to get the Spring Boot community's thoughts on this via this pull request that is why we did it for Console logger for now. We will gladly do it for File appender in case the community finds this useful.  

Respectfully,

Jedd