### PR TITLE
Enforce ordering when ObjectProvider is used

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/jdbc/DataSourcePoolMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/jdbc/DataSourcePoolMetricsAutoConfiguration.java
@@ -68,6 +68,8 @@ public class DataSourcePoolMetricsAutoConfiguration {
 		@Autowired
 		void bindDataSourcesToRegistry(Map<String, DataSource> dataSources, MeterRegistry registry,
 				ObjectProvider<DataSourcePoolMetadataProvider> metadataProviders) {
+			// doesn't matter the ordering here since they are usually distinct and are
+			// used as first match wins basis.
 			List<DataSourcePoolMetadataProvider> metadataProvidersList = metadataProviders.stream()
 					.collect(Collectors.toList());
 			dataSources.forEach(

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/admin/SpringApplicationAdminJmxAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/admin/SpringApplicationAdminJmxAutoConfiguration.java
@@ -62,6 +62,7 @@ public class SpringApplicationAdminJmxAutoConfiguration {
 			ObjectProvider<MBeanExporter> mbeanExporters, Environment environment) throws MalformedObjectNameException {
 		String jmxName = environment.getProperty(JMX_NAME_PROPERTY, DEFAULT_JMX_NAME);
 		if (mbeanExporters != null) { // Make sure to not register that MBean twice
+			// ordering is not important for exporters, thus just iterate them
 			for (MBeanExporter mbeanExporter : mbeanExporters) {
 				mbeanExporter.addExcludedBean(jmxName);
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
@@ -123,6 +123,8 @@ public class FlywayAutoConfiguration {
 			configureCallbacks(configuration, orderedCallbacks);
 			fluentConfigurationCustomizers.orderedStream().forEach((customizer) -> customizer.customize(configuration));
 			configureFlywayCallbacks(configuration, orderedCallbacks);
+			// flyway orders migrations by itself with their versions; thus use normal
+			// stream to collect them
 			List<JavaMigration> migrations = javaMigrations.stream().collect(Collectors.toList());
 			configureJavaMigrations(configuration, migrations);
 			return configuration.load();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/task/TaskExecutionAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/task/TaskExecutionAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.task;
 
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -67,7 +68,7 @@ public class TaskExecutionAutoConfiguration {
 		builder = builder.awaitTermination(shutdown.isAwaitTermination());
 		builder = builder.awaitTerminationPeriod(shutdown.getAwaitTerminationPeriod());
 		builder = builder.threadNamePrefix(properties.getThreadNamePrefix());
-		builder = builder.customizers(taskExecutorCustomizers);
+		builder = builder.customizers(taskExecutorCustomizers.orderedStream().collect(Collectors.toList()));
 		builder = builder.taskDecorator(taskDecorator.getIfUnique());
 		return builder;
 	}


### PR DESCRIPTION
Fix to enforce ordering when `ObjectProvider` is used for retrieving multiple objects.
