### PR TITLE
Optimize CacheKey handling in SpringIterableConfigurationPropertySource

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySourceTests.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import org.springframework.boot.env.OriginTrackedMapPropertySource;
 import org.springframework.boot.origin.Origin;
 import org.springframework.boot.origin.OriginLookup;
 import org.springframework.core.env.EnumerablePropertySource;
@@ -156,12 +157,27 @@ public class SpringIterableConfigurationPropertySourceTests {
 	}
 
 	@Test
-	public void propertySourceKeyDataChangeInvalidatesCache() {
+	public void simpleMapPropertySourceKeyDataChangeInvalidatesCache() {
 		// gh-13344
 		Map<String, Object> map = new LinkedHashMap<>();
 		map.put("key1", "value1");
 		map.put("key2", "value2");
 		EnumerablePropertySource<?> source = new MapPropertySource("test", map);
+		SpringIterableConfigurationPropertySource adapter = new SpringIterableConfigurationPropertySource(
+				source, DefaultPropertyMapper.INSTANCE);
+		assertThat(adapter.stream().count()).isEqualTo(2);
+		map.put("key3", "value3");
+		assertThat(adapter.stream().count()).isEqualTo(3);
+	}
+
+	@Test
+	public void originTrackedMapPropertySourceKeyAdditionInvalidatesCache() {
+		// gh-13344
+		Map<String, Object> map = new LinkedHashMap<>();
+		map.put("key1", "value1");
+		map.put("key2", "value2");
+		EnumerablePropertySource<?> source = new OriginTrackedMapPropertySource("test",
+				map);
 		SpringIterableConfigurationPropertySource adapter = new SpringIterableConfigurationPropertySource(
 				source, DefaultPropertyMapper.INSTANCE);
 		assertThat(adapter.stream().count()).isEqualTo(2);


### PR DESCRIPTION
Hi,

as described in #16401 there is an optimization opportunity in `SpringIterableConfigurationPropertySource` when checking for CacheKey equality. Currently, for large Sets this takes a considerable amount of time as the two Sets are usually equal, but not the same instance. This is due to the fact that the internal key inside CacheKey is copied in order to fix #13344 and can thus not benefit from a `==` comparison.

The idea of this PR is to introduce a flag that effectively disables the copying of the internal key under certain circumstances. Imho, this could be done for `OriginTrackedMapPropertySource` instances which is used to load either `.yaml` or `.properties` files, which usually shouldn't be a subject of change (and even if require a refresh of some sort). I still implemented an additional check for the size of the internal key in a best effort to track key **additions** at least for `OriginTrackedMapPropertySource`s, too.

With the applied changes, I see major improvements compared to a M2 baseline.

|       | Baseline |  New  |
| ----- | -------: | ----: |
|       |    12.757 | 7.947 |
|       |    11.742 | 8.254 |
|       |    12.453 | 7.790 |
|       |    12.819 | 7.513 |
|       |    12.588 | 8.021 |
|       |    12.616 | 8.038 |
|       |    12.541 | 7.495 |
|       |    13.555 | 7.864 |
|       |    12.494 | 8.040 |
|       |    12.009 | 7.726 |
|  Mean |    12.557 | 7.869 |
| Range |    1.813 | 0.759 |

Let me know what you think.

Cheers,
Christoph