### PR TITLE
Detect JDK 13 updates

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -213,6 +213,15 @@ jobs:
         GITHUB_USERNAME: ((github-username))
         JDK_VERSION: java12
       image: spring-boot-ci-image
+    - task: detect-jdk13-update
+      file: git-repo/ci/tasks/detect-jdk-updates.yml
+      params:
+        GITHUB_REPO: spring-boot
+        GITHUB_ORGANIZATION: spring-projects
+        GITHUB_PASSWORD: ((github-password))
+        GITHUB_USERNAME: ((github-username))
+        JDK_VERSION: java13
+      image: spring-boot-ci-image
 - name: build
   serial: true
   public: true

--- a/ci/scripts/detect-jdk-updates.sh
+++ b/ci/scripts/detect-jdk-updates.sh
@@ -13,6 +13,10 @@ case "$JDK_VERSION" in
 		 BASE_URL="https://api.adoptopenjdk.net/v2/info/releases/openjdk12"
 		 ISSUE_TITLE="Upgrade Java 12 version in CI image"
 	;;
+	java13)
+		 BASE_URL="https://api.adoptopenjdk.net/v2/info/nightly/openjdk13"
+		 ISSUE_TITLE="Upgrade Java 13 version in CI image"
+	;;
 	*)
 		echo $"Unknown java version"
 		exit 1;


### PR DESCRIPTION
Hi,

I saw that JDK13 wasn't included yet in the `detect-jdk-updates` CI task. With JDK13 coming in 2-3 weeks every wednesday the task will propose to use the latest nightly - that should be manageable. Even if the created GitHub issue is not tackled, it sticks around and acts as a reminder. So overall, I think it's a good preparation step and as soon as JDK13 goes GA we can simply switch from `nightly` to `releases` in the API url.

It's kind of hard to test for me at the moment, so forgive me if it doesn't work.

Let me know what you think.
Cheers,
Christoph

P.S.: If this is considered to be worthwhile and we're fast enough, we might be included in this week's `detect-jdk-updates` build. 😉 