### PR TITLE
Remove JavaVersion.current() call in BootRun.exec()

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/run/BootRun.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/run/BootRun.java
@@ -18,7 +18,6 @@ package org.springframework.boot.gradle.tasks.run;
 
 import java.lang.reflect.Method;
 
-import org.gradle.api.JavaVersion;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.JavaExec;
@@ -72,7 +71,6 @@ public class BootRun extends JavaExec {
 	public void exec() {
 		if (this.optimizedLaunch) {
 			setJvmArgs(getJvmArgs());
-			JavaVersion.current();
 			if (!isJava13OrLater()) {
 				jvmArgs("-Xverify:none");
 			}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR removes `JavaVersion.current()` call in `BootRun.exec()` as it doesn't seem to be necessary.