### PR TITLE
TestTypeExcludeFilter does not detect JUnit 5's @Testable annotation

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/filter/TestTypeExcludeFilter.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/filter/TestTypeExcludeFilter.java
@@ -33,7 +33,8 @@ import org.springframework.core.type.classreading.MetadataReaderFactory;
 class TestTypeExcludeFilter extends TypeExcludeFilter {
 
 	private static final String[] CLASS_ANNOTATIONS = { "org.junit.runner.RunWith",
-			"org.junit.jupiter.api.extension.ExtendWith", "org.testng.annotations.Test" };
+			"org.junit.jupiter.api.extension.ExtendWith", "org.testng.annotations.Test",
+			"org.junit.platform.commons.annotation.Testable"};
 
 	private static final String[] METHOD_ANNOTATIONS = { "org.junit.Test",
 			"org.junit.platform.commons.annotation.Testable", "org.testng.annotations.Test" };


### PR DESCRIPTION
As a followup to #6898. The annotation `org.junit.platform.commons.annotation.Testable` can also be applied to the test class so it should also be added to the `CLASS_ANNOTATIONS` array. Spock-2.0 uses `@Testable` on the class instead of each test.