### PR TITLE
Pass resolvedType into isOfDifferentType() in JavaBeanBinder.Bean.get()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/JavaBeanBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/JavaBeanBinder.java
@@ -192,12 +192,12 @@ class JavaBeanBinder implements BeanBinder {
 			});
 		}
 
-		private boolean isOfDifferentType(ResolvableType targetType) {
+		private boolean isOfDifferentType(ResolvableType targetType,
+				Class<?> resolvedType) {
 			if (this.type.hasGenerics() || targetType.hasGenerics()) {
 				return !this.type.equals(targetType);
 			}
-			return this.resolvedType == null
-					|| !this.resolvedType.equals(targetType.resolve());
+			return this.resolvedType == null || !this.resolvedType.equals(resolvedType);
 		}
 
 		@SuppressWarnings("unchecked")
@@ -214,7 +214,7 @@ class JavaBeanBinder implements BeanBinder {
 				return null;
 			}
 			Bean<?> bean = Bean.cached;
-			if (bean == null || bean.isOfDifferentType(type)) {
+			if (bean == null || bean.isOfDifferentType(type, resolvedType)) {
 				bean = new Bean<>(type, resolvedType);
 				cached = bean;
 			}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR changes to pass `resolvedType` into `isOfDifferentType()` in `JavaBeanBinder.Bean.get()` as [it could be reassigned](https://github.com/spring-projects/spring-boot/blob/15bdc12335f942c030757e028ee31adb00befd37/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/JavaBeanBinder.java#L211).