### PR TITLE
RedisReactiveHealthIndicator makes blocking call on error

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicator.java
@@ -19,6 +19,7 @@ package org.springframework.boot.actuate.redis;
 import java.util.Properties;
 
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import org.springframework.boot.actuate.health.AbstractReactiveHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
@@ -31,6 +32,7 @@ import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
  *
  * @author Stephane Nicoll
  * @author Mark Paluch
+ * @author Artsiom Yudovin
  * @since 2.0.0
  */
 public class RedisReactiveHealthIndicator extends AbstractReactiveHealthIndicator {
@@ -44,10 +46,14 @@ public class RedisReactiveHealthIndicator extends AbstractReactiveHealthIndicato
 
 	@Override
 	protected Mono<Health> doHealthCheck(Health.Builder builder) {
-		ReactiveRedisConnection connection = this.connectionFactory
-				.getReactiveConnection();
-		return connection.serverCommands().info().map((info) -> up(builder, info))
-				.doFinally((signal) -> connection.closeLater());
+		Mono<ReactiveRedisConnection> connection = Mono
+				.fromSupplier(this.connectionFactory::getReactiveConnection)
+				.subscribeOn(Schedulers.parallel());
+
+		return connection
+				.flatMap((c) -> c.serverCommands().info().map((info) -> up(builder, info))
+						.onErrorResume((e) -> Mono.just(builder.down(e).build()))
+						.doFinally((signal) -> c.closeLater()));
 	}
 
 	private Health up(Health.Builder builder, Properties info) {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicator.java
@@ -53,7 +53,7 @@ public class RedisReactiveHealthIndicator extends AbstractReactiveHealthIndicato
 		return connection
 				.flatMap((c) -> c.serverCommands().info().map((info) -> up(builder, info))
 						.onErrorResume((e) -> Mono.just(builder.down(e).build()))
-						.doFinally((signal) -> c.closeLater()));
+						.flatMap((signal) -> c.closeLater().thenReturn(signal)));
 	}
 
 	private Health up(Health.Builder builder, Properties info) {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicator.java
@@ -47,7 +47,7 @@ public class RedisReactiveHealthIndicator extends AbstractReactiveHealthIndicato
 		ReactiveRedisConnection connection = this.connectionFactory
 				.getReactiveConnection();
 		return connection.serverCommands().info().map((info) -> up(builder, info))
-				.doFinally((signal) -> connection.close());
+				.doFinally((signal) -> connection.closeLater());
 	}
 
 	private Health up(Health.Builder builder, Properties info) {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicatorTests.java
@@ -50,6 +50,7 @@ public class RedisReactiveHealthIndicatorTests {
 		Properties info = new Properties();
 		info.put("redis_version", "2.8.9");
 		ReactiveRedisConnection redisConnection = mock(ReactiveRedisConnection.class);
+		given(redisConnection.closeLater()).willReturn(Mono.empty());
 		ReactiveServerCommands commands = mock(ReactiveServerCommands.class);
 		given(commands.info()).willReturn(Mono.just(info));
 		RedisReactiveHealthIndicator healthIndicator = createHealthIndicator(
@@ -69,6 +70,7 @@ public class RedisReactiveHealthIndicatorTests {
 		given(commands.info()).willReturn(
 				Mono.error(new RedisConnectionFailureException("Connection failed")));
 		ReactiveRedisConnection redisConnection = mock(ReactiveRedisConnection.class);
+		given(redisConnection.closeLater()).willReturn(Mono.empty());
 		RedisReactiveHealthIndicator healthIndicator = createHealthIndicator(
 				redisConnection, commands);
 		Mono<Health> health = healthIndicator.health();

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicatorTests.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.verify;
  * @author Stephane Nicoll
  * @author Mark Paluch
  * @author Nikolay Rybak
+ * @author Artsiom Yudovin
  */
 public class RedisReactiveHealthIndicatorTests {
 
@@ -59,7 +60,7 @@ public class RedisReactiveHealthIndicatorTests {
 			assertThat(h.getDetails()).containsOnlyKeys("version");
 			assertThat(h.getDetails().get("version")).isEqualTo("2.8.9");
 		}).verifyComplete();
-		verify(redisConnection).close();
+		verify(redisConnection).closeLater();
 	}
 
 	@Test
@@ -74,7 +75,7 @@ public class RedisReactiveHealthIndicatorTests {
 		StepVerifier.create(health)
 				.consumeNextWith((h) -> assertThat(h.getStatus()).isEqualTo(Status.DOWN))
 				.verifyComplete();
-		verify(redisConnection).close();
+		verify(redisConnection).closeLater();
 	}
 
 	@Test


### PR DESCRIPTION
See #16705

---

```
Caused by: java.lang.IllegalStateException: block()/blockFirst()/blockLast() are blocking, which is not supported in thread reactor-http-epoll-3
	at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:77)
	at reactor.core.publisher.Mono.block(Mono.java:1494)
	at org.springframework.data.redis.connection.ReactiveRedisConnection.close(ReactiveRedisConnection.java:60)
	at org.springframework.boot.actuate.redis.RedisReactiveHealthIndicator.lambda$doHealthCheck$1(RedisReactiveHealthIndicator.java:50)
	at reactor.core.publisher.FluxDoFinally$DoFinallySubscriber.runFinally(FluxDoFinally.java:156)
	... 203 common frames omitted
```

While running a Spring Cloud Gateway application with Redis as session store, I observed the stack trace above. The cause is a blocking call in: https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicator.java#L49

There is a `Mono<Void> closeLater();` https://github.com/spring-projects/spring-data-redis/blob/master/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java#L68 which could be called instead.