### PR TITLE
Actuator endpoint time-to-live caching is not respected on WebFlux

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvoker.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvoker.java
@@ -16,8 +16,11 @@
 
 package org.springframework.boot.actuate.endpoint.invoker.cache;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
+
+import reactor.core.publisher.Mono;
 
 import org.springframework.boot.actuate.endpoint.InvocationContext;
 import org.springframework.boot.actuate.endpoint.invoke.OperationInvoker;
@@ -67,11 +70,19 @@ public class CachingOperationInvoker implements OperationInvoker {
 		long accessTime = System.currentTimeMillis();
 		CachedResponse cached = this.cachedResponse;
 		if (cached == null || cached.isStale(accessTime, this.timeToLive)) {
-			Object response = this.invoker.invoke(context);
+			Object response = handleMonoResponse(this.invoker.invoke(context));
 			this.cachedResponse = new CachedResponse(response, accessTime);
 			return response;
 		}
 		return cached.getResponse();
+	}
+
+	private Object handleMonoResponse(Object response) {
+		if (response instanceof Mono) {
+			return ((Mono) response).cache(Duration.ofMillis(this.timeToLive));
+		}
+		return response;
+
 	}
 
 	private boolean hasInput(InvocationContext context) {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvoker.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvoker.java
@@ -82,7 +82,6 @@ public class CachingOperationInvoker implements OperationInvoker {
 			return ((Mono) response).cache(Duration.ofMillis(this.timeToLive));
 		}
 		return response;
-
 	}
 
 	private boolean hasInput(InvocationContext context) {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvokerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvokerTests.java
@@ -17,15 +17,21 @@
 package org.springframework.boot.actuate.endpoint.invoker.cache;
 
 import java.security.Principal;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import reactor.core.publisher.Mono;
 
 import org.springframework.boot.actuate.endpoint.InvocationContext;
 import org.springframework.boot.actuate.endpoint.SecurityContext;
+import org.springframework.boot.actuate.endpoint.invoke.MissingParametersException;
 import org.springframework.boot.actuate.endpoint.invoke.OperationInvoker;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -40,6 +46,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  *
  * @author Stephane Nicoll
  */
+@ExtendWith(OutputCaptureExtension.class)
 class CachingOperationInvokerTests {
 
 	@Test
@@ -60,6 +67,21 @@ class CachingOperationInvokerTests {
 		parameters.put("first", null);
 		parameters.put("second", null);
 		assertCacheIsUsed(parameters);
+	}
+
+	@Test
+	void cacheInTtlWithMonoResponse(CapturedOutput capturedOutput) {
+		MonoOperationInvoker target = new MonoOperationInvoker();
+		InvocationContext context = new InvocationContext(mock(SecurityContext.class), Collections.emptyMap());
+		CachingOperationInvoker invoker = new CachingOperationInvoker(target, 500L);
+		Object monoResponse = invoker.invoke(context);
+		assertThat(monoResponse).isInstanceOf(Mono.class);
+		Object response = ((Mono) monoResponse).block(Duration.ofSeconds(30));
+		Object cachedMonoResponse = invoker.invoke(context);
+		assertThat(cachedMonoResponse).isInstanceOf(Mono.class);
+		Object cachedResponse = ((Mono) cachedMonoResponse).block(Duration.ofSeconds(30));
+		assertThat(response).isSameAs(cachedResponse);
+		assertThat(capturedOutput).containsOnlyOnce("invoked");
 	}
 
 	private void assertCacheIsUsed(Map<String, Object> parameters) {
@@ -120,6 +142,20 @@ class CachingOperationInvokerTests {
 		}
 		invoker.invoke(context);
 		verify(target, times(2)).invoke(context);
+	}
+
+	private static class MonoOperationInvoker implements OperationInvoker {
+
+		@Override
+		public Object invoke(InvocationContext context) throws MissingParametersException {
+			return Mono.fromCallable(this::printInvocation);
+		}
+
+		private Mono<String> printInvocation() {
+			System.out.println("MonoOperationInvoker invoked");
+			return Mono.just("test");
+		}
+
 	}
 
 }


### PR DESCRIPTION
Hi,

this PR is an attempt to fix #18324 . I'm not super familiar with the reactive side of things, but the proposed solution seems to fix the provided sample in #18324. A proper review and feedback is therefore highly appreciated.

Let me know what you think.
Cheers,
Christoph