### PR TITLE
Missing TransactionManager when user provides a custom Neo4j SessionFactory.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfiguration.java
@@ -53,28 +53,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * @author Vince Bickers
  * @author Stephane Nicoll
  * @author Kazuki Shimizu
+ * @author Michael Simons
  * @since 1.4.0
  */
 @Configuration
 @ConditionalOnClass({ SessionFactory.class, Neo4jTransactionManager.class, PlatformTransactionManager.class })
-@ConditionalOnMissingBean(SessionFactory.class)
 @EnableConfigurationProperties(Neo4jProperties.class)
 @Import(Neo4jBookmarkManagementConfiguration.class)
 public class Neo4jDataAutoConfiguration {
-
-	@Bean
-	@ConditionalOnMissingBean
-	public org.neo4j.ogm.config.Configuration configuration(Neo4jProperties properties) {
-		return properties.createConfiguration();
-	}
-
-	@Bean
-	public SessionFactory sessionFactory(org.neo4j.ogm.config.Configuration configuration,
-			ApplicationContext applicationContext, ObjectProvider<EventListener> eventListeners) {
-		SessionFactory sessionFactory = new SessionFactory(configuration, getPackagesToScan(applicationContext));
-		eventListeners.stream().forEach(sessionFactory::register);
-		return sessionFactory;
-	}
 
 	@Bean
 	@ConditionalOnMissingBean(PlatformTransactionManager.class)
@@ -91,12 +77,32 @@ public class Neo4jDataAutoConfiguration {
 		return transactionManager;
 	}
 
-	private String[] getPackagesToScan(ApplicationContext applicationContext) {
-		List<String> packages = EntityScanPackages.get(applicationContext).getPackageNames();
-		if (packages.isEmpty() && AutoConfigurationPackages.has(applicationContext)) {
-			packages = AutoConfigurationPackages.get(applicationContext);
+	@Configuration
+	@ConditionalOnMissingBean(SessionFactory.class)
+	protected static class Neo4jOgmSessionFactoryConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean
+		public org.neo4j.ogm.config.Configuration configuration(Neo4jProperties properties) {
+			return properties.createConfiguration();
 		}
-		return StringUtils.toStringArray(packages);
+
+		@Bean
+		public SessionFactory sessionFactory(org.neo4j.ogm.config.Configuration configuration,
+				ApplicationContext applicationContext, ObjectProvider<EventListener> eventListeners) {
+			SessionFactory sessionFactory = new SessionFactory(configuration, getPackagesToScan(applicationContext));
+			eventListeners.stream().forEach(sessionFactory::register);
+			return sessionFactory;
+		}
+
+		private String[] getPackagesToScan(ApplicationContext applicationContext) {
+			List<String> packages = EntityScanPackages.get(applicationContext).getPackageNames();
+			if (packages.isEmpty() && AutoConfigurationPackages.has(applicationContext)) {
+				packages = AutoConfigurationPackages.get(applicationContext);
+			}
+			return StringUtils.toStringArray(packages);
+		}
+
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfigurationTests.java
@@ -98,6 +98,14 @@ public class Neo4jDataAutoConfigurationTests {
 	}
 
 	@Test
+	public void customSessionFactoryShouldNotDisableOtherDefaults() {
+		this.contextRunner.withUserConfiguration(CustomSessionFactory.class).run((context) -> {
+			assertThat(context).hasSingleBean(Neo4jTransactionManager.class);
+			assertThat(context).hasSingleBean(OpenSessionInViewInterceptor.class);
+		});
+	}
+
+	@Test
 	public void customConfiguration() {
 		this.contextRunner.withUserConfiguration(CustomConfiguration.class).run((context) -> {
 			assertThat(context.getBean(org.neo4j.ogm.config.Configuration.class))


### PR DESCRIPTION
Thise commit pushes `@ConditionalOnMissingBean(SessionFactory.class)` from the main Neo4j autoconfiguration class down to the bean declaration level. In addition, the OGM configuration bean won’t be created when there’s already a `SessionFactory`.

Thus, the `Neo4jWebConfiguration` will still be applied, even when user decides to run their own `SessionFactory`.

This change is needed to provide the mechanism proposed in #17610 in an external starter, which would provide the `SessionFactory`. As we like to provide the starter for both Boot 2.2.0 and 2.1.x, I'd like to see this change in both branches if possible.

Thanks for your ongoing support in this case.