### PR TITLE
Improve spring-boot-sample-jersey1

### DIFF
--- a/spring-boot-samples/spring-boot-sample-jersey1/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-jersey1/pom.xml
@@ -31,7 +31,12 @@
 		<dependency>
 			<groupId>com.sun.jersey</groupId>
 			<artifactId>jersey-servlet</artifactId>
-			<version>1.13</version>
+			<version>1.19.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.jersey.contribs</groupId>
+			<artifactId>jersey-spring</artifactId>
+			<version>1.19.1</version>
 		</dependency>
 		<!-- Test -->
 		<dependency>

--- a/spring-boot-samples/spring-boot-sample-jersey1/src/main/java/sample/jersey1/HelloWorldRepository.java
+++ b/spring-boot-samples/spring-boot-sample-jersey1/src/main/java/sample/jersey1/HelloWorldRepository.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.jersey1;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.stereotype.Repository;
+
+/**
+ * Sample repository.
+ *
+ * @author Yiang Guo
+ */
+@Repository
+public class HelloWorldRepository {
+
+	private AtomicInteger count = new AtomicInteger(0);
+
+	public int getCount() {
+		return this.count.incrementAndGet();
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-jersey1/src/main/java/sample/jersey1/HelloWorldResource.java
+++ b/spring-boot-samples/spring-boot-sample-jersey1/src/main/java/sample/jersey1/HelloWorldResource.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.jersey1;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * JAX-RS hello world resource with spring dependency injection.
+ *
+ * @author Yiang Guo
+ */
+@Component
+@Path("/")
+public class HelloWorldResource {
+
+	private final HelloWorldRepository helloWorldRepository;
+
+	public HelloWorldResource(HelloWorldRepository helloWorldRepository) {
+		this.helloWorldRepository = helloWorldRepository;
+	}
+
+	@GET
+	@Produces("text/plain")
+	public String hello() {
+		return "Hello World! Count: " + this.helloWorldRepository.getCount();
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-jersey1/src/main/java/sample/jersey1/SampleJersey1Application.java
+++ b/spring-boot-samples/spring-boot-sample-jersey1/src/main/java/sample/jersey1/SampleJersey1Application.java
@@ -16,28 +16,25 @@
 
 package sample.jersey1;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import java.util.Collections;
 
 import com.sun.jersey.spi.container.servlet.ServletContainer;
+import com.sun.jersey.spi.spring.container.servlet.SpringServlet;
 
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 
-@SpringBootApplication
-@Path("/")
+/**
+ * Sample spring boot application with jersey 1.x.
+ *
+ * @author Yiang Guo
+ */
+@SpringBootApplication(scanBasePackageClasses = SampleJersey1Application.class)
 public class SampleJersey1Application {
-
-	@GET
-	@Produces("text/plain")
-	public String hello() {
-		return "Hello World";
-	}
 
 	@Bean
 	// Not needed if Spring Web MVC is also present on classpath
@@ -46,9 +43,13 @@ public class SampleJersey1Application {
 	}
 
 	@Bean
-	public FilterRegistrationBean<ServletContainer> jersey() {
-		FilterRegistrationBean<ServletContainer> bean = new FilterRegistrationBean<>();
-		bean.setFilter(new ServletContainer());
+	public ServletRegistrationBean<ServletContainer> jersey() {
+		ServletRegistrationBean<ServletContainer> bean = new ServletRegistrationBean<>();
+		// Use SpringServlet to enable jersey spring integration
+		bean.setServlet(new SpringServlet());
+		bean.setUrlMappings(Collections.singletonList("/"));
+		bean.setLoadOnStartup(1);
+		// Jersey resource packages
 		bean.addInitParameter("com.sun.jersey.config.property.packages", "com.sun.jersey;sample.jersey1");
 		return bean;
 	}

--- a/spring-boot-samples/spring-boot-sample-jersey1/src/test/java/sample/jersey1/SampleJersey1ApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-jersey1/src/test/java/sample/jersey1/SampleJersey1ApplicationTests.java
@@ -36,7 +36,8 @@ public class SampleJersey1ApplicationTests {
 
 	@Test
 	public void rootReturnsHelloWorld() {
-		assertThat(this.restTemplate.getForObject("/", String.class)).isEqualTo("Hello World");
+		assertThat(this.restTemplate.getForObject("/", String.class)).isEqualTo("Hello World! Count: 1");
+		assertThat(this.restTemplate.getForObject("/", String.class)).isEqualTo("Hello World! Count: 2");
 	}
 
 }


### PR DESCRIPTION
- Upgrade to jersey 1.19.1
- Added jersey-spring dependency
- Use SpringServlet which will allow jersey resource to be spring managed beans
  - In previous example, jersey resource is not spring managed and dependency injection is not supported
- Use Servlet registration instead of filter
