### PR TITLE
Add a missing @Test in JavaBeanBinderTests

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/JavaBeanBinderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/JavaBeanBinderTests.java
@@ -513,6 +513,7 @@ public class JavaBeanBinderTests {
 		assertThat(bean.getBooleans().get("b").getValue()).isEqualTo(true);
 	}
 
+	@Test
 	public void bindToClassWithOverloadedSetterShouldUseSetterThatMatchesField() {
 		// gh-16206
 		MockConfigurationPropertySource source = new MockConfigurationPropertySource();
@@ -524,9 +525,8 @@ public class JavaBeanBinderTests {
 	}
 
 	@Test
-	public void beanProperiesPreferMatchingType() {
+	public void beanPropertiesPreferMatchingType() {
 		// gh-16206
-
 		ResolvableType type = ResolvableType.forClass(PropertyWithOverloadedSetter.class);
 		Bean<PropertyWithOverloadedSetter> bean = new Bean<PropertyWithOverloadedSetter>(
 				type, type.resolve()) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR adds a missing `@Test` on `JavaBeanBinderTests.bindToClassWithOverloadedSetterShouldUseSetterThatMatchesField()`.