### PR TITLE
Provide an env var that controls the user with which the launch script runs the app

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/deployment.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/deployment.adoc
@@ -794,6 +794,11 @@ The following environment properties are supported with the default script:
  the `stop\|start\|status\|restart` commands work or to `run` if you want to run the
  script in the foreground.
 
+|`RUN_AS_USER`
+|If set, the application will be executed as the informed user. For security reasons, you
+ should never run an user space application as `root`, therefore it's recommended to set
+ this property. Defaults to the user who owns the jar file.
+
 |`USE_START_STOP_DAEMON`
 |Whether the `start-stop-daemon` command, when it's available, should be used to control
  the process. Defaults to `true`.

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -130,6 +130,7 @@ log_file="$LOG_FOLDER/$LOG_FILENAME"
 
 # Force run as informed user (from environment variable)
 if [[ -n "$RUN_AS" ]]; then
+    id -u "$RUN_AS" || { echoRed "Cannot run as '$RUN_AS': no such user"; exit 5; }
     run_user="$RUN_AS"
 fi
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -129,23 +129,23 @@ log_file="$LOG_FOLDER/$LOG_FILENAME"
 [[ $(id -u) == "0" ]] && run_user=$(ls -ld "$jarfile" | awk '{print $3}')
 
 # Force run as informed user (from environment variable)
-if [[ -n "$RUN_AS" ]]; then
+if [[ -n "$RUN_AS_USER" ]]; then
     # checks performed for all actions except 'status' and 'run'
     if ! [[ "$action" =~ ^(status|run)$ ]]; then
         # Issue a error if informed user is not valid
-        id -u "$RUN_AS" || {
-            echoRed "Cannot run as '$RUN_AS': no such user"
+        id -u "$RUN_AS_USER" || {
+            echoRed "Cannot run as '$RUN_AS_USER': no such user"
             exit 5
         }
 
         # Issue a error if we are not root
         [[ $(id -u) == 0 ]] || {
-            echoRed "root required to run as '$RUN_AS'"
+            echoRed "root required to run as '$RUN_AS_USER'"
             exit 6
         }
     fi
 
-    run_user="$RUN_AS"
+    run_user="$RUN_AS_USER"
 fi
 
 # Issue a warning if the application will run as root

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -128,6 +128,11 @@ log_file="$LOG_FOLDER/$LOG_FILENAME"
 # shellcheck disable=SC2012
 [[ $(id -u) == "0" ]] && run_user=$(ls -ld "$jarfile" | awk '{print $3}')
 
+# Force run as informed user (from environment variable)
+if [[ -n "$RUN_AS" ]]; then
+    run_user="$RUN_AS"
+fi
+
 # Issue a warning if the application will run as root
 [[ $(id -u ${run_user}) == "0" ]] && { echoYellow "Application is running as root (UID 0). This is considered insecure."; }
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -130,11 +130,18 @@ log_file="$LOG_FOLDER/$LOG_FILENAME"
 
 # Force run as informed user (from environment variable)
 if [[ -n "$RUN_AS" ]]; then
-    # checks if informed user is valid on all actions except 'status' and 'run'
+    # checks performed for all actions except 'status' and 'run'
     if ! [[ "$action" =~ ^(status|run)$ ]]; then
+        # Issue a error if informed user is not valid
         id -u "$RUN_AS" || {
             echoRed "Cannot run as '$RUN_AS': no such user"
             exit 5
+        }
+
+        # Issue a error if we are not root
+        [[ $(id -u) == 0 ]] || {
+            echoRed "root required to run as '$RUN_AS'"
+            exit 6
         }
     fi
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -130,7 +130,14 @@ log_file="$LOG_FOLDER/$LOG_FILENAME"
 
 # Force run as informed user (from environment variable)
 if [[ -n "$RUN_AS" ]]; then
-    id -u "$RUN_AS" || { echoRed "Cannot run as '$RUN_AS': no such user"; exit 5; }
+    # checks if informed user is valid on all actions except 'status' and 'run'
+    if ! [[ "$action" =~ ^(status|run)$ ]]; then
+        id -u "$RUN_AS" || {
+            echoRed "Cannot run as '$RUN_AS': no such user"
+            exit 5
+        }
+    fi
+
     run_user="$RUN_AS"
 fi
 

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
@@ -276,6 +276,14 @@ public class SysVinitLaunchScriptIT {
 
 	@ParameterizedTest(name = "{0} {1}")
 	@MethodSource("parameters")
+	public void launchWithRunAsInvalidUser(String os, String version) throws Exception {
+		String output = doTest(os, version, "launch-with-run-as-invalid-user.sh");
+		assertThat(output).contains("Status: 5");
+		assertThat(output).has(coloredString(AnsiColor.RED, "Cannot run as 'johndoe': no such user"));
+	}
+
+	@ParameterizedTest(name = "{0} {1}")
+	@MethodSource("parameters")
 	public void launchWithRunAsPreferUserInformed(String os, String version) throws Exception {
 		String output = doTest(os, version, "launch-with-run-as-prefer-user-informed.sh");
 		assertThat(output).contains("wagner root");

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
@@ -289,6 +289,14 @@ public class SysVinitLaunchScriptIT {
 		assertThat(output).contains("wagner root");
 	}
 
+	@ParameterizedTest(name = "{0} {1}")
+	@MethodSource("parameters")
+	public void launchWithRunAsRootRequired(String os, String version) throws Exception {
+		String output = doTest(os, version, "launch-with-run-as-root-required.sh");
+		assertThat(output).contains("Status: 6");
+		assertThat(output).has(coloredString(AnsiColor.RED, "root required to run as 'wagner'"));
+	}
+
 	static List<Object[]> parameters() {
 		List<Object[]> parameters = new ArrayList<>();
 		for (File os : new File("src/test/resources/conf").listFiles()) {

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
@@ -274,6 +274,13 @@ public class SysVinitLaunchScriptIT {
 		assertThat(output).contains("wagner root");
 	}
 
+	@ParameterizedTest(name = "{0} {1}")
+	@MethodSource("parameters")
+	public void launchWithRunAsPreferUserInformed(String os, String version) throws Exception {
+		String output = doTest(os, version, "launch-with-run-as-prefer-user-informed.sh");
+		assertThat(output).contains("wagner root");
+	}
+
 	static List<Object[]> parameters() {
 		List<Object[]> parameters = new ArrayList<>();
 		for (File os : new File("src/test/resources/conf").listFiles()) {

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/java/org/springframework/boot/launchscript/SysVinitLaunchScriptIT.java
@@ -267,6 +267,13 @@ public class SysVinitLaunchScriptIT {
 		assertThat(output).contains("Log written");
 	}
 
+	@ParameterizedTest(name = "{0} {1}")
+	@MethodSource("parameters")
+	public void launchWithRunAs(String os, String version) throws Exception {
+		String output = doTest(os, version, "launch-with-run-as.sh");
+		assertThat(output).contains("wagner root");
+	}
+
 	static List<Object[]> parameters() {
 		List<Object[]> parameters = new ArrayList<>();
 		for (File os : new File("src/test/resources/conf").listFiles()) {

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as-invalid-user.sh
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as-invalid-user.sh
@@ -1,0 +1,7 @@
+source ./test-functions.sh
+install_service
+
+echo 'RUN_AS=johndoe' > /test-service/spring-boot-app.conf
+
+start_service
+echo "Status: $?"

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as-invalid-user.sh
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as-invalid-user.sh
@@ -1,7 +1,7 @@
 source ./test-functions.sh
 install_service
 
-echo 'RUN_AS=johndoe' > /test-service/spring-boot-app.conf
+echo 'RUN_AS_USER=johndoe' > /test-service/spring-boot-app.conf
 
 start_service
 echo "Status: $?"

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as-prefer-user-informed.sh
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as-prefer-user-informed.sh
@@ -2,7 +2,7 @@ source ./test-functions.sh
 install_service
 
 useradd wagner
-echo 'RUN_AS=wagner' > /test-service/spring-boot-app.conf
+echo 'RUN_AS_USER=wagner' > /test-service/spring-boot-app.conf
 
 useradd phil
 chown phil /test-service/spring-boot-app.jar

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as-prefer-user-informed.sh
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as-prefer-user-informed.sh
@@ -1,0 +1,13 @@
+source ./test-functions.sh
+install_service
+
+useradd wagner
+echo 'RUN_AS=wagner' > /test-service/spring-boot-app.conf
+
+useradd phil
+chown phil /test-service/spring-boot-app.jar
+
+start_service
+await_app
+
+ls -la /var/log/spring-boot-app.log

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as-root-required.sh
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as-root-required.sh
@@ -1,0 +1,9 @@
+source ./test-functions.sh
+install_service
+
+useradd wagner
+echo 'RUN_AS=wagner' > /test-service/spring-boot-app.conf
+echo "JAVA_HOME='$JAVA_HOME'" >> /test-service/spring-boot-app.conf
+
+su - wagner -c "$(which service) spring-boot-app start"
+echo "Status: $?"

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as-root-required.sh
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as-root-required.sh
@@ -2,7 +2,7 @@ source ./test-functions.sh
 install_service
 
 useradd wagner
-echo 'RUN_AS=wagner' > /test-service/spring-boot-app.conf
+echo 'RUN_AS_USER=wagner' > /test-service/spring-boot-app.conf
 echo "JAVA_HOME='$JAVA_HOME'" >> /test-service/spring-boot-app.conf
 
 su - wagner -c "$(which service) spring-boot-app start"

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as.sh
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as.sh
@@ -1,0 +1,10 @@
+source ./test-functions.sh
+install_service
+
+useradd wagner
+echo 'RUN_AS=wagner' > /test-service/spring-boot-app.conf
+
+start_service
+await_app
+
+ls -la /var/log/spring-boot-app.log

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as.sh
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/test/resources/scripts/launch-with-run-as.sh
@@ -2,7 +2,7 @@ source ./test-functions.sh
 install_service
 
 useradd wagner
-echo 'RUN_AS=wagner' > /test-service/spring-boot-app.conf
+echo 'RUN_AS_USER=wagner' > /test-service/spring-boot-app.conf
 
 start_service
 await_app


### PR DESCRIPTION
Enhance the launch.script by adding `RUN_AS_USER` option, suitable when run as a service.

Here, it's introduced a new way to make the service change user when starting. The old way, by relying on the jar file ownership is still supported.

Closes gh-16667 