### PR TITLE
Run CompositeHealthIndicator in parallel

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeHealthIndicator.java
@@ -91,17 +91,14 @@ public class CompositeHealthIndicator implements HealthIndicator {
 		return this.registry;
 	}
 
-	// TODO Guarantee preserved ordering
-	// TODO it doesn't seem important but don't make assumptions on other people's behalf
 	@Override
 	public Health health() {
 		/* Gather healths in parallel */
 		Map<String, Health> healths = this.registry.getAll().entrySet().parallelStream()
 				.map((e) -> new SimpleEntry<>(e.getKey(), e.getValue().health()))
-				/* Merge the streams together */
+				/* Merge the entries, preserving original order */
 				.collect(LinkedHashMap::new,
 						(map, e) -> map.put(e.getKey(), e.getValue()), Map::putAll);
-		// .collect(Collectors.toMap(SimpleEntry::getKey, SimpleEntry::getValue,
 		return this.aggregator.aggregate(healths);
 	}
 


### PR DESCRIPTION
See https://github.com/spring-projects/spring-boot/issues/2652

**Problem:** 
The CompositeHealthIndicator polls all the HealthIndicators in the registry sequentially. I have a number of HealtIndicator components that poll remote systems and report on latency and status, and the latency really adds up, especially if there are time-outs involved. 

**Solution:** 
This PR polls the HealthIndicators concurrently. It preserves the original ordering, and outputs the same as the old implementation, except the runtime is proportional to that of the slowest component, rather than the aggregate of all components. The impact of this change should be very small, unless someone's code absolutely depends on HealthIndicators being polled sequentially but in unknown order. 