### PR TITLE
Use dedicated method to turn off Neo4jContainer's authentication

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/neo4j/DataNeo4jTestIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/neo4j/DataNeo4jTestIntegrationTests.java
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 class DataNeo4jTestIntegrationTests {
 
 	@Container
-	static final Neo4jContainer<?> neo4j = new Neo4jContainer<>().withAdminPassword(null);
+	static final Neo4jContainer<?> neo4j = new Neo4jContainer<>().withoutAuthentication();
 
 	@Autowired
 	private Session session;


### PR DESCRIPTION
Just a small thing. We added this method to Testcontainers to have a nicer API.
Thanks again for the hint some time ago.