### PR TITLE
Adds spring.datasource.lazy-connection property to enable Lazy DataSource support

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,8 @@ public class DataSourceAutoConfiguration {
 	@Configuration
 	@Conditional(EmbeddedDatabaseCondition.class)
 	@ConditionalOnMissingBean({ DataSource.class, XADataSource.class })
-	@Import(EmbeddedDataSourceConfiguration.class)
+	@Import({ EmbeddedDataSourceConfiguration.class,
+			LazyConnectionDataSourceConfiguration.class })
 	protected static class EmbeddedDatabaseConfiguration {
 
 	}
@@ -67,7 +68,8 @@ public class DataSourceAutoConfiguration {
 	@ConditionalOnMissingBean({ DataSource.class, XADataSource.class })
 	@Import({ DataSourceConfiguration.Hikari.class, DataSourceConfiguration.Tomcat.class,
 			DataSourceConfiguration.Dbcp2.class, DataSourceConfiguration.Generic.class,
-			DataSourceJmxConfiguration.class })
+			DataSourceJmxConfiguration.class,
+			LazyConnectionDataSourceConfiguration.class })
 	protected static class PooledDataSourceConfiguration {
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,6 +148,11 @@ public class DataSourceProperties implements BeanClassLoaderAware, InitializingB
 	 * SQL scripts encoding.
 	 */
 	private Charset sqlScriptEncoding;
+
+	/**
+	 * Whether datasource must be wrapped in a LazyConnectionDataSourceProxy.
+	 */
+	private boolean lazyConnection = false;
 
 	private EmbeddedDatabaseConnection embeddedDatabaseConnection = EmbeddedDatabaseConnection.NONE;
 
@@ -476,6 +481,14 @@ public class DataSourceProperties implements BeanClassLoaderAware, InitializingB
 
 	public void setXa(Xa xa) {
 		this.xa = xa;
+	}
+
+	public boolean getLazyConnection() {
+		return this.lazyConnection;
+	}
+
+	public void setLazyConnection(boolean lazyConnection) {
+		this.lazyConnection = lazyConnection;
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/LazyConnectionDataSourceBeanPostProcessor.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/LazyConnectionDataSourceBeanPostProcessor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jdbc;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+/**
+ * {@link BeanPostProcessor} to wrap a {@link DataSource} with a
+ * {@link LazyConnectionDataSourceProxy}.
+ *
+ * @author Dmytro Nosan
+ */
+class LazyConnectionDataSourceBeanPostProcessor implements BeanPostProcessor {
+
+	@Override
+	public Object postProcessAfterInitialization(Object bean, String beanName)
+			throws BeansException {
+		if (bean instanceof DataSource) {
+			return new LazyConnectionDataSourceProxy((DataSource) bean);
+		}
+		return bean;
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/LazyConnectionDataSourceConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/LazyConnectionDataSourceConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure.jdbc;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+/**
+ * Configuration to register {@link LazyConnectionDataSourceBeanPostProcessor}, if a
+ * {@code spring.datasource.lazy-connection} property is present and value is
+ * {@code true}.
+ *
+ * @author Dmytro Nosan
+ */
+@Configuration
+@ConditionalOnClass(LazyConnectionDataSourceProxy.class)
+@ConditionalOnProperty(prefix = "spring.datasource", name = "lazy-connection", havingValue = "true")
+class LazyConnectionDataSourceConfiguration {
+
+	@Bean
+	public static LazyConnectionDataSourceBeanPostProcessor lazyConnectionDataSourceBeanPostProcessor() {
+		return new LazyConnectionDataSourceBeanPostProcessor();
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/XADataSourceAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/XADataSourceAutoConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.boot.jdbc.DatabaseDriver;
 import org.springframework.boot.jdbc.XADataSourceWrapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -59,6 +60,7 @@ import org.springframework.util.StringUtils;
 		EmbeddedDatabaseType.class })
 @ConditionalOnBean(XADataSourceWrapper.class)
 @ConditionalOnMissingBean(DataSource.class)
+@Import(LazyConnectionDataSourceConfiguration.class)
 public class XADataSourceAutoConfiguration implements BeanClassLoaderAware {
 
 	private ClassLoader classLoader;

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -3631,7 +3631,22 @@ TIP: See <<howto.adoc#howto-configure-a-datasource,the "`How-to`" section>> for 
 advanced examples, typically to take full control over the configuration of the
 DataSource.
 
+[[boot-features-configure-lazy-datasource]]
+=== Configure a lazy DataSource
+Lazy `javax.sql.DataSource` (`org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy`) allows delaying the obtaining of a `javax.sql.Connection` until a `javax.sql.Connection` is really required.
+JDBC transaction control can happen without fetching a `javax.sql.Connection` from the pool or communicating with the database.
 
+`Connection` initialization properties like `auto-commit`, `transaction-isolation` and `read-only`
+will be kept and applied to the actual JDBC `javax.sql.Connection` as soon as an actual `Connection` is fetched.
+Consequently, _commit_ and _rollback_ calls will be *ignored* if no Statements have been created.
+
+To *enable* this feature `spring.datasource.lazy-connection=true` must be set, by default this feature is disabled.
+
+[NOTE]
+====
+Lazy `javax.sql.DataSource` proxy needs to return wrapped Connections in order to handle lazy fetching of an actual JDBC `Connection`.
+Use `javax.sql.Connection#unwrap` or `static org.springframework.boot.jdbc.DataSourceUnwrapper#unwrap` to retrieve the native JDBC `Connection`.
+====
 
 [[boot-features-embedded-database-support]]
 ==== Embedded Database Support
@@ -3754,8 +3769,6 @@ example:
 	# Validate the connection before borrowing it from the pool.
 	spring.datasource.tomcat.test-on-borrow=true
 ----
-
-
 
 [[boot-features-connecting-to-a-jndi-datasource]]
 ==== Connection to a JNDI DataSource


### PR DESCRIPTION
This commit adds `spring.datasource.lazy-connection` property into a `DataSourceProperties` class to enable a `LazyConnectionDataSourceBeanPostProcessor`. `BeanPostProcessor` wraps an auto-configured `DataSource` in a `LazyConnectionDataSourceProxy`. It will be added only if a
`spring.datasource.lazy-connection` property has `true` and a `LazyConnectionDataSourceProxy`
class is present. The default value of the `spring.datasource.lazy-connection` property is **false**, which means a `lazy-connection` feature is disabled by default.

see gh-15480

**Note!** `LazyConnectionDataSourceBeanPostProcessor` it is being invoked after `DataSourceInitializerPostProcessor` (I'm not sure that is the right behaviour)

Thanks in advance. 
