### PR TITLE
Fix comment position in ZipHeaderPeekInputStreamTests

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/ZipHeaderPeekInputStreamTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/ZipHeaderPeekInputStreamTests.java
@@ -16,11 +16,6 @@
 
 package org.springframework.boot.loader.tools;
 
-/**
- * Tests for {@link ZipHeaderPeekInputStream}.
- *
- * @author Andy Wilkinson
- */
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
@@ -30,6 +25,11 @@ import org.springframework.boot.loader.tools.JarWriter.ZipHeaderPeekInputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for {@link ZipHeaderPeekInputStream}.
+ *
+ * @author Andy Wilkinson
+ */
 class ZipHeaderPeekInputStreamTests {
 
 	@Test


### PR DESCRIPTION
Hi,

I just found this comment that was not placed directly above the class but between package and import statements. I wonder if checkstyle/spring-javaformat could catch that.

Cheers,
Christoph