### PR TITLE
Properties to set default configuration for auto-timed controller metrics

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsProperties.java
@@ -16,16 +16,20 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 /**
  * {@link ConfigurationProperties} for configuring Micrometer-based metrics.
  *
  * @author Jon Schneider
  * @author Alexander Abramov
+ * @author Tadaya Tsuyukubo
  * @since 2.0.0
  */
 @ConfigurationProperties("management.metrics")
@@ -93,10 +97,7 @@ public class MetricsProperties {
 
 		public static class Client {
 
-			/**
-			 * Name of the metric for sent requests.
-			 */
-			private String requestsMetricName = "http.client.requests";
+			private final ClientRequest request = new ClientRequest();
 
 			/**
 			 * Maximum number of unique URI tag values allowed. After the max number of
@@ -105,12 +106,29 @@ public class MetricsProperties {
 			 */
 			private int maxUriTags = 100;
 
+			/**
+			 * Get name of the metric for received requests.
+			 * @return request metric name
+			 * @deprecated since 2.2.0 in favor of {@link ClientRequest#getMetricName()}
+			 */
+			@DeprecatedConfigurationProperty(
+					replacement = "management.metrics.web.client.request.metric-name")
 			public String getRequestsMetricName() {
-				return this.requestsMetricName;
+				return this.request.getMetricName();
 			}
 
+			/**
+			 * Set name of the metric for received requests.
+			 * @param requestsMetricName request metric name
+			 * @deprecated since 2.2.0 in favor of
+			 * {@link ClientRequest#setMetricName(String)}
+			 */
 			public void setRequestsMetricName(String requestsMetricName) {
-				this.requestsMetricName = requestsMetricName;
+				this.request.setMetricName(requestsMetricName);
+			}
+
+			public ClientRequest getRequest() {
+				return this.request;
 			}
 
 			public int getMaxUriTags() {
@@ -121,9 +139,107 @@ public class MetricsProperties {
 				this.maxUriTags = maxUriTags;
 			}
 
+			public static class ClientRequest {
+
+				/**
+				 * Name of the metric for sent requests.
+				 */
+				private String metricName = "http.client.requests";
+
+				/**
+				 * Automatically time requests.
+				 */
+				private final AutoTime autoTime = new AutoTime();
+
+				public AutoTime getAutoTime() {
+					return this.autoTime;
+				}
+
+				public String getMetricName() {
+					return this.metricName;
+				}
+
+				public void setMetricName(String metricName) {
+					this.metricName = metricName;
+				}
+
+			}
+
 		}
 
 		public static class Server {
+
+			private final ServerRequest request = new ServerRequest();
+
+			/**
+			 * Maximum number of unique URI tag values allowed. After the max number of
+			 * tag values is reached, metrics with additional tag values are denied by
+			 * filter.
+			 */
+			private int maxUriTags = 100;
+
+			/**
+			 * Get name of the metric for received requests.
+			 * @return request metric name
+			 * @deprecated since 2.2.0 in favor of {@link ServerRequest#getMetricName()}
+			 */
+			@DeprecatedConfigurationProperty(
+					replacement = "management.metrics.web.server.request.metric-name")
+			public String getRequestsMetricName() {
+				return this.request.getMetricName();
+			}
+
+			/**
+			 * Set name of the metric for received requests.
+			 * @param requestsMetricName request metric name
+			 * @deprecated since 2.2.0 in favor of
+			 * {@link ServerRequest#setMetricName(String)}
+			 */
+			public void setRequestsMetricName(String requestsMetricName) {
+				this.request.setMetricName(requestsMetricName);
+			}
+
+			public ServerRequest getRequest() {
+				return this.request;
+			}
+
+			public int getMaxUriTags() {
+				return this.maxUriTags;
+			}
+
+			public void setMaxUriTags(int maxUriTags) {
+				this.maxUriTags = maxUriTags;
+			}
+
+			public static class ServerRequest {
+
+				/**
+				 * Name of the metric for received requests.
+				 */
+				private String metricName = "http.server.requests";
+
+				/**
+				 * Automatically time requests.
+				 */
+				private final AutoTime autoTime = new AutoTime();
+
+				public AutoTime getAutoTime() {
+					return this.autoTime;
+				}
+
+				public String getMetricName() {
+					return this.metricName;
+				}
+
+				public void setMetricName(String metricName) {
+					this.metricName = metricName;
+				}
+
+			}
+
+		}
+
+		public static class AutoTime {
 
 			/**
 			 * Whether requests handled by Spring MVC, WebFlux or Jersey should be
@@ -131,42 +247,44 @@ public class MetricsProperties {
 			 * on account of request mapping timings, disable this and use 'Timed' on a
 			 * per request mapping basis as needed.
 			 */
-			private boolean autoTimeRequests = true;
+			private boolean enabled = true;
 
 			/**
-			 * Name of the metric for received requests.
+			 * Default percentiles when @Timed annotation is not presented on the
+			 * corresponding request handler. Any @Timed annotation presented will have
+			 * precedence.
 			 */
-			private String requestsMetricName = "http.server.requests";
+			private List<Double> defaultPercentiles = new ArrayList<>();
 
 			/**
-			 * Maximum number of unique URI tag values allowed. After the max number of
-			 * tag values is reached, metrics with additional tag values are denied by
-			 * filter.
+			 * Default histogram when @Timed annotation is not presented on the
+			 * corresponding request handler. Any @Timed annotation presented will have
+			 * precedence.
 			 */
-			private int maxUriTags = 100;
+			private boolean defaultHistogram;
 
-			public boolean isAutoTimeRequests() {
-				return this.autoTimeRequests;
+			public boolean isEnabled() {
+				return this.enabled;
 			}
 
-			public void setAutoTimeRequests(boolean autoTimeRequests) {
-				this.autoTimeRequests = autoTimeRequests;
+			public void setEnabled(boolean enabled) {
+				this.enabled = enabled;
 			}
 
-			public String getRequestsMetricName() {
-				return this.requestsMetricName;
+			public List<Double> getDefaultPercentiles() {
+				return this.defaultPercentiles;
 			}
 
-			public void setRequestsMetricName(String requestsMetricName) {
-				this.requestsMetricName = requestsMetricName;
+			public void setDefaultPercentiles(List<Double> defaultPercentiles) {
+				this.defaultPercentiles = defaultPercentiles;
 			}
 
-			public int getMaxUriTags() {
-				return this.maxUriTags;
+			public boolean isDefaultHistogram() {
+				return this.defaultHistogram;
 			}
 
-			public void setMaxUriTags(int maxUriTags) {
-				this.maxUriTags = maxUriTags;
+			public void setDefaultHistogram(boolean defaultHistogram) {
+				this.defaultHistogram = defaultHistogram;
 			}
 
 		}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/jersey/JerseyServerMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/jersey/JerseyServerMetricsAutoConfiguration.java
@@ -79,14 +79,16 @@ public class JerseyServerMetricsAutoConfiguration {
 			MeterRegistry meterRegistry, JerseyTagsProvider tagsProvider) {
 		Server server = this.properties.getWeb().getServer();
 		return (config) -> config.register(new MetricsApplicationEventListener(
-				meterRegistry, tagsProvider, server.getRequestsMetricName(),
-				server.isAutoTimeRequests(), new AnnotationUtilsAnnotationFinder()));
+				meterRegistry, tagsProvider, server.getRequest().getMetricName(),
+				server.getRequest().getAutoTime().isEnabled(),
+				new AnnotationUtilsAnnotationFinder()));
 	}
 
 	@Bean
 	@Order(0)
 	public MeterFilter jerseyMetricsUriTagFilter() {
-		String metricName = this.properties.getWeb().getServer().getRequestsMetricName();
+		String metricName = this.properties.getWeb().getServer().getRequest()
+				.getMetricName();
 		MeterFilter filter = new OnlyOnceLoggingDenyMeterFilter(() -> String
 				.format("Reached the maximum number of URI tags for '%s'.", metricName));
 		return MeterFilter.maximumAllowableTags(metricName, "uri",

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/HttpClientMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/HttpClientMetricsAutoConfiguration.java
@@ -53,7 +53,7 @@ public class HttpClientMetricsAutoConfiguration {
 	@Bean
 	@Order(0)
 	public MeterFilter metricsHttpClientUriTagFilter(MetricsProperties properties) {
-		String metricName = properties.getWeb().getClient().getRequestsMetricName();
+		String metricName = properties.getWeb().getClient().getRequest().getMetricName();
 		MeterFilter denyFilter = new OnlyOnceLoggingDenyMeterFilter(() -> String
 				.format("Reached the maximum number of URI tags for '%s'. Are you using "
 						+ "'uriVariables'?", metricName));

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsConfiguration.java
@@ -19,6 +19,8 @@ package org.springframework.boot.actuate.autoconfigure.metrics.web.client;
 import io.micrometer.core.instrument.MeterRegistry;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties.Web.AutoTime;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties.Web.Client;
 import org.springframework.boot.actuate.metrics.web.client.DefaultRestTemplateExchangeTagsProvider;
 import org.springframework.boot.actuate.metrics.web.client.MetricsRestTemplateCustomizer;
 import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTagsProvider;
@@ -53,9 +55,13 @@ class RestTemplateMetricsConfiguration {
 			MeterRegistry meterRegistry,
 			RestTemplateExchangeTagsProvider restTemplateExchangeTagsProvider,
 			MetricsProperties properties) {
+
+		Client client = properties.getWeb().getClient();
+		AutoTime autoTime = client.getRequest().getAutoTime();
 		return new MetricsRestTemplateCustomizer(meterRegistry,
-				restTemplateExchangeTagsProvider,
-				properties.getWeb().getClient().getRequestsMetricName());
+				restTemplateExchangeTagsProvider, client.getRequest().getMetricName(),
+				autoTime.isEnabled(), autoTime.getDefaultPercentiles(),
+				autoTime.isDefaultHistogram());
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/WebClientMetricsConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/client/WebClientMetricsConfiguration.java
@@ -49,7 +49,7 @@ class WebClientMetricsConfiguration {
 			MeterRegistry meterRegistry, WebClientExchangeTagsProvider tagsProvider,
 			MetricsProperties properties) {
 		return new MetricsWebClientCustomizer(meterRegistry, tagsProvider,
-				properties.getWeb().getClient().getRequestsMetricName());
+				properties.getWeb().getClient().getRequest().getMetricName());
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/reactive/WebFluxMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/web/reactive/WebFluxMetricsAutoConfiguration.java
@@ -21,6 +21,8 @@ import io.micrometer.core.instrument.config.MeterFilter;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties.Web.AutoTime;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties.Web.Server;
 import org.springframework.boot.actuate.autoconfigure.metrics.OnlyOnceLoggingDenyMeterFilter;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
 import org.springframework.boot.actuate.metrics.web.reactive.server.DefaultWebFluxTagsProvider;
@@ -65,15 +67,18 @@ public class WebFluxMetricsAutoConfiguration {
 	@Bean
 	public MetricsWebFilter webfluxMetrics(MeterRegistry registry,
 			WebFluxTagsProvider tagConfigurer) {
+		Server serverProperties = this.properties.getWeb().getServer();
+		AutoTime autotime = serverProperties.getRequest().getAutoTime();
 		return new MetricsWebFilter(registry, tagConfigurer,
-				this.properties.getWeb().getServer().getRequestsMetricName(),
-				this.properties.getWeb().getServer().isAutoTimeRequests());
+				serverProperties.getRequest().getMetricName(), autotime.isEnabled(),
+				autotime.getDefaultPercentiles(), autotime.isDefaultHistogram());
 	}
 
 	@Bean
 	@Order(0)
 	public MeterFilter metricsHttpServerUriTagFilter() {
-		String metricName = this.properties.getWeb().getServer().getRequestsMetricName();
+		String metricName = this.properties.getWeb().getServer().getRequest()
+				.getMetricName();
 		MeterFilter filter = new OnlyOnceLoggingDenyMeterFilter(() -> String
 				.format("Reached the maximum number of URI tags for '%s'.", metricName));
 		return MeterFilter.maximumAllowableTags(metricName, "uri",

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/reactive/WebFluxMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/reactive/WebFluxMetricsAutoConfigurationTests.java
@@ -102,7 +102,7 @@ public class WebFluxMetricsAutoConfigurationTests {
 				.withConfiguration(AutoConfigurations.of(WebFluxAutoConfiguration.class))
 				.withUserConfiguration(TestController.class)
 				.withPropertyValues(
-						"management.metrics.web.server.auto-time-requests=false")
+						"management.metrics.web.server.request.auto-time.enabled=false")
 				.run((context) -> {
 					MeterRegistry registry = getInitializedMeterRegistry(context);
 					assertThat(registry.find("http.server.requests").meter()).isNull();

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsAutoConfigurationTests.java
@@ -26,6 +26,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,6 +60,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Andy Wilkinson
  * @author Dmytro Nosan
+ * @author Tadaya Tsuyukubo
  */
 public class WebMvcMetricsAutoConfigurationTests {
 
@@ -134,6 +137,27 @@ public class WebMvcMetricsAutoConfigurationTests {
 					assertThat(this.output.toString())
 							.doesNotContain("Reached the maximum number of URI tags "
 									+ "for 'http.server.requests'");
+				});
+	}
+
+	@Test
+	public void autoTimeRequestsDefaultValues() {
+		this.contextRunner.withUserConfiguration(TestController.class)
+				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class,
+						WebMvcAutoConfiguration.class))
+				.withPropertyValues(
+						"management.metrics.web.server.request.auto-time.enabled=true",
+						"management.metrics.web.server.request.auto-time.default-percentiles=0.5,0.7",
+						"management.metrics.web.server.request.auto-time.default-histogram=true")
+				.run((context) -> {
+					MeterRegistry registry = getInitializedMeterRegistry(context);
+					Timer timer = registry.get("http.server.requests").timer();
+					HistogramSnapshot snapshot = timer.takeSnapshot();
+					assertThat(snapshot.percentileValues()).hasSize(2);
+					assertThat(snapshot.percentileValues()[0].percentile())
+							.isEqualTo(0.5);
+					assertThat(snapshot.percentileValues()[1].percentile())
+							.isEqualTo(0.7);
 				});
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/client/MetricsRestTemplateCustomizer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/client/MetricsRestTemplateCustomizer.java
@@ -45,11 +45,33 @@ public class MetricsRestTemplateCustomizer implements RestTemplateCustomizer {
 	 * @param meterRegistry the meter registry
 	 * @param tagProvider the tag provider
 	 * @param metricName the name of the recorded metric
+	 * @deprecated since 2.2.0 in favor of
+	 * {@link #MetricsRestTemplateCustomizer(MeterRegistry, RestTemplateExchangeTagsProvider, String, boolean, List, boolean)}
 	 */
 	public MetricsRestTemplateCustomizer(MeterRegistry meterRegistry,
 			RestTemplateExchangeTagsProvider tagProvider, String metricName) {
 		this.interceptor = new MetricsClientHttpRequestInterceptor(meterRegistry,
 				tagProvider, metricName);
+	}
+
+	/**
+	 * Creates a new {@code MetricsRestTemplateInterceptor}. When {@code autoTimeRequests}
+	 * is set to {@code true}, the interceptor records metrics using the given
+	 * {@code meterRegistry} with tags provided by the given {@code tagProvider} and with
+	 * {@code percentileList} and {@code histogram} configurations.
+	 * @param meterRegistry the meter registry
+	 * @param tagProvider the tag provider
+	 * @param metricName the name of the recorded metric
+	 * @param autoTimeRequests if requests should be automatically timed
+	 * @param percentileList percentiles for auto time requests
+	 * @param histogram histogram or not for auto time requests
+	 * @since 2.2.0
+	 */
+	public MetricsRestTemplateCustomizer(MeterRegistry meterRegistry,
+			RestTemplateExchangeTagsProvider tagProvider, String metricName,
+			boolean autoTimeRequests, List<Double> percentileList, boolean histogram) {
+		this.interceptor = new MetricsClientHttpRequestInterceptor(meterRegistry,
+				tagProvider, metricName, autoTimeRequests, percentileList, histogram);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilter.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilter.java
@@ -19,6 +19,7 @@ package org.springframework.boot.actuate.metrics.web.servlet;
 import java.io.IOException;
 import java.lang.reflect.AnnotatedElement;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -60,6 +61,10 @@ public class WebMvcMetricsFilter extends OncePerRequestFilter {
 
 	private final boolean autoTimeRequests;
 
+	private final double[] autoTimeRequestsPercentiles;
+
+	private final boolean autoTimeRequestsHistogram;
+
 	/**
 	 * Create a new {@link WebMvcMetricsFilter} instance.
 	 * @param registry the meter registry
@@ -67,13 +72,40 @@ public class WebMvcMetricsFilter extends OncePerRequestFilter {
 	 * @param metricName the metric name
 	 * @param autoTimeRequests if requests should be automatically timed
 	 * @since 2.0.7
+	 * @deprecated since 2.1.4 in favor of
+	 * {@link #WebMvcMetricsFilter(MeterRegistry, WebMvcTagsProvider, String, boolean, List, boolean)}
 	 */
+	@Deprecated
 	public WebMvcMetricsFilter(MeterRegistry registry, WebMvcTagsProvider tagsProvider,
 			String metricName, boolean autoTimeRequests) {
+		this(registry, tagsProvider, metricName, autoTimeRequests, null, false);
+	}
+
+	/**
+	 * Create a new {@link WebMvcMetricsFilter} instance.
+	 * @param registry the meter registry
+	 * @param tagsProvider the tags provider
+	 * @param metricName the metric name
+	 * @param autoTimeRequests if requests should be automatically timed
+	 * @param autoTimeRequestsPercentiles default percentiles if requests are auto timed
+	 * @param autoTimeRequestsHistogram default histogram flag if requests are auto timed
+	 * @since 2.2.0
+	 */
+	public WebMvcMetricsFilter(MeterRegistry registry, WebMvcTagsProvider tagsProvider,
+			String metricName, boolean autoTimeRequests,
+			List<Double> autoTimeRequestsPercentiles, boolean autoTimeRequestsHistogram) {
+
+		double[] percentiles = (autoTimeRequestsPercentiles != null)
+				? autoTimeRequestsPercentiles.stream().mapToDouble(Double::doubleValue)
+						.toArray()
+				: null;
+
 		this.registry = registry;
 		this.tagsProvider = tagsProvider;
 		this.metricName = metricName;
 		this.autoTimeRequests = autoTimeRequests;
+		this.autoTimeRequestsPercentiles = percentiles;
+		this.autoTimeRequestsHistogram = autoTimeRequestsHistogram;
 	}
 
 	@Override
@@ -154,7 +186,9 @@ public class WebMvcMetricsFilter extends OncePerRequestFilter {
 				handlerObject, exception);
 		if (annotations.isEmpty()) {
 			if (this.autoTimeRequests) {
-				stop(timerSample, tags, Timer.builder(this.metricName));
+				stop(timerSample, tags, Timer.builder(this.metricName)
+						.publishPercentiles(this.autoTimeRequestsPercentiles)
+						.publishPercentileHistogram(this.autoTimeRequestsHistogram));
 			}
 		}
 		else {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/client/MetricsRestTemplateCustomizerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/client/MetricsRestTemplateCustomizerTests.java
@@ -58,7 +58,8 @@ public class MetricsRestTemplateCustomizerTests {
 		this.restTemplate = new RestTemplate();
 		this.mockServer = MockRestServiceServer.createServer(this.restTemplate);
 		this.customizer = new MetricsRestTemplateCustomizer(this.registry,
-				new DefaultRestTemplateExchangeTagsProvider(), "http.client.requests");
+				new DefaultRestTemplateExchangeTagsProvider(), "http.client.requests",
+				true, null, false);
 		this.customizer.customize(this.restTemplate);
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/MetricsWebFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/MetricsWebFilterTests.java
@@ -50,7 +50,8 @@ public class MetricsWebFilterTests {
 		MockClock clock = new MockClock();
 		this.registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
 		this.webFilter = new MetricsWebFilter(this.registry,
-				new DefaultWebFluxTagsProvider(), REQUEST_METRICS_NAME, true);
+				new DefaultWebFluxTagsProvider(), REQUEST_METRICS_NAME, true, null,
+				false);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilterTests.java
@@ -372,7 +372,7 @@ public class WebMvcMetricsFilterTests {
 		WebMvcMetricsFilter webMetricsFilter(MeterRegistry registry,
 				WebApplicationContext ctx) {
 			return new WebMvcMetricsFilter(registry, new DefaultWebMvcTagsProvider(),
-					"http.server.requests", true);
+					"http.server.requests", true, null, false);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsIntegrationTests.java
@@ -111,7 +111,7 @@ public class WebMvcMetricsIntegrationTests {
 		public WebMvcMetricsFilter webMetricsFilter(MeterRegistry registry,
 				WebApplicationContext ctx) {
 			return new WebMvcMetricsFilter(registry, new DefaultWebMvcTagsProvider(),
-					"http.server.requests", true);
+					"http.server.requests", true, null, false);
 		}
 
 		@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -1801,7 +1801,7 @@ application's absolute start time
 [[production-ready-metrics-spring-mvc]]
 ==== Spring MVC Metrics
 Auto-configuration enables the instrumentation of requests handled by Spring MVC. When
-`management.metrics.web.server.auto-time-requests` is `true`, this instrumentation occurs
+`management.metrics.web.server.request.auto-time.enabled` is `true`, this instrumentation occurs
 for all requests. Alternatively, when set to `false`, you can enable instrumentation by
 adding `@Timed` to a request-handling method:
 
@@ -1896,7 +1896,7 @@ To customize the tags, provide a `@Bean` that implements `WebFluxTagsProvider`.
 [[production-ready-metrics-jersey-server]]
 ==== Jersey Server Metrics
 Auto-configuration enables the instrumentation of requests handled by the Jersey JAX-RS
-implementation. When `management.metrics.web.server.auto-time-requests` is `true`, this
+implementation. When `management.metrics.web.server.request.auto-time.enabled` is `true`, this
 instrumentation occurs for all requests. Alternatively, when set to `false`, you can
 enable instrumentation by adding `@Timed` to a request-handling method:
 


### PR DESCRIPTION
When `management.metrics.web.server.autoTimeRequests` is enabled (default=true), spring-boot collects metrics on controller methods even when they are not annotated with `@Timed`.
When this happens, created metrics are based on the default configuration values of `@Timed`.
Currently, there is no way to specify the default configuration to those auto-timed controller metrics.

This PR introduces two properties:
- `management.metrics.web.server.autoTimeRequestsDefaultPercentiles`
- `management.metrics.web.server.autoTimeRequestsDefaultHistogram`

When values are set to the above properties, they will be applied to auto-timed controller metrics that do not have explicit `@Timed` annotation.
