### PR TITLE
 Add support for configuring Spring Session JDBC flush mode

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HazelcastSessionProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HazelcastSessionProperties.java
@@ -35,7 +35,8 @@ public class HazelcastSessionProperties {
 	private String mapName = "spring:session:sessions";
 
 	/**
-	 * Sessions flush mode.
+	 * Sessions flush mode. Determines when session changes are written to the session
+	 * store.
 	 */
 	private FlushMode flushMode = FlushMode.ON_SAVE;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java
@@ -67,6 +67,7 @@ class JdbcSessionConfiguration {
 			}
 			setTableName(jdbcSessionProperties.getTableName());
 			setCleanupCron(jdbcSessionProperties.getCleanupCron());
+			setFlushMode(jdbcSessionProperties.getFlushMode());
 			setSaveMode(jdbcSessionProperties.getSaveMode());
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionProperties.java
@@ -18,6 +18,7 @@ package org.springframework.boot.autoconfigure.session;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceInitializationMode;
+import org.springframework.session.FlushMode;
 import org.springframework.session.SaveMode;
 
 /**
@@ -57,6 +58,12 @@ public class JdbcSessionProperties {
 	private DataSourceInitializationMode initializeSchema = DataSourceInitializationMode.EMBEDDED;
 
 	/**
+	 * Sessions flush mode. Determines when session changes are written to the session
+	 * store.
+	 */
+	private FlushMode flushMode = FlushMode.ON_SAVE;
+
+	/**
 	 * Sessions save mode. Determines how session changes are tracked and saved to the
 	 * session store.
 	 */
@@ -92,6 +99,14 @@ public class JdbcSessionProperties {
 
 	public void setInitializeSchema(DataSourceInitializationMode initializeSchema) {
 		this.initializeSchema = initializeSchema;
+	}
+
+	public FlushMode getFlushMode() {
+		return this.flushMode;
+	}
+
+	public void setFlushMode(FlushMode flushMode) {
+		this.flushMode = flushMode;
 	}
 
 	public SaveMode getSaveMode() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionProperties.java
@@ -37,7 +37,8 @@ public class RedisSessionProperties {
 	private String namespace = "spring:session";
 
 	/**
-	 * Sessions flush mode.
+	 * Sessions flush mode. Determines when session changes are written to the session
+	 * store.
 	 */
 	private FlushMode flushMode = FlushMode.ON_SAVE;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationJdbcTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationJdbcTests.java
@@ -30,6 +30,7 @@ import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.session.FlushMode;
 import org.springframework.session.SaveMode;
 import org.springframework.session.data.mongo.MongoOperationsSessionRepository;
 import org.springframework.session.data.redis.RedisOperationsSessionRepository;
@@ -127,6 +128,19 @@ class SessionAutoConfigurationJdbcTests extends AbstractSessionAutoConfiguration
 					SpringBootJdbcHttpSessionConfiguration configuration = context
 							.getBean(SpringBootJdbcHttpSessionConfiguration.class);
 					assertThat(configuration).hasFieldOrPropertyWithValue("cleanupCron", "0 0 12 * * *");
+				});
+	}
+
+	@Test
+	void customFlushMode() {
+		this.contextRunner
+				.withPropertyValues("spring.session.store-type=jdbc", "spring.session.jdbc.flush-mode=immediate")
+				.run((context) -> {
+					assertThat(context.getBean(JdbcSessionProperties.class).getFlushMode())
+							.isEqualTo(FlushMode.IMMEDIATE);
+					SpringBootJdbcHttpSessionConfiguration configuration = context
+							.getBean(SpringBootJdbcHttpSessionConfiguration.class);
+					assertThat(configuration).hasFieldOrPropertyWithValue("flushMode", FlushMode.IMMEDIATE);
 				});
 	}
 


### PR DESCRIPTION
This PR adds support for configuring Spring Session JDBC flush mode that was added in Spring Session `Corn-M3`.

I've also added another commit that harmonizes flush mode properties javadoc, similarly to the javadoc for save mode properties that was added in #17514.