### PR TITLE
Polish ConfigurationPropertyName.dashIgnoringElementEquals()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -394,12 +394,16 @@ public final class ConfigurationPropertyName
 				i2++;
 			}
 		}
-		boolean indexed2 = e2.getType(i).isIndexed();
-		while (i2 < l2) {
-			char ch2 = e2.charAt(i, i2++);
-			if (indexed2 || ch2 == '-') {
+		if (i2 < l2) {
+			if (e2.getType(i).isIndexed()) {
 				return false;
 			}
+			do {
+				if (e2.charAt(i, i2++) == '-') {
+					return false;
+				}
+			}
+			while (i2 < l2);
 		}
 		return true;
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR polishes `ConfigurationPropertyName.dashIgnoringElementEquals()` by avoiding repeating `indexed2` `boolean` checks in the loop as checking it only once seems sufficient.