### PR TITLE
ThymeleafAutoConfiguration fails if thymeleaf-spring5 is not present

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration.java
@@ -76,7 +76,7 @@ import org.springframework.web.servlet.resource.ResourceUrlEncodingFilter;
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(ThymeleafProperties.class)
-@ConditionalOnClass(TemplateMode.class)
+@ConditionalOnClass({ TemplateMode.class, SpringTemplateEngine.class })
 @AutoConfigureAfter({ WebMvcAutoConfiguration.class, WebFluxAutoConfiguration.class })
 public class ThymeleafAutoConfiguration {
 


### PR DESCRIPTION
This commit adds an extra check for the presence of thymeleaf-spring5
library on the classpath. Since now ThymeleafAutoConfiguration is
considered only if both thymeleaf-spring5 and thymeleaf jars are present.

gh-16079
