### PR TITLE
Upgrade to Jooq 3.12.0

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqExceptionTranslatorTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqExceptionTranslatorTests.java
@@ -62,9 +62,6 @@ class JooqExceptionTranslatorTests {
 				new Object[] { SQLDialect.MARIADB, sqlException(1054) },
 				new Object[] { SQLDialect.MYSQL, sqlException(1054) },
 				new Object[] { SQLDialect.POSTGRES, sqlException("03000") },
-				new Object[] { SQLDialect.POSTGRES_9_3, sqlException("03000") },
-				new Object[] { SQLDialect.POSTGRES_9_4, sqlException("03000") },
-				new Object[] { SQLDialect.POSTGRES_9_5, sqlException("03000") },
 				new Object[] { SQLDialect.SQLITE, sqlException("21000") } };
 	}
 

--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -134,7 +134,7 @@
 		<!-- Deprecated in favor of "johnzon.version" -->
 		<johnzon-jsonb.version>1.1.13</johnzon-jsonb.version>
 		<johnzon.version>${johnzon-jsonb.version}</johnzon.version>
-		<jooq.version>3.11.11</jooq.version>
+		<jooq.version>3.12.0</jooq.version>
 		<jsonassert.version>1.5.0</jsonassert.version>
 		<json-path.version>2.4.0</json-path.version>
 		<jstl.version>1.2</jstl.version>


### PR DESCRIPTION
This version supports the reactive api (still relying for now on JDBC) which is pretty good for webflux / reactor usage. The supports of Java 11 is also complete in this version 🎉 (https://blog.jooq.org/2019/08/29/jooq-3-12-released-with-a-new-procedural-language-api/)

I've made the PR because this dependency upgrade leads to a complete removal of `SQLDialect` for `POSTGRES_9_3`, `POSTGRES_9_4` and `POSTGRES_9_5`.
