### PR TITLE
Improve handling of non-standard status codes in WebMvcTags

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcTags.java
@@ -175,22 +175,21 @@ public final class WebMvcTags {
 	 */
 	public static Tag outcome(HttpServletResponse response) {
 		if (response != null) {
-			HttpStatus status = extractStatus(response);
-			if (status != null) {
-				if (status.is1xxInformational()) {
+			HttpStatus.Series series = HttpStatus.Series.resolve(response.getStatus());
+			if (series != null) {
+				switch (series) {
+				case INFORMATIONAL:
 					return OUTCOME_INFORMATIONAL;
-				}
-				if (status.is2xxSuccessful()) {
+				case SUCCESSFUL:
 					return OUTCOME_SUCCESS;
-				}
-				if (status.is3xxRedirection()) {
+				case REDIRECTION:
 					return OUTCOME_REDIRECTION;
-				}
-				if (status.is4xxClientError()) {
+				case CLIENT_ERROR:
 					return OUTCOME_CLIENT_ERROR;
+				case SERVER_ERROR:
+					return OUTCOME_SERVER_ERROR;
 				}
 			}
-			return OUTCOME_SERVER_ERROR;
 		}
 		return OUTCOME_UNKNOWN;
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcTagsTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcTagsTests.java
@@ -137,10 +137,24 @@ class WebMvcTagsTests {
 	}
 
 	@Test
+	void outcomeTagIsClientErrorWhenResponseIsNonStandardInClientSeries() {
+		this.response.setStatus(490);
+		Tag tag = WebMvcTags.outcome(this.response);
+		assertThat(tag.getValue()).isEqualTo("CLIENT_ERROR");
+	}
+
+	@Test
 	void outcomeTagIsServerErrorWhenResponseIs5xx() {
 		this.response.setStatus(500);
 		Tag tag = WebMvcTags.outcome(this.response);
 		assertThat(tag.getValue()).isEqualTo("SERVER_ERROR");
+	}
+
+	@Test
+	void outcomeTagIsUnknownWhenResponseStatusIsInUnknownSeries() {
+		this.response.setStatus(701);
+		Tag tag = WebMvcTags.outcome(this.response);
+		assertThat(tag.getValue()).isEqualTo("UNKNOWN");
 	}
 
 }


### PR DESCRIPTION
Hi,

funny enough #17991 reminded me of a similar branch I was working on, but forgot. The changes in this PR align the handling of non-standard status codes in `WebMvcTags` with the latest changes to `WebClientExchangeTags` and now `RestTemplateExchangeTags`. More specifically the more lenient handling of responses with status codes like 490 inside their respective `outcome()` methods.

I wanted to change `WebFluxTags` accordingly, but since `ServerHttpResponse` doesn't expose an API to access the raw status code I didn't see a good way of doing so. `WebFluxTags` additionally returns `HttpStatus.OK` in case of unknown codes inside `WebFluxTags#status()`, which seems questionable. Usually, an unknown status code indicates situations where `OK` isn't appropriate.

With this PR we end up with the following handling at least.

| Class/Method | Status 490 | Status 701 |
| ----- | ----------- | ----------- |
| RestTemplateExchangeTags#status() | 490 | 701 |
| WebClientExchangeTags#status() | 490 | 701 |
| WebMvcTags#status() | 490 | 701 |
| WebFluxTags#status() | 200 | 200 |
| RestTemplateExchangeTags#outcome() | CLIENT_ERROR | UNKNOWN |
| WebClientExchangeTags#outcome() | CLIENT_ERROR | UNKNOWN |
| **WebMvcTags#outcome()** | **CLIENT_ERROR (previously UNKNOWN)** | UNKNOWN |
| WebFluxTags#outcome() | UNKNOWN | UNKNOWN |

Let me know what you think.
Cheers,
Christoph