### PR TITLE
Add Tip that h2 needs to be in your class path for @DataJpaTest to work.

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -7479,7 +7479,8 @@ full end-to-end tests with an actual server>>.
 You can use the `@DataJpaTest` annotation to test JPA applications. By default, it
 configures an in-memory embedded database, scans for `@Entity` classes, and configures
 Spring Data JPA repositories. Regular `@Component` beans are not loaded into the
-`ApplicationContext`.
+`ApplicationContext`. For setup, add an in-memory embedded database such as h2 
+in your build tool's configuration file (ex. pom.xml and build.gradle).
 
 TIP: A list of the auto-configuration settings that are enabled by `@DataJpaTest` can be
 <<appendix.adoc#test-auto-configuration,found in the appendix>>.


### PR DESCRIPTION
Docs "46.3.12 Auto-configured Data JPA Tests" doesn't specify the necessity to configure an in-memory database. It reads as if everything "just" works.
https://docs.spring.io/spring-boot/docs/2.1.4.RELEASE/reference/htmlsingle/#boot-features-testing-spring-boot-applications-testing-autoconfigured-jpa-test

As consequence, I experienced the same issue as indicated in this stack overflow QA.
https://stackoverflow.com/questions/40659912/spring-boot-starter-test-cannot-run-database-integration-test

So, I suggest clarifying that you need to add an embedded in-memory database for setup.