### PR TITLE
added sample app that demonstrates a basic use of spring-boot-starter-mail

### DIFF
--- a/spring-boot-samples/README.adoc
+++ b/spring-boot-samples/README.adoc
@@ -134,6 +134,9 @@ The following sample applications are provided:
 | link:spring-boot-sample-metrics-redis[spring-boot-sample-metrics-redis]
 | Exports metrics to Redis
 
+| link:spring-boot-sample-mail[spring-boot-sample-mail]
+| Demonstrates a basic use of spring-boot-starter-mail.
+
 | link:spring-boot-sample-oauth2-client[spring-boot-sample-oauth2-client]
 | Configure an OAuth2 login client
 

--- a/spring-boot-samples/pom.xml
+++ b/spring-boot-samples/pom.xml
@@ -60,6 +60,7 @@
 		<module>spring-boot-sample-kafka</module>
 		<module>spring-boot-sample-liquibase</module>
 		<module>spring-boot-sample-logback</module>
+		<module>spring-boot-sample-mail</module>
 		<module>spring-boot-sample-oauth2-client</module>
 		<module>spring-boot-sample-oauth2-resource-server</module>
 		<module>spring-boot-sample-parent-context</module>

--- a/spring-boot-samples/spring-boot-sample-mail/README.adoc
+++ b/spring-boot-samples/spring-boot-sample-mail/README.adoc
@@ -1,0 +1,10 @@
+== Spring Boot Mail Sample
+
+This sample demonstrates a basic use of spring-boot-starter-mail.
+
+Fill in src/main/resources/application.properties with your email and password.
+(Also, host and port when necessary).
+
+Note:
+If you are using gmail with 2-Step-Verification enabled, you need to either temporarily disable it, or setup App Passwords.
+Refer to the https://support.google.com/mail/answer/185833?hl=en[official guide] for setup.

--- a/spring-boot-samples/spring-boot-sample-mail/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-mail/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.1.5.RELEASE</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>sample</groupId>
+	<artifactId>mail</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>mail</name>
+	<description>Demo project for Spring Boot</description>
+
+	<properties>
+		<java.version>1.8</java.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/spring-boot-samples/spring-boot-sample-mail/src/main/java/sample/mail/MailApplication.java
+++ b/spring-boot-samples/spring-boot-sample-mail/src/main/java/sample/mail/MailApplication.java
@@ -1,0 +1,31 @@
+package sample.mail;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MailApplication implements CommandLineRunner {
+
+	@Autowired
+	private MailService mailService;
+
+	@Value("${sample.message.to}")
+	private String to;
+
+	@Value("${sample.message.text}")
+	private String text;
+
+	@Override
+	public void run(String... args) {
+		Message message = new Message(to, text);
+		mailService.processMessage(message);
+	}
+
+	public static void main(String[] args) {
+		SpringApplication.run(MailApplication.class, args);
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-mail/src/main/java/sample/mail/MailService.java
+++ b/spring-boot-samples/spring-boot-sample-mail/src/main/java/sample/mail/MailService.java
@@ -1,0 +1,30 @@
+package sample.mail;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.MailException;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MailService {
+
+    private final MailSender mailSender;
+
+    @Autowired
+    public MailService(MailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public void processMessage(Message message) {
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setTo(message.getTo());
+        msg.setText(message.getText());
+        try{
+            this.mailSender.send(msg);
+        }
+        catch (MailException ex) {
+            System.err.println(ex.getMessage());
+        }
+    }
+}

--- a/spring-boot-samples/spring-boot-sample-mail/src/main/java/sample/mail/Message.java
+++ b/spring-boot-samples/spring-boot-sample-mail/src/main/java/sample/mail/Message.java
@@ -1,0 +1,29 @@
+package sample.mail;
+
+public class Message {
+
+    private String to;
+
+    private String text;
+
+    public Message(String to, String text) {
+        this.to = to;
+        this.text = text;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+}

--- a/spring-boot-samples/spring-boot-sample-mail/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-mail/src/main/resources/application.properties
@@ -1,0 +1,12 @@
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=
+spring.mail.password=
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.connectiontimeout=5000
+spring.mail.properties.mail.smtp.timeout=3000
+spring.mail.properties.mail.smtp.writetimeout=5000
+
+sample.message.to=
+sample.message.text=test

--- a/spring-boot-samples/spring-boot-sample-mail/src/test/java/sample/mail/ProcessMessageFailTest.java
+++ b/spring-boot-samples/spring-boot-sample-mail/src/test/java/sample/mail/ProcessMessageFailTest.java
@@ -1,0 +1,34 @@
+package sample.mail;
+
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@TestPropertySource(locations = { "classpath:application.properties", "classpath:fail.properties" })
+public class ProcessMessageFailTest {
+
+    private static ByteArrayOutputStream outContent;
+
+    @BeforeClass
+    public static void setup(){
+        outContent = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(outContent));
+    }
+
+    @Ignore
+    @Test
+    public void processMessagePrintsExceptionWhenInvalidAddress() {
+        assertThat(outContent.toString()).contains("javax.mail.SendFailedException: Invalid Addresses;");
+    }
+}

--- a/spring-boot-samples/spring-boot-sample-mail/src/test/java/sample/mail/SampleMailAppIntegrationTest.java
+++ b/spring-boot-samples/spring-boot-sample-mail/src/test/java/sample/mail/SampleMailAppIntegrationTest.java
@@ -1,0 +1,18 @@
+package sample.mail;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class SampleMailAppIntegrationTest {
+
+    @Ignore
+    @Test
+    public void contextLoadsAndProcessMessageSuccess() {
+
+    }
+}

--- a/spring-boot-samples/spring-boot-sample-mail/src/test/resources/fail.properties
+++ b/spring-boot-samples/spring-boot-sample-mail/src/test/resources/fail.properties
@@ -1,0 +1,1 @@
+sample.message.to=INVALID_EMAIL


### PR DESCRIPTION
I've written a sample app for spring-boot-starter-mail since it was lacking in the collection of samples.

Also added tests and checked that it works, but since I cannot include my own email and password, I’ve @Ignore the tests.