### PR TITLE
Fix a checkstyle issue

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
@@ -157,7 +157,7 @@ class StartupInfoLogger {
 			value = defaultValue;
 		}
 		if (StringUtils.hasLength(value)) {
-			message.append(message.length() > 0 ? " " : "");
+			message.append((message.length() > 0) ? " " : "");
 			message.append(prefix);
 			message.append(value);
 		}


### PR DESCRIPTION
There is a check-style error in recent commit (405135d5a8443cfa33ef817750e1c74b1478323e), this PR can fix it:

```
[INFO] --- maven-checkstyle-plugin:3.0.0:check (checkstyle-validation) @ spring-boot ---
[INFO] There is 1 error reported by Checkstyle 8.18 with src/checkstyle/checkstyle.xml ruleset.
[ERROR] src/main/java/org/springframework/boot/StartupInfoLogger.java:[160,61] (extension) SpringTernary: Ternary operation missing parentheses.
```
