### PR TITLE
Let parallel CI steps fail fast

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -150,6 +150,8 @@ jobs:
     trigger: true
   - get: spring-boot-ci-image
   - in_parallel:
+    fail_fast: true
+    steps:
     - task: detect-jdk8-update
       file: git-repo/ci/tasks/detect-jdk-updates.yml
       params:
@@ -193,6 +195,8 @@ jobs:
       image: spring-boot-ci-image
       file: git-repo/ci/tasks/build-project.yml
     - in_parallel:
+      fail_fast: true
+      steps:
       - task: build-smoke-tests
         timeout: 1h30m
         image: spring-boot-ci-image
@@ -259,6 +263,8 @@ jobs:
       image: spring-boot-ci-image
       file: git-repo/ci/tasks/build-pr-project.yml
     - in_parallel:
+      fail_fast: true
+      steps:
       - task: build-smoke-tests
         timeout: 1h30m
         image: spring-boot-ci-image
@@ -297,6 +303,8 @@ jobs:
       image: spring-boot-jdk11-ci-image
       file: git-repo/ci/tasks/build-project.yml
     - in_parallel:
+      fail_fast: true
+      steps:
       - task: build-smoke-tests
         timeout: 1h30m
         image: spring-boot-jdk11-ci-image
@@ -343,6 +351,8 @@ jobs:
           image: spring-boot-jdk12-ci-image
           file: git-repo/ci/tasks/build-project.yml
         - in_parallel:
+            fail_fast: true
+            steps:
             - task: build-smoke-tests
               timeout: 1h30m
               image: spring-boot-jdk12-ci-image


### PR DESCRIPTION
Hi,

I saw that you updated Concourse to 5.3 and that `in_parallel` is used now. This should give us the possibility to use the `fail_fast` option. Hopefully this will boost build times when parallel steps fail.

Let me know what you think. I didn't see a way of testing this other than providing the PR and seeing if it works there.

Cheers,
Christoph