### PR TITLE
Additional sanitization for URI being exposed over Endpoints

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.context.properties;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Dave Syer
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author HaiTao Zhang
  */
 class ConfigurationPropertiesReportEndpointTests {
 
@@ -175,6 +177,22 @@ class ConfigurationPropertiesReportEndpointTests {
 	}
 
 	@Test
+	void sanitizedUriWithSensitiveInfo() {
+		load((context, properties) -> {
+			Map<String, Object> nestedProperties = properties.getBeans().get("testProperties").getProperties();
+			assertThat(nestedProperties.get("sensitiveUri")).isEqualTo("http://user:******@localhost:8080");
+		});
+	}
+
+	@Test
+	void sanitizedUriWithNoPassword() {
+		load((context, properties) -> {
+			Map<String, Object> nestedProperties = properties.getBeans().get("testProperties").getProperties();
+			assertThat(nestedProperties.get("noPasswordUri")).isEqualTo("http://user:******@localhost:8080");
+		});
+	}
+
+	@Test
 	@SuppressWarnings("unchecked")
 	void listsOfListsAreSanitized() {
 		load((context, properties) -> {
@@ -265,6 +283,10 @@ class ConfigurationPropertiesReportEndpointTests {
 		private String nullValue = null;
 
 		private Duration duration = Duration.ofSeconds(10);
+
+		private URI sensitiveUri = URI.create("http://user:password@localhost:8080");
+
+		private URI noPasswordUri = URI.create("http://user:p@localhost:8080");
 
 		TestProperties() {
 			this.secrets.put("mine", "myPrivateThing");
@@ -375,6 +397,22 @@ class ConfigurationPropertiesReportEndpointTests {
 
 		public void setDuration(Duration duration) {
 			this.duration = duration;
+		}
+
+		public void setSensitiveUri(URI sensitiveUri) {
+			this.sensitiveUri = sensitiveUri;
+		}
+
+		public URI getSensitiveUri() {
+			return this.sensitiveUri;
+		}
+
+		public void setNoPasswordUri(URI noPasswordUri) {
+			this.noPasswordUri = noPasswordUri;
+		}
+
+		public URI getNoPasswordUri() {
+			return this.noPasswordUri;
 		}
 
 		public static class Hidden {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/SanitizerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/SanitizerTests.java
@@ -40,6 +40,8 @@ class SanitizerTests {
 		assertThat(sanitizer.sanitize("sometoken", "secret")).isEqualTo("******");
 		assertThat(sanitizer.sanitize("find", "secret")).isEqualTo("secret");
 		assertThat(sanitizer.sanitize("sun.java.command", "--spring.redis.password=pa55w0rd")).isEqualTo("******");
+		assertThat(sanitizer.sanitize("my.uri", "http://user:password@localhost:8080"))
+				.isEqualTo("http://user:******@localhost:8080");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/env/EnvironmentEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/env/EnvironmentEndpointTests.java
@@ -49,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Stephane Nicoll
  * @author Madhura Bhave
  * @author Andy Wilkinson
+ * @author HaiTao Zhang
  */
 class EnvironmentEndpointTests {
 
@@ -242,6 +243,14 @@ class EnvironmentEndpointTests {
 		assertThat(sources.keySet()).containsExactly("two", "one");
 		assertThat(sources.get("one").getProperties().get("a").getValue()).isEqualTo("alpha");
 		assertThat(sources.get("two").getProperties().get("a").getValue()).isEqualTo("apple");
+	}
+
+	@Test
+	void uriPropertryWithSensitiveInfo() {
+		ConfigurableEnvironment environment = new StandardEnvironment();
+		TestPropertyValues.of("sensitive.uri=http://user:password@localhost:8080").applyTo(environment);
+		EnvironmentEntryDescriptor descriptor = new EnvironmentEndpoint(environment).environmentEntry("sensitive.uri");
+		assertThat(descriptor.getProperty().getValue()).isEqualTo("http://user:******@localhost:8080");
 	}
 
 	private static ConfigurableEnvironment emptyEnvironment() {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This is a fix to GitHub issue #8293 and #17930  . Additional sanitization was added for URI properties that take on the form of `<scheme>://<user>:<password>@<host>:<port>/`. Functionality was added to `Sanitizer` to help sanitize the password specifically and not allowing it to be exposed over `EnvironmentEndpoint` and `ConfigurationPropertiesReportEndpoint`.