### PR TITLE
Use a configurable location to load global Devtools settings

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsHomePropertiesPostProcessor.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsHomePropertiesPostProcessor.java
@@ -44,7 +44,7 @@ public class DevToolsHomePropertiesPostProcessor implements EnvironmentPostProce
 	@Override
 	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
 		if (DevToolsEnablementDeducer.shouldEnable(Thread.currentThread())) {
-			File home = getHomeFolder();
+			File home = getProjectRootFolder();
 			File propertyFile = (home != null) ? new File(home, FILE_NAME) : null;
 			if (propertyFile != null && propertyFile.exists() && propertyFile.isFile()) {
 				FileSystemResource resource = new FileSystemResource(propertyFile);
@@ -59,6 +59,17 @@ public class DevToolsHomePropertiesPostProcessor implements EnvironmentPostProce
 				}
 			}
 		}
+	}
+
+	protected File getProjectRootFolder() {
+		String rootFolder = System.getenv("PROJECT_ROOT_FOLDER");
+		if (rootFolder == null) {
+			rootFolder = System.getProperty("PROJECT_ROOT_FOLDER");
+		}
+		if (StringUtils.hasLength(rootFolder)) {
+			return new File(rootFolder);
+		}
+		return getHomeFolder();
 	}
 
 	protected File getHomeFolder() {

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/env/DevToolsHomePropertiesPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/env/DevToolsHomePropertiesPostProcessorTests.java
@@ -41,9 +41,26 @@ class DevToolsHomePropertiesPostProcessorTests {
 
 	private File home;
 
+	private File rootDir;
+
 	@BeforeEach
-	void setup(@TempDir File tempDir) throws IOException {
+	void setup(@TempDir File tempDir, @TempDir File rootDir) throws IOException {
 		this.home = tempDir;
+		this.rootDir = rootDir;
+	}
+
+	@Test
+	void loadsRootFolderProperties() throws Exception {
+		System.setProperty("PROJECT_ROOT_FOLDER", rootDir.getAbsolutePath());
+		Properties properties = new Properties();
+		properties.put("uvw", "xyz");
+		OutputStream out = new FileOutputStream(new File(this.rootDir, ".spring-boot-devtools.properties"));
+		properties.store(out, null);
+		out.close();
+		ConfigurableEnvironment environment = new MockEnvironment();
+		MockDevToolHomePropertiesPostProcessor postProcessor = new MockDevToolHomePropertiesPostProcessor();
+		runPostProcessor(() -> postProcessor.postProcessEnvironment(environment, null));
+		assertThat(environment.getProperty("uvw")).isEqualTo("xyz");
 	}
 
 	@Test


### PR DESCRIPTION
This allows separate projects to keep their own settings where common settings
such as spring.* or server.* don't conflict.

https://github.com/spring-projects/spring-boot/issues/17923

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
