### PR TITLE
Fix small typo in configuration metadata documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-configuration-metadata.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-configuration-metadata.adoc
@@ -266,7 +266,7 @@ The JSON object contained in the `hints` array can contain the attributes shown 
 | String
 | The full name of the property to which this hint refers.
   Names are in lower-case period-separated form (such as `spring.mvc.servlet.path`).
-  If the property refers to a map (such as `system.contexts`), the hint either applies to the _keys_ of the map (`system.context.keys`) or the _values_ (`system.context.values`) of the map.
+  If the property refers to a map (such as `system.contexts`), the hint either applies to the _keys_ of the map (`system.contexts.keys`) or the _values_ (`system.contexts.values`) of the map.
   This attribute is mandatory.
 
 | `values`


### PR DESCRIPTION
In https://docs.spring.io/spring-boot/docs/2.2.0.BUILD-SNAPSHOT/reference/html/appendix-configuration-metadata.html#configuration-metadata-hints-attributes the examples for configuration metadata hint names in the case of maps were not consistent.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
