### PR TITLE
Fix default values in metadata for HiddenHttpMethodFilter

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -719,7 +719,7 @@
       "name": "spring.mvc.hiddenmethod.filter.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable Spring's HiddenHttpMethodFilter.",
-      "defaultValue": true
+      "defaultValue": false
     },
     {
       "name" : "spring.mvc.media-types",
@@ -2096,7 +2096,7 @@
       "name": "spring.webflux.hiddenmethod.filter.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable Spring's HiddenHttpMethodFilter.",
-      "defaultValue": true
+      "defaultValue": false
     }
   ],
   "hints": [


### PR DESCRIPTION
Hi,

this PR fixes the default values of `spring.mvc.hiddenmethod.filter.enabled` and `spring.webflux.hiddenmethod.filter.enabled` in the metadata and thus in the docs as reported in [this comment](https://github.com/spring-projects/spring-boot/issues/16953#issuecomment-536295963).

Cheers,
Christoph