### PR TITLE
Fix typo in logging.group property description

### DIFF
--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -119,7 +119,7 @@
     {
       "name": "logging.group",
       "type": "java.util.Map<java.lang.String,java.util.List<java.lang.String>>",
-      "description": "Log groups to quickly change multiple loggers at the same time. For instance, `logging.level.db=org.hibernate,org.springframework.jdbc`.",
+      "description": "Log groups to quickly change multiple loggers at the same time. For instance, `logging.group.db=org.hibernate,org.springframework.jdbc`.",
       "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener"
     },
     {


### PR DESCRIPTION
The description of `logging.group` property used wrong name in the example.