### PR TITLE
Updating default embedded mongo version to 3.6.4

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.mongo.embedded;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -153,14 +154,9 @@ public class EmbeddedMongoAutoConfiguration {
 
 	private IFeatureAwareVersion determineVersion() {
 		if (this.embeddedProperties.getFeatures() == null) {
-			for (Version version : Version.values()) {
-				if (version.asInDownloadPath()
-						.equals(this.embeddedProperties.getVersion())) {
-					return version;
-				}
-			}
+			EnumSet<Feature> features = Version.Main.PRODUCTION.getFeatures();
 			return Versions.withFeatures(
-					new GenericVersion(this.embeddedProperties.getVersion()));
+					new GenericVersion(this.embeddedProperties.getVersion()), features);
 		}
 		return Versions.withFeatures(
 				new GenericVersion(this.embeddedProperties.getVersion()),

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoProperties.java
@@ -38,7 +38,7 @@ public class EmbeddedMongoProperties {
 	/**
 	 * Version of Mongo to use.
 	 */
-	private String version = "3.6.4";
+	private String version = "3.6.5";
 
 	private final Storage storage = new Storage();
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoProperties.java
@@ -38,7 +38,7 @@ public class EmbeddedMongoProperties {
 	/**
 	 * Version of Mongo to use.
 	 */
-	private String version = "3.5.5";
+	private String version = "3.6.4";
 
 	private final Storage storage = new Storage();
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfigurationTests.java
@@ -72,7 +72,7 @@ public class EmbeddedMongoAutoConfigurationTests {
 
 	@Test
 	public void defaultVersion() {
-		assertVersionConfiguration(null, "3.5.5");
+		assertVersionConfiguration(null, "3.6.5");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix/application-properties.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix/application-properties.adoc
@@ -928,7 +928,7 @@ content into your application. Rather, pick only the properties that you need.
 	spring.mongodb.embedded.storage.database-dir= # Directory used for data storage.
 	spring.mongodb.embedded.storage.oplog-size= # Maximum size of the oplog.
 	spring.mongodb.embedded.storage.repl-set-name= # Name of the replica set.
-	spring.mongodb.embedded.version=3.5.5 # Version of Mongo to use.
+	spring.mongodb.embedded.version=3.6.5 # Version of Mongo to use.
 
 	# REDIS ({sc-spring-boot-autoconfigure}/data/redis/RedisProperties.{sc-ext}[RedisProperties])
 	spring.redis.cluster.max-redirects= # Maximum number of redirects to follow when executing commands across the cluster.


### PR DESCRIPTION
Hi,
Since Mongo 3.6 alot of new features are introduced so its more practical to use 3.6 instead of 3.5