### PR TITLE
Avoid using deprecated NCSARequestLog

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/servlet/ServletManagementChildContextConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/servlet/ServletManagementChildContextConfiguration.java
@@ -22,8 +22,9 @@ import javax.servlet.Filter;
 
 import org.apache.catalina.Valve;
 import org.apache.catalina.valves.AccessLogValve;
-import org.eclipse.jetty.server.NCSARequestLog;
+import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.RequestLog;
+import org.eclipse.jetty.server.RequestLogWriter;
 import org.eclipse.jetty.server.Server;
 
 import org.springframework.beans.factory.BeanFactory;
@@ -194,17 +195,20 @@ class ServletManagementChildContextConfiguration {
 
 		private void customizeServer(Server server) {
 			RequestLog requestLog = server.getRequestLog();
-			if (requestLog != null && requestLog instanceof NCSARequestLog) {
-				customizeRequestLog((NCSARequestLog) requestLog);
+			if (requestLog != null && requestLog instanceof CustomRequestLog) {
+				customizeRequestLog((CustomRequestLog) requestLog);
 			}
 		}
 
-		private void customizeRequestLog(NCSARequestLog requestLog) {
-			String filename = requestLog.getFilename();
-			if (StringUtils.hasLength(filename)) {
-				File file = new File(filename);
-				file = new File(file.getParentFile(), customizePrefix(file.getName()));
-				requestLog.setFilename(file.getPath());
+		private void customizeRequestLog(CustomRequestLog requestLog) {
+			if (requestLog.getWriter() instanceof RequestLogWriter) {
+				RequestLogWriter writer = (RequestLogWriter) requestLog.getWriter();
+				String filename = writer.getFileName();
+				if (StringUtils.hasLength(filename)) {
+					File file = new File(filename);
+					file = new File(file.getParentFile(), customizePrefix(file.getName()));
+					writer.setFilename(file.getPath());
+				}
 			}
 		}
 


### PR DESCRIPTION
Hi,

while #16416 migrated away from most of the usages of `NCSARequestLog`, it seems to have missed one occurrence in `ServletManagementChildContextConfiguration`.

Unfortunately, the parent-child context topic doesn't seem to be covered by a lot of tests and my time is limited at the moment to improve this (outside of this issue). But feel free to not merge this, because of the missing tests. 

Cheers,
Christoph