### PR TITLE
Update `RestTemplateBuilder` and `TestRestTemplate` to use BasicAuthenticationClientHttpRequestFactory instead of Interceptor

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/BasicAuthentication.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/BasicAuthentication.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.client;
+
+import java.nio.charset.Charset;
+
+import org.springframework.util.Assert;
+
+/**
+ * Basic authentication properties which are used by
+ * {@link BasicAuthenticationClientHttpRequestFactory}.
+ *
+ * @author Dmytro Nosan
+ * @since 2.2.0
+ * @see BasicAuthenticationClientHttpRequestFactory
+ */
+public class BasicAuthentication {
+
+	private final String username;
+
+	private final String password;
+
+	private final Charset charset;
+
+	/**
+	 * Create a new {@link BasicAuthentication}.
+	 * @param username the username to use
+	 * @param password the password to use
+	 */
+	public BasicAuthentication(String username, String password) {
+		this(username, password, null);
+	}
+
+	/**
+	 * Create a new {@link BasicAuthentication}.
+	 * @param username the username to use
+	 * @param password the password to use
+	 * @param charset the charset to use
+	 */
+	public BasicAuthentication(String username, String password, Charset charset) {
+		Assert.notNull(username, "Username must not be null");
+		Assert.notNull(password, "Password must not be null");
+		this.username = username;
+		this.password = password;
+		this.charset = charset;
+	}
+
+	/**
+	 * The username to use.
+	 * @return the username, never {@code null} or {@code empty}.
+	 */
+	public String getUsername() {
+		return this.username;
+	}
+
+	/**
+	 * The password to use.
+	 * @return the password, never {@code null} or {@code empty}.
+	 */
+	public String getPassword() {
+		return this.password;
+	}
+
+	/**
+	 * The charset to use.
+	 * @return the charset, or {@code null}.
+	 */
+	public Charset getCharset() {
+		return this.charset;
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/BasicAuthenticationClientHttpRequestFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/BasicAuthenticationClientHttpRequestFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.client;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.AbstractClientHttpRequestFactoryWrapper;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.util.Assert;
+
+/**
+ * {@link ClientHttpRequestFactory} to apply a given HTTP Basic Authentication
+ * username/password pair, unless a custom Authorization header has been set before.
+ *
+ * @author Dmytro Nosan
+ * @since 2.2.0
+ */
+public class BasicAuthenticationClientHttpRequestFactory
+		extends AbstractClientHttpRequestFactoryWrapper {
+
+	private final BasicAuthentication authentication;
+
+	/**
+	 * Create a new {@link BasicAuthenticationClientHttpRequestFactory} which adds
+	 * {@link HttpHeaders#AUTHORIZATION} header for the given authentication.
+	 * @param authentication the authentication to use
+	 * @param clientHttpRequestFactory the factory to use
+	 */
+	public BasicAuthenticationClientHttpRequestFactory(BasicAuthentication authentication,
+			ClientHttpRequestFactory clientHttpRequestFactory) {
+		super(clientHttpRequestFactory);
+		Assert.notNull(authentication, "Authentication must not be null");
+		this.authentication = authentication;
+	}
+
+	@Override
+	protected ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod,
+			ClientHttpRequestFactory requestFactory) throws IOException {
+		BasicAuthentication authentication = this.authentication;
+		ClientHttpRequest request = requestFactory.createRequest(uri, httpMethod);
+		HttpHeaders headers = request.getHeaders();
+		if (!headers.containsKey(HttpHeaders.AUTHORIZATION)) {
+			headers.setBasicAuth(authentication.getUsername(),
+					authentication.getPassword(), authentication.getCharset());
+		}
+		return request;
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/BasicAuthenticationClientHttpRequestFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/BasicAuthenticationClientHttpRequestFactoryTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.client;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpRequestFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.when;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link BasicAuthenticationClientHttpRequestFactory}.
+ *
+ * @author Dmytro Nosan
+ */
+public class BasicAuthenticationClientHttpRequestFactoryTests {
+
+	private final HttpHeaders headers = new HttpHeaders();
+
+	private final BasicAuthentication authentication = new BasicAuthentication("spring",
+			"boot");
+
+	private ClientHttpRequestFactory requestFactory;
+
+	@Before
+	public void setUp() throws IOException {
+		ClientHttpRequestFactory requestFactory = mock(ClientHttpRequestFactory.class);
+		ClientHttpRequest request = mock(ClientHttpRequest.class);
+		when(requestFactory.createRequest(any(), any())).thenReturn(request);
+		when(request.getHeaders()).thenReturn(this.headers);
+		this.requestFactory = new BasicAuthenticationClientHttpRequestFactory(
+				this.authentication, requestFactory);
+	}
+
+	@Test
+	public void shouldAddAuthorizationHeader() throws IOException {
+		ClientHttpRequest request = createRequest();
+		assertThat(request.getHeaders().get(HttpHeaders.AUTHORIZATION))
+				.containsExactly("Basic c3ByaW5nOmJvb3Q=");
+	}
+
+	@Test
+	public void shouldNotAddAuthorizationHeaderAuthorizationAlreadySet()
+			throws IOException {
+		this.headers.setBasicAuth("boot", "spring");
+		ClientHttpRequest request = createRequest();
+		assertThat(request.getHeaders().get(HttpHeaders.AUTHORIZATION))
+				.doesNotContain("Basic c3ByaW5nOmJvb3Q=");
+
+	}
+
+	private ClientHttpRequest createRequest() throws IOException {
+		return this.requestFactory.createRequest(URI.create("http://localhost:8080"),
+				HttpMethod.POST);
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/RestTemplateBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/RestTemplateBuilderTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.web.client;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Set;
@@ -35,7 +36,6 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.client.InterceptingClientHttpRequestFactory;
 import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
-import org.springframework.http.client.support.BasicAuthenticationInterceptor;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.ResourceHttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
@@ -324,12 +324,13 @@ public class RestTemplateBuilderTests {
 
 	@Test
 	public void basicAuthenticationShouldApply() {
-		RestTemplate template = this.builder.basicAuthentication("spring", "boot")
+		BasicAuthentication basicAuthentication = new BasicAuthentication("spring",
+				"boot", StandardCharsets.UTF_8);
+		RestTemplate template = this.builder.basicAuthentication(basicAuthentication)
 				.build();
-		ClientHttpRequestInterceptor interceptor = template.getInterceptors().get(0);
-		assertThat(interceptor).isInstanceOf(BasicAuthenticationInterceptor.class);
-		assertThat(interceptor).extracting("username").containsExactly("spring");
-		assertThat(interceptor).extracting("password").containsExactly("boot");
+		ClientHttpRequestFactory requestFactory = template.getRequestFactory();
+		assertThat(requestFactory).hasFieldOrPropertyWithValue("authentication",
+				basicAuthentication);
 	}
 
 	@Test
@@ -406,19 +407,19 @@ public class RestTemplateBuilderTests {
 				.messageConverters(this.messageConverter).rootUri("http://localhost:8080")
 				.errorHandler(errorHandler).basicAuthentication("spring", "boot")
 				.requestFactory(() -> requestFactory).customizers((restTemplate) -> {
-					assertThat(restTemplate.getInterceptors()).hasSize(2)
-							.contains(this.interceptor).anyMatch(
-									(ic) -> ic instanceof BasicAuthenticationInterceptor);
+					assertThat(restTemplate.getInterceptors()).hasSize(1);
 					assertThat(restTemplate.getMessageConverters())
 							.contains(this.messageConverter);
 					assertThat(restTemplate.getUriTemplateHandler())
 							.isInstanceOf(RootUriTemplateHandler.class);
 					assertThat(restTemplate.getErrorHandler()).isEqualTo(errorHandler);
-					ClientHttpRequestFactory actualRequestFactory = restTemplate
+					ClientHttpRequestFactory interceptingRequestFactory = restTemplate
 							.getRequestFactory();
-					assertThat(actualRequestFactory)
+					assertThat(interceptingRequestFactory)
 							.isInstanceOf(InterceptingClientHttpRequestFactory.class);
-					assertThat(actualRequestFactory).hasFieldOrPropertyWithValue(
+					Object basicAuthRequestFactory = ReflectionTestUtils
+							.getField(interceptingRequestFactory, "requestFactory");
+					assertThat(basicAuthRequestFactory).hasFieldOrPropertyWithValue(
 							"requestFactory", requestFactory);
 				}).build();
 	}


### PR DESCRIPTION
Update `RestTemplateBuilder` and `TestRestTemplate` to use a custom request factory to add
authentication headers.

Prior to this commit, the `RestTemplateBuilder` and `TestRestTemplate` used the
`BasicAuthenticationInterceptor` to add headers.


see gh-15078

