### PR TITLE
Upgrade to Testcontainers 1.12.2

### DIFF
--- a/spring-boot-project/spring-boot-parent/pom.xml
+++ b/spring-boot-project/spring-boot-parent/pom.xml
@@ -26,7 +26,7 @@
 		<maven.version>3.5.4</maven.version>
 		<maven-resolver.version>1.1.1</maven-resolver.version>
 		<spock.version>1.0-groovy-2.4</spock.version>
-		<testcontainers.version>1.12.0</testcontainers.version>
+		<testcontainers.version>1.12.2</testcontainers.version>
 		<testng.version>6.14.3</testng.version>
 		<spring-doc-resources.version>0.1.3.RELEASE</spring-doc-resources.version>
 		<spring-doc-resources.url>https://repo.spring.io/release/io/spring/docresources/spring-doc-resources/${spring-doc-resources.version}/spring-doc-resources-${spring-doc-resources.version}.zip</spring-doc-resources.url>


### PR DESCRIPTION
Hi,

this PR upgrades Testcontainers to version 1.12.2. Am I right that only the `pom.xml` under `spring-boot-dependencies` is covered by `bomr` and hence the (half-)automatic upgrade process? If not, please ignore this PR. ;-)

Cheers,
Christoph