### PR TITLE
Fix StepVerifier usage in HealthIndicatorReactiveAdapterTests

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthIndicatorReactiveAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthIndicatorReactiveAdapterTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.actuate.health;
 
+import java.time.Duration;
+
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
@@ -44,7 +46,7 @@ class HealthIndicatorReactiveAdapterTests {
 		HealthIndicator delegate = mock(HealthIndicator.class);
 		HealthIndicatorReactiveAdapter adapter = new HealthIndicatorReactiveAdapter(delegate);
 		given(delegate.health()).willThrow(new IllegalStateException("Expected"));
-		StepVerifier.create(adapter.health()).expectError(IllegalStateException.class);
+		StepVerifier.create(adapter.health()).expectError(IllegalStateException.class).verify(Duration.ofSeconds(10));
 	}
 
 	@Test


### PR DESCRIPTION
Hi,

just found a `StepVerifier` that doesn't call `verify()`. In the given test one could change to any exception being thrown and the verifier wouldn't notice.

Cheers,
Christoph