### PR TITLE
Call MimeTypeUtils::parseMimeType earlier to improve performance

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/CompressionCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/CompressionCustomizer.java
@@ -17,7 +17,9 @@
 package org.springframework.boot.web.embedded.netty;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -64,6 +66,10 @@ final class CompressionCustomizer implements NettyServerCustomizer {
 		if (ObjectUtils.isEmpty(mimeTypes)) {
 			return ALWAYS_COMPRESS;
 		}
+
+		List<MimeType> mimeTypeList = Arrays.stream(mimeTypes).map(MimeTypeUtils::parseMimeType)
+				.collect(Collectors.toList());
+
 		return (request, response) -> {
 			String contentType = response.responseHeaders()
 					.get(HttpHeaderNames.CONTENT_TYPE);
@@ -71,7 +77,7 @@ final class CompressionCustomizer implements NettyServerCustomizer {
 				return false;
 			}
 			MimeType contentMimeType = MimeTypeUtils.parseMimeType(contentType);
-			return Arrays.stream(mimeTypes).map(MimeTypeUtils::parseMimeType)
+			return mimeTypeList.stream()
 					.anyMatch((candidate) -> candidate.isCompatibleWith(contentMimeType));
 		};
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/CompressionCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/CompressionCustomizer.java
@@ -67,8 +67,8 @@ final class CompressionCustomizer implements NettyServerCustomizer {
 			return ALWAYS_COMPRESS;
 		}
 
-		List<MimeType> mimeTypeList = Arrays.stream(mimeTypes).map(MimeTypeUtils::parseMimeType)
-				.collect(Collectors.toList());
+		List<MimeType> mimeTypeList = Arrays.stream(mimeTypes)
+				.map(MimeTypeUtils::parseMimeType).collect(Collectors.toList());
 
 		return (request, response) -> {
 			String contentType = response.responseHeaders()


### PR DESCRIPTION
Consider that `MimeTypeUtils.parseMimeType`'s performance is not very good, `MimeTypeUtils::parseMimeType` should be called earlier to avoid the cost. See also: https://github.com/spring-projects/spring-framework/pull/22598