### PR TITLE
URL Cleanup

### DIFF
--- a/eclipse/spring-boot-project.setup
+++ b/eclipse/spring-boot-project.setup
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <setup:Project
     xmi:version="2.0"
-    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xmi="https://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:jdt="http://www.eclipse.org/oomph/setup/jdt/1.0"
-    xmlns:maven="http://www.eclipse.org/oomph/setup/maven/1.0"
-    xmlns:predicates="http://www.eclipse.org/oomph/predicates/1.0"
-    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
-    xmlns:setup.p2="http://www.eclipse.org/oomph/setup/p2/1.0"
-    xmlns:setup.workingsets="http://www.eclipse.org/oomph/setup/workingsets/1.0"
-    xmlns:workingsets="http://www.eclipse.org/oomph/workingsets/1.0"
-    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/setup/maven/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore http://www.eclipse.org/oomph/predicates/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore"
+    xmlns:jdt="https://www.eclipse.org/oomph/setup/jdt/1.0"
+    xmlns:maven="https://www.eclipse.org/oomph/setup/maven/1.0"
+    xmlns:predicates="https://www.eclipse.org/oomph/predicates/1.0"
+    xmlns:setup="https://www.eclipse.org/oomph/setup/1.0"
+    xmlns:setup.p2="https://www.eclipse.org/oomph/setup/p2/1.0"
+    xmlns:setup.workingsets="https://www.eclipse.org/oomph/setup/workingsets/1.0"
+    xmlns:workingsets="https://www.eclipse.org/oomph/workingsets/1.0"
+    xsi:schemaLocation="https://www.eclipse.org/oomph/setup/jdt/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore https://www.eclipse.org/oomph/setup/maven/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore https://www.eclipse.org/oomph/predicates/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore https://www.eclipse.org/oomph/setup/workingsets/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore https://www.eclipse.org/oomph/workingsets/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore"
     name="spring.boot"
     label="Spring Boot">
   <setupTask
@@ -81,19 +81,19 @@
     <requirement
         name="org.springframework.ide.eclipse.boot.feature.feature.group"/>
     <repository
-        url="http://download.eclipse.org/technology/epp/packages/oxygen/R/"/>
+        url="https://download.eclipse.org/technology/epp/packages/oxygen/R/"/>
     <repository
-        url="http://download.eclipse.org/releases/oxygen/"/>
+        url="https://download.eclipse.org/releases/oxygen/"/>
     <repository
         url="http://andrei.gmxhome.de/eclipse/"/>
     <repository
         url="https://dl.bintray.com/spring/javaformat-eclipse/"/>
     <repository
-        url="http://download.eclipse.org/egit/github/updates/"/>
+        url="https://download.eclipse.org/egit/github/updates/"/>
     <repository
-        url="http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-buildhelper/0.15.0/N/0.15.0.201207090124/"/>
+        url="https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-buildhelper/0.15.0/N/0.15.0.201207090124/"/>
     <repository
-        url="http://dist.springsource.com/release/TOOLS/update/e4.7"/>
+        url="https://dist.springsource.com/release/TOOLS/update/e4.7"/>
     <description>
       Install the tools needed in the IDE to work with the
       source code for ${scope.project.label}

--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -17,7 +17,7 @@
 	<licenses>
 		<license>
 			<name>Apache License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0</url>
 		</license>
 	</licenses>
 	<scm>
@@ -28,7 +28,7 @@
 			<name>Pivotal</name>
 			<email>info@pivotal.io</email>
 			<organization>Pivotal Software, Inc.</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://www.spring.io</organizationUrl>
 		</developer>
 	</developers>
 	<properties>

--- a/spring-boot-project/spring-boot-parent/pom.xml
+++ b/spring-boot-project/spring-boot-parent/pom.xml
@@ -32,7 +32,7 @@
 		<spring-doc-resources.version>0.1.0.RELEASE</spring-doc-resources.version>
 	</properties>
 	<scm>
-		<url>http://github.com/spring-projects/spring-boot</url>
+		<url>https://github.com/spring-projects/spring-boot</url>
 		<connection>scm:git:git://github.com/spring-projects/spring-boot.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-boot.git</developerConnection>
 	</scm>

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
@@ -46,7 +46,7 @@ javadoc {
 		author()
 		stylesheetFile = file('src/main/javadoc/spring-javadoc.css')
 		links = [
-			'http://docs.oracle.com/javase/8/docs/api/',
+			'https://docs.oracle.com/javase/8/docs/api/',
 			'https://docs.gradle.org/current/javadoc/'
 		]
 	}

--- a/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-wildfly/pom.xml
+++ b/spring-boot-tests/spring-boot-deployment-tests/spring-boot-deployment-test-wildfly/pom.xml
@@ -14,7 +14,7 @@
 		<main.basedir>${basedir}/../../..</main.basedir>
 		<wildfly.version>12.0.0.Final</wildfly.version>
 		<cargo.container.id>wildfly12x</cargo.container.id>
-		<cargo.container.url>http://download.jboss.org/wildfly/${wildfly.version}/wildfly-${wildfly.version}.zip
+		<cargo.container.url>https://download.jboss.org/wildfly/${wildfly.version}/wildfly-${wildfly.version}.zip
 		</cargo.container.url>
 	</properties>
 	<dependencies>

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/conf/CentOS/6.9-a23bced6/Dockerfile
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/conf/CentOS/6.9-a23bced6/Dockerfile
@@ -4,6 +4,6 @@ RUN yum install -y wget && \
     yum install -y system-config-services && \
     yum install -y curl && \
     wget --output-document jdk.rpm \
-        http://cdn.azul.com/zulu/bin/zulu8.21.0.1-jdk8.0.131-linux.x86_64.rpm && \
+        https://cdn.azul.com/zulu/bin/zulu8.21.0.1-jdk8.0.131-linux.x86_64.rpm && \
     yum --nogpg localinstall -y jdk.rpm && \
     rm -f jdk.rpm


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://andrei.gmxhome.de/eclipse/ (200) migrated to:  
  http://andrei.gmxhome.de/eclipse/ ([https](https://andrei.gmxhome.de/eclipse/) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://dist.springsource.com/release/TOOLS/update/e4.7 (403) migrated to:  
  https://dist.springsource.com/release/TOOLS/update/e4.7 ([https](https://dist.springsource.com/release/TOOLS/update/e4.7) result 403).
* http://download.jboss.org/wildfly/ (403) migrated to:  
  https://download.jboss.org/wildfly/ ([https](https://download.jboss.org/wildfly/) result 403).
* http://www.eclipse.org/oomph/predicates/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/predicates/1.0 ([https](https://www.eclipse.org/oomph/predicates/1.0) result 404).
* http://www.eclipse.org/oomph/setup/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/1.0 ([https](https://www.eclipse.org/oomph/setup/1.0) result 404).
* http://www.eclipse.org/oomph/setup/jdt/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/jdt/1.0 ([https](https://www.eclipse.org/oomph/setup/jdt/1.0) result 404).
* http://www.eclipse.org/oomph/setup/maven/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/maven/1.0 ([https](https://www.eclipse.org/oomph/setup/maven/1.0) result 404).
* http://www.eclipse.org/oomph/setup/p2/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/p2/1.0 ([https](https://www.eclipse.org/oomph/setup/p2/1.0) result 404).
* http://www.eclipse.org/oomph/setup/workingsets/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/workingsets/1.0 ([https](https://www.eclipse.org/oomph/setup/workingsets/1.0) result 404).
* http://www.eclipse.org/oomph/workingsets/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/workingsets/1.0 ([https](https://www.eclipse.org/oomph/workingsets/1.0) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://cdn.azul.com/zulu/bin/zulu8.21.0.1-jdk8.0.131-linux.x86_64.rpm migrated to:  
  https://cdn.azul.com/zulu/bin/zulu8.21.0.1-jdk8.0.131-linux.x86_64.rpm ([https](https://cdn.azul.com/zulu/bin/zulu8.21.0.1-jdk8.0.131-linux.x86_64.rpm) result 200).
* http://docs.oracle.com/javase/8/docs/api/ migrated to:  
  https://docs.oracle.com/javase/8/docs/api/ ([https](https://docs.oracle.com/javase/8/docs/api/) result 200).
* http://download.eclipse.org/egit/github/updates/ migrated to:  
  https://download.eclipse.org/egit/github/updates/ ([https](https://download.eclipse.org/egit/github/updates/) result 200).
* http://download.eclipse.org/releases/oxygen/ migrated to:  
  https://download.eclipse.org/releases/oxygen/ ([https](https://download.eclipse.org/releases/oxygen/) result 200).
* http://download.eclipse.org/technology/epp/packages/oxygen/R/ migrated to:  
  https://download.eclipse.org/technology/epp/packages/oxygen/R/ ([https](https://download.eclipse.org/technology/epp/packages/oxygen/R/) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore) result 200).
* http://github.com/spring-projects/spring-boot migrated to:  
  https://github.com/spring-projects/spring-boot ([https](https://github.com/spring-projects/spring-boot) result 200).
* http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-buildhelper/0.15.0/N/0.15.0.201207090124/ migrated to:  
  https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-buildhelper/0.15.0/N/0.15.0.201207090124/ ([https](https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-buildhelper/0.15.0/N/0.15.0.201207090124/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.omg.org/XMI migrated to:  
  https://www.omg.org/XMI ([https](https://www.omg.org/XMI) result 301).
* http://www.spring.io migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:8080
* http://127.0.0.1:8080/
* http://127.0.0.1:8081/
* http://127.0.0.1:8081/test/
* http://localhost
* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance