### PR TITLE
Update flush mode related Spring Session configuration properties

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HazelcastSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HazelcastSessionConfiguration.java
@@ -58,7 +58,7 @@ class HazelcastSessionConfiguration {
 				setMaxInactiveIntervalInSeconds((int) timeout.getSeconds());
 			}
 			setSessionMapName(hazelcastSessionProperties.getMapName());
-			setHazelcastFlushMode(hazelcastSessionProperties.getFlushMode());
+			setFlushMode(hazelcastSessionProperties.getFlushMode());
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HazelcastSessionProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HazelcastSessionProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.springframework.boot.autoconfigure.session;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.session.hazelcast.HazelcastFlushMode;
+import org.springframework.session.FlushMode;
 
 /**
  * Configuration properties for Hazelcast backed Spring Session.
@@ -36,7 +36,7 @@ public class HazelcastSessionProperties {
 	/**
 	 * Sessions flush mode.
 	 */
-	private HazelcastFlushMode flushMode = HazelcastFlushMode.ON_SAVE;
+	private FlushMode flushMode = FlushMode.ON_SAVE;
 
 	public String getMapName() {
 		return this.mapName;
@@ -46,11 +46,11 @@ public class HazelcastSessionProperties {
 		this.mapName = mapName;
 	}
 
-	public HazelcastFlushMode getFlushMode() {
+	public FlushMode getFlushMode() {
 		return this.flushMode;
 	}
 
-	public void setFlushMode(HazelcastFlushMode flushMode) {
+	public void setFlushMode(FlushMode flushMode) {
 		this.flushMode = flushMode;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisReactiveSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisReactiveSessionConfiguration.java
@@ -53,7 +53,6 @@ class RedisReactiveSessionConfiguration {
 				setMaxInactiveIntervalInSeconds((int) timeout.getSeconds());
 			}
 			setRedisNamespace(redisSessionProperties.getNamespace());
-			setRedisFlushMode(redisSessionProperties.getFlushMode());
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionConfiguration.java
@@ -74,7 +74,7 @@ class RedisSessionConfiguration {
 				setMaxInactiveIntervalInSeconds((int) timeout.getSeconds());
 			}
 			setRedisNamespace(redisSessionProperties.getNamespace());
-			setRedisFlushMode(redisSessionProperties.getFlushMode());
+			setFlushMode(redisSessionProperties.getFlushMode());
 			setCleanupCron(redisSessionProperties.getCleanupCron());
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.boot.autoconfigure.session;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.session.data.redis.RedisFlushMode;
+import org.springframework.session.FlushMode;
 
 /**
  * Configuration properties for Redis backed Spring Session.
@@ -38,7 +38,7 @@ public class RedisSessionProperties {
 	/**
 	 * Sessions flush mode.
 	 */
-	private RedisFlushMode flushMode = RedisFlushMode.ON_SAVE;
+	private FlushMode flushMode = FlushMode.ON_SAVE;
 
 	/**
 	 * The configure action to apply when no user defined ConfigureRedisAction bean is
@@ -59,11 +59,11 @@ public class RedisSessionProperties {
 		this.namespace = namespace;
 	}
 
-	public RedisFlushMode getFlushMode() {
+	public FlushMode getFlushMode() {
 		return this.flushMode;
 	}
 
-	public void setFlushMode(RedisFlushMode flushMode) {
+	public void setFlushMode(FlushMode flushMode) {
 		this.flushMode = flushMode;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/ReactiveSessionAutoConfigurationRedisTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/ReactiveSessionAutoConfigurationRedisTests.java
@@ -27,7 +27,6 @@ import org.springframework.boot.test.context.runner.ContextConsumer;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
 import org.springframework.session.data.mongo.ReactiveMongoOperationsSessionRepository;
 import org.springframework.session.data.redis.ReactiveRedisOperationsSessionRepository;
-import org.springframework.session.data.redis.RedisFlushMode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -48,7 +47,7 @@ class ReactiveSessionAutoConfigurationRedisTests extends AbstractSessionAutoConf
 		this.contextRunner.withPropertyValues("spring.session.store-type=redis")
 				.withConfiguration(
 						AutoConfigurations.of(RedisAutoConfiguration.class, RedisReactiveAutoConfiguration.class))
-				.run(validateSpringSessionUsesRedis("spring:session:", RedisFlushMode.ON_SAVE));
+				.run(validateSpringSessionUsesRedis("spring:session:"));
 	}
 
 	@Test
@@ -56,7 +55,7 @@ class ReactiveSessionAutoConfigurationRedisTests extends AbstractSessionAutoConf
 		this.contextRunner.withClassLoader(new FilteredClassLoader(ReactiveMongoOperationsSessionRepository.class))
 				.withConfiguration(
 						AutoConfigurations.of(RedisAutoConfiguration.class, RedisReactiveAutoConfiguration.class))
-				.run(validateSpringSessionUsesRedis("spring:session:", RedisFlushMode.ON_SAVE));
+				.run(validateSpringSessionUsesRedis("spring:session:"));
 	}
 
 	@Test
@@ -64,18 +63,15 @@ class ReactiveSessionAutoConfigurationRedisTests extends AbstractSessionAutoConf
 		this.contextRunner
 				.withConfiguration(
 						AutoConfigurations.of(RedisAutoConfiguration.class, RedisReactiveAutoConfiguration.class))
-				.withPropertyValues("spring.session.store-type=redis", "spring.session.redis.namespace=foo",
-						"spring.session.redis.flush-mode=immediate")
-				.run(validateSpringSessionUsesRedis("foo:", RedisFlushMode.IMMEDIATE));
+				.withPropertyValues("spring.session.store-type=redis", "spring.session.redis.namespace=foo")
+				.run(validateSpringSessionUsesRedis("foo:"));
 	}
 
-	private ContextConsumer<AssertableReactiveWebApplicationContext> validateSpringSessionUsesRedis(String namespace,
-			RedisFlushMode flushMode) {
+	private ContextConsumer<AssertableReactiveWebApplicationContext> validateSpringSessionUsesRedis(String namespace) {
 		return (context) -> {
 			ReactiveRedisOperationsSessionRepository repository = validateSessionRepository(context,
 					ReactiveRedisOperationsSessionRepository.class);
 			assertThat(repository).hasFieldOrPropertyWithValue("namespace", namespace);
-			assertThat(repository).hasFieldOrPropertyWithValue("redisFlushMode", flushMode);
 		};
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationHazelcastTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationHazelcastTests.java
@@ -26,9 +26,9 @@ import org.springframework.boot.test.context.assertj.AssertableWebApplicationCon
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.session.FlushMode;
 import org.springframework.session.data.mongo.MongoOperationsSessionRepository;
 import org.springframework.session.data.redis.RedisOperationsSessionRepository;
-import org.springframework.session.hazelcast.HazelcastFlushMode;
 import org.springframework.session.hazelcast.HazelcastSessionRepository;
 import org.springframework.session.jdbc.JdbcOperationsSessionRepository;
 
@@ -84,8 +84,7 @@ class SessionAutoConfigurationHazelcastTests extends AbstractSessionAutoConfigur
 				"spring.session.hazelcast.flush-mode=immediate").run((context) -> {
 					HazelcastSessionRepository repository = validateSessionRepository(context,
 							HazelcastSessionRepository.class);
-					assertThat(repository).hasFieldOrPropertyWithValue("hazelcastFlushMode",
-							HazelcastFlushMode.IMMEDIATE);
+					assertThat(repository).hasFieldOrPropertyWithValue("flushMode", FlushMode.IMMEDIATE);
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationRedisTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationRedisTests.java
@@ -32,8 +32,8 @@ import org.springframework.boot.testsupport.testcontainers.DisabledWithoutDocker
 import org.springframework.boot.testsupport.testcontainers.RedisContainer;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.session.FlushMode;
 import org.springframework.session.data.mongo.MongoOperationsSessionRepository;
-import org.springframework.session.data.redis.RedisFlushMode;
 import org.springframework.session.data.redis.RedisOperationsSessionRepository;
 import org.springframework.session.data.redis.config.ConfigureNotifyKeyspaceEventsAction;
 import org.springframework.session.data.redis.config.ConfigureRedisAction;
@@ -64,7 +64,7 @@ class SessionAutoConfigurationRedisTests extends AbstractSessionAutoConfiguratio
 				.withPropertyValues("spring.session.store-type=redis",
 						"spring.redis.port=" + redis.getFirstMappedPort())
 				.withConfiguration(AutoConfigurations.of(RedisAutoConfiguration.class))
-				.run(validateSpringSessionUsesRedis("spring:session:event:0:created:", RedisFlushMode.ON_SAVE,
+				.run(validateSpringSessionUsesRedis("spring:session:event:0:created:", FlushMode.ON_SAVE,
 						"0 * * * * *"));
 	}
 
@@ -75,7 +75,7 @@ class SessionAutoConfigurationRedisTests extends AbstractSessionAutoConfiguratio
 						JdbcOperationsSessionRepository.class, MongoOperationsSessionRepository.class))
 				.withConfiguration(AutoConfigurations.of(RedisAutoConfiguration.class))
 				.withPropertyValues("spring.redis.port=" + redis.getFirstMappedPort())
-				.run(validateSpringSessionUsesRedis("spring:session:event:0:created:", RedisFlushMode.ON_SAVE,
+				.run(validateSpringSessionUsesRedis("spring:session:event:0:created:", FlushMode.ON_SAVE,
 						"0 * * * * *"));
 	}
 
@@ -85,7 +85,7 @@ class SessionAutoConfigurationRedisTests extends AbstractSessionAutoConfiguratio
 				.withPropertyValues("spring.session.store-type=redis", "spring.session.redis.namespace=foo",
 						"spring.session.redis.flush-mode=immediate", "spring.session.redis.cleanup-cron=0 0 12 * * *",
 						"spring.redis.port=" + redis.getFirstMappedPort())
-				.run(validateSpringSessionUsesRedis("foo:event:0:created:", RedisFlushMode.IMMEDIATE, "0 0 12 * * *"));
+				.run(validateSpringSessionUsesRedis("foo:event:0:created:", FlushMode.IMMEDIATE, "0 0 12 * * *"));
 	}
 
 	@Test
@@ -116,12 +116,12 @@ class SessionAutoConfigurationRedisTests extends AbstractSessionAutoConfiguratio
 	}
 
 	private ContextConsumer<AssertableWebApplicationContext> validateSpringSessionUsesRedis(
-			String sessionCreatedChannelPrefix, RedisFlushMode flushMode, String cleanupCron) {
+			String sessionCreatedChannelPrefix, FlushMode flushMode, String cleanupCron) {
 		return (context) -> {
 			RedisOperationsSessionRepository repository = validateSessionRepository(context,
 					RedisOperationsSessionRepository.class);
 			assertThat(repository.getSessionCreatedChannelPrefix()).isEqualTo(sessionCreatedChannelPrefix);
-			assertThat(repository).hasFieldOrPropertyWithValue("redisFlushMode", flushMode);
+			assertThat(repository).hasFieldOrPropertyWithValue("flushMode", flushMode);
 			SpringBootRedisHttpSessionConfiguration configuration = context
 					.getBean(SpringBootRedisHttpSessionConfiguration.class);
 			assertThat(configuration).hasFieldOrPropertyWithValue("cleanupCron", cleanupCron);

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -191,7 +191,7 @@
 		<spring-restdocs.version>2.0.3.RELEASE</spring-restdocs.version>
 		<spring-retry.version>1.2.4.RELEASE</spring-retry.version>
 		<spring-security.version>5.2.0.M3</spring-security.version>
-		<spring-session-bom.version>Corn-M2</spring-session-bom.version>
+		<spring-session-bom.version>Corn-BUILD-SNAPSHOT</spring-session-bom.version>
 		<spring-ws.version>3.0.7.RELEASE</spring-ws.version>
 		<sqlite-jdbc.version>3.27.2</sqlite-jdbc.version>
 		<statsd-client.version>3.1.0</statsd-client.version>


### PR DESCRIPTION
As of Spring Session `Corn-M3` support for configuring flush mode for reactive Redis sessions is deprecated due to removal of immediate mode support.

See spring-projects/spring-session#1441.

PR also contains upgrade to `Corn` snapshots - this would be nice to have on Boot side as we'll have a few configuration refinements for the upcoming `M3` release. I'll provide PRs for Boot side as those happen in Spring Session.