### PR TITLE
Check for Reactor Netty disconnected client errors

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/AbstractErrorWebExceptionHandler.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/AbstractErrorWebExceptionHandler.java
@@ -64,7 +64,8 @@ public abstract class AbstractErrorWebExceptionHandler
 	 * Currently duplicated from Spring WebFlux HttpWebHandlerAdapter.
 	 */
 	private static final Set<String> DISCONNECTED_CLIENT_EXCEPTIONS = new HashSet<>(
-			Arrays.asList("ClientAbortException", "EOFException", "EofException"));
+			Arrays.asList("AbortedException", "ClientAbortException", "EOFException",
+					"EofException"));
 
 	private static final Log logger = HttpLogging
 			.forLogName(AbstractErrorWebExceptionHandler.class);
@@ -268,8 +269,12 @@ public abstract class AbstractErrorWebExceptionHandler
 
 	private boolean isDisconnectedClientError(Throwable ex) {
 		String message = NestedExceptionUtils.getMostSpecificCause(ex).getMessage();
-		if (message != null && message.toLowerCase().contains("broken pipe")) {
-			return true;
+		if (message != null) {
+			String text = message.toLowerCase();
+			if (text.contains("broken pipe")
+					|| text.contains("connection reset by peer")) {
+				return true;
+			}
 		}
 		return DISCONNECTED_CLIENT_EXCEPTIONS.contains(ex.getClass().getSimpleName());
 	}


### PR DESCRIPTION
This PR changes to check for Reactor Netty disconnected client errors by syncing from https://github.com/spring-projects/spring-framework/commit/5f111098b1fae1d2c61334abd4bba0398269c9f8.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
