### PR TITLE
Random management.server.port should not set to the same value as local.server.port

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/SpringBootTestRandomPortEnvironmentPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/SpringBootTestRandomPortEnvironmentPostProcessor.java
@@ -52,7 +52,8 @@ class SpringBootTestRandomPortEnvironmentPostProcessor
 		}
 		Integer managementPort = getPropertyAsInteger(environment,
 				MANAGEMENT_PORT_PROPERTY, null);
-		if (managementPort == null || managementPort.equals(-1)) {
+		if (managementPort == null || managementPort.equals(-1)
+				|| managementPort.equals(0)) {
 			return;
 		}
 		Integer serverPort = getPropertyAsInteger(environment, SERVER_PORT_PROPERTY,

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/SpringBootTestRandomPortEnvironmentPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/SpringBootTestRandomPortEnvironmentPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,17 @@ public class SpringBootTestRandomPortEnvironmentPostProcessorTests {
 	@Test
 	public void postProcessWhenServerAndManagementPortIsZeroInTestPropertySource() {
 		addTestPropertySource("0", "0");
+		this.postProcessor.postProcessEnvironment(this.environment, null);
+		assertThat(this.environment.getProperty("server.port")).isEqualTo("0");
+		assertThat(this.environment.getProperty("management.server.port")).isEqualTo("0");
+	}
+
+	@Test
+	public void postProcessWhenServerPortAndManagementPortIsZeroInDifferentPropertySources() {
+		addTestPropertySource("0", null);
+		Map<String, Object> source = new HashMap<>();
+		source.put("management.server.port", "0");
+		this.propertySources.addLast(new MapPropertySource("other", source));
 		this.postProcessor.postProcessEnvironment(this.environment, null);
 		assertThat(this.environment.getProperty("server.port")).isEqualTo("0");
 		assertThat(this.environment.getProperty("management.server.port")).isEqualTo("0");


### PR DESCRIPTION
`management.server.port` should be **0** when `local.server.port` has the same value and `management.server.port` has been defined in the different `PropertySource`

gh-16102

