### PR TITLE
Fix syntax error in configuration metadata sample in docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-configuration-metadata.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/appendix-configuration-metadata.adoc
@@ -752,12 +752,12 @@ Consider the following class:
 
 [source,java,indent=0,subs="verbatim,quotes,attributes"]
 ----
-	@ConfigurationProperties(prefix="acme.messaging")
+	@ConfigurationProperties(prefix = "acme.messaging")
 	public class MessagingProperties {
 
-		private List<String> addresses = new ArrayList<>(Arrays.asList("a", "b")) ;
+		private List<String> addresses = new ArrayList<>(Arrays.asList("a", "b"));
 
-		private ContainerType = ContainerType.SIMPLE;
+		private ContainerType containerType = ContainerType.SIMPLE;
 
 		// ... getter and setters
 


### PR DESCRIPTION
Hi,

this PR fixes a syntax error in a sample in the [Configuration Metadata section](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/html/appendix-configuration-metadata.html#configuration-metadata-annotation-processor) and does some related polishing.

Cheers,
Christoph