### PR TITLE
Remove redundant dependency management for xml-apis:xml-apis

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -193,7 +193,6 @@
 		<webjars-hal-browser.version>3325375</webjars-hal-browser.version>
 		<webjars-locator-core.version>0.36</webjars-locator-core.version>
 		<wsdl4j.version>1.6.3</wsdl4j.version>
-		<xml-apis.version>1.4.01</xml-apis.version>
 		<xmlunit2.version>2.6.2</xmlunit2.version>
 		<!-- Plugin versions -->
 		<build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
@@ -3057,11 +3056,6 @@
 				<groupId>wsdl4j</groupId>
 				<artifactId>wsdl4j</artifactId>
 				<version>${wsdl4j.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>xml-apis</groupId>
-				<artifactId>xml-apis</artifactId>
-				<version>${xml-apis.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Now that xml-apis has been excluded from hibernate, it is only transitively imported from htmlunit, and the dependency management is therefore no longer needed

Closes gh-7731
