### PR TITLE
Deal with several holes in the article

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/documentation-overview.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/documentation-overview.adoc
@@ -73,7 +73,7 @@ you covered>>:
 <<using-spring-boot.adoc#using-boot-auto-configuration, @EnableAutoConfiguration>> |
 <<using-spring-boot.adoc#using-boot-spring-beans-and-dependency-injection, Beans and
 Dependency Injection>>
-* *Running your code*
+* *Running your code:*
 <<using-spring-boot.adoc#using-boot-running-from-an-ide, IDE>> |
 <<using-spring-boot.adoc#using-boot-running-as-a-packaged-application, Packaged>> |
 <<using-spring-boot.adoc#using-boot-running-with-the-maven-plugin, Maven>> |

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/documentation-overview.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/documentation-overview.adoc
@@ -13,7 +13,7 @@ as a map for the rest of the document.
 [[boot-documentation-about]]
 == About the Documentation
 The latest copy
-of the reference documentation is available at {spring-boot-docs-current}.
+of the reference documentation is available at https://docs.spring.io/spring-boot/docs/current/reference/[spring-boot-docs-current].
 
 Copies of this document may be made for your own use and for distribution to others,
 provided that you do not charge any fee for such copies and further provided that each
@@ -35,7 +35,7 @@ tagged with https://stackoverflow.com/tags/spring-boot[`spring-boot`].
 * Report bugs with Spring Boot at https://github.com/spring-projects/spring-boot/issues.
 
 NOTE: All of Spring Boot is open source, including the documentation. If you find
-problems with the docs or if you want to improve them, please {github-code}[get
+problems with the docs or if you want to improve them, please https://github.com/spring-projects/spring-boot/tree/master[get
 involved].
 
 


### PR DESCRIPTION
These holes has a total of three places：
1.{spring-boot-docs-current},  there is no jump links.
2.{github-code}[getinvolved],  there is no jump links.
3. * *Running your code*,         the lack of punctuation":".
