### PR TITLE
Auto-configure Kafka listener container with user-provided RecordInterceptor

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/ConcurrentKafkaListenerContainerFactoryConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/ConcurrentKafkaListenerContainerFactoryConfigurer.java
@@ -28,6 +28,7 @@ import org.springframework.kafka.listener.BatchErrorHandler;
 import org.springframework.kafka.listener.ConsumerAwareRebalanceListener;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.ErrorHandler;
+import org.springframework.kafka.listener.RecordInterceptor;
 import org.springframework.kafka.support.converter.MessageConverter;
 import org.springframework.kafka.transaction.KafkaAwareTransactionManager;
 
@@ -55,6 +56,8 @@ public class ConcurrentKafkaListenerContainerFactoryConfigurer {
 	private BatchErrorHandler batchErrorHandler;
 
 	private AfterRollbackProcessor<Object, Object> afterRollbackProcessor;
+
+	private RecordInterceptor<Object, Object> recordInterceptor;
 
 	/**
 	 * Set the {@link KafkaProperties} to use.
@@ -122,6 +125,14 @@ public class ConcurrentKafkaListenerContainerFactoryConfigurer {
 	}
 
 	/**
+	 * Set the {@link RecordInterceptor} to use.
+	 * @param recordInterceptor the record interceptor.
+	 */
+	void setRecordInterceptor(RecordInterceptor<Object, Object> recordInterceptor) {
+		this.recordInterceptor = recordInterceptor;
+	}
+
+	/**
 	 * Configure the specified Kafka listener container factory. The factory can be
 	 * further tuned and default settings can be overridden.
 	 * @param listenerFactory the {@link ConcurrentKafkaListenerContainerFactory} instance
@@ -149,6 +160,7 @@ public class ConcurrentKafkaListenerContainerFactoryConfigurer {
 			factory.setErrorHandler(this.errorHandler);
 		}
 		map.from(this.afterRollbackProcessor).to(factory::setAfterRollbackProcessor);
+		map.from(this.recordInterceptor).to(factory::setRecordInterceptor);
 	}
 
 	private void configureContainer(ContainerProperties container) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaAnnotationDrivenConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaAnnotationDrivenConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.kafka.listener.AfterRollbackProcessor;
 import org.springframework.kafka.listener.BatchErrorHandler;
 import org.springframework.kafka.listener.ConsumerAwareRebalanceListener;
 import org.springframework.kafka.listener.ErrorHandler;
+import org.springframework.kafka.listener.RecordInterceptor;
 import org.springframework.kafka.support.converter.BatchMessageConverter;
 import org.springframework.kafka.support.converter.BatchMessagingMessageConverter;
 import org.springframework.kafka.support.converter.MessageConverter;
@@ -66,6 +67,8 @@ class KafkaAnnotationDrivenConfiguration {
 
 	private final AfterRollbackProcessor<Object, Object> afterRollbackProcessor;
 
+	private final RecordInterceptor<Object, Object> recordInterceptor;
+
 	KafkaAnnotationDrivenConfiguration(KafkaProperties properties,
 			ObjectProvider<RecordMessageConverter> messageConverter,
 			ObjectProvider<BatchMessageConverter> batchMessageConverter,
@@ -73,7 +76,8 @@ class KafkaAnnotationDrivenConfiguration {
 			ObjectProvider<KafkaAwareTransactionManager<Object, Object>> kafkaTransactionManager,
 			ObjectProvider<ConsumerAwareRebalanceListener> rebalanceListener, ObjectProvider<ErrorHandler> errorHandler,
 			ObjectProvider<BatchErrorHandler> batchErrorHandler,
-			ObjectProvider<AfterRollbackProcessor<Object, Object>> afterRollbackProcessor) {
+			ObjectProvider<AfterRollbackProcessor<Object, Object>> afterRollbackProcessor,
+			ObjectProvider<RecordInterceptor<Object, Object>> recordInterceptor) {
 		this.properties = properties;
 		this.messageConverter = messageConverter.getIfUnique();
 		this.batchMessageConverter = batchMessageConverter
@@ -84,6 +88,7 @@ class KafkaAnnotationDrivenConfiguration {
 		this.errorHandler = errorHandler.getIfUnique();
 		this.batchErrorHandler = batchErrorHandler.getIfUnique();
 		this.afterRollbackProcessor = afterRollbackProcessor.getIfUnique();
+		this.recordInterceptor = recordInterceptor.getIfUnique();
 	}
 
 	@Bean
@@ -100,6 +105,7 @@ class KafkaAnnotationDrivenConfiguration {
 		configurer.setErrorHandler(this.errorHandler);
 		configurer.setBatchErrorHandler(this.batchErrorHandler);
 		configurer.setAfterRollbackProcessor(this.afterRollbackProcessor);
+		configurer.setRecordInterceptor(this.recordInterceptor);
 		return configurer;
 	}
 


### PR DESCRIPTION
spring-kafka.2.3.0.M3 introduced a new property `RecordInterceptor` to
the container factory.

Auto-configure the property if a single instance is present.
