### PR TITLE
Make dependency available for javadoc generation

### DIFF
--- a/spring-boot-project/spring-boot-docs/pom.xml
+++ b/spring-boot-project/spring-boot-docs/pom.xml
@@ -496,6 +496,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.derby</groupId>
+			<artifactId>derby</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-streams</artifactId>
 			<optional>true</optional>


### PR DESCRIPTION
Hi,

since 95d0e26c35a0e492233075ffa440541038e3617b there is imho a need to include derby as a dependency to have it available for javadoc generation. That should hopefully fix the current failures in JDK 11 and 12 builds.

Cheers,
Christoph