### PR TITLE
Align RestClientAutoConfiguration's use of PropertyMapper::asInt with the rest of the codebase

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/rest/RestClientAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/rest/RestClientAutoConfiguration.java
@@ -72,10 +72,10 @@ public class RestClientAutoConfiguration {
 		});
 		builder.setRequestConfigCallback((requestConfigBuilder) -> {
 			map.from(properties::getConnectionTimeout).whenNonNull()
-					.as(Duration::toMillis).asInt(Math::toIntExact)
+					.asInt(Duration::toMillis)
 					.to(requestConfigBuilder::setConnectTimeout);
-			map.from(properties::getReadTimeout).whenNonNull().as(Duration::toMillis)
-					.asInt(Math::toIntExact).to(requestConfigBuilder::setSocketTimeout);
+			map.from(properties::getReadTimeout).whenNonNull().asInt(Duration::toMillis)
+					.to(requestConfigBuilder::setSocketTimeout);
 			return requestConfigBuilder;
 		});
 		builderCustomizers.orderedStream()


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR removes redundant `as()` calls in `RestClientAutoConfiguration.restClientBuilder()`.