### PR TITLE
Add an annotation for dynamic test properties processing

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestIntegrationTests.java
@@ -25,8 +25,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.boot.test.context.dynamic.property.DynamicTestProperty;
+import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.boot.testsupport.testcontainers.RedisContainer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.redis.connection.RedisConnection;

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestProperty.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestProperty.java
@@ -1,0 +1,13 @@
+package org.springframework.boot.test.context.dynamic.property;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface DynamicTestProperty {
+
+}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestProperty.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestProperty.java
@@ -1,5 +1,20 @@
-package org.springframework.boot.test.context.dynamic.property;
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package org.springframework.boot.test.context.dynamic.property;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -7,11 +22,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation provides an ability to set values
- * of properties in the Spring Context before test execution.
- * You can use this annotation on the method which provides
- * a dynamic value of properties and this value will be
- * evaluated while start application context for tests.
+ * This annotation provides an ability to set values of properties in the Spring Context
+ * before test execution. You can use this annotation on the method which provides a
+ * dynamic value of properties and this value will be evaluated while start application
+ * context for tests.
  *
  * @author Anatoliy Korovin
  */

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestProperty.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestProperty.java
@@ -6,6 +6,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * This annotation provides an ability to set values
+ * of properties in the Spring Context before test execution.
+ * You can use this annotation on the method which provides
+ * a dynamic value of properties and this value will be
+ * evaluated while start application context for tests.
+ *
+ * @author Anatoliy Korovin
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface DynamicTestProperty {

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizer.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizer.java
@@ -1,0 +1,40 @@
+package org.springframework.boot.test.context.dynamic.property;
+
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.MergedContextConfiguration;
+
+import java.util.List;
+import java.util.Objects;
+
+
+public class DynamicTestPropertyContextCustomizer implements ContextCustomizer {
+
+
+	private List<TestPropertyValues> properties;
+
+	public DynamicTestPropertyContextCustomizer(List<TestPropertyValues> properties) {
+		this.properties = properties;
+	}
+
+	@Override
+	public void customizeContext(ConfigurableApplicationContext configurableApplicationContext, MergedContextConfiguration mergedContextConfiguration) {
+		for (TestPropertyValues property : properties) {
+			property.applyTo(configurableApplicationContext);
+		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		DynamicTestPropertyContextCustomizer that = (DynamicTestPropertyContextCustomizer) o;
+		return Objects.equals(properties, that.properties);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(properties);
+	}
+}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizer.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizer.java
@@ -5,17 +5,24 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.ContextCustomizer;
 import org.springframework.test.context.MergedContextConfiguration;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 
+/**
+ * {@link ContextCustomizer} to allow using the {@link DynamicTestProperty} in tests.
+ *
+ * @author Anatoliy Korovin
+ */
 public class DynamicTestPropertyContextCustomizer implements ContextCustomizer {
 
 
-	private List<TestPropertyValues> properties;
+	private Set<TestPropertyValues> properties;
 
 	public DynamicTestPropertyContextCustomizer(List<TestPropertyValues> properties) {
-		this.properties = properties;
+		this.properties =  new HashSet<>(properties);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizer.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizer.java
@@ -1,15 +1,30 @@
-package org.springframework.boot.test.context.dynamic.property;
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import org.springframework.boot.test.util.TestPropertyValues;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.test.context.ContextCustomizer;
-import org.springframework.test.context.MergedContextConfiguration;
+package org.springframework.boot.test.context.dynamic.property;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.MergedContextConfiguration;
 
 /**
  * {@link ContextCustomizer} to allow using the {@link DynamicTestProperty} in tests.
@@ -18,30 +33,36 @@ import java.util.Set;
  */
 public class DynamicTestPropertyContextCustomizer implements ContextCustomizer {
 
-
 	private Set<TestPropertyValues> properties;
 
 	public DynamicTestPropertyContextCustomizer(List<TestPropertyValues> properties) {
-		this.properties =  new HashSet<>(properties);
+		this.properties = new HashSet<>(properties);
 	}
 
 	@Override
-	public void customizeContext(ConfigurableApplicationContext configurableApplicationContext, MergedContextConfiguration mergedContextConfiguration) {
-		for (TestPropertyValues property : properties) {
+	public void customizeContext(
+			ConfigurableApplicationContext configurableApplicationContext,
+			MergedContextConfiguration mergedContextConfiguration) {
+		for (TestPropertyValues property : this.properties) {
 			property.applyTo(configurableApplicationContext);
 		}
 	}
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
 		DynamicTestPropertyContextCustomizer that = (DynamicTestPropertyContextCustomizer) o;
-		return Objects.equals(properties, that.properties);
+		return Objects.equals(this.properties, that.properties);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(properties);
+		return Objects.hash(this.properties);
 	}
+
 }

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizerFactory.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizerFactory.java
@@ -1,0 +1,38 @@
+package org.springframework.boot.test.context.dynamic.property;
+
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.ContextCustomizerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DynamicTestPropertyContextCustomizerFactory implements ContextCustomizerFactory {
+
+	@Override
+	public ContextCustomizer createContextCustomizer(Class<?> aClass, List<ContextConfigurationAttributes> list) {
+
+		List<TestPropertyValues> properties = new ArrayList<>();
+
+		for (Method m : aClass.getDeclaredMethods()) {
+
+			if (m.isAnnotationPresent(DynamicTestProperty.class)) {
+				try {
+					m.setAccessible(true);
+					Object result = m.invoke(null);
+					properties.add((TestPropertyValues) result);
+				} catch (IllegalAccessException e) {
+					e.printStackTrace();
+				} catch (InvocationTargetException e) {
+					e.printStackTrace();
+				}
+			}
+
+		}
+
+		return properties.isEmpty() ? null : new DynamicTestPropertyContextCustomizer(properties);
+	}
+}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizerFactory.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizerFactory.java
@@ -7,9 +7,16 @@ import org.springframework.test.context.ContextCustomizerFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 
+
+/**
+ * {@link ContextCustomizerFactory} to allow using the {@link DynamicTestProperty} in tests.
+ *
+ * @author Anatoliy Korovin
+ */
 public class DynamicTestPropertyContextCustomizerFactory implements ContextCustomizerFactory {
 
 	@Override
@@ -20,14 +27,21 @@ public class DynamicTestPropertyContextCustomizerFactory implements ContextCusto
 		for (Method m : aClass.getDeclaredMethods()) {
 
 			if (m.isAnnotationPresent(DynamicTestProperty.class)) {
+
+				if(!Modifier.isStatic(m.getModifiers())){
+					throw new DynamicTestPropertyException("Annotation DynamicTestProperty must be used on a static method.");
+				}
+
+				if(!m.getReturnType().equals(TestPropertyValues.class)){
+					throw new DynamicTestPropertyException("DynamicTestProperty method must return the instance of TestPropertyValues.");
+				}
+
 				try {
 					m.setAccessible(true);
 					Object result = m.invoke(null);
 					properties.add((TestPropertyValues) result);
-				} catch (IllegalAccessException e) {
-					e.printStackTrace();
-				} catch (InvocationTargetException e) {
-					e.printStackTrace();
+				} catch (Exception e) {
+					throw new DynamicTestPropertyException("Error while trying to get a value of dynamic properties.");
 				}
 			}
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizerFactory.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizerFactory.java
@@ -1,52 +1,78 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.test.context.dynamic.property;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.test.context.ContextConfigurationAttributes;
 import org.springframework.test.context.ContextCustomizer;
 import org.springframework.test.context.ContextCustomizerFactory;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.List;
-
-
 /**
- * {@link ContextCustomizerFactory} to allow using the {@link DynamicTestProperty} in tests.
+ * {@link ContextCustomizerFactory} to allow using the {@link DynamicTestProperty} in
+ * tests.
  *
  * @author Anatoliy Korovin
  */
-public class DynamicTestPropertyContextCustomizerFactory implements ContextCustomizerFactory {
+public class DynamicTestPropertyContextCustomizerFactory
+		implements ContextCustomizerFactory {
 
 	@Override
-	public ContextCustomizer createContextCustomizer(Class<?> aClass, List<ContextConfigurationAttributes> list) {
+	public ContextCustomizer createContextCustomizer(Class<?> aClass,
+			List<ContextConfigurationAttributes> list) {
 
 		List<TestPropertyValues> properties = new ArrayList<>();
 
-		for (Method m : aClass.getDeclaredMethods()) {
+		for (Method method : aClass.getDeclaredMethods()) {
 
-			if (m.isAnnotationPresent(DynamicTestProperty.class)) {
-
-				if(!Modifier.isStatic(m.getModifiers())){
-					throw new DynamicTestPropertyException("Annotation DynamicTestProperty must be used on a static method.");
-				}
-
-				if(!m.getReturnType().equals(TestPropertyValues.class)){
-					throw new DynamicTestPropertyException("DynamicTestProperty method must return the instance of TestPropertyValues.");
-				}
-
-				try {
-					m.setAccessible(true);
-					Object result = m.invoke(null);
-					properties.add((TestPropertyValues) result);
-				} catch (Exception e) {
-					throw new DynamicTestPropertyException("Error while trying to get a value of dynamic properties.");
-				}
+			if (!method.isAnnotationPresent(DynamicTestProperty.class)) {
+				continue;
 			}
 
+			if (!Modifier.isStatic(method.getModifiers())) {
+				throw new DynamicTestPropertyException(
+						"Annotation DynamicTestProperty must be used on a static method.");
+			}
+
+			if (!method.getReturnType().equals(TestPropertyValues.class)) {
+				throw new DynamicTestPropertyException(
+						"DynamicTestProperty method must return the instance of TestPropertyValues.");
+			}
+
+			properties.add(getDynamicPropertyValues(method));
 		}
 
-		return properties.isEmpty() ? null : new DynamicTestPropertyContextCustomizer(properties);
+		return properties.isEmpty() ? null
+				: new DynamicTestPropertyContextCustomizer(properties);
 	}
+
+	private TestPropertyValues getDynamicPropertyValues(Method method) {
+		try {
+			method.setAccessible(true);
+			return (TestPropertyValues) method.invoke(null);
+		}
+		catch (Exception ex) {
+			throw new DynamicTestPropertyException(
+					"Error while trying to get a value of dynamic properties.", ex);
+		}
+	}
+
 }

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyException.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyException.java
@@ -1,7 +1,23 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.test.context.dynamic.property;
 
 /**
- * This exception used in the processing of the {@link DynamicTestProperty}
+ * This exception used in the processing of the {@link DynamicTestProperty}.
  *
  * @author Anatoliy Korovin
  */
@@ -10,4 +26,9 @@ public class DynamicTestPropertyException extends RuntimeException {
 	public DynamicTestPropertyException(String message) {
 		super(message);
 	}
+
+	public DynamicTestPropertyException(String message, Exception cause) {
+		super(message, cause);
+	}
+
 }

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyException.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyException.java
@@ -1,0 +1,13 @@
+package org.springframework.boot.test.context.dynamic.property;
+
+/**
+ * This exception used in the processing of the {@link DynamicTestProperty}
+ *
+ * @author Anatoliy Korovin
+ */
+public class DynamicTestPropertyException extends RuntimeException {
+
+	public DynamicTestPropertyException(String message) {
+		super(message);
+	}
+}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java
@@ -137,15 +137,19 @@ public final class TestPropertyValues {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
 		TestPropertyValues values = (TestPropertyValues) o;
-		return Objects.equals(properties, values.properties);
+		return Objects.equals(this.properties, values.properties);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(properties);
+		return Objects.hash(this.properties);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java
@@ -135,6 +135,19 @@ public final class TestPropertyValues {
 		}
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		TestPropertyValues values = (TestPropertyValues) o;
+		return Objects.equals(properties, values.properties);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(properties);
+	}
+
 	@SuppressWarnings("unchecked")
 	private <E extends Throwable> void rethrow(Throwable e) throws E {
 		throw (E) e;

--- a/spring-boot-project/spring-boot-test/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-test/src/main/resources/META-INF/spring.factories
@@ -5,7 +5,8 @@ org.springframework.boot.test.context.filter.ExcludeFilterContextCustomizerFacto
 org.springframework.boot.test.json.DuplicateJsonObjectContextCustomizerFactory,\
 org.springframework.boot.test.mock.mockito.MockitoContextCustomizerFactory,\
 org.springframework.boot.test.web.client.TestRestTemplateContextCustomizerFactory,\
-org.springframework.boot.test.web.reactive.server.WebTestClientContextCustomizerFactory
+org.springframework.boot.test.web.reactive.server.WebTestClientContextCustomizerFactory,\
+org.springframework.boot.test.context.dynamic.property.DynamicTestPropertyContextCustomizerFactory
 
 # Test Execution Listeners
 org.springframework.test.context.TestExecutionListener=\

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizerFactoryTest.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizerFactoryTest.java
@@ -1,0 +1,122 @@
+package org.springframework.boot.test.context.dynamic.property;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.test.context.ContextCustomizer;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+/**
+ * Tests for {@link DynamicTestPropertyContextCustomizerFactory}
+ *
+ * @author Anatoliy Korovin
+ */
+class DynamicTestPropertyContextCustomizerFactoryTest {
+
+	private DynamicTestPropertyContextCustomizerFactory customizerFactory =
+			new DynamicTestPropertyContextCustomizerFactory();
+
+
+	@Test
+	void singleDynamicTestProperty() {
+		// Arrange
+		DynamicTestPropertyContextCustomizer expectedCustomizer =
+				new DynamicTestPropertyContextCustomizer(Arrays.asList(TestPropertyValues.of("a=123")));
+		// Act
+		ContextCustomizer customizer =
+				customizerFactory.createContextCustomizer(SingleTestPropertyClass.class, null);
+		// Assert
+		assertThat(customizer).isEqualTo(expectedCustomizer);
+	}
+
+	@Test
+	void multipleDynamicTestProperty() {
+		// Arrange
+		DynamicTestPropertyContextCustomizer expectedCustomizer =
+				new DynamicTestPropertyContextCustomizer(Arrays.asList(TestPropertyValues.of("a=123"),
+																	   TestPropertyValues.of("b=456")));
+		// Act
+		ContextCustomizer customizer =
+				customizerFactory.createContextCustomizer(MultipleTestPropertyClass.class, null);
+		// Assert
+		assertThat(customizer).isEqualTo(expectedCustomizer);
+	}
+
+	@Test
+	void notStaticMethod() {
+		DynamicTestPropertyException e =
+				assertThrows(DynamicTestPropertyException.class,
+							 () -> customizerFactory.createContextCustomizer(ErrorWithNoStaticMethodClass.class, null));
+
+		assertThat(e.getMessage()).contains("Annotation DynamicTestProperty must be used on a static method");
+	}
+
+	@Test
+	void wrongReturnTypeOfTheDynamicTestProperty() {
+
+		DynamicTestPropertyException e =
+				assertThrows(DynamicTestPropertyException.class,
+							 () -> customizerFactory.createContextCustomizer(ErrorWithWrongReturnTypeClass.class, null));
+
+		assertThat(e.getMessage()).contains("DynamicTestProperty method must return the instance of TestPropertyValues");
+	}
+
+	@Test
+	void errorWhileTryingToGetTheValueOfProperties() {
+
+		DynamicTestPropertyException e =
+				assertThrows(DynamicTestPropertyException.class,
+							 () -> customizerFactory.createContextCustomizer(ErrorWhileRetrieveTheValueFromMethodClass.class, null));
+
+		assertThat(e.getMessage()).contains("Error while trying to get a value of dynamic properties");
+	}
+
+	private static class SingleTestPropertyClass {
+
+		@DynamicTestProperty
+		private static TestPropertyValues getProps() {
+			return TestPropertyValues.of("a=123");
+		}
+	}
+
+	private static class MultipleTestPropertyClass {
+
+		@DynamicTestProperty
+		private static TestPropertyValues firstProps() {
+			return TestPropertyValues.of("a=123");
+		}
+
+		@DynamicTestProperty
+		private static TestPropertyValues secondProps() {
+			return TestPropertyValues.of("b=456");
+		}
+	}
+
+	private static class ErrorWithNoStaticMethodClass {
+
+		@DynamicTestProperty
+		private TestPropertyValues getProps() {
+			return TestPropertyValues.of("a=123");
+		}
+	}
+
+	private static class ErrorWithWrongReturnTypeClass {
+
+		@DynamicTestProperty
+		private static String getProps() {
+			return "a=123";
+		}
+	}
+
+	private static class ErrorWhileRetrieveTheValueFromMethodClass {
+
+		@DynamicTestProperty
+		private static TestPropertyValues getProps() {
+			throw new RuntimeException("oops");
+		}
+	}
+}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizerFactoryTest.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizerFactoryTest.java
@@ -1,14 +1,31 @@
-package org.springframework.boot.test.context.dynamic.property;
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.util.TestPropertyValues;
-import org.springframework.test.context.ContextCustomizer;
+package org.springframework.boot.test.context.dynamic.property;
 
 import java.util.Arrays;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.test.context.ContextCustomizer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link DynamicTestPropertyContextCustomizerFactory}
@@ -17,18 +34,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class DynamicTestPropertyContextCustomizerFactoryTest {
 
-	private DynamicTestPropertyContextCustomizerFactory customizerFactory =
-			new DynamicTestPropertyContextCustomizerFactory();
-
+	private DynamicTestPropertyContextCustomizerFactory customizerFactory = new DynamicTestPropertyContextCustomizerFactory();
 
 	@Test
 	void singleDynamicTestProperty() {
 		// Arrange
-		DynamicTestPropertyContextCustomizer expectedCustomizer =
-				new DynamicTestPropertyContextCustomizer(Arrays.asList(TestPropertyValues.of("a=123")));
+		DynamicTestPropertyContextCustomizer expectedCustomizer = new DynamicTestPropertyContextCustomizer(
+				Arrays.asList(TestPropertyValues.of("a=123")));
 		// Act
-		ContextCustomizer customizer =
-				customizerFactory.createContextCustomizer(SingleTestPropertyClass.class, null);
+		ContextCustomizer customizer = this.customizerFactory
+				.createContextCustomizer(SingleTestPropertyClass.class, null);
 		// Assert
 		assertThat(customizer).isEqualTo(expectedCustomizer);
 	}
@@ -36,43 +51,47 @@ class DynamicTestPropertyContextCustomizerFactoryTest {
 	@Test
 	void multipleDynamicTestProperty() {
 		// Arrange
-		DynamicTestPropertyContextCustomizer expectedCustomizer =
-				new DynamicTestPropertyContextCustomizer(Arrays.asList(TestPropertyValues.of("a=123"),
-																	   TestPropertyValues.of("b=456")));
+		DynamicTestPropertyContextCustomizer expectedCustomizer = new DynamicTestPropertyContextCustomizer(
+				Arrays.asList(TestPropertyValues.of("a=123"),
+						TestPropertyValues.of("b=456")));
 		// Act
-		ContextCustomizer customizer =
-				customizerFactory.createContextCustomizer(MultipleTestPropertyClass.class, null);
+		ContextCustomizer customizer = this.customizerFactory
+				.createContextCustomizer(MultipleTestPropertyClass.class, null);
 		// Assert
 		assertThat(customizer).isEqualTo(expectedCustomizer);
 	}
 
 	@Test
 	void notStaticMethod() {
-		DynamicTestPropertyException e =
-				assertThrows(DynamicTestPropertyException.class,
-							 () -> customizerFactory.createContextCustomizer(ErrorWithNoStaticMethodClass.class, null));
 
-		assertThat(e.getMessage()).contains("Annotation DynamicTestProperty must be used on a static method");
+		ThrowableAssert.ThrowingCallable act = () -> this.customizerFactory
+				.createContextCustomizer(ErrorWithNoStaticMethodClass.class, null);
+
+		assertThatThrownBy(act).isInstanceOf(DynamicTestPropertyException.class)
+				.hasMessage(
+						"Annotation DynamicTestProperty must be used on a static method.");
 	}
 
 	@Test
 	void wrongReturnTypeOfTheDynamicTestProperty() {
 
-		DynamicTestPropertyException e =
-				assertThrows(DynamicTestPropertyException.class,
-							 () -> customizerFactory.createContextCustomizer(ErrorWithWrongReturnTypeClass.class, null));
+		ThrowableAssert.ThrowingCallable act = () -> this.customizerFactory
+				.createContextCustomizer(ErrorWithWrongReturnTypeClass.class, null);
 
-		assertThat(e.getMessage()).contains("DynamicTestProperty method must return the instance of TestPropertyValues");
+		assertThatThrownBy(act).isInstanceOf(DynamicTestPropertyException.class)
+				.hasMessage(
+						"DynamicTestProperty method must return the instance of TestPropertyValues.");
 	}
 
 	@Test
 	void errorWhileTryingToGetTheValueOfProperties() {
 
-		DynamicTestPropertyException e =
-				assertThrows(DynamicTestPropertyException.class,
-							 () -> customizerFactory.createContextCustomizer(ErrorWhileRetrieveTheValueFromMethodClass.class, null));
+		ThrowableAssert.ThrowingCallable act = () -> this.customizerFactory
+				.createContextCustomizer(ErrorWhileRetrieveTheValueFromMethodClass.class,
+						null);
 
-		assertThat(e.getMessage()).contains("Error while trying to get a value of dynamic properties");
+		assertThatThrownBy(act).isInstanceOf(DynamicTestPropertyException.class)
+				.hasMessage("Error while trying to get a value of dynamic properties.");
 	}
 
 	private static class SingleTestPropertyClass {
@@ -81,6 +100,7 @@ class DynamicTestPropertyContextCustomizerFactoryTest {
 		private static TestPropertyValues getProps() {
 			return TestPropertyValues.of("a=123");
 		}
+
 	}
 
 	private static class MultipleTestPropertyClass {
@@ -94,6 +114,7 @@ class DynamicTestPropertyContextCustomizerFactoryTest {
 		private static TestPropertyValues secondProps() {
 			return TestPropertyValues.of("b=456");
 		}
+
 	}
 
 	private static class ErrorWithNoStaticMethodClass {
@@ -102,6 +123,7 @@ class DynamicTestPropertyContextCustomizerFactoryTest {
 		private TestPropertyValues getProps() {
 			return TestPropertyValues.of("a=123");
 		}
+
 	}
 
 	private static class ErrorWithWrongReturnTypeClass {
@@ -110,6 +132,7 @@ class DynamicTestPropertyContextCustomizerFactoryTest {
 		private static String getProps() {
 			return "a=123";
 		}
+
 	}
 
 	private static class ErrorWhileRetrieveTheValueFromMethodClass {
@@ -118,5 +141,7 @@ class DynamicTestPropertyContextCustomizerFactoryTest {
 		private static TestPropertyValues getProps() {
 			throw new RuntimeException("oops");
 		}
+
 	}
+
 }

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizerTest.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizerTest.java
@@ -1,12 +1,28 @@
-package org.springframework.boot.test.context.dynamic.property;
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.util.TestPropertyValues;
+package org.springframework.boot.test.context.dynamic.property;
 
 import java.util.Arrays;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.test.util.TestPropertyValues;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link DynamicTestPropertyContextCustomizer}
@@ -18,15 +34,13 @@ class DynamicTestPropertyContextCustomizerTest {
 	@Test
 	void equalsOfContextCustomizers() {
 
-		DynamicTestPropertyContextCustomizer firstContextCustomizer =
-				new DynamicTestPropertyContextCustomizer(
-						Arrays.asList(TestPropertyValues.of("a=123"),
-									  TestPropertyValues.of("b=456")));
+		DynamicTestPropertyContextCustomizer firstContextCustomizer = new DynamicTestPropertyContextCustomizer(
+				Arrays.asList(TestPropertyValues.of("a=123"),
+						TestPropertyValues.of("b=456")));
 
-		DynamicTestPropertyContextCustomizer secondContextCustomizer =
-				new DynamicTestPropertyContextCustomizer(
-						Arrays.asList(TestPropertyValues.of("b=456"),
-									  TestPropertyValues.of("a=123")));
+		DynamicTestPropertyContextCustomizer secondContextCustomizer = new DynamicTestPropertyContextCustomizer(
+				Arrays.asList(TestPropertyValues.of("b=456"),
+						TestPropertyValues.of("a=123")));
 
 		assertThat(firstContextCustomizer).isEqualTo(secondContextCustomizer);
 	}
@@ -34,16 +48,15 @@ class DynamicTestPropertyContextCustomizerTest {
 	@Test
 	void notEqualsContextCustomizers() {
 
-		DynamicTestPropertyContextCustomizer firstContextCustomizer =
-				new DynamicTestPropertyContextCustomizer(
-						Arrays.asList(TestPropertyValues.of("a=123"),
-									  TestPropertyValues.of("b=456")));
+		DynamicTestPropertyContextCustomizer firstContextCustomizer = new DynamicTestPropertyContextCustomizer(
+				Arrays.asList(TestPropertyValues.of("a=123"),
+						TestPropertyValues.of("b=456")));
 
-		DynamicTestPropertyContextCustomizer secondContextCustomizer =
-				new DynamicTestPropertyContextCustomizer(
-						Arrays.asList(TestPropertyValues.of("b=456"),
-									  TestPropertyValues.of("a=0")));
+		DynamicTestPropertyContextCustomizer secondContextCustomizer = new DynamicTestPropertyContextCustomizer(
+				Arrays.asList(TestPropertyValues.of("b=456"),
+						TestPropertyValues.of("a=0")));
 
 		assertThat(firstContextCustomizer).isNotEqualTo(secondContextCustomizer);
 	}
+
 }

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizerTest.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyContextCustomizerTest.java
@@ -1,0 +1,49 @@
+package org.springframework.boot.test.context.dynamic.property;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.util.TestPropertyValues;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * Tests for {@link DynamicTestPropertyContextCustomizer}
+ *
+ * @author Anatoliy Korovin
+ */
+class DynamicTestPropertyContextCustomizerTest {
+
+	@Test
+	void equalsOfContextCustomizers() {
+
+		DynamicTestPropertyContextCustomizer firstContextCustomizer =
+				new DynamicTestPropertyContextCustomizer(
+						Arrays.asList(TestPropertyValues.of("a=123"),
+									  TestPropertyValues.of("b=456")));
+
+		DynamicTestPropertyContextCustomizer secondContextCustomizer =
+				new DynamicTestPropertyContextCustomizer(
+						Arrays.asList(TestPropertyValues.of("b=456"),
+									  TestPropertyValues.of("a=123")));
+
+		assertThat(firstContextCustomizer).isEqualTo(secondContextCustomizer);
+	}
+
+	@Test
+	void notEqualsContextCustomizers() {
+
+		DynamicTestPropertyContextCustomizer firstContextCustomizer =
+				new DynamicTestPropertyContextCustomizer(
+						Arrays.asList(TestPropertyValues.of("a=123"),
+									  TestPropertyValues.of("b=456")));
+
+		DynamicTestPropertyContextCustomizer secondContextCustomizer =
+				new DynamicTestPropertyContextCustomizer(
+						Arrays.asList(TestPropertyValues.of("b=456"),
+									  TestPropertyValues.of("a=0")));
+
+		assertThat(firstContextCustomizer).isNotEqualTo(secondContextCustomizer);
+	}
+}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyTests.java
@@ -1,12 +1,28 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.test.context.dynamic.property;
 
 import org.junit.jupiter.api.Test;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.util.TestPropertyValues;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 
 /**
  * Integration test for {@link DynamicTestProperty}
@@ -18,8 +34,7 @@ class DynamicTestPropertyTests {
 
 	@DynamicTestProperty
 	private static TestPropertyValues dynamicProperties() {
-		return TestPropertyValues.of("a=123",
-									 String.format("b=%d", 456));
+		return TestPropertyValues.of("a=123", String.format("b=%d", 456));
 	}
 
 	@Value("${a}")
@@ -30,7 +45,8 @@ class DynamicTestPropertyTests {
 
 	@Test
 	void testPropertyValues() {
-		assertThat(a).isEqualTo("123");
-		assertThat(b).isEqualTo("456");
+		assertThat(this.a).isEqualTo("123");
+		assertThat(this.b).isEqualTo("456");
 	}
+
 }

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyTests.java
@@ -7,12 +7,19 @@ import org.springframework.boot.test.util.TestPropertyValues;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+
+/**
+ * Integration test for {@link DynamicTestProperty}
+ *
+ * @author Anatoliy Korovin
+ */
 @SpringBootTest(classes = DynamicTestPropertyTests.class)
 class DynamicTestPropertyTests {
 
 	@DynamicTestProperty
 	private static TestPropertyValues dynamicProperties() {
-		return TestPropertyValues.of("a=123", "b=456");
+		return TestPropertyValues.of("a=123",
+									 String.format("b=%d", 456));
 	}
 
 	@Value("${a}")

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/dynamic/property/DynamicTestPropertyTests.java
@@ -1,0 +1,29 @@
+package org.springframework.boot.test.context.dynamic.property;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = DynamicTestPropertyTests.class)
+class DynamicTestPropertyTests {
+
+	@DynamicTestProperty
+	private static TestPropertyValues dynamicProperties() {
+		return TestPropertyValues.of("a=123", "b=456");
+	}
+
+	@Value("${a}")
+	public String a;
+
+	@Value("${b}")
+	public String b;
+
+	@Test
+	void testPropertyValues() {
+		assertThat(a).isEqualTo("123");
+		assertThat(b).isEqualTo("456");
+	}
+}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/util/TestPropertyValuesTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/util/TestPropertyValuesTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.test.util;
 
 import org.junit.jupiter.api.Test;
+
 import org.springframework.boot.test.util.TestPropertyValues.Type;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.PropertySource;
@@ -31,48 +32,48 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Madhura Bhave
  * @author Phillip Webb
  */
-public class TestPropertyValuesTests {
+class TestPropertyValuesTests {
 
 	private final ConfigurableEnvironment environment = new StandardEnvironment();
 
 	@Test
-	public void applyToEnvironmentShouldAttachConfigurationPropertySource() {
+	void applyToEnvironmentShouldAttachConfigurationPropertySource() {
 		TestPropertyValues.of("foo.bar=baz").applyTo(this.environment);
 		PropertySource<?> source = this.environment.getPropertySources()
-												   .get("configurationProperties");
+				.get("configurationProperties");
 		assertThat(source).isNotNull();
 	}
 
 	@Test
-	public void applyToDefaultPropertySource() {
+	void applyToDefaultPropertySource() {
 		TestPropertyValues.of("foo.bar=baz", "hello.world=hi").applyTo(this.environment);
 		assertThat(this.environment.getProperty("foo.bar")).isEqualTo("baz");
 		assertThat(this.environment.getProperty("hello.world")).isEqualTo("hi");
 	}
 
 	@Test
-	public void applyToSystemPropertySource() {
+	void applyToSystemPropertySource() {
 		TestPropertyValues.of("FOO_BAR=BAZ").applyTo(this.environment,
-													 Type.SYSTEM_ENVIRONMENT);
+				Type.SYSTEM_ENVIRONMENT);
 		assertThat(this.environment.getProperty("foo.bar")).isEqualTo("BAZ");
 		assertThat(this.environment.getPropertySources().contains(
 				"test-" + StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME))
-				.isTrue();
+						.isTrue();
 	}
 
 	@Test
-	public void applyToWithSpecificName() {
+	void applyToWithSpecificName() {
 		TestPropertyValues.of("foo.bar=baz").applyTo(this.environment, Type.MAP, "other");
 		assertThat(this.environment.getPropertySources().get("other")).isNotNull();
 		assertThat(this.environment.getProperty("foo.bar")).isEqualTo("baz");
 	}
 
 	@Test
-	public void applyToExistingNameAndDifferentTypeShouldOverrideExistingOne() {
+	void applyToExistingNameAndDifferentTypeShouldOverrideExistingOne() {
 		TestPropertyValues.of("foo.bar=baz", "hello.world=hi").applyTo(this.environment,
-																	   Type.MAP, "other");
+				Type.MAP, "other");
 		TestPropertyValues.of("FOO_BAR=BAZ").applyTo(this.environment,
-													 Type.SYSTEM_ENVIRONMENT, "other");
+				Type.SYSTEM_ENVIRONMENT, "other");
 		assertThat(this.environment.getPropertySources().get("other"))
 				.isInstanceOf(SystemEnvironmentPropertySource.class);
 		assertThat(this.environment.getProperty("foo.bar")).isEqualTo("BAZ");
@@ -80,25 +81,25 @@ public class TestPropertyValuesTests {
 	}
 
 	@Test
-	public void applyToExistingNameAndSameTypeShouldMerge() {
+	void applyToExistingNameAndSameTypeShouldMerge() {
 		TestPropertyValues.of("foo.bar=baz", "hello.world=hi").applyTo(this.environment,
-																	   Type.MAP);
+				Type.MAP);
 		TestPropertyValues.of("foo.bar=new").applyTo(this.environment, Type.MAP);
 		assertThat(this.environment.getProperty("foo.bar")).isEqualTo("new");
 		assertThat(this.environment.getProperty("hello.world")).isEqualTo("hi");
 	}
 
 	@Test
-	public void andShouldChainAndAddSingleKeyValue() {
+	void andShouldChainAndAddSingleKeyValue() {
 		TestPropertyValues.of("foo.bar=baz").and("hello.world=hi").and("bling.blah=bing")
-						  .applyTo(this.environment, Type.MAP);
+				.applyTo(this.environment, Type.MAP);
 		assertThat(this.environment.getProperty("foo.bar")).isEqualTo("baz");
 		assertThat(this.environment.getProperty("hello.world")).isEqualTo("hi");
 		assertThat(this.environment.getProperty("bling.blah")).isEqualTo("bing");
 	}
 
 	@Test
-	public void applyToSystemPropertiesShouldSetSystemProperties() {
+	void applyToSystemPropertiesShouldSetSystemProperties() {
 		TestPropertyValues.of("foo=bar").applyToSystemProperties(() -> {
 			assertThat(System.getProperty("foo")).isEqualTo("bar");
 			return null;
@@ -106,7 +107,7 @@ public class TestPropertyValuesTests {
 	}
 
 	@Test
-	public void applyToSystemPropertiesShouldRestoreSystemProperties() {
+	void applyToSystemPropertiesShouldRestoreSystemProperties() {
 		System.setProperty("foo", "bar1");
 		System.clearProperty("baz");
 		try {
@@ -117,13 +118,14 @@ public class TestPropertyValuesTests {
 			});
 			assertThat(System.getProperty("foo")).isEqualTo("bar1");
 			assertThat(System.getProperties()).doesNotContainKey("baz");
-		} finally {
+		}
+		finally {
 			System.clearProperty("foo");
 		}
 	}
 
 	@Test
-	public void applyToSystemPropertiesWhenValueIsNullShouldRemoveProperty() {
+	void applyToSystemPropertiesWhenValueIsNullShouldRemoveProperty() {
 		System.setProperty("foo", "bar1");
 		try {
 			TestPropertyValues.of("foo").applyToSystemProperties(() -> {
@@ -131,16 +133,24 @@ public class TestPropertyValuesTests {
 				return null;
 			});
 			assertThat(System.getProperty("foo")).isEqualTo("bar1");
-		} finally {
+		}
+		finally {
 			System.clearProperty("foo");
 		}
 	}
 
-
 	@Test
-	void equalsOfDifferentTestPropertyValues() {
+	void equalsOfSameTestPropertyValues() {
 		TestPropertyValues first = TestPropertyValues.of("a=123", "b=456");
 		TestPropertyValues second = TestPropertyValues.of("b=456", "a=123");
 		assertThat(first).isEqualTo(second);
 	}
+
+	@Test
+	void notEqualsOfDifferentTestPropertyValues() {
+		TestPropertyValues first = TestPropertyValues.of("a=123", "b=456");
+		TestPropertyValues second = TestPropertyValues.of("b=456", "a=000");
+		assertThat(first).isNotEqualTo(second);
+	}
+
 }

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/util/TestPropertyValuesTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/util/TestPropertyValuesTests.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.test.util;
 
 import org.junit.jupiter.api.Test;
-
 import org.springframework.boot.test.util.TestPropertyValues.Type;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.PropertySource;
@@ -40,7 +39,7 @@ public class TestPropertyValuesTests {
 	public void applyToEnvironmentShouldAttachConfigurationPropertySource() {
 		TestPropertyValues.of("foo.bar=baz").applyTo(this.environment);
 		PropertySource<?> source = this.environment.getPropertySources()
-				.get("configurationProperties");
+												   .get("configurationProperties");
 		assertThat(source).isNotNull();
 	}
 
@@ -54,11 +53,11 @@ public class TestPropertyValuesTests {
 	@Test
 	public void applyToSystemPropertySource() {
 		TestPropertyValues.of("FOO_BAR=BAZ").applyTo(this.environment,
-				Type.SYSTEM_ENVIRONMENT);
+													 Type.SYSTEM_ENVIRONMENT);
 		assertThat(this.environment.getProperty("foo.bar")).isEqualTo("BAZ");
 		assertThat(this.environment.getPropertySources().contains(
 				"test-" + StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME))
-						.isTrue();
+				.isTrue();
 	}
 
 	@Test
@@ -71,9 +70,9 @@ public class TestPropertyValuesTests {
 	@Test
 	public void applyToExistingNameAndDifferentTypeShouldOverrideExistingOne() {
 		TestPropertyValues.of("foo.bar=baz", "hello.world=hi").applyTo(this.environment,
-				Type.MAP, "other");
+																	   Type.MAP, "other");
 		TestPropertyValues.of("FOO_BAR=BAZ").applyTo(this.environment,
-				Type.SYSTEM_ENVIRONMENT, "other");
+													 Type.SYSTEM_ENVIRONMENT, "other");
 		assertThat(this.environment.getPropertySources().get("other"))
 				.isInstanceOf(SystemEnvironmentPropertySource.class);
 		assertThat(this.environment.getProperty("foo.bar")).isEqualTo("BAZ");
@@ -83,7 +82,7 @@ public class TestPropertyValuesTests {
 	@Test
 	public void applyToExistingNameAndSameTypeShouldMerge() {
 		TestPropertyValues.of("foo.bar=baz", "hello.world=hi").applyTo(this.environment,
-				Type.MAP);
+																	   Type.MAP);
 		TestPropertyValues.of("foo.bar=new").applyTo(this.environment, Type.MAP);
 		assertThat(this.environment.getProperty("foo.bar")).isEqualTo("new");
 		assertThat(this.environment.getProperty("hello.world")).isEqualTo("hi");
@@ -92,7 +91,7 @@ public class TestPropertyValuesTests {
 	@Test
 	public void andShouldChainAndAddSingleKeyValue() {
 		TestPropertyValues.of("foo.bar=baz").and("hello.world=hi").and("bling.blah=bing")
-				.applyTo(this.environment, Type.MAP);
+						  .applyTo(this.environment, Type.MAP);
 		assertThat(this.environment.getProperty("foo.bar")).isEqualTo("baz");
 		assertThat(this.environment.getProperty("hello.world")).isEqualTo("hi");
 		assertThat(this.environment.getProperty("bling.blah")).isEqualTo("bing");
@@ -118,8 +117,7 @@ public class TestPropertyValuesTests {
 			});
 			assertThat(System.getProperty("foo")).isEqualTo("bar1");
 			assertThat(System.getProperties()).doesNotContainKey("baz");
-		}
-		finally {
+		} finally {
 			System.clearProperty("foo");
 		}
 	}
@@ -133,10 +131,16 @@ public class TestPropertyValuesTests {
 				return null;
 			});
 			assertThat(System.getProperty("foo")).isEqualTo("bar1");
-		}
-		finally {
+		} finally {
 			System.clearProperty("foo");
 		}
 	}
 
+
+	@Test
+	void equalsOfDifferentTestPropertyValues() {
+		TestPropertyValues first = TestPropertyValues.of("a=123", "b=456");
+		TestPropertyValues second = TestPropertyValues.of("b=456", "a=123");
+		assertThat(first).isEqualTo(second);
+	}
 }


### PR DESCRIPTION
I made an annotation for integration tests, which allows setting a value of properties in the spring context before test execution, but this value can be not constant. 

Something like this discussed in the issue #16886 
 
DynamicTestProperrty allows declaring a method which will provide values of properties for a test. It provides an ability to use a not constant value as the value of test properties. 

For example, you can set a value of the "spring.redis.port" property after start the Redis TestContainer:

```java
@Testcontainers
@DataRedisTest
class DataRedisTestIntegrationTests {

    @Container
    private static RedisContainer redis = new RedisContainer();

    @DynamicTestProperty
    private static TestPropertyValues setContainerProperties() {
        return TestPropertyValues.of("spring.redis.port=" + redis.getMappedPort());
    }
    
    @Test
    void testRedis(){
      ...
    }
}
```

Also, this solution correctly works with the spring context cache. If a value of the property changes then it reflects on the key of the context in cache and spring-test will run a new application context for test.