### PR TITLE
Optimize JavaBeanBinder

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/JavaBeanBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/JavaBeanBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,8 @@ class JavaBeanBinder implements BeanBinder {
 	@Override
 	public <T> T bind(ConfigurationPropertyName name, Bindable<T> target, Context context,
 			BeanPropertyBinder propertyBinder) {
-		boolean hasKnownBindableProperties = hasKnownBindableProperties(name, context);
+		boolean hasKnownBindableProperties = target.getValue() != null
+				&& hasKnownBindableProperties(name, context);
 		Bean<T> bean = Bean.get(target, hasKnownBindableProperties);
 		if (bean == null) {
 			return null;


### PR DESCRIPTION
Hi,

I'm currently working on some improvements for #16401. While I have some more stuff that I want to try out, there is an optimization possibility in `JavaBeanBinder` that skips some costly checks, which I want to get out already. This shows the following results when I test it with @wilkinsona's benchmark harness:

|       | Baseline |  New  |
| ----- | -------: | ----: |
|       |    14.824 | 12.224 |
|       |    13.320 | 12.324 |
|       |    14.376 | 13.065 |
|       |    14.902 | 13.218 |
|       |    15.523 | 12.692 |
|       |    14.849 | 14.740 |
|       |    13.884 | 12.450 |
|       |    14.202 | 15.886 |
|       |    14.793 | 12.219 |
|       |    15.091 | 12.556 |
|  Mean |    14.576 | 13.137 |
| Range |    2.203 | 3.667 |

Let me know what you think.
Cheers,
Christoph