### PR TITLE
Fix 'spring.resources.cache.period' for WebMvc

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
@@ -333,14 +333,19 @@ public class WebMvcAutoConfiguration {
 				return;
 			}
 			Duration cachePeriod = this.resourceProperties.getCache().getPeriod();
-			CacheControl cacheControl = this.resourceProperties.getCache()
-					.getCachecontrol().toHttpCacheControl();
+			ResourceProperties.Cache.Cachecontrol cacheControl = this.resourceProperties
+					.getCache().getCachecontrol();
+			if (cachePeriod != null && cacheControl.getMaxAge() == null) {
+				cacheControl.setMaxAge(cachePeriod);
+			}
+			CacheControl httpCacheControl = cacheControl.toHttpCacheControl();
+
 			if (!registry.hasMappingForPattern("/webjars/**")) {
 				customizeResourceHandlerRegistration(registry
 						.addResourceHandler("/webjars/**")
 						.addResourceLocations("classpath:/META-INF/resources/webjars/")
 						.setCachePeriod(getSeconds(cachePeriod))
-						.setCacheControl(cacheControl));
+						.setCacheControl(httpCacheControl));
 			}
 			String staticPathPattern = this.mvcProperties.getStaticPathPattern();
 			if (!registry.hasMappingForPattern(staticPathPattern)) {
@@ -349,7 +354,7 @@ public class WebMvcAutoConfiguration {
 								.addResourceLocations(getResourceLocations(
 										this.resourceProperties.getStaticLocations()))
 								.setCachePeriod(getSeconds(cachePeriod))
-								.setCacheControl(cacheControl));
+								.setCacheControl(httpCacheControl));
 			}
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.ValidatorFactory;
 
+import org.assertj.core.api.Assertions;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
@@ -800,10 +801,11 @@ public class WebMvcAutoConfigurationTests {
 	}
 
 	private void assertCachePeriod(AssertableWebApplicationContext context) {
+		Assertions.setExtractBareNamePropertyMethods(false);
 		Map<String, Object> handlerMap = getHandlerMap(
 				context.getBean("resourceHandlerMapping", HandlerMapping.class));
 		assertThat(handlerMap).hasSize(2);
-		for (Object handler : handlerMap.keySet()) {
+		for (Object handler : handlerMap.values()) {
 			if (handler instanceof ResourceHttpRequestHandler) {
 				assertThat(((ResourceHttpRequestHandler) handler).getCacheSeconds())
 						.isEqualTo(-1);
@@ -812,6 +814,7 @@ public class WebMvcAutoConfigurationTests {
 								CacheControl.maxAge(5, TimeUnit.SECONDS));
 			}
 		}
+		Assertions.setExtractBareNamePropertyMethods(true);
 	}
 
 	@Test


### PR DESCRIPTION
Before this change it got overwritten and resulted in resources not
getting cached properly.

Also:
* Fixes bug in testcase which prevented it to assert anything
* Introduces setExtractBareNamePropertyMethods to testcase
  in order to compare objects correctly
  (see WebFluxAutoConfigurationTests)

See: #16488