### PR TITLE
'spring.resources.cache.period' is always overridden by 'spring.resources.cache.cachecontrol'

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ResourceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ResourceProperties.java
@@ -476,6 +476,10 @@ public class ResourceProperties {
 						.staleIfError(duration.getSeconds(), TimeUnit.SECONDS));
 				map.from(this::getSMaxAge).whenNonNull().to((duration) -> control
 						.sMaxAge(duration.getSeconds(), TimeUnit.SECONDS));
+				// check if cacheControl remained untouched
+				if (control.getHeaderValue() == null) {
+					return null;
+				}
 				return control;
 			}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ResourcePropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ResourcePropertiesTests.java
@@ -76,7 +76,7 @@ public class ResourcePropertiesTests {
 	public void emptyCacheControl() {
 		CacheControl cacheControl = this.properties.getCache().getCachecontrol()
 				.toHttpCacheControl();
-		assertThat(cacheControl.getHeaderValue()).isNull();
+		assertThat(cacheControl).isNull();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
@@ -803,13 +803,12 @@ public class WebMvcAutoConfigurationTests {
 		Map<String, Object> handlerMap = getHandlerMap(
 				context.getBean("resourceHandlerMapping", HandlerMapping.class));
 		assertThat(handlerMap).hasSize(2);
-		for (Object handler : handlerMap.keySet()) {
+		for (Object handler : handlerMap.values()) {
 			if (handler instanceof ResourceHttpRequestHandler) {
 				assertThat(((ResourceHttpRequestHandler) handler).getCacheSeconds())
-						.isEqualTo(-1);
+						.isEqualTo(5);
 				assertThat(((ResourceHttpRequestHandler) handler).getCacheControl())
-						.isEqualToComparingFieldByField(
-								CacheControl.maxAge(5, TimeUnit.SECONDS));
+						.isNull();
 			}
 		}
 	}


### PR DESCRIPTION
Before this change it got overwritten by forwarding an empty
CacheControl to Spring. Spring itself sets CacheSeconds already
correctly in absence (=null) of a CacheControl.

Also:
* Fixes bug in WebMvcAutoConfigurationTests.cachePeriod which prevented it to assert anything

See: #16488
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
