### PR TITLE
solve maven.compiler.source doesn't work

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/pom.xml
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/pom.xml
@@ -21,6 +21,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<maven.compiler.release>${java.version}</maven.compiler.release>
 	</properties>
 	<build>
 		<!-- Turn on filtering by default for application properties -->


### PR DESCRIPTION
`<maven.compiler.source>` and `<maven.compiler.target>` don't work at jdk11 + Maven 3.6.2,  when I set 

```xml
<properties>
	<java.version>11</java.version>
</properties>
```

it still use JavaSE-8 library. I solved this problem by adding `<maven.compiler.release>${java.version}</maven.compiler.release>` in `pom.xml` or `spring-boot-starter-parent-2.2.1.RELEASE.pom`.

This may be caused by maven's bug, but `<maven.compiler.release>` is better since Java9 and Maven 3.6. You can find this in https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html