### PR TITLE
Adjust RSocketServerAutoConfiguration to use renamed methods

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/rsocket/RSocketServerAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/rsocket/RSocketServerAutoConfiguration.java
@@ -69,7 +69,7 @@ public class RSocketServerAutoConfiguration {
 		RSocketWebSocketNettyRouteProvider rSocketWebsocketRouteProvider(RSocketProperties properties,
 				RSocketMessageHandler messageHandler) {
 			return new RSocketWebSocketNettyRouteProvider(properties.getServer().getMappingPath(),
-					messageHandler.serverAcceptor());
+					messageHandler.serverResponder());
 		}
 
 	}
@@ -101,7 +101,7 @@ public class RSocketServerAutoConfiguration {
 		@ConditionalOnMissingBean
 		RSocketServerBootstrap rSocketServerBootstrap(RSocketServerFactory rSocketServerFactory,
 				RSocketMessageHandler rSocketMessageHandler) {
-			return new RSocketServerBootstrap(rSocketServerFactory, rSocketMessageHandler.serverAcceptor());
+			return new RSocketServerBootstrap(rSocketServerFactory, rSocketMessageHandler.serverResponder());
 		}
 
 	}


### PR DESCRIPTION
Hi,

since https://github.com/spring-projects/spring-framework/commit/68c99dafcfbb58b7caae16f8f195bc6d458ff322 `RSocketMessageHandler.serverAcceptor()` needs to be `RSocketMessageHandler.serverResponder()`.

Cheers,
Christoph