### PR TITLE
Add new auto-configuration properties for jms.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/DefaultJmsListenerContainerFactoryConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/DefaultJmsListenerContainerFactoryConfigurer.java
@@ -88,6 +88,8 @@ public final class DefaultJmsListenerContainerFactoryConfigurer {
 		Assert.notNull(connectionFactory, "ConnectionFactory must not be null");
 		factory.setConnectionFactory(connectionFactory);
 		factory.setPubSubDomain(this.jmsProperties.isPubSubDomain());
+		factory.setSubscriptionDurable(this.jmsProperties.isSubscriptionDurable());
+		factory.setSubscriptionShared(this.jmsProperties.isSubscriptionShared());
 		if (this.transactionManager != null) {
 			factory.setTransactionManager(this.transactionManager);
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsProperties.java
@@ -37,6 +37,18 @@ public class JmsProperties {
 	private boolean pubSubDomain = false;
 
 	/**
+	 * Set whether to make the subscription shared.
+	 * <p>Default is "false". Set this to "true" to register a shared subscription.
+	 */
+	private boolean subscriptionShared = false;
+
+	/**
+	 * Set whether to make the subscription durable.
+	 * <p>Default is "false". Set this to "true" to register a durable subscription.
+	 */
+	private boolean subscriptionDurable = false;
+
+	/**
 	 * Connection factory JNDI name. When set, takes precedence to others connection
 	 * factory auto-configurations.
 	 */
@@ -52,8 +64,30 @@ public class JmsProperties {
 		return this.pubSubDomain;
 	}
 
+	/**
+	 * Return whether to make the subscription shared.
+	 */
+	public boolean isSubscriptionShared() {
+		return this.subscriptionShared;
+	}
+
+	/**
+	 * Return whether to make the subscription durable.
+	 */
+	public boolean isSubscriptionDurable() {
+		return this.subscriptionDurable;
+	}
+
 	public void setPubSubDomain(boolean pubSubDomain) {
 		this.pubSubDomain = pubSubDomain;
+	}
+
+	public void setSubscriptionShared(boolean subscriptionShared){
+		this.subscriptionShared = subscriptionShared;
+	}
+
+	public void setSubscriptionDurable(boolean subscriptionDurable){
+		this.subscriptionDurable = subscriptionDurable;
 	}
 
 	public String getJndiName() {


### PR DESCRIPTION
Now you can use 
```
spring.jms.subscription-shared=true
spring.jms.subscription-durable=true
```
for making your jms subscription shared or/and durable.

With these changes you can use default auto-configuration from 
_org.springframework.boot.autoconfigure.jms.JmsAnnotationDrivenConfiguration#jmsListenerContainerFactory_
 And you don't need to make your own bean just for that.

There is example **without** these changes:

```
@Configuration
@EnableJms
public class JmsConfig {

    @Bean
    DefaultJmsListenerContainerFactory jmsListenerContainerFactory(
            DefaultJmsListenerContainerFactoryConfigurer configurer, ConnectionFactory connectionFactory) {
        DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
        factory.setSubscriptionShared(true);
        factory.setSubscriptionDurable(true);
        configurer.configure(factory, connectionFactory);
        return factory;
    }
}

```

There is example **with** these changes:

```
@Configuration
@EnableJms
public class JmsConfig {
}

```

And some properties in your config:
```
spring.jms.subscription-shared=true
spring.jms.subscription-durable=true
```

I think it is more comfortable, Thanks!

