### PR TITLE
Make optimizedLaunch property name more consistent

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunMojo.java
@@ -60,7 +60,7 @@ public class RunMojo extends AbstractRunMojo {
 	 * Whether the JVM's launch should be optimized.
 	 * @since 2.2.0
 	 */
-	@Parameter(property = "optimizedLaunch", defaultValue = "true")
+	@Parameter(property = "spring-boot.run.optimizedLaunch", defaultValue = "true")
 	private boolean optimizedLaunch;
 
 	@Override


### PR DESCRIPTION
Rename maven spring boot plugin `optimizedLaunch` property to `spring-boot.run.optimizedLaunch` to make it more consistent with the other spring-boot:run goal property names.