### PR TITLE
Separate compound properties in appendices

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-docs/src/main/java/org/springframework/boot/configurationdocs/CompoundKeyEntry.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-docs/src/main/java/org/springframework/boot/configurationdocs/CompoundKeyEntry.java
@@ -46,9 +46,10 @@ class CompoundKeyEntry extends AbstractConfigurationEntry {
 
 	@Override
 	public void writeAsciidoc(StringBuilder builder) {
-		builder.append("|`+++");
-		this.configurationKeys.forEach((key) -> builder.append(key).append(NEWLINE));
-		builder.append("+++`").append(NEWLINE).append("|").append(NEWLINE).append("|+++")
+		builder.append("|");
+		this.configurationKeys.forEach((key) -> builder.append("`+").append(key)
+				.append("+`").append(" +").append(NEWLINE));
+		builder.append(NEWLINE).append("|").append(NEWLINE).append("|+++")
 				.append(this.description).append("+++").append(NEWLINE);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-docs/src/test/java/org/springframework/boot/configurationdocs/CompoundKeyEntryTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-docs/src/test/java/org/springframework/boot/configurationdocs/CompoundKeyEntryTests.java
@@ -49,9 +49,10 @@ public class CompoundKeyEntryTests {
 		StringBuilder builder = new StringBuilder();
 		entry.writeAsciidoc(builder);
 
-		assertThat(builder.toString()).isEqualTo("|`+++spring.test.first" + NEWLINE
-				+ "spring.test.second" + NEWLINE + "spring.test.third" + NEWLINE + "+++`"
-				+ NEWLINE + "|" + NEWLINE + "|+++This is a description.+++" + NEWLINE);
+		assertThat(builder.toString()).isEqualTo(
+				"|`+spring.test.first+` +" + NEWLINE + "`+spring.test.second+` +"
+						+ NEWLINE + "`+spring.test.third+` +" + NEWLINE + NEWLINE + "|"
+						+ NEWLINE + "|+++This is a description.+++" + NEWLINE);
 	}
 
 }


### PR DESCRIPTION
Hi,

I just noticed that compound properties in the current [appendices docs](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/html/appendix.html#common-application-properties) look a bit weird as they seem to be missing newlines and therefore make them hard to read. See the following screenshot for a better explanation:

![grafik](https://user-images.githubusercontent.com/6304496/55688244-c6554200-5976-11e9-8169-c894d8825273.png)

This PR is an attempt to fix this. To be honest I struggled a bit with asciidoc and the only way I found needs a change in https://github.com/spring-io/spring-doc-resources/pull/12 where I'm not sure about its side-effects.

Anyhow. If I apply the changes the table looks like this:
![grafik](https://user-images.githubusercontent.com/6304496/55688229-9443e000-5976-11e9-8e44-0ff4cecf6bce.png)

Let me know what you think. 
Cheers,
Christoph