### PR TITLE
OAuth2 Resource Server Opaque Token configuration property namespace has a hyphen in its name

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/OAuth2ResourceServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/OAuth2ResourceServerProperties.java
@@ -66,7 +66,7 @@ public class OAuth2ResourceServerProperties {
 
 	private void handleError(String property) {
 		throw new IllegalStateException(
-				"Only one of " + property + " and opaque-token.introspection-uri should be configured.");
+				"Only one of " + property + " and opaquetoken.introspection-uri should be configured.");
 	}
 
 	public static class Jwt {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/OAuth2ResourceServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/OAuth2ResourceServerProperties.java
@@ -43,10 +43,10 @@ public class OAuth2ResourceServerProperties {
 		return this.jwt;
 	}
 
-	private final Opaquetoken Opaquetoken = new Opaquetoken();
+	private final Opaquetoken opaqueToken = new Opaquetoken();
 
 	public Opaquetoken getOpaquetoken() {
-		return this.Opaquetoken;
+		return this.opaqueToken;
 	}
 
 	@PostConstruct
@@ -66,7 +66,7 @@ public class OAuth2ResourceServerProperties {
 
 	private void handleError(String property) {
 		throw new IllegalStateException(
-				"Only one of " + property + " and Opaquetoken.introspection-uri should be configured.");
+				"Only one of " + property + " and opaquetoken.introspection-uri should be configured.");
 	}
 
 	public static class Jwt {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/OAuth2ResourceServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/OAuth2ResourceServerProperties.java
@@ -43,15 +43,15 @@ public class OAuth2ResourceServerProperties {
 		return this.jwt;
 	}
 
-	private final OpaqueToken opaqueToken = new OpaqueToken();
+	private final Opaquetoken Opaquetoken = new Opaquetoken();
 
-	public OpaqueToken getOpaqueToken() {
-		return this.opaqueToken;
+	public Opaquetoken getOpaquetoken() {
+		return this.Opaquetoken;
 	}
 
 	@PostConstruct
 	public void validate() {
-		if (this.getOpaqueToken().getIntrospectionUri() != null) {
+		if (this.getOpaquetoken().getIntrospectionUri() != null) {
 			if (this.getJwt().getJwkSetUri() != null) {
 				handleError("jwt.jwk-set-uri");
 			}
@@ -66,7 +66,7 @@ public class OAuth2ResourceServerProperties {
 
 	private void handleError(String property) {
 		throw new IllegalStateException(
-				"Only one of " + property + " and opaquetoken.introspection-uri should be configured.");
+				"Only one of " + property + " and Opaquetoken.introspection-uri should be configured.");
 	}
 
 	public static class Jwt {
@@ -137,7 +137,7 @@ public class OAuth2ResourceServerProperties {
 
 	}
 
-	public static class OpaqueToken {
+	public static class Opaquetoken {
 
 		/**
 		 * Client id used to authenticate with the token introspection endpoint.

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerOpaqueTokenConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerOpaqueTokenConfiguration.java
@@ -44,7 +44,7 @@ class ReactiveOAuth2ResourceServerOpaqueTokenConfiguration {
 		@ConditionalOnProperty(name = "spring.security.oauth2.resourceserver.opaquetoken.introspection-uri")
 		public NimbusReactiveOAuth2TokenIntrospectionClient oAuth2TokenIntrospectionClient(
 				OAuth2ResourceServerProperties properties) {
-			OAuth2ResourceServerProperties.OpaqueToken opaqueToken = properties.getOpaquetoken();
+			OAuth2ResourceServerProperties.Opaquetoken opaqueToken = properties.getOpaquetoken();
 			return new NimbusReactiveOAuth2TokenIntrospectionClient(opaqueToken.getIntrospectionUri(),
 					opaqueToken.getClientId(), opaqueToken.getClientSecret());
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerOpaqueTokenConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerOpaqueTokenConfiguration.java
@@ -44,7 +44,7 @@ class ReactiveOAuth2ResourceServerOpaqueTokenConfiguration {
 		@ConditionalOnProperty(name = "spring.security.oauth2.resourceserver.opaquetoken.introspection-uri")
 		public NimbusReactiveOAuth2TokenIntrospectionClient oAuth2TokenIntrospectionClient(
 				OAuth2ResourceServerProperties properties) {
-			OAuth2ResourceServerProperties.OpaqueToken opaqueToken = properties.getOpaqueToken();
+			OAuth2ResourceServerProperties.OpaqueToken opaqueToken = properties.getOpaquetoken();
 			return new NimbusReactiveOAuth2TokenIntrospectionClient(opaqueToken.getIntrospectionUri(),
 					opaqueToken.getClientId(), opaqueToken.getClientSecret());
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerOpaqueTokenConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerOpaqueTokenConfiguration.java
@@ -41,7 +41,7 @@ class ReactiveOAuth2ResourceServerOpaqueTokenConfiguration {
 	static class OpaqueTokenIntrospectionClientConfiguration {
 
 		@Bean
-		@ConditionalOnProperty(name = "spring.security.oauth2.resourceserver.opaque-token.introspection-uri")
+		@ConditionalOnProperty(name = "spring.security.oauth2.resourceserver.opaquetoken.introspection-uri")
 		public NimbusReactiveOAuth2TokenIntrospectionClient oAuth2TokenIntrospectionClient(
 				OAuth2ResourceServerProperties properties) {
 			OAuth2ResourceServerProperties.OpaqueToken opaqueToken = properties.getOpaqueToken();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerOpaqueTokenConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerOpaqueTokenConfiguration.java
@@ -44,7 +44,7 @@ class OAuth2ResourceServerOpaqueTokenConfiguration {
 		@ConditionalOnProperty(name = "spring.security.oauth2.resourceserver.opaquetoken.introspection-uri")
 		public NimbusOAuth2TokenIntrospectionClient oAuth2TokenIntrospectionClient(
 				OAuth2ResourceServerProperties properties) {
-			OAuth2ResourceServerProperties.OpaqueToken opaqueToken = properties.getOpaquetoken();
+			OAuth2ResourceServerProperties.Opaquetoken opaqueToken = properties.getOpaquetoken();
 			return new NimbusOAuth2TokenIntrospectionClient(opaqueToken.getIntrospectionUri(),
 					opaqueToken.getClientId(), opaqueToken.getClientSecret());
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerOpaqueTokenConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerOpaqueTokenConfiguration.java
@@ -41,7 +41,7 @@ class OAuth2ResourceServerOpaqueTokenConfiguration {
 	static class OpaqueTokenIntrospectionClientConfiguration {
 
 		@Bean
-		@ConditionalOnProperty(name = "spring.security.oauth2.resourceserver.opaque-token.introspection-uri")
+		@ConditionalOnProperty(name = "spring.security.oauth2.resourceserver.opaquetoken.introspection-uri")
 		public NimbusOAuth2TokenIntrospectionClient oAuth2TokenIntrospectionClient(
 				OAuth2ResourceServerProperties properties) {
 			OAuth2ResourceServerProperties.OpaqueToken opaqueToken = properties.getOpaqueToken();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerOpaqueTokenConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerOpaqueTokenConfiguration.java
@@ -44,7 +44,7 @@ class OAuth2ResourceServerOpaqueTokenConfiguration {
 		@ConditionalOnProperty(name = "spring.security.oauth2.resourceserver.opaquetoken.introspection-uri")
 		public NimbusOAuth2TokenIntrospectionClient oAuth2TokenIntrospectionClient(
 				OAuth2ResourceServerProperties properties) {
-			OAuth2ResourceServerProperties.OpaqueToken opaqueToken = properties.getOpaqueToken();
+			OAuth2ResourceServerProperties.OpaqueToken opaqueToken = properties.getOpaquetoken();
 			return new NimbusOAuth2TokenIntrospectionClient(opaqueToken.getIntrospectionUri(),
 					opaqueToken.getClientId(), opaqueToken.getClientSecret());
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
@@ -212,9 +212,9 @@ class ReactiveOAuth2ResourceServerAutoConfigurationTests {
 	void autoConfigurationWhenIntrospectionUriAvailableShouldConfigureIntrospectionClient() {
 		this.contextRunner
 				.withPropertyValues(
-						"spring.security.oauth2.resourceserver.opaque-token.introspection-uri=https://check-token.com",
-						"spring.security.oauth2.resourceserver.opaque-token.client-id=my-client-id",
-						"spring.security.oauth2.resourceserver.opaque-token.client-secret=my-client-secret")
+						"spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://check-token.com",
+						"spring.security.oauth2.resourceserver.opaquetoken.client-id=my-client-id",
+						"spring.security.oauth2.resourceserver.opaquetoken.client-secret=my-client-secret")
 				.run((context) -> {
 					assertThat(context).hasSingleBean(ReactiveOAuth2TokenIntrospectionClient.class);
 					assertFilterConfiguredWithOpaqueTokenAuthenticationManager(context);
@@ -225,7 +225,7 @@ class ReactiveOAuth2ResourceServerAutoConfigurationTests {
 	void oAuth2TokenIntrospectionClientIsConditionalOnMissingBean() {
 		this.contextRunner
 				.withPropertyValues(
-						"spring.security.oauth2.resourceserver.opaque-token.introspection-uri=https://check-token.com")
+						"spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://check-token.com")
 				.withUserConfiguration(OAuth2TokenIntrospectionClientConfig.class)
 				.run((this::assertFilterConfiguredWithOpaqueTokenAuthenticationManager));
 	}
@@ -234,9 +234,9 @@ class ReactiveOAuth2ResourceServerAutoConfigurationTests {
 	void autoConfigurationForOpaqueTokenWhenSecurityWebFilterChainConfigPresentShouldNotAddOne() {
 		this.contextRunner
 				.withPropertyValues(
-						"spring.security.oauth2.resourceserver.opaque-token.introspection-uri=https://check-token.com",
-						"spring.security.oauth2.resourceserver.opaque-token.client-id=my-client-id",
-						"spring.security.oauth2.resourceserver.opaque-token.client-secret=my-client-secret")
+						"spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://check-token.com",
+						"spring.security.oauth2.resourceserver.opaquetoken.client-id=my-client-id",
+						"spring.security.oauth2.resourceserver.opaquetoken.client-secret=my-client-secret")
 				.withUserConfiguration(SecurityWebFilterChainConfig.class).run((context) -> {
 					assertThat(context).hasSingleBean(SecurityWebFilterChain.class);
 					assertThat(context).hasBean("testSpringSecurityFilterChain");
@@ -247,9 +247,9 @@ class ReactiveOAuth2ResourceServerAutoConfigurationTests {
 	void autoConfigurationWhenIntrospectionUriAvailableShouldBeConditionalOnClass() {
 		this.contextRunner.withClassLoader(new FilteredClassLoader(OAuth2IntrospectionAuthenticationToken.class))
 				.withPropertyValues(
-						"spring.security.oauth2.resourceserver.opaque-token.introspection-uri=https://check-token.com",
-						"spring.security.oauth2.resourceserver.opaque-token.client-id=my-client-id",
-						"spring.security.oauth2.resourceserver.opaque-token.client-secret=my-client-secret")
+						"spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://check-token.com",
+						"spring.security.oauth2.resourceserver.opaquetoken.client-id=my-client-id",
+						"spring.security.oauth2.resourceserver.opaquetoken.client-secret=my-client-secret")
 				.run((context) -> assertThat(context).doesNotHaveBean(OAuth2TokenIntrospectionClient.class));
 	}
 
@@ -257,30 +257,30 @@ class ReactiveOAuth2ResourceServerAutoConfigurationTests {
 	void autoConfigurationWhenBothJwkSetUriAndTokenIntrospectionUriSetShouldFail() {
 		this.contextRunner
 				.withPropertyValues(
-						"spring.security.oauth2.resourceserver.opaque-token.introspection-uri=https://check-token.com",
+						"spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://check-token.com",
 						"spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://jwk-set-uri.com")
 				.run((context) -> assertThat(context).hasFailed().getFailure().hasMessageContaining(
-						"Only one of jwt.jwk-set-uri and opaque-token.introspection-uri should be configured."));
+						"Only one of jwt.jwk-set-uri and opaquetoken.introspection-uri should be configured."));
 	}
 
 	@Test
 	void autoConfigurationWhenBothJwtIssuerUriAndTokenIntrospectionUriSetShouldFail() {
 		this.contextRunner
 				.withPropertyValues(
-						"spring.security.oauth2.resourceserver.opaque-token.introspection-uri=https://check-token.com",
+						"spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://check-token.com",
 						"spring.security.oauth2.resourceserver.jwt.issuer-uri=https://jwk-oidc-issuer-location.com")
 				.run((context) -> assertThat(context).hasFailed().getFailure().hasMessageContaining(
-						"Only one of jwt.issuer-uri and opaque-token.introspection-uri should be configured."));
+						"Only one of jwt.issuer-uri and opaquetoken.introspection-uri should be configured."));
 	}
 
 	@Test
 	void autoConfigurationWhenBothJwtKeyLocationAndTokenIntrospectionUriSetShouldFail() {
 		this.contextRunner
 				.withPropertyValues(
-						"spring.security.oauth2.resourceserver.opaque-token.introspection-uri=https://check-token.com",
+						"spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://check-token.com",
 						"spring.security.oauth2.resourceserver.jwt.public-key-location=classpath:public-key-location")
 				.run((context) -> assertThat(context).hasFailed().getFailure().hasMessageContaining(
-						"Only one of jwt.public-key-location and opaque-token.introspection-uri should be configured."));
+						"Only one of jwt.public-key-location and opaquetoken.introspection-uri should be configured."));
 	}
 
 	private void assertFilterConfiguredWithJwtAuthenticationManager(AssertableReactiveWebApplicationContext context) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
@@ -227,9 +227,9 @@ class OAuth2ResourceServerAutoConfigurationTests {
 	void autoConfigurationWhenIntrospectionUriAvailableShouldConfigureIntrospectionClient() {
 		this.contextRunner
 				.withPropertyValues(
-						"spring.security.oauth2.resourceserver.opaque-token.introspection-uri=https://check-token.com",
-						"spring.security.oauth2.resourceserver.opaque-token.client-id=my-client-id",
-						"spring.security.oauth2.resourceserver.opaque-token.client-secret=my-client-secret")
+						"spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://check-token.com",
+						"spring.security.oauth2.resourceserver.opaquetoken.client-id=my-client-id",
+						"spring.security.oauth2.resourceserver.opaquetoken.client-secret=my-client-secret")
 				.run((context) -> {
 					assertThat(context).hasSingleBean(OAuth2TokenIntrospectionClient.class);
 					assertThat(getBearerTokenFilter(context)).isNotNull();
@@ -240,7 +240,7 @@ class OAuth2ResourceServerAutoConfigurationTests {
 	void oAuth2TokenIntrospectionClientIsConditionalOnMissingBean() {
 		this.contextRunner
 				.withPropertyValues(
-						"spring.security.oauth2.resourceserver.opaque-token.introspection-uri=https://check-token.com")
+						"spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://check-token.com")
 				.withUserConfiguration(OAuth2TokenIntrospectionClientConfig.class)
 				.run((context) -> assertThat(getBearerTokenFilter(context)).isNotNull());
 	}
@@ -249,9 +249,9 @@ class OAuth2ResourceServerAutoConfigurationTests {
 	void autoConfigurationWhenIntrospectionUriAvailableShouldBeConditionalOnClass() {
 		this.contextRunner.withClassLoader(new FilteredClassLoader(OAuth2IntrospectionAuthenticationToken.class))
 				.withPropertyValues(
-						"spring.security.oauth2.resourceserver.opaque-token.introspection-uri=https://check-token.com",
-						"spring.security.oauth2.resourceserver.opaque-token.client-id=my-client-id",
-						"spring.security.oauth2.resourceserver.opaque-token.client-secret=my-client-secret")
+						"spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://check-token.com",
+						"spring.security.oauth2.resourceserver.opaquetoken.client-id=my-client-id",
+						"spring.security.oauth2.resourceserver.opaquetoken.client-secret=my-client-secret")
 				.run((context) -> assertThat(context).doesNotHaveBean(OAuth2TokenIntrospectionClient.class));
 	}
 
@@ -259,30 +259,30 @@ class OAuth2ResourceServerAutoConfigurationTests {
 	void autoConfigurationWhenBothJwkSetUriAndTokenIntrospectionUriSetShouldFail() {
 		this.contextRunner
 				.withPropertyValues(
-						"spring.security.oauth2.resourceserver.opaque-token.introspection-uri=https://check-token.com",
+						"spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://check-token.com",
 						"spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://jwk-set-uri.com")
 				.run((context) -> assertThat(context).hasFailed().getFailure().hasMessageContaining(
-						"Only one of jwt.jwk-set-uri and opaque-token.introspection-uri should be configured."));
+						"Only one of jwt.jwk-set-uri and opaquetoken.introspection-uri should be configured."));
 	}
 
 	@Test
 	void autoConfigurationWhenBothJwtIssuerUriAndTokenIntrospectionUriSetShouldFail() {
 		this.contextRunner
 				.withPropertyValues(
-						"spring.security.oauth2.resourceserver.opaque-token.introspection-uri=https://check-token.com",
+						"spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://check-token.com",
 						"spring.security.oauth2.resourceserver.jwt.issuer-uri=https://jwk-oidc-issuer-location.com")
 				.run((context) -> assertThat(context).hasFailed().getFailure().hasMessageContaining(
-						"Only one of jwt.issuer-uri and opaque-token.introspection-uri should be configured."));
+						"Only one of jwt.issuer-uri and opaquetoken.introspection-uri should be configured."));
 	}
 
 	@Test
 	void autoConfigurationWhenBothJwtKeyLocationAndTokenIntrospectionUriSetShouldFail() {
 		this.contextRunner
 				.withPropertyValues(
-						"spring.security.oauth2.resourceserver.opaque-token.introspection-uri=https://check-token.com",
+						"spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://check-token.com",
 						"spring.security.oauth2.resourceserver.jwt.public-key-location=classpath:public-key-location")
 				.run((context) -> assertThat(context).hasFailed().getFailure().hasMessageContaining(
-						"Only one of jwt.public-key-location and opaque-token.introspection-uri should be configured."));
+						"Only one of jwt.public-key-location and opaquetoken.introspection-uri should be configured."));
 	}
 
 	private Filter getBearerTokenFilter(AssertableWebApplicationContext context) {

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -3830,9 +3830,9 @@ to validate tokens via introspection:
 
 [source,properties,indent=0]
 ----
-	spring.security.oauth2.resourceserver.opaque-token.introspection-uri=https://example.com/check-token
-	spring.security.oauth2.resourceserver.opaque-token.client-id=my-client-id
-	spring.security.oauth2.resourceserver.opaque-token.client-secret-my-client-secret
+	spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://example.com/check-token
+	spring.security.oauth2.resourceserver.opaquetoken.client-id=my-client-id
+	spring.security.oauth2.resourceserver.opaquetoken.client-secret-my-client-secret
 ----
 
 Again, the same properties are applicable for both servlet and reactive applications.


### PR DESCRIPTION
Fix for bug #17265 in which "OAuth2 Resource Server Opaque Token configuration property namespace has a hyphen in its name"

A rename from: `spring.security.oauth2.resourceserver.opaque-token.`

to: `spring.security.oauth2.resourceserver.opaquetoken.`
