### PR TITLE
Do not enable ReactorDebugAgent so easily

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/reactor/DebugAgentEnvironmentPostProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/reactor/DebugAgentEnvironmentPostProcessor.java
@@ -49,7 +49,7 @@ public class DebugAgentEnvironmentPostProcessor implements EnvironmentPostProces
 					debugAgent.getMethod("init").invoke(null);
 				}
 				catch (Exception ex) {
-					throw new RuntimeException("Failed to init Reactor's debug agent");
+					throw new RuntimeException("Failed to init Reactor's debug agent", ex);
 				}
 			}
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/reactor/DebugAgentEnvironmentPostProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/reactor/DebugAgentEnvironmentPostProcessor.java
@@ -43,7 +43,7 @@ public class DebugAgentEnvironmentPostProcessor implements EnvironmentPostProces
 	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
 		if (ClassUtils.isPresent(REACTOR_DEBUGAGENT_CLASS, null)) {
 			Boolean agentEnabled = environment.getProperty(DEBUGAGENT_ENABLED_CONFIG_KEY, Boolean.class);
-			if (agentEnabled != Boolean.FALSE) {
+			if (Boolean.TRUE.equals(agentEnabled)) {
 				try {
 					Class<?> debugAgent = Class.forName(REACTOR_DEBUGAGENT_CLASS);
 					debugAgent.getMethod("init").invoke(null);


### PR DESCRIPTION
The ReactorDebugAgent is enabled even if the property `reactor.debug-agent.enabled` in the `application.yml` is set to `false`. Debugging the `DebugAgentEnvironmentPostProcessor` has revealed that the processor gets called so early that the property is not yet set, so the value `null` is returned. This leads to the activation of the agent. Our application fails at that point as the agent only works in a JDK, but in a JRE.

This PR fixes it and also keeps the stacktrace of the error of the failed activation. A workaround for our application is the following environment post processor, which of course needs to be enabled via `spring.factories`:

```
public class DisableDebugAgentEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {

    @Override
    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
        MapPropertySource mapPropertySource = new MapPropertySource(
                "disableDebugAgentEnvironmentPostProcessorPropertySource",
                ImmutableMap.of(
                        "spring.reactor.debug-agent.enabled", false
                )
        );
        environment.getPropertySources().addLast(mapPropertySource);
    }

    @Override
    public int getOrder() {
        return Ordered.HIGHEST_PRECEDENCE;
    }
}
```

