### PR TITLE
Adds loadOnStartup property to EndpointServlet

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/EndpointServlet.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/EndpointServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.servlet.Servlet;
+import javax.servlet.ServletRegistration;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.util.Assert;
@@ -35,23 +36,31 @@ public final class EndpointServlet {
 
 	private final Servlet servlet;
 
+	private final int loadOnStartup;
+
 	private final Map<String, String> initParameters;
 
 	public EndpointServlet(Class<? extends Servlet> servlet) {
 		Assert.notNull(servlet, "Servlet must not be null");
 		this.servlet = BeanUtils.instantiateClass(servlet);
 		this.initParameters = Collections.emptyMap();
+		this.loadOnStartup = -1;
+
 	}
 
 	public EndpointServlet(Servlet servlet) {
 		Assert.notNull(servlet, "Servlet must not be null");
 		this.servlet = servlet;
 		this.initParameters = Collections.emptyMap();
+		this.loadOnStartup = -1;
 	}
 
-	private EndpointServlet(Servlet servlet, Map<String, String> initParameters) {
+	private EndpointServlet(Servlet servlet, Map<String, String> initParameters,
+			int loadOnStartup) {
 		this.servlet = servlet;
 		this.initParameters = Collections.unmodifiableMap(initParameters);
+		this.loadOnStartup = loadOnStartup;
+
 	}
 
 	public EndpointServlet withInitParameter(String name, String value) {
@@ -67,7 +76,23 @@ public final class EndpointServlet {
 		Map<String, String> mergedInitParameters = new LinkedHashMap<>(
 				this.initParameters);
 		mergedInitParameters.putAll(initParameters);
-		return new EndpointServlet(this.servlet, mergedInitParameters);
+		return new EndpointServlet(this.servlet, mergedInitParameters,
+				this.loadOnStartup);
+	}
+
+	/**
+	 * Sets the <code>loadOnStartup</code> priority that will be set on Servlet
+	 * registration
+	 * <p>
+	 * The default value for <tt>loadOnStartup</tt> is <code>-1</code>.
+	 * @param loadOnStartup the initialization priority of the Servlet
+	 * @return a new instance of {@link EndpointServlet} with the provided
+	 * <tt>loadOnStartup</tt> value set
+	 * @since 2.2.0
+	 * @see ServletRegistration.Dynamic#setLoadOnStartup(int)
+	 */
+	public EndpointServlet withLoadOnStartup(int loadOnStartup) {
+		return new EndpointServlet(this.servlet, this.initParameters, loadOnStartup);
 	}
 
 	Servlet getServlet() {
@@ -76,6 +101,10 @@ public final class EndpointServlet {
 
 	Map<String, String> getInitParameters() {
 		return this.initParameters;
+	}
+
+	int getLoadOnStartup() {
+		return this.loadOnStartup;
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/EndpointServlet.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/EndpointServlet.java
@@ -21,7 +21,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.servlet.Servlet;
-import javax.servlet.ServletRegistration;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.util.Assert;

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/ServletEndpointRegistrar.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/ServletEndpointRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,7 @@ public class ServletEndpointRegistrar implements ServletContextInitializer {
 				endpointServlet.getServlet());
 		registration.addMapping(urlMapping);
 		registration.setInitParameters(endpointServlet.getInitParameters());
+		registration.setLoadOnStartup(endpointServlet.getLoadOnStartup());
 		logger.info("Registered '" + path + "' to " + name);
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/EndpointServletTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/EndpointServletTests.java
@@ -132,6 +132,32 @@ public class EndpointServletTests {
 
 	}
 
+	@Test
+	public void withLoadOnStartupNotSetShouldReturnDefaultValue() {
+		EndpointServlet endpointServlet = new EndpointServlet(TestServlet.class);
+		assertThat(endpointServlet.getLoadOnStartup()).isEqualTo(-1);
+	}
+
+	@Test
+	public void withLoadOnStartupSetShouldReturnValue() {
+		final int loadOnStartupTestValue = 3;
+		EndpointServlet endpointServlet = new EndpointServlet(TestServlet.class)
+				.withLoadOnStartup(loadOnStartupTestValue);
+		assertThat(endpointServlet.getLoadOnStartup()).isEqualTo(loadOnStartupTestValue);
+	}
+
+	@Test
+	public void withLoadOnStartupAndInitParamsShouldReturnValue() {
+		final int loadOnStartupTestValue = 9;
+		EndpointServlet endpointServlet = new EndpointServlet(TestServlet.class)
+				.withLoadOnStartup(loadOnStartupTestValue).withInitParameter("a", "b")
+				.withInitParameter("c", "d");
+		Map<String, String> extra = new LinkedHashMap<>();
+		extra.put("a", "b1");
+		extra.put("e", "f");
+		assertThat(endpointServlet.getLoadOnStartup()).isEqualTo(loadOnStartupTestValue);
+	}
+
 	private static class TestServlet extends GenericServlet {
 
 		@Override

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/ServletEndpointRegistrarTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/ServletEndpointRegistrarTests.java
@@ -120,6 +120,30 @@ public class ServletEndpointRegistrarTests {
 		verify(this.dynamic).setInitParameters(Collections.singletonMap("a", "b"));
 	}
 
+	@Test
+	public void onStartupWhenHasLoadOnStartupShouldRegisterLoadOnStartup()
+			throws Exception {
+		final int loadOnStartupTestValue = 7;
+		ExposableServletEndpoint endpoint = mockEndpoint(
+				new EndpointServlet(TestServlet.class)
+						.withLoadOnStartup(loadOnStartupTestValue));
+		ServletEndpointRegistrar registrar = new ServletEndpointRegistrar("/actuator",
+				Collections.singleton(endpoint));
+		registrar.onStartup(this.servletContext);
+		verify(this.dynamic).setLoadOnStartup(loadOnStartupTestValue);
+	}
+
+	@Test
+	public void onStartupWhenHasNotLoadOnStartupShouldRegisterDefaultValue()
+			throws Exception {
+		ExposableServletEndpoint endpoint = mockEndpoint(
+				new EndpointServlet(TestServlet.class));
+		ServletEndpointRegistrar registrar = new ServletEndpointRegistrar("/actuator",
+				Collections.singleton(endpoint));
+		registrar.onStartup(this.servletContext);
+		verify(this.dynamic).setLoadOnStartup(-1);
+	}
+
 	private ExposableServletEndpoint mockEndpoint(EndpointServlet endpointServlet) {
 		ExposableServletEndpoint endpoint = mock(ExposableServletEndpoint.class);
 		given(endpoint.getEndpointId()).willReturn(EndpointId.of("test"));


### PR DESCRIPTION
loadOnStartup property was missing from EndpointServlet and cannot
be set inside ServletEndpointRegistrar. Now it can be set and register
a Servlet with that integer property ready to act upon registration

Fixes #15672


