### PR TITLE
Disable nulls serialization when spring.gson.serialize-nulls is set to false

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfiguration.java
@@ -84,7 +84,8 @@ public class GsonAutoConfiguration {
 					.toCall(builder::generateNonExecutableJson);
 			map.from(properties::getExcludeFieldsWithoutExposeAnnotation)
 					.toCall(builder::excludeFieldsWithoutExposeAnnotation);
-			map.from(properties::getSerializeNulls).toCall(builder::serializeNulls);
+			map.from(properties::getSerializeNulls).whenTrue()
+					.toCall(builder::serializeNulls);
 			map.from(properties::getEnableComplexMapKeySerialization)
 					.toCall(builder::enableComplexMapKeySerialization);
 			map.from(properties::getDisableInnerClassSerialization)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfigurationTests.java
@@ -80,11 +80,20 @@ public class GsonAutoConfigurationTests {
 	}
 
 	@Test
-	public void serializeNulls() {
+	public void serializeNullsTrue() {
 		this.contextRunner.withPropertyValues("spring.gson.serialize-nulls:true")
 				.run((context) -> {
 					Gson gson = context.getBean(Gson.class);
 					assertThat(gson.serializeNulls()).isTrue();
+				});
+	}
+
+	@Test
+	public void serializeNullsFalse() {
+		this.contextRunner.withPropertyValues("spring.gson.serialize-nulls:false")
+				.run((context) -> {
+					Gson gson = context.getBean(Gson.class);
+					assertThat(gson.serializeNulls()).isFalse();
 				});
 	}
 


### PR DESCRIPTION
fix: #13622

gson should not serialize null value when set `spring.gson.serialize-nulls=false`

test case:

```
       @Test
	public void serializeNullsFalse() {
		this.contextRunner.withPropertyValues("spring.gson.serialize-nulls:false")
				.run((context) -> {
					Gson gson = context.getBean(Gson.class);
					assertThat(gson.serializeNulls()).isFalse();
				});
	}
```
