### PR TITLE
Introduce dedicated interface to listen for ClassPathChangedEvents.

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -100,7 +100,7 @@ public class LocalDevToolsAutoConfiguration {
 		}
 
 		@Bean
-		public ApplicationListener<ClassPathChangedEvent> restartingClassPathChangedEventListener(
+		public ClassPathChangedEventListener restartingClassPathChangedEventListener(
 				FileSystemWatcherFactory fileSystemWatcherFactory) {
 			return (event) -> {
 				if (event.isRestartRequired()) {
@@ -151,6 +151,10 @@ public class LocalDevToolsAutoConfiguration {
 				watcher.addSourceFolder(path.getAbsoluteFile());
 			}
 			return watcher;
+		}
+
+		interface ClassPathChangedEventListener extends ApplicationListener<ClassPathChangedEvent> {
+
 		}
 
 	}


### PR DESCRIPTION
So far, `LocalDevToolsAutoConfiguration` had registered a Lambda-based event listener for `ClassPathChangedEvents`. As the generics information is not available for lookup from a Lambda defined generic interface, `SimpleApplicationEventMulticaster.doInvokeListener(…)` has no chance but to submit *all* events published to the listener, catching the `ClassCastExceptions` resulting from that to log them into the `TRACE` level.

For applications that produce a lot of events (esp. during startup) like ones that use Spring Data MongoDB which uses the events to trigger index creation etc., this means that a lot of exceptions are thrown and ultimately discarded most of the time.

This commit introduces a dedicated interface for that particular application listener so that it can be discarded for all events but the one it's really interested in, thus avoiding the superfluous exceptions being produced and ultimately leading to better (startup) performance.

This was tested using Spring Data Examples (rest/starbucks) and lead to a startup time improvement of ~500ms. The example uses Spring Data MongoDB whose object mapping is heavily making use of application events when reading and writing objects to the database. I assume the effect will be less visible in applications using application events less intensively.