### PR TITLE
Make layout parameter available as a user property

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-default/invoker.properties
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-default/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=package

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-default/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-default/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.boot.maven.it</groupId>
+	<artifactId>repackage-layout-default</artifactId>
+	<version>0.0.1.BUILD-SNAPSHOT</version>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>@java.version@</maven.compiler.source>
+		<maven.compiler.target>@java.version@</maven.compiler.target>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-default/src/main/java/org/test/SampleApplication.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-default/src/main/java/org/test/SampleApplication.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.test;
+
+public class SampleApplication {
+
+	public static void main(String[] args) {
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-default/verify.groovy
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-default/verify.groovy
@@ -1,0 +1,4 @@
+import static org.junit.Assert.assertFalse
+
+def file = new File(basedir, "build.log")
+assertFalse file.text.contains("Layout:")

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-property/invoker.properties
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-property/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=package -Dspring-boot.repackage.layout=ZIP

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-property/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-property/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.boot.maven.it</groupId>
+	<artifactId>repackage-layout-default</artifactId>
+	<version>0.0.1.BUILD-SNAPSHOT</version>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>@java.version@</maven.compiler.source>
+		<maven.compiler.target>@java.version@</maven.compiler.target>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-property/src/main/java/org/test/SampleApplication.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-property/src/main/java/org/test/SampleApplication.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.test;
+
+public class SampleApplication {
+
+	public static void main(String[] args) {
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-property/verify.groovy
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/it/repackage-layout-property/verify.groovy
@@ -1,0 +1,4 @@
+import static org.junit.Assert.assertTrue
+
+def file = new File(basedir, "build.log")
+assertTrue file.text.contains("Layout: ZIP")

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
@@ -138,7 +138,7 @@ public class RepackageMojo extends AbstractDependencyFilterMojo {
 	 * archive type.
 	 * @since 1.0
 	 */
-	@Parameter
+	@Parameter(property = "spring-boot.repackage.layout")
 	private LayoutType layout;
 
 	/**


### PR DESCRIPTION
We need to change the packaging layout in some special cases (in CI builds) and don't want to clutter or production code adding overwritable properties to our POMs - furthermore we'd have to define a default that would disable the standard behavior of layout auto-detection.

With this PR the _layout_ parameter of the _repackage_ goal can be set from the
command line, using the system property `spring-boot.repackage.layout`.