### PR TITLE
bug fixed for Unable to use off for enum values in yaml file #17798

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/YamlPropertySourceLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/YamlPropertySourceLoader.java
@@ -19,9 +19,9 @@ package org.springframework.boot.env;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Iterator;
 
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.Resource;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/YamlPropertySourceLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/YamlPropertySourceLoader.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Iterator;
+
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.ClassUtils;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/YamlPropertySourceLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/YamlPropertySourceLoader.java
@@ -17,8 +17,11 @@
 package org.springframework.boot.env;
 
 import java.io.IOException;
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Iterator;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.ClassUtils;
@@ -52,11 +55,11 @@ public class YamlPropertySourceLoader implements PropertySourceLoader {
 		for (int i = 0; i < loaded.size(); i++) {
 			Map<String, Object> curr = loaded.get(i);
 			Iterator<String> iter = curr.keySet().iterator();
-			while(iter.hasNext()){
+			while (iter.hasNext()) {
 				String key = iter.next();
 				String value = curr.get(key).toString();
-				if(key != null && key.startsWith("logging.level")
-						&& ("true".equals(value) || "false".equals(value))){
+				if (key != null && key.startsWith("logging.level")
+						&& ("true".equals(value) || "false".equals(value))) {
 					curr.put(key, value);
 				}
 			}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/YamlPropertySourceLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/YamlPropertySourceLoader.java
@@ -59,8 +59,7 @@ public class YamlPropertySourceLoader implements PropertySourceLoader {
 			while (iter.hasNext()) {
 				String key = iter.next();
 				String value = curr.get(key).toString();
-				if (key != null && key.startsWith("logging.level")
-						&& ("true".equals(value) || "false".equals(value))) {
+				if (key != null && key.startsWith("logging.level") && ("true".equals(value) || "false".equals(value))) {
 					curr.put(key, value);
 				}
 			}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/YamlPropertySourceLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/YamlPropertySourceLoader.java
@@ -17,10 +17,7 @@
 package org.springframework.boot.env;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.Resource;
@@ -53,6 +50,16 @@ public class YamlPropertySourceLoader implements PropertySourceLoader {
 		}
 		List<PropertySource<?>> propertySources = new ArrayList<>(loaded.size());
 		for (int i = 0; i < loaded.size(); i++) {
+			Map<String, Object> curr = loaded.get(i);
+			Iterator<String> iter = curr.keySet().iterator();
+			while(iter.hasNext()){
+				String key = iter.next();
+				String value = curr.get(key).toString();
+				if(key != null && key.startsWith("logging.level")
+						&& ("true".equals(value) || "false".equals(value))){
+					curr.put(key, value);
+				}
+			}
 			String documentNumber = (loaded.size() != 1) ? " (document #" + i + ")" : "";
 			propertySources.add(new OriginTrackedMapPropertySource(name + documentNumber,
 					Collections.unmodifiableMap(loaded.get(i)), true));

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponent.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonComponent.java
@@ -92,7 +92,7 @@ public @interface JsonComponent {
 	Scope scope() default Scope.VALUES;
 
 	/**
-	 * The various scopes under which a serializer/deserialzier can be registered.
+	 * The various scopes under which a serializer/deserializer can be registered.
 	 */
 	enum Scope {
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogLevel.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LogLevel.java
@@ -24,6 +24,6 @@ package org.springframework.boot.logging;
  */
 public enum LogLevel {
 
-	TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF
+	TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF, ON
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/java/JavaLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/java/JavaLoggingSystemTests.java
@@ -139,8 +139,8 @@ class JavaLoggingSystemTests extends AbstractLoggingSystemTests {
 
 	@Test
 	void getSupportedLevels() {
-		assertThat(this.loggingSystem.getSupportedLogLevels()).isEqualTo(
-				EnumSet.of(LogLevel.TRACE, LogLevel.DEBUG, LogLevel.INFO, LogLevel.WARN, LogLevel.ERROR, LogLevel.OFF, LogLevel.ON));
+		assertThat(this.loggingSystem.getSupportedLogLevels()).isEqualTo(EnumSet.of(LogLevel.TRACE, LogLevel.DEBUG,
+				LogLevel.INFO, LogLevel.WARN, LogLevel.ERROR, LogLevel.OFF, LogLevel.ON));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/java/JavaLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/java/JavaLoggingSystemTests.java
@@ -140,7 +140,7 @@ class JavaLoggingSystemTests extends AbstractLoggingSystemTests {
 	@Test
 	void getSupportedLevels() {
 		assertThat(this.loggingSystem.getSupportedLogLevels()).isEqualTo(
-				EnumSet.of(LogLevel.TRACE, LogLevel.DEBUG, LogLevel.INFO, LogLevel.WARN, LogLevel.ERROR, LogLevel.OFF));
+				EnumSet.of(LogLevel.TRACE, LogLevel.DEBUG, LogLevel.INFO, LogLevel.WARN, LogLevel.ERROR, LogLevel.OFF, LogLevel.ON));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -160,7 +160,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 	@Test
 	void getSupportedLevels() {
 		assertThat(this.loggingSystem.getSupportedLogLevels()).isEqualTo(
-				EnumSet.of(LogLevel.TRACE, LogLevel.DEBUG, LogLevel.INFO, LogLevel.WARN, LogLevel.ERROR, LogLevel.OFF));
+				EnumSet.of(LogLevel.TRACE, LogLevel.DEBUG, LogLevel.INFO, LogLevel.WARN, LogLevel.ERROR, LogLevel.OFF, LogLevel.ON));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -159,8 +159,8 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 
 	@Test
 	void getSupportedLevels() {
-		assertThat(this.loggingSystem.getSupportedLogLevels()).isEqualTo(
-				EnumSet.of(LogLevel.TRACE, LogLevel.DEBUG, LogLevel.INFO, LogLevel.WARN, LogLevel.ERROR, LogLevel.OFF, LogLevel.ON));
+		assertThat(this.loggingSystem.getSupportedLogLevels()).isEqualTo(EnumSet.of(LogLevel.TRACE, LogLevel.DEBUG,
+				LogLevel.INFO, LogLevel.WARN, LogLevel.ERROR, LogLevel.OFF, LogLevel.ON));
 	}
 
 	@Test


### PR DESCRIPTION
bug fixed for Unable to use off for enum values in yaml file #17798 and the [comment](https://github.com/spring-projects/spring-boot/issues/17385#issuecomment-518825344)

I found that `off` and `false` resolved to `Boolean false` in yaml, but it can't found mapping logging lever，so i added some codes to make Boolean to String.I am not sure if the location of the code is appropriate, but it works fine.
