### PR TITLE
Fix deprecated StandardAnnotationMetadata usages

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementContextConfigurationImportSelectorTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementContextConfigurationImportSelectorTests.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
 import org.springframework.boot.actuate.autoconfigure.web.ManagementContextType;
 import org.springframework.core.annotation.Order;
-import org.springframework.core.type.StandardAnnotationMetadata;
+import org.springframework.core.type.AnnotationMetadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,7 +41,7 @@ public class ManagementContextConfigurationImportSelectorTests {
 	public void selectImportsShouldOrderResult() {
 		String[] imports = new TestManagementContextConfigurationsImportSelector(C.class,
 				A.class, D.class, B.class).selectImports(
-						new StandardAnnotationMetadata(EnableChildContext.class));
+						AnnotationMetadata.introspect(EnableChildContext.class));
 		assertThat(imports).containsExactly(A.class.getName(), B.class.getName(),
 				C.class.getName(), D.class.getName());
 	}
@@ -50,7 +50,7 @@ public class ManagementContextConfigurationImportSelectorTests {
 	public void selectImportsFiltersChildOnlyConfigurationWhenUsingSameContext() {
 		String[] imports = new TestManagementContextConfigurationsImportSelector(
 				ChildOnly.class, SameOnly.class, A.class).selectImports(
-						new StandardAnnotationMetadata(EnableSameContext.class));
+						AnnotationMetadata.introspect(EnableSameContext.class));
 		assertThat(imports).containsExactlyInAnyOrder(SameOnly.class.getName(),
 				A.class.getName());
 	}
@@ -59,7 +59,7 @@ public class ManagementContextConfigurationImportSelectorTests {
 	public void selectImportsFiltersSameOnlyConfigurationWhenUsingChildContext() {
 		String[] imports = new TestManagementContextConfigurationsImportSelector(
 				ChildOnly.class, SameOnly.class, A.class).selectImports(
-						new StandardAnnotationMetadata(EnableChildContext.class));
+						AnnotationMetadata.introspect(EnableChildContext.class));
 		assertThat(imports).containsExactlyInAnyOrder(ChildOnly.class.getName(),
 				A.class.getName());
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/AbstractRepositoryConfigurationSourceSupport.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/AbstractRepositoryConfigurationSourceSupport.java
@@ -30,7 +30,6 @@ import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.type.AnnotationMetadata;
-import org.springframework.core.type.StandardAnnotationMetadata;
 import org.springframework.data.repository.config.AnnotationRepositoryConfigurationSource;
 import org.springframework.data.repository.config.BootstrapMode;
 import org.springframework.data.repository.config.RepositoryConfigurationDelegate;
@@ -66,8 +65,7 @@ public abstract class AbstractRepositoryConfigurationSourceSupport
 
 	private AnnotationRepositoryConfigurationSource getConfigurationSource(
 			BeanDefinitionRegistry registry, BeanNameGenerator importBeanNameGenerator) {
-		StandardAnnotationMetadata metadata = new StandardAnnotationMetadata(
-				getConfiguration(), true);
+		AnnotationMetadata metadata = AnnotationMetadata.introspect(getConfiguration());
 		return new AutoConfiguredAnnotationRepositoryConfigurationSource(metadata,
 				getAnnotation(), this.resourceLoader, this.environment, registry,
 				importBeanNameGenerator) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationScanRegistrar.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationScanRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
 import org.springframework.core.type.AnnotationMetadata;
-import org.springframework.core.type.StandardAnnotationMetadata;
 import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.integration.config.IntegrationComponentScanRegistrar;
 
@@ -49,8 +48,8 @@ class IntegrationAutoConfigurationScanRegistrar extends IntegrationComponentScan
 	@Override
 	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata,
 			final BeanDefinitionRegistry registry) {
-		super.registerBeanDefinitions(new StandardAnnotationMetadata(
-				IntegrationComponentScanConfiguration.class, true), registry);
+		super.registerBeanDefinitions(AnnotationMetadata
+				.introspect(IntegrationComponentScanConfiguration.class), registry);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelectorTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelectorTests.java
@@ -37,7 +37,7 @@ import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfigurati
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.support.SpringFactoriesLoader;
-import org.springframework.core.type.StandardAnnotationMetadata;
+import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.mock.env.MockEnvironment;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -220,7 +220,7 @@ public class AutoConfigurationImportSelectorTests {
 	}
 
 	private String[] selectImports(Class<?> source) {
-		return this.importSelector.selectImports(new StandardAnnotationMetadata(source));
+		return this.importSelector.selectImports(AnnotationMetadata.introspect(source));
 	}
 
 	private List<String> getAutoConfigurationClassNames() {

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/ImportsContextCustomizer.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/ImportsContextCustomizer.java
@@ -46,7 +46,6 @@ import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.core.type.AnnotationMetadata;
-import org.springframework.core.type.StandardAnnotationMetadata;
 import org.springframework.test.context.ContextCustomizer;
 import org.springframework.test.context.MergedContextConfiguration;
 import org.springframework.util.ReflectionUtils;
@@ -284,8 +283,8 @@ class ImportsContextCustomizer implements ContextCustomizer {
 		private Set<Object> determineImports(Set<Annotation> annotations,
 				Class<?> testClass) {
 			Set<Object> determinedImports = new LinkedHashSet<>();
-			AnnotationMetadata testClassMetadata = new StandardAnnotationMetadata(
-					testClass);
+			AnnotationMetadata testClassMetadata = AnnotationMetadata
+					.introspect(testClass);
 			for (Annotation annotation : annotations) {
 				for (Class<?> source : getImports(annotation)) {
 					Set<Object> determinedSourceImports = determineImports(source,


### PR DESCRIPTION
Hi,

just noticed some deprecation warnings around StandardAnnotationMetadata. I wasn't entirely sure about the usages of `new StandardAnnotationMetadata(Class)` as they set the `nestedAnnotationsAsMap` field to `false` and the new method `AnnotationMetadata.introspect` generates them with `true`, but from what I saw this doesn't make a difference in the applied cases. Maybe you could check this though before you merge this.

Cheers,
Christoph