### PR TITLE
Redis pooling minIdle property is ignored as timeBetweenEvictionRun defaults to -1 and cannot be configured

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/JedisConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/JedisConnectionConfiguration.java
@@ -113,6 +113,10 @@ class JedisConnectionConfiguration extends RedisConnectionConfiguration {
 		config.setMaxTotal(pool.getMaxActive());
 		config.setMaxIdle(pool.getMaxIdle());
 		config.setMinIdle(pool.getMinIdle());
+		if (pool.getTimeBetweenEvictionRuns() != null) {
+			config.setTimeBetweenEvictionRunsMillis(
+					pool.getTimeBetweenEvictionRuns().toMillis());
+		}
 		if (pool.getMaxWait() != null) {
 			config.setMaxWaitMillis(pool.getMaxWait().toMillis());
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
@@ -147,7 +147,7 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 			config.setMaxIdle(properties.getMaxIdle());
 			config.setMinIdle(properties.getMinIdle());
 			config.setTimeBetweenEvictionRunsMillis(
-					properties.getIdleEvictPeriod().toMillis());
+					properties.getTimeBetweenEvictionRuns().toMillis());
 			if (properties.getMaxWait() != null) {
 				config.setMaxWaitMillis(properties.getMaxWait().toMillis());
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
@@ -146,6 +146,8 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 			config.setMaxTotal(properties.getMaxActive());
 			config.setMaxIdle(properties.getMaxIdle());
 			config.setMinIdle(properties.getMinIdle());
+			config.setTimeBetweenEvictionRunsMillis(
+					properties.getIdleEvictPeriod().toMillis());
 			if (properties.getMaxWait() != null) {
 				config.setMaxWaitMillis(properties.getMaxWait().toMillis());
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
@@ -146,8 +146,10 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 			config.setMaxTotal(properties.getMaxActive());
 			config.setMaxIdle(properties.getMaxIdle());
 			config.setMinIdle(properties.getMinIdle());
-			config.setTimeBetweenEvictionRunsMillis(
-					properties.getTimeBetweenEvictionRuns().toMillis());
+			if (properties.getTimeBetweenEvictionRuns() != null) {
+				config.setTimeBetweenEvictionRunsMillis(
+						properties.getTimeBetweenEvictionRuns().toMillis());
+			}
 			if (properties.getMaxWait() != null) {
 				config.setMaxWaitMillis(properties.getMaxWait().toMillis());
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -173,8 +173,8 @@ public class RedisProperties {
 		 * Target for the minimum number of idle connections to maintain in the pool. This
 		 * setting only has an effect if it is positive.
 		 *
-		 * This setting only has an effect if it is positive and `idleEvictPeriod` is
-		 * greater than zero.
+		 * This setting only has an effect if it is positive and `timeBetweenEvictionRuns`
+		 * is greater than zero.
 		 */
 		private int minIdle = 0;
 
@@ -192,12 +192,12 @@ public class RedisProperties {
 		private Duration maxWait = Duration.ofMillis(-1);
 
 		/**
-		 * Time of milliseconds to sleep between runs of the idle object evictor thread.
+		 * Time to sleep between runs of the idle object evictor thread.
 		 *
 		 * When positive, the idle object evictor thread starts. When non-positive, no
 		 * idle object evictor thread runs.
 		 */
-		private Duration idleEvictPeriod = Duration.ofMillis(-1);
+		private Duration timeBetweenEvictionRuns = Duration.ofMillis(-1);
 
 		public int getMaxIdle() {
 			return this.maxIdle;
@@ -231,12 +231,12 @@ public class RedisProperties {
 			this.maxWait = maxWait;
 		}
 
-		public Duration getIdleEvictPeriod() {
-			return this.idleEvictPeriod;
+		public Duration getTimeBetweenEvictionRuns() {
+			return this.timeBetweenEvictionRuns;
 		}
 
-		public void setIdleEvictPeriod(Duration idleEvictPeriod) {
-			this.idleEvictPeriod = idleEvictPeriod;
+		public void setTimeBetweenEvictionRuns(Duration timeBetweenEvictionRuns) {
+			this.timeBetweenEvictionRuns = timeBetweenEvictionRuns;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -172,6 +172,9 @@ public class RedisProperties {
 		/**
 		 * Target for the minimum number of idle connections to maintain in the pool. This
 		 * setting only has an effect if it is positive.
+		 *
+		 * This setting only has an effect if it is positive and `idleEvictPeriod` is
+		 * greater than zero.
 		 */
 		private int minIdle = 0;
 
@@ -187,6 +190,14 @@ public class RedisProperties {
 		 * indefinitely.
 		 */
 		private Duration maxWait = Duration.ofMillis(-1);
+
+		/**
+		 * Time of milliseconds to sleep between runs of the idle object evictor thread.
+		 *
+		 * When positive, the idle object evictor thread starts. When non-positive, no
+		 * idle object evictor thread runs.
+		 */
+		private Duration idleEvictPeriod = Duration.ofMillis(-1);
 
 		public int getMaxIdle() {
 			return this.maxIdle;
@@ -218,6 +229,14 @@ public class RedisProperties {
 
 		public void setMaxWait(Duration maxWait) {
 			this.maxWait = maxWait;
+		}
+
+		public Duration getIdleEvictPeriod() {
+			return this.idleEvictPeriod;
+		}
+
+		public void setIdleEvictPeriod(Duration idleEvictPeriod) {
+			this.idleEvictPeriod = idleEvictPeriod;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -197,7 +197,7 @@ public class RedisProperties {
 		 * When positive, the idle object evictor thread starts. When non-positive, no
 		 * idle object evictor thread runs.
 		 */
-		private Duration timeBetweenEvictionRuns = Duration.ofMillis(-1);
+		private Duration timeBetweenEvictionRuns;
 
 		public int getMaxIdle() {
 			return this.maxIdle;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationJedisTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationJedisTests.java
@@ -134,11 +134,14 @@ public class RedisAutoConfigurationJedisTests {
 
 	@Test
 	public void testRedisConfigurationWithPool() {
-		this.contextRunner.withPropertyValues("spring.redis.host:foo",
-				"spring.redis.jedis.pool.min-idle:1",
-				"spring.redis.jedis.pool.max-idle:4",
-				"spring.redis.jedis.pool.max-active:16",
-				"spring.redis.jedis.pool.max-wait:2000").run((context) -> {
+		this.contextRunner
+				.withPropertyValues("spring.redis.host:foo",
+						"spring.redis.jedis.pool.min-idle:1",
+						"spring.redis.jedis.pool.max-idle:4",
+						"spring.redis.jedis.pool.max-active:16",
+						"spring.redis.jedis.pool.max-wait:2000",
+						"spring.redis.jedis.pool.time-between-eviction-runs:30000")
+				.run((context) -> {
 					JedisConnectionFactory cf = context
 							.getBean(JedisConnectionFactory.class);
 					assertThat(cf.getHostName()).isEqualTo("foo");
@@ -146,6 +149,8 @@ public class RedisAutoConfigurationJedisTests {
 					assertThat(cf.getPoolConfig().getMaxIdle()).isEqualTo(4);
 					assertThat(cf.getPoolConfig().getMaxTotal()).isEqualTo(16);
 					assertThat(cf.getPoolConfig().getMaxWaitMillis()).isEqualTo(2000);
+					assertThat(cf.getPoolConfig().getTimeBetweenEvictionRunsMillis())
+							.isEqualTo(30000);
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -155,7 +155,7 @@ public class RedisAutoConfigurationTests {
 				"spring.redis.lettuce.pool.max-idle:4",
 				"spring.redis.lettuce.pool.max-active:16",
 				"spring.redis.lettuce.pool.max-wait:2000",
-				"spring.redis.lettuce.pool.idle-evict-period:30000",
+				"spring.redis.lettuce.pool.time-between-eviction-runs:30000",
 				"spring.redis.lettuce.shutdown-timeout:1000").run((context) -> {
 					LettuceConnectionFactory cf = context
 							.getBean(LettuceConnectionFactory.class);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -155,6 +155,7 @@ public class RedisAutoConfigurationTests {
 				"spring.redis.lettuce.pool.max-idle:4",
 				"spring.redis.lettuce.pool.max-active:16",
 				"spring.redis.lettuce.pool.max-wait:2000",
+				"spring.redis.lettuce.pool.idle-evict-period:30000",
 				"spring.redis.lettuce.shutdown-timeout:1000").run((context) -> {
 					LettuceConnectionFactory cf = context
 							.getBean(LettuceConnectionFactory.class);
@@ -165,6 +166,8 @@ public class RedisAutoConfigurationTests {
 					assertThat(poolConfig.getMaxIdle()).isEqualTo(4);
 					assertThat(poolConfig.getMaxTotal()).isEqualTo(16);
 					assertThat(poolConfig.getMaxWaitMillis()).isEqualTo(2000);
+					assertThat(poolConfig.getTimeBetweenEvictionRunsMillis())
+							.isEqualTo(30000);
 					assertThat(cf.getShutdownTimeout()).isEqualTo(1000);
 				});
 	}


### PR DESCRIPTION
Hi :D
I found the bug that `min-idle` does not work when configure Lettuce with pool config.

You can find out why the problem occurred by looking below link.
[https://commons.apache.org/GenericObjectPool.html#setMinIdle](https://commons.apache.org/proper/commons-pool/apidocs/org/apache/commons/pool2/impl/GenericObjectPool.html#setMinIdle-int-)
```
This setting only has an effect if it is positive and BaseGenericObjectPool.getTimeBetweenEvictionRunsMillis() is greater than zero.
```

`TimeBetweenEvictionRunsMillis` need to configured greater then zero for the `min-idle` to working correctly.

Some users can trust settings and use them incorrectly in an environment that does not work properly.
So, I added that property, but I don't know if this is a perfectly good solution.

Please review and let me know what you think about this issue.
Thank you :)