### PR TITLE
Upgrade to Flyway 4.2.0

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -72,7 +72,7 @@
 		<ehcache.version>2.10.5</ehcache.version>
 		<ehcache3.version>3.2.3</ehcache3.version>
 		<embedded-mongo.version>1.50.5</embedded-mongo.version>
-		<flyway.version>3.2.1</flyway.version>
+		<flyway.version>4.2.0</flyway.version>
 		<freemarker.version>2.3.28</freemarker.version>
 		<elasticsearch.version>2.4.6</elasticsearch.version>
 		<gemfire.version>8.2.13</gemfire.version>


### PR DESCRIPTION
There is a breaking change when you try To upgrade Spring Boot app from 1.5.x to 2.1.X with Flyway. 

Important note for users upgrading from Flyway 3.x: This release no longer supports a schema history table upgrade from Flyway 3.x. You must upgrade to Flyway 4.2.0 first before upgrading to Flyway 5.0.0.
https://flywaydb.org/documentation/releaseNotes#5.0.0


Spring Boot 1.5.20
Flyway 3.2.1
https://github.com/spring-projects/spring-boot/blob/v1.5.20.RELEASE/spring-boot-dependencies/pom.xml#L75

Spring Boot 2.1.4
Flyway 5.2.4
https://github.com/spring-projects/spring-boot/blob/v2.1.4.RELEASE/spring-boot-project/spring-boot-dependencies/pom.xml#L62

