### PR TITLE
Enable users to provide custom time and datetime formats for MVC and WebFlux type conversion

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/format/WebConversionService.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/format/WebConversionService.java
@@ -59,15 +59,32 @@ public class WebConversionService extends DefaultFormattingConversionService {
 
 	private final String dateFormat;
 
+	private final String timeFormat;
+
+	private final String dateTimeFormat;
+
 	/**
 	 * Create a new WebConversionService that configures formatters with the provided date
 	 * format, or register the default ones if no custom format is provided.
 	 * @param dateFormat the custom date format to use for date conversions
 	 */
 	public WebConversionService(String dateFormat) {
+		this(dateFormat, null, null);
+	}
+
+	/**
+	 * Create a new WebConversionService that configures formatters with the provided date
+	 * and time formats, or register the default ones if no custom formats are provided.
+	 * @param dateFormat the custom date format to use for date conversions
+	 * @param timeFormat the custom time format to use for time conversions
+	 * @param dateTimeFormat the custom datetime format to use for datetime conversions
+	 */
+	public WebConversionService(String dateFormat, String timeFormat, String dateTimeFormat) {
 		super(false);
-		this.dateFormat = StringUtils.hasText(dateFormat) ? dateFormat : null;
-		if (this.dateFormat != null) {
+		this.dateFormat = getNonEmptyFormat(dateFormat);
+		this.timeFormat = getNonEmptyFormat(timeFormat);
+		this.dateTimeFormat = getNonEmptyFormat(dateTimeFormat);
+		if (this.dateFormat != null || this.timeFormat != null || this.dateTimeFormat != null) {
 			addFormatters();
 		}
 		else {
@@ -95,6 +112,17 @@ public class WebConversionService extends DefaultFormattingConversionService {
 			dateTime.setDateFormatter(
 					DateTimeFormatter.ofPattern(this.dateFormat).withResolverStyle(ResolverStyle.SMART));
 		}
+
+		if (this.timeFormat != null) {
+			dateTime.setTimeFormatter(
+					DateTimeFormatter.ofPattern(this.timeFormat).withResolverStyle(ResolverStyle.SMART));
+		}
+
+		if (this.dateTimeFormat != null) {
+			dateTime.setDateTimeFormatter(
+					DateTimeFormatter.ofPattern(this.dateTimeFormat).withResolverStyle(ResolverStyle.SMART));
+		}
+
 		dateTime.registerFormatters(this);
 	}
 
@@ -115,6 +143,10 @@ public class WebConversionService extends DefaultFormattingConversionService {
 			dateFormatterRegistrar.setFormatter(dateFormatter);
 		}
 		dateFormatterRegistrar.registerFormatters(this);
+	}
+
+	private static String getNonEmptyFormat(final String format) {
+		return StringUtils.hasText(format) ? format : null;
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfiguration.java
@@ -203,7 +203,8 @@ public class WebFluxAutoConfiguration {
 		@Bean
 		@Override
 		public FormattingConversionService webFluxConversionService() {
-			WebConversionService conversionService = new WebConversionService(this.webFluxProperties.getDateFormat());
+			WebConversionService conversionService = new WebConversionService(this.webFluxProperties.getDateFormat(),
+					this.webFluxProperties.getTimeFormat(), this.webFluxProperties.getDateTimeFormat());
 			addFormatters(conversionService);
 			return conversionService;
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxProperties.java
@@ -33,6 +33,16 @@ public class WebFluxProperties {
 	private String dateFormat;
 
 	/**
+	 * Time format to use. For instance, `HH:mm:ss`.
+	 */
+	private String timeFormat;
+
+	/**
+	 * Datetime format to use. For instance, `yyyy-MM-dd HH:mm:ss`.
+	 */
+	private String dateTimeFormat;
+
+	/**
 	 * Path pattern used for static resources.
 	 */
 	private String staticPathPattern = "/**";
@@ -43,6 +53,22 @@ public class WebFluxProperties {
 
 	public void setDateFormat(String dateFormat) {
 		this.dateFormat = dateFormat;
+	}
+
+	public String getTimeFormat() {
+		return this.timeFormat;
+	}
+
+	public void setTimeFormat(final String timeFormat) {
+		this.timeFormat = timeFormat;
+	}
+
+	public String getDateTimeFormat() {
+		return this.dateTimeFormat;
+	}
+
+	public void setDateTimeFormat(final String dateTimeFormat) {
+		this.dateTimeFormat = dateTimeFormat;
 	}
 
 	public String getStaticPathPattern() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
@@ -421,7 +421,8 @@ public class WebMvcAutoConfiguration {
 		@Bean
 		@Override
 		public FormattingConversionService mvcConversionService() {
-			WebConversionService conversionService = new WebConversionService(this.mvcProperties.getDateFormat());
+			WebConversionService conversionService = new WebConversionService(this.mvcProperties.getDateFormat(),
+					this.mvcProperties.getTimeFormat(), this.mvcProperties.getDateTimeFormat());
 			addFormatters(conversionService);
 			return conversionService;
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcProperties.java
@@ -61,6 +61,16 @@ public class WebMvcProperties {
 	private String dateFormat;
 
 	/**
+	 * Time format to use. For instance, `HH:mm:ss`.
+	 */
+	private String timeFormat;
+
+	/**
+	 * Datetime format to use. For instance, `yyyy-MM-dd HH:mm:ss`.
+	 */
+	private String dateTimeFormat;
+
+	/**
 	 * Whether to dispatch TRACE requests to the FrameworkServlet doService method.
 	 */
 	private boolean dispatchTraceRequest = false;
@@ -138,6 +148,22 @@ public class WebMvcProperties {
 
 	public void setDateFormat(String dateFormat) {
 		this.dateFormat = dateFormat;
+	}
+
+	public String getTimeFormat() {
+		return this.timeFormat;
+	}
+
+	public void setTimeFormat(final String timeFormat) {
+		this.timeFormat = timeFormat;
+	}
+
+	public String getDateTimeFormat() {
+		return this.dateTimeFormat;
+	}
+
+	public void setDateTimeFormat(final String dateTimeFormat) {
+		this.dateTimeFormat = dateTimeFormat;
 	}
 
 	public boolean isIgnoreDefaultModelOnRedirect() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/format/WebConversionServiceTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/format/WebConversionServiceTests.java
@@ -50,9 +50,29 @@ class WebConversionServiceTests {
 		customDateFormat(java.time.LocalDate.of(2018, 1, 1));
 	}
 
+	@Test
+	void customTimeFormatWithJavaTime() {
+		customTimeFormat(java.time.LocalTime.of(13, 37, 42));
+	}
+
+	@Test
+	void customDateTimeFormatWithJavaTime() {
+		customDateTimeFormat(java.time.LocalDateTime.of(2019, 10, 28, 13, 37, 42));
+	}
+
 	private void customDateFormat(Object input) {
 		WebConversionService conversionService = new WebConversionService("dd*MM*yyyy");
 		assertThat(conversionService.convert(input, String.class)).isEqualTo("01*01*2018");
+	}
+
+	private void customTimeFormat(Object input) {
+		WebConversionService conversionService = new WebConversionService(null, "HH*mm*ss", null);
+		assertThat(conversionService.convert(input, String.class)).isEqualTo("13*37*42");
+	}
+
+	private void customDateTimeFormat(Object input) {
+		WebConversionService conversionService = new WebConversionService(null, null, "dd*MM*yyyy HH*mm*ss");
+		assertThat(conversionService.convert(input, String.class)).isEqualTo("28*10*2019 13*37*42");
 	}
 
 	@Test


### PR DESCRIPTION
Extend WebFlux and WebMvc properties with timeFormat and dateTimeFormat
properties to allow users to customize format of LocalTime and
LocalDateTime instances.

This should add the missing functionality to #18511