### PR TITLE
Restore setExtractBareNamePropertyMethods() for AssertJ

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfigurationTests.java
@@ -413,23 +413,25 @@ public class WebFluxAutoConfigurationTests {
 
 	@Test
 	public void cachePeriod() {
+		Assertions.setExtractBareNamePropertyMethods(false);
 		this.contextRunner.withPropertyValues("spring.resources.cache.period:5")
 				.run((context) -> {
 					Map<PathPattern, Object> handlerMap = getHandlerMap(context);
 					assertThat(handlerMap).hasSize(2);
 					for (Object handler : handlerMap.values()) {
 						if (handler instanceof ResourceWebHandler) {
-							Assertions.setExtractBareNamePropertyMethods(false);
 							assertThat(((ResourceWebHandler) handler).getCacheControl())
 									.isEqualToComparingFieldByField(
 											CacheControl.maxAge(5, TimeUnit.SECONDS));
 						}
 					}
 				});
+		Assertions.setExtractBareNamePropertyMethods(true);
 	}
 
 	@Test
 	public void cacheControl() {
+		Assertions.setExtractBareNamePropertyMethods(false);
 		this.contextRunner
 				.withPropertyValues("spring.resources.cache.cachecontrol.max-age:5",
 						"spring.resources.cache.cachecontrol.proxy-revalidate:true")
@@ -438,7 +440,6 @@ public class WebFluxAutoConfigurationTests {
 					assertThat(handlerMap).hasSize(2);
 					for (Object handler : handlerMap.values()) {
 						if (handler instanceof ResourceWebHandler) {
-							Assertions.setExtractBareNamePropertyMethods(false);
 							assertThat(((ResourceWebHandler) handler).getCacheControl())
 									.isEqualToComparingFieldByField(
 											CacheControl.maxAge(5, TimeUnit.SECONDS)
@@ -446,6 +447,7 @@ public class WebFluxAutoConfigurationTests {
 						}
 					}
 				});
+		Assertions.setExtractBareNamePropertyMethods(true);
 	}
 
 	private Map<PathPattern, Object> getHandlerMap(ApplicationContext context) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR changes to restore `setExtractBareNamePropertyMethods()` for AssertJ.