### PR TITLE
Remove duplicate code from HealthWebEndpointResponseMapper

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthWebEndpointResponseMapper.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthWebEndpointResponseMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,10 +88,7 @@ public class HealthWebEndpointResponseMapper {
 	 */
 	public WebEndpointResponse<Health> map(Health health, SecurityContext securityContext,
 			ShowDetails showDetails) {
-		if (showDetails == ShowDetails.NEVER
-				|| (showDetails == ShowDetails.WHEN_AUTHORIZED
-						&& (securityContext.getPrincipal() == null
-								|| !isUserInRole(securityContext)))) {
+		if (!canSeeDetails(securityContext, showDetails)) {
 			health = Health.status(health.getStatus()).build();
 		}
 		return createWebEndpointResponse(health);


### PR DESCRIPTION
While debugging I noticed there's some duplicate code in `HealthWebEndpointResponseMapper` that could easily be removed.