### PR TITLE
Let Liquibase smoke test pass on non-english systems

### DIFF
--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-liquibase/src/test/java/smoketest/liquibase/SampleLiquibaseApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-liquibase/src/test/java/smoketest/liquibase/SampleLiquibaseApplicationTests.java
@@ -17,7 +17,10 @@
 package smoketest.liquibase;
 
 import java.net.ConnectException;
+import java.util.Locale;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -29,6 +32,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(OutputCaptureExtension.class)
 class SampleLiquibaseApplicationTests {
+
+	private Locale defaultLocale;
+
+	@BeforeEach
+	void init() throws SecurityException {
+		this.defaultLocale = Locale.getDefault();
+		Locale.setDefault(Locale.ENGLISH);
+	}
+
+	@AfterEach
+	void restoreLocale() {
+		Locale.setDefault(this.defaultLocale);
+	}
 
 	@Test
 	void testDefaultSettings(CapturedOutput output) throws Exception {


### PR DESCRIPTION
Hi,

I noticed yesterday that the Liquibase smoke test failed on my machine. After having a quick look this is caused by a localized string that breaks the output assertion. On non-english systems it is therefore not possible to run the full smoke-test suite.

This PR simply sets `Locale.ENGLISH` for the test in question and resets it afterwards.

I didn't feel comfortable with changing the assertion, because it covers the whole lifespan of the liquibase changelog process currently. Cutting it down to check less stuff didn't seem like the appropriate thing to do, but I'm happy to do it if you think that's favorable.

Cheers,
Christoph