### PR TITLE
Handle JSON keys containing a dot from CF environment as a single path segment

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudFoundryVcapEnvironmentPostProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudFoundryVcapEnvironmentPostProcessor.java
@@ -224,6 +224,9 @@ public class CloudFoundryVcapEnvironmentPostProcessor implements EnvironmentPost
 		if (key.startsWith("[")) {
 			return path + key;
 		}
+		if (key.contains(".")) {
+			return path + "[" + key + "]";
+		}
 		return path + "." + key;
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/cloudfoundry/CloudFoundryVcapEnvironmentPostProcessorTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/cloudfoundry/CloudFoundryVcapEnvironmentPostProcessorTests.java
@@ -116,6 +116,16 @@ class CloudFoundryVcapEnvironmentPostProcessorTests {
 		assertThat(getProperty("vcap.services.mysql.credentials.port")).isEqualTo("3306");
 	}
 
+	@Test
+	void testServicePropertiesContainingKeysWithDot() {
+		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context,
+				"VCAP_SERVICES={\"user-provided\":[{\"name\":\"test\",\"label\":\"test-label\","
+						+ "\"credentials\":{\"key.with.dots\":\"some-value\"}}]}");
+		this.initializer.postProcessEnvironment(this.context.getEnvironment(), null);
+		assertThat(getProperty("vcap.services.test.name")).isEqualTo("test");
+		assertThat(getProperty("vcap.services.test.credentials[key.with.dots]")).isEqualTo("some-value");
+	}
+
 	private String getProperty(String key) {
 		return this.context.getEnvironment().getProperty(key);
 	}


### PR DESCRIPTION
This PR changes the handling of JSON keys in the CloudFoundry VCAP_SERVICES environment variable so that they represent only a single path segment at a time.

Before this change, if the JSON contained an object key with dots, the key would be treated as individual path segments, instead of a single one.
E.g. the VCAP_SERVICES variable
```json
{
  "user-provided": [
    {
      "name": "test",
      "label": "test-label",
      "credentials": {
        "key.with.dots": {
          "username": "foo",
          "password": "bar"
        }
      }
    }
  ]
}
```
Would lead to the spring property:
`vcap.services.test.credentials.key.with.dots.username=foo`
Instead of the escaped version:
`vcap.services.test.credentials[key.with.dots].username=foo`

This causes problems e.g. when trying to bind these properties to a map, as it would not be filled with any values:
```java
@ConfigurationProperties("vcap.services.test")
public class CfEnvCredentials {
    public final Map<String, BasicAuthentication> credentials;
    [...]
}
```