### PR TITLE
Allow for custom ElasticSearch's EntityMapper bean

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchDataConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchDataConfiguration.java
@@ -48,6 +48,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * their order of execution.
  *
  * @author Brian Clozel
+ * @author Peter-Josef Meisch
  */
 abstract class ElasticsearchDataConfiguration {
 
@@ -67,6 +68,7 @@ abstract class ElasticsearchDataConfiguration {
 		}
 
 		@Bean
+		@ConditionalOnMissingBean
 		EntityMapper entityMapper(SimpleElasticsearchMappingContext mappingContext) {
 			return new DefaultEntityMapper(mappingContext);
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchDataAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchDataAutoConfigurationTests.java
@@ -28,6 +28,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.testsupport.testcontainers.DisabledWithoutDockerTestcontainers;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.core.ElasticsearchEntityMapper;
 import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
 import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
 import org.springframework.data.elasticsearch.core.EntityMapper;
@@ -91,6 +92,11 @@ class ElasticsearchDataAutoConfigurationTests {
 	}
 
 	@Test
+	void defaultEntityMapperRegistered() {
+		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(EntityMapper.class));
+	}
+
+	@Test
 	void customTransportTemplateShouldBeUsed() {
 		this.contextRunner.withUserConfiguration(CustomTransportTemplate.class).run((context) -> assertThat(context)
 				.getBeanNames(ElasticsearchTemplate.class).hasSize(1).contains("elasticsearchTemplate"));
@@ -107,6 +113,12 @@ class ElasticsearchDataAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(CustomReactiveRestTemplate.class)
 				.run((context) -> assertThat(context).getBeanNames(ReactiveElasticsearchTemplate.class).hasSize(1)
 						.contains("reactiveElasticsearchTemplate"));
+	}
+
+	@Test
+	void customEntityMapperShouldeBeUsed() {
+		this.contextRunner.withUserConfiguration(CustomEntityMapper.class).run((context) -> assertThat(context)
+				.getBeanNames(EntityMapper.class).containsExactly("elasticsearchEntityMapper"));
 	}
 
 	@Configuration(proxyBeanMethods = false)
@@ -135,6 +147,16 @@ class ElasticsearchDataAutoConfigurationTests {
 		@Bean
 		ReactiveElasticsearchTemplate reactiveElasticsearchTemplate() {
 			return mock(ReactiveElasticsearchTemplate.class);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomEntityMapper {
+
+		@Bean
+		EntityMapper elasticsearchEntityMapper() {
+			return mock(ElasticsearchEntityMapper.class);
 		}
 
 	}


### PR DESCRIPTION
In the upcoming Spring-Data Moore Release of spring-data-elasticsearch we not only have the `DefaultEntityMapper` but also a second implementation of the `EntityMapper` interface named `ElasticsearchEntityMapper`, which provides more and better functionality.

This PR makes it possible to provide an `ElasticsearchEntityMapper` bean without conflicting with the auto-configured instance.

