### PR TITLE
make repackager thread-safe

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Repackager.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Repackager.java
@@ -44,6 +44,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author Issam El-atif
  */
 public class Repackager {
 
@@ -168,7 +169,7 @@ public class Repackager {
 	 * @throws IOException if the file cannot be repackaged
 	 * @since 1.3.0
 	 */
-	public void repackage(File destination, Libraries libraries,
+	public synchronized void repackage(File destination, Libraries libraries,
 			LaunchScript launchScript) throws IOException {
 		if (destination == null || destination.isDirectory()) {
 			throw new IllegalArgumentException("Invalid destination");
@@ -181,7 +182,7 @@ public class Repackager {
 		}
 		destination = destination.getAbsoluteFile();
 		File workingSource = this.source;
-		if (alreadyRepackaged() && this.source.equals(destination)) {
+		if (alreadyRepackaged()) {
 			return;
 		}
 		if (this.source.equals(destination)) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/RepackagerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/RepackagerTests.java
@@ -60,6 +60,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Issam El-atif
  */
 public class RepackagerTests {
 
@@ -246,6 +247,20 @@ public class RepackagerTests {
 				.doesNotExist();
 		assertThat(hasLauncherClasses(source)).isFalse();
 		assertThat(hasLauncherClasses(dest)).isTrue();
+	}
+
+	@Test
+	public void differentDestinationWithSourceAlreadyRepackaged() throws Exception {
+		this.testJarFile.addClass("a/b/C.class", ClassWithMainMethod.class);
+		File source = this.testJarFile.getFile();
+		TestJarFile destJarFile = new TestJarFile(this.temporaryFolder);
+		destJarFile.addClass("a/b/C.class", ClassWithMainMethod.class);
+		File dest = destJarFile.getFile();
+		Repackager repackager = new Repackager(source);
+		repackager.repackage(NO_LIBRARIES);
+		repackager.repackage(dest, NO_LIBRARIES);
+		assertThat(hasLauncherClasses(source)).isTrue();
+		assertThat(hasLauncherClasses(dest)).isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
This commit makes the repackager thread-safe when it is invoked concurrently in the same lifecycle. Closes gh-16828

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
