### PR TITLE
SolrHealthIndicator reports down when baseUrl references a core instead of the root context

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/solr/SolrHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/solr/SolrHealthIndicator.java
@@ -91,8 +91,8 @@ public class SolrHealthIndicator extends AbstractHealthIndicator {
 			}
 		}
 		Status status = (statusCode != 0) ? Status.DOWN : Status.UP;
-		builder.status(status).withDetail("status", statusCode)
-				.withDetail("detectedPathType", this.detectedPathType.toString());
+		builder.status(status).withDetail("status", statusCode).withDetail("detectedPathType",
+				this.detectedPathType.toString());
 	}
 
 	private int doCoreAdminCheck() throws IOException, SolrServerException {
@@ -106,7 +106,7 @@ public class SolrHealthIndicator extends AbstractHealthIndicator {
 		return this.solrClient.ping().getStatus();
 	}
 
-	private enum PathType {
+	enum PathType {
 
 		ROOT, PARTICULAR_CORE, UNKNOWN
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/solr/SolrHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/solr/SolrHealthIndicator.java
@@ -17,6 +17,8 @@
 package org.springframework.boot.actuate.solr;
 
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.CoreAdminRequest;
 import org.apache.solr.client.solrj.response.CoreAdminResponse;
 import org.apache.solr.common.params.CoreAdminParams;
@@ -25,31 +27,89 @@ import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.actuate.health.Status;
+import org.springframework.http.HttpStatus;
+
+import java.io.IOException;
 
 /**
  * {@link HealthIndicator} for Apache Solr.
  *
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author Markus Schuch
  * @since 2.0.0
  */
 public class SolrHealthIndicator extends AbstractHealthIndicator {
 
 	private final SolrClient solrClient;
 
+	private PathType detectedPathType = PathType.UNKNOWN;
+
 	public SolrHealthIndicator(SolrClient solrClient) {
 		super("Solr health check failed");
 		this.solrClient = solrClient;
 	}
 
-	@Override
 	protected void doHealthCheck(Health.Builder builder) throws Exception {
+		int statusCode;
+
+		if (detectedPathType == PathType.ROOT) {
+			statusCode = doCoreAdminCheck();
+		}
+		else if (detectedPathType == PathType.PARTICULAR_CORE) {
+			statusCode = doPingCheck();
+		}
+		else {
+			// We do not know yet, which is the promising
+			// health check strategy, so we start trying with
+			// a CoreAdmin check, which is the common case
+			try {
+				statusCode = doCoreAdminCheck();
+				// When the CoreAdmin request returns with a
+				// valid response, we can assume that this
+				// SolrClient is configured with a baseUrl
+				// pointing to the root path of the Solr instance
+				detectedPathType = PathType.ROOT;
+			}
+			catch (HttpSolrClient.RemoteSolrException e) {
+				// CoreAdmin requests to not work with
+				// SolrClients configured with a baseUrl pointing to
+				// a particular core and a 404 response indicates
+				// that this might be the case.
+				if (e.code() == HttpStatus.NOT_FOUND.value()) {
+					statusCode = doPingCheck();
+					// When the SolrPing returns with a valid
+					// response, we can assume that the baseUrl
+					// of this SolrClient points to a particular core
+					detectedPathType = PathType.PARTICULAR_CORE;
+				}
+				else {
+					// Rethrow every other response code leaving us
+					// in the dark about the type of the baseUrl
+					throw e;
+				}
+			}
+		}
+		Status status = statusCode != 0 ? Status.DOWN : Status.UP;
+		builder.status(status).withDetail("status", statusCode)
+				.withDetail("detectedPathType", detectedPathType.toString());
+	}
+
+	private int doCoreAdminCheck() throws IOException, SolrServerException {
 		CoreAdminRequest request = new CoreAdminRequest();
 		request.setAction(CoreAdminParams.CoreAdminAction.STATUS);
 		CoreAdminResponse response = request.process(this.solrClient);
-		int statusCode = response.getStatus();
-		Status status = (statusCode != 0) ? Status.DOWN : Status.UP;
-		builder.status(status).withDetail("status", statusCode);
+		return response.getStatus();
+	}
+
+	private int doPingCheck() throws IOException, SolrServerException {
+		return this.solrClient.ping().getStatus();
+	}
+
+	private enum PathType {
+
+		ROOT, PARTICULAR_CORE, UNKNOWN
+
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/solr/SolrHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/solr/SolrHealthIndicatorTests.java
@@ -34,7 +34,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
  * Tests for {@link SolrHealthIndicator}
@@ -60,8 +63,7 @@ class SolrHealthIndicatorTests {
 		Health health = healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
 		assertThat(health.getDetails().get("status")).isEqualTo(0);
-		assertThat(health.getDetails().get("detectedPathType"))
-				.isEqualTo(SolrHealthIndicator.PathType.ROOT.toString());
+		assertThat(health.getDetails().get("detectedPathType")).isEqualTo(SolrHealthIndicator.PathType.ROOT.toString());
 		verify(solrClient, times(1)).request(any(CoreAdminRequest.class), isNull());
 		verifyNoMoreInteractions(solrClient);
 	}
@@ -94,9 +96,8 @@ class SolrHealthIndicatorTests {
 		verify(solrClient, times(1)).request(any(CoreAdminRequest.class), isNull());
 		verify(solrClient, times(1)).ping();
 		verifyNoMoreInteractions(solrClient);
-		reset(solrClient);
 		healthIndicator.health();
-		verify(solrClient, times(1)).ping();
+		verify(solrClient, times(2)).ping();
 		verifyNoMoreInteractions(solrClient);
 	}
 
@@ -108,15 +109,13 @@ class SolrHealthIndicatorTests {
 		Health health = healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
 		assertThat(health.getDetails().get("status")).isEqualTo(400);
-		assertThat(health.getDetails().get("detectedPathType"))
-				.isEqualTo(SolrHealthIndicator.PathType.ROOT.toString());
+		assertThat(health.getDetails().get("detectedPathType")).isEqualTo(SolrHealthIndicator.PathType.ROOT.toString());
 		verify(solrClient, times(1)).request(any(CoreAdminRequest.class), isNull());
 		verifyNoMoreInteractions(solrClient);
 	}
 
 	@Test
-	void solrIsUpAndRequestFailedWithBaseUrlPointsToParticularCore()
-			throws Exception {
+	void solrIsUpAndRequestFailedWithBaseUrlPointsToParticularCore() throws Exception {
 		SolrClient solrClient = mock(SolrClient.class);
 		given(solrClient.request(any(CoreAdminRequest.class), isNull()))
 				.willThrow(new HttpSolrClient.RemoteSolrException("mock", 404, "", null));


### PR DESCRIPTION
Added heuristic approach to fallback to SolrPing if CoreAdmin request returns a 404 which might indicate the SolrClient's baseUrl points to a particular core

Fixes gh-16256