### PR TITLE
Update Kotlin documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -8638,7 +8638,7 @@ Overflow] if you need support.
 
 [[boot-features-kotlin-requirements]]
 === Requirements
-Spring Boot supports Kotlin 1.2.x. To use Kotlin, `org.jetbrains.kotlin:kotlin-stdlib` and
+Spring Boot supports Kotlin 1.3.x. To use Kotlin, `org.jetbrains.kotlin:kotlin-stdlib` and
 `org.jetbrains.kotlin:kotlin-reflect` must be present on the classpath. The
 `kotlin-stdlib` variants `kotlin-stdlib-jdk7` and `kotlin-stdlib-jdk8` can also be used.
 
@@ -8741,16 +8741,9 @@ make it possible to take advantage of Kotlin reified type parameters.
 
 [[boot-features-kotlin-dependency-management]]
 === Dependency management
-In order to avoid mixing different version of Kotlin dependencies on the classpath,
-dependency management of the following Kotlin dependencies is provided:
-
- - `kotlin-reflect`
- - `kotlin-runtime`
- - `kotlin-stdlib`
- - `kotlin-stdlib-jdk7`
- - `kotlin-stdlib-jdk8`
- - `kotlin-stdlib-jre7`
- - `kotlin-stdlib-jre8`
+In order to avoid mixing different versions of Kotlin dependencies on the classpath,
+https://search.maven.org/artifact/org.jetbrains.kotlin/kotlin-bom/[Kotlin BOM] is
+included in Spring Boot dependency management to set the version of Kotlin dependencies.
 
 With Maven, the Kotlin version can be customized via the `kotlin.version` property and
 plugin management is provided for `kotlin-maven-plugin`. With Gradle, the Spring Boot
@@ -8760,35 +8753,24 @@ plugin automatically aligns the `kotlin.version` with the version of the Kotlin 
 
 [[boot-features-kotlin-configuration-properties]]
 === `@ConfigurationProperties`
-`@ConfigurationProperties` currently only works with `lateinit` or nullable `var`
-properties (the former is recommended), since immutable classes initialized by
-constructors are {github-issues}8762[not yet supported].
+As of Spring Boot 2.2, `@ConfigurationProperties` supports classes with immutable `val` properties.
 
 [source,kotlin,indent=0]
 ----
 @ConfigurationProperties("example.kotlin")
-class KotlinExampleProperties {
+data class KotlinExampleProperties(
+		val name: String,
+		val description: String,
+		val myService: MyService
+)
 
-	lateinit var name: String
-
-	lateinit var description: String
-
-	val myService = MyService()
-
-	class MyService {
-
-		lateinit var apiToken: String
-
-		lateinit var uri: URI
-
-	}
-
-}
+data class MyService(
+	val apiToken: String,
+	val uri: URI
+)
 ----
 
-TIP: To generate <<appendix.adoc#configuration-metadata-annotation-processor,your own
-metadata>> using the annotation processor, {kotlin-documentation}kapt.html[`kapt` should
-be configured] with the `spring-boot-configuration-processor` dependency.
+WARNING: <<appendix.adoc#configuration-metadata-annotation-processor,Metadata>> is not working yet.
 
 
 [[boot-features-kotlin-testing]]


### PR DESCRIPTION
This commit updates Kotlin reference documentation according to latest features like immutable `@ConfigurationProperties` and Kotlin BOM support.