### PR TITLE
Add jOOQ to SQL logging group

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
@@ -135,6 +135,7 @@ public class LoggingApplicationListener implements GenericApplicationListener {
 				"org.springframework.boot.web.servlet.ServletContextInitializerBeans");
 		loggers.add("sql", "org.springframework.jdbc.core");
 		loggers.add("sql", "org.hibernate.SQL");
+		loggers.add("sql", "org.jooq.tools.LoggerListener");
 		DEFAULT_GROUP_LOGGERS = Collections.unmodifiableMap(loggers);
 	}
 


### PR DESCRIPTION
Since Spring Boot comes with support for JOOQ it would be also nice if the `sql` logging group also include it.

After this change, setting `logging.level.sql=debug` and executing query through jOOQ will result entries like one below in logs:

```
Executing query          : select "public"."property_ad"."id", "public"."property_ad"."bathrooms", "public"."property_ad"."price", "public"."property_ad"."rooms", "public"."property_ad"."surface_area" from "public"."property_ad"
Fetched result           : +----+---------+-----+-----+------------+
                         : |  id|bathrooms|price|rooms|surface_area|
                         : +----+---------+-----+-----+------------+
                         : |   1|        1|   40|    3|         120|
                         : |   2|        2|   80|    5|         150|
                         : +----+---------+-----+-----+------------+
Fetched row(s)           : 2
```
Pinging @lukaseder in case I missed something.