### PR TITLE
URL Cleanup

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/docs/SCRAPBOOK.md
+++ b/docs/docs/SCRAPBOOK.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/docs/autoconfig.md
+++ b/docs/docs/autoconfig.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/docs/howto.md
+++ b/docs/docs/howto.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#howto
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#howto

--- a/docs/spring-boot-actuator/README.md
+++ b/docs/spring-boot-actuator/README.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/spring-boot-actuator/docs/Features.md
+++ b/docs/spring-boot-actuator/docs/Features.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/spring-boot-autoconfigure/README.md
+++ b/docs/spring-boot-autoconfigure/README.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/spring-boot-cli/README.md
+++ b/docs/spring-boot-cli/README.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/spring-boot-samples/README.md
+++ b/docs/spring-boot-samples/README.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/spring-boot-starters/README.md
+++ b/docs/spring-boot-starters/README.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/spring-boot-tools/README.md
+++ b/docs/spring-boot-tools/README.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/spring-boot-tools/spring-boot-gradle-plugin/README.md
+++ b/docs/spring-boot-tools/spring-boot-gradle-plugin/README.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/spring-boot-tools/spring-boot-loader-tools/README.md
+++ b/docs/spring-boot-tools/spring-boot-loader-tools/README.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/spring-boot-tools/spring-boot-loader/README.md
+++ b/docs/spring-boot-tools/spring-boot-loader/README.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/spring-boot-tools/spring-boot-maven-plugin/README.md
+++ b/docs/spring-boot-tools/spring-boot-maven-plugin/README.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/docs/spring-boot/README.md
+++ b/docs/spring-boot/README.md
@@ -3,4 +3,4 @@ layout: documentation_page
 ---
 # Documentation has been moved
 
-Please see http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/
+Please see https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/

--- a/index.html
+++ b/index.html
@@ -2,10 +2,10 @@
 <html lang="en-US">
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="http://spring.io/projects/spring-boot">
-  <meta http-equiv="refresh" content="0; url=http://spring.io/projects/spring-boot">
+  <link rel="canonical" href="https://spring.io/projects/spring-boot">
+  <meta http-equiv="refresh" content="0; url=https://spring.io/projects/spring-boot">
   <meta name="robots" content="noindex">
   <h1>Redirecting&hellip;</h1>
-  <a href="http://spring.io/projects/spring-boot">Click here if you are not redirected.</a>
-  <script>location="http://spring.io/projects/spring-boot"</script>
+  <a href="https://spring.io/projects/spring-boot">Click here if you are not redirected.</a>
+  <script>location="https://spring.io/projects/spring-boot"</script>
 </html>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/ (301) with 17 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://spring.io/projects/spring-boot with 4 occurrences migrated to:  
  https://spring.io/projects/spring-boot ([https](https://spring.io/projects/spring-boot) result 200).