### PR TITLE
Polish OutputCapture and its JUnit Jupiter extension

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/system/CapturedOutput.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/system/CapturedOutput.java
@@ -23,7 +23,7 @@ package org.springframework.boot.test.system;
  * <pre class="code">
  * assertThat(output).contains("started"); // Checks all output
  * assertThat(output.getErr()).contains("failed"); // Only checks System.err
- * assertThat(output.getOut()).contains("ok"); // Only checks System.put
+ * assertThat(output.getOut()).contains("ok"); // Only checks System.out
  * </pre>
  *
  * @author Madhura Bhave

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/system/OutputCapture.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/system/OutputCapture.java
@@ -39,6 +39,7 @@ import org.springframework.util.ClassUtils;
  * @author Madhura Bhave
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Sam Brannen
  * @since 2.2.0
  * @see OutputCaptureExtension
  * @see OutputCaptureRule
@@ -128,8 +129,11 @@ class OutputCapture implements CapturedOutput {
 
 	private String get(Predicate<Type> filter) {
 		Assert.state(!this.systemCaptures.isEmpty(),
-				"No system captures found. Check that you have used @RegisterExtension "
-						+ "or @ExtendWith and the fields are not private");
+				"No system captures found. When using JUnit 4, ensure that you have "
+						+ "registered the OutputCaptureRule via @ClassRule or @Rule "
+						+ "and that the field is public. "
+						+ "When using JUnit Jupiter, ensure that you have registered "
+						+ "the OutputCaptureExtension via @ExtendWith.");
 		StringBuilder builder = new StringBuilder();
 		for (SystemCapture systemCapture : this.systemCaptures) {
 			systemCapture.append(builder, filter);

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/system/OutputCaptureExtension.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/system/OutputCaptureExtension.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
@@ -66,30 +68,28 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 public class OutputCaptureExtension implements BeforeAllCallback, AfterAllCallback,
 		BeforeEachCallback, AfterEachCallback, ParameterResolver {
 
-	private final OutputCapture outputCapture = new OutputCapture();
-
 	OutputCaptureExtension() {
 		// Package private to prevent users from directly creating an instance.
 	}
 
 	@Override
 	public void beforeAll(ExtensionContext context) throws Exception {
-		this.outputCapture.push();
+		getOutputCapture(context).push();
 	}
 
 	@Override
 	public void afterAll(ExtensionContext context) throws Exception {
-		this.outputCapture.pop();
+		getOutputCapture(context).pop();
 	}
 
 	@Override
 	public void beforeEach(ExtensionContext context) throws Exception {
-		this.outputCapture.push();
+		getOutputCapture(context).push();
 	}
 
 	@Override
 	public void afterEach(ExtensionContext context) throws Exception {
-		this.outputCapture.pop();
+		getOutputCapture(context).pop();
 	}
 
 	@Override
@@ -100,8 +100,16 @@ public class OutputCaptureExtension implements BeforeAllCallback, AfterAllCallba
 
 	@Override
 	public Object resolveParameter(ParameterContext parameterContext,
-			ExtensionContext extensionContext) throws ParameterResolutionException {
-		return this.outputCapture;
+			ExtensionContext extensionContext) {
+		return getOutputCapture(extensionContext);
+	}
+
+	private OutputCapture getOutputCapture(ExtensionContext context) {
+		return getStore(context).getOrComputeIfAbsent(OutputCapture.class);
+	}
+
+	private Store getStore(ExtensionContext context) {
+		return context.getStore(Namespace.create(getClass()));
 	}
 
 }

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/system/OutputCaptureExtension.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/system/OutputCaptureExtension.java
@@ -27,14 +27,14 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
 /**
- * JUnit 5 {@code @Extension} to capture {@link System#out System.out} and
- * {@link System#err System.err}. Can be used on a test class via
- * {@link ExtendWith @ExtendWith}. This extension provides {@link ParameterResolver
- * parameter resolution} for a {@link CapturedOutput} instance which can be used to assert
- * that the correct output was written.
+ * JUnit Jupiter {@code @Extension} to capture {@link System#out System.out} and
+ * {@link System#err System.err}. Can be registered for an entire test class or for an
+ * individual test method via {@link ExtendWith @ExtendWith}. This extension provides
+ * {@linkplain ParameterResolver parameter resolution} for a {@link CapturedOutput}
+ * instance which can be used to assert that the correct output was written.
  * <p>
  * To use with {@link ExtendWith @ExtendWith}, inject the {@link CapturedOutput} as an
- * argument to your test class constructor or test method:
+ * argument to your test class constructor, test method, or lifecycle methods:
  *
  * <pre class="code">
  * &#064;ExtendWith(OutputCaptureExtension.class)
@@ -42,7 +42,15 @@ import org.junit.jupiter.api.extension.ParameterResolver;
  *
  *     &#064;Test
  *     void test(CapturedOutput output) {
+ *         System.out.println("ok");
  *         assertThat(output).contains("ok");
+ *         System.err.println("error");
+ *     }
+ *
+ *     &#064;AfterEach
+ *     void after(CapturedOutput output) {
+ *         assertThat(output.getOut()).contains("ok");
+ *         assertThat(output.getErr()).contains("error");
  *     }
  *
  * }
@@ -51,6 +59,7 @@ import org.junit.jupiter.api.extension.ParameterResolver;
  * @author Madhura Bhave
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Sam Brannen
  * @since 2.2.0
  * @see CapturedOutput
  */

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/ConcurrentOutputCaptureExtensionTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/ConcurrentOutputCaptureExtensionTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.system;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.RepetitionInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link OutputCaptureExtension} when test methods are executed concurrently.
+ *
+ * @author Sam Brannen
+ */
+@ExtendWith(OutputCaptureExtension.class)
+@Execution(ExecutionMode.CONCURRENT)
+@Disabled("OutputCaptureExtension currently does not support concurrent execution")
+class ConcurrentOutputCaptureExtensionTests {
+
+	@BeforeEach
+	void beforeEach() {
+		System.out.println("beforeEach");
+	}
+
+	@RepeatedTest(5)
+	void captureOutput(RepetitionInfo repetitionInfo, CapturedOutput output) {
+		String testOutput = "test output: " + repetitionInfo.getCurrentRepetition();
+		String testError = "test error: " + repetitionInfo.getCurrentRepetition();
+
+		System.out.println(testOutput);
+		System.err.println(testError);
+
+		assertThat(lines(output))//
+				.containsExactlyInAnyOrder("beforeEach", testOutput, testError);
+		assertThat(lines(output.getOut()))//
+				.containsExactly("beforeEach", testOutput);
+		assertThat(lines(output.getErr()))//
+				.containsExactly(testError);
+	}
+
+	private String[] lines(CharSequence text) {
+		return text.toString().split(System.lineSeparator());
+	}
+
+	@AfterEach
+	void after(CapturedOutput output) {
+		assertThat(output.getOut()).contains("beforeEach", "test output");
+		assertThat(output.getErr()).contains("test error");
+	}
+
+}

--- a/spring-boot-project/spring-boot-test/src/test/resources/junit-platform.properties
+++ b/spring-boot-project/spring-boot-test/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.execution.parallel.enabled=true


### PR DESCRIPTION
This PR contains a number of individual commits to improve the output capture extensions for JUnit 4 and JUnit Jupiter.

Commit 490e31570c9f856e57c470b9018906f5567bc051 is not essential, but the changes will likely be necessary to support parallel test execution. The subsequent commit (8ce12377d337b0d1cfcf7d25beb5acf9fc5e44b0) introduces a failing, disable test case which demonstrates that parallel execution is currently not supported. If the team decides not to support parallel test execution, I recommend that a note be added to the Javadoc and Reference Manual to document this known shortcoming.