### PR TITLE
Support spying on final classes

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/spring-boot-project/spring-boot-test/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanOnFinalBeanIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanOnFinalBeanIntegrationTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.mock.mockito;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.example.ExampleServiceCaller;
+import org.springframework.boot.test.mock.mockito.example.FinalSimpleExampleService;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test {@link SpyBean} on a final class.
+ *
+ * @author Camille Vienot
+ */
+@RunWith(SpringRunner.class)
+public class SpyBeanOnFinalBeanIntegrationTests {
+
+	@SpyBean
+	private FinalSimpleExampleService service;
+
+	@Autowired
+	private ExampleServiceCaller caller;
+
+	@Test
+	public void testSpying() {
+		assertThat(this.caller.sayGreeting()).isEqualTo("I say final");
+		verify(this.service).greeting();
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Import({ ExampleServiceCaller.class })
+	static class Config {
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/example/FinalSimpleExampleService.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/example/FinalSimpleExampleService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.mock.mockito.example;
+
+/**
+ * Example service final implementation for spy tests.
+ *
+ * @author Camille Vienot
+ */
+public final class FinalSimpleExampleService extends RealExampleService {
+
+	public FinalSimpleExampleService() {
+		super("final");
+	}
+
+}


### PR DESCRIPTION
Closes gh-7033

We currently cannot spy on spring data repositories because the proxy are finals.
We can work around this limitation by using mockito inline-mocker-maker plugin. 