### PR TITLE
Optimize ConfigurationPropertyName.buildToString()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -448,9 +448,9 @@ public final class ConfigurationPropertyName
 				result.append('.');
 			}
 			if (indexed) {
-				result.append("[");
+				result.append('[');
 				result.append(getElement(i, Form.ORIGINAL));
-				result.append("]");
+				result.append(']');
 			}
 			else {
 				result.append(getElement(i, Form.DASHED));


### PR DESCRIPTION
Hi,

though minor this PR optimizes calls to StringBuilder.append with a single character in `ConfigurationPropertyName.buildToString()`. In the example provided in #16401 this is called 33k times at least and every little helps.

Cheers,
Christoph