### PR TITLE
Handle all getters first in JavaBeanBinder.addProperties()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/JavaBeanBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/JavaBeanBinder.java
@@ -133,9 +133,9 @@ class JavaBeanBinder implements BeanBinder {
 			}
 			for (Method method : declaredMethods) {
 				addMethodIfPossible(method, "get", 0, BeanProperty::addGetter);
+				addMethodIfPossible(method, "is", 0, BeanProperty::addGetter);
 			}
 			for (Method method : declaredMethods) {
-				addMethodIfPossible(method, "is", 0, BeanProperty::addGetter);
 				addMethodIfPossible(method, "set", 1, BeanProperty::addSetter);
 			}
 			for (Field field : declaredFields) {


### PR DESCRIPTION
This PR changes to handle all getters first in `JavaBeanBinder.addProperties()` to align with the description in https://github.com/spring-projects/spring-boot/issues/16206#issuecomment-492495443.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
