### PR TITLE
Remove reference to non-existent --edit option in CLI docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-cli.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-cli.adoc
@@ -48,8 +48,6 @@ You can type `spring help` to get more details about any of the supported comman
 	--autoconfigure [Boolean]  Add autoconfigure compiler
 	                             transformations (default: true)
 	--classpath, -cp           Additional classpath entries
-	-e, --edit                 Open the file with the default system
-	                             editor
 	--no-guess-dependencies    Do not attempt to guess dependencies
 	--no-guess-imports         Do not attempt to guess imports
 	-q, --quiet                Quiet logging


### PR DESCRIPTION
Hi,

I just noticed that the docs mention `--edit` as an option to the CLI command `spring run`. This option is long gone as it seems. See #611

Cheers,
Christoph