### PR TITLE
Fix syntax errors in docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -908,7 +908,7 @@ interface. The following code shows a sample `ReactiveHealthIndicator` implement
 		@Override
 		public Mono<Health> health() {
 			return doHealthCheck() //perform some specific health check that returns a Mono<Health>
-				.onErrorResume(ex -> Mono.just(new Health.Builder().down(ex).build())));
+				.onErrorResume(ex -> Mono.just(new Health.Builder().down(ex).build()));
 		}
 
 	}

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -8316,7 +8316,7 @@ which auto-configures one for you.
 		@Test
 		void testName(CapturedOutput output) {
 			System.out.println("Hello World!");
-			assertThat(output).contains("World"));
+			assertThat(output).contains("World");
 		}
 
 	}


### PR DESCRIPTION
Hi,

this PR fixes two syntax errors in code examples inside the docs.

Cheers,
Christoph