### PR TITLE
Add support for AWS Redshift JDBC driver

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
@@ -100,6 +100,11 @@ public enum DatabaseDriver {
 			"SELECT 1"),
 
 	/**
+	 * AWS Redshift.
+	 */
+	REDSHIFT("Amazon Redshift", "com.amazon.redshift.jdbc.Driver", null, "SELECT 1"),
+
+	/**
 	 * HANA - SAP HANA Database - HDB.
 	 * @since 2.1.0
 	 */

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DatabaseDriverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DatabaseDriverTests.java
@@ -81,6 +81,8 @@ public class DatabaseDriverTests {
 				.isEqualTo(DatabaseDriver.ORACLE);
 		assertThat(DatabaseDriver.fromProductName("PostgreSQL"))
 				.isEqualTo(DatabaseDriver.POSTGRESQL);
+		assertThat(DatabaseDriver.fromProductName("Amazon Redshift"))
+				.isEqualTo(DatabaseDriver.REDSHIFT);
 		assertThat(DatabaseDriver.fromProductName("Microsoft SQL Server"))
 				.isEqualTo(DatabaseDriver.SQLSERVER);
 		assertThat(DatabaseDriver.fromProductName("SQL SERVER"))
@@ -120,6 +122,9 @@ public class DatabaseDriverTests {
 				.isEqualTo(DatabaseDriver.ORACLE);
 		assertThat(DatabaseDriver.fromJdbcUrl("jdbc:postgresql://127.0.0.1:5432/sample"))
 				.isEqualTo(DatabaseDriver.POSTGRESQL);
+		assertThat(DatabaseDriver.fromJdbcUrl(
+				"jdbc:redshift://foo.bar.us-east-1.redshift.amazonaws.com:5439/postgres"))
+						.isEqualTo(DatabaseDriver.REDSHIFT);
 		assertThat(
 				DatabaseDriver.fromJdbcUrl("jdbc:jtds:sqlserver://127.0.0.1:1433/sample"))
 						.isEqualTo(DatabaseDriver.JTDS);


### PR DESCRIPTION
Hi,

Nothing fancy here - just added AWS Redshift JDBC driver definition to DatabaseDriver enum, so it could be auto-detected by `DataSourceBuilder`.

Thanks!