### PR TITLE
Align JavaVersion.NINE name with JDK versioning

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnJavaTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnJavaTests.java
@@ -80,14 +80,14 @@ class ConditionalOnJavaTests {
 	void equalOrNewerMessage() {
 		ConditionOutcome outcome = this.condition.getMatchOutcome(Range.EQUAL_OR_NEWER, JavaVersion.NINE,
 				JavaVersion.EIGHT);
-		assertThat(outcome.getMessage()).isEqualTo("@ConditionalOnJava (1.8 or newer) found 1.9");
+		assertThat(outcome.getMessage()).isEqualTo("@ConditionalOnJava (1.8 or newer) found 9");
 	}
 
 	@Test
 	void olderThanMessage() {
 		ConditionOutcome outcome = this.condition.getMatchOutcome(Range.OLDER_THAN, JavaVersion.NINE,
 				JavaVersion.EIGHT);
-		assertThat(outcome.getMessage()).isEqualTo("@ConditionalOnJava (older than 1.8) found 1.9");
+		assertThat(outcome.getMessage()).isEqualTo("@ConditionalOnJava (older than 1.8) found 9");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/JavaVersion.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/JavaVersion.java
@@ -38,9 +38,9 @@ public enum JavaVersion {
 	EIGHT("1.8", Optional.class, "empty"),
 
 	/**
-	 * Java 1.9.
+	 * Java 9.
 	 */
-	NINE("1.9", Optional.class, "stream"),
+	NINE("9", Optional.class, "stream"),
 
 	/**
 	 * Java 10.


### PR DESCRIPTION
Hi,

this PR aligns the version of JavaVersion.NINE with the JDK versioning as described in https://github.com/spring-projects/spring-boot/issues/17565#issuecomment-513387154.

Cheers,
Christoph