### PR TITLE
Remove usage of @InjectMocks

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/integration/IntegrationGraphEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/integration/IntegrationGraphEndpointTests.java
@@ -18,7 +18,6 @@ package org.springframework.boot.actuate.integration;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -40,12 +39,12 @@ class IntegrationGraphEndpointTests {
 	@Mock
 	private IntegrationGraphServer integrationGraphServer;
 
-	@InjectMocks
 	private IntegrationGraphEndpoint integrationGraphEndpoint;
 
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.initMocks(this);
+		this.integrationGraphEndpoint = new IntegrationGraphEndpoint(this.integrationGraphServer);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/integration/IntegrationGraphEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/integration/IntegrationGraphEndpointTests.java
@@ -16,10 +16,7 @@
 
 package org.springframework.boot.actuate.integration;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import org.springframework.integration.graph.Graph;
 import org.springframework.integration.graph.IntegrationGraphServer;
@@ -36,30 +33,23 @@ import static org.mockito.Mockito.verify;
  */
 class IntegrationGraphEndpointTests {
 
-	@Mock
-	private IntegrationGraphServer integrationGraphServer;
+	private final IntegrationGraphServer server = mock(IntegrationGraphServer.class);
 
-	private IntegrationGraphEndpoint integrationGraphEndpoint;
-
-	@BeforeEach
-	void setUp() {
-		MockitoAnnotations.initMocks(this);
-		this.integrationGraphEndpoint = new IntegrationGraphEndpoint(this.integrationGraphServer);
-	}
+	private final IntegrationGraphEndpoint endpoint = new IntegrationGraphEndpoint(this.server);
 
 	@Test
 	void readOperationShouldReturnGraph() {
 		Graph mockedGraph = mock(Graph.class);
-		given(this.integrationGraphServer.getGraph()).willReturn(mockedGraph);
-		Graph graph = this.integrationGraphEndpoint.graph();
-		verify(this.integrationGraphServer).getGraph();
+		given(this.server.getGraph()).willReturn(mockedGraph);
+		Graph graph = this.endpoint.graph();
+		verify(this.server).getGraph();
 		assertThat(graph).isEqualTo(mockedGraph);
 	}
 
 	@Test
 	void writeOperationShouldRebuildGraph() {
-		this.integrationGraphEndpoint.rebuild();
-		verify(this.integrationGraphServer).rebuild();
+		this.endpoint.rebuild();
+		verify(this.server).rebuild();
 	}
 
 }

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -15,7 +15,7 @@
 			<property name="illegalPkgs"
 				value="^sun.*, ^org\.apache\.commons\.(?!compress|dbcp2|lang|lang3|logging|pool2).*, ^com\.google\.common.*, ^org\.flywaydb\.core\.internal.*, ^org\.testcontainers\.shaded.*" />
 			<property name="illegalClasses"
-				value="^com\.hazelcast\.util\.Base64, ^org\.junit\.rules\.ExpectedException, ^org\.slf4j\.LoggerFactory, ^reactor\.core\.support\.Assert" />
+				value="^com\.hazelcast\.util\.Base64, ^org\.junit\.rules\.ExpectedException, ^org\.mockito\.InjectMocks, ^org\.slf4j\.LoggerFactory, ^reactor\.core\.support\.Assert" />
 		</module>
 		<module
 			name="com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck">


### PR DESCRIPTION
Hi,

this PR removes the usage of `@InjectMocks` inside tests. For some people - including me - it's similar to field injection and thus not desirable to have.

Cheers,
Christoph