### PR TITLE
/actuator/scheduletasks endpoint fails with null pointer exception when there is custom SchedulingConfigurer

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/scheduling/ScheduledTasksEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/scheduling/ScheduledTasksEndpoint.java
@@ -127,8 +127,8 @@ public class ScheduledTasksEndpoint {
 		private static TaskDescription of(Task task) {
 			return DESCRIBERS.entrySet().stream()
 					.filter((entry) -> entry.getKey().isInstance(task))
-					.map((entry) -> entry.getValue().apply(task)).findFirst()
-					.orElse(null);
+					.map((entry) -> entry.getValue().apply(task)).filter(Objects::nonNull)
+					.findFirst().orElse(null);
 		}
 
 		private static TaskDescription describeTriggerTask(TriggerTask triggerTask) {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/scheduling/ScheduledTasksEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/scheduling/ScheduledTasksEndpointTests.java
@@ -28,6 +28,7 @@ import org.springframework.boot.actuate.scheduling.ScheduledTasksEndpoint.FixedR
 import org.springframework.boot.actuate.scheduling.ScheduledTasksEndpoint.ScheduledTasksReport;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
@@ -136,6 +137,15 @@ public class ScheduledTasksEndpointTests {
 		});
 	}
 
+	@Test
+	public void customTriggerIsReported() {
+		run(CustomTriggerTask.class, (tasks) -> {
+			assertThat(tasks.getCron()).isEmpty();
+			assertThat(tasks.getFixedDelay()).isEmpty();
+			assertThat(tasks.getFixedRate()).hasSize(0);
+		});
+	}
+
 	private void run(Class<?> configuration, Consumer<ScheduledTasksReport> consumer) {
 		this.contextRunner.withUserConfiguration(configuration).run((context) -> consumer
 				.accept(context.getBean(ScheduledTasksEndpoint.class).scheduledTasks()));
@@ -208,6 +218,17 @@ public class ScheduledTasksEndpointTests {
 		public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
 			taskRegistrar.addTriggerTask(new CronTriggerRunnable(),
 					new CronTrigger("0 0 0/6 1/1 * ?"));
+		}
+
+	}
+
+	private static class CustomTriggerTask implements SchedulingConfigurer {
+
+		@Override
+		public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+			Trigger trigger = (triggerContext) -> null;
+			taskRegistrar.addTriggerTask(() -> {
+			}, trigger);
 		}
 
 	}


### PR DESCRIPTION
this [bug](https://github.com/spring-projects/spring-boot/issues/15815)