### PR TITLE
Move the JUnit 4 support to Surefire and Failsafe

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/pom.xml
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/pom.xml
@@ -92,6 +92,24 @@
 					<configuration>
 						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
 					</configuration>
+					<dependencies>
+						<dependency>
+							<groupId>org.junit.vintage</groupId>
+							<artifactId>junit-vintage-engine</artifactId>
+							<version>${junit-jupiter.version}</version>
+						</dependency>
+					</dependencies>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<dependencies>
+						<dependency>
+							<groupId>org.junit.vintage</groupId>
+							<artifactId>junit-vintage-engine</artifactId>
+							<version>${junit-jupiter.version}</version>
+						</dependency>
+					</dependencies>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-test/pom.xml
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-test/pom.xml
@@ -40,16 +40,6 @@
 			<artifactId>junit-jupiter</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.hamcrest</groupId>
-					<artifactId>hamcrest-core</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-junit-jupiter</artifactId>
 		</dependency>


### PR DESCRIPTION
The previous support required the JUnit Jupiter engine on the classpath. This further clarifies the default support for JUnit 4 to require an extra dependency within projects that require it, while the default support will be JUnit 5.

It was odd to me that brand new projects require an exclusion from `spring-boot-starter-test` to kick off the default support for JUnit 5. Since it is as simple as adding a user dependency to the vintage engine, why not go with that?