### PR TITLE
Use LinkedHashSet for deterministic order in test assertions

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/CollectionBinderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/CollectionBinderTests.java
@@ -19,7 +19,7 @@ package org.springframework.boot.context.properties.bind;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -433,7 +433,7 @@ class CollectionBinderTests {
 
 		private List<String> items = new ArrayList<>();
 
-		private Set<String> itemsSet = new HashSet<>();
+		private Set<String> itemsSet = new LinkedHashSet<>();
 
 		List<String> getItems() {
 			return this.items;


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Test `org.springframework.boot.context.properties.bind.CollectionBinderTests#bindToSetShouldNotAllowDuplicateValues` depends on the iteration order of `itemsSet` in `ExampleCollectionBean`. However, it is a `HashSet` and `HashSet` does not guarantee any specific order of entries. Thus, test can fail due to a different iteration order.

In this PR, we propose to use a `LinkedHashSet` instead to guarantee the iteration order (as the insertion orders).