### PR TITLE
Set UTF-8 charset for whitelabel HTML error pages

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandler.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandler.java
@@ -105,6 +105,8 @@ public class DefaultErrorWebExceptionHandler extends AbstractErrorWebExceptionHa
 				this::renderErrorResponse);
 	}
 
+	private static final MediaType HTML_CONTENT_TYPE =  MediaType.valueOf(MediaType.TEXT_HTML_VALUE+";charset=UTF-8");
+
 	/**
 	 * Render the error information as an HTML view.
 	 * @param request the current request
@@ -115,7 +117,7 @@ public class DefaultErrorWebExceptionHandler extends AbstractErrorWebExceptionHa
 		Map<String, Object> error = getErrorAttributes(request, includeStackTrace);
 		HttpStatus errorStatus = getHttpStatus(error);
 		ServerResponse.BodyBuilder responseBody = ServerResponse.status(errorStatus)
-				.contentType(MediaType.TEXT_HTML);
+				.contentType(HTML_CONTENT_TYPE);
 		return Flux
 				.just("error/" + errorStatus.value(),
 						"error/" + SERIES_VIEWS.get(errorStatus.series()), "error/error")


### PR DESCRIPTION
change Whitelabel Error Page  Content-Type  to "text/html;charset=UTF-8"
or change AbstractErrorWebExceptionHandler.renderDefaultErrorView html content with `<meta charset=\"utf-8\">`

Otherwise " ⇢"  maybe not work!

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
