### PR TITLE
Fix typo in HealthContributors definition

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/production-ready-features.adoc
@@ -653,7 +653,7 @@ Spring Boot includes a number of auto-configured `HealthContributors` and you ca
 A `HealthContributor` can either be a `HealthIndicator` or a `CompositeHealthContributor`.
 A `HealthIndicator` provides actual health information, including a `Status`.
 A `CompositeHealthContributor` provides a composite of other `HealthContributors`.
-Taken together, contributor for a tree structure to represent the overall system heath.
+Taken together, contributors form a tree structure to represent the overall system health.
 
 By default, the final system health is derived by a `StatusAggregator` which sorts the statuses from each `HealthIndicator` based on an ordered list of statuses.
 The first status in the sorted list is used as the overall health status.


### PR DESCRIPTION
Fixed typos in a sentence describing the hierarchy of HealthContributors.