### PR TITLE
Add annotation to support registering Jackson key serializer/deserializers

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponent.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponent.java
@@ -25,15 +25,16 @@ import java.lang.annotation.Target;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 
+import com.fasterxml.jackson.databind.KeyDeserializer;
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;
 
 /**
  * {@link Component} that provides {@link JsonSerializer} and/or {@link JsonDeserializer}
  * implementations to be registered with Jackson when {@link JsonComponentModule} is in
- * use. Can be used to annotate {@link JsonSerializer} or {@link JsonDeserializer}
- * implementations directly or a class that contains them as inner-classes. For example:
- * <pre class="code">
+ * use. Can be used to annotate {@link JsonSerializer}, {@link JsonDeserializer}, or
+ * {@link KeyDeserializer} implementations directly or a class that contains them as
+ * inner-classes. For example: <pre class="code">
  * &#064;JsonComponent
  * public class CustomerJsonComponent {
  *
@@ -72,20 +73,35 @@ public @interface JsonComponent {
 	String value() default "";
 
 	/**
-	 * Indicates whether the component should be registered as a type
-	 * serializer/deserializer or a key serializer/deserializer
+	 * Indicates whether the component should be registered as a type serializer and/or
+	 * deserializer or a key serializer and/or deserializer
 	 * @return the component's handle type
 	 */
 	Handle handle() default Handle.TYPES;
 
 	/**
+	 * Specify the classes handled by the serialization and/or deserialization of the
+	 * component. Necessary to be specified for a {@link KeyDeserializer}, as the type
+	 * cannot be inferred. On other types can be used to only handle a subset of
+	 * subclasses.
 	 * @return the classes that should be handled by the component
 	 */
 	Class<?>[] handleClasses() default {};
 
+	/**
+	 * An enumeration of possible handling types for the component
+	 */
 	enum Handle {
 
-		TYPES, KEYS
+		/**
+		 * Register the component as a Type serializer and/or deserializer
+		 */
+		TYPES,
+
+		/**
+		 * Register the component as a Key serializer and/or deserializer
+		 */
+		KEYS
 
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponent.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponent.java
@@ -72,14 +72,16 @@ public @interface JsonComponent {
 	String value() default "";
 
 	/**
-	 * Indicates whether the component should be registered as a type serializer/deserializer
-	 * or a key serializer/deserializer
+	 * Indicates whether the component should be registered as a type
+	 * serializer/deserializer or a key serializer/deserializer
 	 * @return the component's handle type
 	 */
 	Handle handle() default Handle.TYPES;
 
 	enum Handle {
-		TYPES,
-		KEYS
+
+		TYPES, KEYS
+
 	}
+
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponent.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponent.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Target;
 
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
-
 import com.fasterxml.jackson.databind.KeyDeserializer;
+
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;
 
@@ -74,7 +74,7 @@ public @interface JsonComponent {
 
 	/**
 	 * Indicates whether the component should be registered as a type serializer and/or
-	 * deserializer or a key serializer and/or deserializer
+	 * deserializer or a key serializer and/or deserializer.
 	 * @return the component's handle type
 	 */
 	Handle handle() default Handle.TYPES;
@@ -89,17 +89,17 @@ public @interface JsonComponent {
 	Class<?>[] handleClasses() default {};
 
 	/**
-	 * An enumeration of possible handling types for the component
+	 * An enumeration of possible handling types for the component.
 	 */
 	enum Handle {
 
 		/**
-		 * Register the component as a Type serializer and/or deserializer
+		 * Register the component as a Type serializer and/or deserializer.
 		 */
 		TYPES,
 
 		/**
-		 * Register the component as a Key serializer and/or deserializer
+		 * Register the component as a Key serializer and/or deserializer.
 		 */
 		KEYS
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponent.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponent.java
@@ -21,6 +21,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -77,6 +78,8 @@ public @interface JsonComponent {
 	 * @return the component's handle type
 	 */
 	Handle handle() default Handle.TYPES;
+
+	Class<?>[] handleClasses() default {};
 
 	enum Handle {
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponent.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponent.java
@@ -71,4 +71,15 @@ public @interface JsonComponent {
 	@AliasFor(annotation = Component.class)
 	String value() default "";
 
+	/**
+	 * Indicates whether the component should be registered as a type serializer/deserializer
+	 * or a key serializer/deserializer
+	 * @return the component's handle type
+	 */
+	Handle handle() default Handle.TYPES;
+
+	enum Handle {
+		TYPES,
+		KEYS
+	}
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponent.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponent.java
@@ -21,7 +21,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -79,6 +78,9 @@ public @interface JsonComponent {
 	 */
 	Handle handle() default Handle.TYPES;
 
+	/**
+	 * @return the classes that should be handled by the component
+	 */
 	Class<?>[] handleClasses() default {};
 
 	enum Handle {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
@@ -88,7 +88,8 @@ public class JsonComponentModule extends SimpleModule implements BeanFactoryAwar
 		for (Class<?> innerClass : bean.getClass().getDeclaredClasses()) {
 			if (!Modifier.isAbstract(innerClass.getModifiers())
 					&& (JsonSerializer.class.isAssignableFrom(innerClass)
-							|| JsonDeserializer.class.isAssignableFrom(innerClass))) {
+							|| JsonDeserializer.class.isAssignableFrom(innerClass)
+							|| StdKeyDeserializer.class.isAssignableFrom(innerClass))) {
 				try {
 					addJsonBean(innerClass.newInstance(), handle);
 				}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
@@ -68,8 +68,8 @@ public class JsonComponentModule extends SimpleModule implements BeanFactoryAwar
 		Map<String, Object> beans = beanFactory
 				.getBeansWithAnnotation(JsonComponent.class);
 		for (Object bean : beans.values()) {
-			JsonComponent annotation =
-					AnnotationUtils.findAnnotation(bean.getClass(), JsonComponent.class);
+			JsonComponent annotation = AnnotationUtils.findAnnotation(bean.getClass(),
+					JsonComponent.class);
 			addJsonBean(bean, annotation.handle());
 		}
 	}
@@ -96,18 +96,21 @@ public class JsonComponentModule extends SimpleModule implements BeanFactoryAwar
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	private <T> void addSerializerWithDeducedType(JsonSerializer<T> serializer, JsonComponent.Handle handle) {
+	private <T> void addSerializerWithDeducedType(JsonSerializer<T> serializer,
+			JsonComponent.Handle handle) {
 		ResolvableType type = ResolvableType.forClass(JsonSerializer.class,
 				serializer.getClass());
 		if (JsonComponent.Handle.KEYS.equals(handle)) {
 			addKeySerializer((Class<T>) type.resolveGeneric(), serializer);
-		} else {
+		}
+		else {
 			addSerializer((Class<T>) type.resolveGeneric(), serializer);
 		}
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	private <T> void addDeserializerWithDeducedType(JsonDeserializer<T> deserializer, JsonComponent.Handle handle) {
+	private <T> void addDeserializerWithDeducedType(JsonDeserializer<T> deserializer,
+			JsonComponent.Handle handle) {
 		ResolvableType type = ResolvableType.forClass(JsonDeserializer.class,
 				deserializer.getClass());
 		addDeserializer((Class<T>) type.resolveGeneric(), deserializer);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
@@ -24,6 +24,7 @@ import javax.annotation.PostConstruct;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import org.springframework.beans.BeansException;
@@ -78,8 +79,11 @@ public class JsonComponentModule extends SimpleModule implements BeanFactoryAwar
 		if (bean instanceof JsonSerializer) {
 			addSerializerWithDeducedType((JsonSerializer<?>) bean, handle);
 		}
+		if (bean instanceof StdKeyDeserializer) {
+			addKeyDeserializer((StdKeyDeserializer) bean);
+		}
 		if (bean instanceof JsonDeserializer) {
-			addDeserializerWithDeducedType((JsonDeserializer<?>) bean, handle);
+			addDeserializerWithDeducedType((JsonDeserializer<?>) bean);
 		}
 		for (Class<?> innerClass : bean.getClass().getDeclaredClasses()) {
 			if (!Modifier.isAbstract(innerClass.getModifiers())
@@ -109,11 +113,15 @@ public class JsonComponentModule extends SimpleModule implements BeanFactoryAwar
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	private <T> void addDeserializerWithDeducedType(JsonDeserializer<T> deserializer,
-			JsonComponent.Handle handle) {
+	private <T> void addDeserializerWithDeducedType(JsonDeserializer<T> deserializer) {
 		ResolvableType type = ResolvableType.forClass(JsonDeserializer.class,
 				deserializer.getClass());
 		addDeserializer((Class<T>) type.resolveGeneric(), deserializer);
+
+	}
+
+	private void addKeyDeserializer(StdKeyDeserializer deserializer) {
+		addKeyDeserializer(deserializer.getKeyClass(), deserializer);
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
@@ -91,7 +91,8 @@ public class JsonComponentModule extends SimpleModule implements BeanFactoryAwar
 					annotation.handleClasses());
 		}
 		if (bean instanceof JsonDeserializer) {
-			addDeserializerWithDeducedType((JsonDeserializer<?>) bean);
+			addDeserializerForTypes((JsonDeserializer<?>) bean,
+					currentAnnotation.handleClasses());
 		}
 		for (Class<?> innerClass : bean.getClass().getDeclaredClasses()) {
 			if (!Modifier.isAbstract(innerClass.getModifiers())
@@ -118,17 +119,29 @@ public class JsonComponentModule extends SimpleModule implements BeanFactoryAwar
 		if (ArrayUtils.isEmpty(types)) {
 			ResolvableType type = ResolvableType.forClass(JsonSerializer.class,
 					serializer.getClass());
-			addSerializerWithType(serializer, handle,
-					(Class<T>) type.resolveGeneric());
+			addSerializerWithType(serializer, handle, (Class<T>) type.resolveGeneric());
 		}
 	}
 
 	private <T> void addSerializerWithType(JsonSerializer<T> serializer,
-										   JsonComponent.Handle handle, Class<? extends T> type) {
+			JsonComponent.Handle handle, Class<? extends T> type) {
 		if (JsonComponent.Handle.KEYS.equals(handle)) {
 			addKeySerializer(type, serializer);
-		} else {
+		}
+		else {
 			addSerializer(type, serializer);
+		}
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	private <T> void addDeserializerForTypes(JsonDeserializer<T> deserializer,
+			Class<?>[] types) {
+		for (Class<?> type : types) {
+			addDeserializer((Class<T>) type, deserializer);
+		}
+
+		if (ArrayUtils.isEmpty(types)) {
+			addDeserializerWithDeducedType(deserializer);
 		}
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.jackson;
 
 import java.lang.reflect.Modifier;
-import java.util.Arrays;
 import java.util.Map;
 
 import javax.annotation.PostConstruct;
@@ -28,8 +27,6 @@ import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
-import kotlin.collections.ArraysKt;
-import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -84,7 +81,8 @@ public class JsonComponentModule extends SimpleModule implements BeanFactoryAwar
 			addSerializerWithDeducedType((JsonSerializer<?>) bean, handle);
 		}
 		if (bean instanceof KeyDeserializer) {
-			addKeyDeserializerForType((KeyDeserializer) bean, annotation.handleClasses());
+			addKeyDeserializerForTypes((KeyDeserializer) bean,
+					annotation.handleClasses());
 		}
 		if (bean instanceof JsonDeserializer) {
 			addDeserializerWithDeducedType((JsonDeserializer<?>) bean);
@@ -125,9 +123,9 @@ public class JsonComponentModule extends SimpleModule implements BeanFactoryAwar
 
 	}
 
-	private void addKeyDeserializerForType(KeyDeserializer deserializer,
-			Class<?>[] classes) {
-		for (Class<?> type : classes) {
+	private void addKeyDeserializerForTypes(KeyDeserializer deserializer,
+			Class<?>[] types) {
+		for (Class<?> type : types) {
 			addKeyDeserializer(type, deserializer);
 		}
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
@@ -18,7 +18,6 @@ package org.springframework.boot.jackson;
 
 import java.lang.reflect.Modifier;
 import java.util.Map;
-import java.util.Optional;
 
 import javax.annotation.PostConstruct;
 
@@ -28,7 +27,6 @@ import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -113,7 +111,7 @@ public class JsonComponentModule extends SimpleModule implements BeanFactoryAwar
 			addSerializerWithType(serializer, handle, (Class<T>) type);
 		}
 
-		if (ArrayUtils.isEmpty(types)) {
+		if (types.length == 0) {
 			ResolvableType type = ResolvableType.forClass(JsonSerializer.class,
 					serializer.getClass());
 			addSerializerWithType(serializer, handle, (Class<T>) type.resolveGeneric());
@@ -137,7 +135,7 @@ public class JsonComponentModule extends SimpleModule implements BeanFactoryAwar
 			addDeserializer((Class<T>) type, deserializer);
 		}
 
-		if (ArrayUtils.isEmpty(types)) {
+		if (types.length == 0) {
 			addDeserializerWithDeducedType(deserializer);
 		}
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
@@ -78,13 +78,9 @@ public class JsonComponentModule extends SimpleModule implements BeanFactoryAwar
 	}
 
 	private void addJsonBean(Object bean, JsonComponent annotation) {
-		JsonComponent currentAnnotation = Optional.ofNullable(
-				AnnotationUtils.findAnnotation(bean.getClass(), JsonComponent.class))
-				.orElse(annotation);
-
 		if (bean instanceof JsonSerializer) {
-			addSerializerForTypes((JsonSerializer<?>) bean, currentAnnotation.handle(),
-					currentAnnotation.handleClasses());
+			addSerializerForTypes((JsonSerializer<?>) bean, annotation.handle(),
+					annotation.handleClasses());
 		}
 		if (bean instanceof KeyDeserializer) {
 			addKeyDeserializerForTypes((KeyDeserializer) bean,
@@ -92,7 +88,7 @@ public class JsonComponentModule extends SimpleModule implements BeanFactoryAwar
 		}
 		if (bean instanceof JsonDeserializer) {
 			addDeserializerForTypes((JsonDeserializer<?>) bean,
-					currentAnnotation.handleClasses());
+					annotation.handleClasses());
 		}
 		for (Class<?> innerClass : bean.getClass().getDeclaredClasses()) {
 			if (!Modifier.isAbstract(innerClass.getModifiers())

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponentModule.java
@@ -42,6 +42,7 @@ import org.springframework.core.annotation.AnnotationUtils;
  * beans.
  *
  * @author Phillip Webb
+ * @author Paul Aly
  * @since 1.4.0
  * @see JsonComponent
  */

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.After;
 import org.junit.Test;
-import org.springframework.boot.jackson.JsonComponent.Handle;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.io.IOException;
@@ -198,13 +197,14 @@ public class JsonComponentModuleTests {
 
 	}
 
-	@JsonComponent(handle = Handle.KEYS)
+	@JsonComponent(handle = JsonComponent.Handle.KEYS)
 	static class OnlyKeySerializer extends NameAndAgeJsonKeyComponent.Serializer {
 
 	}
 
-	@JsonComponent(handle = Handle.KEYS, handleClasses = NameAndAge.class)
+	@JsonComponent(handle = JsonComponent.Handle.KEYS, handleClasses = NameAndAge.class)
 	static class OnlyKeyDeserializer extends NameAndAgeJsonKeyComponent.Deserializer {
 
 	}
+
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
@@ -103,24 +103,8 @@ public class JsonComponentModuleTests {
 	}
 
 	@Test
-	public void moduleShouldRegisterSerializersForSpecifiedClasses() throws Exception {
-		load(NameJsonComponent.NameSerializer.class);
-		JsonComponentModule module = this.context.getBean(JsonComponentModule.class);
-		assertSerialize(module, new NameAndCareer("spring", "developer"),
-				"{\"name\":\"spring\"}");
-		assertSerialize(module);
-	}
-
-	@Test
-	public void moduleShouldRegisterDeserializersForSpecifiedClasses() throws Exception {
-		load(NameJsonComponent.NameDeserializer.class);
-		JsonComponentModule module = this.context.getBean(JsonComponentModule.class);
-		assertDeserializeForSpecifiedClasses(module);
-	}
-
-	@Test
-	public void moduleShouldRespectAnnotationsOnInnerClasses() throws Exception {
-		load(NameJsonComponent.class);
+	public void moduleShouldRegisterOnlyForSpecifiedClasses() throws Exception {
+		load(NameAndCareerJsonComponent.class);
 		JsonComponentModule module = this.context.getBean(JsonComponentModule.class);
 		assertSerialize(module, new NameAndCareer("spring", "developer"),
 				"{\"name\":\"spring\"}");
@@ -222,5 +206,4 @@ public class JsonComponentModuleTests {
 	static class OnlyKeyDeserializer extends NameAndAgeJsonKeyComponent.Deserializer {
 
 	}
-
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  *
  * @author Phillip Webb
  * @author Vladimir Tsanev
+ * @author Paul Aly
  */
 public class JsonComponentModuleTests {
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
@@ -16,17 +16,18 @@
 
 package org.springframework.boot.jackson;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.After;
 import org.junit.Test;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
@@ -173,7 +173,7 @@ public class JsonComponentModuleTests {
 
 	}
 
-	@JsonComponent(handle = Handle.KEYS)
+	@JsonComponent(handle = Handle.KEYS, handleClasses = NameAndAge.class)
 	static class OnlyKeyDeserializer extends NameAndAgeJsonKeyComponent.Deserializer {
 
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
@@ -129,8 +129,10 @@ public class JsonComponentModuleTests {
 	private void assertKeyDeserialize(Module module) throws IOException {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.registerModule(module);
-		TypeReference<Map<NameAndAge, Boolean>> typeRef = new TypeReference<Map<NameAndAge, Boolean>>() {};
-		Map<NameAndAge, Boolean> map = mapper.readValue("{\"spring is 100\":  true}", typeRef);
+		TypeReference<Map<NameAndAge, Boolean>> typeRef = new TypeReference<Map<NameAndAge, Boolean>>() {
+		};
+		Map<NameAndAge, Boolean> map = mapper.readValue("{\"spring is 100\":  true}",
+				typeRef);
 		assertThat(map).containsEntry(new NameAndAge("spring", 100), true);
 	}
 
@@ -167,4 +169,5 @@ public class JsonComponentModuleTests {
 	static class OnlyKeyDeserializer extends NameAndAgeJsonKeyComponent.Deserializer {
 
 	}
+
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.After;
 import org.junit.Test;
-
 import org.springframework.boot.jackson.JsonComponent.Handle;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
@@ -101,6 +100,14 @@ public class JsonComponentModuleTests {
 		assertKeyDeserialize(module);
 	}
 
+	@Test
+	public void moduleShouldRegisterSerializersForSpecifiedClasses() throws Exception {
+		load(NameJsonComponent.NameSerializer.class);
+		JsonComponentModule module = this.context.getBean(JsonComponentModule.class);
+		assertSerialize(module, new NameAndCareer("spring", "developer"), "{\"name\":\"spring\"}");
+		assertSerialize(module);
+	}
+
 	private void load(Class<?>... configs) {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 		context.register(configs);
@@ -109,11 +116,16 @@ public class JsonComponentModuleTests {
 		this.context = context;
 	}
 
-	private void assertSerialize(Module module) throws Exception {
+	private void assertSerialize(Module module, Name value, String expectedJson)
+			throws Exception {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.registerModule(module);
-		String json = mapper.writeValueAsString(new NameAndAge("spring", 100));
-		assertThat(json).isEqualToIgnoringWhitespace("{\"name\":\"spring\",\"age\":100}");
+		String json = mapper.writeValueAsString(value);
+		assertThat(json).isEqualToIgnoringWhitespace(expectedJson);
+	}
+
+	private void assertSerialize(Module module) throws Exception {
+		assertSerialize(module, new NameAndAge("spring", 100), "{\"name\":\"spring\",\"age\":100}");
 	}
 
 	private void assertDeserialize(Module module) throws Exception {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
@@ -29,7 +29,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * Tests for {@link JsonComponentModule}.
@@ -119,7 +120,12 @@ public class JsonComponentModuleTests {
 
 	@Test
 	public void moduleShouldRespectAnnotationsOnInnerClasses() throws Exception {
-
+		load(NameJsonComponent.class);
+		JsonComponentModule module = this.context.getBean(JsonComponentModule.class);
+		assertSerialize(module, new NameAndCareer("spring", "developer"),
+				"{\"name\":\"spring\"}");
+		assertSerialize(module);
+		assertDeserializeForSpecifiedClasses(module);
 	}
 
 	private void load(Class<?>... configs) {
@@ -152,12 +158,14 @@ public class JsonComponentModuleTests {
 		assertThat(nameAndAge.getAge()).isEqualTo(100);
 	}
 
-	private void assertDeserializeForSpecifiedClasses(JsonComponentModule module) throws IOException {
+	private void assertDeserializeForSpecifiedClasses(JsonComponentModule module)
+			throws IOException {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.registerModule(module);
 		assertThatExceptionOfType(JsonMappingException.class).isThrownBy(() -> mapper
 				.readValue("{\"name\":\"spring\",\"age\":100}", NameAndAge.class));
-		NameAndCareer nameAndCareer = mapper.readValue("{\"name\":\"spring\",\"career\":\"developer\"}", NameAndCareer.class);
+		NameAndCareer nameAndCareer = mapper.readValue(
+				"{\"name\":\"spring\",\"career\":\"developer\"}", NameAndCareer.class);
 		assertThat(nameAndCareer.getName()).isEqualTo("spring");
 		assertThat(nameAndCareer.getCareer()).isEqualTo("developer");
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonComponentModuleTests.java
@@ -93,6 +93,14 @@ public class JsonComponentModuleTests {
 		assertKeyDeserialize(module);
 	}
 
+	@Test
+	public void moduleShouldRegisterInnerClassesForKeyHandlers() throws Exception {
+		load(NameAndAgeJsonKeyComponent.class);
+		JsonComponentModule module = this.context.getBean(JsonComponentModule.class);
+		assertKeySerialize(module);
+		assertKeyDeserialize(module);
+	}
+
 	private void load(Class<?>... configs) {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 		context.register(configs);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/Name.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/Name.java
@@ -6,6 +6,7 @@ package org.springframework.boot.jackson;
  * @author Paul Aly
  */
 public class Name {
+
 	protected final String name;
 
 	public Name(String name) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/Name.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/Name.java
@@ -1,0 +1,14 @@
+package org.springframework.boot.jackson;
+
+public class Name {
+	protected final String name;
+
+	public Name(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/Name.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/Name.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.jackson;
 
 /**

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/Name.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/Name.java
@@ -1,5 +1,10 @@
 package org.springframework.boot.jackson;
 
+/**
+ * Sample object used for tests.
+ *
+ * @author Paul Aly
+ */
 public class Name {
 	protected final String name;
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAge.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAge.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.jackson;
 
+import org.springframework.util.ObjectUtils;
+
 /**
  * Sample object used for tests.
  *
@@ -49,4 +51,34 @@ public final class NameAndAge {
 	public String asKey() {
 		return name + " is " + age;
 	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+
+		if (obj instanceof NameAndAge) {
+			NameAndAge other = (NameAndAge) obj;
+			boolean rtn = true;
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.name, other.name);
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.age, other.age);
+			return rtn;
+		}
+
+		return super.equals(obj);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ObjectUtils.nullSafeHashCode(this.name);
+		result = prime * result + ObjectUtils.nullSafeHashCode(this.age);
+		return result;
+	}
+
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAge.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAge.java
@@ -23,19 +23,13 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Phillip Webb
  */
-public final class NameAndAge {
-
-	private final String name;
+public final class NameAndAge extends Name {
 
 	private final int age;
 
 	public NameAndAge(String name, int age) {
-		this.name = name;
+		super(name);
 		this.age = age;
-	}
-
-	public String getName() {
-		return this.name;
 	}
 
 	public int getAge() {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAge.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAge.java
@@ -34,12 +34,6 @@ public final class NameAndAge {
 		this.age = age;
 	}
 
-	public NameAndAge(String nameAndAge) {
-		String[] keys = nameAndAge.split("is");
-		this.name = keys[0].trim();
-		this.age = Integer.valueOf(keys[1].trim());
-	}
-
 	public String getName() {
 		return this.name;
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAge.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAge.java
@@ -32,6 +32,12 @@ public final class NameAndAge {
 		this.age = age;
 	}
 
+	public NameAndAge(String nameAndAge) {
+		String[] keys = nameAndAge.split("is");
+		this.name = keys[0].trim();
+		this.age = Integer.valueOf(keys[1].trim());
+	}
+
 	public String getName() {
 		return this.name;
 	}
@@ -40,4 +46,7 @@ public final class NameAndAge {
 		return this.age;
 	}
 
+	public String asKey() {
+		return name + " is " + age;
+	}
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
@@ -14,15 +14,21 @@ public class NameAndAgeJsonKeyComponent {
 	public static class Serializer extends JsonSerializer<NameAndAge> {
 
 		@Override
-		public void serialize(NameAndAge value, JsonGenerator jgen, SerializerProvider serializers) throws IOException {
+		public void serialize(NameAndAge value, JsonGenerator jgen,
+				SerializerProvider serializers) throws IOException {
 			jgen.writeFieldName(value.asKey());
 		}
+
 	}
 
 	public static class Deserializer extends KeyDeserializer {
+
 		@Override
-		public NameAndAge deserializeKey(String key, DeserializationContext ctxt) throws IOException {
+		public NameAndAge deserializeKey(String key, DeserializationContext ctxt)
+				throws IOException {
 			return new NameAndAge(key);
 		}
+
 	}
+
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
@@ -3,12 +3,12 @@ package org.springframework.boot.jackson;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializer;
 
 import java.io.IOException;
 
-@JsonComponent(handle = JsonComponent.Handle.KEYS)
+@JsonComponent(handle = JsonComponent.Handle.KEYS, handleClasses = NameAndAge.class)
 public class NameAndAgeJsonKeyComponent {
 
 	public static class Serializer extends JsonSerializer<NameAndAge> {
@@ -21,11 +21,7 @@ public class NameAndAgeJsonKeyComponent {
 
 	}
 
-	public static class Deserializer extends StdKeyDeserializer {
-
-		protected Deserializer() {
-			super(TYPE_CLASS, NameAndAge.class);
-		}
+	public static class Deserializer extends KeyDeserializer {
 
 		@Override
 		public NameAndAge deserializeKey(String key, DeserializationContext ctxt)

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
@@ -1,5 +1,21 @@
 package org.springframework.boot.jackson;
 
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonSerializer;

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
@@ -1,0 +1,28 @@
+package org.springframework.boot.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+@JsonComponent(handle = JsonComponent.Handle.KEYS)
+public class NameAndAgeJsonKeyComponent {
+
+	public static class Serializer extends JsonSerializer<NameAndAge> {
+
+		@Override
+		public void serialize(NameAndAge value, JsonGenerator jgen, SerializerProvider serializers) throws IOException {
+			jgen.writeString(value.asKey());
+		}
+	}
+
+	public static class Deserializer extends KeyDeserializer {
+		@Override
+		public NameAndAge deserializeKey(String key, DeserializationContext ctxt) throws IOException {
+			return new NameAndAge(key);
+		}
+	}
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
@@ -1,5 +1,3 @@
-package org.springframework.boot.jackson;
-
 /*
  * Copyright 2012-2017 the original author or authors.
  *
@@ -16,13 +14,15 @@ package org.springframework.boot.jackson;
  * limitations under the License.
  */
 
+package org.springframework.boot.jackson;
+
+import java.io.IOException;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-
-import java.io.IOException;
 
 /**
  * Sample {@link JsonComponent} used for tests.

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
@@ -3,8 +3,8 @@ package org.springframework.boot.jackson;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializer;
 
 import java.io.IOException;
 
@@ -21,12 +21,17 @@ public class NameAndAgeJsonKeyComponent {
 
 	}
 
-	public static class Deserializer extends KeyDeserializer {
+	public static class Deserializer extends StdKeyDeserializer {
+
+		protected Deserializer() {
+			super(TYPE_CLASS, NameAndAge.class);
+		}
 
 		@Override
 		public NameAndAge deserializeKey(String key, DeserializationContext ctxt)
 				throws IOException {
-			return new NameAndAge(key);
+			String[] keys = key.split("is");
+			return new NameAndAge(keys[0].trim(), Integer.valueOf(keys[1].trim()));
 		}
 
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
@@ -15,7 +15,7 @@ public class NameAndAgeJsonKeyComponent {
 
 		@Override
 		public void serialize(NameAndAge value, JsonGenerator jgen, SerializerProvider serializers) throws IOException {
-			jgen.writeString(value.asKey());
+			jgen.writeFieldName(value.asKey());
 		}
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndAgeJsonKeyComponent.java
@@ -8,6 +8,11 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 
+/**
+ * Sample {@link JsonComponent} used for tests.
+ *
+ * @author Paul Aly
+ */
 @JsonComponent(handle = JsonComponent.Handle.KEYS, handleClasses = NameAndAge.class)
 public class NameAndAgeJsonKeyComponent {
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareer.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareer.java
@@ -31,7 +31,7 @@ public class NameAndCareer extends Name {
 	}
 
 	public String getCareer() {
-		return career;
+		return this.career;
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareer.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareer.java
@@ -1,5 +1,10 @@
 package org.springframework.boot.jackson;
 
+/**
+ * Sample object used for tests.
+ *
+ * @author Paul Aly
+ */
 public class NameAndCareer extends Name {
 
 	private final String career;

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareer.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareer.java
@@ -17,4 +17,5 @@ public class NameAndCareer extends Name {
 	public String getCareer() {
 		return career;
 	}
+
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareer.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.jackson;
 
 /**

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareer.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareer.java
@@ -1,0 +1,15 @@
+package org.springframework.boot.jackson;
+
+public class NameAndCareer extends Name {
+
+	private final String career;
+
+	public NameAndCareer(String name, String career) {
+		super(name);
+		this.career = career;
+	}
+
+	public String getCareer() {
+		return career;
+	}
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareerJsonComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareerJsonComponent.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.jackson;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.SerializerProvider;
-
-import java.io.IOException;
 
 /**
  * Sample {@link JsonComponent} used for tests.

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareerJsonComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareerJsonComponent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.jackson;
 
 import com.fasterxml.jackson.core.JsonGenerator;

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareerJsonComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareerJsonComponent.java
@@ -9,12 +9,10 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 
-@JsonComponent(handle = JsonComponent.Handle.KEYS,
-		handleClasses = { Name.class, NameAndCareer.class, NameAndAge.class })
-public class NameJsonComponent {
+@JsonComponent(handleClasses = NameAndCareer.class)
+public class NameAndCareerJsonComponent {
 
-	@JsonComponent(handleClasses = NameAndCareer.class)
-	public static class NameSerializer extends JsonObjectSerializer<Name> {
+	public static class Serializer extends JsonObjectSerializer<Name> {
 
 		@Override
 		protected void serializeObject(Name value, JsonGenerator jgen,
@@ -24,8 +22,7 @@ public class NameJsonComponent {
 
 	}
 
-	@JsonComponent(handleClasses = NameAndCareer.class)
-	public static class NameDeserializer extends JsonObjectDeserializer<Name> {
+	public static class Deserializer extends JsonObjectDeserializer<Name> {
 
 		@Override
 		protected Name deserializeObject(JsonParser jsonParser,

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareerJsonComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameAndCareerJsonComponent.java
@@ -9,6 +9,11 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 
+/**
+ * Sample {@link JsonComponent} used for tests.
+ *
+ * @author Paul Aly
+ */
 @JsonComponent(handleClasses = NameAndCareer.class)
 public class NameAndCareerJsonComponent {
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameJsonComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameJsonComponent.java
@@ -1,0 +1,19 @@
+package org.springframework.boot.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+@JsonComponent
+public class NameJsonComponent {
+
+	@JsonComponent(handleClasses = NameAndCareer.class)
+	public static class NameSerializer extends JsonObjectSerializer<Name> {
+
+		@Override
+		protected void serializeObject(Name value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+			jgen.writeStringField("name", value.getName());
+		}
+	}
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameJsonComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameJsonComponent.java
@@ -1,6 +1,10 @@
 package org.springframework.boot.jackson;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
@@ -12,8 +16,25 @@ public class NameJsonComponent {
 	public static class NameSerializer extends JsonObjectSerializer<Name> {
 
 		@Override
-		protected void serializeObject(Name value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+		protected void serializeObject(Name value, JsonGenerator jgen,
+				SerializerProvider provider) throws IOException {
 			jgen.writeStringField("name", value.getName());
 		}
+
 	}
+
+	@JsonComponent(handleClasses = NameAndCareer.class)
+	public static class NameDeserializer extends JsonObjectDeserializer<Name> {
+
+		@Override
+		protected Name deserializeObject(JsonParser jsonParser,
+				DeserializationContext context, ObjectCodec codec, JsonNode tree)
+				throws IOException {
+			String name = nullSafeValue(tree.get("name"), String.class);
+			String career = nullSafeValue(tree.get("career"), String.class);
+			return new NameAndCareer(name, career);
+		}
+
+	}
+
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameJsonComponent.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/NameJsonComponent.java
@@ -9,7 +9,8 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 
-@JsonComponent
+@JsonComponent(handle = JsonComponent.Handle.KEYS,
+		handleClasses = { Name.class, NameAndCareer.class, NameAndAge.class })
 public class NameJsonComponent {
 
 	@JsonComponent(handleClasses = NameAndCareer.class)


### PR DESCRIPTION
Fixes #16469 

Updates `@JsonComponent` so that serializers/deserializers can be registered as key based. Also allows for explicitly declaring the classes the component can handle. 