### PR TITLE
Add missing @Test annotations

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySourceTests.java
@@ -185,8 +185,11 @@ public class SpringIterableConfigurationPropertySourceTests {
 				source, DefaultPropertyMapper.INSTANCE);
 		assertThat(adapter.stream().count()).isEqualTo(2);
 		map.setThrowException(true);
+		map.put("key3", "value3");
+		assertThat(adapter.stream().count()).isEqualTo(3);
 	}
 
+	@Test
 	public void originTrackedMapPropertySourceKeyAdditionInvalidatesCache() {
 		// gh-13344
 		Map<String, Object> map = new LinkedHashMap<>();
@@ -201,6 +204,7 @@ public class SpringIterableConfigurationPropertySourceTests {
 		assertThat(adapter.stream().count()).isEqualTo(3);
 	}
 
+	@Test
 	public void readOnlyOriginTrackedMapPropertySourceKeyAdditionDoesNotInvalidateCache() {
 		// gh-16717
 		Map<String, Object> map = new LinkedHashMap<>();


### PR DESCRIPTION
This PR adds missing `@Test` annotations in `SpringIterableConfigurationPropertySourceTests`.

This PR also restores assertion removed in 44d832158a60ba518565869e868052f72d0a972e which doesn't seem to be intentional.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
