### PR TITLE
Remove obsolete checkstyle suppressions

### DIFF
--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -37,8 +37,6 @@
 	<suppress files="RemoteUrlPropertyExtractorTests\.java" checks="IllegalImport" />
 	<suppress files="SampleLogbackApplication\.java" checks="IllegalImport" />
 	<suppress files="FlywayAutoConfigurationTests\.java" checks="IllegalImport" />
-	<suppress files="ModifiedClassPathRunnerOverridesTests" checks="SpringJUnit5" />
-	<suppress files="ModifiedClassPathRunnerExclusionsTests" checks="SpringJUnit5" />
 	<suppress files="[\\/]src[\\/]test[\\/]java[\\/]org[\\/]springframework[\\/]boot[\\/]test[\\/]rule[\\/]" checks="SpringJUnit5" />
 	<suppress files="OutputCaptureRuleTests" checks="SpringJUnit5" />
 	<suppress files="SampleJUnitVintageApplicationTests" checks="SpringJUnit5" />


### PR DESCRIPTION
Hi,

this PR is a follow-up after #17491 got merged and the `ModifiedClassPathRunner` related tests were removed - which makes the checkstyle suppression entries obsolete.

Cheers,
Christoph