### PR TITLE
Use HTTPS for external links from XML files where possible

### DIFF
--- a/.settings-template.xml
+++ b/.settings-template.xml
@@ -1,6 +1,6 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
 	<profiles>
 		<profile>
 			<id>snapshot</id>

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/META-INF/mappings/non-annotated.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/META-INF/mappings/non-annotated.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <entity-mappings xmlns="http://xmlns.jcp.org/xml/ns/persistence/orm"
 				 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-				 xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence/orm http://xmlns.jcp.org/xml/ns/persistence/orm_2_1.xsd"
+				 xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence/orm https://www.oracle.com/webfolder/technetwork/jsc/xml/ns/persistence/orm_2_1.xsd"
 				 version="2.1">
 	<entity class="org.springframework.boot.autoconfigure.orm.jpa.mapping.NonAnnotatedEntity">
 		<table name="NON_ANNOTATED"/>

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/META-INF/persistence.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/META-INF/persistence.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+<persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
 	<persistence-unit name="manually-configured">
 		<class>org.springframework.boot.autoconfigure.orm.jpa.test.City</class>
 		<exclude-unlisted-classes>true</exclude-unlisted-classes>

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/db/changelog/db.changelog-override.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/db/changelog/db.changelog-override.xml
@@ -3,8 +3,8 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
-        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
     <changeSet id="1" author="marceloverdijk">
         <createTable tableName="customer">

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/early-init-test.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/early-init-test.xml
@@ -2,7 +2,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="earlyInit" class="org.springframework.boot.autoconfigure.EarlyInitFactoryBean" >
 		<property name="propertyFromConfig" value="${foo}" />

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/ehcache3.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/ehcache3.xml
@@ -3,8 +3,8 @@
 		xmlns='http://www.ehcache.org/v3'
 		xmlns:jsr107='http://www.ehcache.org/v3/jsr107'
 		xsi:schemaLocation="
-        http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.1.xsd
-        http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.1.xsd">
+        http://www.ehcache.org/v3 https://www.ehcache.org/schema/ehcache-core-3.1.xsd
+        http://www.ehcache.org/v3/jsr107 https://www.ehcache.org/schema/ehcache-107-ext-3.1.xsd">
 
 	<cache-template name="example">
 		<heap unit="entries">200</heap>

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/condition/factorybean.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/condition/factorybean.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="example"
 		class="org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBeanTests.ExampleFactoryBean">

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/condition/foo.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/condition/foo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="foo" class="java.lang.String">
 		<constructor-arg value="foo" />

--- a/spring-boot-project/spring-boot-cli/samples/runner.xml
+++ b/spring-boot-project/spring-boot-cli/samples/runner.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="runner" class="org.test.Runner"/>
 

--- a/spring-boot-project/spring-boot-cli/src/main/assembly/jar-with-dependencies.xml
+++ b/spring-boot-project/spring-boot-cli/src/main/assembly/jar-with-dependencies.xml
@@ -2,7 +2,7 @@
 <assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 https://maven.apache.org/xsd/assembly-1.1.2.xsd">
 	<id>full</id>
 	<formats>
 		<format>jar</format>

--- a/spring-boot-project/spring-boot-cli/src/test/resources/.m2/settings.xml
+++ b/spring-boot-project/spring-boot-cli/src/test/resources/.m2/settings.xml
@@ -1,12 +1,12 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-		http://maven.apache.org/xsd/settings-1.0.0.xsd">
+		https://maven.apache.org/xsd/settings-1.0.0.xsd">
 
 	<mirrors>
 		<mirror>
 			<id>central-mirror</id>
-			<url>http://central-mirror.example.com/maven2</url>
+			<url>https://central-mirror.example.com/maven2</url>
 			<mirrorOf>central</mirrorOf>
 		</mirror>
 	</mirrors>

--- a/spring-boot-project/spring-boot-cli/src/test/resources/maven-settings/active-profile-repositories/.m2/settings.xml
+++ b/spring-boot-project/spring-boot-cli/src/test/resources/maven-settings/active-profile-repositories/.m2/settings.xml
@@ -3,7 +3,7 @@
 	<mirrors>
 		<mirror>
 			<id>my-mirror</id>
-			<url>http://maven.example.com/mirror</url>
+			<url>https://maven.example.com/mirror</url>
 			<mirrorOf>my-server</mirrorOf>
 		</mirror>
 	</mirrors>

--- a/spring-boot-project/spring-boot-cli/src/test/resources/maven-settings/basic/.m2/settings.xml
+++ b/spring-boot-project/spring-boot-cli/src/test/resources/maven-settings/basic/.m2/settings.xml
@@ -3,7 +3,7 @@
 	<mirrors>
 		<mirror>
 			<id>my-mirror</id>
-			<url>http://maven.example.com/mirror</url>
+			<url>https://maven.example.com/mirror</url>
 			<mirrorOf>my-server</mirrorOf>
 		</mirror>
 	</mirrors>
@@ -39,7 +39,7 @@
 	    	<repositories>
 	        	<repository>
 	            	<id>example-repository</id>
-	            	<url>http://repo.example.com</url>
+	            	<url>https://repo.example.com</url>
 	        	</repository>
 	    	</repositories>
 		</profile>

--- a/spring-boot-project/spring-boot-cli/src/test/resources/maven-settings/encrypted/.m2/settings.xml
+++ b/spring-boot-project/spring-boot-cli/src/test/resources/maven-settings/encrypted/.m2/settings.xml
@@ -3,7 +3,7 @@
 	<mirrors>
 		<mirror>
 			<id>my-mirror</id>
-			<url>http://maven.example.com/mirror</url>
+			<url>https://maven.example.com/mirror</url>
 			<mirrorOf>my-server</mirrorOf>
 		</mirror>
 	</mirrors>

--- a/spring-boot-project/spring-boot-cli/src/test/resources/maven-settings/property-interpolation/.m2/settings.xml
+++ b/spring-boot-project/spring-boot-cli/src/test/resources/maven-settings/property-interpolation/.m2/settings.xml
@@ -1,7 +1,7 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-		http://maven.apache.org/xsd/settings-1.0.0.xsd">
+		https://maven.apache.org/xsd/settings-1.0.0.xsd">
 
 	<localRepository>${foo}/repository</localRepository>
 

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl-config.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl-config.xml
@@ -19,5 +19,5 @@
 	<highlighter id="properties" file="./xslthl/properties-hl.xml" />
 	<highlighter id="json" file="./xslthl/json-hl.xml" />
 	<highlighter id="yaml" file="./xslthl/yaml-hl.xml" />
-	<namespace prefix="xslthl" uri="http://xslthl.sf.net" />
+	<namespace prefix="xslthl" uri="http://xslthl.sourceforge.net/" />
 </xslthl-config>

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/bourne-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/bourne-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for SH
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2010 Mathieu Malaterre
 
 This software is provided 'as-is', without any express or implied

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/c-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/c-hl.xml
@@ -3,7 +3,7 @@
 Syntax highlighting definition for C
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/cpp-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/cpp-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for C++
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/csharp-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/csharp-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for C#
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/css-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/css-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for CSS files
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2011-2012 Martin Hujer, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied
@@ -26,7 +26,7 @@ freely, subject to the following restrictions:
 Martin Hujer <mhujer at users.sourceforge.net>
 Michiel Hendriks <elmuerte at users.sourceforge.net>
 
-Reference: http://www.w3.org/TR/CSS21/propidx.html
+Reference: https://www.w3.org/TR/CSS21/propidx.html
 
 -->
 <highlighters>

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/html-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/html-hl.xml
@@ -7,7 +7,7 @@
   myxml-hl.xml - konfigurace zvyraznovace XML, ktera zvlast zvyrazni
                  HTML elementy a XSL elementy
 
-  This file has been customized for the Asciidoctor project (http://asciidoctor.org).
+  This file has been customized for the Asciidoctor project (https://asciidoctor.org).
 -->
 <highlighters>
   <highlighter type="xml">

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/ini-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/ini-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for ini files
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/java-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/java-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for Java
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/javascript-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/javascript-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for JavaScript
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/perl-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/perl-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for Perl
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/php-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/php-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for PHP
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/properties-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/properties-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for Java
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/python-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/python-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for Python
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/ruby-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/ruby-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for Ruby
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/sql2003-hl.xml
+++ b/spring-boot-project/spring-boot-docs/src/main/docbook/xsl/xslthl/sql2003-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for SQL:1999
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2012 Michiel Hendriks, Martin Hujer, k42b3
 
 This software is provided 'as-is', without any express or implied

--- a/spring-boot-project/spring-boot-starters/src/main/assembly/starter-poms-assembly.xml
+++ b/spring-boot-project/spring-boot-starters/src/main/assembly/starter-poms-assembly.xml
@@ -1,6 +1,6 @@
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd">
 	<id>starter-poms</id>
 	<formats>
 		<format>zip</format>

--- a/spring-boot-project/spring-boot-test/src/test/resources/org/springframework/boot/test/SpringApplicationConfigurationXmlConventionConfigurationTests-context.xml
+++ b/spring-boot-project/spring-boot-test/src/test/resources/org/springframework/boot/test/SpringApplicationConfigurationXmlConventionConfigurationTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<bean id="foo" class="java.lang.String">
 		<constructor-arg>

--- a/spring-boot-project/spring-boot-test/src/test/resources/org/springframework/boot/test/context/SpringBootTestXmlConventionConfigurationTests-context.xml
+++ b/spring-boot-project/spring-boot-test/src/test/resources/org/springframework/boot/test/context/SpringBootTestXmlConventionConfigurationTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<bean id="foo" class="java.lang.String">
 		<constructor-arg>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-jar/src/main/assembly/jar-with-dependencies.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-jar/src/main/assembly/jar-with-dependencies.xml
@@ -2,7 +2,7 @@
 <assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 https://maven.apache.org/xsd/assembly-1.1.2.xsd">
 	<id>full</id>
 	<formats>
 		<format>jar</format>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-props-lib/src/main/assembly/app.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-props-lib/src/main/assembly/app.xml
@@ -2,7 +2,7 @@
 <assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 https://maven.apache.org/xsd/assembly-1.1.2.xsd">
 	<id>app</id>
 	<formats>
 		<format>jar</format>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-props-lib/src/main/assembly/dependencies.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-props-lib/src/main/assembly/dependencies.xml
@@ -2,7 +2,7 @@
 <assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 https://maven.apache.org/xsd/assembly-1.1.2.xsd">
 	<id>dependencies</id>
 	<formats>
 		<format>jar</format>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-props/src/main/assembly/jar-with-dependencies.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-props/src/main/assembly/jar-with-dependencies.xml
@@ -2,7 +2,7 @@
 <assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 https://maven.apache.org/xsd/assembly-1.1.2.xsd">
 	<id>full</id>
 	<formats>
 		<format>jar</format>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/resources/root/META-INF/spring/application.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/resources/root/META-INF/spring/application.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 </beans>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/site/site.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/site/site.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/DECORATION/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 https://maven.apache.org/xsd/decoration-1.0.0.xsd">
 	<body>
 		<menu name="Overview">
 			<item name="Introduction" href="index.html"/>

--- a/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/context/embedded/tomcat/empty-web.xml
+++ b/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/context/embedded/tomcat/empty-web.xml
@@ -2,5 +2,5 @@
 <web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-	http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+	https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
 </web-app>

--- a/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/context/properties/testProperties.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/context/properties/testProperties.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean
 		id="org.springframework.boot.context.properties.ConfigurationPropertiesTests$BasicProperties"

--- a/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/diagnostics/analyzer/nounique/consumer.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/diagnostics/analyzer/nounique/consumer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean class="org.springframework.boot.diagnostics.analyzer.nounique.TestBeanConsumer"/>
 

--- a/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/diagnostics/analyzer/nounique/producer.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/diagnostics/analyzer/nounique/producer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean class="org.springframework.boot.diagnostics.analyzer.nounique.TestBean" name="xmlTestBean"/>
 

--- a/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/sample-beans.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/sample-beans.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<bean id="myXmlComponent" class="org.springframework.boot.sampleconfig.MyComponent"/>
 </beans>

--- a/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/web/servlet/context/exampleEmbeddedWebApplicationConfiguration.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/web/servlet/context/exampleEmbeddedWebApplicationConfiguration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean name="servletContainerFactory"
 		class="org.springframework.boot.web.servlet.server.MockServletWebServerFactory" />

--- a/spring-boot-samples/spring-boot-sample-cache/src/main/resources/ehcache3.xml
+++ b/spring-boot-samples/spring-boot-sample-cache/src/main/resources/ehcache3.xml
@@ -1,8 +1,8 @@
 <config xmlns='http://www.ehcache.org/v3'
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:jsr107="http://www.ehcache.org/v3/jsr107"
-		xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd
-							http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd">
+		xsi:schemaLocation="http://www.ehcache.org/v3 https://www.ehcache.org/schema/ehcache-core-3.0.xsd
+							http://www.ehcache.org/v3/jsr107 https://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd">
 	<cache alias="countries">
 		<expiry>
 			<ttl unit="seconds">600</ttl>

--- a/spring-boot-samples/spring-boot-sample-traditional/src/main/webapp/WEB-INF/web.xml
+++ b/spring-boot-samples/spring-boot-sample-traditional/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 
 	<servlet>
 		<servlet-name>appServlet</servlet-name>

--- a/spring-boot-samples/spring-boot-sample-xml/src/main/resources/META-INF/application-context.xml
+++ b/spring-boot-samples/spring-boot-sample-xml/src/main/resources/META-INF/application-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:annotation-config/>
 	<context:property-placeholder/>

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/test/resources/pom-template.xml
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/test/resources/pom-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>

--- a/src/checkstyle/import-control.xml
+++ b/src/checkstyle/import-control.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE import-control PUBLIC "-//Puppy Crawl//DTD Import Control 1.1//EN" "http://www.puppycrawl.com/dtds/import_control_1_1.dtd">
+<!DOCTYPE import-control PUBLIC "-//Puppy Crawl//DTD Import Control 1.1//EN" "https://www.puppycrawl.com/dtds/import_control_1_1.dtd">
 <import-control pkg="org.springframework.boot">
 	<allow pkg=".*" regex="true" />
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://xslthl.sf.net (301) with 1 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://central-mirror.example.com/maven2 (UnknownHostException) with 1 occurrences migrated to:  
  https://central-mirror.example.com/maven2 ([https](https://central-mirror.example.com/maven2) result UnknownHostException).
* [ ] http://maven.example.com/mirror (UnknownHostException) with 3 occurrences migrated to:  
  https://maven.example.com/mirror ([https](https://maven.example.com/mirror) result UnknownHostException).
* [ ] http://repo.example.com (UnknownHostException) with 1 occurrences migrated to:  
  https://repo.example.com ([https](https://repo.example.com) result UnknownHostException).
* [ ] http://www.puppycrawl.com/dtds/import_control_1_1.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/import_control_1_1.dtd ([https](https://www.puppycrawl.com/dtds/import_control_1_1.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://asciidoctor.org with 1 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* [ ] http://maven.apache.org/xsd/assembly-1.1.2.xsd with 5 occurrences migrated to:  
  https://maven.apache.org/xsd/assembly-1.1.2.xsd ([https](https://maven.apache.org/xsd/assembly-1.1.2.xsd) result 200).
* [ ] http://maven.apache.org/xsd/assembly-1.1.3.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/assembly-1.1.3.xsd ([https](https://maven.apache.org/xsd/assembly-1.1.3.xsd) result 200).
* [ ] http://maven.apache.org/xsd/decoration-1.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/decoration-1.0.0.xsd ([https](https://maven.apache.org/xsd/decoration-1.0.0.xsd) result 200).
* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* [ ] http://maven.apache.org/xsd/settings-1.0.0.xsd with 3 occurrences migrated to:  
  https://maven.apache.org/xsd/settings-1.0.0.xsd ([https](https://maven.apache.org/xsd/settings-1.0.0.xsd) result 200).
* [ ] http://sourceforge.net/projects/xslthl/ with 14 occurrences migrated to:  
  https://sourceforge.net/projects/xslthl/ ([https](https://sourceforge.net/projects/xslthl/) result 200).
* [ ] http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd with 1 occurrences migrated to:  
  https://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd ([https](https://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd) result 200).
* [ ] http://www.ehcache.org/schema/ehcache-107-ext-3.1.xsd with 1 occurrences migrated to:  
  https://www.ehcache.org/schema/ehcache-107-ext-3.1.xsd ([https](https://www.ehcache.org/schema/ehcache-107-ext-3.1.xsd) result 200).
* [ ] http://www.ehcache.org/schema/ehcache-core-3.0.xsd with 1 occurrences migrated to:  
  https://www.ehcache.org/schema/ehcache-core-3.0.xsd ([https](https://www.ehcache.org/schema/ehcache-core-3.0.xsd) result 200).
* [ ] http://www.ehcache.org/schema/ehcache-core-3.1.xsd with 1 occurrences migrated to:  
  https://www.ehcache.org/schema/ehcache-core-3.1.xsd ([https](https://www.ehcache.org/schema/ehcache-core-3.1.xsd) result 200).
* [ ] http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd with 1 occurrences migrated to:  
  https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd ([https](https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd) result 200).
* [ ] http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd with 1 occurrences migrated to:  
  https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd ([https](https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd) result 200).
* [ ] http://xmlns.jcp.org/xml/ns/persistence/orm_2_1.xsd (301) with 1 occurrences migrated to:  
  https://www.oracle.com/webfolder/technetwork/jsc/xml/ns/persistence/orm_2_1.xsd ([https](https://xmlns.jcp.org/xml/ns/persistence/orm_2_1.xsd) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 13 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* [ ] http://www.w3.org/TR/CSS21/propidx.html with 1 occurrences migrated to:  
  https://www.w3.org/TR/CSS21/propidx.html ([https](https://www.w3.org/TR/CSS21/propidx.html) result 200).
* [ ] http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd ([https](https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd) result 302).
* [ ] http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd ([https](https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd) result 302).
* [ ] http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/persistence/persistence_2_0.xsd ([https](https://java.sun.com/xml/ns/persistence/persistence_2_0.xsd) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/dtd/properties.dtd with 1 occurrences
* http://java.sun.com/xml/ns/javaee with 4 occurrences
* http://java.sun.com/xml/ns/persistence with 2 occurrences
* http://localhost with 1 occurrences
* http://maven.apache.org/DECORATION/1.0.0 with 2 occurrences
* http://maven.apache.org/POM/4.0.0 with 470 occurrences
* http://maven.apache.org/SETTINGS/1.0.0 with 8 occurrences
* http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 with 10 occurrences
* http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 with 2 occurrences
* http://www.ehcache.org/v3 with 4 occurrences
* http://www.ehcache.org/v3/jsr107 with 4 occurrences
* http://www.hazelcast.com/schema/client-config with 2 occurrences
* http://www.hazelcast.com/schema/config with 16 occurrences
* http://www.liquibase.org/xml/ns/dbchangelog with 2 occurrences
* http://www.liquibase.org/xml/ns/dbchangelog-ext with 2 occurrences
* http://www.springframework.org/schema/beans with 26 occurrences
* http://www.springframework.org/schema/context with 8 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 276 occurrences
* http://xmlns.jcp.org/xml/ns/persistence/orm with 2 occurrences