### PR TITLE
Switch FaviconRequestHandler visibility to package private

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
@@ -449,8 +449,7 @@ public class WebMvcAutoConfiguration {
 
 		}
 
-		static final class FaviconRequestHandler
-				extends ResourceHttpRequestHandler {
+		static final class FaviconRequestHandler extends ResourceHttpRequestHandler {
 
 			FaviconRequestHandler(List<Resource> locations) {
 				setLocations(locations);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
@@ -449,10 +449,10 @@ public class WebMvcAutoConfiguration {
 
 		}
 
-		private static final class FaviconRequestHandler
+		static final class FaviconRequestHandler
 				extends ResourceHttpRequestHandler {
 
-			private FaviconRequestHandler(List<Resource> locations) {
+			FaviconRequestHandler(List<Resource> locations) {
 				setLocations(locations);
 			}
 


### PR DESCRIPTION
This PR makes `WebMvcAutoConfiguration.FaviconRequestHandler` class package private.
I havnt wrote any unit tests for this as its a keyword `private` remove. But I am open to any unit tests suggestions.

thank you.