### PR TITLE
Use file: URL rather than jar:file: URL to speed up exploded application launch

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/archive/ExplodedArchive.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/archive/ExplodedArchive.java
@@ -117,7 +117,7 @@ public class ExplodedArchive implements Archive {
 	protected Archive getNestedArchive(Entry entry) throws IOException {
 		File file = ((FileEntry) entry).getFile();
 		return (file.isDirectory() ? new ExplodedArchive(file)
-				: new JarFileArchive(file));
+				: new JarFileArchive(file, file.toURI().toURL()));
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/JarLauncherTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/JarLauncherTests.java
@@ -44,9 +44,7 @@ public class JarLauncherTests extends AbstractExecutableArchiveLauncherTests {
 		assertThat(archives).hasSize(2);
 		assertThat(getUrls(archives)).containsOnly(
 				new File(explodedRoot, "BOOT-INF/classes").toURI().toURL(),
-				new URL("jar:"
-						+ new File(explodedRoot, "BOOT-INF/lib/foo.jar").toURI().toURL()
-						+ "!/"));
+				new File(explodedRoot, "BOOT-INF/lib/foo.jar").toURI().toURL());
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/PropertiesLauncherTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/PropertiesLauncherTests.java
@@ -142,7 +142,7 @@ public class PropertiesLauncherTests {
 		assertThat(ReflectionTestUtils.getField(launcher, "paths").toString())
 				.isEqualTo("[jars/]");
 		List<Archive> archives = launcher.getClassPathArchives();
-		assertThat(archives).areExactly(1, endingWith("app.jar!/"));
+		assertThat(archives).areExactly(1, endingWith("app.jar"));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/WarLauncherTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/WarLauncherTests.java
@@ -44,9 +44,7 @@ public class WarLauncherTests extends AbstractExecutableArchiveLauncherTests {
 		assertThat(archives).hasSize(2);
 		assertThat(getUrls(archives)).containsOnly(
 				new File(explodedRoot, "WEB-INF/classes").toURI().toURL(),
-				new URL("jar:"
-						+ new File(explodedRoot, "WEB-INF/lib/foo.jar").toURI().toURL()
-						+ "!/"));
+				new File(explodedRoot, "WEB-INF/lib/foo.jar").toURI().toURL());
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/archive/ExplodedArchiveTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/archive/ExplodedArchiveTests.java
@@ -127,7 +127,7 @@ public class ExplodedArchiveTests {
 		Entry entry = getEntriesMap(this.archive).get("nested.jar");
 		Archive nested = this.archive.getNestedArchive(entry);
 		assertThat(nested.getUrl().toString())
-				.isEqualTo("jar:" + this.rootFolder.toURI() + "nested.jar!/");
+				.isEqualTo(this.rootFolder.toURI() + "nested.jar");
 	}
 
 	@Test


### PR DESCRIPTION
Convert the jar file URL to file URL. 

For example, convert `jar:file:demo.jar` to `file:demo.jar`.

In URLClassLoader, file URL is faster than jar file URL.