### PR TITLE
Update Quartz smoke test to use JDBC job store

### DIFF
--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-quartz/pom.xml
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-quartz/pom.xml
@@ -14,11 +14,22 @@
 		<main.basedir>${basedir}/../../..</main.basedir>
 	</properties>
 	<dependencies>
+		<!-- Compile -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-quartz</artifactId>
 		</dependency>
-
+		<!-- Runtime -->
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<!-- Test -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-quartz/src/main/resources/application.properties
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-quartz/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.quartz.job-store-type=jdbc


### PR DESCRIPTION
This PR updates Quartz smoke test to use JDBC job store backed by an embedded H2 database. This is more representative of a typical Quartz usage and therefore better suited to catch relevant issues.