### PR TITLE
Micrometer dependency management does not include its micrometer-registry-cloudwatch2 module

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -1076,6 +1076,11 @@
 			</dependency>
 			<dependency>
 				<groupId>io.micrometer</groupId>
+				<artifactId>micrometer-registry-cloudwatch2</artifactId>
+				<version>${micrometer.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.micrometer</groupId>
 				<artifactId>micrometer-registry-datadog</artifactId>
 				<version>${micrometer.version}</version>
 			</dependency>


### PR DESCRIPTION
Hi,

this PR adds dependency management for **micrometer-registry-cloudwatch2**. In the absence of a Micrometer BOM (that hopefully comes with 1.3) I guess we should add this manually for now. As there is no autoconfiguration for cloudwatch2 (much like cloudwatch) this is for the sole purpose of completing the micrometer dependency management. So feel free to close this PR if you think it's not worth it.

Cheers,
Christoph