### PR TITLE
Improve Spring Session DefaultCookieSerializer auto-configuration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionAutoConfiguration.java
@@ -56,6 +56,7 @@ import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.session.ReactiveSessionRepository;
 import org.springframework.session.Session;
 import org.springframework.session.SessionRepository;
+import org.springframework.session.security.web.authentication.SpringSessionRememberMeServices;
 import org.springframework.session.web.http.CookieHttpSessionIdResolver;
 import org.springframework.session.web.http.CookieSerializer;
 import org.springframework.session.web.http.DefaultCookieSerializer;
@@ -88,6 +89,14 @@ public class SessionAutoConfiguration {
 			SessionRepositoryFilterConfiguration.class })
 	static class ServletSessionConfiguration {
 
+		private final SpringSessionRememberMeServices springSessionRememberMeServices;
+
+		ServletSessionConfiguration(
+				ObjectProvider<SpringSessionRememberMeServices> springSessionRememberMeServices) {
+			this.springSessionRememberMeServices = springSessionRememberMeServices
+					.getIfAvailable();
+		}
+
 		@Bean
 		@Conditional(DefaultCookieSerializerCondition.class)
 		public DefaultCookieSerializer cookieSerializer(
@@ -102,6 +111,10 @@ public class SessionAutoConfiguration {
 			map.from(cookie::getSecure).to(cookieSerializer::setUseSecureCookie);
 			map.from(cookie::getMaxAge).to((maxAge) -> cookieSerializer
 					.setCookieMaxAge((int) maxAge.getSeconds()));
+			if (this.springSessionRememberMeServices != null) {
+				cookieSerializer.setRememberMeRequestAttribute(
+						SpringSessionRememberMeServices.REMEMBER_ME_LOGIN_ATTR);
+			}
 			return cookieSerializer;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
@@ -34,6 +34,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.session.MapSessionRepository;
 import org.springframework.session.SessionRepository;
 import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
+import org.springframework.session.security.web.authentication.SpringSessionRememberMeServices;
 import org.springframework.session.web.http.CookieHttpSessionIdResolver;
 import org.springframework.session.web.http.DefaultCookieSerializer;
 import org.springframework.session.web.http.HeaderHttpSessionIdResolver;
@@ -245,6 +246,19 @@ public class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurat
 						context.getBeansOfType(DefaultCookieSerializer.class)).isEmpty());
 	}
 
+	@Test
+	public void autoConfiguredCookieSerializerIsConfiguredWithRememberMeRequestAttribute() {
+		this.contextRunner
+				.withUserConfiguration(SpringSessionRememberMeServicesConfiguration.class)
+				.run((context) -> {
+					DefaultCookieSerializer cookieSerializer = context
+							.getBean(DefaultCookieSerializer.class);
+					assertThat(cookieSerializer).hasFieldOrPropertyWithValue(
+							"rememberMeRequestAttribute",
+							SpringSessionRememberMeServices.REMEMBER_ME_LOGIN_ATTR);
+				});
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	@EnableSpringHttpSession
 	static class SessionRepositoryConfiguration {
@@ -305,6 +319,18 @@ public class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurat
 		@Bean
 		public HttpSessionIdResolver httpSessionStrategy() {
 			return mock(HttpSessionIdResolver.class);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableSpringHttpSession
+	static class SpringSessionRememberMeServicesConfiguration
+			extends SessionRepositoryConfiguration {
+
+		@Bean
+		public SpringSessionRememberMeServices rememberMeServices() {
+			return new SpringSessionRememberMeServices();
 		}
 
 	}


### PR DESCRIPTION
Spring Session's own configuration support (i.e. `SpringHttpSessionConfiguration`) will configure the default `DefaultCookieSerializer` with `rememberMeRequestAttribute` if `SpringSessionRememberMeServices` bean has been detected in the application context.

In contrast, Spring Boot's auto-configured `DefaultCookieSerializer` does not do this which results in a different out-of-the-box experience for users that rely on Spring Session's remember-me integration.

This PR improves Spring Session `DefaultCookieSerializer` auto-configuration to match Spring Session's behavior and make the auto-configured `DefaultCookieSerializer` aware of `SpringSessionRememberMeServices` bean.