### PR TITLE
Doc the pros and cons of Out-of-Container and Integration Tests

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -7039,6 +7039,13 @@ following example:
 include::{code-examples}/test/web/MockWebTestClientExampleTests.java[tag=test-mock-web-test-client]
 ----
 
+Testing within a mocked environment enables fast runs as it does not require the cost of 
+setting up a full Servlet container. Although this works fine in most cases, you cannot 
+test situations where the servlet container takes precedence. For example, Spring Boot's
+error handling is based on Servlet container’s error mappings. Therefore, exceptions behave
+differently in the container-less mock environment than the real environment. If you need to
+test the precise format of the error response, test with a fully running server as follows.
+
 
 
 [[boot-features-testing-spring-boot-applications-testing-with-running-server]]


### PR DESCRIPTION
The current doc does not explain why one should choose either the mockMVC or a full running server. 
https://docs.spring.io/spring-boot/docs/2.1.4.RELEASE/reference/htmlsingle/#boot-features-testing-spring-boot-applications-testing-with-mock-environment

I happened to choose mockMVC without knowing its’ shortcomings that error handling behaves differently than the real environment. This bumping point was indicated in this issue as well. (https://github.com/spring-projects/spring-boot/issues/7321) Therefore, I suggest explaining its pros and cons more clearly in the docs.