### PR TITLE
Remove duplicated dependency in spring-boot-docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/pom.xml
+++ b/spring-boot-project/spring-boot-docs/pom.xml
@@ -1005,11 +1005,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.data</groupId>
-			<artifactId>spring-data-jdbc</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-jpa</artifactId>
 			<optional>true</optional>
 		</dependency>


### PR DESCRIPTION
Hi,

I noticed while working on other PRs that running `mvn checkstyle:check@checkstyle-validation` (for example) prints a warning about a duplicated dependency:
```
[WARNING] Some problems were encountered while building the effective model for org.springframework.boot:spring-boot-docs:jar:2.2.0.BUILD-SNAPSHOT

[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.springframework.data:spring-data-jdbc:jar -> duplicate declaration of version (?) @ org.springframework.boot:spring-boot-docs:[unknown-version], ..\spring-boot\spring-boot-project\spring-boot-docs\pom.xml, line 1006, column 15
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```

Commit 368eb566fb0d62ffedbd37ad42cf1ec18eeb7371 seems to have introduced it, but I doubt it was on purpose, so this PR is an attempt to get rid of the warning again.

Cheers,
Christoph