### PR TITLE
Upgrade Neo4j-OGM to 3.2.0-alpha04.

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Eric Spiegelberg
  * @author Stephane Nicoll
+ * @author Michael Simons
  */
 public class Neo4jHealthIndicatorTests {
 
@@ -77,9 +78,8 @@ public class Neo4jHealthIndicatorTests {
 
 	@Test
 	public void neo4jDown() {
-		CypherException cypherException = new CypherException("Error executing Cypher",
-				"Neo.ClientError.Statement.SyntaxError",
-				"Unable to execute invalid Cypher");
+		CypherException cypherException = new CypherException(
+				"Neo.ClientError.Statement.SyntaxError", "Error executing Cypher");
 		given(this.session.query(Neo4jHealthIndicator.CYPHER, Collections.emptyMap()))
 				.willThrow(cypherException);
 		Health health = this.neo4jHealthIndicator.health();

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -138,7 +138,7 @@
 		<mssql-jdbc.version>6.4.0.jre8</mssql-jdbc.version>
 		<mysql.version>8.0.15</mysql.version>
 		<nekohtml.version>1.9.22</nekohtml.version>
-		<neo4j-ogm.version>3.1.7</neo4j-ogm.version>
+		<neo4j-ogm.version>3.2.0-alpha04</neo4j-ogm.version>
 		<netty.version>4.1.33.Final</netty.version>
 		<netty-tcnative.version>2.0.20.Final</netty-tcnative.version>
 		<nio-multipart-parser.version>1.1.0</nio-multipart-parser.version>


### PR DESCRIPTION
This is not just a simple dependency upgrade but needs some adaption in a test class (`Neo4jHealthIndicatorTests`). 

The upgrade uses an "alpha" version of Neo4j-OGM, which Neo4j publishes to central.
That alpha will be a final before the Spring Data "Moore" release, as we align those.

Please note that Neo4j-OGM 3.2 is to be used with Spring Data "Moore" and should therefor not be part of the Spring Boot 2.1 (or worse 2.0) line. 