### PR TITLE
Drop deprecated spring.version pom property in favor of spring-framework.version

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -178,13 +178,11 @@
 		<slf4j.version>1.7.26</slf4j.version>
 		<snakeyaml.version>1.24</snakeyaml.version>
 		<solr.version>8.0.0</solr.version>
-		<!-- deprecated in favor of "spring-framework.version" -->
-		<spring.version>5.2.0.BUILD-SNAPSHOT</spring.version>
 		<spring-amqp.version>2.2.0.M2</spring-amqp.version>
 		<spring-batch.version>4.2.0.M2</spring-batch.version>
 		<spring-cloud-connectors.version>2.0.5.RELEASE</spring-cloud-connectors.version>
 		<spring-data-releasetrain.version>Moore-BUILD-SNAPSHOT</spring-data-releasetrain.version>
-		<spring-framework.version>${spring.version}</spring-framework.version>
+		<spring-framework.version>5.2.0.BUILD-SNAPSHOT</spring-framework.version>
 		<spring-hateoas.version>1.0.0.BUILD-SNAPSHOT</spring-hateoas.version>
 		<spring-integration.version>5.2.0.M2</spring-integration.version>
 		<spring-kafka.version>2.3.0.M2</spring-kafka.version>

--- a/spring-boot-project/spring-boot-docs/pom.xml
+++ b/spring-boot-project/spring-boot-docs/pom.xml
@@ -1444,8 +1444,8 @@
 								<spring-security-docs-version>${spring-security.version}</spring-security-docs-version>
 								<spring-webservices-docs-version>${spring-ws.version}</spring-webservices-docs-version>
 								<github-tag>${github-tag}</github-tag>
-								<spring-version>${spring.version}</spring-version>
-								<spring-docs-version>${spring.version}</spring-docs-version>
+								<spring-version>${spring-framework.version}</spring-version>
+								<spring-docs-version>${spring-framework.version}</spring-docs-version>
 								<spring-boot-version>${revision}</spring-boot-version>
 								<sources-root>${project.basedir}/src/</sources-root>
 								<generated-resources-root>${project.basedir}/target/generated-resources</generated-resources-root>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-dir/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-dir/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-jar/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-jar/pom.xml
@@ -105,7 +105,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-props-lib/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-props-lib/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-props/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-props/pom.xml
@@ -95,7 +95,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-war/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/it/executable-war/pom.xml
@@ -84,7 +84,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/build-info-additional-properties/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/build-info-additional-properties/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/build-info-custom-file/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/build-info-custom-file/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/build-info/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/build-info/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-attach-disabled/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-attach-disabled/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-classifier-main-attach-disabled/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-classifier-main-attach-disabled/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-classifier-main/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-classifier-main/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-classifier-source-attach-disabled/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-classifier-source-attach-disabled/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-classifier-source/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-classifier-source/pom.xml
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-create-dir/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-create-dir/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-custom-dir/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-custom-dir/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-custom-launcher/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-custom-launcher/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-exclude-entry/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-exclude-entry/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-exclude-group/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-exclude-group/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-executable/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-executable/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-lib-name-conflict/acme-lib/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-lib-name-conflict/acme-lib/pom.xml
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-non-executable/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-non-executable/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-pom/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-pom/pom.xml
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-system-scope-default/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-system-scope-default/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-system-scope/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-system-scope/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-test-scope/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-test-scope/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-with-kotlin-module/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-with-kotlin-module/pom.xml
@@ -73,7 +73,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-with-unpack/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar-with-unpack/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/jar/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/prop/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/prop/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/run-use-test-classpath/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/run-use-test-classpath/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/war-reactor/war/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/war-reactor/war/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/war-with-unpack/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/war-with-unpack/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/war/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/war/pom.xml
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>@spring.version@</version>
+			<version>@spring-framework.version@</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>


### PR DESCRIPTION
Creating this pr (for https://github.com/spring-projects/spring-boot/issues/17037) to help removing deprecated  pom property spring.version 

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
