### PR TITLE
Add dependency management for Kotlin Coroutines BOM

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -51,6 +51,7 @@
 		<commons-lang3.version>3.9</commons-lang3.version>
 		<commons-pool.version>1.6</commons-pool.version>
 		<commons-pool2.version>2.6.2</commons-pool2.version>
+		<coroutines.version>1.3.0-RC</coroutines.version>
 		<couchbase-client.version>2.7.7</couchbase-client.version>
 		<couchbase-cache-client.version>2.1.0</couchbase-cache-client.version>
 		<derby.version>10.14.2.0</derby.version>
@@ -2592,6 +2593,13 @@
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-bom</artifactId>
 				<version>${kotlin.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlinx</groupId>
+				<artifactId>kotlinx-coroutines-bom</artifactId>
+				<version>${coroutines.version}</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>

--- a/spring-boot-tests/spring-boot-smoke-tests/pom.xml
+++ b/spring-boot-tests/spring-boot-smoke-tests/pom.xml
@@ -98,6 +98,7 @@
 		<module>spring-boot-smoke-test-web-static</module>
 		<module>spring-boot-smoke-test-web-ui</module>
 		<module>spring-boot-smoke-test-webflux</module>
+		<module>spring-boot-smoke-test-webflux-coroutines</module>
 		<module>spring-boot-smoke-test-websocket-jetty</module>
 		<module>spring-boot-smoke-test-websocket-tomcat</module>
 		<module>spring-boot-smoke-test-websocket-undertow</module>

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webflux-coroutines/pom.xml
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webflux-coroutines/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<!-- Your own application should inherit from spring-boot-starter-parent -->
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-smoke-tests</artifactId>
+		<version>${revision}</version>
+	</parent>
+	<artifactId>spring-boot-smoke-test-webflux-coroutines</artifactId>
+	<name>Spring Boot WebFlux Coroutines Smoke Test</name>
+	<description>Spring Boot WebFlux Coroutines Smoke Test</description>
+	<properties>
+		<main.basedir>${basedir}/../../..</main.basedir>
+		<m2eclipse.wtp.contextRoot>/</m2eclipse.wtp.contextRoot>
+	</properties>
+	<dependencies>
+		<!-- Compile -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-kotlin</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib-jdk8</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlinx</groupId>
+			<artifactId>kotlinx-coroutines-reactor</artifactId>
+		</dependency>
+		<!-- Test -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+		<testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-maven-plugin</artifactId>
+				<configuration>
+					<args>
+						<arg>-Xjsr305=strict</arg>
+					</args>
+					<compilerPlugins>
+						<plugin>spring</plugin>
+					</compilerPlugins>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.jetbrains.kotlin</groupId>
+						<artifactId>kotlin-maven-allopen</artifactId>
+						<version>${kotlin.version}</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<useSystemClassLoader>false</useSystemClassLoader>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webflux-coroutines/src/main/kotlin/smoketest/coroutines/CoroutinesApplication.kt
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webflux-coroutines/src/main/kotlin/smoketest/coroutines/CoroutinesApplication.kt
@@ -1,0 +1,10 @@
+package smoketest.coroutines
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class CoroutinesApplication
+fun main(args: Array<String>) {
+	runApplication<CoroutinesApplication>(*args)
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webflux-coroutines/src/main/kotlin/smoketest/coroutines/CoroutinesController.kt
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webflux-coroutines/src/main/kotlin/smoketest/coroutines/CoroutinesController.kt
@@ -1,0 +1,24 @@
+package smoketest.coroutines
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class CoroutinesController {
+
+	@GetMapping("/suspending")
+	suspend fun suspendingFunction(): String {
+		delay(10)
+		return "Hello World"
+	}
+
+	@GetMapping("/flow")
+	fun flow() = flow {
+		delay(10)
+		emit("Hello ")
+		delay(10)
+		emit("World")
+	}
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webflux-coroutines/src/test/kotlin/smoketest/coroutines/CoroutinesApplicationTests.kt
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webflux-coroutines/src/test/kotlin/smoketest/coroutines/CoroutinesApplicationTests.kt
@@ -1,0 +1,25 @@
+package smoketest.coroutines
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.*
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class CoroutinesApplicationTests(@Autowired private val webClient: WebTestClient) {
+
+	@Test
+	fun testSuspendingFunction() {
+		webClient.get().uri("/suspending").accept(MediaType.TEXT_PLAIN).exchange()
+				.expectBody<String>().isEqualTo("Hello World")
+	}
+
+	@Test
+	fun testFlow() {
+		webClient.get().uri("/flow").accept(MediaType.TEXT_PLAIN).exchange()
+				.expectBody<String>().isEqualTo("Hello World")
+	}
+}


### PR DESCRIPTION
This pull request adds the Coroutines BOM to Spring Boot dependencies as discussed in gh-16555, as well as the related smoke test. 

The Coroutines BOM is not strictly needed for Spring Boot itself since I have managed to make the support transparent at Boot infra level (no new bean introduced) and fully handled at Spring Framework level.

That said for end users, it is critical to have this Coroutines BOM included at Spring Boot dependencies level in order to:
 - Be sure developers leverage Coroutines 1.3+ (we do not support previous ones)
 -  Avoid mixing versions of Coroutines dependencies which in practice occurs very frequently (for example when developer specify only `kotlinx-coroutines-reactor` and get an older incompatible `kotlinx-coroutines-reactive` dependency)
 - Provide a consistent first class Coroutines support at both Spring Framework 5.2 and Spring Boot 2.2 levels.

In term of context, it is also important to notice that with Spring Framework 5.2 / Spring Boot 2.2, Coroutines are likely going to be the most popular way to consume WebFlux for Kotlin developers.