### PR TITLE
Narrow type for Tomcat 'locale' and 'encoding' properties

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2171,6 +2171,28 @@
       ]
     },
     {
+      "name": "server.tomcat.accesslog.encoding",
+      "providers": [
+        {
+          "name": "handle-as",
+          "parameters": {
+            "target": "java.nio.charset.Charset"
+          }
+        }
+      ]
+    },
+    {
+      "name": "server.tomcat.accesslog.locale",
+      "providers": [
+        {
+          "name": "handle-as",
+          "parameters": {
+            "target": "java.util.Locale"
+          }
+        }
+      ]
+    },
+    {
       "name": "spring.liquibase.change-log",
       "providers": [
         {


### PR DESCRIPTION
It might make sense to define `handle-as` providers for `server.tomcat.accesslog.locale` and `server.tomcat.accesslog.encoding` configuration properties.

Both are strings but represent a `java.util.Locale` and a `java.nio.charset.CharSet` respectively.

This way IDEs can provide completion for those properties.