### PR TITLE
Rename Maven project name of spring-boot-project to avoid already used name "Spring Boot Build"

### DIFF
--- a/spring-boot-project/pom.xml
+++ b/spring-boot-project/pom.xml
@@ -9,8 +9,8 @@
 	</parent>
 	<artifactId>spring-boot-project</artifactId>
 	<packaging>pom</packaging>
-	<name>Spring Boot Build</name>
-	<description>Spring Boot Build</description>
+	<name>Spring Boot Project</name>
+	<description>Spring Boot Project</description>
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
 	</properties>


### PR DESCRIPTION
The name _Spring Boot Build_ is used by the _root pom.xml_ and _spring-boot-project/pom.xml_. 
I renamed the Maven project name of spring-boot-project to _Spring Boot Project_.