### PR TITLE
Trim trailing whitespace from value of spring.server.servlet.context-path

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -240,7 +240,6 @@ public class ServerProperties {
 				}
 				return ctxPath;
 			}
-
 			return contextPath;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -232,7 +232,7 @@ public class ServerProperties {
 
 		private String cleanContextPath(String contextPath) {
 			if (StringUtils.hasLength(contextPath)) {
-				// remove leading and trailing whitespaces
+				// remove leading and trailing whitespaces if any exists
 				String ctxPath = StringUtils.trimWhitespace(contextPath);
 
 				if (contextPath.endsWith("/")) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -235,8 +235,8 @@ public class ServerProperties {
 				// remove leading and trailing whitespaces if any exists
 				String ctxPath = StringUtils.trimWhitespace(contextPath);
 
-				if (contextPath.endsWith("/")) {
-					ctxPath = contextPath.substring(0, contextPath.length() - 1);
+				if (ctxPath.endsWith("/")) {
+					ctxPath = ctxPath.substring(0, ctxPath.length() - 1);
 				}
 				return ctxPath;
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -231,9 +231,16 @@ public class ServerProperties {
 		}
 
 		private String cleanContextPath(String contextPath) {
-			if (StringUtils.hasText(contextPath) && contextPath.endsWith("/")) {
-				return contextPath.substring(0, contextPath.length() - 1);
+			if (StringUtils.hasLength(contextPath)) {
+				// remove leading and trailing whitespaces
+				String ctxPath = StringUtils.trimWhitespace(contextPath);
+
+				if (contextPath.endsWith("/")) {
+					ctxPath = contextPath.substring(0, contextPath.length() - 1);
+				}
+				return ctxPath;
 			}
+
 			return contextPath;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -150,6 +150,30 @@ public class ServerPropertiesTests {
 	}
 
 	@Test
+	public void makeSureTrailingAndLeadingWhitespacesRemoved_case1() {
+		bind("server.servlet.context-path", " /assets");
+		assertThat(this.properties.getServlet().getContextPath()).isEqualTo("/assets");
+	}
+
+	@Test
+	public void makeSureTrailingAndLeadingWhitespacesRemoved_case2() {
+		bind("server.servlet.context-path", " /assets ");
+		assertThat(this.properties.getServlet().getContextPath()).isEqualTo("/assets");
+	}
+
+	@Test
+	public void makeSureTrailingAndLeadingWhitespacesRemoved_case3() {
+		bind("server.servlet.context-path", "/assets/copy/ ");
+		assertThat(this.properties.getServlet().getContextPath()).isEqualTo("/assets/copy");
+	}
+
+	@Test
+	public void makeSureTrailingAndLeadingWhitespacesRemoved_case4() {
+		bind("server.servlet.context-path", "  /assets /copy/    ");
+		assertThat(this.properties.getServlet().getContextPath()).isEqualTo("/assets /copy");
+	}
+
+	@Test
 	public void testCustomizeUriEncoding() {
 		bind("server.tomcat.uri-encoding", "US-ASCII");
 		assertThat(this.properties.getTomcat().getUriEncoding())

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -164,13 +164,15 @@ public class ServerPropertiesTests {
 	@Test
 	public void makeSureTrailingAndLeadingWhitespacesRemoved_case3() {
 		bind("server.servlet.context-path", "/assets/copy/ ");
-		assertThat(this.properties.getServlet().getContextPath()).isEqualTo("/assets/copy");
+		assertThat(this.properties.getServlet().getContextPath())
+				.isEqualTo("/assets/copy");
 	}
 
 	@Test
 	public void makeSureTrailingAndLeadingWhitespacesRemoved_case4() {
 		bind("server.servlet.context-path", "  /assets /copy/    ");
-		assertThat(this.properties.getServlet().getContextPath()).isEqualTo("/assets /copy");
+		assertThat(this.properties.getServlet().getContextPath())
+				.isEqualTo("/assets /copy");
 	}
 
 	@Test


### PR DESCRIPTION
This PR is the fix for issue [#15972](https://github.com/spring-projects/spring-boot/issues/15972).
I have added few unit tests to make sure the changes works.

**Describing the problem:**
Servlet context path specified in the application.properties file doesnt remove leading or trailing spaces and and it may result in 404 errors.