### PR TITLE
Use AssertJ facilities for expected exceptions

### DIFF
--- a/spring-boot-project/spring-boot-cli/src/test/java/org/springframework/boot/cli/compiler/grape/AetherGrapeEngineTests.java
+++ b/spring-boot-project/spring-boot-cli/src/test/java/org/springframework/boot/cli/compiler/grape/AetherGrapeEngineTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.boot.cli.compiler.dependencies.SpringBootDependencies
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  * Tests for {@link AetherGrapeEngine}.
@@ -147,13 +148,15 @@ public class AetherGrapeEngineTests {
 		assertThat(this.groovyClassLoader.getURLs().length).isEqualTo(1);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void differingTypeAndExt() {
 		Map<String, Object> dependency = createDependency("org.grails",
 				"grails-dependencies", "2.4.0");
 		dependency.put("type", "foo");
 		dependency.put("ext", "bar");
-		createGrapeEngine().grab(Collections.emptyMap(), dependency);
+		AetherGrapeEngine grapeEngine = createGrapeEngine();
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> grapeEngine.grab(Collections.emptyMap(), dependency));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/client/AutoConfigureMockRestServiceServerEnabledFalseIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/client/AutoConfigureMockRestServiceServerEnabledFalseIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ import org.springframework.boot.test.web.client.MockServerRestTemplateCustomizer
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 /**
  * Tests for {@link AutoConfigureMockRestServiceServer} with {@code enabled=false}.
  *
@@ -38,9 +40,11 @@ public class AutoConfigureMockRestServiceServerEnabledFalseIntegrationTests {
 	@Autowired
 	private ApplicationContext applicationContext;
 
-	@Test(expected = NoSuchBeanDefinitionException.class)
+	@Test
 	public void mockServerRestTemplateCustomizerShouldNotBeRegistered() {
-		this.applicationContext.getBean(MockServerRestTemplateCustomizer.class);
+		assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+				.isThrownBy(() -> this.applicationContext
+						.getBean(MockServerRestTemplateCustomizer.class));
 	}
 
 }

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/client/RestClientTestNoComponentIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/client/RestClientTestNoComponentIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.MockRestServiceServer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
@@ -49,9 +50,10 @@ public class RestClientTestNoComponentIntegrationTests {
 	@Autowired
 	private MockRestServiceServer server;
 
-	@Test(expected = NoSuchBeanDefinitionException.class)
+	@Test
 	public void exampleRestClientIsNotInjected() {
-		this.applicationContext.getBean(ExampleRestClient.class);
+		assertThatExceptionOfType(NoSuchBeanDefinitionException.class).isThrownBy(
+				() -> this.applicationContext.getBean(ExampleRestClient.class));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SimpleMainTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SimpleMainTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  * Tests for {@link SpringApplication} main method.
@@ -43,10 +44,10 @@ public class SimpleMainTests {
 
 	private static final String SPRING_STARTUP = "Started SpringApplication in";
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void emptyApplicationContext() throws Exception {
-		SpringApplication.main(getArgs());
-		assertThat(getOutput()).contains(SPRING_STARTUP);
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> SpringApplication.main(getArgs()));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/FileEncodingApplicationListenerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/FileEncodingApplicationListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.context;
 
-import org.junit.Assume;
 import org.junit.Test;
 
 import org.springframework.boot.SpringApplication;
@@ -25,6 +24,9 @@ import org.springframework.boot.context.properties.source.ConfigurationPropertyS
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.context.support.TestPropertySourceUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
  * Tests for {@link FileEncodingApplicationListener}.
@@ -40,12 +42,13 @@ public class FileEncodingApplicationListenerTests {
 	private final ApplicationEnvironmentPreparedEvent event = new ApplicationEnvironmentPreparedEvent(
 			new SpringApplication(), new String[0], this.environment);
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testIllegalState() {
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.environment,
 				"spring.mandatory_file_encoding=FOO");
 		ConfigurationPropertySources.attach(this.environment);
-		this.initializer.onApplicationEvent(this.event);
+		assertThatIllegalStateException()
+				.isThrownBy(() -> this.initializer.onApplicationEvent(this.event));
 	}
 
 	@Test
@@ -55,7 +58,7 @@ public class FileEncodingApplicationListenerTests {
 
 	@Test
 	public void testSunnyDayMandated() {
-		Assume.assumeNotNull(System.getProperty("file.encoding"));
+		assertThat(System.getProperty("file.encoding")).isNotNull();
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.environment,
 				"spring.mandatory_file_encoding:" + System.getProperty("file.encoding"));
 		ConfigurationPropertySources.attach(this.environment);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LoggingSystemTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.springframework.boot.logging.LoggingSystem.NoOpLoggingSystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * Tests for {@link LoggingSystem}.
@@ -42,14 +43,16 @@ public class LoggingSystemTests {
 		assertThat(loggingSystem).isInstanceOf(NoOpLoggingSystem.class);
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void getLoggerConfigurationIsUnsupported() {
-		new StubLoggingSystem().getLoggerConfiguration("test-logger-name");
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(
+				() -> new StubLoggingSystem().getLoggerConfiguration("test-logger-name"));
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void listLoggerConfigurationsIsUnsupported() {
-		new StubLoggingSystem().getLoggerConfigurations();
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> new StubLoggingSystem().getLoggerConfigurations());
 	}
 
 	private static final class StubLoggingSystem extends LoggingSystem {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/java/JavaLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/java/JavaLoggingSystemTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
  * Tests for {@link JavaLoggingSystem}.
@@ -137,11 +138,11 @@ public class JavaLoggingSystemTests extends AbstractLoggingSystemTests {
 		assertThat(output).contains("INFO: Hello");
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testNonexistentConfigLocation() {
 		this.loggingSystem.beforeInitialize();
-		this.loggingSystem.initialize(null, "classpath:logging-nonexistent.properties",
-				null);
+		assertThatIllegalStateException().isThrownBy(() -> this.loggingSystem
+				.initialize(null, "classpath:logging-nonexistent.properties", null));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
@@ -46,6 +46,7 @@ import org.springframework.boot.testsupport.rule.OutputCapture;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.contentOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -125,10 +126,11 @@ public class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		assertThat(configuration.getWatchManager().getIntervalSeconds()).isEqualTo(30);
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testNonexistentConfigLocation() {
 		this.loggingSystem.beforeInitialize();
-		this.loggingSystem.initialize(null, "classpath:log4j2-nonexistent.xml", null);
+		assertThatIllegalStateException().isThrownBy(() -> this.loggingSystem
+				.initialize(null, "classpath:log4j2-nonexistent.xml", null));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -57,6 +57,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.contentOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -172,11 +173,11 @@ public class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		}
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testNonexistentConfigLocation() {
 		this.loggingSystem.beforeInitialize();
-		this.loggingSystem.initialize(this.initializationContext,
-				"classpath:logback-nonexistent.xml", null);
+		assertThatIllegalStateException().isThrownBy(() -> this.loggingSystem.initialize(
+				this.initializationContext, "classpath:logback-nonexistent.xml", null));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/server/MimeMappingsTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/server/MimeMappingsTests.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * Tests for {@link MimeMappings}.
@@ -32,9 +33,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class MimeMappingsTests {
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void defaultsCannotBeModified() {
-		MimeMappings.DEFAULT.add("foo", "foo/bar");
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> MimeMappings.DEFAULT.add("foo", "foo/bar"));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
@@ -532,7 +532,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 				.isEqualTo("test");
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void sslNeedsClientAuthenticationFailsWithoutClientCertificate()
 			throws Exception {
 		AbstractServletWebServerFactory factory = getFactory();
@@ -547,7 +547,8 @@ public abstract class AbstractServletWebServerFactoryTests {
 				.build();
 		HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(
 				httpClient);
-		getResponse(getLocalUrl("https", "/test.txt"), requestFactory);
+		String localUrl = getLocalUrl("https", "/test.txt");
+		assertThatIOException().isThrownBy(() -> getResponse(localUrl, requestFactory));
 	}
 
 	@Test


### PR DESCRIPTION
Hi,

I just noticed some usages of `@Test(expected = SomeException.class)` that could probably benefit from using AssertJ facilities. E.g. by making clear what is expected to fail in a test.

Let me know what you think.
Cheers,
Christoph