### PR TITLE
Values for 'management.endpoints.web.exposure'

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1926,6 +1926,152 @@
       ]
     },
     {
+      "name": "management.endpoints.jmx.exposure.include",
+      "values": [
+        {
+          "value": "*"
+        },
+        {
+          "value": "auditevents"
+        },
+        {
+          "value": "beans"
+        },
+        {
+          "value": "conditions"
+        },
+        {
+          "value": "configprops"
+        },
+        {
+          "value": "env"
+        },
+        {
+          "value": "flyway"
+        },
+        {
+          "value": "health"
+        },
+        {
+          "value": "heapdump"
+        },
+        {
+          "value": "httptrace"
+        },
+        {
+          "value": "info"
+        },
+        {
+          "value": "liquibase"
+        },
+        {
+          "value": "logfile"
+        },
+        {
+          "value": "loggers"
+        },
+        {
+          "value": "mappings"
+        },
+        {
+          "value": "metrics"
+        },
+        {
+          "value": "prometheus"
+        },
+        {
+          "value": "scheduledtasks"
+        },
+        {
+          "value": "sessions"
+        },
+        {
+          "value": "shutdown"
+        },
+        {
+          "value": "threaddump"
+        }
+      ],
+      "providers": [
+        {
+          "name": "any"
+        }
+      ]
+    },
+    {
+      "name": "management.endpoints.jmx.exposure.exclude",
+      "values": [
+        {
+          "value": "*"
+        },
+        {
+          "value": "auditevents"
+        },
+        {
+          "value": "beans"
+        },
+        {
+          "value": "conditions"
+        },
+        {
+          "value": "configprops"
+        },
+        {
+          "value": "env"
+        },
+        {
+          "value": "flyway"
+        },
+        {
+          "value": "health"
+        },
+        {
+          "value": "heapdump"
+        },
+        {
+          "value": "httptrace"
+        },
+        {
+          "value": "info"
+        },
+        {
+          "value": "liquibase"
+        },
+        {
+          "value": "logfile"
+        },
+        {
+          "value": "loggers"
+        },
+        {
+          "value": "mappings"
+        },
+        {
+          "value": "metrics"
+        },
+        {
+          "value": "prometheus"
+        },
+        {
+          "value": "scheduledtasks"
+        },
+        {
+          "value": "sessions"
+        },
+        {
+          "value": "shutdown"
+        },
+        {
+          "value": "threaddump"
+        }
+      ],
+      "providers": [
+        {
+          "name": "any"
+        }
+      ]
+    },
+    {
       "name": "management.endpoints.web.exposure.include",
       "values": [
         {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1926,6 +1926,152 @@
       ]
     },
     {
+      "name": "management.endpoints.web.exposure.include",
+      "values": [
+        {
+          "value": "*"
+        },
+        {
+          "value": "auditevents"
+        },
+        {
+          "value": "beans"
+        },
+        {
+          "value": "conditions"
+        },
+        {
+          "value": "configprops"
+        },
+        {
+          "value": "env"
+        },
+        {
+          "value": "flyway"
+        },
+        {
+          "value": "health"
+        },
+        {
+          "value": "heapdump"
+        },
+        {
+          "value": "httptrace"
+        },
+        {
+          "value": "info"
+        },
+        {
+          "value": "liquibase"
+        },
+        {
+          "value": "logfile"
+        },
+        {
+          "value": "loggers"
+        },
+        {
+          "value": "mappings"
+        },
+        {
+          "value": "metrics"
+        },
+        {
+          "value": "prometheus"
+        },
+        {
+          "value": "scheduledtasks"
+        },
+        {
+          "value": "sessions"
+        },
+        {
+          "value": "shutdown"
+        },
+        {
+          "value": "threaddump"
+        }
+      ],
+      "providers": [
+        {
+          "name": "any"
+        }
+      ]
+    },
+    {
+      "name": "management.endpoints.web.exposure.exclude",
+      "values": [
+        {
+          "value": "*"
+        },
+        {
+          "value": "auditevents"
+        },
+        {
+          "value": "beans"
+        },
+        {
+          "value": "conditions"
+        },
+        {
+          "value": "configprops"
+        },
+        {
+          "value": "env"
+        },
+        {
+          "value": "flyway"
+        },
+        {
+          "value": "health"
+        },
+        {
+          "value": "heapdump"
+        },
+        {
+          "value": "httptrace"
+        },
+        {
+          "value": "info"
+        },
+        {
+          "value": "liquibase"
+        },
+        {
+          "value": "logfile"
+        },
+        {
+          "value": "loggers"
+        },
+        {
+          "value": "mappings"
+        },
+        {
+          "value": "metrics"
+        },
+        {
+          "value": "prometheus"
+        },
+        {
+          "value": "scheduledtasks"
+        },
+        {
+          "value": "sessions"
+        },
+        {
+          "value": "shutdown"
+        },
+        {
+          "value": "threaddump"
+        }
+      ],
+      "providers": [
+        {
+          "name": "any"
+        }
+      ]
+    },
+    {
       "name": "management.health.status.order",
       "values": [
         {


### PR DESCRIPTION
It might make sense to add values hints and `any` provider to `management.endpoints.web.exposure.include` and `management.endpoints.web.exposure.exclude` configuration properties.

The hinted values are the basic available actuators endpoint ids plus `*`.

This way IDEs could help building the comma separated list of actuator endpoints to hide/expose providing completion on endpoints names. For example I have added such support to NetBeans SpringBoot plugin in commit https://github.com/AlexFalappa/nb-springboot/commit/3fb9478560aa77393f116ae06397187685d1181a

Such type of hint is similar to that for `management.health.status.order` configuration property of type `List<String>`.

Feel free to also backport to 2.1.x line if it makes sense.