### PR TITLE
Auto-configured OpenEntityManagerInViewInterceptor does not back off when an OpenEntityManagerInViewFilter is only defined as a registration bean

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/JpaBaseConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/JpaBaseConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.boot.autoconfigure.domain.EntityScanPackages;
 import org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizers;
+import org.springframework.boot.autoconfigure.web.servlet.ConditionalOnMissingFilterBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
@@ -211,6 +212,7 @@ public abstract class JpaBaseConfiguration implements BeanFactoryAware {
 	@ConditionalOnClass(WebMvcConfigurer.class)
 	@ConditionalOnMissingBean({ OpenEntityManagerInViewInterceptor.class,
 			OpenEntityManagerInViewFilter.class })
+	@ConditionalOnMissingFilterBean(OpenEntityManagerInViewFilter.class)
 	@ConditionalOnProperty(prefix = "spring.jpa", name = "open-in-view", havingValue = "true", matchIfMissing = true)
 	protected static class JpaWebConfiguration {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/AbstractJpaAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/AbstractJpaAutoConfigurationTests.java
@@ -38,6 +38,7 @@ import org.springframework.boot.test.context.assertj.AssertableApplicationContex
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.ContextConsumer;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -157,6 +158,32 @@ public abstract class AbstractJpaAutoConfigurationTests {
 						TransactionAutoConfiguration.class, this.autoConfiguredClass))
 				.run((context) -> assertThat(context)
 						.doesNotHaveBean(OpenEntityManagerInViewInterceptor.class));
+	}
+
+	@Test
+	public void openEntityManagerInViewInterceptorIsNotRegisteredWhenFilterRegistrationPresent() {
+		new WebApplicationContextRunner()
+				.withPropertyValues("spring.datasource.generate-unique-name=true")
+				.withUserConfiguration(TestFilterRegistrationConfiguration.class)
+				.withConfiguration(AutoConfigurations.of(
+						DataSourceAutoConfiguration.class,
+						TransactionAutoConfiguration.class, this.autoConfiguredClass))
+				.run((context) -> assertThat(context)
+						.doesNotHaveBean(OpenEntityManagerInViewInterceptor.class));
+	}
+
+	@Test
+	public void openEntityManagerInViewInterceptorAutoConfigurationBacksOffWhenManuallyRegistered() {
+		new WebApplicationContextRunner()
+				.withPropertyValues("spring.datasource.generate-unique-name=true")
+				.withUserConfiguration(TestInterceptorManualConfiguration.class)
+				.withConfiguration(AutoConfigurations.of(
+						DataSourceAutoConfiguration.class,
+						TransactionAutoConfiguration.class, this.autoConfiguredClass))
+				.run((context) -> assertThat(context)
+						.getBean(OpenEntityManagerInViewInterceptor.class)
+						.isExactlyInstanceOf(
+								TestInterceptorManualConfiguration.ManualOpenEntityManagerInViewInterceptor.class));
 	}
 
 	@Test
@@ -294,6 +321,33 @@ public abstract class AbstractJpaAutoConfigurationTests {
 		@Bean
 		public OpenEntityManagerInViewFilter openEntityManagerInViewFilter() {
 			return new OpenEntityManagerInViewFilter();
+		}
+
+	}
+
+	@Configuration
+	@TestAutoConfigurationPackage(City.class)
+	protected static class TestFilterRegistrationConfiguration {
+
+		@Bean
+		public FilterRegistrationBean<OpenEntityManagerInViewFilter> OpenEntityManagerInViewFilterFilterRegistrationBean() {
+			return new FilterRegistrationBean<>();
+		}
+
+	}
+
+	@Configuration
+	@TestAutoConfigurationPackage(City.class)
+	protected static class TestInterceptorManualConfiguration {
+
+		@Bean
+		public OpenEntityManagerInViewInterceptor openEntityManagerInViewInterceptor() {
+			return new ManualOpenEntityManagerInViewInterceptor();
+		}
+
+		protected static class ManualOpenEntityManagerInViewInterceptor
+				extends OpenEntityManagerInViewInterceptor {
+
 		}
 
 	}


### PR DESCRIPTION
Make auto-configured OpenEntityManagerInViewFilter backoff when defined as registration bean. Fixes GH-15879.

I also added a unit test for when a OpenEntityManagerInViewInterceptor has been manually created.