### PR TITLE
Allow RabbitConnectionFactoryBean to be customized (to set SaslConfig for example)

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -69,6 +69,11 @@ public class RabbitProperties {
 	private final Ssl ssl = new Ssl();
 
 	/**
+	 * DefaultSaslConfig with an explicit mechanism to use.
+	 */
+	private String saslConfig;
+
+	/**
 	 * Virtual host to use when connecting to the broker.
 	 */
 	private String virtualHost;
@@ -240,6 +245,14 @@ public class RabbitProperties {
 
 	public Ssl getSsl() {
 		return this.ssl;
+	}
+
+	public String getSaslConfig() {
+		return this.saslConfig;
+	}
+
+	public void setSaslConfig(String saslConfig) {
+		this.saslConfig = saslConfig;
 	}
 
 	public String getVirtualHost() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -25,6 +25,7 @@ import javax.net.ssl.TrustManager;
 
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.DefaultSaslConfig;
 import com.rabbitmq.client.SslContextFactory;
 import com.rabbitmq.client.TrustEverythingTrustManager;
 import org.aopalliance.aop.Advice;
@@ -79,6 +80,7 @@ import static org.mockito.Mockito.verify;
  * @author Greg Turnquist
  * @author Stephane Nicoll
  * @author Gary Russell
+ * @author Artsiom Yudovin
  */
 public class RabbitAutoConfigurationTests {
 
@@ -791,6 +793,19 @@ public class RabbitAutoConfigurationTests {
 					TrustManager trustManager = getTrustManager(rabbitConnectionFactory);
 					assertThat(trustManager)
 							.isNotInstanceOf(TrustEverythingTrustManager.class);
+				});
+	}
+
+	@Test
+	public void enableSaslDefaultSaslConfig() {
+		this.contextRunner.withUserConfiguration(TestConfiguration.class)
+				.withPropertyValues("spring.rabbitmq.saslConfig=EXTERNAL")
+				.run((context) -> {
+					assertThat(context).hasNotFailed();
+					com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory = getTargetConnectionFactory(
+							context);
+					assertThat(rabbitConnectionFactory.getSaslConfig())
+							.isEqualTo(DefaultSaslConfig.EXTERNAL);
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Dave Syer
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author Artsiom Yudovin
  */
 public class RabbitPropertiesTests {
 
@@ -252,6 +253,17 @@ public class RabbitPropertiesTests {
 		assertThat(direct.isAutoStartup()).isEqualTo(container.isAutoStartup());
 		assertThat(container).hasFieldOrPropertyWithValue("missingQueuesFatal",
 				direct.isMissingQueuesFatal());
+	}
+
+	@Test
+	public void saslConfigDefaultsToNull() {
+		assertThat(this.properties.getSaslConfig()).isNull();
+	}
+
+	@Test
+	public void customSaslConfig() {
+		this.properties.setSaslConfig("EXTERNAL");
+		assertThat(this.properties.getSaslConfig()).isEqualTo("EXTERNAL");
 	}
 
 }


### PR DESCRIPTION
this [enhancement](https://github.com/spring-projects/spring-boot/issues/6719) 