### PR TITLE
Clean up SpringPropertyAction.getValue()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringPropertyAction.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringPropertyAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,17 +65,7 @@ class SpringPropertyAction extends Action {
 			addWarn("No Spring Environment available to resolve " + source);
 			return defaultValue;
 		}
-		String value = this.environment.getProperty(source);
-		if (value != null) {
-			return value;
-		}
-		int lastDot = source.lastIndexOf('.');
-		if (lastDot > 0) {
-			String prefix = source.substring(0, lastDot + 1);
-			return this.environment.getProperty(prefix + source.substring(lastDot + 1),
-					defaultValue);
-		}
-		return defaultValue;
+		return this.environment.getProperty(source, defaultValue);
 	}
 
 	@Override


### PR DESCRIPTION
Hi,

while looking through the code of `SpringPropertyAction` I noticed a String concatenation like this: `source.substring(0, lastDot + 1) + source.substring(lastDot + 1)`. This should be effectively the same as using `source` directly. By doing so we can cleanup the code a bit.

Let me know what you think.
Cheers,
Christoph