### PR TITLE
Add support @LocalServerPort for RSocket Port

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/rsocket/RSocketServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/rsocket/RSocketServerAutoConfigurationTests.java
@@ -89,7 +89,7 @@ class RSocketServerAutoConfigurationTests {
 					assertThat(context).hasSingleBean(RSocketServerFactory.class)
 							.hasSingleBean(RSocketServerBootstrap.class)
 							.hasSingleBean(ServerRSocketFactoryCustomizer.class);
-					assertThat(context.getEnvironment().getProperty("local.server.port")).isNotNull();
+					assertThat(context.getEnvironment().getProperty("local.rsocket.server.port")).isNotNull();
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/rsocket/RSocketServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/rsocket/RSocketServerAutoConfigurationTests.java
@@ -24,6 +24,7 @@ import org.springframework.boot.rsocket.server.RSocketServerFactory;
 import org.springframework.boot.rsocket.server.ServerRSocketFactoryCustomizer;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.boot.web.context.RSocketPortInfoApplicationContextInitializer;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,6 +40,7 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link RSocketServerAutoConfiguration}.
  *
  * @author Brian Clozel
+ * @author Verónica Vásquez
  */
 class RSocketServerAutoConfigurationTests {
 
@@ -78,6 +80,17 @@ class RSocketServerAutoConfigurationTests {
 				.run((context) -> assertThat(context).hasSingleBean(RSocketServerFactory.class)
 						.hasSingleBean(RSocketServerBootstrap.class)
 						.hasSingleBean(ServerRSocketFactoryCustomizer.class));
+	}
+
+	@Test
+	void shouldSetLocalServerPortWhenRSocketServerPortIsSet() {
+		reactiveWebContextRunner().withPropertyValues("spring.rsocket.server.port=0")
+				.withInitializer(new RSocketPortInfoApplicationContextInitializer()).run((context) -> {
+					assertThat(context).hasSingleBean(RSocketServerFactory.class)
+							.hasSingleBean(RSocketServerBootstrap.class)
+							.hasSingleBean(ServerRSocketFactoryCustomizer.class);
+					assertThat(context.getEnvironment().getProperty("local.server.port")).isNotNull();
+				});
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/context/RSocketPortInfoApplicationContextInitializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/context/RSocketPortInfoApplicationContextInitializer.java
@@ -35,7 +35,7 @@ import org.springframework.core.env.PropertySource;
 /**
  * {@link ApplicationContextInitializer} that sets {@link Environment} properties for the
  * ports that {@link RSocketServer} servers are actually listening on. The property
- * {@literal "local.server.port"} can be injected directly into tests using
+ * {@literal "local.rsocket.server.port"} can be injected directly into tests using
  * {@link Value @Value} or obtained via the {@link Environment}.
  * <p>
  * Properties are automatically propagated up to any parent context.
@@ -58,7 +58,7 @@ public class RSocketPortInfoApplicationContextInitializer
 
 	@Override
 	public void onApplicationEvent(RSocketServerInitializedEvent event) {
-		String propertyName = "local.server.port";
+		String propertyName = "local.rsocket.server.port";
 		setPortProperty(this.applicationContext, propertyName, event.getrSocketServer().address().getPort());
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/context/RSocketPortInfoApplicationContextInitializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/context/RSocketPortInfoApplicationContextInitializer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.context;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.rsocket.context.RSocketServerInitializedEvent;
+import org.springframework.boot.rsocket.server.RSocketServer;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * {@link ApplicationContextInitializer} that sets {@link Environment} properties for the
+ * ports that {@link RSocketServer} servers are actually listening on. The property
+ * {@literal "local.server.port"} can be injected directly into tests using
+ * {@link Value @Value} or obtained via the {@link Environment}.
+ * <p>
+ * Properties are automatically propagated up to any parent context.
+ *
+ * @author Verónica Vásquez
+ * @author Eddú Meléndez
+ * @since 2.2.0
+ */
+public class RSocketPortInfoApplicationContextInitializer
+		implements ApplicationContextInitializer<ConfigurableApplicationContext>,
+		ApplicationListener<RSocketServerInitializedEvent> {
+
+	private ConfigurableApplicationContext applicationContext;
+
+	@Override
+	public void initialize(ConfigurableApplicationContext applicationContext) {
+		applicationContext.addApplicationListener(this);
+		this.applicationContext = applicationContext;
+	}
+
+	@Override
+	public void onApplicationEvent(RSocketServerInitializedEvent event) {
+		String propertyName = "local.server.port";
+		setPortProperty(this.applicationContext, propertyName, event.getrSocketServer().address().getPort());
+	}
+
+	private void setPortProperty(ApplicationContext context, String propertyName, int port) {
+		if (context instanceof ConfigurableApplicationContext) {
+			setPortProperty(((ConfigurableApplicationContext) context).getEnvironment(), propertyName, port);
+		}
+		if (context.getParent() != null) {
+			setPortProperty(context.getParent(), propertyName, port);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private void setPortProperty(ConfigurableEnvironment environment, String propertyName, int port) {
+		MutablePropertySources sources = environment.getPropertySources();
+		PropertySource<?> source = sources.get("server.ports");
+		if (source == null) {
+			source = new MapPropertySource("server.ports", new HashMap<>());
+			sources.addFirst(source);
+		}
+		((Map<String, Object>) source.getSource()).put(propertyName, port);
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/LocalRSocketServerPort.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/LocalRSocketServerPort.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.server;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * Annotation at the field or method/constructor parameter level that injects the RSocket
+ * port that got allocated at runtime. Provides a convenient alternative for
+ * <code>&#064;Value(&quot;${local.rsocket.server.port}&quot;)</code>.
+ *
+ * @author Verónica Vásquez
+ * @author Eddú Meléndez
+ * @since 2.2.0
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Value("${local.rsocket.server.port}")
+public @interface LocalRSocketServerPort {
+
+}

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/spring.factories
@@ -16,7 +16,8 @@ org.springframework.context.ApplicationContextInitializer=\
 org.springframework.boot.context.ConfigurationWarningsApplicationContextInitializer,\
 org.springframework.boot.context.ContextIdApplicationContextInitializer,\
 org.springframework.boot.context.config.DelegatingApplicationContextInitializer,\
-org.springframework.boot.web.context.ServerPortInfoApplicationContextInitializer
+org.springframework.boot.web.context.ServerPortInfoApplicationContextInitializer,\
+org.springframework.boot.web.context.RSocketPortInfoApplicationContextInitializer
 
 # Application Listeners
 org.springframework.context.ApplicationListener=\

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/builder/SpringApplicationBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/builder/SpringApplicationBuilderTests.java
@@ -240,7 +240,7 @@ class SpringApplicationBuilderTests {
 		SpringApplicationBuilder application = new SpringApplicationBuilder(ExampleConfig.class)
 				.web(WebApplicationType.NONE);
 		this.context = application.run();
-		assertThat(application.application().getInitializers()).hasSize(4);
+		assertThat(application.application().getInitializers()).hasSize(5);
 	}
 
 	@Test
@@ -248,7 +248,7 @@ class SpringApplicationBuilderTests {
 		SpringApplicationBuilder application = new SpringApplicationBuilder(ExampleConfig.class)
 				.child(ChildConfig.class).web(WebApplicationType.NONE);
 		this.context = application.run();
-		assertThat(application.application().getInitializers()).hasSize(5);
+		assertThat(application.application().getInitializers()).hasSize(6);
 	}
 
 	@Test
@@ -257,7 +257,7 @@ class SpringApplicationBuilderTests {
 				.web(WebApplicationType.NONE).initializers((ConfigurableApplicationContext applicationContext) -> {
 				});
 		this.context = application.run();
-		assertThat(application.application().getInitializers()).hasSize(5);
+		assertThat(application.application().getInitializers()).hasSize(6);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/server/LocalRSocketServerPortTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/server/LocalRSocketServerPortTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.server;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link LocalRSocketServerPort @LocalRSocketServerPort}.
+ *
+ * @author Verónica Vásquez
+ * @author Eddú Meléndez
+ */
+@ExtendWith(SpringExtension.class)
+@TestPropertySource(properties = "local.rsocket.server.port=8181")
+class LocalRSocketServerPortTests {
+
+	@Value("${local.rsocket.server.port}")
+	private String fromValue;
+
+	@LocalRSocketServerPort
+	private String fromAnnotation;
+
+	@Test
+	void testLocalRSocketServerPortAnnotation() {
+		assertThat(this.fromAnnotation).isNotNull().isEqualTo(this.fromValue);
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class Config {
+
+	}
+
+}


### PR DESCRIPTION
Currently `@LocalServerPort` does not resolve `spring.rsocket.server.port`
configuration property. This commit allows to set `local.server.port`
when it is used.

See gh-18179

Co-authored-by: Eddú Meléndez <eddu.melendez@gmail.com>

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
