### PR TITLE
Spring Boot CLI is unable to always capture ctrl-c

### DIFF
--- a/spring-boot-project/spring-boot-cli/src/main/executablecontent/bin/spring
+++ b/spring-boot-project/spring-boot-cli/src/main/executablecontent/bin/spring
@@ -113,4 +113,4 @@ if $cygwin; then
 fi
 
 IFS=" " read -r -a javaOpts <<< "$JAVA_OPTS"
-"${JAVA_HOME}/bin/java" "${javaOpts[@]}" -cp "$CLASSPATH" org.springframework.boot.loader.JarLauncher "$@"
+exec "${JAVA_HOME}/bin/java" "${javaOpts[@]}" -cp "$CLASSPATH" org.springframework.boot.loader.JarLauncher "$@"


### PR DESCRIPTION
Previously, when the Spring Boot CLI ran the Java command line for an application it did a straight invocation which suppressed propagation of signals to the JVM in certain circumstances (e.g. within Docker containers).

This change prepends the command with `exec` which causes the Java process to replace the script process in a shell ensuring that signals are propagated to the Java process without suppression.