### PR TITLE
Additional server properties added for Jetty

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -62,6 +62,7 @@ import org.springframework.util.unit.DataSize;
  * @author Andrew McGhie
  * @author Rafiullah Hamedy
  * @author Dirk Deyne
+ * @author HaiTao Zhang
  * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = true)
@@ -905,6 +906,21 @@ public class ServerProperties {
 		 */
 		private Integer selectors = -1;
 
+		/**
+		 * Maximum amount of threads.
+		 */
+		private Integer maxThreads = 200;
+
+		/**
+		 * Minimum amount of threads.
+		 */
+		private Integer minThreads = 8;
+
+		/**
+		 * Maximum thread idle time.
+		 */
+		private Integer idleTimeout = 60000;
+
 		public Accesslog getAccesslog() {
 			return this.accesslog;
 		}
@@ -931,6 +947,30 @@ public class ServerProperties {
 
 		public void setSelectors(Integer selectors) {
 			this.selectors = selectors;
+		}
+
+		public void setMinThreads(Integer minThreads) {
+			this.minThreads = minThreads;
+		}
+
+		public Integer getMinThreads() {
+			return this.minThreads;
+		}
+
+		public void setMaxThreads(Integer maxThreads) {
+			this.maxThreads = maxThreads;
+		}
+
+		public Integer getMaxThreads() {
+			return this.maxThreads;
+		}
+
+		public void setIdleTimeout(Integer idleTimeout) {
+			this.idleTimeout = idleTimeout;
+		}
+
+		public Integer getIdleTimeout() {
+			return this.idleTimeout;
 		}
 
 		/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -74,6 +74,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Quinten De Swaef
  * @author Venil Noronha
  * @author Andrew McGhie
+ * @author HaiTao Zhang
  */
 class ServerPropertiesTests {
 
@@ -216,6 +217,24 @@ class ServerPropertiesTests {
 	void testCustomizeJettySelectors() {
 		bind("server.jetty.selectors", "10");
 		assertThat(this.properties.getJetty().getSelectors()).isEqualTo(10);
+	}
+
+	@Test
+	void testCustomizeJettyMaxThreads() {
+		bind("server.jetty.max-threads", "10");
+		assertThat(this.properties.getJetty().getMaxThreads()).isEqualTo(10);
+	}
+
+	@Test
+	void testCustomizeJettyMinThreads() {
+		bind("server.jetty.min-threads", "10");
+		assertThat(this.properties.getJetty().getMinThreads()).isEqualTo(10);
+	}
+
+	@Test
+	void testCustomizeJettyIdleTimeout() {
+		bind("server.jetty.idle-timeout", "10");
+		assertThat(this.properties.getJetty().getIdleTimeout()).isEqualTo(10);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
@@ -27,6 +27,8 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConfiguration.ConnectionFactory;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.RequestLogWriter;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ThreadPool;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -49,6 +51,7 @@ import static org.mockito.Mockito.verify;
  *
  * @author Brian Clozel
  * @author Phillip Webb
+ * @author HaiTao Zhang
  */
 class JettyWebServerFactoryCustomizerTests {
 
@@ -110,6 +113,36 @@ class JettyWebServerFactoryCustomizerTests {
 		RequestLogWriter logWriter = getLogWriter(requestLog);
 		assertThat(logWriter.getFileName()).isNull();
 		assertThat(logWriter.isAppend()).isFalse();
+	}
+
+	@Test
+	void maxThreadsCanBeCustomized() throws IOException {
+		bind("server.jetty.max-threads=100");
+		JettyWebServer server = customizeAndGetServer();
+		ThreadPool threadPool = server.getServer().getThreadPool();
+		if (threadPool instanceof QueuedThreadPool) {
+			assertThat(((QueuedThreadPool) threadPool).getMaxThreads()).isEqualTo(100);
+		}
+	}
+
+	@Test
+	void minThreadsCanBeCustomized() throws IOException {
+		bind("server.jetty.min-threads=100");
+		JettyWebServer server = customizeAndGetServer();
+		ThreadPool threadPool = server.getServer().getThreadPool();
+		if (threadPool instanceof QueuedThreadPool) {
+			assertThat(((QueuedThreadPool) threadPool).getMinThreads()).isEqualTo(100);
+		}
+	}
+
+	@Test
+	void idleTimeoutCanBeCustomized() throws IOException {
+		bind("server.jetty.idle-timeout=100");
+		JettyWebServer server = customizeAndGetServer();
+		ThreadPool threadPool = server.getServer().getThreadPool();
+		if (threadPool instanceof QueuedThreadPool) {
+			assertThat(((QueuedThreadPool) threadPool).getIdleTimeout()).isEqualTo(100);
+		}
 	}
 
 	private CustomRequestLog getRequestLog(JettyWebServer server) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This is a fix to GitHub issue #5314 which allows for configuration of Jetty's default thread pool, `QueuedThreadPool`,  via the environment. Updated server properties are to include maxThreads, minThreads, and idleTimeout. 



