### PR TITLE
Fix broken links for master snapshot builds

### DIFF
--- a/spring-boot-project/spring-boot-docs/pom.xml
+++ b/spring-boot-project/spring-boot-docs/pom.xml
@@ -1677,7 +1677,7 @@
 										</stringutil>
 										<var name="github-tag" value="v${revision}" />
 										<propertyregex property="github-tag" override="true"
-											input="${github-tag}" regexp=".*SNAPSHOT" replace="2.1.x" />
+											input="${github-tag}" regexp=".*SNAPSHOT" replace="master" />
 									</target>
 								</configuration>
 							</execution>


### PR DESCRIPTION
Hi,

I just noticed that some links in the `2.2.0.BUILD-SNAPSHOT` docs point to the `2.1.x` tree. E.g. the links in the [Reactive Health Indicators](https://docs.spring.io/spring-boot/docs/2.2.0.BUILD-SNAPSHOT/reference/htmlsingle/#reactive-health-indicators) section lead to "Page not found" errors.

This seems to have been introduced in 7f9d143e0143a6ec4a0701711a0e225a9fccd887 in the 2.1.x mainline, so 2.1.x SNAPSHOT builds don't point to master.

Cheers,
Christoph 