### PR TITLE
GH-17610 - Provide dedicated Neo4j driver auto-configuration.

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
@@ -363,6 +363,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.neo4j.driver</groupId>
+			<artifactId>neo4j-java-driver</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
 			<optional>true</optional>

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/neo4j/Neo4jNativeHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/neo4j/Neo4jNativeHealthIndicator.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.neo4j;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.exceptions.SessionExpiredException;
+import org.neo4j.driver.v1.summary.ResultSummary;
+import org.neo4j.driver.v1.summary.ServerInfo;
+
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+
+/**
+ * {@link HealthIndicator} that tests the status of Neo4j by executing a Cypher statement
+ * and extracting server and database information. This health indicator uses the native
+ * bolt connection and an optimized query to check for a servers health in contrast to
+ * {@link Neo4jHealthIndicator}.
+ *
+ * @author Michael J. Simons
+ * @since 2.2.0
+ */
+public final class Neo4jNativeHealthIndicator extends AbstractHealthIndicator {
+
+	private static final Log logger = LogFactory.getLog(Neo4jHealthIndicator.class);
+
+	/**
+	 * The Cypher statement used to verify Neo4j is up.
+	 */
+	static final String CYPHER = "RETURN 1 AS result";
+
+	/**
+	 * Message indicating that the health check failed.
+	 */
+	static final String MESSAGE_HEALTH_CHECK_FAILED = "Neo4j health check failed";
+
+	/**
+	 * Message logged before retrying a health check.
+	 */
+	static final String MESSAGE_SESSION_EXPIRED = "Neo4j session has expired, retrying one single time to retrieve server health.";
+
+	/**
+	 * The driver for this health indicator instance.
+	 */
+	private final Driver driver;
+
+	public Neo4jNativeHealthIndicator(Driver driver) {
+		super(MESSAGE_HEALTH_CHECK_FAILED);
+		this.driver = driver;
+	}
+
+	@Override
+	protected void doHealthCheck(Health.Builder builder) {
+
+		try {
+			ResultSummary resultSummary;
+			// Retry one time when the session has been expired
+			try {
+				resultSummary = runHealthCheckQuery();
+			}
+			catch (SessionExpiredException sessionExpiredException) {
+				logger.warn(MESSAGE_SESSION_EXPIRED);
+				resultSummary = runHealthCheckQuery();
+			}
+			buildStatusUp(resultSummary, builder);
+		}
+		catch (Exception ex) {
+			builder.down().withException(ex);
+		}
+	}
+
+	/**
+	 * Applies the given {@link ResultSummary} to the {@link Health.Builder builder}
+	 * without actually calling {@code build}.
+	 * @param resultSummary the result summary returned by the server
+	 * @param builder the health builder to be modified
+	 * @return the modified health builder
+	 */
+	static Health.Builder buildStatusUp(ResultSummary resultSummary, Health.Builder builder) {
+
+		ServerInfo serverInfo = resultSummary.server();
+		builder.up().withDetail("server", serverInfo.version() + "@" + serverInfo.address());
+
+		return builder;
+	}
+
+	ResultSummary runHealthCheckQuery() {
+		// We use WRITE here to make sure UP is returned for a server that supports
+		// all possible workloads
+		try (Session session = this.driver.session(AccessMode.WRITE)) {
+			ResultSummary resultSummary = session.run(CYPHER).consume();
+			return resultSummary;
+		}
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jNativeHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jNativeHealthIndicatorTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.neo4j;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
+import org.neo4j.driver.v1.exceptions.SessionExpiredException;
+import org.neo4j.driver.v1.summary.ResultSummary;
+import org.neo4j.driver.v1.summary.ServerInfo;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.when;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * @author Michael J. Simons
+ */
+@ExtendWith(MockitoExtension.class)
+class Neo4jNativeHealthIndicatorTests {
+
+	@Mock
+	protected Driver driver;
+
+	@Mock
+	protected ResultSummary resultSummary;
+
+	@Mock
+	protected ServerInfo serverInfo;
+
+	@Mock
+	private Session session;
+
+	@Mock
+	private StatementResult statementResult;
+
+	@Test
+	void neo4jIsUp() {
+
+		when(this.serverInfo.version()).thenReturn("4711");
+		when(this.serverInfo.address()).thenReturn("somehost:7687");
+		when(this.resultSummary.server()).thenReturn(this.serverInfo);
+		when(this.statementResult.consume()).thenReturn(this.resultSummary);
+		when(this.session.run(anyString())).thenReturn(this.statementResult);
+
+		when(this.driver.session(AccessMode.WRITE)).thenReturn(this.session);
+
+		Neo4jNativeHealthIndicator healthIndicator = new Neo4jNativeHealthIndicator(this.driver);
+		Health health = healthIndicator.health();
+		assertThat(health.getStatus()).isEqualTo(Status.UP);
+		assertThat(health.getDetails()).containsEntry("server", "4711@somehost:7687");
+
+		verify(this.session).close();
+		verifyNoMoreInteractions(this.driver, this.session, this.statementResult, this.resultSummary, this.serverInfo);
+	}
+
+	@Test
+	void neo4jSessionIsExpiredOnce() {
+
+		AtomicInteger cnt = new AtomicInteger(0);
+
+		when(this.serverInfo.version()).thenReturn("4711");
+		when(this.serverInfo.address()).thenReturn("somehost:7687");
+		when(this.resultSummary.server()).thenReturn(this.serverInfo);
+		when(this.statementResult.consume()).thenReturn(this.resultSummary);
+		when(this.session.run(anyString())).thenAnswer((invocation) -> {
+			if (cnt.compareAndSet(0, 1)) {
+				throw new SessionExpiredException("Session expired");
+			}
+			return Neo4jNativeHealthIndicatorTests.this.statementResult;
+		});
+		when(this.driver.session(AccessMode.WRITE)).thenReturn(this.session);
+
+		Neo4jNativeHealthIndicator healthIndicator = new Neo4jNativeHealthIndicator(this.driver);
+		Health health = healthIndicator.health();
+
+		assertThat(health.getStatus()).isEqualTo(Status.UP);
+		assertThat(health.getDetails()).containsEntry("server", "4711@somehost:7687");
+
+		verify(this.session, times(2)).close();
+		verifyNoMoreInteractions(this.driver, this.session, this.statementResult, this.resultSummary, this.serverInfo);
+	}
+
+	@Test
+	void neo4jSessionIsDown() {
+
+		when(this.driver.session(AccessMode.WRITE)).thenThrow(ServiceUnavailableException.class);
+
+		Neo4jNativeHealthIndicator healthIndicator = new Neo4jNativeHealthIndicator(this.driver);
+		Health health = healthIndicator.health();
+
+		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+		assertThat(health.getDetails()).containsKeys("error");
+
+		verifyNoMoreInteractions(this.driver, this.session, this.statementResult, this.resultSummary, this.serverInfo);
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/pom.xml
@@ -464,6 +464,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.neo4j.driver</groupId>
+			<artifactId>neo4j-java-driver</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
 			<optional>true</optional>
@@ -940,6 +945,11 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>elasticsearch</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>neo4j</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDriverAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDriverAutoConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.neo4j;
+
+import org.neo4j.driver.v1.AuthToken;
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.data.neo4j.Neo4jDataAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Automatic configuration of Neo4js Java Driver.
+ * <p>
+ * Provides an instance of {@link org.neo4j.driver.v1.Driver} if the required library is
+ * available and no other instance has been manually configured.
+ *
+ * @author Michael J. Simons
+ * @since 2.2.0
+ */
+@Configuration(proxyBeanMethods = false)
+@AutoConfigureBefore(Neo4jDataAutoConfiguration.class)
+@ConditionalOnClass(Driver.class)
+@EnableConfigurationProperties(Neo4jDriverProperties.class)
+public class Neo4jDriverAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean(Driver.class)
+	@ConditionalOnProperty(prefix = Neo4jDriverProperties.PREFIX, name = "uri")
+	@Lazy // The current 1.7 driver does automatically verify connections
+	public Driver neo4jDriver(final Neo4jDriverProperties driverProperties) {
+
+		final AuthToken authToken = driverProperties.getAuthentication().asAuthToken();
+		final Config config = driverProperties.asDriverConfig();
+
+		return GraphDatabase.driver(driverProperties.getUri(), authToken, config);
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDriverProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDriverProperties.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.neo4j;
+
+import java.io.File;
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.driver.v1.AuthToken;
+import org.neo4j.driver.v1.AuthTokens;
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.net.ServerAddressResolver;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
+import org.springframework.util.StringUtils;
+
+/**
+ * Used to configure an instance of the {@link org.neo4j.driver.v1.Driver
+ * Neo4j-Java-Driver}.
+ *
+ * @author Michael J. Simons
+ * @since 2.2.0
+ */
+@ConfigurationProperties(prefix = Neo4jDriverProperties.PREFIX)
+public class Neo4jDriverProperties {
+
+	static final String PREFIX = "spring.neo4j";
+
+	/**
+	 * The uri this driver should connect to. The driver supports bolt, bolt+routing or
+	 * neo4j as schemes.
+	 */
+	private URI uri = URI.create("bolt://localhost:7687");
+
+	/**
+	 * The authentication the driver is supposed to use.
+	 */
+	private Authentication authentication = new Authentication();
+
+	/**
+	 * The configuration of the connection pool.
+	 */
+	private PoolSettings pool = new PoolSettings();
+
+	/**
+	 * Detailed configuration of the driver.
+	 */
+	private DriverSettings config = new DriverSettings();
+
+	public URI getUri() {
+		return this.uri;
+	}
+
+	public void setUri(URI uri) {
+		this.uri = uri;
+	}
+
+	public Authentication getAuthentication() {
+		return this.authentication;
+	}
+
+	public void setAuthentication(Authentication authentication) {
+		this.authentication = authentication;
+	}
+
+	public PoolSettings getPool() {
+		return this.pool;
+	}
+
+	public void setPool(PoolSettings pool) {
+		this.pool = pool;
+	}
+
+	public DriverSettings getConfig() {
+		return this.config;
+	}
+
+	public void setConfig(DriverSettings config) {
+		this.config = config;
+	}
+
+	public AuthToken getAuthToken() {
+		return this.authentication.asAuthToken();
+	}
+
+	public Config asDriverConfig() {
+
+		Config.ConfigBuilder builder = Config.builder();
+		this.pool.applyTo(builder);
+		this.config.applyTo(builder);
+
+		return builder.withLogging(new Neo4jSpringJclLogging()).build();
+	}
+
+	public static class Authentication {
+
+		/**
+		 * The login of the user connecting to the database.
+		 */
+		private String username;
+
+		/**
+		 * The password of the user connecting to the database.
+		 */
+		private String password;
+
+		/**
+		 * The realm to connect to.
+		 */
+		private String realm;
+
+		/**
+		 * A kerberos ticket for connecting to the database. Mutual exclusive with a given
+		 * username.
+		 */
+		private String kerberosTicket;
+
+		public String getUsername() {
+			return this.username;
+		}
+
+		public void setUsername(String username) {
+			this.username = username;
+		}
+
+		public String getPassword() {
+			return this.password;
+		}
+
+		public void setPassword(String password) {
+			this.password = password;
+		}
+
+		public String getRealm() {
+			return this.realm;
+		}
+
+		public void setRealm(String realm) {
+			this.realm = realm;
+		}
+
+		public String getKerberosTicket() {
+			return this.kerberosTicket;
+		}
+
+		public void setKerberosTicket(String kerberosTicket) {
+			this.kerberosTicket = kerberosTicket;
+		}
+
+		AuthToken asAuthToken() {
+
+			boolean hasUsername = StringUtils.hasText(this.username);
+			boolean hasPassword = StringUtils.hasText(this.password);
+			boolean hasKerberosTicket = StringUtils.hasText(this.kerberosTicket);
+
+			if (hasUsername && hasKerberosTicket) {
+				throw new InvalidConfigurationPropertyValueException(PREFIX + ".authentication",
+						"username=" + username + ",kerberos-ticket=" + kerberosTicket,
+						"Cannot specify both username and kerberos ticket.");
+			}
+
+			if (hasUsername && hasPassword) {
+				return AuthTokens.basic(this.username, this.password, this.realm);
+			}
+
+			if (hasKerberosTicket) {
+				return AuthTokens.kerberos(this.kerberosTicket);
+			}
+
+			return AuthTokens.none();
+		}
+
+	}
+
+	public static class PoolSettings {
+
+		/**
+		 * Flag, if leaked sessions logging is enabled.
+		 */
+		private boolean logLeakedSessions = false;
+
+		/**
+		 * The maximum amount of connections in the connection pool towards a single
+		 * database.
+		 */
+		private int maxConnectionPoolSize = org.neo4j.driver.internal.async.pool.PoolSettings.DEFAULT_MAX_CONNECTION_POOL_SIZE;
+
+		/**
+		 * Pooled connections that have been idle in the pool for longer than this timeout
+		 * will be tested before they are used again.
+		 */
+		private Duration idleTimeBeforeConnectionTest;
+
+		/**
+		 * Pooled connections older than this threshold will be closed and removed from
+		 * the pool.
+		 */
+		private Duration maxConnectionLifetime = Duration
+				.ofMillis(org.neo4j.driver.internal.async.pool.PoolSettings.DEFAULT_MAX_CONNECTION_LIFETIME);
+
+		/**
+		 * Acquisition of new connections will be attempted for at most configured
+		 * timeout.
+		 */
+		private Duration connectionAcquisitionTimeout = Duration
+				.ofMillis(org.neo4j.driver.internal.async.pool.PoolSettings.DEFAULT_CONNECTION_ACQUISITION_TIMEOUT);
+
+		public boolean isLogLeakedSessions() {
+			return this.logLeakedSessions;
+		}
+
+		public void setLogLeakedSessions(boolean logLeakedSessions) {
+			this.logLeakedSessions = logLeakedSessions;
+		}
+
+		public int getMaxConnectionPoolSize() {
+			return this.maxConnectionPoolSize;
+		}
+
+		public void setMaxConnectionPoolSize(int maxConnectionPoolSize) {
+			this.maxConnectionPoolSize = maxConnectionPoolSize;
+		}
+
+		public Duration getIdleTimeBeforeConnectionTest() {
+			return this.idleTimeBeforeConnectionTest;
+		}
+
+		public void setIdleTimeBeforeConnectionTest(Duration idleTimeBeforeConnectionTest) {
+			this.idleTimeBeforeConnectionTest = idleTimeBeforeConnectionTest;
+		}
+
+		public Duration getMaxConnectionLifetime() {
+			return this.maxConnectionLifetime;
+		}
+
+		public void setMaxConnectionLifetime(Duration maxConnectionLifetime) {
+			this.maxConnectionLifetime = maxConnectionLifetime;
+		}
+
+		public Duration getConnectionAcquisitionTimeout() {
+			return this.connectionAcquisitionTimeout;
+		}
+
+		public void setConnectionAcquisitionTimeout(Duration connectionAcquisitionTimeout) {
+			this.connectionAcquisitionTimeout = connectionAcquisitionTimeout;
+		}
+
+		private void applyTo(Config.ConfigBuilder builder) {
+
+			if (this.logLeakedSessions) {
+				builder.withLeakedSessionsLogging();
+			}
+			builder.withMaxConnectionPoolSize(this.maxConnectionPoolSize);
+			if (this.idleTimeBeforeConnectionTest != null) {
+				builder.withConnectionLivenessCheckTimeout(this.idleTimeBeforeConnectionTest.toMillis(),
+						TimeUnit.MILLISECONDS);
+			}
+			builder.withMaxConnectionLifetime(this.maxConnectionLifetime.toMillis(), TimeUnit.MILLISECONDS);
+			builder.withConnectionAcquisitionTimeout(this.connectionAcquisitionTimeout.toMillis(),
+					TimeUnit.MILLISECONDS);
+		}
+
+	}
+
+	public static class DriverSettings {
+
+		public enum LoadBalancingStrategy {
+
+			ROUND_ROBIN, LEAST_CONNECTED;
+
+			Config.LoadBalancingStrategy toInternalRepresentation() {
+				return Config.LoadBalancingStrategy.valueOf(this.name());
+			}
+
+		}
+
+		/**
+		 * Flag, if the driver should use encrypted traffic.
+		 */
+		private boolean encrypted = true;
+
+		/**
+		 * Specify how to determine the authenticity of an encryption certificate provided
+		 * by the Neo4j instance we are connecting to. Defaults to trust all.
+		 */
+		private TrustSettings trustSettings = new TrustSettings();
+
+		/**
+		 * Provide an alternative load balancing strategy for the routing driver to use.
+		 */
+		private LoadBalancingStrategy loadBalancingStrategy = LoadBalancingStrategy.LEAST_CONNECTED;
+
+		/**
+		 * Specify socket connection timeout.
+		 */
+		private Duration connectionTimeout = Duration.ofSeconds(5);
+
+		/**
+		 * Specify the maximum time transactions are allowed to retry.
+		 */
+		private Duration maxTransactionRetryTime = Duration
+				.ofMillis(org.neo4j.driver.internal.retry.RetrySettings.DEFAULT.maxRetryTimeMs());
+
+		/**
+		 * Specify a custom server address resolver used by the routing driver to resolve
+		 * the initial address used to create the driver.
+		 */
+		private Class<? extends ServerAddressResolver> serverAddressResolverClass;
+
+		public boolean isEncrypted() {
+			return this.encrypted;
+		}
+
+		public void setEncrypted(boolean encrypted) {
+			this.encrypted = encrypted;
+		}
+
+		public TrustSettings getTrustSettings() {
+			return this.trustSettings;
+		}
+
+		public void setTrustSettings(TrustSettings trustSettings) {
+			this.trustSettings = trustSettings;
+		}
+
+		public LoadBalancingStrategy getLoadBalancingStrategy() {
+			return this.loadBalancingStrategy;
+		}
+
+		public void setLoadBalancingStrategy(LoadBalancingStrategy loadBalancingStrategy) {
+			this.loadBalancingStrategy = loadBalancingStrategy;
+		}
+
+		public Duration getConnectionTimeout() {
+			return this.connectionTimeout;
+		}
+
+		public void setConnectionTimeout(Duration connectionTimeout) {
+			this.connectionTimeout = connectionTimeout;
+		}
+
+		public Duration getMaxTransactionRetryTime() {
+			return this.maxTransactionRetryTime;
+		}
+
+		public void setMaxTransactionRetryTime(Duration maxTransactionRetryTime) {
+			this.maxTransactionRetryTime = maxTransactionRetryTime;
+		}
+
+		public Class<? extends ServerAddressResolver> getServerAddressResolverClass() {
+			return this.serverAddressResolverClass;
+		}
+
+		public void setServerAddressResolverClass(Class<? extends ServerAddressResolver> serverAddressResolverClass) {
+			this.serverAddressResolverClass = serverAddressResolverClass;
+		}
+
+		private void applyTo(Config.ConfigBuilder builder) {
+
+			if (this.encrypted) {
+				builder.withEncryption();
+			}
+			else {
+				builder.withoutEncryption();
+			}
+			builder.withTrustStrategy(this.trustSettings.toInternalRepresentation());
+			builder.withLoadBalancingStrategy(this.loadBalancingStrategy.toInternalRepresentation());
+			builder.withConnectionTimeout(this.connectionTimeout.toMillis(), TimeUnit.MILLISECONDS);
+			builder.withMaxTransactionRetryTime(this.maxTransactionRetryTime.toMillis(), TimeUnit.MILLISECONDS);
+
+			if (this.serverAddressResolverClass != null) {
+				builder.withResolver(BeanUtils.instantiateClass(this.serverAddressResolverClass));
+			}
+		}
+
+	}
+
+	public static class TrustSettings {
+
+		public enum Strategy {
+
+			TRUST_ALL_CERTIFICATES,
+
+			TRUST_CUSTOM_CA_SIGNED_CERTIFICATES,
+
+			TRUST_SYSTEM_CA_SIGNED_CERTIFICATES
+
+		}
+
+		/**
+		 * Configures the strategy to use use.
+		 */
+		private TrustSettings.Strategy strategy = Strategy.TRUST_ALL_CERTIFICATES;
+
+		/**
+		 * The file of the certificate to use.
+		 */
+		private File certFile;
+
+		/**
+		 * Flag, if hostname verification is used.
+		 */
+		private boolean hostnameVerificationEnabled = false;
+
+		public TrustSettings.Strategy getStrategy() {
+			return this.strategy;
+		}
+
+		public void setStrategy(TrustSettings.Strategy strategy) {
+			this.strategy = strategy;
+		}
+
+		public File getCertFile() {
+			return this.certFile;
+		}
+
+		public void setCertFile(File certFile) {
+			this.certFile = certFile;
+		}
+
+		public boolean isHostnameVerificationEnabled() {
+			return this.hostnameVerificationEnabled;
+		}
+
+		public void setHostnameVerificationEnabled(boolean hostnameVerificationEnabled) {
+			this.hostnameVerificationEnabled = hostnameVerificationEnabled;
+		}
+
+		Config.TrustStrategy toInternalRepresentation() {
+			String propertyName = Neo4jDriverProperties.PREFIX + ".config.trust-settings";
+
+			Config.TrustStrategy internalRepresentation;
+			switch (this.strategy) {
+			case TRUST_ALL_CERTIFICATES:
+				internalRepresentation = Config.TrustStrategy.trustAllCertificates();
+				break;
+			case TRUST_SYSTEM_CA_SIGNED_CERTIFICATES:
+				internalRepresentation = Config.TrustStrategy.trustSystemCertificates();
+				break;
+			case TRUST_CUSTOM_CA_SIGNED_CERTIFICATES:
+				if (this.certFile == null || !this.certFile.isFile()) {
+					throw new InvalidConfigurationPropertyValueException(propertyName, this.strategy.name(),
+							"Configured trust strategy requires a certificate file.");
+				}
+				internalRepresentation = Config.TrustStrategy.trustCustomCertificateSignedBy(this.certFile);
+				break;
+			default:
+				throw new InvalidConfigurationPropertyValueException(propertyName, this.strategy.name(),
+						"Unknown strategy.");
+			}
+
+			if (this.hostnameVerificationEnabled) {
+				internalRepresentation.withHostnameVerification();
+			}
+			else {
+				internalRepresentation.withoutHostnameVerification();
+			}
+
+			return internalRepresentation;
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jSpringJclLogging.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/Neo4jSpringJclLogging.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.neo4j;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.neo4j.driver.v1.Logger;
+import org.neo4j.driver.v1.Logging;
+
+/**
+ * Shim to use Spring JCL implementation, delegating all the hard work of deciding the
+ * underlying system to Spring and Spring Boot.
+ *
+ * @author Michael J. Simons
+ * @since 2.2.0
+ */
+public final class Neo4jSpringJclLogging implements Logging {
+
+	/**
+	 * This prefix gets added to the log names the driver requests to add some namespace
+	 * around it in a bigger application scenario.
+	 */
+	private static final String AUTOMATIC_PREFIX = "org.neo4j.driver.";
+
+	@Override
+	public Logger getLog(String name) {
+
+		String requestedLog = name;
+		if (!requestedLog.startsWith(AUTOMATIC_PREFIX)) {
+			requestedLog = AUTOMATIC_PREFIX + name;
+		}
+		Log springJclLog = LogFactory.getLog(requestedLog);
+		return new SpringJclLogger(springJclLog);
+	}
+
+	static final class SpringJclLogger implements Logger {
+
+		private final Log delegate;
+
+		SpringJclLogger(Log delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public void error(String message, Throwable cause) {
+			this.delegate.error(message, cause);
+		}
+
+		@Override
+		public void info(String format, Object... params) {
+			this.delegate.info(String.format(format, params));
+		}
+
+		@Override
+		public void warn(String format, Object... params) {
+			this.delegate.warn(String.format(format, params));
+		}
+
+		@Override
+		public void warn(String message, Throwable cause) {
+			this.delegate.warn(message, cause);
+		}
+
+		@Override
+		public void debug(String format, Object... params) {
+			if (isDebugEnabled()) {
+				this.delegate.debug(String.format(format, params));
+			}
+		}
+
+		@Override
+		public void trace(String format, Object... params) {
+			if (isTraceEnabled()) {
+				this.delegate.trace(String.format(format, params));
+			}
+		}
+
+		@Override
+		public boolean isTraceEnabled() {
+			return this.delegate.isTraceEnabled();
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return this.delegate.isDebugEnabled();
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/package-info.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/neo4j/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for the Neo4j Java Driver.
+ */
+package org.springframework.boot.autoconfigure.neo4j;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -98,6 +98,7 @@ org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfigura
 org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,\
 org.springframework.boot.autoconfigure.mongo.MongoReactiveAutoConfiguration,\
 org.springframework.boot.autoconfigure.mustache.MustacheAutoConfiguration,\
+org.springframework.boot.autoconfigure.neo4j.Neo4jDriverAutoConfiguration,\
 org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,\
 org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration,\
 org.springframework.boot.autoconfigure.rsocket.RSocketMessagingAutoConfiguration,\

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoAutoConfigurationTests.java
@@ -44,7 +44,10 @@ class MongoAutoConfigurationTests {
 
 	@Test
 	void clientExists() {
-		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(MongoClient.class));
+		this.contextRunner.run((context) -> {
+			assertThat(context).hasSingleBean(MongoClient.class);
+			context.getBean(MongoClient.class).getDatabase("asd");
+		});
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDriverAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDriverAutoConfigurationIntegrationTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.neo4j;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.StatementResult;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Michael J. Simons
+ */
+@SpringBootTest
+@Testcontainers
+@ContextConfiguration(
+		initializers = Neo4jDriverAutoConfigurationIntegrationTests.Neo4jContainerBasedTestPropertyProvider.class)
+class Neo4jDriverAutoConfigurationIntegrationTests {
+
+	@Container
+	private static Neo4jContainer neo4jServer = new Neo4jContainer<>();
+
+	private final Driver driver;
+
+	@Autowired
+	Neo4jDriverAutoConfigurationIntegrationTests(Driver driver) {
+		this.driver = driver;
+	}
+
+	@Test
+	void ensureDriverIsOpen() {
+
+		try (Session session = this.driver.session()) {
+			StatementResult statementResult = session.run("MATCH (n:Thing) RETURN n LIMIT 1");
+			assertThat(statementResult.hasNext()).isFalse();
+		}
+	}
+
+	static class Neo4jContainerBasedTestPropertyProvider
+			implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+		@Override
+		public void initialize(ConfigurableApplicationContext applicationContext) {
+			TestPropertyValues.of(Neo4jDriverProperties.PREFIX + ".uri = " + neo4jServer.getBoltUrl(),
+					Neo4jDriverProperties.PREFIX + ".authentication.username = neo4j",
+					Neo4jDriverProperties.PREFIX + ".authentication.password = " + neo4jServer.getAdminPassword())
+					.applyTo(applicationContext.getEnvironment());
+		}
+
+	}
+
+	@Configuration
+	@ImportAutoConfiguration(Neo4jDriverAutoConfiguration.class)
+	static class TestConfiguration {
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDriverAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDriverAutoConfigurationTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.neo4j;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.v1.Driver;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Michael J. Simons
+ */
+class Neo4jDriverAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(Neo4jDriverAutoConfiguration.class));
+
+	@Test
+	void shouldRequireAllNeededClasses() {
+
+		this.contextRunner.withPropertyValues(Neo4jDriverProperties.PREFIX + ".uri=bolt://localhost:4711")
+				.withClassLoader(new FilteredClassLoader(Driver.class))
+				.run((ctx) -> assertThat(ctx).doesNotHaveBean(Driver.class));
+	}
+
+	@Test
+	void shouldRequireUri() {
+
+		this.contextRunner.run((ctx) -> assertThat(ctx).doesNotHaveBean(Driver.class));
+	}
+
+	@Test
+	void shouldCreateDriver() {
+
+		this.contextRunner.withPropertyValues(Neo4jDriverProperties.PREFIX + ".uri=bolt://localhost:4711")
+				.run((ctx) -> assertThat(ctx).hasSingleBean(Driver.class));
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDriverPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jDriverPropertiesTests.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.neo4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.internal.retry.RetrySettings;
+import org.neo4j.driver.v1.AuthTokens;
+import org.neo4j.driver.v1.Config;
+
+import org.springframework.boot.autoconfigure.neo4j.Neo4jDriverProperties.Authentication;
+import org.springframework.boot.autoconfigure.neo4j.Neo4jDriverProperties.DriverSettings;
+import org.springframework.boot.autoconfigure.neo4j.Neo4jDriverProperties.PoolSettings;
+import org.springframework.boot.autoconfigure.neo4j.Neo4jDriverProperties.TrustSettings;
+import org.springframework.boot.autoconfigure.neo4j.Neo4jDriverProperties.TrustSettings.Strategy;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Michael J. Simons
+ */
+class Neo4jDriverPropertiesTests {
+
+	private AnnotationConfigApplicationContext context;
+
+	private Neo4jDriverProperties load(String... properties) {
+
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		TestPropertyValues.of(properties).applyTo(ctx);
+		ctx.register(TestConfiguration.class);
+		ctx.refresh();
+		this.context = ctx;
+		return this.context.getBean(Neo4jDriverProperties.class);
+	}
+
+	@AfterEach
+	void closeContext() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	private static void assertDuration(Duration duration, long expectedValueInMillis) {
+		if (expectedValueInMillis == org.neo4j.driver.internal.async.pool.PoolSettings.NOT_CONFIGURED) {
+			assertThat(duration).isNull();
+		}
+		else {
+			assertThat(duration.toMillis()).isEqualTo(expectedValueInMillis);
+		}
+	}
+
+	@Nested
+	@DisplayName("Configuration of authentication")
+	class AuthenticationTest {
+
+		@Test
+		@DisplayName("…should not be empty by default")
+		void shouldAllowEmptyListOfURIs() {
+
+			Neo4jDriverProperties driverProperties = load();
+			assertThat(driverProperties.getAuthentication()).isNotNull();
+		}
+
+		@Test
+		@DisplayName("…should default to none")
+		void noAuthenticationShouldWork() {
+
+			Authentication authentication = new Authentication();
+			assertThat(authentication.asAuthToken()).isEqualTo(AuthTokens.none());
+		}
+
+		@Test
+		@DisplayName("…should configure basic auth")
+		void basicAuthShouldWork() {
+
+			Authentication authentication = new Authentication();
+			authentication.setUsername("Farin");
+			authentication.setPassword("Urlaub");
+
+			assertThat(authentication.asAuthToken()).isEqualTo(AuthTokens.basic("Farin", "Urlaub"));
+		}
+
+		@Test
+		@DisplayName("…should configure basic auth with realm")
+		void basicAuthWithRealmShouldWork() {
+
+			Authentication authentication = new Authentication();
+			authentication.setUsername("Farin");
+			authentication.setPassword("Urlaub");
+			authentication.setRealm("Die Ärzte");
+
+			assertThat(authentication.asAuthToken()).isEqualTo(AuthTokens.basic("Farin", "Urlaub", "Die Ärzte"));
+		}
+
+		@Test
+		@DisplayName("…should configure kerberos")
+		void kerberosAuthShouldWork() {
+
+			Authentication authentication = new Authentication();
+			authentication.setKerberosTicket("AABBCCDDEE");
+
+			assertThat(authentication.asAuthToken()).isEqualTo(AuthTokens.kerberos("AABBCCDDEE"));
+		}
+
+		@Test
+		@DisplayName("…should not allow ambiguous config")
+		void ambiguousShouldNotBeAllowed() {
+
+			Authentication authentication = new Authentication();
+			authentication.setUsername("Farin");
+			authentication.setKerberosTicket("AABBCCDDEE");
+
+			assertThatExceptionOfType(InvalidConfigurationPropertyValueException.class)
+					.isThrownBy(() -> authentication.asAuthToken())
+					.withMessage("Property " + Neo4jDriverProperties.PREFIX
+							+ ".authentication with value 'username=Farin,kerberos-ticket=AABBCCDDEE' is invalid: Cannot specify both username and kerberos ticket.");
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Pool properties")
+	class PoolSettingsTest {
+
+		@Test
+		@DisplayName("…should default to drivers values")
+		void shouldDefaultToDriversValues() {
+
+			Config defaultConfig = Config.defaultConfig();
+
+			Neo4jDriverProperties driverProperties = load();
+
+			PoolSettings poolSettings = driverProperties.getPool();
+			assertThat(poolSettings.isLogLeakedSessions()).isEqualTo(defaultConfig.logLeakedSessions());
+			assertThat(poolSettings.getMaxConnectionPoolSize()).isEqualTo(defaultConfig.maxConnectionPoolSize());
+			assertDuration(poolSettings.getIdleTimeBeforeConnectionTest(),
+					defaultConfig.idleTimeBeforeConnectionTest());
+			assertDuration(poolSettings.getMaxConnectionLifetime(), defaultConfig.maxConnectionLifetimeMillis());
+			assertDuration(poolSettings.getConnectionAcquisitionTimeout(),
+					defaultConfig.connectionAcquisitionTimeoutMillis());
+		}
+
+		@Test
+		void logLeakedSessionsSettingsShouldWork() {
+
+			Neo4jDriverProperties driverProperties;
+
+			driverProperties = new Neo4jDriverProperties();
+			driverProperties.getPool().setLogLeakedSessions(true);
+			assertThat(driverProperties.asDriverConfig().logLeakedSessions()).isTrue();
+
+			driverProperties = new Neo4jDriverProperties();
+			driverProperties.getPool().setLogLeakedSessions(false);
+			assertThat(driverProperties.asDriverConfig().logLeakedSessions()).isFalse();
+		}
+
+		@Test
+		void maxConnectionPoolSizeSettingsShouldWork() {
+
+			Neo4jDriverProperties driverProperties = new Neo4jDriverProperties();
+			driverProperties.getPool().setMaxConnectionPoolSize(4711);
+			assertThat(driverProperties.asDriverConfig().maxConnectionPoolSize()).isEqualTo(4711);
+		}
+
+		@Test
+		void idleTimeBeforeConnectionTestSettingsShouldWork() {
+
+			Neo4jDriverProperties driverProperties;
+
+			driverProperties = new Neo4jDriverProperties();
+			assertThat(driverProperties.asDriverConfig().idleTimeBeforeConnectionTest()).isEqualTo(-1);
+
+			driverProperties = new Neo4jDriverProperties();
+			driverProperties.getPool().setIdleTimeBeforeConnectionTest(Duration.ofSeconds(23));
+			assertThat(driverProperties.asDriverConfig().idleTimeBeforeConnectionTest()).isEqualTo(23_000);
+		}
+
+		@Test
+		void connectionAcquisitionTimeoutSettingsShouldWork() {
+
+			Neo4jDriverProperties driverProperties = new Neo4jDriverProperties();
+			driverProperties.getPool().setConnectionAcquisitionTimeout(Duration.ofSeconds(23));
+			assertThat(driverProperties.asDriverConfig().connectionAcquisitionTimeoutMillis()).isEqualTo(23_000);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Config properties")
+	class DriverSettingsTest {
+
+		@Test
+		@DisplayName("…should default to drivers values")
+		void shouldDefaultToDriversValues() {
+
+			Config defaultConfig = Config.defaultConfig();
+
+			Neo4jDriverProperties driverProperties = load();
+
+			DriverSettings driverSettings = driverProperties.getConfig();
+			assertThat(driverSettings.isEncrypted()).isEqualTo(defaultConfig.encrypted());
+			assertThat(driverSettings.getTrustSettings().getStrategy().name())
+					.isEqualTo(defaultConfig.trustStrategy().strategy().name());
+			assertThat(driverSettings.getLoadBalancingStrategy().name())
+					.isEqualTo(defaultConfig.loadBalancingStrategy().name());
+			assertDuration(driverSettings.getConnectionTimeout(), defaultConfig.connectionTimeoutMillis());
+			assertDuration(driverSettings.getMaxTransactionRetryTime(), RetrySettings.DEFAULT.maxRetryTimeMs());
+			assertThat(driverSettings.getServerAddressResolverClass()).isNull();
+		}
+
+		@Test
+		void encryptedSettingsShouldWork() {
+
+			Neo4jDriverProperties driverProperties;
+
+			driverProperties = new Neo4jDriverProperties();
+			driverProperties.getConfig().setEncrypted(true);
+			assertThat(driverProperties.asDriverConfig().encrypted()).isTrue();
+
+			driverProperties = new Neo4jDriverProperties();
+			driverProperties.getConfig().setEncrypted(false);
+			assertThat(driverProperties.asDriverConfig().encrypted()).isFalse();
+		}
+
+		@Test
+		void trustSettingsShouldWork() {
+
+			Neo4jDriverProperties driverProperties = new Neo4jDriverProperties();
+			TrustSettings trustSettings = new TrustSettings();
+			trustSettings.setStrategy(Strategy.TRUST_SYSTEM_CA_SIGNED_CERTIFICATES);
+			driverProperties.getConfig().setTrustSettings(trustSettings);
+			assertThat(driverProperties.asDriverConfig().trustStrategy().strategy())
+					.isEqualTo(Config.TrustStrategy.Strategy.TRUST_SYSTEM_CA_SIGNED_CERTIFICATES);
+		}
+
+		@Test
+		void loadBalancingStrategySettingsShouldWork() {
+
+			Neo4jDriverProperties configProperties = new Neo4jDriverProperties();
+			configProperties.getConfig().setLoadBalancingStrategy(DriverSettings.LoadBalancingStrategy.ROUND_ROBIN);
+			assertThat(configProperties.asDriverConfig().loadBalancingStrategy())
+					.isEqualTo(Config.LoadBalancingStrategy.ROUND_ROBIN);
+		}
+
+		@Test
+		void connectionTimeoutSettingsShouldWork() {
+
+			Neo4jDriverProperties driverProperties = new Neo4jDriverProperties();
+			driverProperties.getConfig().setConnectionTimeout(Duration.ofSeconds(23));
+			assertThat(driverProperties.asDriverConfig().connectionTimeoutMillis()).isEqualTo(23_000);
+		}
+
+		@Test
+		@Disabled("The internal driver has no means of retrieving that value back again")
+		void maxTransactionRetryTimeSettingsShouldWork() {
+
+			DriverSettings driverSettings = new DriverSettings();
+			driverSettings.setMaxTransactionRetryTime(Duration.ofSeconds(23));
+		}
+
+		@Test
+		void serverAddressResolverClassSettingsShouldWork() {
+
+			Neo4jDriverProperties driverProperties = new Neo4jDriverProperties();
+			driverProperties.getConfig().setServerAddressResolverClass(TestServerAddressResolver.class);
+			assertThat(driverProperties.asDriverConfig().resolver()).isNotNull()
+					.isInstanceOf(TestServerAddressResolver.class);
+		}
+
+		@Test
+		void shouldUseSpringJclLogging() {
+
+			Neo4jDriverProperties driverProperties = new Neo4jDriverProperties();
+			assertThat(driverProperties.asDriverConfig().logging()).isNotNull()
+					.isInstanceOf(Neo4jSpringJclLogging.class);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Trust settings")
+	class TrustSettingsTest {
+
+		@Test
+		void trustAllCertificatesShouldWork() {
+
+			TrustSettings settings = new TrustSettings();
+			settings.setStrategy(Strategy.TRUST_ALL_CERTIFICATES);
+
+			assertThat(settings.toInternalRepresentation().strategy())
+					.isEqualTo(Config.TrustStrategy.Strategy.TRUST_ALL_CERTIFICATES);
+		}
+
+		@Test
+		void shouldEnableHostnameVerification() {
+
+			TrustSettings settings = new TrustSettings();
+			settings.setStrategy(Strategy.TRUST_ALL_CERTIFICATES);
+			settings.setHostnameVerificationEnabled(true);
+
+			assertThat(settings.toInternalRepresentation().isHostnameVerificationEnabled()).isTrue();
+		}
+
+		@Test
+		void trustSystemCertificatesShouldWork() {
+
+			TrustSettings settings = new TrustSettings();
+			settings.setStrategy(Strategy.TRUST_SYSTEM_CA_SIGNED_CERTIFICATES);
+
+			assertThat(settings.toInternalRepresentation().strategy())
+					.isEqualTo(Config.TrustStrategy.Strategy.TRUST_SYSTEM_CA_SIGNED_CERTIFICATES);
+		}
+
+		@Test
+		@DisplayName("…should recognize correctly configured custom certificates")
+		void trustCustomCertificatesShouldWork1() throws IOException {
+
+			File certFile = File.createTempFile("sdnrx", ".cert");
+
+			TrustSettings settings = new TrustSettings();
+			settings.setStrategy(Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES);
+			settings.setCertFile(certFile);
+
+			Config.TrustStrategy trustStrategy = settings.toInternalRepresentation();
+			assertThat(trustStrategy.strategy())
+					.isEqualTo(Config.TrustStrategy.Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES);
+			assertThat(trustStrategy.certFile()).isEqualTo(certFile);
+		}
+
+		@Test
+		@DisplayName("…should fail on custom certificates without cert file")
+		void trustCustomCertificatesShouldWork2() throws IOException {
+
+			TrustSettings settings = new TrustSettings();
+			settings.setStrategy(Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES);
+
+			assertThatExceptionOfType(InvalidConfigurationPropertyValueException.class)
+					.isThrownBy(() -> settings.toInternalRepresentation())
+					.withMessage("Property " + Neo4jDriverProperties.PREFIX
+							+ ".config.trust-settings with value 'TRUST_CUSTOM_CA_SIGNED_CERTIFICATES' is invalid: Configured trust strategy requires a certificate file.");
+		}
+
+	}
+
+	@Configuration
+	@EnableConfigurationProperties(Neo4jDriverProperties.class)
+	static class TestConfiguration {
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/TestServerAddressResolver.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/TestServerAddressResolver.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.neo4j;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.neo4j.driver.v1.net.ServerAddress;
+import org.neo4j.driver.v1.net.ServerAddressResolver;
+
+/**
+ * Resolver used only for configuration tests.
+ *
+ * @author Michael J. Simons
+ */
+class TestServerAddressResolver implements ServerAddressResolver {
+
+	@Override
+	public Set<ServerAddress> resolve(ServerAddress address) {
+		return Collections.emptySet();
+	}
+
+}

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -153,7 +153,8 @@
 		<mssql-jdbc.version>6.4.0.jre8</mssql-jdbc.version>
 		<mysql.version>8.0.16</mysql.version>
 		<nekohtml.version>1.9.22</nekohtml.version>
-		<neo4j-ogm.version>3.2.0-alpha05</neo4j-ogm.version>
+		<neo4j-java-driver.version>1.7.5</neo4j-java-driver.version>
+		<neo4j-ogm.version>3.2.0-RC1</neo4j-ogm.version>
 		<netty.version>4.1.36.Final</netty.version>
 		<netty-tcnative.version>2.0.25.Final</netty-tcnative.version>
 		<nio-multipart-parser.version>1.1.0</nio-multipart-parser.version>
@@ -2697,6 +2698,11 @@
 				<groupId>org.mortbay.jasper</groupId>
 				<artifactId>apache-el</artifactId>
 				<version>${jetty-el.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.neo4j.driver</groupId>
+				<artifactId>neo4j-java-driver</artifactId>
+				<version>${neo4j-java-driver.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.neo4j</groupId>


### PR DESCRIPTION
This is a proposal for #17610. 

It consists of three major changes:

1. Adding the native driver to the managed dependencies
1. Adding the actual autoconfiguration
1. Adapting and extending the health contributor

The ideas behind 2. are implemented via `Neo4jDriverAutoConfiguration` and `Neo4jDriverProperties`. 

The main configurational parts are taken from the next-gen driver configuration (see https://github.com/neo4j/neo4j-java-driver-spring-boot-starter). 
Important things to look at:
* A driver bean is only then created when `spring.neo4j.uri` is actually set, we don't default here, as that would change behaviour for all users immediate
* The driver bean for the 1.7 driver is `Lazy`, as that version eagerly tries to open a connection

While all this is probably "standard" auto config, a bit of more thought was needed to adapt `Neo4jDataAutoConfiguration`.

1. It still reads `spring.data.neo4j` into a properties class
1. It still creates an OGM configuration bean (`org.neo4j.ogm.config.Configuration`)
1. It now *conditionally* creates an OGM driver bean (`org.neo4j.ogm.driver.Driver`) as well when a native driver bean `org.neo4j.driver.v1.Driver` is in the context. 
1. Depending on the outcome of 3., the creation of the OGM `SessionFactory` now either uses the OGM driver or falls back to the previous behaviour.

## Supported scenarios

Now the following scenarios are supported

### User doesn't change anything

* No driver bean is present in the context
* No OGM driver is created
* Initialization of drivers happens solely in the `SessionFactory` of OGM
* User is free to use `bolt`, `http`, `embedded` as fit

### Users configures the driver via the new properties

* Driver bean is present in the context
* OGM driver is created
* Shared config is applied
* `SessionFactory` is preconfigured

### Users adds a custom native driver bean

See above

### Users adds a custom OGM driver bean

* Shared config is applied
* `SessionFactory` is preconfigured


All of this is a huge advantage for users, especially the ability to add their own native driver bean, either through the new configuration or as it is recognised by the OGM configuration.

## Health

The third commit adapts the health support to the new scenarios. If at least one native Driver bean is present in the context, a native Neo4j health indicator is used, that employs an optimised query.

This happens under the assumption that when a driver bean is present, it is used to configure the session factory as well.

## Outlook

This change would add official support for things our users are currently doing manual and even more important, allows for switching to the next generation bolt driver at some point in the future, together with our revamped Spring Data Neo4j version.