### PR TITLE
Rename tests to match Surefire expectations

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/elasticsearch/ElasticsearchRestHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/elasticsearch/ElasticsearchRestHealthIndicatorTests.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.mock;
  * @author Artsiom Yudovin
  * @author Filip Hrisafov
  */
-class ElasticsearchRestHealthIndicatorTest {
+class ElasticsearchRestHealthIndicatorTests {
 
 	private final RestClient restClient = mock(RestClient.class);
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/context/WebServerPortFileWriterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/context/WebServerPortFileWriterTests.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.mock;
  * @author Phillip Webb
  * @author Andy Wilkinson
  */
-class WebServerPortFileWriterTest {
+class WebServerPortFileWriterTests {
 
 	@TempDir
 	File tempDir;


### PR DESCRIPTION
Hi,

just noticed two tests that don't match the include pattern for surefire and are thus not run during CI builds.

Cheers,
Christoph