### PR TITLE
Autoconfigure custom OAuth2RequestValidator bean

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/authserver/OAuth2AuthorizationServerConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/authserver/OAuth2AuthorizationServerConfiguration.java
@@ -45,6 +45,7 @@ import org.springframework.security.oauth2.config.annotation.web.configuration.A
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
+import org.springframework.security.oauth2.provider.OAuth2RequestValidator;
 import org.springframework.security.oauth2.provider.client.BaseClientDetails;
 import org.springframework.security.oauth2.provider.token.AccessTokenConverter;
 import org.springframework.security.oauth2.provider.token.TokenStore;
@@ -77,17 +78,21 @@ public class OAuth2AuthorizationServerConfiguration
 
 	private final AccessTokenConverter tokenConverter;
 
+	private final OAuth2RequestValidator requestValidator;
+
 	private final AuthorizationServerProperties properties;
 
 	public OAuth2AuthorizationServerConfiguration(BaseClientDetails details,
 			AuthenticationManager authenticationManager,
 			ObjectProvider<TokenStore> tokenStore,
 			ObjectProvider<AccessTokenConverter> tokenConverter,
+			ObjectProvider<OAuth2RequestValidator> requestValidator,
 			AuthorizationServerProperties properties) {
 		this.details = details;
 		this.authenticationManager = authenticationManager;
 		this.tokenStore = tokenStore.getIfAvailable();
 		this.tokenConverter = tokenConverter.getIfAvailable();
+		this.requestValidator = requestValidator.getIfAvailable();
 		this.properties = properties;
 	}
 
@@ -133,6 +138,9 @@ public class OAuth2AuthorizationServerConfiguration
 		}
 		if (this.details.getAuthorizedGrantTypes().contains("password")) {
 			endpoints.authenticationManager(this.authenticationManager);
+		}
+		if (this.requestValidator != null) {
+			endpoints.requestValidator(this.requestValidator);
 		}
 	}
 

--- a/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/OAuth2AutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/OAuth2AutoConfigurationTests.java
@@ -82,6 +82,7 @@ import org.springframework.security.oauth2.config.annotation.web.configurers.Aut
 import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.ClientDetailsService;
+import org.springframework.security.oauth2.provider.OAuth2RequestValidator;
 import org.springframework.security.oauth2.provider.approval.ApprovalStore;
 import org.springframework.security.oauth2.provider.approval.ApprovalStoreUserApprovalHandler;
 import org.springframework.security.oauth2.provider.approval.TokenApprovalStore;
@@ -318,6 +319,21 @@ public class OAuth2AutoConfigurationTests {
 		assertThat(countBeans(AUTHORIZATION_SERVER_CONFIG)).isEqualTo(0);
 		assertThat(countBeans(RESOURCE_SERVER_CONFIG)).isEqualTo(1);
 		verifyAuthentication(config);
+	}
+
+	@Test
+	public void testRequestValidatorOverride() {
+		this.context = new AnnotationConfigEmbeddedWebApplicationContext();
+		this.context.register(RequestValidatorConfiguration.class,
+				AuthorizationServerConfiguration.class,
+				MinimalSecureWebApplication.class);
+		this.context.refresh();
+		AuthorizationEndpoint endpoint = this.context
+				.getBean(AuthorizationEndpoint.class);
+		OAuth2RequestValidator requestValidator = (OAuth2RequestValidator) ReflectionTestUtils
+				.getField(endpoint, "oauth2RequestValidator");
+		assertThat(requestValidator)
+				.isSameAs(this.context.getBean(OAuth2RequestValidator.class));
 	}
 
 	@Test
@@ -675,6 +691,16 @@ public class OAuth2AutoConfigurationTests {
 		@Bean
 		public PermissionEvaluator permissionEvaluator() {
 			return mock(PermissionEvaluator.class);
+		}
+
+	}
+
+	@Configuration
+	protected static class RequestValidatorConfiguration {
+
+		@Bean
+		public OAuth2RequestValidator requestValidator() {
+			return mock(OAuth2RequestValidator.class);
 		}
 
 	}


### PR DESCRIPTION
It is currently awkward to use a custom `OAuth2RequestValidator` when using the default `AuthorizationServerConfigurer`. Specifying a custom configurer to use the `AuthorizationServerEndpointsConfigurer` disables all other autoconfiguration.

This change automatically configures any registered `OAuth2RequestValidator` bean on the `AuthorizationServerEndpointsConfigurer`.