### PR TITLE
Remove accidental usage of UnsupportedOptionException

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/support/ErrorPageFilterIntegrationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/support/ErrorPageFilterIntegrationTests.java
@@ -26,7 +26,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.xnio.channels.UnsupportedOptionException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
@@ -190,7 +189,7 @@ class ErrorPageFilterIntegrationTests {
 
 		@Override
 		public ApplicationContext loadContext(String... locations) {
-			throw new UnsupportedOptionException();
+			throw new UnsupportedOperationException();
 		}
 
 		@Override
@@ -200,7 +199,7 @@ class ErrorPageFilterIntegrationTests {
 
 		@Override
 		protected String getResourceSuffix() {
-			throw new UnsupportedOptionException();
+			throw new UnsupportedOperationException();
 		}
 
 	}


### PR DESCRIPTION
Hi,

just noticed the usage of `org.xnio.channels.UnsupportedOptionException` that seems accidental. Probably Java's `UnsupportedOperationException` was wanted here. Let me know when I should add this to the illegalClasses check - I wasn't sure if I should do this already.

Cheers,
Christoph