### PR TITLE
Exclude AWS Redshift from DatabaseDriverClassNameTests

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DatabaseDriverClassNameTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DatabaseDriverClassNameTests.java
@@ -46,7 +46,8 @@ public class DatabaseDriverClassNameTests {
 	private static final Set<DatabaseDriver> EXCLUDED_DRIVERS = Collections
 			.unmodifiableSet(EnumSet.of(DatabaseDriver.UNKNOWN, DatabaseDriver.ORACLE,
 					DatabaseDriver.DB2, DatabaseDriver.DB2_AS400, DatabaseDriver.INFORMIX,
-					DatabaseDriver.HANA, DatabaseDriver.TERADATA));
+					DatabaseDriver.HANA, DatabaseDriver.TERADATA,
+					DatabaseDriver.REDSHIFT));
 
 	private final String className;
 


### PR DESCRIPTION
Hi,

apparently 146f35d broke the current master as the new driver is not excluded from DatabaseDriverClassNameTests. For simplicity reasons, I simply excluded it for now.

Cheers,
Christoph