### PR TITLE
Checks the existence of 'dependsOn' beans before adding them to `BeanDefinition`

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AbstractDependsOnBeanFactoryPostProcessor.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AbstractDependsOnBeanFactoryPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,9 @@ public abstract class AbstractDependsOnBeanFactoryPostProcessor
 		for (String beanName : getBeanNames(beanFactory)) {
 			BeanDefinition definition = getBeanDefinition(beanName, beanFactory);
 			String[] dependencies = definition.getDependsOn();
-			for (String bean : this.dependsOn) {
+			String[] dependsOn = Arrays.stream(this.dependsOn)
+					.filter(beanFactory::containsBean).toArray(String[]::new);
+			for (String bean : dependsOn) {
 				dependencies = StringUtils.addStringToArray(dependencies, bean);
 			}
 			definition.setDependsOn(dependencies);


### PR DESCRIPTION
Consider the following example:
```
public class EmbeddedMongoAutoConfigurationTests {

	private AnnotationConfigApplicationContext context;

	@After
	public void close() {
		if (this.context != null) {
			this.context.close();
		}
	}

	@Test
	public void customMongoServer() {
		load(CustomMongoConfiguration.class);
	}

	private void load(Class<?> config, String... environment) {
		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
		if (config != null) {
			ctx.register(config);
		}
		TestPropertyValues.of(environment).applyTo(ctx);
		ctx.register(EmbeddedMongoAutoConfiguration.class, MongoAutoConfiguration.class,
				PropertyPlaceholderAutoConfiguration.class);
		ctx.refresh();
		this.context = ctx;
	}

	@Configuration
	static class CustomMongoConfiguration {

		@Bean(initMethod = "start", destroyMethod = "stop")
		public MongodExecutable customMongoServer(IMongodConfig mongodConfig,
				IRuntimeConfig runtimeConfig, ApplicationContext context) throws IOException {
			MongodStarter mongodStarter = MongodStarter.getInstance(runtimeConfig);
			return mongodStarter.prepare(mongodConfig);
		}

	}
}
```

This test does not work because of 
```
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'mongo' defined in org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration: 'mongo' depends on missing bean 'embeddedMongoServer'; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No bean named 'embeddedMongoServer' available

	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:310)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:199)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:849)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
	...
Caused by: org.springframework.beans.factory.NoSuchBeanDefinitionException: No bean named 'embeddedMongoServer' available
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBeanDefinition(DefaultListableBeanFactory.java:775)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getMergedLocalBeanDefinition(AbstractBeanFactory.java:1221)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:294)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:199)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:307)
	... 31 more

```

So, If we define a custom bean with a different name from `embeddedMongoServer`, `ApplicationContext` will not start, as `EmbeddedMongoDependencyConfiguration` has added `dependsOn` to `{ MongoClient.class, MongoClientFactoryBean.class }` beans, but `embeddedMongoServer`  has not existed anymore as it was substituted by a custom bean.

This PR tries to fix this.

Thanks