### PR TITLE
Delete Javadoc references to removed code

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/MultipartConfigFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/MultipartConfigFactory.java
@@ -21,8 +21,7 @@ import javax.servlet.MultipartConfigElement;
 import org.springframework.util.unit.DataSize;
 
 /**
- * Factory that can be used to create a {@link MultipartConfigElement}. Size values can be
- * set using {@link DataSize} variants.
+ * Factory that can be used to create a {@link MultipartConfigElement}.
  *
  * @author Phillip Webb
  * @since 1.4.0

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/MultipartConfigFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/MultipartConfigFactory.java
@@ -22,8 +22,7 @@ import org.springframework.util.unit.DataSize;
 
 /**
  * Factory that can be used to create a {@link MultipartConfigElement}. Size values can be
- * set using traditional {@literal long} values which are set in bytes or using more
- * convenient {@link DataSize} variants.
+ * set using {@link DataSize} variants.
  *
  * @author Phillip Webb
  * @since 1.4.0


### PR DESCRIPTION
A trivial update of the documentation, removing references to methods that were first deprecated and then removed.
@pivotal-issuemaster This is an Obvious Fix
Rework of #18668 