### PR TITLE
Make excludeDevtools available as a user property

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
@@ -186,7 +186,7 @@ public class RepackageMojo extends AbstractDependencyFilterMojo {
 	 * Exclude Spring Boot devtools from the repackaged archive.
 	 * @since 1.3
 	 */
-	@Parameter(defaultValue = "true")
+	@Parameter(property = "spring-boot.excludeDevtools", defaultValue = "true")
 	private boolean excludeDevtools = true;
 
 	/**


### PR DESCRIPTION
Add Maven user property spring-boot.excludeDevtools
so it can be used from the command line.
See #16694 