### PR TITLE
Test compression with invalid content type for all webservers

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/netty/NettyReactiveWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/netty/NettyReactiveWebServerFactoryTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.web.embedded.netty;
 
-import java.time.Duration;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
@@ -25,10 +24,7 @@ import reactor.netty.http.server.HttpServer;
 
 import org.springframework.boot.web.reactive.server.AbstractReactiveWebServerFactory;
 import org.springframework.boot.web.reactive.server.AbstractReactiveWebServerFactoryTests;
-import org.springframework.boot.web.server.Compression;
 import org.springframework.boot.web.server.PortInUseException;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -85,17 +81,6 @@ class NettyReactiveWebServerFactoryTests extends AbstractReactiveWebServerFactor
 		NettyReactiveWebServerFactory factory = getFactory();
 		factory.setUseForwardHeaders(true);
 		assertForwardHeaderIsUsed(factory);
-	}
-
-	@Test
-	void noCompressionForResponseWithInvalidContentType() {
-		Compression compression = new Compression();
-		compression.setEnabled(true);
-		compression.setMimeTypes(new String[] { "application/json" });
-		WebClient client = prepareCompressionTest(compression, "test~plain");
-		ResponseEntity<Void> response = client.get().exchange().flatMap((res) -> res.toEntity(Void.class))
-				.block(Duration.ofSeconds(30));
-		assertResponseIsNotCompressed(response);
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/server/AbstractReactiveWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/server/AbstractReactiveWebServerFactoryTests.java
@@ -274,6 +274,17 @@ public abstract class AbstractReactiveWebServerFactoryTests {
 	}
 
 	@Test
+	void noCompressionForResponseWithInvalidContentType() {
+		Compression compression = new Compression();
+		compression.setEnabled(true);
+		compression.setMimeTypes(new String[] { "application/json" });
+		WebClient client = prepareCompressionTest(compression, "test~plain");
+		ResponseEntity<Void> response = client.get().exchange().flatMap((res) -> res.toEntity(Void.class))
+				.block(Duration.ofSeconds(30));
+		assertResponseIsNotCompressed(response);
+	}
+
+	@Test
 	void whenSslIsEnabledAndNoKeyStoreIsConfiguredThenServerFailsToStart() {
 		assertThatThrownBy(() -> testBasicSslWithKeyStore(null, null))
 				.hasMessageContaining("Could not load key store 'null'");


### PR DESCRIPTION
Hi,

as https://github.com/spring-projects/spring-framework/issues/23553 is fixed we can move the test introduced for #18018 so all webserver implementations are covered and produce the same result.

Cheers,
Christoph