### PR TITLE
Allow forcing self-closing Liquibase datasource

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseDataSource.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseDataSource.java
@@ -34,7 +34,15 @@ import org.springframework.beans.factory.annotation.Qualifier;
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Qualifier
+@Qualifier("liquibaseDataSource")
 public @interface LiquibaseDataSource {
+
+	/**
+	 * Defines whether this datasource should automatically be closed once migrations have
+	 * been applied.
+	 * @return whether the {@code SpringLiquibase} created with the annotated datasource
+	 * should specifically be a {@code DataSourceClosingSpringLiquibase}.
+	 */
+	boolean closeDataSourceOnceMigrated() default false;
 
 }


### PR DESCRIPTION
Hello,

As per the comments on #18126, here's a PR that adds a property to `@LiquibaseDataSource` to be able to use a `DataSourceClosingSpringLiquibase` with minimal effort when defining your own datasource bean.

This is by opposition to now where you must rely on `LiquibaseProperties` or lose most advantages of the `LiquibaseAutoConfiguration`.

Note that as mentionned in the issue conversation, retrieving the `@LiquibaseDataSource` annotation on the bean declaration is not easy.
The solution here is less than ideal, but I could not find much better.

There are some nicer ways via the bean registry or some concrete context implementations, but I am not familiar enough with how these are picked to make safe assumptions by myself

Let me know if anything is not acceptable.

Thanks,
Tristan Deloche