### PR TITLE
Add slf4j exclusion on nio-multipart-parser

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-webflux/pom.xml
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-webflux/pom.xml
@@ -48,6 +48,12 @@
 		<dependency>
 			<groupId>org.synchronoss.cloud</groupId>
 			<artifactId>nio-multipart-parser</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Add  slf4j exclusion on nio-multipart-parser
The slf4j version is supposed to be set by the spring-boot-starter-logging
