### PR TITLE
Added bootstrap* properties files to resources with active filtering.

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/pom.xml
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/pom.xml
@@ -32,6 +32,9 @@
 					<include>**/application*.yml</include>
 					<include>**/application*.yaml</include>
 					<include>**/application*.properties</include>
+					<include>**/bootstrap*.yml</include>
+					<include>**/bootstrap*.yaml</include>
+					<include>**/bootstrap*.properties</include>
 				</includes>
 			</resource>
 			<resource>
@@ -40,6 +43,9 @@
 					<exclude>**/application*.yml</exclude>
 					<exclude>**/application*.yaml</exclude>
 					<exclude>**/application*.properties</exclude>
+					<exclude>**/bootstrap*.yml</exclude>
+					<exclude>**/bootstrap*.yaml</exclude>
+					<exclude>**/bootstrap*.properties</exclude>
 				</excludes>
 			</resource>
 		</resources>


### PR DESCRIPTION
Added bootstrap* properties files to resources with filtering on. This allows to use maven property placeholders in side them.

This is useful for example when using spring-cloud-config. I wanted to use
```
spring:
    application:
        name: '@project.artifactId@'
```
in bootstrap.yaml but it was not replaced with the appropriate value.