### PR TITLE
Add extra validators to ConfigurationProperties

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationProperties.java
@@ -23,6 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.core.annotation.AliasFor;
+import org.springframework.validation.Validator;
 
 /**
  * Annotation for externalized configuration. Add this to a class definition or a
@@ -33,6 +34,7 @@ import org.springframework.core.annotation.AliasFor;
  * values are externalized.
  *
  * @author Dave Syer
+ * @author Jurrian Fahner
  * @since 1.0.0
  * @see ConfigurationPropertiesBindingPostProcessor
  * @see EnableConfigurationProperties
@@ -59,6 +61,13 @@ public @interface ConfigurationProperties {
 	 */
 	@AliasFor("value")
 	String prefix() default "";
+
+	/**
+	 * Convenient way to register extra validators to be applied on this object. These
+	 * classes needs to implement the {@link Validator} interface.
+	 * @return the validators to use on this object
+	 */
+	Class<? extends Validator>[] validators() default {};
 
 	/**
 	 * Flag to indicate that when binding to this object invalid fields should be ignored.


### PR DESCRIPTION
Under spring-boot 2.1.x there are limited options to add validators to properties:

- implement the Validator interface
- add a `configurationPropertiesValidator` bean
- apply jsr303

For the use-case that somebody wants to have more validators on one configuration properties class, see also [an example implementation](https://github.com/JurrianFahner/demo-configuration-properties/blob/master/src/main/java/nl/ensignprojects/configurationpropertiesvalidation/AppConfigurationProperties.java) (see for even more info also the [readme](https://github.com/JurrianFahner/demo-configuration-properties/blob/master/Readme.md)), that is not so easy implemented now.

In the way how it is now set up, it is also not easy to reuse the code for validators. For example if somebody wants the validation logic in a library.   

The whole idea of this enhancement request is that it is trivial to add more than one validator. Also code reuse for the validation can be done more easily, especially if an interface is implemented on the properties class. 