### PR TITLE
spring-boot-starters for Embedded Cassandra and @DataCassandraTest.

### DIFF
--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -187,4 +187,10 @@ do as they were designed before this was clarified.
 | http://alexo.github.io/wro4j/[Wro4j]
 | https://github.com/michael-simons/wro4j-spring-boot-starter
 
+| https://github.com/nosan/embedded-cassandra[Embedded Cassandra]
+| https://github.com/nosan/embedded-cassandra-spring-boot
+
+| `@DataCassandraTest` annotation to test `Cassandra` components
+| https://github.com/nosan/cassandra-data-test-spring-boot
+
 |===


### PR DESCRIPTION
Hi there,
This PR adds links to:
 - [Cassandra Spring Boot Starter](https://github.com/nosan/embedded-cassandra-spring-boot) for [Embedded Cassandra Project](https://github.com/nosan/embedded-cassandra)
- [@DataCassandraTest Spring Boot Starter](https://github.com/nosan/cassandra-data-test-spring-boot)

P.S. as we discussed [here](https://github.com/spring-projects/spring-boot/pull/13033#issuecomment-400430466) with @philwebb, `@DataCassandraTest`, should be separate, at least until the library becomes established.

Please, let me know if you have willing to integrate `@DataCassandraTest`  in the future, I will do my best for helping.

Thanks in advance