### PR TITLE
Add a link to SpringMockK in the Kotlin documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -8610,6 +8610,12 @@ documentation] for more details. You also need to
 {junit5-documentation}/#writing-tests-test-instance-lifecycle-changing-default[switch test
 instance lifecycle to "per-class"].
 
+For mocking Kotlin classes, using https://mockk.io/[Mockk] is recommended. If you need the
+Mockk equivalent of the Mockito specific
+<<boot-features-testing-spring-boot-applications-mocking-beans,`@MockBean` and `@SpyBean` annotations>>,
+you can use https://github.com/Ninja-Squad/springmockk[SpringMockK] which provides similar `@MockkBean`
+and `@SpykBean` annotations.
+
 
 
 [[boot-features-kotlin-resources]]


### PR DESCRIPTION
As a follow-up of #15749, and as discussed with @wilkinsona, I propose this documentation update to make Kotlin developers aware of the [SpringMockK](https://github.com/Ninja-Squad/springmockk). Using Mockito in Kotlin is not an easy ride, so I took this opportunity to recommend [Mockk](https://mockk.io/) like I did [in Framework documentation](https://docs.spring.io/spring/docs/5.1.5.RELEASE/spring-framework-reference/languages.html#testing).