### PR TITLE
Switch Jersey starter to use Spring 5 module

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
@@ -557,7 +557,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.ext</groupId>
-			<artifactId>jersey-spring4</artifactId>
+			<artifactId>jersey-spring5</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-project/spring-boot-actuator/pom.xml
+++ b/spring-boot-project/spring-boot-actuator/pom.xml
@@ -367,7 +367,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.ext</groupId>
-			<artifactId>jersey-spring4</artifactId>
+			<artifactId>jersey-spring5</artifactId>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>

--- a/spring-boot-project/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/pom.xml
@@ -186,7 +186,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.ext</groupId>
-			<artifactId>jersey-spring4</artifactId>
+			<artifactId>jersey-spring5</artifactId>
 			<optional>true</optional>
 			<exclusions>
 				<exclusion>

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -2254,6 +2254,12 @@
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
+			<!-- Remove once https://github.com/eclipse-ee4j/jersey/issues/4184 is fixed -->
+			<dependency>
+				<groupId>org.glassfish.jersey.ext</groupId>
+				<artifactId>jersey-spring5</artifactId>
+				<version>${jersey.version}</version>
+			</dependency>
 			<dependency>
 				<groupId>org.hamcrest</groupId>
 				<artifactId>hamcrest</artifactId>

--- a/spring-boot-project/spring-boot-docs/pom.xml
+++ b/spring-boot-project/spring-boot-docs/pom.xml
@@ -669,7 +669,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.ext</groupId>
-			<artifactId>jersey-spring4</artifactId>
+			<artifactId>jersey-spring5</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-jersey/pom.xml
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-jersey/pom.xml
@@ -93,7 +93,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.ext</groupId>
-			<artifactId>jersey-spring4</artifactId>
+			<artifactId>jersey-spring5</artifactId>
 			<exclusions>
 				<exclusion>
 					<groupId>org.jvnet</groupId>


### PR DESCRIPTION
Hi,

I noticed that we upgraded to Jersey 2.29 recently. That should give us the possibility to switch from `jersey-spring4` to `jersey-spring5`. Unfortunately, the new module doesn't seem to be exposed through the BOM yet, so I added it explicitly for the time being and opened https://github.com/eclipse-ee4j/jersey/issues/4184 to include this in the BOM.

Let me know what you think.
Cheers,
Christoph