### PR TITLE
Use Duration for ServerProperties.Jetty.idleTimeout

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -919,7 +919,7 @@ public class ServerProperties {
 		/**
 		 * Maximum thread idle time.
 		 */
-		private Integer idleTimeout = 60000;
+		private Duration idleTimeout = Duration.ofMillis(60000);
 
 		public Accesslog getAccesslog() {
 			return this.accesslog;
@@ -965,11 +965,11 @@ public class ServerProperties {
 			return this.maxThreads;
 		}
 
-		public void setIdleTimeout(Integer idleTimeout) {
+		public void setIdleTimeout(Duration idleTimeout) {
 			this.idleTimeout = idleTimeout;
 		}
 
-		public Integer getIdleTimeout() {
+		public Duration getIdleTimeout() {
 			return this.idleTimeout;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
@@ -86,8 +86,9 @@ public class JettyWebServerFactoryCustomizer
 				.to((maxThreads) -> customizeThreadPool(factory, (threadPool) -> threadPool.setMaxThreads(maxThreads)));
 		propertyMapper.from(jettyProperties::getMinThreads).when(this::isPositive)
 				.to((minThreads) -> customizeThreadPool(factory, (threadPool) -> threadPool.setMinThreads(minThreads)));
-		propertyMapper.from(jettyProperties::getIdleTimeout).when(this::isPositive).to(
-				(idleTimeout) -> customizeThreadPool(factory, (threadPool) -> threadPool.setIdleTimeout(idleTimeout)));
+		propertyMapper.from(jettyProperties::getIdleTimeout).whenNonNull()
+				.to((idleTimeout) -> customizeThreadPool(factory,
+						(threadPool) -> threadPool.setIdleTimeout((int) idleTimeout.toMillis())));
 		propertyMapper.from(properties::getConnectionTimeout).whenNonNull()
 				.to((connectionTimeout) -> customizeConnectionTimeout(factory, connectionTimeout));
 		propertyMapper.from(jettyProperties::getAccesslog).when(ServerProperties.Jetty.Accesslog::isEnabled)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -233,8 +233,8 @@ class ServerPropertiesTests {
 
 	@Test
 	void testCustomizeJettyIdleTimeout() {
-		bind("server.jetty.idle-timeout", "10");
-		assertThat(this.properties.getJetty().getIdleTimeout()).isEqualTo(10);
+		bind("server.jetty.idle-timeout", "10s");
+		assertThat(this.properties.getJetty().getIdleTimeout()).isEqualTo(Duration.ofSeconds(10));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
@@ -132,10 +132,10 @@ class JettyWebServerFactoryCustomizerTests {
 
 	@Test
 	void idleTimeoutCanBeCustomized() {
-		bind("server.jetty.idle-timeout=100");
+		bind("server.jetty.idle-timeout=100s");
 		JettyWebServer server = customizeAndGetServer();
 		QueuedThreadPool threadPool = (QueuedThreadPool) server.getServer().getThreadPool();
-		assertThat(threadPool.getIdleTimeout()).isEqualTo(100);
+		assertThat(threadPool.getIdleTimeout()).isEqualTo(100000);
 	}
 
 	private CustomRequestLog getRequestLog(JettyWebServer server) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR changes to use `Duration` for `ServerProperties.Jetty.idleTimeout`.