### PR TITLE
LegacyReactiveHealthEndpointCompatibilityConfiguration activates in non-reactive application

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/health/LegacyHealthEndpointCompatibilityConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/health/LegacyHealthEndpointCompatibilityConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.health;
 
-import io.micrometer.shaded.reactor.core.publisher.Mono;
+import reactor.core.publisher.Mono;
 
 import org.springframework.boot.actuate.health.HealthAggregator;
 import org.springframework.boot.actuate.health.HealthContributorRegistry;

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/health/HealthEndpointAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/health/HealthEndpointAutoConfigurationTests.java
@@ -47,6 +47,7 @@ import org.springframework.boot.actuate.health.ReactiveHealthIndicator;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.actuate.health.StatusAggregator;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -291,6 +292,12 @@ class HealthEndpointAutoConfigurationTests {
 			HealthStatusHttpMapper mapper = context.getBean(HealthStatusHttpMapper.class);
 			assertThat(mapper.mapStatus(Status.DOWN)).isEqualTo(503);
 		});
+	}
+
+	@Test // gh-18570
+	void runDoesNotFailWithoutReactorOnClasspath() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader(Mono.class.getPackage().getName()))
+				.run((context) -> assertThat(context).hasNotFailed());
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
Hi,

this PR is an attempt to fix #18570 by changing `LegacyHealthEndpointCompatibilityConfiguration$LegacyReactiveHealthEndpointCompatibilityConfiguration` to only kick in when `reactor.core.publisher.Mono` is available instead of `io.micrometer.shaded.reactor.core.publisher.Mono`.

Let me know what you think.
Cheers,
Christoph