### PR TITLE
Logfile endpoint cannot be disabled using the standard property

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.actuate.autoconfigure.logging;
 
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnEnabledEndpoint;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnExposedEndpoint;
 import org.springframework.boot.actuate.logging.LogFileWebEndpoint;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
@@ -40,6 +42,8 @@ import org.springframework.util.StringUtils;
  * @since 2.0.0
  */
 @Configuration(proxyBeanMethods = false)
+@ConditionalOnEnabledEndpoint(endpoint = LogFileWebEndpoint.class)
+@ConditionalOnExposedEndpoint(endpoint = LogFileWebEndpoint.class)
 @EnableConfigurationProperties(LogFileWebEndpointProperties.class)
 public class LogFileWebEndpointAutoConfiguration {
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/logging/LogFileWebEndpointAutoConfigurationTests.java
@@ -89,7 +89,16 @@ public class LogFileWebEndpointAutoConfigurationTests {
 				.withPropertyValues("logging.file.name:test.log",
 						"management.endpoint.logfile.enabled:false")
 				.run((context) -> assertThat(context)
-						.hasSingleBean(LogFileWebEndpoint.class));
+						.doesNotHaveBean(LogFileWebEndpoint.class));
+	}
+
+	@Test
+	public void logFileWebEndpointCanBeExcluded() {
+		this.contextRunner
+				.withPropertyValues("logging.file.name:test.log",
+						"management.endpoints.web.exposure.exclude=logfile")
+				.run((context) -> assertThat(context)
+						.doesNotHaveBean(LogFileWebEndpoint.class));
 	}
 
 	@Test


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Currently in the project _spring-boot-actuator-autoconfigure 2.1.3_ there is no way to declaratively disable _logfile_ endpoint if _logging.file_ property exists. 
So this PR is created to _logfile_ actuator behave as other actuators.
And while i was fixing tests I had noticed that the test's method name was "logFileWebEndpointCanBeDisabled" whereas it tests bean creation.
