### PR TITLE
Migrate Kotlin tests to Mockk

### DIFF
--- a/spring-boot-project/spring-boot-parent/pom.xml
+++ b/spring-boot-project/spring-boot-parent/pom.xml
@@ -61,23 +61,9 @@
 				<version>1.3.3</version>
 			</dependency>
 			<dependency>
-				<groupId>com.nhaarman</groupId>
-				<artifactId>mockito-kotlin</artifactId>
-				<version>1.6.0</version>
-				<exclusions>
-					<exclusion>
-						<groupId>org.jetbrains.kotlin</groupId>
-						<artifactId>kotlin-stdlib</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>org.jetbrains.kotlin</groupId>
-						<artifactId>kotlin-reflect</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>org.mockito</groupId>
-						<artifactId>mockito-core</artifactId>
-					</exclusion>
-				</exclusions>
+				<groupId>io.mockk</groupId>
+				<artifactId>mockk</artifactId>
+				<version>1.9.1.kotlin12</version>
 			</dependency>
 			<dependency>
 				<groupId>org.sonatype.plexus</groupId>

--- a/spring-boot-project/spring-boot-test/pom.xml
+++ b/spring-boot-project/spring-boot-test/pom.xml
@@ -188,8 +188,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.nhaarman</groupId>
-			<artifactId>mockito-kotlin</artifactId>
+			<groupId>io.mockk</groupId>
+			<artifactId>mockk</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-project/spring-boot-test/src/test/kotlin/org/springframework/boot/test/web/client/TestRestTemplateExtensionsTests.kt
+++ b/spring-boot-project/spring-boot-test/src/test/kotlin/org/springframework/boot/test/web/client/TestRestTemplateExtensionsTests.kt
@@ -16,15 +16,10 @@
 
 package org.springframework.boot.test.web.client
 
-import com.nhaarman.mockito_kotlin.mock
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Assert
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
-import org.mockito.junit.MockitoJUnitRunner
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
@@ -40,11 +35,9 @@ import kotlin.reflect.jvm.kotlinFunction
  *
  * @author Sebastien Deleuze
  */
-@RunWith(MockitoJUnitRunner::class)
 class TestRestTemplateExtensionsTests {
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var template: TestRestTemplate
+	val template = mockk<TestRestTemplate>(relaxed = true)
 
 	@Test
 	fun `getForObject with reified type parameters, String and varargs`() {
@@ -53,7 +46,7 @@ class TestRestTemplateExtensionsTests {
 		val var2 = "var2"
 		template.getForObject<Foo>(url, var1, var2)
 		template.restTemplate
-		verify(template, times(1)).getForObject(url, Foo::class.java, var1, var2)
+		verify(exactly = 1) { template.getForObject(url, Foo::class.java, var1, var2) }
 	}
 
 	@Test
@@ -61,21 +54,21 @@ class TestRestTemplateExtensionsTests {
 		val url = "https://spring.io"
 		val vars = mapOf(Pair("key1", "value1"), Pair("key2", "value2"))
 		template.getForObject<Foo>(url, vars)
-		verify(template, times(1)).getForObject(url, Foo::class.java, vars)
+		verify(exactly = 1) { template.getForObject(url, Foo::class.java, vars) }
 	}
 
 	@Test
 	fun `getForObject with reified type parameters and URI`() {
 		val url = URI("https://spring.io")
 		template.getForObject<Foo>(url)
-		verify(template, times(1)).getForObject(url, Foo::class.java)
+		verify(exactly = 1) { template.getForObject(url, Foo::class.java) }
 	}
 
 	@Test
 	fun `getForEntity with reified type parameters and URI`() {
 		val url = URI("https://spring.io")
 		template.getForEntity<Foo>(url)
-		verify(template, times(1)).getForEntity(url, Foo::class.java)
+		verify(exactly = 1) { template.getForEntity(url, Foo::class.java) }
 	}
 
 	@Test
@@ -84,7 +77,7 @@ class TestRestTemplateExtensionsTests {
 		val var1 = "var1"
 		val var2 = "var2"
 		template.getForEntity<Foo>(url, var1, var2)
-		verify(template, times(1)).getForEntity(url, Foo::class.java, var1, var2)
+		verify(exactly = 1) { template.getForEntity(url, Foo::class.java, var1, var2) }
 	}
 
 	@Test
@@ -92,7 +85,7 @@ class TestRestTemplateExtensionsTests {
 		val url = "https://spring.io"
 		val vars = mapOf(Pair("key1", "value1"), Pair("key2", "value2"))
 		template.getForEntity<Foo>(url, vars)
-		verify(template, times(1)).getForEntity(url, Foo::class.java, vars)
+		verify(exactly = 1) { template.getForEntity(url, Foo::class.java, vars) }
 	}
 
 	@Test
@@ -102,7 +95,7 @@ class TestRestTemplateExtensionsTests {
 		val var1 = "var1"
 		val var2 = "var2"
 		template.patchForObject<Foo>(url, body, var1, var2)
-		verify(template, times(1)).patchForObject(url, body, Foo::class.java, var1, var2)
+		verify(exactly = 1) { template.patchForObject(url, body, Foo::class.java, var1, var2) }
 	}
 
 	@Test
@@ -111,7 +104,7 @@ class TestRestTemplateExtensionsTests {
 		val body: Any = "body"
 		val vars = mapOf(Pair("key1", "value1"), Pair("key2", "value2"))
 		template.patchForObject<Foo>(url, body, vars)
-		verify(template, times(1)).patchForObject(url, body, Foo::class.java, vars)
+		verify(exactly = 1) { template.patchForObject(url, body, Foo::class.java, vars) }
 	}
 
 	@Test
@@ -119,14 +112,14 @@ class TestRestTemplateExtensionsTests {
 		val url = "https://spring.io"
 		val body: Any = "body"
 		template.patchForObject<Foo>(url, body)
-		verify(template, times(1)).patchForObject(url, body, Foo::class.java)
+		verify(exactly = 1) { template.patchForObject(url, body, Foo::class.java) }
 	}
 
 	@Test
 	fun `patchForObject with reified type parameters`() {
 		val url = "https://spring.io"
 		template.patchForObject<Foo>(url)
-		verify(template, times(1)).patchForObject(url, null, Foo::class.java)
+		verify(exactly = 1) { template.patchForObject(url, null, Foo::class.java) }
 	}
 
 	@Test
@@ -136,7 +129,7 @@ class TestRestTemplateExtensionsTests {
 		val var1 = "var1"
 		val var2 = "var2"
 		template.postForObject<Foo>(url, body, var1, var2)
-		verify(template, times(1)).postForObject(url, body, Foo::class.java, var1, var2)
+		verify(exactly = 1) { template.postForObject(url, body, Foo::class.java, var1, var2) }
 	}
 
 	@Test
@@ -145,7 +138,7 @@ class TestRestTemplateExtensionsTests {
 		val body: Any = "body"
 		val vars = mapOf(Pair("key1", "value1"), Pair("key2", "value2"))
 		template.postForObject<Foo>(url, body, vars)
-		verify(template, times(1)).postForObject(url, body, Foo::class.java, vars)
+		verify(exactly = 1) { template.postForObject(url, body, Foo::class.java, vars) }
 	}
 
 	@Test
@@ -153,14 +146,14 @@ class TestRestTemplateExtensionsTests {
 		val url = "https://spring.io"
 		val body: Any = "body"
 		template.postForObject<Foo>(url, body)
-		verify(template, times(1)).postForObject(url, body, Foo::class.java)
+		verify(exactly = 1) { template.postForObject(url, body, Foo::class.java) }
 	}
 
 	@Test
 	fun `postForObject with reified type parameters`() {
 		val url = "https://spring.io"
 		template.postForObject<Foo>(url)
-		verify(template, times(1)).postForObject(url, null, Foo::class.java)
+		verify(exactly = 1) { template.postForObject(url, null, Foo::class.java) }
 	}
 
 	@Test
@@ -170,7 +163,7 @@ class TestRestTemplateExtensionsTests {
 		val var1 = "var1"
 		val var2 = "var2"
 		template.postForEntity<Foo>(url, body, var1, var2)
-		verify(template, times(1)).postForEntity(url, body, Foo::class.java, var1, var2)
+		verify(exactly = 1) { template.postForEntity(url, body, Foo::class.java, var1, var2) }
 	}
 
 	@Test
@@ -179,7 +172,7 @@ class TestRestTemplateExtensionsTests {
 		val body: Any = "body"
 		val vars = mapOf(Pair("key1", "value1"), Pair("key2", "value2"))
 		template.postForEntity<Foo>(url, body, vars)
-		verify(template, times(1)).postForEntity(url, body, Foo::class.java, vars)
+		verify(exactly = 1) { template.postForEntity(url, body, Foo::class.java, vars) }
 	}
 
 	@Test
@@ -187,55 +180,55 @@ class TestRestTemplateExtensionsTests {
 		val url = "https://spring.io"
 		val body: Any = "body"
 		template.postForEntity<Foo>(url, body)
-		verify(template, times(1)).postForEntity(url, body, Foo::class.java)
+		verify(exactly = 1) { template.postForEntity(url, body, Foo::class.java) }
 	}
 
 	@Test
 	fun `postForEntity with reified type parameters`() {
 		val url = "https://spring.io"
 		template.postForEntity<Foo>(url)
-		verify(template, times(1)).postForEntity(url, null, Foo::class.java)
+		verify(exactly = 1) { template.postForEntity(url, null, Foo::class.java) }
 	}
 
 	@Test
 	fun `exchange with reified type parameters, String, HttpMethod, HttpEntity and varargs`() {
 		val url = "https://spring.io"
 		val method = HttpMethod.GET
-		val entity = mock<HttpEntity<Foo>>()
+		val entity = mockk<HttpEntity<Foo>>()
 		val var1 = "var1"
 		val var2 = "var2"
 		template.exchange<List<Foo>>(url, method, entity, var1, var2)
-		verify(template, times(1)).exchange(url, method, entity,
-				object : ParameterizedTypeReference<List<Foo>>() {}, var1, var2)
+		verify(exactly = 1) { template.exchange(url, method, entity,
+				object : ParameterizedTypeReference<List<Foo>>() {}, var1, var2) }
 	}
 
 	@Test
 	fun `exchange with reified type parameters, String, HttpMethod, HttpEntity and Map`() {
 		val url = "https://spring.io"
 		val method = HttpMethod.GET
-		val entity = mock<HttpEntity<Foo>>()
+		val entity = mockk<HttpEntity<Foo>>()
 		val vars = mapOf(Pair("key1", "value1"), Pair("key2", "value2"))
 		template.exchange<List<Foo>>(url, method, entity, vars)
-		verify(template, times(1)).exchange(url, method, entity,
-				object : ParameterizedTypeReference<List<Foo>>() {}, vars)
+		verify(exactly = 1) { template.exchange(url, method, entity,
+				object : ParameterizedTypeReference<List<Foo>>() {}, vars) }
 	}
 
 	@Test
 	fun `exchange with reified type parameters, String, HttpMethod, HttpEntity`() {
 		val url = "https://spring.io"
 		val method = HttpMethod.GET
-		val entity = mock<HttpEntity<Foo>>()
+		val entity = mockk<HttpEntity<Foo>>()
 		template.exchange<List<Foo>>(url, method, entity)
-		verify(template, times(1)).exchange(url, method, entity,
-				object : ParameterizedTypeReference<List<Foo>>() {})
+		verify(exactly = 1) { template.exchange(url, method, entity,
+				object : ParameterizedTypeReference<List<Foo>>() {}) }
 	}
 
 	@Test
 	fun `exchange with reified type parameters and HttpEntity`() {
-		val entity = mock<RequestEntity<Foo>>()
+		val entity = mockk<RequestEntity<Foo>>()
 		template.exchange<List<Foo>>(entity)
-		verify(template, times(1)).exchange(entity,
-				object : ParameterizedTypeReference<List<Foo>>() {})
+		verify(exactly = 1) { template.exchange(entity,
+				object : ParameterizedTypeReference<List<Foo>>() {}) }
 	}
 
 	@Test
@@ -243,8 +236,8 @@ class TestRestTemplateExtensionsTests {
 		val url = "https://spring.io"
 		val method = HttpMethod.GET
 		template.exchange<List<Foo>>(url, method)
-		verify(template, times(1)).exchange(url, method, null,
-				object : ParameterizedTypeReference<List<Foo>>() {})
+		verify(exactly = 1) { template.exchange(url, method, null,
+				object : ParameterizedTypeReference<List<Foo>>() {}) }
 	}
 
 	@Test


### PR DESCRIPTION
In order to be consistent with Spring Framework 5.2 tests and recommendation to use [Mockk](https://mockk.io/) for Kotlin tests, and in order to be consistent with the upcoming Coroutines pull requests for Spring Data MongoDB and R2DBC which are using Mockk as well, I have migrated Spring Boot tests.