### PR TITLE
Remove references to archived spring-boot-issues repo

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -18,10 +18,9 @@ please ask on https://stackoverflow.com[Stack Overflow]. The Spring Boot team an
 broader community monitor the https://stackoverflow.com/tags/spring-boot[`spring-boot`]
 tag.
 
-If you are reporting a bug, please help to speed up problem diagnosis by providing as much
-information as possible. Ideally, that would include a small
-https://github.com/spring-projects/spring-boot-issues[sample project] that reproduces the
-problem.
+If you are reporting a bug, please help to speed up problem diagnosis by providing as
+much information as possible. Ideally, that would include a small sample project that
+reproduces the problem.
 
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -85,10 +85,8 @@ requests. If you want to raise an issue, please follow the recommendations below
   JVM version.
 * If you need to paste code, or include a stack trace use Markdown +++```+++ escapes
   before and after your text.
-* If possible try to create a test-case or project that replicates the issue. You can
-  submit sample projects as pull-requests against the
-  https://github.com/spring-projects/spring-boot-issues[spring-boot-issues] GitHub
-  project. Use the issue number for the name of your project.
+* If possible try to create a test-case or project that replicates the problem and attach
+  it to the issue.
 
 
 

--- a/SUPPORT.adoc
+++ b/SUPPORT.adoc
@@ -7,9 +7,8 @@ usage question please do not open a GitHub issue, but use one of the other chann
 described below.
 
 If you are reporting a bug, please help to speed up problem diagnosis by providing as
-much information as possible. Ideally, that would include a small
-https://github.com/spring-projects/spring-boot-issues[sample project] that reproduces the
-problem.
+much information as possible. Ideally, that would include a small sample project that
+reproduces the problem.
 
 == Stack Overflow
 The Spring Boot community monitors the


### PR DESCRIPTION
Hi,

I noticed that https://github.com/spring-projects/spring-boot-issues is archived, but there are still some links pointing to it.

Cheers,
Christoph