### PR TITLE
Added Cassandra Cluster factory and Default implementation.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraAutoConfiguration.java
@@ -50,7 +50,7 @@ public class CassandraAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public CassandraClusterFactory cassandraClusterFactory(){
+	public CassandraClusterFactory cassandraClusterFactory() {
 		return new CassandraClusterFactoryImpl();
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraAutoConfiguration.java
@@ -40,6 +40,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @auther Steffen F. Qvistgaard
  * @since 1.3.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -49,8 +50,15 @@ public class CassandraAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
+	public CassandraClusterFactory cassandraClusterFactory(){
+		return new CassandraClusterFactoryImpl();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
 	public Cluster cassandraCluster(CassandraProperties properties,
-			ObjectProvider<ClusterBuilderCustomizer> builderCustomizers) {
+			ObjectProvider<ClusterBuilderCustomizer> builderCustomizers,
+			CassandraClusterFactory clusterFactory) {
 		PropertyMapper map = PropertyMapper.get();
 		Cluster.Builder builder = Cluster.builder()
 				.withClusterName(properties.getClusterName())
@@ -71,7 +79,8 @@ public class CassandraAutoConfiguration {
 				.toCall(builder::withoutJMXReporting);
 		builderCustomizers.orderedStream()
 				.forEach((customizer) -> customizer.customize(builder));
-		return builder.build();
+
+		return clusterFactory.build(builder);
 	}
 
 	private QueryOptions getQueryOptions(CassandraProperties properties) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraClusterFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraClusterFactory.java
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.autoconfigure.cassandra;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Cluster.Initializer;
 
 /**
- * Cassandra Cluster Factory Interface
+ * Cassandra Cluster Factory Interface.
  *
  * This interface allows the default cassandra cluster builder to be overwritten
  *

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraClusterFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraClusterFactory.java
@@ -28,5 +28,7 @@ import com.datastax.driver.core.Cluster.Initializer;
  * @since 2.2.0
  */
 public interface CassandraClusterFactory {
+
 	Cluster build(Initializer initializer);
+
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraClusterFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraClusterFactory.java
@@ -1,0 +1,16 @@
+package org.springframework.boot.autoconfigure.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Cluster.Initializer;
+
+/**
+ * Cassandra Cluster Factory Interface
+ *
+ * This interface allows the default cassandra cluster builder to be overwritten
+ *
+ * @auther Steffen F. Qvistgaard
+ * @since 2.2.0
+ */
+public interface CassandraClusterFactory {
+	Cluster build(Initializer initializer);
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraClusterFactoryImpl.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraClusterFactoryImpl.java
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.autoconfigure.cassandra;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Cluster.Initializer;
 
 /**
- * Default Cassandra Cluster Factory Implementation
+ * Default Cassandra Cluster Factory Implementation.
  *
  * @auther Steffen F. Qvistgaard
  * @since 2.2.0

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraClusterFactoryImpl.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraClusterFactoryImpl.java
@@ -31,4 +31,5 @@ public class CassandraClusterFactoryImpl implements CassandraClusterFactory {
 	public Cluster build(final Initializer initializer) {
 		return Cluster.buildFrom(initializer);
 	}
+
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraClusterFactoryImpl.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraClusterFactoryImpl.java
@@ -1,0 +1,18 @@
+package org.springframework.boot.autoconfigure.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Cluster.Initializer;
+
+/**
+ * Default Cassandra Cluster Factory Implementation
+ *
+ * @auther Steffen F. Qvistgaard
+ * @since 2.2.0
+ */
+public class CassandraClusterFactoryImpl implements CassandraClusterFactory {
+
+	@Override
+	public Cluster build(final Initializer initializer) {
+		return Cluster.buildFrom(initializer);
+	}
+}


### PR DESCRIPTION
This allows the default cassandra builder to be overwritten. This is useful for example, when implementing jaeger/opentracing