### PR TITLE
JVM can't exit due to threads left if Tomcat throws exceptions during shutdown

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
@@ -122,6 +122,7 @@ public class TomcatWebServer implements WebServer {
 			}
 			catch (Exception ex) {
 				stopSilently();
+				destroySilently();
 				throw new WebServerException("Unable to start embedded Tomcat", ex);
 			}
 		}
@@ -236,6 +237,15 @@ public class TomcatWebServer implements WebServer {
 	private void stopSilently() {
 		try {
 			stopTomcat();
+		}
+		catch (LifecycleException ex) {
+			// Ignore
+		}
+	}
+
+	private void destroySilently() {
+		try {
+			this.tomcat.destroy();
 		}
 		catch (LifecycleException ex) {
 			// Ignore

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactoryTests.java
@@ -575,6 +575,25 @@ public class TomcatServletWebServerFactoryTests
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 	}
 
+	@Test
+	public void exceptionThrownOnContextListenerDestroysServer() {
+		TomcatServletWebServerFactory factory = new TomcatServletWebServerFactory(0) {
+			@Override
+			protected TomcatWebServer getTomcatWebServer(Tomcat tomcat) {
+				try {
+					return super.getTomcatWebServer(tomcat);
+				}
+				finally {
+					assertThat(tomcat.getServer().getState())
+							.isEqualTo(LifecycleState.DESTROYED);
+				}
+			}
+		};
+		assertThatExceptionOfType(WebServerException.class)
+				.isThrownBy(() -> factory.getWebServer((context) -> context
+						.addListener(new FailingServletContextListener())));
+	}
+
 	@Override
 	protected JspServlet getJspServlet() throws ServletException {
 		Tomcat tomcat = ((TomcatWebServer) this.webServer).getTomcat();

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
@@ -1402,6 +1402,15 @@ public abstract class AbstractServletWebServerFactoryTests {
 
 	}
 
+	public static class FailingServletContextListener implements ServletContextListener {
+
+		@Override
+		public void contextInitialized(ServletContextEvent sce) {
+			throw new FailingServletException();
+		}
+
+	}
+
 	private static class FailingServletException extends RuntimeException {
 
 		FailingServletException() {


### PR DESCRIPTION
**Summary**
If [`TomcatWebServer#rethrowDeferredStartupExceptions`](https://github.com/spring-projects/spring-boot/blob/cce8c45ae63d2d10f781963e40b6a65c18abc112/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java#L157) throws an exception, the embedded Tomcat instance may not allow the the JVM to terminate.

**Symptoms**
We have been running into some sporadic issues in which startup errors will sometime leave the JVM running, although the main thread has since died (the one running the `@SpringBootApplication` main).

Things like a failing Liquibase migration, that were being applied fairly early during the startup of the application, would leave the service hanging, and not truly failing (exiting with a status code != 0).

**Analysis**
The problem stems from the fact that some beans require early initialization in order for them to be injected into the Tomcat context.
Beans like Servlet Filters (and Servlet Filter Registrations) or Servlet Listeners (and Servlet Listener Registrations) are needed before the Tomcat context is started, so they (and their dependents) are created very early.
The remaining beans are created after the Tomcat context has been created.

If an exception occurs after the Tomcat context is started, the Tomcat is properly disposed of. However, if an error occurs early, the instance will not be fully created, and the instance will not be closed and destroyed.

This leaves some non daemon threads running and, those kind of threads do not allow the JVM to terminate, even if the exception propagates all the way to the main method.

**Technical background**
The method [`org.springframework.boot.web.embedded.tomcat.TomcatStarter#onStartup`](https://github.com/spring-projects/spring-boot/blob/cce8c45ae63d2d10f781963e40b6a65c18abc112/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatStarter.java#L50) is called to run all `ServletContextInitializers`
Spring Boot uses a `ServletContextInitializer` to initialize the Spring framework that comes from [`org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext#getSelfInitializer`](https://github.com/spring-projects/spring-boot/blob/cce8c45ae63d2d10f781963e40b6a65c18abc112/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContext.java#L225).

This `ServletContextInitializer` calls [`org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext#getServletContextInitializerBeans`](https://github.com/spring-projects/spring-boot/blob/cce8c45ae63d2d10f781963e40b6a65c18abc112/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContext.java#L260) to fetch available `org.springframework.boot.web.servlet.ServletContextInitializerBeans`
 - Beans like Servlet Filters and Servlet Listeners are initialized here
 - If such beans throw errors (or one of their dependents) the exception is deferred and stored in the catch clause of [`org.springframework.boot.web.embedded.tomcat.TomcatStarter#onStartup`](https://github.com/spring-projects/spring-boot/blob/cce8c45ae63d2d10f781963e40b6a65c18abc112/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatStarter.java#L50)

Back to [`org.springframework.boot.web.embedded.tomcat.TomcatWebServer#initialize`](https://github.com/spring-projects/spring-boot/blob/cce8c45ae63d2d10f781963e40b6a65c18abc112/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java#L109), after `tomcat.start()` is done, [`org.springframework.boot.web.embedded.tomcat.TomcatWebServer#rethrowDeferredStartupExceptions`](https://github.com/spring-projects/spring-boot/blob/cce8c45ae63d2d10f781963e40b6a65c18abc112/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java#L157) is called to rethrow any deferred exceptions, which is immediately caught and:
 - the Tomcat server is stopped silently with [`org.springframework.boot.web.embedded.tomcat.TomcatWebServer#stopSilently`](https://github.com/spring-projects/spring-boot/blob/cce8c45ae63d2d10f781963e40b6a65c18abc112/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java#L124)
 - checked `Exception` is wrapped in a `WebServerException` and
 - result is thrown

Since `initialize()` is called from the constructor of `TomcatWebServer`, a webServer instance is never stored in [`org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext#createWebServer`](https://github.com/spring-projects/spring-boot/blob/cce8c45ae63d2d10f781963e40b6a65c18abc112/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContext.java#L181)

Down the stack, [`org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext#refresh`](https://github.com/spring-projects/spring-boot/blob/cce8c45ae63d2d10f781963e40b6a65c18abc112/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContext.java#L145) will catch the `WebServerException` and call [`org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext#stopAndReleaseWebServer`](https://github.com/spring-projects/spring-boot/blob/cce8c45ae63d2d10f781963e40b6a65c18abc112/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContext.java#L316).
However, since a `webServer` was never fully initialized, there is none to call `stop()` upon.

Notice that `stop()` is not the same as `stopSilently()`. `stop()` will stop and destroy and destroy the Tomcat instance. `stopSilently()` does not destroy the Tomcat instance.

**Root cause**
A Tomcat server (`org.apache.catalina.Server`) depends on destroy to release certain resources.
One such resource is the `utilityExecutor` stored in `org.apache.catalina.core.StandardServer`.
This executor creates threads that are not marked as daemon (`org.apache.catalina.core.StandardServer#utilityThreadsAsDaemon` is by default `false`).
Since these threads are not daemon, they do not allow the JVM to die after the main thread finishes.
The executor is stopped from `org.apache.catalina.core.StandardServer#destroyInternal`, which depends on Tomcat being destroyed.