### PR TITLE
Add reference to picocli starter

### DIFF
--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -145,6 +145,9 @@ do as they were designed before this was clarified.
 | https://orika-mapper.github.io/orika-docs/[Orika]
 | https://github.com/akihyro/orika-spring-boot-starter
 
+| https://picocli.info/[picocli]
+| https://github.com/remkop/picocli/tree/master/picocli-spring-boot-starter
+
 | https://www.rabbitmq.com/[RabbitMQ] (Advanced usage)
 | https://github.com/societe-generale/rabbitmq-advanced-spring-boot-starter
 


### PR DESCRIPTION
This PR adds a link to the [picocli Spring Boot starter](https://github.com/remkop/picocli/tree/master/picocli-spring-boot-starter) to the list of Spring Boot starters.