### PR TITLE
Set 'posix' for tarLongFileMode attribute in 'maven-assembly-plugin'

### DIFF
--- a/spring-boot-project/spring-boot-cli/pom.xml
+++ b/spring-boot-project/spring-boot-cli/pom.xml
@@ -259,6 +259,7 @@
 							<goal>single</goal>
 						</goals>
 						<configuration>
+							<tarLongFileMode>posix</tarLongFileMode>
 							<descriptors>
 								<descriptor>src/main/assembly/jar-with-dependencies.xml</descriptor>
 							</descriptors>
@@ -281,6 +282,7 @@
 							<goal>single</goal>
 						</goals>
 						<configuration>
+							<tarLongFileMode>posix</tarLongFileMode>
 							<descriptors>
 								<descriptor>src/main/assembly/bin-package.xml</descriptor>
 							</descriptors>


### PR DESCRIPTION
I'm not able to build a project because of
> [INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 21.478 s
[INFO] Finished at: 2019-10-25T13:45:31+03:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.1.1:single (bin-package) on project spring-boot-cli: Execution bin-package of goal org.apache.maven.plugins:maven-assembly-plugin:3.1.1:single failed: group id '216156898' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit -> [Help 1]

Software information:
```
System Version: macOS 10.14.6 (18G95)
Kernel Version: Darwin 18.7.0
java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
Java HotSpot(TM) 64-Bit Server VM (build 25.201-b09, mixed mode)
EPUALVIW1499:current dmytro_nosan$ 
```

Seems like without setting `posix` for **tarLongFileMode** attribute there is no way to build a project 😭 