### PR TITLE
Define the classloader for FluentConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
@@ -113,7 +113,7 @@ public class FlywayAutoConfiguration {
 				ObjectProvider<FlywayConfigurationCustomizer> fluentConfigurationCustomizers,
 				ObjectProvider<Callback> callbacks,
 				ObjectProvider<FlywayCallback> flywayCallbacks) {
-			FluentConfiguration configuration = new FluentConfiguration();
+			FluentConfiguration configuration = new FluentConfiguration(resourceLoader.getClassLoader());
 			DataSource dataSourceToMigrate = configureDataSource(configuration,
 					properties, dataSourceProperties, flywayDataSource.getIfAvailable(),
 					dataSource.getIfAvailable());


### PR DESCRIPTION
The out of the box support for Flyway currently does not work with a custom class loader defined in `ResourceLoader`. Without this compatibility, Flyway will not be able to load scripts inside the `resources` folder. I experienced this issue when developing a [custom starter](https://github.com/Alan-Gomes/mcspring-boot) which runs inside a personalized class loader.