### PR TITLE
Polish AbstractDependsOnBeanFactoryPostProcessor

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AbstractDependsOnBeanFactoryPostProcessor.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AbstractDependsOnBeanFactoryPostProcessor.java
@@ -134,16 +134,14 @@ public abstract class AbstractDependsOnBeanFactoryPostProcessor implements BeanF
 	}
 
 	private static BeanDefinition getBeanDefinition(String beanName, ConfigurableListableBeanFactory beanFactory) {
-		try {
+		if (beanFactory.containsBeanDefinition(beanName)) {
 			return beanFactory.getBeanDefinition(beanName);
 		}
-		catch (NoSuchBeanDefinitionException ex) {
-			BeanFactory parentBeanFactory = beanFactory.getParentBeanFactory();
-			if (parentBeanFactory instanceof ConfigurableListableBeanFactory) {
-				return getBeanDefinition(beanName, (ConfigurableListableBeanFactory) parentBeanFactory);
-			}
-			throw ex;
+		BeanFactory parentBeanFactory = beanFactory.getParentBeanFactory();
+		if (parentBeanFactory instanceof ConfigurableListableBeanFactory) {
+			return getBeanDefinition(beanName, ((ConfigurableListableBeanFactory) parentBeanFactory));
 		}
+		throw new NoSuchBeanDefinitionException(beanName);
 	}
 
 }


### PR DESCRIPTION
Polish AbstractDependsOnBeanFactoryPostProcessor to avoid using `try {} catch` block
