### PR TITLE
Fix assertion for outcomeWhenDevtoolsShouldBeEnabledIsTrueShouldMatch()

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/OnEnabledDevToolsConditionTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/OnEnabledDevToolsConditionTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.devtools.autoconfigure;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,13 +45,15 @@ public class OnEnabledDevToolsConditionTests {
 
 	@Test
 	public void outcomeWhenDevtoolsShouldBeEnabledIsTrueShouldMatch() throws Exception {
+		AtomicBoolean containsBean = new AtomicBoolean();
 		Thread thread = new Thread(() -> {
 			OnEnabledDevToolsConditionTests.this.context.refresh();
-			assertThat(OnEnabledDevToolsConditionTests.this.context.containsBean("test"))
-					.isTrue();
+			containsBean.set(
+					OnEnabledDevToolsConditionTests.this.context.containsBean("test"));
 		});
 		thread.start();
 		thread.join();
+		assertThat(containsBean).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR fixes the assertion for `OnEnabledDevToolsConditionTests.outcomeWhenDevtoolsShouldBeEnabledIsTrueShouldMatch()`.