### PR TITLE
Remove prohibited version of Maven Invoker Plugin

### DIFF
--- a/.bomr/bomr.yaml
+++ b/.bomr/bomr.yaml
@@ -8,10 +8,6 @@ bomr:
         - 'type: dependency-upgrade'
     policy: same-major-version
     prohibited:
-      - project: maven-invoker-plugin
-        versions:
-          # NPE in InstallMojo.installProjectPom (InstallMojo.java:387)
-          - '[3.2.0]'
       - project: derby
         versions:
           # 10.15 requires Java 9


### PR DESCRIPTION
Hi,

since Maven Invoker Plugin was updated to 3.2.1 lately, I guess the prohibited version for 3.2.0 can be removed from the `bomr.yaml`. I wasn't sure if it should stick around, but a downgrade that makes this relevant again seems unlikely.

Let me know what you think.
Cheers,
Christoph