### PR TITLE
Add kafka-streams-test-utils to dependency

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -1793,6 +1793,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.kafka</groupId>
+				<artifactId>kafka-streams-test-utils</artifactId>
+				<version>${kafka.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.kafka</groupId>
 				<artifactId>kafka-tools</artifactId>
 				<version>${kafka.version}</version>
 			</dependency>


### PR DESCRIPTION
This jar is now a dependency of spring-kafka-test which is added in
test scope by initializr.

See https://github.com/spring-projects/spring-kafka/issues/1084

