### PR TITLE
2.10.2 fixes a major bug in connection pool

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -101,7 +101,7 @@
 		<jboss-logging.version>3.3.2.Final</jboss-logging.version>
 		<jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
 		<jdom2.version>2.0.6</jdom2.version>
-		<jedis.version>2.9.1</jedis.version>
+		<jedis.version>2.10.2</jedis.version>
 		<jersey.version>2.27</jersey.version>
 		<jest.version>6.3.1</jest.version>
 		<jetty.version>9.4.14.v20181114</jetty.version>


### PR DESCRIPTION
Jedis 2.9.1 has a major bug in the connection pool which was fixed in 2.10.2 see - https://github.com/xetorthio/jedis/issues/1945

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
