### PR TITLE
Add support for Diagnostic MBean in actuator

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/DiagnosticsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/DiagnosticsEndpoint.java
@@ -48,7 +48,7 @@ public class DiagnosticsEndpoint {
 
 	private static final String CURRENT_DIRECTORY = ".";
 
-	private VMDiagnostics virtualMachineDiagnostics;
+	private final VMDiagnostics virtualMachineDiagnostics;
 
 	@Value("${management.endpoints.diagnostics.resources.extensions:}#{T(java.util.Collections).emptyList()}")
 	private List<String> extensions;

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/DiagnosticsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/DiagnosticsEndpoint.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.diagnostics;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
+import org.springframework.util.Assert;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * {@link RestControllerEndpoint @RestControllerEndpoint} to expose diagnostics info.
+ *
+ * @author Luis De Bello
+ * @since 2.0.0
+ */
+@RestControllerEndpoint(id = "diagnostics")
+public class DiagnosticsEndpoint {
+
+	private static final Log logger = LogFactory.getLog(DiagnosticsEndpoint.class);
+
+	private static final String CURRENT_DIRECTORY = ".";
+
+	private VMDiagnostics virtualMachineDiagnostics;
+
+	@Value("${management.endpoints.diagnostics.resources.extensions:}#{T(java.util.Collections).emptyList()}")
+	private List<String> extensions;
+
+	public DiagnosticsEndpoint() {
+		this.virtualMachineDiagnostics = VMDiagnostics.newInstance();
+	}
+
+	@GetMapping
+	public String getOperations() {
+		return this.virtualMachineDiagnostics.getOperations();
+	}
+
+	@GetMapping("/{operation}")
+	public String getOperationDetails(@PathVariable String operation) {
+		Assert.notNull(operation, "Operation must not be null");
+		return this.virtualMachineDiagnostics.getOperationDetails(operation);
+	}
+
+	@PostMapping("/{operation}")
+	public String executeOperation(@PathVariable String operation,
+			@RequestBody(required = false) Map<String, String> parameters) {
+		Assert.notNull(operation, "Operation must not be null");
+		return this.virtualMachineDiagnostics.executeOperation(operation, parameters);
+	}
+
+	@GetMapping("/resources")
+	public String getResources() {
+		logger.info("Listing resources");
+		StringJoiner result = new StringJoiner(System.lineSeparator());
+		File[] files = new File(CURRENT_DIRECTORY)
+				.listFiles((file, name) -> this.extensions.contains(getExtensionFile(name)));
+		for (File file : files) {
+			if (file.isFile()) {
+				result.add(file.getName());
+			}
+		}
+		return result.toString();
+	}
+
+	@GetMapping("/resources/{name}")
+	public byte[] getResource(@PathVariable String name) throws IOException {
+		logger.info(String.format("Getting resource: %s", name));
+		if (this.extensions.contains(getExtensionFile(name))) {
+			File resource = new File((name));
+			return (resource.exists() && resource.isFile()) ? Files.readAllBytes(resource.toPath()) : null;
+		}
+		return null;
+	}
+
+	@DeleteMapping("/resources/{name}")
+	public void deleteResource(@PathVariable String name) throws IOException {
+		logger.info(String.format("Deleting resource: %s", name));
+		if (this.extensions.contains(getExtensionFile(name))) {
+			File resource = new File((name));
+			if (resource.exists() && resource.isFile()) {
+				Files.delete(resource.toPath());
+				logger.info(String.format("Resource %s deleted", name));
+			}
+		}
+	}
+
+	private String getExtensionFile(String fileName) {
+		return (fileName.contains(CURRENT_DIRECTORY) && fileName.lastIndexOf(CURRENT_DIRECTORY) != 0)
+				? fileName.substring(fileName.lastIndexOf(CURRENT_DIRECTORY) + 1) : "";
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/DiagnosticsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/DiagnosticsEndpoint.java
@@ -39,7 +39,7 @@ import org.springframework.web.bind.annotation.RequestBody;
  * {@link RestControllerEndpoint @RestControllerEndpoint} to expose diagnostics info.
  *
  * @author Luis De Bello
- * @since 2.0.0
+ * @since 2.2.0
  */
 @RestControllerEndpoint(id = "diagnostics")
 public class DiagnosticsEndpoint {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/VMDiagnostics.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/VMDiagnostics.java
@@ -24,6 +24,7 @@ import java.util.StringJoiner;
 import javax.management.Descriptor;
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
+import javax.management.MBeanException;
 import javax.management.MBeanOperationInfo;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
@@ -207,7 +208,7 @@ public final class VMDiagnostics {
 			result = (String) this.server.invoke(this.objectName, operation, params,
 					new String[] { String[].class.getName() });
 		}
-		catch (Exception ex) {
+		catch (ReflectionException | InstanceNotFoundException | MBeanException ex) {
 			logger.info(String.format("Unable to access operation: %s", operation), ex);
 			result = String.format("Unable to access operation: '%s' - %s", operation, ex.getMessage());
 		}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/VMDiagnostics.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/VMDiagnostics.java
@@ -52,7 +52,7 @@ public final class VMDiagnostics {
 	 */
 	static final String NO_HELP_AVAILABLE_ERROR_MESSAGE = "No help available";
 
-	private static final Log logger = LogFactory.getLog(DiagnosticsEndpoint.class);
+	private static final Log logger = LogFactory.getLog(VMDiagnostics.class);
 
 	/**
 	 * Object Name of DiagnosticCommandMBean.

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/VMDiagnostics.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/VMDiagnostics.java
@@ -37,7 +37,7 @@ import org.apache.commons.logging.LogFactory;
  * Expose diagnostics information from DiagnosticCommandMBean.
  *
  * @author Luis De Bello
- * @since 2.0.0
+ * @since 2.2.0
  */
 public final class VMDiagnostics {
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/VMDiagnostics.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/VMDiagnostics.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.diagnostics;
+
+import java.lang.management.ManagementFactory;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+import javax.management.Descriptor;
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.MBeanOperationInfo;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Expose diagnostics information from DiagnosticCommandMBean.
+ *
+ * @author Luis De Bello
+ * @since 2.0.0
+ */
+public final class VMDiagnostics {
+
+	/**
+	 * Error message for get operations.
+	 */
+	static final String GET_OPERATIONS_ERROR_MESSAGE = "Unable to get operations";
+
+	/**
+	 * Error message for no help available.
+	 */
+	static final String NO_HELP_AVAILABLE_ERROR_MESSAGE = "No help available";
+
+	private static final Log logger = LogFactory.getLog(DiagnosticsEndpoint.class);
+
+	/**
+	 * Object Name of DiagnosticCommandMBean.
+	 */
+	private static final String DIAGNOSTIC_COMMAND_MBEAN_OBJECT_NAME = "com.sun.management:type=DiagnosticCommand";
+
+	/**
+	 * Field name for help in the operation descriptor.
+	 */
+	private static final String HELP_FIELD_OPERATION_DESCRIPTOR = "dcmd.help";
+
+	/**
+	 * Field name for arguments in the operation descriptor.
+	 */
+	private static final String ARGUMENTS_FIELD_OPERATION_DESCRIPTOR = "dcmd.arguments";
+
+	/**
+	 * Argument name.
+	 */
+	private static final String ARGUMENT_NAME_DESCRIPTOR = "dcmd.arg.name";
+
+	/**
+	 * Argument type.
+	 */
+	private static final String ARGUMENT_TYPE_DESCRIPTOR = "dcmd.arg.type";
+
+	/**
+	 * Argument position.
+	 */
+	private static final String ARGUMENT_POSITION_DESCRIPTOR = "dcmd.arg.position";
+
+	/**
+	 * Platform MBean Server.
+	 */
+	private final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+
+	/**
+	 * Object Name.
+	 */
+	private final ObjectName objectName;
+
+	/**
+	 * create an instance of diagnostics with the provided object name.
+	 * @param objectName objectName associated with DiagnosticCommand MBean.
+	 */
+	private VMDiagnostics(ObjectName objectName) {
+		this.objectName = objectName;
+	}
+
+	/**
+	 * factory method to {@link VMDiagnostics}.
+	 * @return a new instance of {@link VMDiagnostics}.
+	 */
+	public static VMDiagnostics newInstance() {
+		try {
+			return new VMDiagnostics(new ObjectName(DIAGNOSTIC_COMMAND_MBEAN_OBJECT_NAME));
+		}
+		catch (MalformedObjectNameException ex) {
+			logger.info("Unable to create VMDiagnostics", ex);
+			throw new RuntimeException("Unable to create VMDiagnostics", ex);
+		}
+	}
+
+	/**
+	 * list operations.
+	 * @return a list of operations.
+	 */
+	public String getOperations() {
+		StringJoiner result = new StringJoiner(System.lineSeparator());
+		try {
+			MBeanOperationInfo[] operations = this.server.getMBeanInfo(this.objectName).getOperations();
+			for (MBeanOperationInfo operation : operations) {
+				result.add(operation.getName());
+			}
+		}
+		catch (InstanceNotFoundException | IntrospectionException | ReflectionException ex) {
+			logger.info(GET_OPERATIONS_ERROR_MESSAGE, ex);
+			result.add(String.format("%s: %s", GET_OPERATIONS_ERROR_MESSAGE, ex.getMessage()));
+		}
+
+		return result.toString();
+	}
+
+	/**
+	 * get operation details.
+	 * @param operation operation name to get details.
+	 * @return the details for this operation.
+	 */
+	public String getOperationDetails(String operation) {
+		return getOperationDescriptor(operation).map(this::extractOperationHelp)
+				.orElse(NO_HELP_AVAILABLE_ERROR_MESSAGE);
+	}
+
+	/**
+	 * execute an operation with optional parameters.
+	 * @param operation operation name to execute.
+	 * @param parameters parameters to the operation.
+	 * @return the result of the operation
+	 */
+	public String executeOperation(String operation, Map<String, String> parameters) {
+		return getOperationDescriptor(operation)
+				.map((operationDescriptor) -> executeOperation(operation, parameters, operationDescriptor))
+				.orElse("Operation cannot be executed");
+	}
+
+	/**
+	 * get operation descriptor based on operation name.
+	 * @param operation name.
+	 * @return the operation descriptor.
+	 */
+	private Optional<Descriptor> getOperationDescriptor(String operation) {
+		Optional<Descriptor> maybeOperationDescriptor = Optional.empty();
+
+		try {
+			MBeanOperationInfo[] operations = this.server.getMBeanInfo(this.objectName).getOperations();
+			for (MBeanOperationInfo currentOperation : operations) {
+				if (currentOperation.getName().equals(operation)) {
+					Descriptor operationDescriptor = currentOperation.getDescriptor();
+					maybeOperationDescriptor = Optional.of(operationDescriptor);
+				}
+			}
+		}
+		catch (InstanceNotFoundException | IntrospectionException | ReflectionException ex) {
+			logger.info("Operation Descriptor Not Found", ex);
+
+		}
+		return maybeOperationDescriptor;
+	}
+
+	/**
+	 * get operation help based on operation descriptor.
+	 * @param operationDescriptor descriptor.
+	 * @return help for the operation.
+	 */
+	private String extractOperationHelp(Descriptor operationDescriptor) {
+		Object operationHelp = operationDescriptor.getFieldValue(HELP_FIELD_OPERATION_DESCRIPTOR);
+
+		return (operationHelp != null) ? operationHelp.toString() : NO_HELP_AVAILABLE_ERROR_MESSAGE;
+	}
+
+	/**
+	 * execute a operation with the provided parameters.
+	 * @param operation operation name.
+	 * @param parameters parameters.
+	 * @param operationDescriptor descriptor.
+	 * @return result for the operation.
+	 */
+	private String executeOperation(String operation, Map<String, String> parameters, Descriptor operationDescriptor) {
+		String result;
+		try {
+			Object[] params = buildOperationParameters(parameters, operationDescriptor);
+
+			result = (String) this.server.invoke(this.objectName, operation, params,
+					new String[] { String[].class.getName() });
+		}
+		catch (Exception ex) {
+			logger.info(String.format("Unable to access operation: %s", operation), ex);
+			result = String.format("Unable to access operation: '%s' - %s", operation, ex.getMessage());
+		}
+		return result;
+	}
+
+	/**
+	 * build operation parameters wrapped in a array of objects.
+	 * @param parameters parameters.
+	 * @param operationDescriptor descriptor.
+	 * @return object array to use.
+	 */
+	private Object[] buildOperationParameters(Map<String, String> parameters, Descriptor operationDescriptor) {
+		Optional<Descriptor> maybeArgumentsDescriptor = Optional
+				.ofNullable((Descriptor) operationDescriptor.getFieldValue(ARGUMENTS_FIELD_OPERATION_DESCRIPTOR));
+		return new Object[] { maybeArgumentsDescriptor
+				.map((argumentsDescriptor) -> buildParameters(parameters, argumentsDescriptor)).orElse(null) };
+
+	}
+
+	/**
+	 * build operation parameters as array of strings.
+	 * @param parameters parameters.
+	 * @param argumentsDescriptor descriptor.
+	 * @return parameters as array of strings.
+	 */
+	private String[] buildParameters(Map<String, String> parameters, Descriptor argumentsDescriptor) {
+		String[] argumentNames = argumentsDescriptor.getFieldNames();
+		String[] values = new String[argumentNames.length];
+
+		if (parameters != null) {
+			for (Map.Entry<String, String> entry : parameters.entrySet()) {
+				String parameterName = entry.getKey();
+				String parameterValue = entry.getValue();
+
+				Descriptor parameterDescriptor = (Descriptor) argumentsDescriptor.getFieldValue(parameterName);
+				if (parameterDescriptor != null) {
+					values[computeParameterPosition(parameterDescriptor)] = computeParameterValue(parameterDescriptor,
+							parameterValue);
+				}
+				else {
+					logger.info(String.format("Invalid parameter: %s", parameterName));
+				}
+			}
+		}
+
+		return removeTrailingNullValues(values);
+	}
+
+	/**
+	 * remove trailing null for parameters.
+	 * @param values array of parameter values.
+	 * @return parameter values without trailing nulls.
+	 */
+	private String[] removeTrailingNullValues(String[] values) {
+		int trailingNulls = 0;
+		for (int i = values.length - 1; i >= 0; i--) {
+			if (values[i] == null) {
+				trailingNulls++;
+			}
+			else {
+				break;
+			}
+		}
+
+		if (trailingNulls == 0) {
+			return values;
+		}
+		else if (values.length == trailingNulls) {
+			return null;
+		}
+		else {
+			int newSize = values.length - trailingNulls;
+			String[] newValues = new String[newSize];
+			for (int i = 0; i < newSize; i++) {
+				newValues[i] = values[i];
+			}
+			return newValues;
+		}
+	}
+
+	/**
+	 * calculate parameter position.
+	 * @param parameterDescriptor descriptor.
+	 * @return the index based on the parameter descriptor.
+	 */
+	private int computeParameterPosition(Descriptor parameterDescriptor) {
+		Integer parameterPosition = (Integer) parameterDescriptor.getFieldValue(ARGUMENT_POSITION_DESCRIPTOR);
+		return (parameterPosition != -1) ? parameterPosition : 0;
+	}
+
+	/**
+	 * calculate parameter value based on parameters.
+	 * @param parameterDescriptor descriptor.
+	 * @param parameterValue value.
+	 * @return value.
+	 */
+	private String computeParameterValue(Descriptor parameterDescriptor, String parameterValue) {
+		String parameterType = (String) parameterDescriptor.getFieldValue(ARGUMENT_TYPE_DESCRIPTOR);
+
+		if (Boolean.class.getSimpleName().toUpperCase().equals(parameterType)) {
+			return Boolean.valueOf(parameterValue)
+					? parameterDescriptor.getFieldValue(ARGUMENT_NAME_DESCRIPTOR).toString() : null;
+		}
+		else {
+			return parameterValue;
+		}
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/VMDiagnostics.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/VMDiagnostics.java
@@ -283,9 +283,8 @@ public final class VMDiagnostics {
 		else {
 			int newSize = values.length - trailingNulls;
 			String[] newValues = new String[newSize];
-			for (int i = 0; i < newSize; i++) {
-				newValues[i] = values[i];
-			}
+			System.arraycopy(values, 0, newValues, 0, newSize);
+
 			return newValues;
 		}
 	}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/package-info.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/diagnostics/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Actuator support for diagnostics.
+ */
+package org.springframework.boot.actuate.diagnostics;

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/diagnostics/DiagnosticsEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/diagnostics/DiagnosticsEndpointTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.diagnostics;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DiagnosticsEndpoint}.
+ *
+ * @author Luis De Bello
+ */
+public class DiagnosticsEndpointTests {
+
+	private static DiagnosticsEndpoint diagnosticsEndpoint;
+
+	@BeforeAll
+	static void createDiagnosticsEndpoint() {
+		diagnosticsEndpoint = new DiagnosticsEndpoint();
+	}
+
+	@Test
+	void checkOperationsAreNotNull() {
+		String operations = diagnosticsEndpoint.getOperations();
+		assertThat(operations).isNotNull();
+	}
+
+	@Test
+	void checkOperationsDoesNotContainsErrorMessage() {
+		String operations = diagnosticsEndpoint.getOperations();
+		assertThat(operations).doesNotContain(VMDiagnostics.GET_OPERATIONS_ERROR_MESSAGE);
+	}
+
+	@Test
+	void checkOperationDetails() throws IOException {
+		String operations = diagnosticsEndpoint.getOperations();
+		try (BufferedReader reader = new BufferedReader(new StringReader(operations))) {
+			String firstOperation = reader.readLine();
+			String firstOperationDetails = diagnosticsEndpoint.getOperationDetails(firstOperation);
+			assertThat(firstOperationDetails).isNotNull();
+		}
+	}
+
+	@Test
+	void checkOperationDetailsDoesNotContainsErrorMessage() throws IOException {
+		String operations = diagnosticsEndpoint.getOperations();
+		try (BufferedReader reader = new BufferedReader(new StringReader(operations))) {
+			String firstOperation = reader.readLine();
+			String firstOperationDetails = diagnosticsEndpoint.getOperationDetails(firstOperation);
+			assertThat(firstOperationDetails).doesNotContain(VMDiagnostics.NO_HELP_AVAILABLE_ERROR_MESSAGE);
+		}
+	}
+
+}


### PR DESCRIPTION
Hi,

Currently at work I have created a simple endpoint for exposing Diagnostic MBean from actuator, so I decided to contribute to it with this change.

Functionality:
- Expose operations from Diagnostic MBean.
- Get details for one specific operation.
- Execute an operation with or without parameters.
- Also this endpoint allows to get some resources (This is because some operations like JFR, generate a file for the result, anyway there is a mechanism to filter which kind of resources can be fetched).

Screenshots

Get Operations
![image](https://user-images.githubusercontent.com/2062115/65356360-ad5de780-dbca-11e9-845b-1695aa84c522.png)

Get Operation Details
![image](https://user-images.githubusercontent.com/2062115/65356441-ded6b300-dbca-11e9-9ea8-cdf06d443ab7.png)

Execute Operation
![image](https://user-images.githubusercontent.com/2062115/65356469-f31ab000-dbca-11e9-8d32-97a82d845c99.png)

If you consider this can be useful but it requires more changes I can work on that but if you consider this is not a valid use case for actuator endpoints just close the pull request.