### PR TITLE
Use a single instance of `EventLoopGroup` to configure `NettyStreamFactory`

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveAutoConfiguration.java
@@ -91,8 +91,7 @@ public class MongoReactiveAutoConfiguration {
 		@Override
 		public void customize(Builder builder) {
 			if (!isStreamFactoryFactoryDefined(this.settings.getIfAvailable())) {
-				NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup();
-				this.eventLoopGroup = eventLoopGroup;
+				EventLoopGroup eventLoopGroup = eventLoopGroup();
 				builder.streamFactoryFactory(
 						NettyStreamFactoryFactory.builder().eventLoopGroup(eventLoopGroup).build());
 			}
@@ -109,6 +108,20 @@ public class MongoReactiveAutoConfiguration {
 
 		private boolean isStreamFactoryFactoryDefined(MongoClientSettings settings) {
 			return settings != null && settings.getStreamFactoryFactory() != null;
+		}
+
+		private EventLoopGroup eventLoopGroup() {
+			EventLoopGroup eventLoopGroup = this.eventLoopGroup;
+			if (eventLoopGroup == null) {
+				synchronized (this) {
+					eventLoopGroup = this.eventLoopGroup;
+					if (eventLoopGroup == null) {
+						eventLoopGroup = new NioEventLoopGroup();
+						this.eventLoopGroup = eventLoopGroup;
+					}
+				}
+			}
+			return eventLoopGroup;
 		}
 
 	}


### PR DESCRIPTION

Prior to this commit, `NettyDriverMongoClientSettingsBuilderCustomizer` could create more than one instance of `NioEventLoopGroup` in case if it has been invoked for several `MongoClientSettings`, but the reference was only to the last instance, hence shutdown was invoked only for the last `NioEventLoopGroup`.

see gh-17533
