### PR TITLE
Declare configuration annotation processors as incremental for Gradle

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigureprocessor.AutoConfigureAnnotationProcessor,aggregating

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+org.springframework.boot.configurationprocessor.ConfigurationMetadataAnnotationProcessor,aggregating


### PR DESCRIPTION
Gradle 5.4 [removes the limitation](https://github.com/gradle/gradle/issues/4702) that incremental annotation processors cannot create resources, so these can now be marked as incremental annotation processors.