### PR TITLE
Add support for jdbc:firebird: url prefix

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
@@ -140,7 +140,7 @@ public enum DatabaseDriver {
 
 		@Override
 		protected Collection<String> getUrlPrefixes() {
-			return Collections.singleton("firebirdsql");
+			return Arrays.asList("firebirdsql", "firebird");
 		}
 
 		@Override

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DatabaseDriverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DatabaseDriverTests.java
@@ -129,6 +129,8 @@ public class DatabaseDriverTests {
 				.isEqualTo(DatabaseDriver.SQLSERVER);
 		assertThat(DatabaseDriver.fromJdbcUrl("jdbc:firebirdsql://localhost/sample"))
 				.isEqualTo(DatabaseDriver.FIREBIRD);
+		assertThat(DatabaseDriver.fromJdbcUrl("jdbc:firebird://localhost/sample"))
+				.isEqualTo(DatabaseDriver.FIREBIRD);
 		assertThat(DatabaseDriver.fromJdbcUrl("jdbc:db2://localhost:50000/sample "))
 				.isEqualTo(DatabaseDriver.DB2);
 		assertThat(DatabaseDriver.fromJdbcUrl("jdbc:as400://localhost"))


### PR DESCRIPTION
Adds support for `jdbc:firebird:` URL prefix for Firebird. 

The next major version of Jaybird (Firebird JDBC driver), version 4, will add `jdbc:firebird:` as a JDBC URL prefix in addition to the existing `jdbc:firebirdsql:` prefix. 

See also:

- http://tracker.firebirdsql.org/browse/JDBC-520
- https://github.com/FirebirdSQL/jaybird/blob/master/src/documentation/release_notes.md#new-jdbc-protocol-prefix-jdbcfirebird
