### PR TITLE
Use LinkedHashSet for deterministic order in test assertion

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/CompositeHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/CompositeHealthIndicatorTests.java
@@ -18,6 +18,7 @@ package org.springframework.boot.actuate.health;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -72,7 +73,7 @@ class CompositeHealthIndicatorTests {
 
 	@Test
 	void testSerialization() throws Exception {
-		Map<String, HealthIndicator> indicators = new HashMap<>();
+		Map<String, HealthIndicator> indicators = new LinkedHashMap<>();
 		indicators.put("db1", this.one);
 		indicators.put("db2", this.two);
 		CompositeHealthIndicator innerComposite = new CompositeHealthIndicator(this.healthAggregator, indicators);


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Test case `testSerialization` is trying to test the serialization of CompositeHealthIndicator. However, there is a subtle dependency that the serialization depends on, which is the iteration order of HashMap it uses. However, HashMap does not guarantee any specific order of entries. Therefore, the assertions will fail if the order is different.
Test cases should pass regardless of the HashMap iteration orders, otherwise it cannot serve as a regression test. 

This PR proposes to change HashMap to use LinkedHashMap that makes the iteration order deterministic, which is the insertion order. The test also assumes this order so no need to modify the test assertion.
