### PR TITLE
fix whitespace issue

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
@@ -125,7 +125,7 @@ benefit of the dependency management (but not the plugin management) by using a
 [source,xml,indent=0,subs="verbatim,quotes,attributes"]
 ----
 	<dependencyManagement>
- 		<dependencies>
+		<dependencies>
 			<dependency>
 				<!-- Import dependency management from Spring Boot -->
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Obvious Fix: There was a space too much which caused an indentation error in the docs.