### PR TITLE
Remove java-statsd-client dependency

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
@@ -70,11 +70,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.timgroup</groupId>
-			<artifactId>java-statsd-client</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP</artifactId>
 			<optional>true</optional>

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -194,7 +194,6 @@
 		<spring-session-bom.version>Corn-BUILD-SNAPSHOT</spring-session-bom.version>
 		<spring-ws.version>3.0.7.RELEASE</spring-ws.version>
 		<sqlite-jdbc.version>3.28.0</sqlite-jdbc.version>
-		<statsd-client.version>3.1.0</statsd-client.version>
 		<sun-mail.version>${jakarta-mail.version}</sun-mail.version>
 		<saaj-impl.version>1.5.1</saaj-impl.version>
 		<thymeleaf.version>3.0.11.RELEASE</thymeleaf.version>
@@ -833,11 +832,6 @@
 				<groupId>com.sun.xml.messaging.saaj</groupId>
 				<artifactId>saaj-impl</artifactId>
 				<version>${saaj-impl.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.timgroup</groupId>
-				<artifactId>java-statsd-client</artifactId>
-				<version>${statsd-client.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.unboundid</groupId>

--- a/spring-boot-project/spring-boot-docs/pom.xml
+++ b/spring-boot-project/spring-boot-docs/pom.xml
@@ -204,11 +204,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.timgroup</groupId>
-			<artifactId>java-statsd-client</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>com.unboundid</groupId>
 			<artifactId>unboundid-ldapsdk</artifactId>
 			<optional>true</optional>


### PR DESCRIPTION
Hi,

I noticed that there is a dependency to `java-statsd-client` that seems superseded by the micrometer StatsD support. At least there is no direct usage of it anymore as far as I can tell, but maybe you know of any libs that need this dependency to be declared.

Let me know what you think.
Cheers,
Christoph