### PR TITLE
Use properties not method parameter but injected field

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointAutoConfiguration.java
@@ -112,9 +112,8 @@ public class WebEndpointAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public PathMappedEndpoints pathMappedEndpoints(Collection<EndpointsSupplier<?>> endpointSuppliers,
-			WebEndpointProperties webEndpointProperties) {
-		return new PathMappedEndpoints(webEndpointProperties.getBasePath(), endpointSuppliers);
+	public PathMappedEndpoints pathMappedEndpoints(Collection<EndpointsSupplier<?>> endpointSuppliers) {
+		return new PathMappedEndpoints(properties.getBasePath(), endpointSuppliers);
 	}
 
 	@Bean


### PR DESCRIPTION
Like other beans declared in `WebEndpointAutoConfiguration`, I modified `PathMappedEndpoints` bean to also use injected `WebEndpointProperties`.