### PR TITLE
Use Assertions.contentOf() where possible

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,9 +48,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.util.FileCopyUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
 
 /**
  * Tests for {@link LiquibaseAutoConfiguration}.
@@ -286,8 +286,7 @@ public class LiquibaseAutoConfigurationTests {
 					File actualFile = (File) ReflectionTestUtils.getField(liquibase,
 							"rollbackFile");
 					assertThat(actualFile).isEqualTo(file).exists();
-					String content = new String(FileCopyUtils.copyToByteArray(file));
-					assertThat(content).contains("DROP TABLE PUBLIC.customer;");
+					assertThat(contentOf(file)).contains("DROP TABLE PUBLIC.customer;");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/RestarterTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/RestarterTests.java
@@ -38,7 +38,6 @@ import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.util.FileCopyUtils;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -125,7 +124,7 @@ public class RestarterTests {
 	}
 
 	@Test
-	public void addClassLoaderFiles() throws Exception {
+	public void addClassLoaderFiles() {
 		ClassLoaderFiles classLoaderFiles = new ClassLoaderFiles();
 		classLoaderFiles.addFile("f", new ClassLoaderFile(Kind.ADDED, "abc".getBytes()));
 		Restarter restarter = Restarter.getInstance();
@@ -133,8 +132,7 @@ public class RestarterTests {
 		restarter.restart();
 		ClassLoader classLoader = ((TestableRestarter) restarter)
 				.getRelaunchClassLoader();
-		assertThat(FileCopyUtils.copyToByteArray(classLoader.getResourceAsStream("f")))
-				.isEqualTo("abc".getBytes());
+		assertThat(classLoader.getResourceAsStream("f")).hasContent("abc");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/Verify.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/Verify.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,9 @@ import java.util.zip.ZipFile;
 
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.support.PropertiesLoaderUtils;
-import org.springframework.util.FileCopyUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
 
 /**
  * Verification utility for use with maven-invoker-plugin verification scripts.
@@ -182,7 +182,7 @@ public final class Verify {
 			assertThat(this.file).exists().isFile();
 
 			if (scriptContents.length > 0 && executable) {
-				String contents = new String(FileCopyUtils.copyToByteArray(this.file));
+				String contents = contentOf(this.file);
 				contents = contents.substring(0, contents
 						.indexOf(new String(new byte[] { 0x50, 0x4b, 0x03, 0x04 })));
 				for (String content : scriptContents) {
@@ -191,7 +191,7 @@ public final class Verify {
 			}
 
 			if (!executable) {
-				String contents = new String(FileCopyUtils.copyToByteArray(this.file));
+				String contents = contentOf(this.file);
 				assertThat(contents).as("Is executable")
 						.startsWith(new String(new byte[] { 0x50, 0x4b, 0x03, 0x04 }));
 			}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/ApplicationPidFileWriterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/ApplicationPidFileWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.boot.context;
 
 import java.io.File;
-import java.io.FileReader;
 
 import org.junit.After;
 import org.junit.Before;
@@ -35,10 +34,10 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.mock.env.MockPropertySource;
-import org.springframework.util.FileCopyUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.contentOf;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -72,8 +71,7 @@ public class ApplicationPidFileWriterTests {
 		File file = this.temporaryFolder.newFile();
 		ApplicationPidFileWriter listener = new ApplicationPidFileWriter(file);
 		listener.onApplicationEvent(EVENT);
-		FileReader reader = new FileReader(file);
-		assertThat(FileCopyUtils.copyToString(reader)).isNotEmpty();
+		assertThat(contentOf(file)).isNotEmpty();
 	}
 
 	@Test
@@ -82,8 +80,7 @@ public class ApplicationPidFileWriterTests {
 		System.setProperty("PIDFILE", this.temporaryFolder.newFile().getAbsolutePath());
 		ApplicationPidFileWriter listener = new ApplicationPidFileWriter(file);
 		listener.onApplicationEvent(EVENT);
-		FileReader reader = new FileReader(System.getProperty("PIDFILE"));
-		assertThat(FileCopyUtils.copyToString(reader)).isNotEmpty();
+		assertThat(contentOf(new File(System.getProperty("PIDFILE")))).isNotEmpty();
 	}
 
 	@Test
@@ -93,7 +90,7 @@ public class ApplicationPidFileWriterTests {
 				file.getAbsolutePath());
 		ApplicationPidFileWriter listener = new ApplicationPidFileWriter();
 		listener.onApplicationEvent(event);
-		assertThat(FileCopyUtils.copyToString(new FileReader(file))).isNotEmpty();
+		assertThat(contentOf(file)).isNotEmpty();
 	}
 
 	@Test
@@ -103,10 +100,10 @@ public class ApplicationPidFileWriterTests {
 				file.getAbsolutePath());
 		ApplicationPidFileWriter listener = new ApplicationPidFileWriter();
 		listener.onApplicationEvent(event);
-		assertThat(FileCopyUtils.copyToString(new FileReader(file))).isEmpty();
+		assertThat(contentOf(file)).isEmpty();
 		listener.setTriggerEventType(ApplicationEnvironmentPreparedEvent.class);
 		listener.onApplicationEvent(event);
-		assertThat(FileCopyUtils.copyToString(new FileReader(file))).isNotEmpty();
+		assertThat(contentOf(file)).isNotEmpty();
 	}
 
 	@Test
@@ -116,10 +113,10 @@ public class ApplicationPidFileWriterTests {
 				file.getAbsolutePath());
 		ApplicationPidFileWriter listener = new ApplicationPidFileWriter();
 		listener.onApplicationEvent(event);
-		assertThat(FileCopyUtils.copyToString(new FileReader(file))).isEmpty();
+		assertThat(contentOf(file)).isEmpty();
 		listener.setTriggerEventType(ApplicationReadyEvent.class);
 		listener.onApplicationEvent(event);
-		assertThat(FileCopyUtils.copyToString(new FileReader(file))).isNotEmpty();
+		assertThat(contentOf(file)).isNotEmpty();
 	}
 
 	@Test
@@ -129,7 +126,7 @@ public class ApplicationPidFileWriterTests {
 		listener.setTriggerEventType(ApplicationStartingEvent.class);
 		listener.onApplicationEvent(
 				new ApplicationStartingEvent(new SpringApplication(), new String[] {}));
-		assertThat(FileCopyUtils.copyToString(new FileReader(file))).isNotEmpty();
+		assertThat(contentOf(file)).isNotEmpty();
 	}
 
 	@Test
@@ -138,7 +135,7 @@ public class ApplicationPidFileWriterTests {
 		file.setReadOnly();
 		ApplicationPidFileWriter listener = new ApplicationPidFileWriter(file);
 		listener.onApplicationEvent(EVENT);
-		assertThat(FileCopyUtils.copyToString(new FileReader(file))).isEmpty();
+		assertThat(contentOf(file)).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.boot.logging.log4j2;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
-import java.io.FileReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -44,10 +43,10 @@ import org.springframework.boot.logging.LoggingSystem;
 import org.springframework.boot.logging.LoggingSystemProperties;
 import org.springframework.boot.testsupport.assertj.Matched;
 import org.springframework.boot.testsupport.rule.OutputCapture;
-import org.springframework.util.FileCopyUtils;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
@@ -243,14 +242,13 @@ public class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	@Test
-	public void exceptionsIncludeClassPackaging() throws Exception {
+	public void exceptionsIncludeClassPackaging() {
 		this.loggingSystem.beforeInitialize();
 		this.loggingSystem.initialize(null, null, getLogFile(null, tmpDir()));
 		Matcher<String> expectedOutput = containsString("[junit-");
 		this.output.expect(expectedOutput);
 		this.logger.warn("Expected exception", new RuntimeException("Expected"));
-		String fileContents = FileCopyUtils
-				.copyToString(new FileReader(new File(tmpDir() + "/spring.log")));
+		String fileContents = contentOf(new File(tmpDir() + "/spring.log"));
 		assertThat(fileContents).is(Matched.by(expectedOutput));
 	}
 
@@ -262,7 +260,7 @@ public class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	@Test
-	public void customExceptionConversionWord() throws Exception {
+	public void customExceptionConversionWord() {
 		System.setProperty(LoggingSystemProperties.EXCEPTION_CONVERSION_WORD, "%ex");
 		try {
 			this.loggingSystem.beforeInitialize();
@@ -274,8 +272,7 @@ public class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 			this.output.expect(expectedOutput);
 			this.logger.warn("Expected exception",
 					new RuntimeException("Expected", new RuntimeException("Cause")));
-			String fileContents = FileCopyUtils
-					.copyToString(new FileReader(new File(tmpDir() + "/spring.log")));
+			String fileContents = contentOf(new File(tmpDir() + "/spring.log"));
 			assertThat(fileContents).is(Matched.by(expectedOutput));
 		}
 		finally {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.boot.logging.logback;
 
 import java.io.File;
-import java.io.FileReader;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.logging.Handler;
@@ -55,10 +54,10 @@ import org.springframework.boot.testsupport.runner.classpath.ClassPathExclusions
 import org.springframework.boot.testsupport.runner.classpath.ModifiedClassPathRunner;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.util.FileCopyUtils;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
@@ -89,15 +88,13 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 
 	private LoggingInitializationContext initializationContext;
 
-	private MockEnvironment environment;
-
 	@Before
 	public void setup() {
 		this.loggingSystem.cleanUp();
 		this.logger = ((LoggerContext) StaticLoggerBinder.getSingleton()
 				.getLoggerFactory()).getLogger(getClass());
-		this.environment = new MockEnvironment();
-		this.initializationContext = new LoggingInitializationContext(this.environment);
+		MockEnvironment environment = new MockEnvironment();
+		this.initializationContext = new LoggingInitializationContext(environment);
 	}
 
 	@Override
@@ -120,7 +117,7 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	@Test
-	public void withFile() throws Exception {
+	public void withFile() {
 		this.loggingSystem.beforeInitialize();
 		this.logger.info("Hidden");
 		this.loggingSystem.initialize(this.initializationContext, null,
@@ -340,7 +337,7 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	@Test
-	public void testFilePatternProperty() throws Exception {
+	public void testFilePatternProperty() {
 		MockEnvironment environment = new MockEnvironment();
 		environment.setProperty("logging.pattern.file", "%logger %msg");
 		LoggingInitializationContext loggingInitializationContext = new LoggingInitializationContext(
@@ -355,7 +352,7 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	@Test
-	public void testMaxFileSizeProperty() throws Exception {
+	public void testMaxFileSizeProperty() {
 		MockEnvironment environment = new MockEnvironment();
 		environment.setProperty("logging.file.max-size", "100MB");
 		LoggingInitializationContext loggingInitializationContext = new LoggingInitializationContext(
@@ -370,7 +367,7 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	@Test
-	public void testMaxFileSizePropertyWithXmlConfiguration() throws Exception {
+	public void testMaxFileSizePropertyWithXmlConfiguration() {
 		MockEnvironment environment = new MockEnvironment();
 		environment.setProperty("logging.file.max-size", "100MB");
 		LoggingInitializationContext loggingInitializationContext = new LoggingInitializationContext(
@@ -386,7 +383,7 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	@Test
-	public void testMaxHistoryProperty() throws Exception {
+	public void testMaxHistoryProperty() {
 		MockEnvironment environment = new MockEnvironment();
 		environment.setProperty("logging.file.max-history", "30");
 		LoggingInitializationContext loggingInitializationContext = new LoggingInitializationContext(
@@ -415,20 +412,19 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	@Test
-	public void exceptionsIncludeClassPackaging() throws Exception {
+	public void exceptionsIncludeClassPackaging() {
 		this.loggingSystem.beforeInitialize();
 		this.loggingSystem.initialize(this.initializationContext, null,
 				getLogFile(null, tmpDir()));
 		Matcher<String> expectedOutput = containsString("[junit-");
 		this.output.expect(expectedOutput);
 		this.logger.warn("Expected exception", new RuntimeException("Expected"));
-		String fileContents = FileCopyUtils
-				.copyToString(new FileReader(new File(tmpDir() + "/spring.log")));
+		String fileContents = contentOf(new File(tmpDir() + "/spring.log"));
 		assertThat(fileContents).is(Matched.by(expectedOutput));
 	}
 
 	@Test
-	public void customExceptionConversionWord() throws Exception {
+	public void customExceptionConversionWord() {
 		System.setProperty(LoggingSystemProperties.EXCEPTION_CONVERSION_WORD, "%ex");
 		try {
 			this.loggingSystem.beforeInitialize();
@@ -441,8 +437,7 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 			this.output.expect(expectedOutput);
 			this.logger.warn("Expected exception",
 					new RuntimeException("Expected", new RuntimeException("Cause")));
-			String fileContents = FileCopyUtils
-					.copyToString(new FileReader(new File(tmpDir() + "/spring.log")));
+			String fileContents = contentOf(new File(tmpDir() + "/spring.log"));
 			assertThat(fileContents).is(Matched.by(expectedOutput));
 		}
 		finally {
@@ -512,9 +507,8 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		return (SizeAndTimeBasedRollingPolicy<?>) getFileAppender().getRollingPolicy();
 	}
 
-	private String getLineWithText(File file, String outputSearch) throws Exception {
-		return getLineWithText(FileCopyUtils.copyToString(new FileReader(file)),
-				outputSearch);
+	private String getLineWithText(File file, String outputSearch) {
+		return getLineWithText(contentOf(file), outputSearch);
 	}
 
 	private String getLineWithText(String output, String outputSearch) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/system/ApplicationPidTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/system/ApplicationPidTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,14 @@
 package org.springframework.boot.system;
 
 import java.io.File;
-import java.io.FileReader;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import org.springframework.util.FileCopyUtils;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.contentOf;
 
 /**
  * Tests for {@link ApplicationPid}.
@@ -49,7 +47,7 @@ public class ApplicationPidTests {
 	}
 
 	@Test
-	public void throwIllegalStateWritingMissingPid() throws Exception {
+	public void throwIllegalStateWritingMissingPid() {
 		ApplicationPid pid = new ApplicationPid(null);
 		assertThatIllegalStateException()
 				.isThrownBy(() -> pid.write(this.temporaryFolder.newFile()))
@@ -61,8 +59,7 @@ public class ApplicationPidTests {
 		ApplicationPid pid = new ApplicationPid("123");
 		File file = this.temporaryFolder.newFile();
 		pid.write(file);
-		String actual = FileCopyUtils.copyToString(new FileReader(file));
-		assertThat(actual).isEqualTo("123");
+		assertThat(contentOf(file)).isEqualTo("123");
 	}
 
 	@Test
@@ -72,8 +69,7 @@ public class ApplicationPidTests {
 		File file = this.temporaryFolder.newFile();
 		file.delete();
 		pid.write(file);
-		String actual = FileCopyUtils.copyToString(new FileReader(file));
-		assertThat(actual).isEqualTo("123");
+		assertThat(contentOf(file)).isEqualTo("123");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/context/WebServerPortFileWriterTest.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/context/WebServerPortFileWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.boot.web.context;
 
 import java.io.File;
-import java.io.FileReader;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -29,10 +28,10 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import org.springframework.boot.web.server.WebServer;
-import org.springframework.util.FileCopyUtils;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -59,7 +58,7 @@ public class WebServerPortFileWriterTest {
 		File file = this.temporaryFolder.newFile();
 		WebServerPortFileWriter listener = new WebServerPortFileWriter(file);
 		listener.onApplicationEvent(mockEvent("", 8080));
-		assertThat(FileCopyUtils.copyToString(new FileReader(file))).isEqualTo("8080");
+		assertThat(contentOf(file)).isEqualTo("8080");
 	}
 
 	@Test
@@ -67,8 +66,8 @@ public class WebServerPortFileWriterTest {
 		System.setProperty("PORTFILE", this.temporaryFolder.newFile().getAbsolutePath());
 		WebServerPortFileWriter listener = new WebServerPortFileWriter();
 		listener.onApplicationEvent(mockEvent("", 8080));
-		FileReader reader = new FileReader(System.getProperty("PORTFILE"));
-		assertThat(FileCopyUtils.copyToString(reader)).isEqualTo("8080");
+		String content = contentOf(new File(System.getProperty("PORTFILE")));
+		assertThat(content).isEqualTo("8080");
 	}
 
 	@Test
@@ -77,8 +76,8 @@ public class WebServerPortFileWriterTest {
 		System.setProperty("PORTFILE", this.temporaryFolder.newFile().getAbsolutePath());
 		WebServerPortFileWriter listener = new WebServerPortFileWriter(file);
 		listener.onApplicationEvent(mockEvent("", 8080));
-		FileReader reader = new FileReader(System.getProperty("PORTFILE"));
-		assertThat(FileCopyUtils.copyToString(reader)).isEqualTo("8080");
+		String content = contentOf(new File(System.getProperty("PORTFILE")));
+		assertThat(content).isEqualTo("8080");
 	}
 
 	@Test
@@ -87,15 +86,14 @@ public class WebServerPortFileWriterTest {
 		WebServerPortFileWriter listener = new WebServerPortFileWriter(file);
 		listener.onApplicationEvent(mockEvent("", 8080));
 		listener.onApplicationEvent(mockEvent("management", 9090));
-		assertThat(FileCopyUtils.copyToString(new FileReader(file))).isEqualTo("8080");
+		assertThat(contentOf(file)).isEqualTo("8080");
 		String managementFile = file.getName();
 		managementFile = managementFile.substring(0, managementFile.length()
 				- StringUtils.getFilenameExtension(managementFile).length() - 1);
 		managementFile = managementFile + "-management."
 				+ StringUtils.getFilenameExtension(file.getName());
-		FileReader reader = new FileReader(
-				new File(file.getParentFile(), managementFile));
-		assertThat(FileCopyUtils.copyToString(reader)).isEqualTo("9090");
+		String content = contentOf(new File(file.getParentFile(), managementFile));
+		assertThat(content).isEqualTo("9090");
 		assertThat(collectFileNames(file.getParentFile())).contains(managementFile);
 	}
 
@@ -110,9 +108,8 @@ public class WebServerPortFileWriterTest {
 				- StringUtils.getFilenameExtension(managementFile).length() - 1);
 		managementFile = managementFile + "-MANAGEMENT."
 				+ StringUtils.getFilenameExtension(file.getName());
-		FileReader reader = new FileReader(
-				new File(file.getParentFile(), managementFile));
-		assertThat(FileCopyUtils.copyToString(reader)).isEqualTo("9090");
+		String content = contentOf(new File(file.getParentFile(), managementFile));
+		assertThat(content).isEqualTo("9090");
 		assertThat(collectFileNames(file.getParentFile())).contains(managementFile);
 	}
 


### PR DESCRIPTION
Hi,

this PR makes use of `Assertions.contentOf()` more often and includes some general polishing.

I just noticed after pushing that a change in `RestarterTests` is included, that is not using `Assertions.contentOf()` but cleans the assertion on an `InputStream` via `hasContent`. I hope that's okay - otherwise I'll revert this for the PR.

Cheers,
Christoph