### PR TITLE
Upgrade to rest-assured 4.1.2

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -172,7 +172,7 @@
 		<querydsl.version>4.2.1</querydsl.version>
 		<rabbit-amqp-client.version>5.7.3</rabbit-amqp-client.version>
 		<reactor-bom.version>Dysprosium-RELEASE</reactor-bom.version>
-		<rest-assured.version>3.3.0</rest-assured.version>
+		<rest-assured.version>4.1.2</rest-assured.version>
 		<reactive-streams.version>1.0.3</reactive-streams.version>
 		<rsocket.version>1.0.0-RC5</rsocket.version>
 		<rxjava.version>1.3.8</rxjava.version>


### PR DESCRIPTION
Hi,

Since there are some breaking changes between rest-assured 3.3 and 4.0, I think it would be nice to upgrade to 4.x before Spring Boot 2.2 release.

Have a good day.