### PR TITLE
Use hasSize() assertion in favor of length checks

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -471,7 +471,7 @@ class RabbitAutoConfigurationTests {
 			RetryPolicy retryPolicy) {
 		Advice[] adviceChain = rabbitListenerContainerFactory.getAdviceChain();
 		assertThat(adviceChain).isNotNull();
-		assertThat(adviceChain.length).isEqualTo(1);
+		assertThat(adviceChain).hasSize(1);
 		Advice advice = adviceChain[0];
 		RetryTemplate retryTemplate = (RetryTemplate) ReflectionTestUtils.getField(advice, "retryOperations");
 		assertThat(retryTemplate).hasFieldOrPropertyWithValue("retryPolicy", retryPolicy);
@@ -533,7 +533,7 @@ class RabbitAutoConfigurationTests {
 		assertThat(containerFactory).hasFieldOrPropertyWithValue("idleEventInterval", 5L);
 		Advice[] adviceChain = containerFactory.getAdviceChain();
 		assertThat(adviceChain).isNotNull();
-		assertThat(adviceChain.length).isEqualTo(1);
+		assertThat(adviceChain).hasSize(1);
 		Advice advice = adviceChain[0];
 		MessageRecoverer messageRecoverer = context.getBean("myMessageRecoverer", MessageRecoverer.class);
 		MethodInvocationRecoverer<?> mir = (MethodInvocationRecoverer<?>) ReflectionTestUtils.getField(advice,

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfigurationTests.java
@@ -64,7 +64,7 @@ class CassandraDataAutoConfigurationTests {
 	@Test
 	void templateExists() {
 		load(TestExcludeConfiguration.class);
-		assertThat(this.context.getBeanNamesForType(CassandraTemplate.class).length).isEqualTo(1);
+		assertThat(this.context.getBeanNamesForType(CassandraTemplate.class)).hasSize(1);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchAutoConfigurationTests.java
@@ -69,7 +69,7 @@ class ElasticsearchAutoConfigurationTests {
 		this.context.register(CustomConfiguration.class, PropertyPlaceholderAutoConfiguration.class,
 				ElasticsearchAutoConfiguration.class);
 		this.context.refresh();
-		assertThat(this.context.getBeanNamesForType(Client.class).length).isEqualTo(1);
+		assertThat(this.context.getBeanNamesForType(Client.class)).hasSize(1);
 		assertThat(this.context.getBean("myClient")).isSameAs(this.context.getBean(Client.class));
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisAutoConfigurationTests.java
@@ -376,7 +376,7 @@ class ArtemisAutoConfigurationTests {
 	private TransportConfiguration getSingleTransportConfiguration(ActiveMQConnectionFactory connectionFactory) {
 		TransportConfiguration[] transportConfigurations = connectionFactory.getServerLocator()
 				.getStaticTransportConfigurations();
-		assertThat(transportConfigurations.length).isEqualTo(1);
+		assertThat(transportConfigurations).hasSize(1);
 		return transportConfigurations[0];
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisEmbeddedConfigurationFactoryTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisEmbeddedConfigurationFactoryTests.java
@@ -59,7 +59,7 @@ class ArtemisEmbeddedConfigurationFactoryTests {
 	void generatedClusterPassword() {
 		ArtemisProperties properties = new ArtemisProperties();
 		Configuration configuration = new ArtemisEmbeddedConfigurationFactory(properties).createConfiguration();
-		assertThat(configuration.getClusterPassword().length()).isEqualTo(36);
+		assertThat(configuration.getClusterPassword()).hasSize(36);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfigurationTests.java
@@ -122,13 +122,13 @@ class JooqAutoConfigurationTests {
 					assertThat(dsl.configuration().recordUnmapperProvider().getClass())
 							.isEqualTo(TestRecordUnmapperProvider.class);
 					assertThat(dsl.configuration().executorProvider().getClass()).isEqualTo(TestExecutorProvider.class);
-					assertThat(dsl.configuration().recordListenerProviders().length).isEqualTo(1);
+					assertThat(dsl.configuration().recordListenerProviders()).hasSize(1);
 					ExecuteListenerProvider[] executeListenerProviders = dsl.configuration().executeListenerProviders();
-					assertThat(executeListenerProviders.length).isEqualTo(2);
+					assertThat(executeListenerProviders).hasSize(2);
 					assertThat(executeListenerProviders[0]).isInstanceOf(DefaultExecuteListenerProvider.class);
 					assertThat(executeListenerProviders[1]).isInstanceOf(TestExecuteListenerProvider.class);
-					assertThat(dsl.configuration().visitListenerProviders().length).isEqualTo(1);
-					assertThat(dsl.configuration().transactionListenerProviders().length).isEqualTo(1);
+					assertThat(dsl.configuration().visitListenerProviders()).hasSize(1);
+					assertThat(dsl.configuration().transactionListenerProviders()).hasSize(1);
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/embedded/EmbeddedLdapAutoConfigurationTests.java
@@ -108,7 +108,7 @@ class EmbeddedLdapAutoConfigurationTests {
 	void testQueryEmbeddedLdap() {
 		this.contextRunner.withPropertyValues("spring.ldap.embedded.base-dn:dc=spring,dc=org")
 				.withConfiguration(AutoConfigurations.of(LdapAutoConfiguration.class)).run((context) -> {
-					assertThat(context.getBeanNamesForType(LdapTemplate.class).length).isEqualTo(1);
+					assertThat(context).hasSingleBean(LdapTemplate.class);
 					LdapTemplate ldapTemplate = context.getBean(LdapTemplate.class);
 					assertThat(ldapTemplate.list("ou=company1,c=Sweden,dc=spring,dc=org")).hasSize(4);
 				});

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
@@ -91,7 +91,7 @@ class JettyWebServerFactoryCustomizerTests {
 		JettyWebServer server = customizeAndGetServer();
 		CustomRequestLog requestLog = getRequestLog(server);
 		assertThat(requestLog.getFormatString()).isEqualTo(CustomRequestLog.EXTENDED_NCSA_FORMAT);
-		assertThat(requestLog.getIgnorePaths().length).isEqualTo(2);
+		assertThat(requestLog.getIgnorePaths()).hasSize(2);
 		assertThat(requestLog.getIgnorePaths()).containsExactly("/a/path", "/b/path");
 		RequestLogWriter logWriter = getLogWriter(requestLog);
 		assertThat(logWriter.getFileName()).isEqualTo(logFile.getAbsolutePath());

--- a/spring-boot-project/spring-boot-cli/src/test/java/org/springframework/boot/cli/compiler/grape/AetherGrapeEngineTests.java
+++ b/spring-boot-project/spring-boot-cli/src/test/java/org/springframework/boot/cli/compiler/grape/AetherGrapeEngineTests.java
@@ -108,7 +108,7 @@ class AetherGrapeEngineTests {
 				createDependency("org.springframework", "spring-jdbc", "3.2.4.RELEASE"),
 				createDependency("org.springframework", "spring-beans", "3.2.4.RELEASE"));
 
-		assertThat(this.groovyClassLoader.getURLs().length).isEqualTo(3);
+		assertThat(this.groovyClassLoader.getURLs()).hasSize(3);
 	}
 
 	@Test
@@ -117,7 +117,7 @@ class AetherGrapeEngineTests {
 
 		createGrapeEngine().grab(args, createDependency("org.springframework", "spring-jdbc", "3.2.4.RELEASE", false));
 
-		assertThat(this.groovyClassLoader.getURLs().length).isEqualTo(1);
+		assertThat(this.groovyClassLoader.getURLs()).hasSize(1);
 	}
 
 	@Test
@@ -129,8 +129,8 @@ class AetherGrapeEngineTests {
 		createGrapeEngine(this.springMilestones).grab(args,
 				createDependency("org.springframework", "spring-jdbc", null));
 
-		assertThat(this.groovyClassLoader.getURLs().length).isEqualTo(0);
-		assertThat(customClassLoader.getURLs().length).isEqualTo(5);
+		assertThat(this.groovyClassLoader.getURLs()).isEmpty();
+		assertThat(customClassLoader.getURLs()).hasSize(5);
 	}
 
 	@Test
@@ -142,7 +142,7 @@ class AetherGrapeEngineTests {
 				"0.1.1.RELEASE");
 		dependency.put("ext", "zip");
 		grapeEngine.grab(args, dependency);
-		assertThat(this.groovyClassLoader.getURLs().length).isEqualTo(1);
+		assertThat(this.groovyClassLoader.getURLs()).hasSize(1);
 	}
 
 	@Test
@@ -162,7 +162,7 @@ class AetherGrapeEngineTests {
 		dependency.put("type", "pom");
 		createGrapeEngine().grab(args, dependency);
 		URL[] urls = this.groovyClassLoader.getURLs();
-		assertThat(urls.length).isEqualTo(1);
+		assertThat(urls).hasSize(1);
 		assertThat(urls[0].toExternalForm().endsWith(".pom")).isTrue();
 	}
 
@@ -174,7 +174,7 @@ class AetherGrapeEngineTests {
 		dependency.put("ext", "pom");
 		createGrapeEngine().grab(args, dependency);
 		URL[] urls = this.groovyClassLoader.getURLs();
-		assertThat(urls.length).isEqualTo(1);
+		assertThat(urls).hasSize(1);
 		assertThat(urls[0].toExternalForm().endsWith(".pom")).isTrue();
 	}
 
@@ -187,7 +187,7 @@ class AetherGrapeEngineTests {
 		createGrapeEngine().grab(args, dependency);
 
 		URL[] urls = this.groovyClassLoader.getURLs();
-		assertThat(urls.length).isEqualTo(1);
+		assertThat(urls).hasSize(1);
 		assertThat(urls[0].toExternalForm().endsWith("-sources.jar")).isTrue();
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/livereload/FrameTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/livereload/FrameTests.java
@@ -75,7 +75,7 @@ class FrameTests {
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		frame.write(bos);
 		byte[] bytes = bos.toByteArray();
-		assertThat(bytes.length).isEqualTo(130);
+		assertThat(bytes).hasSize(130);
 		assertThat(bytes[0]).isEqualTo((byte) 0x81);
 		assertThat(bytes[1]).isEqualTo((byte) 0x7E);
 		assertThat(bytes[2]).isEqualTo((byte) 0x00);

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/web/SpringBootMockServletContextTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/web/SpringBootMockServletContextTests.java
@@ -35,7 +35,6 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.web.context.ServletContextAware;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Tests for {@link SpringBootMockServletContext}.
@@ -81,12 +80,12 @@ class SpringBootMockServletContextTests implements ServletContextAware {
 			}
 		};
 		URL resource = context.getResource("/");
-		assertThat(resource).isNotEqualTo(nullValue());
+		assertThat(resource).isNotNull();
 		File file = new File(URLDecoder.decode(resource.getPath(), "UTF-8"));
 		assertThat(file).exists().isDirectory();
 		String[] contents = file.list((dir, name) -> !(".".equals(name) || "..".equals(name)));
-		assertThat(contents).isNotEqualTo(nullValue());
-		assertThat(contents.length).isEqualTo(0);
+		assertThat(contents).isNotNull();
+		assertThat(contents).isEmpty();
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/RepackagerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/RepackagerTests.java
@@ -296,7 +296,7 @@ class RepackagerTests {
 		assertThat(entry.getTime()).isEqualTo(JAN_1_1985);
 		entry = getEntry(file, "BOOT-INF/lib/" + libJarFileToUnpack.getName());
 		assertThat(entry.getComment()).startsWith("UNPACK:");
-		assertThat(entry.getComment().length()).isEqualTo(47);
+		assertThat(entry.getComment()).hasSize(47);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/RunArgumentsTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/RunArgumentsTests.java
@@ -31,14 +31,14 @@ class RunArgumentsTests {
 	void parseNull() {
 		String[] args = parseArgs(null);
 		assertThat(args).isNotNull();
-		assertThat(args.length).isEqualTo(0);
+		assertThat(args).isEmpty();
 	}
 
 	@Test
 	void parseNullArray() {
 		String[] args = new RunArguments((String[]) null).asArray();
 		assertThat(args).isNotNull();
-		assertThat(args.length).isEqualTo(0);
+		assertThat(args).isEmpty();
 	}
 
 	@Test
@@ -59,13 +59,13 @@ class RunArgumentsTests {
 	void parseEmpty() {
 		String[] args = parseArgs("   ");
 		assertThat(args).isNotNull();
-		assertThat(args.length).isEqualTo(0);
+		assertThat(args).isEmpty();
 	}
 
 	@Test
 	void parseDebugFlags() {
 		String[] args = parseArgs("-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005");
-		assertThat(args.length).isEqualTo(2);
+		assertThat(args).hasSize(2);
 		assertThat(args[0]).isEqualTo("-Xdebug");
 		assertThat(args[1]).isEqualTo("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005");
 	}
@@ -73,7 +73,7 @@ class RunArgumentsTests {
 	@Test
 	void parseWithExtraSpaces() {
 		String[] args = parseArgs("     -Dfoo=bar        -Dfoo2=bar2  ");
-		assertThat(args.length).isEqualTo(2);
+		assertThat(args).hasSize(2);
 		assertThat(args[0]).isEqualTo("-Dfoo=bar");
 		assertThat(args[1]).isEqualTo("-Dfoo2=bar2");
 	}
@@ -81,7 +81,7 @@ class RunArgumentsTests {
 	@Test
 	void parseWithNewLinesAndTabs() {
 		String[] args = parseArgs("     -Dfoo=bar \n\t\t -Dfoo2=bar2  ");
-		assertThat(args.length).isEqualTo(2);
+		assertThat(args).hasSize(2);
 		assertThat(args[0]).isEqualTo("-Dfoo=bar");
 		assertThat(args[1]).isEqualTo("-Dfoo2=bar2");
 	}
@@ -89,7 +89,7 @@ class RunArgumentsTests {
 	@Test
 	void quoteHandledProperly() {
 		String[] args = parseArgs("-Dvalue=\"My Value\"    ");
-		assertThat(args.length).isEqualTo(1);
+		assertThat(args).hasSize(1);
 		assertThat(args[0]).isEqualTo("-Dvalue=My Value");
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/ImageBannerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/ImageBannerTests.java
@@ -165,7 +165,7 @@ class ImageBannerTests {
 		int frames = 138;
 		int linesPerFrame = 36;
 		assertThat(banner).contains("\r");
-		assertThat(lines.length).isEqualTo(frames * linesPerFrame - 1);
+		assertThat(lines).hasSize(frames * linesPerFrame - 1);
 	}
 
 	private int getBannerHeight(String banner) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/TomcatReactiveWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/TomcatReactiveWebServerFactoryTests.java
@@ -185,7 +185,7 @@ class TomcatReactiveWebServerFactoryTests extends AbstractReactiveWebServerFacto
 		factory.addAdditionalTomcatConnectors(connectors);
 		this.webServer = factory.getWebServer(mock(HttpHandler.class));
 		Map<Service, Connector[]> connectorsByService = ((TomcatWebServer) this.webServer).getServiceConnectors();
-		assertThat(connectorsByService.values().iterator().next().length).isEqualTo(connectors.length + 1);
+		assertThat(connectorsByService.values().iterator().next()).hasSize(connectors.length + 1);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactoryTests.java
@@ -225,7 +225,7 @@ class TomcatServletWebServerFactoryTests extends AbstractServletWebServerFactory
 		factory.addAdditionalTomcatConnectors(connectors);
 		this.webServer = factory.getWebServer();
 		Map<Service, Connector[]> connectorsByService = ((TomcatWebServer) this.webServer).getServiceConnectors();
-		assertThat(connectorsByService.values().iterator().next().length).isEqualTo(connectors.length + 1);
+		assertThat(connectorsByService.values().iterator().next()).hasSize(connectors.length + 1);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
@@ -665,7 +665,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 		getResponse(getLocalUrl("/session"));
 		this.webServer.stop();
 		File[] dirContents = sessionStoreDir.listFiles((dir, name) -> !(".".equals(name) || "..".equals(name)));
-		assertThat(dirContents.length).isGreaterThan(0);
+		assertThat(dirContents).isNotEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
Hi,

this PR polishes code snippets like the following:

`assertThat(something.length).isEqualTo(1);`

to make use of shorter and arguably cleaner assertions like `hasSize()` etc.:

`assertThat(something).hasSize(1);`

Cheers,
Christoph
 