### PR TITLE
Support amqps:// URIs in spring.rabbitmq.addresses

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -960,6 +960,10 @@ public class RabbitProperties {
 
 		private static final int DEFAULT_PORT = 5672;
 
+		private static final String PREFIX_AMQP_SECURE = "amqps://";
+
+		private static final int DEFAULT_PORT_SECURE = 5671;
+
 		private String host;
 
 		private int port;
@@ -970,6 +974,8 @@ public class RabbitProperties {
 
 		private String virtualHost;
 
+		private boolean isSecureConnection;
+
 		private Address(String input) {
 			input = input.trim();
 			input = trimPrefix(input);
@@ -979,6 +985,10 @@ public class RabbitProperties {
 		}
 
 		private String trimPrefix(String input) {
+			if (input.startsWith(PREFIX_AMQP_SECURE)) {
+				this.isSecureConnection = true;
+				return input.substring(PREFIX_AMQP_SECURE.length());
+			}
 			if (input.startsWith(PREFIX_AMQP)) {
 				input = input.substring(PREFIX_AMQP.length());
 			}
@@ -1015,7 +1025,11 @@ public class RabbitProperties {
 			int portIndex = input.indexOf(':');
 			if (portIndex == -1) {
 				this.host = input;
-				this.port = DEFAULT_PORT;
+				if (this.isSecureConnection) {
+					this.port = DEFAULT_PORT_SECURE;
+				} else {
+					this.port = DEFAULT_PORT;
+				}
 			}
 			else {
 				this.host = input.substring(0, portIndex);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -1027,7 +1027,8 @@ public class RabbitProperties {
 				this.host = input;
 				if (this.isSecureConnection) {
 					this.port = DEFAULT_PORT_SECURE;
-				} else {
+				} 
+				else {
 					this.port = DEFAULT_PORT;
 				}
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
@@ -72,6 +72,13 @@ class RabbitPropertiesTests {
 	}
 
 	@Test
+	void usingSecuredConnections() {
+		this.properties.setAddresses("amqps://root:password@otherhost,amqps://root:password2@otherhost2");
+		assertThat(this.properties.determinePort()).isEqualTo(5671);
+		assertThat(this.properties.determineAddresses()).isEqualTo("otherhost:5671,otherhost2:5671");
+	}
+
+	@Test
 	void determinePortReturnsPortOfFirstAddress() {
 		this.properties.setAddresses("rabbit1.example.com:1234,rabbit2.example.com:2345");
 		assertThat(this.properties.determinePort()).isEqualTo(1234);


### PR DESCRIPTION
If `ampqs` is used in the URI and no explicit port is declared, the port number 5671 will be used instead of 5672

Resolves #6401


