### PR TITLE
Fix package of java.time.Duration in documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -1442,7 +1442,7 @@ available:
 `@DurationUnit` has been specified)
 * The standard ISO-8601 format
 {java-javadoc}/java/time/Duration.html#parse-java.lang.CharSequence-[used by
-`java.util.Duration`]
+`java.time.Duration`]
 * A more readable format where the value and the unit are coupled (e.g. `10s` means 10
 seconds)
 


### PR DESCRIPTION
The discussed Duration class is actually in the `java.time` package.