### PR TITLE
Fix deprecation warnings in spring-boot-actuator

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeReactiveHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/CompositeReactiveHealthIndicator.java
@@ -78,8 +78,9 @@ public class CompositeReactiveHealthIndicator implements ReactiveHealthIndicator
 
 	@Override
 	public Mono<Health> health() {
-		return Flux.fromIterable(this.registry.getAll().entrySet()).flatMap(
-				(entry) -> Mono.zip(Mono.just(entry.getKey()), entry.getValue().health().compose(this.timeoutCompose)))
+		return Flux.fromIterable(this.registry.getAll().entrySet())
+				.flatMap((entry) -> Mono.zip(Mono.just(entry.getKey()),
+						entry.getValue().health().transformDeferred(this.timeoutCompose)))
 				.collectMap(Tuple2::getT1, Tuple2::getT2).map(this.healthAggregator::aggregate);
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/MetricsWebFilter.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/MetricsWebFilter.java
@@ -85,7 +85,7 @@ public class MetricsWebFilter implements WebFilter {
 		if (!this.autoTimer.isEnabled()) {
 			return chain.filter(exchange);
 		}
-		return chain.filter(exchange).compose((call) -> filter(exchange, call));
+		return chain.filter(exchange).transformDeferred((call) -> filter(exchange, call));
 	}
 
 	private Publisher<Void> filter(ServerWebExchange exchange, Mono<Void> call) {


### PR DESCRIPTION
Hi,

this PR fixes two deprecation warnings in `spring-boot-actuator` by replacing `Mono.compose(Function)` with `Mono.transformDeferred(Function)`.

Cheers,
Christoph