### PR TITLE
RestTemplateExchangeTags does not handle non-standard status codes

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/client/RestTemplateExchangeTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/client/RestTemplateExchangeTags.java
@@ -18,6 +18,9 @@ package org.springframework.boot.actuate.metrics.web.client;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import io.micrometer.core.instrument.Tag;
@@ -53,6 +56,18 @@ public final class RestTemplateExchangeTags {
 	private static final Tag OUTCOME_CLIENT_ERROR = Tag.of("outcome", "CLIENT_ERROR");
 
 	private static final Tag OUTCOME_SERVER_ERROR = Tag.of("outcome", "SERVER_ERROR");
+
+	private static final Map<HttpStatus.Series, Tag> SERIES_OUTCOMES;
+
+	static {
+		Map<HttpStatus.Series, Tag> seriesOutcomes = new HashMap<>();
+		seriesOutcomes.put(HttpStatus.Series.INFORMATIONAL, OUTCOME_INFORMATIONAL);
+		seriesOutcomes.put(HttpStatus.Series.SUCCESSFUL, OUTCOME_SUCCESS);
+		seriesOutcomes.put(HttpStatus.Series.REDIRECTION, OUTCOME_REDIRECTION);
+		seriesOutcomes.put(HttpStatus.Series.CLIENT_ERROR, OUTCOME_CLIENT_ERROR);
+		seriesOutcomes.put(HttpStatus.Series.SERVER_ERROR, OUTCOME_SERVER_ERROR);
+		SERIES_OUTCOMES = Collections.unmodifiableMap(seriesOutcomes);
+	}
 
 	private RestTemplateExchangeTags() {
 	}
@@ -132,7 +147,7 @@ public final class RestTemplateExchangeTags {
 
 	/**
 	 * Creates an {@code outcome} {@code Tag} derived from the
-	 * {@link ClientHttpResponse#getStatusCode() status} of the given {@code response}.
+	 * {@link ClientHttpResponse#getRawStatusCode() status} of the given {@code response}.
 	 * @param response the response
 	 * @return the outcome tag
 	 * @since 2.2.0
@@ -140,28 +155,16 @@ public final class RestTemplateExchangeTags {
 	public static Tag outcome(ClientHttpResponse response) {
 		try {
 			if (response != null) {
-				HttpStatus statusCode = response.getStatusCode();
-				if (statusCode.is1xxInformational()) {
-					return OUTCOME_INFORMATIONAL;
-				}
-				if (statusCode.is2xxSuccessful()) {
-					return OUTCOME_SUCCESS;
-				}
-				if (statusCode.is3xxRedirection()) {
-					return OUTCOME_REDIRECTION;
-				}
-				if (statusCode.is4xxClientError()) {
-					return OUTCOME_CLIENT_ERROR;
-				}
-				if (statusCode.is5xxServerError()) {
-					return OUTCOME_SERVER_ERROR;
+				HttpStatus.Series series = HttpStatus.Series.resolve(response.getRawStatusCode());
+				if (series != null) {
+					return SERIES_OUTCOMES.getOrDefault(series, OUTCOME_UNKNOWN);
 				}
 			}
-			return OUTCOME_UNKNOWN;
 		}
 		catch (IOException | IllegalArgumentException ex) {
-			return OUTCOME_UNKNOWN;
+			// Continue
 		}
+		return OUTCOME_UNKNOWN;
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/client/WebClientExchangeTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/client/WebClientExchangeTags.java
@@ -140,7 +140,7 @@ public final class WebClientExchangeTags {
 
 	/**
 	 * Creates an {@code outcome} {@code Tag} derived from the
-	 * {@link ClientResponse#statusCode() status} of the given {@code response}.
+	 * {@link ClientResponse#rawStatusCode() status} of the given {@code response}.
 	 * @param response the response
 	 * @return the outcome tag
 	 * @since 2.2.0
@@ -154,7 +154,7 @@ public final class WebClientExchangeTags {
 				}
 			}
 		}
-		catch (IllegalArgumentException exc) {
+		catch (IllegalArgumentException ex) {
 			// Continue
 		}
 		return OUTCOME_UNKNOWN;

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/client/RestTemplateExchangeTagsTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/client/RestTemplateExchangeTagsTests.java
@@ -81,7 +81,7 @@ class RestTemplateExchangeTagsTests {
 	@Test
 	void outcomeTagIsUnknownWhenResponseThrowsIOException() throws Exception {
 		ClientHttpResponse response = mock(ClientHttpResponse.class);
-		given(response.getStatusCode()).willThrow(IOException.class);
+		given(response.getRawStatusCode()).willThrow(IOException.class);
 		Tag tag = RestTemplateExchangeTags.outcome(response);
 		assertThat(tag.getValue()).isEqualTo("UNKNOWN");
 	}
@@ -89,7 +89,23 @@ class RestTemplateExchangeTagsTests {
 	@Test
 	void outcomeTagIsUnknownForCustomResponseStatus() throws Exception {
 		ClientHttpResponse response = mock(ClientHttpResponse.class);
-		given(response.getStatusCode()).willThrow(IllegalArgumentException.class);
+		given(response.getRawStatusCode()).willThrow(IllegalArgumentException.class);
+		Tag tag = RestTemplateExchangeTags.outcome(response);
+		assertThat(tag.getValue()).isEqualTo("UNKNOWN");
+	}
+
+	@Test
+	void outcomeTagIsClientErrorWhenResponseIsNonStandardInKnownSeries() throws IOException {
+		ClientHttpResponse response = mock(ClientHttpResponse.class);
+		given(response.getRawStatusCode()).willReturn(490);
+		Tag tag = RestTemplateExchangeTags.outcome(response);
+		assertThat(tag.getValue()).isEqualTo("CLIENT_ERROR");
+	}
+
+	@Test
+	void outcomeTagIsUnknownWhenResponseStatusIsInUnknownSeries() throws IOException {
+		ClientHttpResponse response = mock(ClientHttpResponse.class);
+		given(response.getRawStatusCode()).willReturn(701);
 		Tag tag = RestTemplateExchangeTags.outcome(response);
 		assertThat(tag.getValue()).isEqualTo("UNKNOWN");
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/client/WebClientExchangeTagsTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/client/WebClientExchangeTagsTests.java
@@ -148,7 +148,7 @@ class WebClientExchangeTagsTests {
 	}
 
 	@Test
-	void outcomeTagIsServerErrorWhenResponseIsNonStandardInKnownSeries() {
+	void outcomeTagIsClientErrorWhenResponseIsNonStandardInKnownSeries() {
 		given(this.response.rawStatusCode()).willReturn(490);
 		Tag tag = WebClientExchangeTags.outcome(this.response);
 		assertThat(tag.getValue()).isEqualTo("CLIENT_ERROR");


### PR DESCRIPTION
This PR applies changes similar to gh-17695 but for `RestTemplate`.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
