### PR TITLE
Update bomr config to suggest upgrades with same major version

### DIFF
--- a/.bomr/bomr.yaml
+++ b/.bomr/bomr.yaml
@@ -6,7 +6,7 @@ bomr:
       repository: spring-boot
       issue-labels:
         - 'type: dependency-upgrade'
-    policy: same-minor-version
+    policy: same-major-version
     prohibited:
       - project: derby
         versions:


### PR DESCRIPTION
Hi,

commit b6e557c changed the config to only suggest versions with the same minor version in order to minimize risks during release creation for 2.2.0. As 2.2.0 is released we can go back to suggesting more upgrades, I guess.

Let me know what you think.
Cheers,
Christoph