### PR TITLE
Add property support for Neo4j additional causal cluster URIs.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jProperties.java
@@ -34,6 +34,7 @@ import org.springframework.util.ClassUtils;
  * @author Vince Bickers
  * @author Aurélien Leboulanger
  * @author Michael Simons
+ * @author Gerrit Meier
  * @since 1.4.0
  */
 @ConfigurationProperties(prefix = "spring.data.neo4j")
@@ -51,6 +52,11 @@ public class Neo4jProperties implements ApplicationContextAware {
 	 * URI used by the driver. Auto-detected by default.
 	 */
 	private String uri;
+
+	/**
+	 * (Optional) additional core URIs used for causal cluster.
+	 */
+	private String[] uris;
 
 	/**
 	 * Login user of the server.
@@ -88,6 +94,14 @@ public class Neo4jProperties implements ApplicationContextAware {
 
 	public void setUri(String uri) {
 		this.uri = uri;
+	}
+
+	public String[] getUris() {
+		return this.uris;
+	}
+
+	public void setUris(String[] uris) {
+		this.uris = uris;
 	}
 
 	public String getUsername() {
@@ -153,7 +167,10 @@ public class Neo4jProperties implements ApplicationContextAware {
 		if (this.uri != null) {
 			builder.uri(this.uri);
 		}
-		else {
+		if (this.uris != null) {
+			builder.uris(this.uris);
+		}
+		if (this.uri == null && (this.uris == null || this.uris.length == 0)) {
 			configureUriWithDefaults(builder);
 		}
 		if (this.username != null && this.password != null) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jPropertiesTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Stephane Nicoll
  * @author Michael Simons
+ * @author Gerrit Meier
  */
 public class Neo4jPropertiesTests {
 
@@ -86,6 +87,17 @@ public class Neo4jPropertiesTests {
 				"spring.data.neo4j.uri=bolt://localhost:7687");
 		Configuration configuration = properties.createConfiguration();
 		assertDriver(configuration, Neo4jProperties.BOLT_DRIVER, "bolt://localhost:7687");
+	}
+
+	@Test
+	public void boltUrisGetPassedToBoltDriver() {
+		Neo4jProperties properties = load(true,
+				"spring.data.neo4j.uris=bolt+routing://localhost:7687, bolt+routing://localhost:7697");
+		Configuration configuration = properties.createConfiguration();
+
+		String[] expectedAdditionalUris = { "bolt+routing://localhost:7687",
+				"bolt+routing://localhost:7697" };
+		assertThat(configuration.getURIS()).isEqualTo(expectedAdditionalUris);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -4611,6 +4611,15 @@ properties, as shown in the following example:
 	spring.data.neo4j.password=secret
 ----
 
+If you want to connect to a causal cluster you have the option to provide additional
+core instances by setting the `spring.data.neo4j.uris` property.
+
+[source,properties,indent=0]
+----
+	spring.data.neo4j.uri=bolt+routing://core-server-1:7687
+	spring.data.neo4j.uris=bolt+routing://core-server-2:7687,bolt+routing://core-server-3:7687
+----
+
 You can take full control over the session creation by adding a
 `org.neo4j.ogm.config.Configuration` `@Bean`. Also, adding a `@Bean` of type
 `SessionFactory` disables the auto-configuration and gives you full control.


### PR DESCRIPTION
Expose the setting of additional URIs for cluster members to the users by offering a property.
The API in Neo4j-OGM exists for a long time but was never made accessible through the auto configuration.

