### PR TITLE
Add support for Quartz in Actuator

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -87,6 +87,7 @@ dependencies {
 	optional("org.mongodb:mongodb-driver-reactivestreams")
 	optional("org.mongodb:mongodb-driver-sync")
 	optional("org.neo4j.driver:neo4j-java-driver")
+	optional("org.quartz-scheduler:quartz")
 	optional("org.springframework:spring-jdbc")
 	optional("org.springframework:spring-jms")
 	optional("org.springframework:spring-messaging")

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/docs/asciidoc/endpoints/quartz.adoc
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/docs/asciidoc/endpoints/quartz.adoc
@@ -1,0 +1,92 @@
+[[quartz]]
+= Quartz (`quartz`)
+
+The `quartz` endpoint allows you to monitor the Quartz's Scheduler.
+
+NOTE: All the following quartz's endpoint are also available for triggers by simply replace `/actuator/quartz/jobs/` by `/actuator/quartz/triggers/`.
+
+
+[[jobs-all]]
+== Retrieving all jobs
+To retrieve jobs registered in the scheduler of your application, make a `GET` request to `/actuator/quartz/jobs`, as shown in the following curl-based example:
+
+include::{snippets}/quartz/jobs-all/curl-request.adoc[]
+
+The resulting response is similar to the following:
+
+include::{snippets}/quartz/jobs-all/http-response.adoc[]
+
+
+[[jobs-all-response-structure]]
+=== Response Structure
+The response contains minimal informations of the application’s scheduled jobs (only the identifier).
+The following table describes the structure of the response:
+
+include::{snippets}/quartz/jobs-all/response-fields.adoc[]
+
+
+
+[[jobs-group]]
+== Retrieving jobs for group
+To retrieve jobs by group, make a `GET` request to `/actuator/quartz/jobs/{group}`, as shown in the following curl-based example:
+
+include::{snippets}/quartz/jobs-group/curl-request.adoc[]
+
+The resulting response is similar to the following:
+
+include::{snippets}/quartz/jobs-group/http-response.adoc[]
+
+[[jobs-group-response-structure]]
+=== Response Structure
+The response contains minimal informations of the application’s scheduled jobs (only the identifier).
+The following table describes the structure of the response:
+
+include::{snippets}/quartz/jobs-group/response-fields.adoc[]
+
+
+
+[[jobs-group-name]]
+== Retrieving job by identifier
+To retrieve a job by group and name, make a `GET` request to `/actuator/quartz/jobs/{group}/{name}`, as shown in the following curl-based example:
+
+include::{snippets}/quartz/jobs-group-name/curl-request.adoc[]
+
+The resulting response is similar to the following:
+
+include::{snippets}/quartz/jobs-group-name/http-response.adoc[]
+
+[[jobs-group-name-structure]]
+=== Response Structure
+The response details of the application’s scheduled job.
+The following table describes the structure of the response:
+
+include::{snippets}/quartz/jobs-group-name/response-fields.adoc[]
+
+
+
+[[jobs-pause-resume]]
+== Change state of job
+To resume or pause a given job depending on its current state, make a `POST` request to `/actuator/quartz/jobs/{group}/{name}`, as shown in the following curl-based example:
+
+include::{snippets}/quartz/jobs-pause-resume/curl-request.adoc[]
+
+The resulting response is similar to the following:
+
+include::{snippets}/quartz/jobs-pause-resume/http-response.adoc[]
+
+NOTE: A paused job will be resume and an active job will be paused.
+
+[[jobs-pause-resume-structure]]
+=== Response Structure
+The response details of the application’s scheduled job.
+The following table describes the structure of the response:
+
+include::{snippets}/quartz/jobs-pause-resume/response-fields.adoc[]
+
+
+
+[[jobs-delete]]
+== Delete a job
+To delete a job, make a `DELETE` request to `/actuator/quartz/jobs/{group}/{name}`, as shown in the following curl-based example:
+
+include::{snippets}/quartz/jobs-delete/curl-request.adoc[]

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/scheduling/QuartzEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/scheduling/QuartzEndpointAutoConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.scheduling;
+
+import org.quartz.Scheduler;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
+import org.springframework.boot.actuate.scheduling.QuartzEndpoint;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for {@link QuartzEndpoint}.
+ *
+ * @author Jordan Couret
+ * @since 2.4.0
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(Scheduler.class)
+@ConditionalOnBean(Scheduler.class)
+@AutoConfigureAfter(QuartzAutoConfiguration.class)
+@ConditionalOnAvailableEndpoint(endpoint = QuartzEndpoint.class)
+public class QuartzEndpointAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	public QuartzEndpoint quartzEndpoint(ObjectProvider<Scheduler> scheduler) {
+		return new QuartzEndpoint(scheduler.getIfAvailable());
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -83,6 +83,7 @@ org.springframework.boot.actuate.autoconfigure.r2dbc.ConnectionFactoryHealthCont
 org.springframework.boot.actuate.autoconfigure.redis.RedisHealthContributorAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.redis.RedisReactiveHealthContributorAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.scheduling.ScheduledTasksEndpointAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.scheduling.QuartzEndpointAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.security.reactive.ReactiveManagementWebSecurityAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.session.SessionsEndpointAutoConfiguration,\

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/QuartzEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/QuartzEndpointDocumentationTests.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.endpoint.web.documentation;
+
+import java.sql.Date;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.SimpleTrigger;
+import org.quartz.TriggerBuilder;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.scheduling.QuartzEndpoint;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.payload.FieldDescriptor;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Tests for generating documentation describing the {@link QuartzEndpoint}
+ *
+ * @author Jordan Couret
+ */
+public class QuartzEndpointDocumentationTests extends MockMvcEndpointDocumentationTests {
+
+	@Autowired
+	private Scheduler scheduler;
+
+	private static final JobKey jobKey = JobKey.jobKey("jobName", "jobGroup");
+
+	private static final List<FieldDescriptor> fullFields = Arrays.asList(
+			fieldWithPath("jobKey.name").description("Name of the job."),
+			fieldWithPath("jobKey.group").description("Name of the job's group."),
+			fieldWithPath("triggerKey.name").description("Name of the trigger."),
+			fieldWithPath("triggerKey.group").description("Name of the trigger's group."),
+			fieldWithPath("jobClass").description("Simple class name of the job."),
+			fieldWithPath("data").description("Map that's represent the job's JobDataMap."),
+			fieldWithPath("triggerState").description("State of the job."),
+			fieldWithPath("nextFireDate").description("The next fire date of the job.")
+	);
+
+	@Override
+	@BeforeEach
+	void setup(RestDocumentationContextProvider restDocumentation) {
+		super.setup(restDocumentation);
+		this.generateJob();
+	}
+
+	@AfterEach
+	void clean() throws SchedulerException {
+		this.cleanJob();
+	}
+
+
+	@Test
+	void allJobs() throws Exception {
+		this.mockMvc.perform(get("/actuator/quartz/jobs")).andExpect(status().isOk())
+				.andDo(MockMvcRestDocumentation.document("quartz/jobs-all",
+						responseFields(fieldWithPath("[].name").description("Name of the job."),
+								fieldWithPath("[].group").description("Group of the job."))));
+	}
+
+	@Test
+	void jobsForGroup() throws Exception {
+		this.mockMvc.perform(get("/actuator/quartz/jobs/jobGroup")).andExpect(status().isOk())
+				.andDo(MockMvcRestDocumentation.document("quartz/jobs-group",
+						responseFields(fieldWithPath("[].name").description("Name of the job."),
+								fieldWithPath("[].group").description("Group of the job."))));
+	}
+
+	@Test
+	void jobsForGroupAndName() throws Exception {
+		this.mockMvc.perform(get("/actuator/quartz/jobs/jobGroup/jobName")).andExpect(status().isOk())
+				.andDo(MockMvcRestDocumentation.document("quartz/jobs-group-name", responseFields(fullFields)));
+	}
+
+	@Test
+	void pauseOrResumeJob() throws Exception {
+		this.mockMvc.perform(post("/actuator/quartz/jobs/jobGroup/jobName")).andExpect(status().isOk())
+				.andDo(MockMvcRestDocumentation.document("quartz/jobs-pause-resume", responseFields(fullFields)));
+	}
+
+	@Test
+	void deleteJob() throws Exception {
+		this.mockMvc.perform(delete("/actuator/quartz/jobs/jobGroup/jobName")).andExpect(status().isOk())
+				.andDo(MockMvcRestDocumentation.document("quartz/jobs-delete"));
+	}
+
+	@Test
+	void allTriggers() throws Exception {
+		this.mockMvc.perform(get("/actuator/quartz/triggers")).andExpect(status().isOk())
+				.andDo(MockMvcRestDocumentation.document("quartz/triggers-all",
+						responseFields(fieldWithPath("[].name").description("Name of the trigger."),
+								fieldWithPath("[].group").description("Group of the trigger."))));
+	}
+
+	@Test
+	void triggerssForGroup() throws Exception {
+		this.mockMvc.perform(get("/actuator/quartz/triggers/triggerGroup")).andExpect(status().isOk())
+				.andDo(MockMvcRestDocumentation.document("quartz/triggers-group",
+						responseFields(fieldWithPath("[].name").description("Name of the trigger."),
+								fieldWithPath("[].group").description("Group of the trigger."))));
+	}
+
+	@Test
+	void triggersForGroupAndName() throws Exception {
+		this.mockMvc.perform(get("/actuator/quartz/triggers/triggerGroup/triggerName")).andExpect(status().isOk())
+				.andDo(MockMvcRestDocumentation.document("quartz/triggers-group-name", responseFields(fullFields)));
+	}
+
+	@Test
+	void pauseOrResumeTrigger() throws Exception {
+		this.mockMvc.perform(post("/actuator/quartz/triggers/triggerGroup/triggerName")).andExpect(status().isOk())
+				.andDo(MockMvcRestDocumentation.document("quartz/triggers-pause-resume", responseFields(fullFields)));
+	}
+
+	@Test
+	void deleteTrigger() throws Exception {
+		this.mockMvc.perform(delete("/actuator/quartz/triggers/triggerGroup/triggerName")).andExpect(status().isOk())
+				.andDo(MockMvcRestDocumentation.document("quartz/triggers-delete"));
+	}
+
+	private void generateJob() {
+		try {
+			JobDetail jobDetail = JobBuilder.newJob(SampleJob.class).withIdentity(jobKey)
+					.usingJobData(new JobDataMap()).build();
+
+			java.util.Date start = Date
+					.from(LocalDateTime.now().plusYears(1).atZone(ZoneId.systemDefault()).toInstant());
+
+			SimpleTrigger sampleTrigger = TriggerBuilder.newTrigger().forJob(jobDetail)
+					.withIdentity("triggerName", "triggerGroup")
+					.withSchedule(SimpleScheduleBuilder.simpleSchedule()).startAt(start).build();
+
+			scheduler.scheduleJob(jobDetail, sampleTrigger);
+		}
+		catch (SchedulerException e) {
+			throw new RuntimeException(e.getMessage(), e.getCause());
+		}
+	}
+
+	private void cleanJob() throws SchedulerException {
+		if (scheduler.checkExists(jobKey)) {
+			scheduler.deleteJob(jobKey);
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Import({ BaseDocumentationConfiguration.class, QuartzAutoConfiguration.class })
+	@AutoConfigureAfter(QuartzAutoConfiguration.class)
+	static class TestConfiguration {
+
+		@Bean
+		QuartzEndpoint endpoint(Scheduler scheduler) {
+			return new QuartzEndpoint(scheduler);
+		}
+
+	}
+
+	public static class SampleJob implements Job {
+		@Override
+		public void execute(JobExecutionContext context) {
+			// Do nothing
+		}
+	}
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/scheduling/QuartzEndpointAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/scheduling/QuartzEndpointAutoConfigurationTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.scheduling;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.scheduling.QuartzEndpoint;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link QuartzEndpointAutoConfiguration}.
+ *
+ * @author Jordan Couret
+ */
+class QuartzEndpointAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withConfiguration(
+			AutoConfigurations.of(QuartzAutoConfiguration.class, QuartzEndpointAutoConfiguration.class));
+
+	@Test
+	void endpointQuartzIsAutoConfigured() {
+		this.contextRunner.withPropertyValues("management.endpoints.web.exposure.include=quartz")
+				.run((context) -> assertThat(context).hasSingleBean(QuartzEndpoint.class));
+	}
+
+	@Test
+	void endpointQuartzNotAutoConfiguredWhenNotExposed() {
+		this.contextRunner.run((context) -> assertThat(context).doesNotHaveBean(QuartzEndpoint.class));
+	}
+
+	@Test
+	void endpointQuartzCanBeDisabled() {
+		this.contextRunner.withPropertyValues("management.endpoint.quartz.enabled:false")
+				.run((context) -> assertThat(context).doesNotHaveBean(QuartzEndpoint.class));
+	}
+}

--- a/spring-boot-project/spring-boot-actuator/build.gradle
+++ b/spring-boot-project/spring-boot-actuator/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	optional("io.r2dbc:r2dbc-spi")
 	optional("io.reactivex:rxjava-reactive-streams")
 	optional("org.elasticsearch.client:elasticsearch-rest-client")
+	optional("org.quartz-scheduler:quartz")
 	optional("io.undertow:undertow-servlet") {
 		exclude group: "org.jboss.spec.javax.annotation", module: "jboss-annotations-api_1.2_spec"
 		exclude group: "org.jboss.spec.javax.servlet", module: "jboss-servlet-api_4.0_spec"

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/scheduling/QuartzDelegate.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/scheduling/QuartzDelegate.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.scheduling;
+
+import java.util.List;
+
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+
+import org.springframework.boot.actuate.scheduling.QuartzEndpoint.QuartzDescriptor;
+import org.springframework.boot.actuate.scheduling.QuartzEndpoint.QuartzKey;
+
+/**
+ * Delegate to retrieve informations about {@link Scheduler} object.
+ *
+ * @author Jordan Couret
+ * @since 2.4.0
+ */
+public interface QuartzDelegate {
+
+	List<String> getGroupName() throws SchedulerException;
+
+	List<QuartzKey> getKeys(String groupName);
+
+	QuartzKey getKey(String group, String name);
+
+	QuartzDescriptor getDescriptor(QuartzKey key) throws SchedulerException;
+
+	boolean exist(QuartzKey key) throws SchedulerException;
+
+	boolean isInPausedMode(QuartzKey key) throws SchedulerException;
+
+	void resume(QuartzKey key) throws SchedulerException;
+
+	void pause(QuartzKey key) throws SchedulerException;
+
+	boolean delete(QuartzKey key) throws SchedulerException;
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/scheduling/QuartzEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/scheduling/QuartzEndpoint.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.scheduling;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerKey;
+
+import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.util.Assert;
+
+/**
+ * {@link Endpoint} that provides access to {@link Scheduler} informations.
+ *
+ * @author Jordan Couret
+ * @since 2.4.0
+ */
+@Endpoint(id = "quartz")
+public class QuartzEndpoint {
+
+	private final Map<String, QuartzDelegate> delegateMap = new HashMap<>();
+
+	public QuartzEndpoint(Scheduler scheduler) {
+		Assert.notNull(scheduler, "Scheduler must not be null");
+		this.delegateMap.put("jobs", new QuartzJobDelegate(scheduler));
+		this.delegateMap.put("triggers", new QuartzTriggerDelegate(scheduler));
+	}
+
+	/**
+	 * Retrieve all {@link Job}'s key OR {@link Trigger}'s key registered
+	 * @param delegateName : define the target (should be 'jobs' or 'triggers')
+	 * @throws SpringQuartzException if invalid delegateName or if SchedulerExcepetion was thrown during scheduler
+	 * access
+	 * @return list of key
+	 */
+	@ReadOperation
+	public List<QuartzKey> findAll(@Selector String delegateName) {
+		try {
+
+			QuartzDelegate delegate = this.getDelegate(delegateName);
+			return delegate.getGroupName().stream().map(delegate::getKeys)
+					.flatMap(List::stream).collect(Collectors.toList());
+		}
+		catch (SchedulerException e) {
+			throw new SpringQuartzException(e);
+		}
+	}
+
+	/**
+	 * Retrieve all {@link Job}'s key OR {@link Trigger}'s key registered with a specific group
+	 * @param delegateName : define the target (should be 'jobs' or 'triggers')
+	 * @param group : the given group
+	 * @return list of key
+	 */
+	@ReadOperation
+	public List<QuartzKey> findByGroup(@Selector String delegateName, @Selector String group) {
+		return this.getDelegate(delegateName).getKeys(group);
+	}
+
+	/**
+	 * Return a {@link QuartzDescriptor} with details information about the {@link Job} or {@link Trigger}.
+	 * @param delegateName : define the target (should be 'jobs' or 'triggers')
+	 * @param group : the given group
+	 * @param name : the given name
+	 * @throws SpringQuartzException if invalid delegateName or if SchedulerExcepetion was thrown during scheduler
+	 * access
+	 * @return a quartz descriptor
+	 */
+	@ReadOperation
+	public QuartzDescriptor findByGroupAndName(@Selector String delegateName, @Selector String group,
+			@Selector String name) {
+		try {
+
+			QuartzDelegate delegate = this.getDelegate(delegateName);
+			QuartzKey key = delegate.getKey(group, name);
+			return delegate.exist(key) ? delegate.getDescriptor(key) : null;
+		}
+		catch (SchedulerException e) {
+			throw new SpringQuartzException(e);
+		}
+	}
+
+	/**
+	 * According to the current state of {@link Job} or {@link Trigger}, it will pause or resume the given item.
+	 * @param delegateName : define the target (should be 'jobs' or 'triggers')
+	 * @param group : the given group
+	 * @param name : the given name
+	 * @throws SpringQuartzException if invalid delegateName or if SchedulerExcepetion was thrown during scheduler
+	 * access
+	 * @return a quartz descriptor with the new state
+	 */
+	@WriteOperation
+	public QuartzDescriptor pauseOrResumeKey(@Selector String delegateName, @Selector String group,
+			@Selector String name) {
+		QuartzDelegate delegate = this.getDelegate(delegateName);
+		QuartzKey key = delegate.getKey(group, name);
+
+		try {
+			if (delegate.exist(key)) {
+				if (delegate.isInPausedMode(key)) {
+					delegate.resume(key);
+				}
+				else {
+					delegate.pause(key);
+				}
+				return delegate.getDescriptor(key);
+			}
+		}
+		catch (SchedulerException e) {
+			throw new SpringQuartzException(e);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Delete a {@link Job} or a {@link Trigger}.
+	 * @param delegateName : define the target (should be 'jobs' or 'triggers')
+	 * @param group : the given group
+	 * @param name : the given name
+	 * @throws SpringQuartzException if invalid delegateName or if SchedulerExcepetion was thrown during scheduler
+	 * access
+	 * @return a quartz descriptor with the new state
+	 */
+	@DeleteOperation
+	public boolean deleteKey(@Selector String delegateName, @Selector String group, @Selector String name) {
+		try {
+			QuartzDelegate delegate = this.getDelegate(delegateName);
+			QuartzKey key = delegate.getKey(group, name);
+			return delegate.exist(key) && delegate.delete(key);
+		}
+		catch (SchedulerException e) {
+			throw new SpringQuartzException(e);
+		}
+	}
+
+	private QuartzDelegate getDelegate(String delegateName) {
+		return Optional.ofNullable(this.delegateMap.get(delegateName))
+				.orElseThrow(() -> new SpringQuartzException("URL should be /quartz/job OR /quartz/triggers"));
+	}
+
+	/**
+	 * Generic object to retrieve details informations about a {@link Job} or a {@link Trigger}, primarily intended
+	 * for serialization to JSON.
+	 */
+	public static class QuartzDescriptor {
+
+		private QuartzKey jobKey;
+
+		private QuartzKey triggerKey;
+
+		private String description;
+
+		private Class<? extends Job> jobClass;
+
+		private Map<String, Object> data;
+
+		private LocalDateTime nextFireDate;
+
+		private String triggerState;
+
+		public QuartzDescriptor(JobDetail jobDetail, Trigger trigger, String triggerState) {
+			this.jobKey = new QuartzKey(jobDetail.getKey().getName(), jobDetail.getKey().getGroup());
+			this.description = jobDetail.getDescription();
+			this.jobClass = jobDetail.getJobClass();
+			this.data = Optional.ofNullable(jobDetail.getJobDataMap()).orElse(new JobDataMap())
+					.getWrappedMap();
+			this.nextFireDate = trigger.getNextFireTime().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+			this.triggerKey = new QuartzKey(trigger.getKey().getName(), trigger.getKey().getGroup());
+			this.triggerState = triggerState;
+		}
+
+		public QuartzDescriptor(JobDetail jobDetail) {
+			this.jobKey = new QuartzKey(jobDetail.getKey().getName(), jobDetail.getKey().getGroup());
+			this.description = jobDetail.getDescription();
+			this.jobClass = jobDetail.getJobClass();
+			this.data = Optional.ofNullable(jobDetail.getJobDataMap()).orElse(new JobDataMap())
+					.getWrappedMap();
+		}
+
+		public QuartzKey getJobKey() {
+			return jobKey;
+		}
+
+		public QuartzKey getTriggerKey() {
+			return triggerKey;
+		}
+
+		public String getDescription() {
+			return description;
+		}
+
+		public Class<? extends Job> getJobClass() {
+			return jobClass;
+		}
+
+		public Map<String, Object> getData() {
+			return data;
+		}
+
+		public LocalDateTime getNextFireDate() {
+			return nextFireDate;
+		}
+
+		public String getTriggerState() {
+			return triggerState;
+		}
+	}
+
+	/**
+	 * A representation of {@link org.quartz.utils.Key}, primarily intended for serialization to
+	 * JSON.
+	 */
+	public static class QuartzKey {
+		private final String name;
+
+		private final String group;
+
+		public QuartzKey(String name, String group) {
+			this.name = name;
+			this.group = group;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public String getGroup() {
+			return group;
+		}
+
+		public JobKey toJobKey() {
+			return new JobKey(this.getName(), this.getGroup());
+		}
+
+		public TriggerKey toTriggerKey() {
+			return new TriggerKey(this.getName(), this.getGroup());
+		}
+	}
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/scheduling/QuartzJobDelegate.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/scheduling/QuartzJobDelegate.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.scheduling;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.quartz.Job;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.Trigger.TriggerState;
+import org.quartz.TriggerKey;
+import org.quartz.impl.matchers.GroupMatcher;
+
+import org.springframework.boot.actuate.scheduling.QuartzEndpoint.QuartzDescriptor;
+import org.springframework.boot.actuate.scheduling.QuartzEndpoint.QuartzKey;
+
+/**
+ * Delegate that provides access to {@link Job} registered in the {@link Scheduler}.
+ *
+ * @author Jordan Couret
+ * @since 2.4.0
+ */
+public class QuartzJobDelegate implements QuartzDelegate {
+
+	private final Scheduler scheduler;
+
+	public QuartzJobDelegate(Scheduler scheduler) {
+		this.scheduler = scheduler;
+	}
+
+	@Override
+	public List<String> getGroupName() throws SchedulerException {
+		return this.scheduler.getJobGroupNames();
+	}
+
+	@Override
+	public List<QuartzKey> getKeys(String groupName) {
+		try {
+			return this.scheduler.getJobKeys(GroupMatcher.groupEquals(groupName)).stream()
+					.map(jobKey -> new QuartzKey(jobKey.getName(), jobKey.getGroup())).collect(Collectors.toList());
+		}
+		catch (SchedulerException e) {
+			return Collections.emptyList();
+		}
+	}
+
+	@Override
+	public QuartzKey getKey(String group, String name) {
+		return new QuartzKey(name, group);
+	}
+
+	@Override
+	public QuartzDescriptor getDescriptor(QuartzKey key) throws SchedulerException {
+		JobDetail jobDetail = this.scheduler.getJobDetail(key.toJobKey());
+		List<? extends Trigger> triggers = this.scheduler.getTriggersOfJob(key.toJobKey());
+		if (triggers != null && triggers.size() >= 1) {
+			Trigger trigger = triggers.get(0);
+			String triggerState = this.scheduler.getTriggerState(trigger.getKey()).name();
+			return new QuartzDescriptor(jobDetail, trigger, triggerState);
+		}
+		else {
+			return new QuartzDescriptor(jobDetail);
+		}
+	}
+
+	@Override
+	public boolean exist(QuartzKey key) throws SchedulerException {
+		return this.scheduler.checkExists(key.toJobKey());
+	}
+
+	@Override
+	public boolean isInPausedMode(QuartzKey key) throws SchedulerException {
+		List<? extends Trigger> triggersOfJob = this.scheduler.getTriggersOfJob(key.toJobKey());
+		return triggersOfJob.stream().map(Trigger::getKey).map(getGetTriggerState())
+				.filter(Objects::nonNull).allMatch(TriggerState.PAUSED::equals);
+	}
+
+	@Override
+	public void resume(QuartzKey key) throws SchedulerException {
+		this.scheduler.resumeJob(key.toJobKey());
+	}
+
+	@Override
+	public void pause(QuartzKey key) throws SchedulerException {
+		this.scheduler.pauseJob(key.toJobKey());
+	}
+
+	@Override
+	public boolean delete(QuartzKey key) throws SchedulerException {
+		return this.scheduler.deleteJob(key.toJobKey());
+	}
+
+	private Function<TriggerKey, TriggerState> getGetTriggerState() {
+		return (triggerKey) -> {
+			try {
+				return this.scheduler.getTriggerState(triggerKey);
+			}
+			catch (SchedulerException ignored) {
+				return null;
+			}
+		};
+	}
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/scheduling/QuartzTriggerDelegate.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/scheduling/QuartzTriggerDelegate.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.scheduling;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.Trigger.TriggerState;
+import org.quartz.impl.matchers.GroupMatcher;
+
+import org.springframework.boot.actuate.scheduling.QuartzEndpoint.QuartzDescriptor;
+import org.springframework.boot.actuate.scheduling.QuartzEndpoint.QuartzKey;
+
+/**
+ * Delegate that provides access to {@link Trigger} registered in the {@link Scheduler}.
+ *
+ * @author Jordan Couret
+ * @since 2.4.0
+ */
+public class QuartzTriggerDelegate implements QuartzDelegate {
+
+	private final Scheduler scheduler;
+
+	public QuartzTriggerDelegate(Scheduler scheduler) {
+		this.scheduler = scheduler;
+	}
+
+	@Override
+	public List<String> getGroupName() throws SchedulerException {
+		return this.scheduler.getTriggerGroupNames();
+	}
+
+	@Override
+	public List<QuartzKey> getKeys(String groupName) {
+		try {
+			return this.scheduler.getTriggerKeys(GroupMatcher.groupEquals(groupName)).stream()
+					.map(triggerKey -> new QuartzKey(triggerKey.getName(), triggerKey.getGroup()))
+					.collect(Collectors.toList());
+		}
+		catch (SchedulerException ignored) {
+			return Collections.emptyList();
+		}
+	}
+
+	@Override
+	public QuartzKey getKey(String group, String name) {
+		return new QuartzKey(name, group);
+	}
+
+	@Override
+	public QuartzDescriptor getDescriptor(QuartzKey key) throws SchedulerException {
+		Trigger trigger = this.scheduler.getTrigger(key.toTriggerKey());
+		JobDetail jobDetail = this.scheduler.getJobDetail(trigger.getJobKey());
+		TriggerState triggerState = this.scheduler.getTriggerState(trigger.getKey());
+		return new QuartzDescriptor(jobDetail, trigger, triggerState.name());
+	}
+
+	@Override
+	public boolean exist(QuartzKey key) throws SchedulerException {
+		return this.scheduler.checkExists(key.toTriggerKey());
+	}
+
+	@Override
+	public boolean isInPausedMode(QuartzKey key) throws SchedulerException {
+		return TriggerState.PAUSED.equals(this.scheduler.getTriggerState(key.toTriggerKey()));
+	}
+
+	@Override
+	public void resume(QuartzKey key) throws SchedulerException {
+		this.scheduler.resumeTrigger(key.toTriggerKey());
+	}
+
+	@Override
+	public void pause(QuartzKey key) throws SchedulerException {
+		this.scheduler.pauseTrigger(key.toTriggerKey());
+	}
+
+	@Override
+	public boolean delete(QuartzKey key) throws SchedulerException {
+		return this.scheduler.unscheduleJob(key.toTriggerKey());
+	}
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/scheduling/SpringQuartzException.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/scheduling/SpringQuartzException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.scheduling;
+
+import org.quartz.SchedulerException;
+
+public class SpringQuartzException extends RuntimeException {
+	public SpringQuartzException(String message) {
+		super(message);
+	}
+
+	public SpringQuartzException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public SpringQuartzException(SchedulerException e) {
+		super(e.getMessage(), e.getCause());
+	}
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/scheduling/QuartzEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/scheduling/QuartzEndpointTests.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.scheduling;
+
+import java.sql.Date;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.SimpleTrigger;
+import org.quartz.Trigger.TriggerState;
+import org.quartz.TriggerBuilder;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.scheduling.QuartzEndpoint.QuartzDescriptor;
+import org.springframework.boot.actuate.scheduling.QuartzEndpoint.QuartzKey;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Tests for {@link QuartzEndpoint}.
+ *
+ * @author Jordan Couret
+ * @since 2.4.0
+ */
+
+class QuartzEndpointTests {
+	private final static String JOB_NAME = "JOB_NAME";
+
+	private final static String JOB_GROUP_NAME = "JOB_GROUP_NAME";
+
+	private final static String TRIGGER_NAME = "TRIGGER_NAME";
+
+	private final static String TRIGGER_GROUP_NAME = "TRIGGER_GROUP_NAME";
+
+	private final static String JOB_DELEGATE = "jobs";
+
+	private final static String TRIGGER_DELEGATE = "triggers";
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(QuartzAutoConfiguration.class, BaseConfiguration.class));
+
+	@Test
+	void shouldThrowExceptionIfUnrecognizedUrl() {
+		this.contextRunner.run((context) -> {
+			Assertions.assertThat(context).hasSingleBean(QuartzEndpoint.class);
+			QuartzEndpoint endpoint = context.getBean(QuartzEndpoint.class);
+			Assertions.assertThatThrownBy(() -> endpoint.findAll("INVALID"))
+					.isInstanceOf(SpringQuartzException.class).hasMessage("URL should be /quartz/job OR /quartz/triggers");
+		});
+	}
+
+	@Test
+	void shouldFindAllJob() {
+		this.contextRunner.run((context) -> {
+			this.createJob(context);
+
+			Assertions.assertThat(context).hasSingleBean(QuartzEndpoint.class);
+			QuartzEndpoint endpoint = context.getBean(QuartzEndpoint.class);
+			Assertions.assertThat(endpoint.findAll(JOB_DELEGATE)).hasSize(1);
+		});
+	}
+
+	@Test
+	void shouldFindJobByGroup() {
+		this.contextRunner.run((context) -> {
+			this.createJob(context);
+
+			Assertions.assertThat(context).hasSingleBean(QuartzEndpoint.class);
+			QuartzEndpoint endpoint = context.getBean(QuartzEndpoint.class);
+			List<QuartzKey> searchByGroup = endpoint.findByGroup(JOB_DELEGATE, JOB_GROUP_NAME);
+			Assertions.assertThat(searchByGroup).hasSize(1);
+			searchByGroup.forEach((jobKey) -> Assertions.assertThat(jobKey.getGroup()).isEqualTo(JOB_GROUP_NAME));
+		});
+	}
+
+	@Test
+	void shouldFindJobByGroupAndName() {
+		this.contextRunner.run((context) -> {
+			this.createJob(context);
+
+			Assertions.assertThat(context).hasSingleBean(QuartzEndpoint.class);
+			QuartzEndpoint endpoint = context.getBean(QuartzEndpoint.class);
+			QuartzDescriptor searchByGroupAndName = endpoint.findByGroupAndName(JOB_DELEGATE, JOB_GROUP_NAME, JOB_NAME);
+			Assertions.assertThat(searchByGroupAndName.getJobKey().getName()).isEqualTo(JOB_NAME);
+			Assertions.assertThat(searchByGroupAndName.getJobKey().getGroup()).isEqualTo(JOB_GROUP_NAME);
+		});
+	}
+
+	@Test
+	void shouldDeleteJob() {
+		this.contextRunner.run((context) -> {
+			Assertions.assertThat(context).hasSingleBean(Scheduler.class);
+			Scheduler scheduler = context.getBean(Scheduler.class);
+			this.createJob(context);
+
+			Assertions.assertThat(context).hasSingleBean(QuartzEndpoint.class);
+			QuartzEndpoint endpoint = context.getBean(QuartzEndpoint.class);
+			endpoint.deleteKey(JOB_DELEGATE, JOB_GROUP_NAME, JOB_NAME);
+			JobDetail jobDetail = scheduler.getJobDetail(JobKey.jobKey(JOB_NAME, JOB_GROUP_NAME));
+			Assertions.assertThat(jobDetail).isNull();
+		});
+	}
+
+	@Test
+	void shouldPutInPauseThenResumeJob() {
+		this.contextRunner.run((context) -> {
+			Assertions.assertThat(context).hasSingleBean(Scheduler.class);
+			Scheduler scheduler = context.getBean(Scheduler.class);
+			SimpleTrigger simpleTrigger = this.createJob(context);
+
+			// In pause
+			Assertions.assertThat(context).hasSingleBean(QuartzEndpoint.class);
+			QuartzEndpoint endpoint = context.getBean(QuartzEndpoint.class);
+			Assertions.assertThat(endpoint.pauseOrResumeKey(JOB_DELEGATE, JOB_GROUP_NAME, JOB_NAME)).isNotNull();
+			Assertions.assertThat(scheduler.getTriggerState(simpleTrigger.getKey())).isEqualTo(TriggerState.PAUSED);
+
+			// Resume
+			Assertions.assertThat(endpoint.pauseOrResumeKey(JOB_DELEGATE, JOB_GROUP_NAME, JOB_NAME)).isNotNull();
+			Assertions.assertThat(scheduler.getTriggerState(simpleTrigger.getKey())).isNotEqualTo(TriggerState.PAUSED);
+		});
+	}
+
+	@Test
+	void shouldFindAllTrigger() {
+		this.contextRunner.run((context) -> {
+			this.createJob(context);
+
+			Assertions.assertThat(context).hasSingleBean(QuartzEndpoint.class);
+			QuartzEndpoint endpoint = context.getBean(QuartzEndpoint.class);
+			Assertions.assertThat(endpoint.findAll(TRIGGER_DELEGATE)).hasSize(1);
+		});
+	}
+
+	@Test
+	void shouldFindTriggerByGroup() {
+		this.contextRunner.run((context) -> {
+			this.createJob(context);
+
+			Assertions.assertThat(context).hasSingleBean(QuartzEndpoint.class);
+			QuartzEndpoint endpoint = context.getBean(QuartzEndpoint.class);
+			List<QuartzKey> searchByGroup = endpoint.findByGroup(TRIGGER_DELEGATE, TRIGGER_GROUP_NAME);
+			Assertions.assertThat(searchByGroup).hasSize(1);
+			searchByGroup.forEach(
+					(triggerKey) -> Assertions.assertThat(triggerKey.getGroup()).isEqualTo(TRIGGER_GROUP_NAME));
+		});
+	}
+
+	@Test
+	void shouldFindTriggerByGroupAndName() {
+		this.contextRunner.run((context) -> {
+			this.createJob(context);
+
+			Assertions.assertThat(context).hasSingleBean(QuartzEndpoint.class);
+			QuartzEndpoint endpoint = context.getBean(QuartzEndpoint.class);
+			QuartzDescriptor searchByGroupAndName = endpoint.findByGroupAndName(TRIGGER_DELEGATE,
+					TRIGGER_GROUP_NAME, TRIGGER_NAME);
+			Assertions.assertThat(searchByGroupAndName.getTriggerKey().getName()).isEqualTo(TRIGGER_NAME);
+			Assertions.assertThat(searchByGroupAndName.getTriggerKey().getGroup()).isEqualTo(TRIGGER_GROUP_NAME);
+		});
+	}
+
+	@Test
+	void shouldPutInPauseThenResumeTrigger() {
+		this.contextRunner.run((context) -> {
+			Assertions.assertThat(context).hasSingleBean(Scheduler.class);
+			Scheduler scheduler = context.getBean(Scheduler.class);
+			SimpleTrigger simpleTrigger = this.createJob(context);
+
+			// In pause
+			Assertions.assertThat(context).hasSingleBean(QuartzEndpoint.class);
+			QuartzEndpoint endpoint = context.getBean(QuartzEndpoint.class);
+			Assertions.assertThat(
+					endpoint.pauseOrResumeKey(TRIGGER_DELEGATE, TRIGGER_GROUP_NAME, TRIGGER_NAME)).isNotNull();
+			Assertions.assertThat(scheduler.getTriggerState(simpleTrigger.getKey())).isEqualTo(TriggerState.PAUSED);
+
+			// Resume
+			Assertions.assertThat(endpoint.pauseOrResumeKey(TRIGGER_DELEGATE, TRIGGER_GROUP_NAME, TRIGGER_NAME))
+					.isNotNull();
+			Assertions.assertThat(scheduler.getTriggerState(simpleTrigger.getKey())).isNotEqualTo(TriggerState.PAUSED);
+		});
+	}
+
+	@Test
+	void shouldDeleteTrigger() {
+		this.contextRunner.run((context) -> {
+			Assertions.assertThat(context).hasSingleBean(Scheduler.class);
+			Scheduler scheduler = context.getBean(Scheduler.class);
+			this.createJob(context);
+
+			Assertions.assertThat(context).hasSingleBean(QuartzEndpoint.class);
+			QuartzEndpoint endpoint = context.getBean(QuartzEndpoint.class);
+			endpoint.deleteKey(TRIGGER_DELEGATE, TRIGGER_GROUP_NAME, TRIGGER_NAME);
+
+			JobDetail jobDetail = scheduler.getJobDetail(JobKey.jobKey(JOB_NAME, JOB_GROUP_NAME));
+			Assertions.assertThat(jobDetail).isNull();
+		});
+	}
+
+	private SimpleTrigger createJob(AssertableApplicationContext context) throws SchedulerException {
+		Assertions.assertThat(context).hasSingleBean(Scheduler.class);
+		Scheduler scheduler = context.getBean(Scheduler.class);
+
+		JobDataMap map = new JobDataMap();
+		map.put("name", JOB_NAME);
+		JobDetail jobDetail = JobBuilder.newJob(SampleJob.class).withIdentity(JOB_NAME, JOB_GROUP_NAME)
+				.usingJobData(map).build();
+
+		java.util.Date start = Date
+				.from(LocalDateTime.now().plusSeconds(15).atZone(ZoneId.systemDefault()).toInstant());
+
+		SimpleTrigger sampleTrigger = TriggerBuilder.newTrigger().forJob(jobDetail)
+				.withIdentity(TRIGGER_NAME, TRIGGER_GROUP_NAME)
+				.withSchedule(SimpleScheduleBuilder.simpleSchedule()).startAt(start).build();
+
+		scheduler.scheduleJob(jobDetail, sampleTrigger);
+		return sampleTrigger;
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@AutoConfigureAfter(QuartzAutoConfiguration.class)
+	public static class BaseConfiguration {
+
+		@Bean
+		public QuartzEndpoint quartzEndpoint(ObjectProvider<Scheduler> scheduler) {
+			return new QuartzEndpoint(scheduler.getIfAvailable());
+
+		}
+	}
+
+	public static class SampleJob implements Job {
+		@Override
+		public void execute(JobExecutionContext context) throws JobExecutionException {
+			// Do nothing
+		}
+	}
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/quartz/QuartzAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/quartz/QuartzAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -923,7 +923,7 @@ bom {
 			]
 		}
 	}
-	library("Kotlin Coroutines", "1.3.8") {
+	library("Kotlin Coroutines", "1.3.9") {
 		group("org.jetbrains.kotlinx") {
 			imports = [
 				"kotlinx-coroutines-bom"


### PR DESCRIPTION
Add endpoints to improve the monitoring of a spring-boot-quartz application ([see this](https://github.com/spring-projects/spring-boot/pull/10364#issuecomment-356288779))

**Group**:  
* ```GET /actuator/quartzgroup```: List all groups registered in quartz (group by type : trigger and job).  
  
**Job**:
* ```GET /actuator/quartzjob/```: List all jobs registered in quartz (JobGroup and JobName).
* ```GET /actuator/quartzjob/{group}```: List all jobs for a given group (JobGroup and JobName).
* ```GET /actuator/quartzjob/{group}/{name}```: Get all information of a job (next fired date, data map etc...).
* ```POST /actuator/quartzjob/{group}/{name}```: Pause / Resume a job.
* ```DELETE /actuator/quartzjob/{group}/{name}```: Delete a job from the scheduler.  

**Trigger**:
* ```GET /actuator/quartztrigger/```: List all triggers registered in quartz (Group and Name).
* ```GET /actuator/quartztrigger/{group}```: List all triggers for a given group (Group and Name).
* ```GET /actuator/quartztrigger/{group}/{name}```: Get all information of a trigger (next fired date, state of trigger etc...).
* ```POST /actuator/quartztrigger/{group}/{name}```: Pause / Resume a trigger.
* ```DELETE /actuator/quartzjob/{group}/{name}```: Delete the job link to a trigger from the scheduler.  

Sample: [Actuator](http://jco.ovh:8077/actuator/)

To test it and see the performance, you can use the branch on my fork : [quartz-actuator-bench](https://github.com/JordanCouret/spring-boot/tree/quartz-actuator-bench) - A spring boot quartz application with 30000 jobs create at launch  