### PR TITLE
Support multiple drives in CLI's spring script

### DIFF
--- a/spring-boot-project/spring-boot-cli/src/main/executablecontent/bin/spring
+++ b/spring-boot-project/spring-boot-cli/src/main/executablecontent/bin/spring
@@ -18,7 +18,7 @@ case "$(uname)" in
 esac
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched.
-if ${cygwin} ; then
+if $cygwin ; then
 	[ -n "${JAVA_HOME}" ] && JAVA_HOME=$(cygpath --unix "${JAVA_HOME}")
 fi
 
@@ -99,12 +99,14 @@ if [ ! -d "${SPRING_HOME}" ]; then
 	exit 2
 fi
 
-CLASSPATH=.:${SPRING_HOME}/bin
-if [ -d "${SPRING_HOME}/ext" ]; then
-	CLASSPATH=$CLASSPATH:${SPRING_HOME}/ext
+[[ $cygwin ]] && SPRINGPATH=$(cygpath "${SPRING_HOME}") || SPRINGPATH=$SPRING_HOME
+CLASSPATH=.:${SPRINGPATH}/bin
+if [ -d "${SPRINGPATH}/ext" ]; then
+	CLASSPATH=$CLASSPATH:${SPRINGPATH}/ext
 fi
-for f in "${SPRING_HOME}"/lib/*; do
-	CLASSPATH=$CLASSPATH:$f
+for f in "${SPRINGPATH}"/lib/*; do
+	[[ $cygwin ]] && LIBFILE=$(cygpath "$f") || LIBFILE=$f
+	CLASSPATH=$CLASSPATH:$LIBFILE
 done
 
 if $cygwin; then


### PR DESCRIPTION
Hi there,

This PR is to fix an edge case for MinGW and Cygwin users where projects and source files are stored on different drives, causing the Spring Boot CLI to fail on startup. I searched through the Issue log and unfortunately didn't find anything about this so I haven't attached an issue number.

I _originally_ noticed that the Spring Boot CLI wouldn't run on my home PC due to a space in the `SPRING_HOME` folder path (i.e. `C:\Program Files\...`) for the Windows Batch executable script (which unfortunately is not included in the current branch so I've omitted that fix from this PR).

The error message was `Error: Could not find or load main class org.springframework.boot.loader.JarLauncher` and after researching a bit I narrowed it the issue down to two separate problems:

I found the problem to be that the `$CLASSPATH` variable was being parsed incorrectly as my Spring project was stored on a different hard drive, `F:\`, as opposed to my `$SPRING_HOME` folder, `C:\`. Because of this, the part of the Shell script where it assembles the $CLASSPATH variable via `cygpath` would get confused about what the root drive actually is and so I'd end up with a bunch of `/f/` prefixes to each $CLASSPATH folder, which in turn led to the above error message.

To fix this, I added two ternary checks to modify what exactly we're feeding into the `$SPRING_HOME` and `$CLASSPATH` variables before we actually attempt to run the `java -cp` command. Lastly, I also noticed a minor cosmetic consistency thing where `${}` was used in one place and `$` was used in another so I adjusted that to stay consistent. Lastly, the space in the folder path (i.e. `Program Files`) didn't help the situation so I added some double quotes ("") to take care of that edge case as well.

Of course, please test my changes for yourselves and if you think this change is worthy of a merge then I look forward to living the dream of one day seeing that purple icon on my notifications page.



Well, that's my Pull Request! Thanks for reading.