### PR TITLE
Add Spring-specific styling to Actuator's API documentation

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
@@ -14,6 +14,7 @@
 	<description>Spring Boot Actuator AutoConfigure</description>
 	<properties>
 		<main.basedir>${basedir}/../..</main.basedir>
+		<refdocs.build.directory>${project.build.directory}/refdocs/</refdocs.build.directory>
 	</properties>
 	<dependencies>
 		<!-- Compile -->
@@ -636,6 +637,24 @@
 			<build>
 				<plugins>
 					<plugin>
+						<groupId>com.googlecode.maven-download-plugin</groupId>
+						<artifactId>download-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>unpack-doc-resources</id>
+								<phase>generate-resources</phase>
+								<goals>
+									<goal>wget</goal>
+								</goals>
+								<configuration>
+									<url>https://repo.spring.io/release/io/spring/docresources/spring-doc-resources/${spring-doc-resources.version}/spring-doc-resources-${spring-doc-resources.version}.zip</url>
+									<unpack>true</unpack>
+									<outputDirectory>${refdocs.build.directory}</outputDirectory>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-antrun-plugin</artifactId>
 						<dependencies>
@@ -732,7 +751,18 @@
 									<goal>process-asciidoc</goal>
 								</goals>
 								<configuration>
-									<backend>html</backend>
+									<backend>html5</backend>
+									<sourceHighlighter>highlight.js</sourceHighlighter>
+									<doctype>book</doctype>
+									<attributes>
+										<highlightjsdir>js/highlight</highlightjsdir>
+										<highlightjs-theme>atom-one-dark-reasonable</highlightjs-theme>
+										<linkcss>true</linkcss>
+										<imagesdir>./images</imagesdir>
+										<icons>font</icons>
+										<stylesdir>css/</stylesdir>
+										<stylesheet>spring.css</stylesheet>
+									</attributes>
 								</configuration>
 							</execution>
 							<execution>
@@ -747,7 +777,8 @@
 							</execution>
 						</executions>
 						<configuration>
-							<sourceDocumentName>index.adoc</sourceDocumentName>
+							<sourceDirectory>${refdocs.build.directory}</sourceDirectory>
+							<outputDirectory>${project.build.directory}/generated-docs/reference/html</outputDirectory>
 							<attributes>
 								<version-type>${version-type}</version-type>
 								<version>${project.version}</version>
@@ -761,6 +792,28 @@
 								<version>1.5.0-alpha.11</version>
 							</dependency>
 						</dependencies>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-resources-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>copy-asciidoc-resources</id>
+								<phase>generate-resources</phase>
+								<goals>
+									<goal>copy-resources</goal>
+								</goals>
+								<configuration>
+									<outputDirectory>${refdocs.build.directory}</outputDirectory>
+									<resources>
+										<resource>
+											<directory>src/main/asciidoc</directory>
+											<filtering>false</filtering>
+										</resource>
+									</resources>
+								</configuration>
+							</execution>
+						</executions>
 					</plugin>
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/asciidoc/index.adoc
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/asciidoc/index.adoc
@@ -7,6 +7,7 @@ Andy Wilkinson
 :numbered:
 :icons: font
 :hide-uri-scheme:
+:docinfo: shared,private
 
 This API documentation describes Spring Boot Actuators web endpoints.
 


### PR DESCRIPTION
This commit replaces the default Asciidoctor styling with
Spring specific styling.

First, we need to unzip the contents of the Spring Asciidoctor
documentation resources provided by the
`io.spring.docsresources:spring-docs-resources` distribution zip. This
is done in a `/target/refdocs` folder. We then copy all files from
`src/main/asciidoc` to the same location, and then launch the generation
process.

Closes https://github.com/spring-projects/spring-boot/issues/15991.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
