### PR TITLE
Flyway and Liquibase auto-configuration does not consider DataSource properties configured via @AutoConfigureTestDatabase

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
@@ -79,6 +79,7 @@ import org.springframework.util.StringUtils;
  * @author Eddú Meléndez
  * @author Dominic Gunn
  * @author Dan Zheng
+ * @author András Deák
  * @since 1.1.0
  */
 @SuppressWarnings("deprecation")
@@ -163,11 +164,11 @@ public class FlywayAutoConfiguration {
 		private DataSource configureDataSource(FluentConfiguration configuration) {
 			if (this.properties.isCreateDataSource()) {
 				String url = getProperty(this.properties::getUrl,
-						this.dataSourceProperties::getUrl);
+						this.dataSourceProperties::determineUrl);
 				String user = getProperty(this.properties::getUser,
-						this.dataSourceProperties::getUsername);
+						this.dataSourceProperties::determineUsername);
 				String password = getProperty(this.properties::getPassword,
-						this.dataSourceProperties::getPassword);
+						this.dataSourceProperties::determinePassword);
 				configuration.dataSource(url, user, password);
 				if (!CollectionUtils.isEmpty(this.properties.getInitSqls())) {
 					String initSql = StringUtils.collectionToDelimitedString(

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -61,6 +61,7 @@ import org.springframework.util.Assert;
  * @author Andy Wilkinson
  * @author Dominic Gunn
  * @author Dan Zheng
+ * @author András Deák
  * @since 1.1.0
  */
 @Configuration
@@ -163,11 +164,11 @@ public class LiquibaseAutoConfiguration {
 
 		private DataSource createNewDataSource() {
 			String url = getProperty(this.properties::getUrl,
-					this.dataSourceProperties::getUrl);
+					this.dataSourceProperties::determineUrl);
 			String user = getProperty(this.properties::getUser,
-					this.dataSourceProperties::getUsername);
+					this.dataSourceProperties::determineUsername);
 			String password = getProperty(this.properties::getPassword,
-					this.dataSourceProperties::getPassword);
+					this.dataSourceProperties::determinePassword);
 			return DataSourceBuilder.create().url(url).username(user).password(password)
 					.build();
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
@@ -30,6 +30,7 @@ import org.flywaydb.core.api.callback.Callback;
 import org.flywaydb.core.api.callback.Context;
 import org.flywaydb.core.api.callback.Event;
 import org.flywaydb.core.api.callback.FlywayCallback;
+import org.flywaydb.core.internal.jdbc.DriverDataSource;
 import org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -66,6 +67,7 @@ import static org.mockito.Mockito.mock;
  * @author Eddú Meléndez
  * @author Stephane Nicoll
  * @author Dominic Gunn
+ * @author András Deák
  */
 @SuppressWarnings("deprecation")
 public class FlywayAutoConfigurationTests {
@@ -98,6 +100,31 @@ public class FlywayAutoConfigurationTests {
 				.run((context) -> {
 					assertThat(context).hasSingleBean(Flyway.class);
 					assertThat(context.getBean(Flyway.class).getDataSource()).isNotNull();
+				});
+	}
+
+	@Test
+	public void createDataSourceFallbackToEmbeddedProperties() {
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+				.withPropertyValues("spring.flyway.url:jdbc:hsqldb:mem:flywaytest")
+				.run((context) -> {
+					assertThat(context).hasSingleBean(Flyway.class);
+					assertThat(context.getBean(Flyway.class).getDataSource()).isNotNull();
+					assertThat(((DriverDataSource) context.getBean(Flyway.class)
+							.getDataSource()).getUser()).isEqualTo("sa");
+					assertThat(((DriverDataSource) context.getBean(Flyway.class)
+							.getDataSource()).getPassword()).isEqualTo("");
+				});
+	}
+
+	@Test
+	public void createDataSourceWithUserAndFallbackToEmbeddedProperties() {
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+				.withPropertyValues("spring.flyway.user:sa").run((context) -> {
+					assertThat(context).hasSingleBean(Flyway.class);
+					assertThat(context.getBean(Flyway.class).getDataSource()).isNotNull();
+					assertThat(((DriverDataSource) context.getBean(Flyway.class)
+							.getDataSource()).getUrl()).startsWith("jdbc:h2:mem:");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
@@ -60,6 +60,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  * @author Dominic Gunn
+ * @author András Deák
  */
 public class LiquibaseAutoConfigurationTests {
 
@@ -218,6 +219,32 @@ public class LiquibaseAutoConfigurationTests {
 							.isEqualTo("jdbc:hsqldb:mem:normal");
 					assertThat(((HikariDataSource) dataSource).getUsername())
 							.isEqualTo("sa");
+				}));
+	}
+
+	@Test
+	public void overrideDataSourceAndFallbackToEmbeddedProperties() {
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+				.withPropertyValues("spring.liquibase.url:jdbc:hsqldb:mem:liquibase")
+				.run(assertLiquibase((liquibase) -> {
+					DataSource dataSource = liquibase.getDataSource();
+					assertThat(((HikariDataSource) dataSource).isClosed()).isTrue();
+					assertThat(((HikariDataSource) dataSource).getUsername())
+							.isEqualTo("sa");
+					assertThat(((HikariDataSource) dataSource).getPassword())
+							.isEqualTo("");
+				}));
+	}
+
+	@Test
+	public void overrideUserAndFallbackToEmbeddedProperties() {
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+				.withPropertyValues("spring.liquibase.user:sa")
+				.run(assertLiquibase((liquibase) -> {
+					DataSource dataSource = liquibase.getDataSource();
+					assertThat(((HikariDataSource) dataSource).isClosed()).isTrue();
+					assertThat(((HikariDataSource) dataSource).getJdbcUrl())
+							.startsWith("jdbc:h2:mem:");
 				}));
 	}
 

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -35,4 +35,5 @@
 	<suppress files="LogbackMetricsAutoConfiguration\.java" checks="IllegalImport" />
 	<suppress files="RemoteUrlPropertyExtractorTests\.java" checks="IllegalImport" />
 	<suppress files="SampleLogbackApplication\.java" checks="IllegalImport" />
+	<suppress files="FlywayAutoConfigurationTests\.java" checks="IllegalImport" />
 </suppressions>


### PR DESCRIPTION
Both Flyway and Liquibase makes use of `DataSourceProperties` to get default properties.
However both uses strictly the configuration properties and fail to consider
embedded datasource properties autoconfigured by `@AutoConfigureTestDatabase`.
In case a database layer test e.g. `@JdbcTest` relies on the autoconfigured
embedded datasource, Flyway and Liquibase autoconfiguration fails
as they are not aware of the embedded datasource properties.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
