### PR TITLE
Polish GradleCompatibilityExtension's javadoc

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleCompatibilityExtension.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleCompatibilityExtension.java
@@ -29,16 +29,16 @@ import org.springframework.boot.gradle.testkit.GradleBuild;
 import org.springframework.boot.gradle.testkit.GradleBuildExtension;
 
 /**
- * {@link Extension} that runs {@link TestTemplate templated tests} against multiple
- * versions of Gradle. Test classes using the extension must have non-private and
- * non-final {@link GradleBuild} field named {@code gradleBuild}.
+ * {@link Extension} that runs {@link org.junit.jupiter.api.TestTemplate templated tests}
+ * against multiple versions of Gradle. Test classes using the extension must have a
+ * non-private and non-final {@link GradleBuild} field named {@code gradleBuild}.
  *
  * @author Andy Wilkinson
  */
 public final class GradleCompatibilityExtension implements TestTemplateInvocationContextProvider {
 
 	private static final List<String> GRADLE_VERSIONS = Arrays.asList("default", "5.0", "5.1.1", "5.2.1", "5.3.1",
-			"5.4.1");
+			"5.4.1", "5.5");
 
 	@Override
 	public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {


### PR DESCRIPTION
Hi,

since Gradle 5.5 is out it might be good to test against it. I did some additional javadoc polishing in `GradleCompatibilityExtension` - hope that's okay. 

Cheers,
Christoph