### PR TITLE
Mention Java 13 in system requirements docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/getting-started.adoc
@@ -29,7 +29,7 @@ Our primary goals are:
 
 [[getting-started-system-requirements]]
 == System Requirements
-Spring Boot {spring-boot-version} requires https://www.java.com[Java 8] and is compatible up to Java 12 (included).
+Spring Boot {spring-boot-version} requires https://www.java.com[Java 8] and is compatible up to Java 13 (included).
 {spring-framework-docs}[Spring Framework {spring-framework-version}] or above is also required.
 
 Explicit build support is provided for the following build tools:


### PR DESCRIPTION
Hi,

the System requirements section in the docs mention Java 12 as the upper limit, but I guess it's safe to mention 13 here.

Let me know what you think.
Cheers,
Christoph