### PR TITLE
(Obvious Fix) Add dependency management for JUnit Jupiter Aggregator

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -2504,6 +2504,12 @@
 				<type>pom</type>
 			</dependency>
 			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter</artifactId>
+				<version>${junit-jupiter.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.jvnet.mimepull</groupId>
 				<artifactId>mimepull</artifactId>
 				<version>${mimepull.version}</version>


### PR DESCRIPTION
Obvious Fix
## Enhancement

Additionally to [_JUnit Bom_](https://mvnrepository.com/artifact/org.junit/junit-bom) starting from version `5.4.0` the project provides [_JUnit Jupiter (Aggregator)_](https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter) dependency, which simplifies dependency management for common cases, e.g. when one needs only `api+engine+params`, which seems to be the most common case. Gradle example:
  - now:
    ```
    dependencies {
         testImplementation 'org.junit.jupiter:junit-jupiter-api'
         testImplementation 'org.junit.jupiter:junit-jupiter-params'
         testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
    }
    ```
  - after enhancement:
    ```
    dependencies {
        testImplementation 'org.junit.jupiter:junit-jupiter'
    }
    ```
**Note:** in the PR for new added `org.junit.jupiter:junit-jupiter` dependency I reused the same _`${junit-jupiter.version}`_ as for `org.junit:junit-bom`

### More detailed information:
  
  - [_JUnit Jupiter (Aggregator)_ on Maven Central](https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter)
    - [POM](http://central.maven.org/maven2/org/junit/jupiter/junit-jupiter/5.4.0/junit-jupiter-5.4.0.pom)
  - [JUnit subproject sources](https://github.com/junit-team/junit5/blob/master/junit-jupiter/junit-jupiter.gradle.kts)
  - [Blog post with usage example](https://sormuras.github.io/blog/2018-12-26-junit-jupiter-aggregator.html)

