### PR TITLE
Test the Gradle plugin against Gradle 4.10.3 and 5.1.1

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleCompatibilitySuite.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleCompatibilitySuite.java
@@ -39,7 +39,7 @@ import org.springframework.boot.gradle.testkit.GradleBuild;
 public final class GradleCompatibilitySuite extends Suite {
 
 	private static final List<String> GRADLE_VERSIONS = Arrays.asList("default", "4.5.1",
-			"4.6", "4.7", "4.8.1", "4.9", "4.10.2", "5.0");
+			"4.6", "4.7", "4.8.1", "4.9", "4.10.3", "5.0", "5.1.1");
 
 	public GradleCompatibilitySuite(Class<?> clazz) throws InitializationError {
 		super(clazz, createRunners(clazz));

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/testkit/GradleBuild.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/testkit/GradleBuild.java
@@ -193,7 +193,7 @@ public class GradleBuild implements TestRule {
 			gradleRunner.withGradleVersion(this.gradleVersion);
 		}
 		else if (this.dsl == Dsl.KOTLIN) {
-			gradleRunner.withGradleVersion("4.10.2");
+			gradleRunner.withGradleVersion("4.10.3");
 		}
 		List<String> allArguments = new ArrayList<>();
 		allArguments.add("-PbootVersion=" + getBootVersion());


### PR DESCRIPTION
Hi,

this PR includes/updates the newest Gradle versions in `GradleCompatibilitySuite`. Especially the recently released 5.1.x mainline was missing here and is probably worthwhile to add.

Cheers,
Christoph