### PR TITLE
Use alwaysApplyingWhenNonNull PropertyMapper to set the values in the LdapContextSource

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -55,12 +56,14 @@ public class LdapAutoConfiguration {
 	@ConditionalOnMissingBean
 	public LdapContextSource ldapContextSource() {
 		LdapContextSource source = new LdapContextSource();
-		source.setUserDn(this.properties.getUsername());
-		source.setPassword(this.properties.getPassword());
-		source.setAnonymousReadOnly(this.properties.getAnonymousReadOnly());
-		source.setBase(this.properties.getBase());
-		source.setUrls(this.properties.determineUrls(this.environment));
-		source.setBaseEnvironmentProperties(Collections.unmodifiableMap(this.properties.getBaseEnvironment()));
+		PropertyMapper propertyMapper = PropertyMapper.get().alwaysApplyingWhenNonNull();
+		propertyMapper.from(this.properties.getUsername()).to(source::setUserDn);
+		propertyMapper.from(this.properties.getPassword()).to(source::setPassword);
+		propertyMapper.from(this.properties.getAnonymousReadOnly()).to(source::setAnonymousReadOnly);
+		propertyMapper.from(this.properties.getBase()).to(source::setBase);
+		propertyMapper.from(this.properties.determineUrls(this.environment)).to(source::setUrls);
+		propertyMapper.from(this.properties.getBaseEnvironment()).to(
+				(baseEnvironment) -> source.setBaseEnvironmentProperties(Collections.unmodifiableMap(baseEnvironment)));
 		return source;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfigurationTests.java
@@ -91,6 +91,17 @@ public class LdapAutoConfigurationTests {
 	}
 
 	@Test
+	public void contextSourceWithNoCustomization() {
+		this.contextRunner.run((context) -> {
+			LdapContextSource contextSource = context.getBean(LdapContextSource.class);
+			assertThat(contextSource.getUserDn()).isEqualTo("");
+			assertThat(contextSource.getPassword()).isEqualTo("");
+			assertThat(contextSource.isAnonymousReadOnly()).isFalse();
+			assertThat(contextSource.getBaseLdapPathAsString()).isEqualTo("");
+		});
+	}
+
+	@Test
 	public void templateExists() {
 		this.contextRunner.withPropertyValues("spring.ldap.urls:ldap://localhost:389")
 				.run((context) -> assertThat(context).hasSingleBean(LdapTemplate.class));


### PR DESCRIPTION
The `userDn` and `password` in `LdapContextSource` are not nullable.
The default values for `userDn` and `password` in `LdapProperties` are `null.

When the values are set to null there will eventually be a `NullPointerException`
during `AbstractContextSource#setupAuthenticatedEnvironment` since `HashTable` doesn't allow null for values

I am not sure whether this should be fixed here in spring-boot, or perhaps directly within `LdapContextSource`.



