### PR TITLE
Handle ApiVersion in CachingOperationInvoker

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvokerAdvisor.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvokerAdvisor.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import org.springframework.boot.actuate.endpoint.EndpointId;
 import org.springframework.boot.actuate.endpoint.OperationType;
 import org.springframework.boot.actuate.endpoint.SecurityContext;
+import org.springframework.boot.actuate.endpoint.http.ApiVersion;
 import org.springframework.boot.actuate.endpoint.invoke.OperationInvoker;
 import org.springframework.boot.actuate.endpoint.invoke.OperationInvokerAdvisor;
 import org.springframework.boot.actuate.endpoint.invoke.OperationParameter;
@@ -54,7 +55,8 @@ public class CachingOperationInvokerAdvisor implements OperationInvokerAdvisor {
 
 	private boolean hasMandatoryParameter(OperationParameters parameters) {
 		for (OperationParameter parameter : parameters) {
-			if (parameter.isMandatory() && !SecurityContext.class.isAssignableFrom(parameter.getType())) {
+			if (parameter.isMandatory() && !ApiVersion.class.isAssignableFrom(parameter.getType())
+					&& !SecurityContext.class.isAssignableFrom(parameter.getType())) {
 				return true;
 			}
 		}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvokerAdvisorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvokerAdvisorTests.java
@@ -27,6 +27,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.boot.actuate.endpoint.EndpointId;
 import org.springframework.boot.actuate.endpoint.OperationType;
 import org.springframework.boot.actuate.endpoint.SecurityContext;
+import org.springframework.boot.actuate.endpoint.http.ApiVersion;
 import org.springframework.boot.actuate.endpoint.invoke.OperationInvoker;
 import org.springframework.boot.actuate.endpoint.invoke.OperationParameters;
 import org.springframework.boot.actuate.endpoint.invoke.reflect.OperationMethod;
@@ -117,6 +118,13 @@ class CachingOperationInvokerAdvisorTests {
 		assertAdviseIsApplied(parameters);
 	}
 
+	@Test
+	void applyWithApiVersionShouldAddAdvise() {
+		OperationParameters parameters = getParameters("getWithApiVersion", ApiVersion.class, String.class);
+		given(this.timeToLive.apply(any())).willReturn(100L);
+		assertAdviseIsApplied(parameters);
+	}
+
 	private void assertAdviseIsApplied(OperationParameters parameters) {
 		OperationInvoker advised = this.advisor.apply(EndpointId.of("foo"), OperationType.READ, parameters,
 				this.invoker);
@@ -149,6 +157,10 @@ class CachingOperationInvokerAdvisorTests {
 		}
 
 		String getWithSecurityContext(SecurityContext securityContext, @Nullable String bar) {
+			return "";
+		}
+
+		String getWithApiVersion(ApiVersion apiVersion, @Nullable String bar) {
 			return "";
 		}
 


### PR DESCRIPTION
Hi,

this is a proposal for fixing #18959.

Prior to this commit, `ApiVersion` was treated as a mandatory parameter in `CachingOperationInvokerAdvisor` and thus prevented the `CachingOperationInvoker` to kick in. By skipping `ApiVersion` in the same way we're skipping `SecurityContext` we can avoid this.

In order to not return the same cached response, this commit also changes the cache handling in `CachingOperationInvoker` to account for different `ApiVersion`s being passed.

Let me know what you think.
Cheers,
Christoph