### PR TITLE
Upgrade to AssertJ 3.13.2

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/jolokia/JolokiaEndpointAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/jolokia/JolokiaEndpointAutoConfigurationTests.java
@@ -89,7 +89,7 @@ class JolokiaEndpointAutoConfigurationTests {
 				.withPropertyValues("management.endpoints.web.exposure.include=jolokia").run((context) -> {
 					ExposableServletEndpoint endpoint = getEndpoint(context);
 					assertThat(endpoint.getEndpointServlet()).extracting("initParameters")
-							.containsOnly(Collections.singletonMap("debug", "true"));
+							.isEqualTo(Collections.singletonMap("debug", "true"));
 				});
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsAutoConfigurationTests.java
@@ -149,7 +149,7 @@ class WebMvcMetricsAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(TestController.class)
 				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, WebMvcAutoConfiguration.class))
 				.run((context) -> assertThat(context.getBean(RequestMappingHandlerMapping.class))
-						.extracting("interceptors").element(0).asList().extracting((item) -> (Class) item.getClass())
+						.extracting("interceptors").asList().extracting((item) -> (Class) item.getClass())
 						.contains(LongTaskTimingHandlerInterceptor.class));
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
@@ -132,7 +132,7 @@ class FlywayAutoConfigurationTests {
 					assertThat(context).hasSingleBean(Flyway.class);
 					DataSource dataSource = context.getBean(Flyway.class).getDataSource();
 					assertThat(dataSource).isNotNull();
-					assertThat(dataSource).extracting("url").hasSize(1).first().asString().startsWith("jdbc:h2:mem:");
+					assertThat(dataSource).extracting("url").asString().startsWith("jdbc:h2:mem:");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/sendgrid/SendGridAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/sendgrid/SendGridAutoConfigurationTests.java
@@ -52,7 +52,7 @@ class SendGridAutoConfigurationTests {
 	void expectedSendGridBeanCreatedApiKey() {
 		loadContext("spring.sendgrid.api-key:SG.SECRET-API-KEY");
 		SendGrid sendGrid = this.context.getBean(SendGrid.class);
-		assertThat(sendGrid).extracting("apiKey").containsExactly("SG.SECRET-API-KEY");
+		assertThat(sendGrid).extracting("apiKey").isEqualTo("SG.SECRET-API-KEY");
 	}
 
 	@Test
@@ -66,7 +66,7 @@ class SendGridAutoConfigurationTests {
 	void autoConfigurationNotFiredWhenBeanAlreadyCreated() {
 		loadContext(ManualSendGridConfiguration.class, "spring.sendgrid.api-key:SG.SECRET-API-KEY");
 		SendGrid sendGrid = this.context.getBean(SendGrid.class);
-		assertThat(sendGrid).extracting("apiKey").containsExactly("SG.CUSTOM_API_KEY");
+		assertThat(sendGrid).extracting("apiKey").isEqualTo("SG.CUSTOM_API_KEY");
 	}
 
 	@Test
@@ -75,7 +75,7 @@ class SendGridAutoConfigurationTests {
 				"spring.sendgrid.proxy.port:5678");
 		SendGrid sendGrid = this.context.getBean(SendGrid.class);
 		assertThat(sendGrid).extracting("client").extracting("httpClient").extracting("routePlanner")
-				.hasOnlyElementsOfType(DefaultProxyRoutePlanner.class);
+				.isInstanceOf(DefaultProxyRoutePlanner.class);
 	}
 
 	private void loadContext(String... environment) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/DispatcherServletAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/DispatcherServletAutoConfigurationTests.java
@@ -145,11 +145,11 @@ class DispatcherServletAutoConfigurationTests {
 	void dispatcherServletDefaultConfig() {
 		this.contextRunner.run((context) -> {
 			DispatcherServlet dispatcherServlet = context.getBean(DispatcherServlet.class);
-			assertThat(dispatcherServlet).extracting("throwExceptionIfNoHandlerFound").containsExactly(false);
-			assertThat(dispatcherServlet).extracting("dispatchOptionsRequest").containsExactly(true);
-			assertThat(dispatcherServlet).extracting("dispatchTraceRequest").containsExactly(false);
-			assertThat(dispatcherServlet).extracting("enableLoggingRequestDetails").containsExactly(false);
-			assertThat(dispatcherServlet).extracting("publishEvents").containsExactly(true);
+			assertThat(dispatcherServlet).extracting("throwExceptionIfNoHandlerFound").isEqualTo(false);
+			assertThat(dispatcherServlet).extracting("dispatchOptionsRequest").isEqualTo(true);
+			assertThat(dispatcherServlet).extracting("dispatchTraceRequest").isEqualTo(false);
+			assertThat(dispatcherServlet).extracting("enableLoggingRequestDetails").isEqualTo(false);
+			assertThat(dispatcherServlet).extracting("publishEvents").isEqualTo(true);
 			assertThat(context.getBean("dispatcherServletRegistration")).hasFieldOrPropertyWithValue("loadOnStartup",
 					-1);
 		});
@@ -163,10 +163,10 @@ class DispatcherServletAutoConfigurationTests {
 						"spring.mvc.publish-request-handled-events:false", "spring.mvc.servlet.load-on-startup=5")
 				.run((context) -> {
 					DispatcherServlet dispatcherServlet = context.getBean(DispatcherServlet.class);
-					assertThat(dispatcherServlet).extracting("throwExceptionIfNoHandlerFound").containsExactly(true);
-					assertThat(dispatcherServlet).extracting("dispatchOptionsRequest").containsExactly(false);
-					assertThat(dispatcherServlet).extracting("dispatchTraceRequest").containsExactly(true);
-					assertThat(dispatcherServlet).extracting("publishEvents").containsExactly(false);
+					assertThat(dispatcherServlet).extracting("throwExceptionIfNoHandlerFound").isEqualTo(true);
+					assertThat(dispatcherServlet).extracting("dispatchOptionsRequest").isEqualTo(false);
+					assertThat(dispatcherServlet).extracting("dispatchTraceRequest").isEqualTo(true);
+					assertThat(dispatcherServlet).extracting("publishEvents").isEqualTo(false);
 					assertThat(context.getBean("dispatcherServletRegistration"))
 							.hasFieldOrPropertyWithValue("loadOnStartup", 5);
 				});

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
@@ -355,14 +355,14 @@ class WebMvcAutoConfigurationTests {
 	@Test
 	void ignoreDefaultModelOnRedirectIsTrue() {
 		this.contextRunner.run((context) -> assertThat(context.getBean(RequestMappingHandlerAdapter.class))
-				.extracting("ignoreDefaultModelOnRedirect").containsExactly(true));
+				.extracting("ignoreDefaultModelOnRedirect").isEqualTo(true));
 	}
 
 	@Test
 	void overrideIgnoreDefaultModelOnRedirect() {
 		this.contextRunner.withPropertyValues("spring.mvc.ignore-default-model-on-redirect:false")
 				.run((context) -> assertThat(context.getBean(RequestMappingHandlerAdapter.class))
-						.extracting("ignoreDefaultModelOnRedirect").containsExactly(false));
+						.extracting("ignoreDefaultModelOnRedirect").isEqualTo(false));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -39,7 +39,7 @@
 		<appengine-sdk.version>1.9.75</appengine-sdk.version>
 		<artemis.version>2.9.0</artemis.version>
 		<aspectj.version>1.9.4</aspectj.version>
-		<assertj.version>3.13.0</assertj.version>
+		<assertj.version>3.13.1</assertj.version>
 		<atomikos.version>4.0.6</atomikos.version>
 		<bitronix.version>2.1.4</bitronix.version>
 		<byte-buddy.version>1.9.13</byte-buddy.version>

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -39,7 +39,7 @@
 		<appengine-sdk.version>1.9.75</appengine-sdk.version>
 		<artemis.version>2.9.0</artemis.version>
 		<aspectj.version>1.9.4</aspectj.version>
-		<assertj.version>3.12.2</assertj.version>
+		<assertj.version>3.13.0</assertj.version>
 		<atomikos.version>4.0.6</atomikos.version>
 		<bitronix.version>2.1.4</bitronix.version>
 		<byte-buddy.version>1.9.13</byte-buddy.version>

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/MockServerRestTemplateCustomizerTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/MockServerRestTemplateCustomizerTests.java
@@ -50,7 +50,7 @@ class MockServerRestTemplateCustomizerTests {
 		MockServerRestTemplateCustomizer customizer = new MockServerRestTemplateCustomizer();
 		customizer.customize(new RestTemplate());
 		assertThat(customizer.getServer()).extracting("expectationManager")
-				.hasAtLeastOneElementOfType(SimpleRequestExpectationManager.class);
+				.isInstanceOf(SimpleRequestExpectationManager.class);
 	}
 
 	@Test
@@ -65,7 +65,7 @@ class MockServerRestTemplateCustomizerTests {
 				UnorderedRequestExpectationManager.class);
 		customizer.customize(new RestTemplate());
 		assertThat(customizer.getServer()).extracting("expectationManager")
-				.hasAtLeastOneElementOfType(UnorderedRequestExpectationManager.class);
+				.isInstanceOf(UnorderedRequestExpectationManager.class);
 	}
 
 	@Test
@@ -74,7 +74,7 @@ class MockServerRestTemplateCustomizerTests {
 				UnorderedRequestExpectationManager.class);
 		customizer.customize(new RestTemplateBuilder().rootUri("https://example.com").build());
 		assertThat(customizer.getServer()).extracting("expectationManager")
-				.hasAtLeastOneElementOfType(RootUriRequestExpectationManager.class);
+				.isInstanceOf(RootUriRequestExpectationManager.class);
 	}
 
 	@Test
@@ -82,7 +82,7 @@ class MockServerRestTemplateCustomizerTests {
 		this.customizer.setDetectRootUri(false);
 		this.customizer.customize(new RestTemplateBuilder().rootUri("https://example.com").build());
 		assertThat(this.customizer.getServer()).extracting("expectationManager")
-				.hasAtLeastOneElementOfType(SimpleRequestExpectationManager.class);
+				.isInstanceOf(SimpleRequestExpectationManager.class);
 
 	}
 
@@ -153,8 +153,8 @@ class MockServerRestTemplateCustomizerTests {
 		this.customizer.customize(template2);
 		RequestExpectationManager manager1 = this.customizer.getExpectationManagers().get(template1);
 		RequestExpectationManager manager2 = this.customizer.getExpectationManagers().get(template2);
-		assertThat(this.customizer.getServer(template1)).extracting("expectationManager").containsOnly(manager1);
-		assertThat(this.customizer.getServer(template2)).extracting("expectationManager").containsOnly(manager2);
+		assertThat(this.customizer.getServer(template1)).extracting("expectationManager").isEqualTo(manager1);
+		assertThat(this.customizer.getServer(template2)).extracting("expectationManager").isEqualTo(manager2);
 	}
 
 }

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/RootUriRequestExpectationManagerTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/RootUriRequestExpectationManagerTests.java
@@ -142,7 +142,7 @@ class RootUriRequestExpectationManagerTests {
 		RequestExpectationManager actual = RootUriRequestExpectationManager.forRestTemplate(restTemplate,
 				this.delegate);
 		assertThat(actual).isInstanceOf(RootUriRequestExpectationManager.class);
-		assertThat(actual).extracting("rootUri").containsExactly(this.uri);
+		assertThat(actual).extracting("rootUri").isEqualTo(this.uri);
 	}
 
 	@Test


### PR DESCRIPTION
Hi,

this PR upgrades the codebase to AssertJ 3.13.0 and does a couple of necessary changes caused by a [breaking change](https://assertj.github.io/doc/#assertj-core-3-13-0-release-notes) to `extracting(String)`.

Let me know what you think.
Cheers,
Christoph