### PR TITLE
Fix regular expression used in devools documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/using-spring-boot.adoc
@@ -974,8 +974,8 @@ pattern that is applied to the classpath, as shown in the following example:
 
 [source,properties,indent=0]
 ----
-	restart.exclude.companycommonlibs=/mycorp-common-[\\w-]+\.jar
-	restart.include.projectcommon=/mycorp-myproj-[\\w-]+\.jar
+	restart.exclude.companycommonlibs=/mycorp-common-[\\w\\d-\.]+\.jar
+	restart.include.projectcommon=/mycorp-myproj-[\\w\\d-\.]+\.jar
 ----
 
 NOTE: All property keys must be unique. As long as a property starts with


### PR DESCRIPTION
In the docs for customizing the Spring Boot Devtools RestartClassLoader, the example regex captures jars named mycorp-common-abc.jar but does not capture normal Maven versioned jars that would appear in BOOT-INF, like mycorp-common-1.0.4-GA.jar or mycorp-common-1.0.5-SNAPSHOT.jar.

This updates the regex to have a more sensible default for users that copy/paste the example into their own project.
