### PR TITLE
Add missing appendices to PDF reference documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-reference.pdfadoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-reference.pdfadoc
@@ -14,4 +14,15 @@ include::deployment.adoc[leveloffset=+1]
 include::spring-boot-cli.adoc[leveloffset=+1]
 include::build-tool-plugins.adoc[leveloffset=+1]
 include::howto.adoc[leveloffset=+1]
-include::appendix.adoc[leveloffset=+1]
+
+
+
+[[appendix]]
+== Appendices
+
+include::appendix-application-properties.adoc[leveloffset=+2]
+include::appendix-configuration-metadata.adoc[leveloffset=+2]
+include::appendix-auto-configuration-classes.adoc[leveloffset=+2]
+include::appendix-test-auto-configuration.adoc[leveloffset=+2]
+include::appendix-executable-jar-format.adoc[leveloffset=+2]
+include::appendix-dependency-versions.adoc[leveloffset=+2]


### PR DESCRIPTION
Hi,

this PR is an attempt to fix #18370. It seems that the change made to `index.htmlsingleadoc` in d5adbbb62675889606aed75eede4f8d40bb25358 was simply forgotten in the `.pdfadoc` file.

Cheers,
Christoph