### PR TITLE
Rename "Devtools" to "DevTools" in class names

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/DevToolsEnablementDeducer.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/DevToolsEnablementDeducer.java
@@ -21,11 +21,12 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
- * Utility to deduce if Devtools should be enabled in the current context.
+ * Utility to deduce if DevTools should be enabled in the current context.
  *
  * @author Madhura Bhave
+ * @since 2.2.0
  */
-public final class DevtoolsEnablementDeducer {
+public final class DevToolsEnablementDeducer {
 
 	private static final Set<String> SKIPPED_STACK_ELEMENTS;
 
@@ -38,7 +39,7 @@ public final class DevtoolsEnablementDeducer {
 		SKIPPED_STACK_ELEMENTS = Collections.unmodifiableSet(skipped);
 	}
 
-	private DevtoolsEnablementDeducer() {
+	private DevToolsEnablementDeducer() {
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsDataSourceAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsDataSourceAutoConfiguration.java
@@ -55,7 +55,7 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
  * @since 1.3.3
  */
 @AutoConfigureAfter(DataSourceAutoConfiguration.class)
-@Conditional({ OnEnabledDevtoolsCondition.class, DevToolsDataSourceCondition.class })
+@Conditional({ OnEnabledDevToolsCondition.class, DevToolsDataSourceCondition.class })
 @Configuration(proxyBeanMethods = false)
 public class DevToolsDataSourceAutoConfiguration {
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/OnEnabledDevToolsCondition.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/OnEnabledDevToolsCondition.java
@@ -19,7 +19,7 @@ package org.springframework.boot.devtools.autoconfigure;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
-import org.springframework.boot.devtools.DevtoolsEnablementDeducer;
+import org.springframework.boot.devtools.DevToolsEnablementDeducer;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
@@ -27,14 +27,15 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
  * A condition that checks if DevTools should be enabled.
  *
  * @author Madhura Bhave
+ * @since 2.2.0
  */
-public class OnEnabledDevtoolsCondition extends SpringBootCondition {
+public class OnEnabledDevToolsCondition extends SpringBootCondition {
 
 	@Override
 	public ConditionOutcome getMatchOutcome(ConditionContext context,
 			AnnotatedTypeMetadata metadata) {
 		ConditionMessage.Builder message = ConditionMessage.forCondition("Devtools");
-		boolean shouldEnable = DevtoolsEnablementDeducer
+		boolean shouldEnable = DevToolsEnablementDeducer
 				.shouldEnable(Thread.currentThread());
 		if (!shouldEnable) {
 			return ConditionOutcome.noMatch(

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/RemoteDevToolsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/RemoteDevToolsAutoConfiguration.java
@@ -56,7 +56,7 @@ import org.springframework.http.server.ServerHttpRequest;
  * @since 1.3.0
  */
 @Configuration(proxyBeanMethods = false)
-@Conditional(OnEnabledDevtoolsCondition.class)
+@Conditional(OnEnabledDevToolsCondition.class)
 @ConditionalOnProperty(prefix = "spring.devtools.remote", name = "secret")
 @ConditionalOnClass({ Filter.class, ServerHttpRequest.class })
 @EnableConfigurationProperties({ ServerProperties.class, DevToolsProperties.class })

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsHomePropertiesPostProcessor.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsHomePropertiesPostProcessor.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.util.Properties;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.devtools.DevtoolsEnablementDeducer;
+import org.springframework.boot.devtools.DevToolsEnablementDeducer;
 import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.PropertiesPropertySource;
@@ -44,7 +44,7 @@ public class DevToolsHomePropertiesPostProcessor implements EnvironmentPostProce
 	@Override
 	public void postProcessEnvironment(ConfigurableEnvironment environment,
 			SpringApplication application) {
-		if (DevtoolsEnablementDeducer.shouldEnable(Thread.currentThread())) {
+		if (DevToolsEnablementDeducer.shouldEnable(Thread.currentThread())) {
 			File home = getHomeFolder();
 			File propertyFile = (home != null) ? new File(home, FILE_NAME) : null;
 			if (propertyFile != null && propertyFile.exists() && propertyFile.isFile()) {

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsPropertyDefaultsPostProcessor.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsPropertyDefaultsPostProcessor.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.devtools.DevtoolsEnablementDeducer;
+import org.springframework.boot.devtools.DevToolsEnablementDeducer;
 import org.springframework.boot.devtools.logger.DevToolsLogFactory;
 import org.springframework.boot.devtools.restart.Restarter;
 import org.springframework.boot.env.EnvironmentPostProcessor;
@@ -80,7 +80,7 @@ public class DevToolsPropertyDefaultsPostProcessor implements EnvironmentPostPro
 	@Override
 	public void postProcessEnvironment(ConfigurableEnvironment environment,
 			SpringApplication application) {
-		if (DevtoolsEnablementDeducer.shouldEnable(Thread.currentThread())
+		if (DevToolsEnablementDeducer.shouldEnable(Thread.currentThread())
 				&& isLocalApplication(environment)) {
 			if (canAddProperties(environment)) {
 				logger.info("Devtools property defaults active! Set '" + ENABLED

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/DefaultRestartInitializer.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/DefaultRestartInitializer.java
@@ -18,7 +18,7 @@ package org.springframework.boot.devtools.restart;
 
 import java.net.URL;
 
-import org.springframework.boot.devtools.DevtoolsEnablementDeducer;
+import org.springframework.boot.devtools.DevToolsEnablementDeducer;
 
 /**
  * Default {@link RestartInitializer} that only enable initial restart when running a
@@ -36,7 +36,7 @@ public class DefaultRestartInitializer implements RestartInitializer {
 		if (!isMain(thread)) {
 			return null;
 		}
-		if (!DevtoolsEnablementDeducer.shouldEnable(thread)) {
+		if (!DevToolsEnablementDeducer.shouldEnable(thread)) {
 			return null;
 		}
 		return getUrls(thread);

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/OnEnabledDevToolsConditionTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/OnEnabledDevToolsConditionTests.java
@@ -27,11 +27,11 @@ import org.springframework.context.annotation.Configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link OnEnabledDevtoolsCondition}.
+ * Tests for {@link OnEnabledDevToolsCondition}.
  *
  * @author Madhura Bhave
  */
-public class OnEnabledDevtoolsConditionTests {
+public class OnEnabledDevToolsConditionTests {
 
 	private AnnotationConfigApplicationContext context;
 
@@ -44,8 +44,8 @@ public class OnEnabledDevtoolsConditionTests {
 	@Test
 	public void outcomeWhenDevtoolsShouldBeEnabledIsTrueShouldMatch() throws Exception {
 		Thread thread = new Thread(() -> {
-			OnEnabledDevtoolsConditionTests.this.context.refresh();
-			assertThat(OnEnabledDevtoolsConditionTests.this.context.containsBean("test"))
+			OnEnabledDevToolsConditionTests.this.context.refresh();
+			assertThat(OnEnabledDevToolsConditionTests.this.context.containsBean("test"))
 					.isTrue();
 		});
 		thread.start();
@@ -54,8 +54,8 @@ public class OnEnabledDevtoolsConditionTests {
 
 	@Test
 	public void outcomeWhenDevtoolsShouldBeEnabledIsFalseShouldNotMatch() {
-		OnEnabledDevtoolsConditionTests.this.context.refresh();
-		assertThat(OnEnabledDevtoolsConditionTests.this.context.containsBean("test"))
+		OnEnabledDevToolsConditionTests.this.context.refresh();
+		assertThat(OnEnabledDevToolsConditionTests.this.context.containsBean("test"))
 				.isFalse();
 	}
 
@@ -63,7 +63,7 @@ public class OnEnabledDevtoolsConditionTests {
 	static class TestConfiguration {
 
 		@Bean
-		@Conditional(OnEnabledDevtoolsCondition.class)
+		@Conditional(OnEnabledDevToolsCondition.class)
 		public String test() {
 			return "hello";
 		}


### PR DESCRIPTION
I can see there are mixed uses between "Devtools" to "DevTools" but it seems to use "DevTools" at least for class names consistently. This PR renames "Devtools" to "DevTools" in class names.

This PR also adds missing `@since` tags.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
