### PR TITLE
Optimize JarEntry construction

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/CentralDirectoryFileHeader.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/CentralDirectoryFileHeader.java
@@ -153,6 +153,10 @@ final class CentralDirectoryFileHeader implements FileHeader {
 		return this.extra;
 	}
 
+	public boolean hasExtra() {
+		return this.extra.length > 0;
+	}
+
 	public AsciiBytes getComment() {
 		return this.comment;
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarEntry.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarEntry.java
@@ -56,7 +56,9 @@ class JarEntry extends java.util.jar.JarEntry implements FileHeader {
 		setComment(header.getComment().toString());
 		setSize(header.getSize());
 		setTime(header.getTime());
-		setExtra(header.getExtra());
+		if (header.hasExtra()) {
+			setExtra(header.getExtra());
+		}
 	}
 
 	AsciiBytes getAsciiBytesName() {


### PR DESCRIPTION
Hi,

while profiling one of my applications I noticed that the respective inlining logs showed the following line:
```
@ 3   java.util.zip.ZipEntry::setExtra0 (360 bytes)   hot method too big
```

It seems that most of the time there is no extra information available anyway, so we could skip the call to the apparently expensive `setExtra()`. Before we go into the benchmarks let me say that this PR changes behaviour a bit as `getExtra()` will now return null instead of an empty byte array. But imho this is actually closer to the javadoc of `ZipEntry.getExtra()`:
```
@return the extra field data for the entry, or null if none
```

In an isolated benchmark (I'm just calling setExtra on a ZipEntry) I get the following results:
```
Benchmark             Mode  Cnt          Score         Error  Units
MyBenchmark.testNew  thrpt   10  308679323,969 ± 6449223,651  ops/s
MyBenchmark.testOld  thrpt   10  179973009,964 ± 2125668,778  ops/s
```

Let me know what you think.
Cheers,
Christoph