### PR TITLE
fix issue: #13622

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfiguration.java
@@ -84,7 +84,7 @@ public class GsonAutoConfiguration {
 					.toCall(builder::generateNonExecutableJson);
 			map.from(properties::getExcludeFieldsWithoutExposeAnnotation)
 					.toCall(builder::excludeFieldsWithoutExposeAnnotation);
-			map.from(properties::getSerializeNulls).toCall(builder::serializeNulls);
+			map.from(properties::getSerializeNulls).whenTrue().toCall(builder::serializeNulls);
 			map.from(properties::getEnableComplexMapKeySerialization)
 					.toCall(builder::enableComplexMapKeySerialization);
 			map.from(properties::getDisableInnerClassSerialization)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfigurationTests.java
@@ -89,6 +89,15 @@ public class GsonAutoConfigurationTests {
 	}
 
 	@Test
+	public void serializeNulls() {
+		this.contextRunner.withPropertyValues("spring.gson.serialize-nulls:false")
+				.run((context) -> {
+					Gson gson = context.getBean(Gson.class);
+					assertThat(gson.serializeNulls()).isFalse();
+				});
+	}
+
+	@Test
 	public void enableComplexMapKeySerialization() {
 		this.contextRunner
 				.withPropertyValues(


### PR DESCRIPTION
the serialize null should be false when set `spring.gson.serialize-nulls=false`

fix issue: #13622

test case:

```
@Test
	public void serializeNulls() {
		this.contextRunner.withPropertyValues("spring.gson.serialize-nulls:false")
				.run((context) -> {
					Gson gson = context.getBean(Gson.class);
					assertThat(gson.serializeNulls()).isFalse();
				});
	}

```