### PR TITLE
add webflux sample to text-stream post stream

### DIFF
--- a/spring-boot-samples/spring-boot-sample-webflux/src/main/java/sample/webflux/SampleWebFluxApplication.java
+++ b/spring-boot-samples/spring-boot-sample-webflux/src/main/java/sample/webflux/SampleWebFluxApplication.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
 import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
@@ -34,7 +35,8 @@ public class SampleWebFluxApplication {
 
 	@Bean
 	public RouterFunction<ServerResponse> monoRouterFunction(EchoHandler echoHandler) {
-		return route(POST("/echo"), echoHandler::echo);
+		return route(POST("/echo"), echoHandler::echo).andRoute(GET("/echo"),
+				echoHandler::getEcho);
 	}
 
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Hello. 

I see the sample code of `spring-boot-sample-webflux` project and think that it 'd be better for adding post-stream api on sample code.

I changed get `echo` router to return application value every second by requesting like below. 
`curl -v localhost:8080/echo  -H 'Accept: text/event-stream'`

Also, added post  `echo` router for changing application value (after doing this, value from stream changed).  example are like below.
`curl -v localhost:8080/echo  -H 'Accept: text/event-stream' -X POST -d "ok" -H "Content-Type:application/json"` .

I think that  user can understand what `webflux`  is. 

This is only the suggestion and my opinion, but example code should include data-stream pattern because it is one of the most import function of `webflux`. 

Thank you, best regards.


