### PR TITLE
Optimize ConfigurationPropertyName

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -237,7 +237,7 @@ public final class ConfigurationPropertyName
 		if (this.getNumberOfElements() >= name.getNumberOfElements()) {
 			return false;
 		}
-		for (int i = 0; i < this.elements.getSize(); i++) {
+		for (int i = this.elements.getSize() - 1; i >= 0; i--) {
 			if (!elementEquals(this.elements, name.elements, i)) {
 				return false;
 			}
@@ -309,7 +309,7 @@ public final class ConfigurationPropertyName
 				&& other.elements.canShortcutWithSource(ElementType.UNIFORM)) {
 			return toString().equals(other.toString());
 		}
-		for (int i = 0; i < this.elements.getSize(); i++) {
+		for (int i = this.elements.getSize() - 1; i >= 0; i--) {
 			if (!elementEquals(this.elements, other.elements, i)) {
 				return false;
 			}


### PR DESCRIPTION
Hi,

while looking into some possible improvements for #15760 I noticed a possible optimization that effectively turns around the iteration order when checking for element equality of two `ConfigurationPropertyName` instances via `elementEquals`.

This is largely based on the educated guess that child elements will likely differ while parent elements stay the same. (Almost everything is prefixed with a common `spring` or `initializr`, but the following elements are often different).

The reason for this improvement came apparent when I profiled the `BinderApplication` provided by @dsyer. There are a lot of calls to `elementEquals` and the corresponding `charAt` methods called in it.

I also ran the provided benchmarks of #15760  and got these results:

**Before**
![grafik](https://user-images.githubusercontent.com/6304496/51708294-da4e0080-2023-11e9-8006-efa5b567d207.png)

```
Benchmark                        (prof)   Mode  Cnt      Score      Error  Units
PropertiesBenchmarkIT.auto       medium  thrpt   10    101,083 ±   47,304  ops/s
PropertiesBenchmarkIT.auto:size  medium  thrpt   10   1340,000                 #
PropertiesBenchmarkIT.auto        small  thrpt   10  11800,645 ± 3892,176  ops/s
PropertiesBenchmarkIT.auto:size   small  thrpt   10     10,000                 #
PropertiesBenchmarkIT.auto        large  thrpt   10      1,292 ±    0,261  ops/s
PropertiesBenchmarkIT.auto:size   large  thrpt   10  10930,000                 #

Benchmark                 (prof)  Mode  Cnt  Score   Error  Units
LauncherBenchmarkIT.auto  medium  avgt   10  1,106 ± 0,159   s/op
LauncherBenchmarkIT.auto   small  avgt   10  0,777 ± 0,092   s/op
LauncherBenchmarkIT.auto   large  avgt   10  2,562 ± 0,315   s/op
```

**After**
![grafik](https://user-images.githubusercontent.com/6304496/51707660-0cf6f980-2022-11e9-8d3e-a4d2bb5c3c78.png)

```
Benchmark                        (prof)   Mode  Cnt      Score      Error  Units
PropertiesBenchmarkIT.auto       medium  thrpt   10    181,640 ±   94,044  ops/s
PropertiesBenchmarkIT.auto:size  medium  thrpt   10   1340,000                 #
PropertiesBenchmarkIT.auto        small  thrpt   10  13601,079 ± 5695,056  ops/s
PropertiesBenchmarkIT.auto:size   small  thrpt   10     10,000                 #
PropertiesBenchmarkIT.auto        large  thrpt   10      2,505 ±    0,650  ops/s
PropertiesBenchmarkIT.auto:size   large  thrpt   10  10930,000                 #

Benchmark                 (prof)  Mode  Cnt  Score   Error  Units
LauncherBenchmarkIT.auto  medium  avgt   10  1,078 ± 0,109   s/op
LauncherBenchmarkIT.auto   small  avgt   10  0,783 ± 0,093   s/op
LauncherBenchmarkIT.auto   large  avgt   10  2,309 ± 0,223   s/op
```

I think this shows that we save quite a bit of cycles in the large example, while not loosing too much in the small one. But in the end it is an educated guess, so feel free to decline this PR.

Let me know what you think.
Cheers,
Christoph

P.S.: Don't pay too much attention to the timings in the screenshots. Due to the profiling overhead they are quite a bit off. The overall distribution and total calls are more important here.