### PR TITLE
Permit use of @JsonTest without Jackson

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonExcludeFilter.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonExcludeFilter.java
@@ -20,13 +20,12 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import com.fasterxml.jackson.databind.Module;
-
 import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.jackson.JsonComponent;
 import org.springframework.boot.test.autoconfigure.filter.AnnotationCustomizableTypeExcludeFilter;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.util.ClassUtils;
 
 /**
  * {@link TypeExcludeFilter} for {@link JsonTest @JsonTest}.
@@ -39,8 +38,12 @@ class JsonExcludeFilter extends AnnotationCustomizableTypeExcludeFilter {
 
 	static {
 		Set<Class<?>> includes = new LinkedHashSet<>();
-		includes.add(Module.class);
 		includes.add(JsonComponent.class);
+		try {
+			includes.add(ClassUtils.forName("com.fasterxml.jackson.databind.Module", null));
+		} catch (Exception ex) {
+			// Ignore
+		}
 		DEFAULT_INCLUDES = Collections.unmodifiableSet(includes);
 	}
 


### PR DESCRIPTION
I think @JsonTest is not only Jackson.

```xml
<dependencies>
    <dependency>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-starter</artifactId>
    </dependency>
    <dependency>
        <groupId>com.google.code.gson</groupId>
        <artifactId>gson</artifactId>
    </dependency>
</dependencies>
```

No dependency Jackson.

```java
@RunWith(SpringRunner.class)
@JsonTest
public class SpringBootJsontestApplicationTests {

    @Autowired
    private GsonTester<VehicleDetails> json;
    ...
}
```

Error Message 
`java.lang.NoClassDefFoundError: com/fasterxml/jackson/databind/Module`
