### PR TITLE
Signed jar dependency performance problem when repackaged in a single jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .recommenders
 .settings
 .springBeans
+.vscode
 /code
 MANIFEST.MF
 _site/

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarEntry.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarEntry.java
@@ -87,7 +87,7 @@ class JarEntry extends java.util.jar.JarEntry implements FileHeader {
 
 	@Override
 	public Certificate[] getCertificates() {
-		if (this.jarFile.isSigned() && this.certificates == null) {
+		if (this.jarFile.isSigned() && this.certificates == null && isSignable()) {
 			this.jarFile.setupEntryCertificates(this);
 		}
 		return this.certificates;
@@ -109,6 +109,10 @@ class JarEntry extends java.util.jar.JarEntry implements FileHeader {
 	@Override
 	public long getLocalHeaderOffset() {
 		return this.localHeaderOffset;
+	}
+
+	private boolean isSignable() {
+		return !isDirectory() && !getName().startsWith("META-INF");
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarEntry.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarEntry.java
@@ -88,15 +88,15 @@ class JarEntry extends java.util.jar.JarEntry implements FileHeader {
 	@Override
 	public Certificate[] getCertificates() {
 		if (this.jarFile.isSigned() && this.certificates == null && isSignable()) {
-			this.jarFile.setupEntryCertificates(this);
+			this.jarFile.setupEntryCertificates();
 		}
 		return this.certificates;
 	}
 
 	@Override
 	public CodeSigner[] getCodeSigners() {
-		if (this.jarFile.isSigned() && this.codeSigners == null) {
-			this.jarFile.setupEntryCertificates(this);
+		if (this.jarFile.isSigned() && this.codeSigners == null && isSignable()) {
+			this.jarFile.setupEntryCertificates();
 		}
 		return this.codeSigners;
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarFile.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarFile.java
@@ -359,19 +359,15 @@ public class JarFile extends java.util.jar.JarFile implements Iterable<java.util
 		return this.signed;
 	}
 
-	void setupEntryCertificates(JarEntry entry) {
+	void setupEntryCertificates() {
 		// Fallback to JarInputStream to obtain certificates, not fast but hopefully not
 		// happening that often.
 		try {
-			try (JarInputStream inputStream = new JarInputStream(getData().getInputStream())) {
-				java.util.jar.JarEntry certEntry = inputStream.getNextJarEntry();
-				while (certEntry != null) {
-					inputStream.closeEntry();
-					if (entry.getName().equals(certEntry.getName())) {
-						setCertificates(entry, certEntry);
-					}
+			try (JarInputStream jarStream = new JarInputStream(getData().getInputStream())) {
+				java.util.jar.JarEntry certEntry = null;
+				while ((certEntry = jarStream.getNextJarEntry()) != null) {
+					jarStream.closeEntry();
 					setCertificates(getJarEntry(certEntry.getName()), certEntry);
-					certEntry = inputStream.getNextJarEntry();
 				}
 			}
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarFileEntries.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarFileEntries.java
@@ -363,7 +363,7 @@ class JarFileEntries implements CentralDirectoryVisitor, Iterable<JarEntry> {
 			}
 			int entryIndex = JarFileEntries.this.positions[this.index];
 			this.index++;
-			return getEntry(entryIndex, JarEntry.class, false, null);
+			return getEntry(entryIndex, JarEntry.class, true, null);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
@@ -28,6 +28,9 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
@@ -404,17 +407,27 @@ class JarFileTests {
 		java.util.jar.JarFile jarFile = new JarFile(new File(signedJarFile));
 		jarFile.getManifest();
 		Enumeration<JarEntry> jarEntries = jarFile.entries();
+
+		// Make sure this whole certificates routine runs in an acceptable time (few
+		// seconds at most)
+		// Some signed jars took from 30s to 5 min depending on the implementation.
+		Instant start = Instant.now();
 		while (jarEntries.hasMoreElements()) {
 			JarEntry jarEntry = jarEntries.nextElement();
 			InputStream inputStream = jarFile.getInputStream(jarEntry);
 			inputStream.skip(Long.MAX_VALUE);
 			inputStream.close();
+
+			Certificate[] certs = jarEntry.getCertificates();
 			if (!jarEntry.getName().startsWith("META-INF") && !jarEntry.isDirectory()
 					&& !jarEntry.getName().endsWith("TigerDigest.class")) {
-				assertThat(jarEntry.getCertificates()).isNotNull();
+				assertThat(certs).isNotNull();
 			}
 		}
 		jarFile.close();
+
+		// 3 seconds is still quite long, but low enough to catch most problems
+		assertThat(ChronoUnit.SECONDS.between(start, Instant.now())).isLessThanOrEqualTo(3L);
 	}
 
 	@Test


### PR DESCRIPTION
### Issue
Some 3rd party jars verify their own signature and makes sure it is signed by a specific signer, calling JarEntry.getCertificates() in the process. When these jars are handled by the Spring Boot Loader (as is the case when the jar is repackaged into a single jar), a long time can be spent searching for the certificates in the original jar entry and setting them in the loader's own entries. We have a case where it takes up to 5 min, delaying the startup of the Spring boot application.

### Workaround
The current workaround is to not use Spring Boot maven plugin to generate an executable jar, and use the classic way of launching the jar with a classpath entry.

### Fix
The fix is to filter out the entries we know won't be signed, ie directory entries and META-INF entries. It seems that specifically processing a directory messes up the "find & set certificate" routines, ending up being what it seems to be quadratic.

The test for this (JarFileTests.verifySignedJar) hid this problem by pre-filtering unsigned entries. If the test is modified to call getCertificates on all entries, the current jar used in the test (bouncy castle) takes close to 7 sec, which is too much. 

I fiexd the issue by filtering out the unsigned entries. I also modified the test to detect this issue by setting up a maximum amount of time it should take for a jar to load.
