### PR TITLE
Fix NoClassDefFoundError when Spring Session is used without Spring Security

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionAutoConfiguration.java
@@ -23,7 +23,9 @@ import java.util.Locale;
 
 import javax.annotation.PostConstruct;
 
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -53,6 +55,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.security.web.authentication.RememberMeServices;
 import org.springframework.session.ReactiveSessionRepository;
 import org.springframework.session.Session;
 import org.springframework.session.SessionRepository;
@@ -91,8 +94,8 @@ public class SessionAutoConfiguration {
 
 		@Bean
 		@Conditional(DefaultCookieSerializerCondition.class)
-		public DefaultCookieSerializer cookieSerializer(ServerProperties serverProperties,
-				ObjectProvider<SpringSessionRememberMeServices> springSessionRememberMeServices) {
+		public DefaultCookieSerializer cookieSerializer(
+				ServerProperties serverProperties) {
 			Cookie cookie = serverProperties.getServlet().getSession().getCookie();
 			DefaultCookieSerializer cookieSerializer = new DefaultCookieSerializer();
 			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
@@ -103,9 +106,6 @@ public class SessionAutoConfiguration {
 			map.from(cookie::getSecure).to(cookieSerializer::setUseSecureCookie);
 			map.from(cookie::getMaxAge).to((maxAge) -> cookieSerializer
 					.setCookieMaxAge((int) maxAge.getSeconds()));
-			springSessionRememberMeServices.ifAvailable((
-					rememberMeServices) -> cookieSerializer.setRememberMeRequestAttribute(
-							SpringSessionRememberMeServices.REMEMBER_ME_LOGIN_ATTR));
 			return cookieSerializer;
 		}
 
@@ -114,6 +114,33 @@ public class SessionAutoConfiguration {
 		@Import({ ServletSessionRepositoryImplementationValidator.class,
 				ServletSessionConfigurationImportSelector.class })
 		static class ServletSessionRepositoryConfiguration {
+
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		@ConditionalOnClass(RememberMeServices.class)
+		static class RememberMeServicesConfiguration {
+
+			@Bean
+			public BeanPostProcessor rememberMeServicesBeanPostProcessor(
+					ObjectProvider<SpringSessionRememberMeServices> springSessionRememberMeServices) {
+				return new BeanPostProcessor() {
+
+					@Override
+					public Object postProcessBeforeInitialization(Object bean,
+							String beanName) throws BeansException {
+						if (bean instanceof DefaultCookieSerializer) {
+							DefaultCookieSerializer cookieSerializer = (DefaultCookieSerializer) bean;
+							springSessionRememberMeServices
+									.ifAvailable((rememberMeServices) -> cookieSerializer
+											.setRememberMeRequestAttribute(
+													SpringSessionRememberMeServices.REMEMBER_ME_LOGIN_ATTR));
+						}
+						return bean;
+					}
+
+				};
+			}
 
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/AbstractSessionAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/AbstractSessionAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,16 @@
 
 package org.springframework.boot.autoconfigure.session;
 
+import java.util.Collections;
+
 import org.springframework.boot.test.context.assertj.AssertableReactiveWebApplicationContext;
 import org.springframework.boot.test.context.assertj.AssertableWebApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.MapSessionRepository;
 import org.springframework.session.ReactiveSessionRepository;
 import org.springframework.session.SessionRepository;
+import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
 import org.springframework.session.web.http.SessionRepositoryFilter;
 import org.springframework.web.server.session.WebSessionManager;
 
@@ -49,6 +55,17 @@ public abstract class AbstractSessionAutoConfigurationTests {
 				.getBean(ReactiveSessionRepository.class);
 		assertThat(repository).as("Wrong session repository type").isInstanceOf(type);
 		return type.cast(repository);
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableSpringHttpSession
+	static class SessionRepositoryConfiguration {
+
+		@Bean
+		public MapSessionRepository mySessionRepository() {
+			return new MapSessionRepository(Collections.emptyMap());
+		}
+
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.autoconfigure.session;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.EnumSet;
 
 import javax.servlet.DispatcherType;
@@ -256,17 +255,6 @@ public class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurat
 							"rememberMeRequestAttribute",
 							SpringSessionRememberMeServices.REMEMBER_ME_LOGIN_ATTR);
 				});
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	@EnableSpringHttpSession
-	static class SessionRepositoryConfiguration {
-
-		@Bean
-		public MapSessionRepository mySessionRepository() {
-			return new MapSessionRepository(Collections.emptyMap());
-		}
-
 	}
 
 	@EnableConfigurationProperties(ServerProperties.class)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationWithoutSecurityTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationWithoutSecurityTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.session;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.testsupport.runner.classpath.ClassPathExclusions;
+import org.springframework.boot.testsupport.runner.classpath.ModifiedClassPathRunner;
+import org.springframework.session.web.http.DefaultCookieSerializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SessionAutoConfiguration} when Spring Security is not on the
+ * classpath.
+ *
+ * @author Vedran Pavic
+ */
+@RunWith(ModifiedClassPathRunner.class)
+@ClassPathExclusions("spring-security-*")
+public class SessionAutoConfigurationWithoutSecurityTests
+		extends AbstractSessionAutoConfigurationTests {
+
+	private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(SessionAutoConfiguration.class));
+
+	@Test
+	public void sessionCookieConfigurationIsAppliedToAutoConfiguredCookieSerializer() {
+		this.contextRunner.withUserConfiguration(SessionRepositoryConfiguration.class)
+				.run((context) -> {
+					DefaultCookieSerializer cookieSerializer = context
+							.getBean(DefaultCookieSerializer.class);
+					assertThat(cookieSerializer).hasFieldOrPropertyWithValue(
+							"rememberMeRequestAttribute", null);
+				});
+	}
+
+}


### PR DESCRIPTION
This resolves #16871 by ensuring auto-configuration of Spring Session's DefaultCookieSerializer doesn't break when Spring Security is not present on the classpath.

The approach taken in this PR uses an anonymous `BeanPostProcessor` - I'm not sure this is an acceptable approach but introducing some sort of a customizer bean seemed like an overhead in `DefaultCookieSerializer` case.

Regarding the anonymous `BeanPostProcessor` pattern, it is also present in `LiquibaseEndpointAutoConfiguration`.