### PR TITLE
Remove management.health.status.order from docs

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/health/HealthProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/health/HealthProperties.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Properties used to configure the health endpoint and endpoint groups.
@@ -33,6 +34,7 @@ import org.springframework.boot.actuate.health.HealthEndpoint;
  */
 public abstract class HealthProperties {
 
+	@NestedConfigurationProperty
 	private final Status status = new Status();
 
 	/**

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -29,6 +29,15 @@
       "defaultValue": "never"
     },
     {
+      "name": "management.endpoint.health.status.order",
+      "defaultValue": [
+        "DOWN",
+        "OUT_OF_SERVICE",
+        "UP",
+        "UNKNOWN"
+      ]
+    },
+    {
       "name": "management.endpoints.enabled-by-default",
       "type": "java.lang.Boolean",
       "description": "Whether to enable or disable all endpoints by default."
@@ -162,7 +171,10 @@
         "OUT_OF_SERVICE",
         "UP",
         "UNKNOWN"
-      ]
+      ],
+      "deprecation": {
+        "replacement": "management.endpoint.health.status.order"
+      }
     },
     {
       "name": "management.health.mail.enabled",

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -748,7 +748,7 @@ NOTE: The identifier for a given `HealthIndicator` is the name of the bean witho
 In the preceding example, the health information is available in an entry named `my`.
 
 In addition to Spring Boot's predefined {spring-boot-actuator-module-code}/health/Status.java[`Status`] types, it is also possible for `Health` to return a custom `Status` that represents a new system state.
-In such cases, a custom implementation of the{spring-boot-actuator-module-code}/health/StatusAggregator.java[`StatusAggregator`] interface also needs to be provided, or the default implementation has to be configured by using the `management.endpoint.health.status.order` configuration property.
+In such cases, a custom implementation of the {spring-boot-actuator-module-code}/health/StatusAggregator.java[`StatusAggregator`] interface also needs to be provided, or the default implementation has to be configured by using the `management.endpoint.health.status.order` configuration property.
 
 For example, assume a new `Status` with code `FATAL` is being used in one of your `HealthIndicator` implementations.
 To configure the severity order, add the following property to your application properties:


### PR DESCRIPTION
Hi,

while working on another PR I noticed that `management.health.status.order` is still showing in the [Actuator Properties](https://docs.spring.io/spring-boot/docs/2.2.0.BUILD-SNAPSHOT/reference/htmlsingle/#actuator-properties) section of the docs, although it should be deprecated.

This PR also fixes `management.endpoint.health.status.http-mapping.*` not showing up at all as a side-effect.

Let me know what you think. I found it quite "unintuitive" - maybe that's the word I'm looking for - to work with the metadata stuff and I'm not sure if this should be solved differently or if there is a convention for the metadata.json files.

Cheers,
Christoph