### PR TITLE
Configuration properties that use the builder pattern are not recognized when used with a generic

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java
@@ -28,6 +28,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
@@ -116,8 +117,25 @@ class TypeElementMembers {
 
 	private boolean isSetterReturnType(ExecutableElement method) {
 		TypeMirror returnType = method.getReturnType();
-		return (TypeKind.VOID == returnType.getKind()
-				|| this.env.getTypeUtils().isSameType(method.getEnclosingElement().asType(), returnType));
+		// void
+		if (TypeKind.VOID == returnType.getKind()) {
+			return true;
+		}
+
+		TypeMirror classType = method.getEnclosingElement().asType();
+		TypeUtils typeUtils = this.env.getTypeUtils();
+		// Chain
+		if (typeUtils.isSameType(classType, returnType)) {
+			return true;
+		}
+
+		// Chain generic type
+		List<? extends TypeMirror> arguments = ((DeclaredType) classType).getTypeArguments();
+		if (arguments.size() != 1) {
+			return false;
+		}
+		TypeMirror classGenericType = arguments.get(0);
+		return typeUtils.isSameType(classGenericType, returnType);
 	}
 
 	private String getAccessorName(String methodName) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java
@@ -132,7 +132,7 @@ class TypeElementMembers {
 
 		// Chain generic type, <T extends classType>
 		List<? extends TypeMirror> genericTypes = ((DeclaredType) classType).getTypeArguments();
-		return genericTypes.stream().anyMatch(genericType -> {
+		return genericTypes.stream().anyMatch((genericType) -> {
 			TypeMirror upperBound = ((TypeVariable) genericType).getUpperBound();
 			String classTypeName = typeUtils.getQualifiedName(((DeclaredType) classType).asElement());
 			String genericTypeName = typeUtils.getQualifiedName(((DeclaredType) upperBound).asElement());

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java
@@ -31,6 +31,7 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.ElementFilter;
 
 /**
@@ -129,13 +130,14 @@ class TypeElementMembers {
 			return true;
 		}
 
-		// Chain generic type
-		List<? extends TypeMirror> arguments = ((DeclaredType) classType).getTypeArguments();
-		if (arguments.size() != 1) {
-			return false;
-		}
-		TypeMirror classGenericType = arguments.get(0);
-		return typeUtils.isSameType(classGenericType, returnType);
+		// Chain generic type, <T extends classType>
+		List<? extends TypeMirror> genericTypes = ((DeclaredType) classType).getTypeArguments();
+		return genericTypes.stream().anyMatch(genericType -> {
+			TypeMirror upperBound = ((TypeVariable) genericType).getUpperBound();
+			String classTypeName = typeUtils.getQualifiedName(((DeclaredType) classType).asElement());
+			String genericTypeName = typeUtils.getQualifiedName(((DeclaredType) upperBound).asElement());
+			return classTypeName.equals(genericTypeName);
+		});
 	}
 
 	private String getAccessorName(String methodName) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/GenericsMetadataGenerationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/GenericsMetadataGenerationTests.java
@@ -30,7 +30,6 @@ import org.springframework.boot.configurationsample.generic.UnresolvedGenericPro
 import org.springframework.boot.configurationsample.generic.UpperBoundGenericPojo;
 import org.springframework.boot.configurationsample.generic.WildcardConfig;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -119,9 +118,10 @@ class GenericsMetadataGenerationTests extends AbstractMetadataGenerationTests {
 		assertThat(metadata).has(Metadata.withGroup("generic").fromSource(ChainGenericProperties.class));
 		assertThat(metadata).has(Metadata.withProperty("generic.config", ChainGenericConfig.class)
 				.fromSource(ChainGenericProperties.class).withDescription("Generic config.").withDefaultValue(null));
-		assertThat(metadata).has(Metadata
-				.withProperty("generic.config.ping-timeout", Integer.TYPE)
-				.fromSource(ChainGenericConfig.class).withDescription("Generic config pingTimeout.").withDefaultValue(null));
+		assertThat(metadata).has(
+				Metadata.withProperty("generic.config.ping-timeout", Integer.TYPE).fromSource(ChainGenericConfig.class)
+						.withDescription("Generic config pingTimeout.").withDefaultValue(null));
 		assertThat(metadata.getItems()).hasSize(1);
 	}
+
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/GenericsMetadataGenerationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/GenericsMetadataGenerationTests.java
@@ -20,7 +20,15 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.configurationprocessor.metadata.ConfigurationMetadata;
 import org.springframework.boot.configurationprocessor.metadata.Metadata;
-import org.springframework.boot.configurationsample.generic.*;
+import org.springframework.boot.configurationsample.generic.AbstractGenericProperties;
+import org.springframework.boot.configurationsample.generic.ComplexGenericProperties;
+import org.springframework.boot.configurationsample.generic.GenericConfig;
+import org.springframework.boot.configurationsample.generic.SimpleGenericProperties;
+import org.springframework.boot.configurationsample.generic.UnresolvedGenericProperties;
+import org.springframework.boot.configurationsample.generic.UpperBoundGenericPojo;
+import org.springframework.boot.configurationsample.generic.WildcardConfig;
+import org.springframework.boot.configurationsample.generic.ChainGenericProperties;
+import org.springframework.boot.configurationsample.generic.ChainGenericConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/GenericsMetadataGenerationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/GenericsMetadataGenerationTests.java
@@ -21,14 +21,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.configurationprocessor.metadata.ConfigurationMetadata;
 import org.springframework.boot.configurationprocessor.metadata.Metadata;
 import org.springframework.boot.configurationsample.generic.AbstractGenericProperties;
+import org.springframework.boot.configurationsample.generic.ChainGenericConfig;
+import org.springframework.boot.configurationsample.generic.ChainGenericProperties;
 import org.springframework.boot.configurationsample.generic.ComplexGenericProperties;
 import org.springframework.boot.configurationsample.generic.GenericConfig;
 import org.springframework.boot.configurationsample.generic.SimpleGenericProperties;
 import org.springframework.boot.configurationsample.generic.UnresolvedGenericProperties;
 import org.springframework.boot.configurationsample.generic.UpperBoundGenericPojo;
 import org.springframework.boot.configurationsample.generic.WildcardConfig;
-import org.springframework.boot.configurationsample.generic.ChainGenericProperties;
-import org.springframework.boot.configurationsample.generic.ChainGenericConfig;
+
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/GenericsMetadataGenerationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/GenericsMetadataGenerationTests.java
@@ -20,13 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.configurationprocessor.metadata.ConfigurationMetadata;
 import org.springframework.boot.configurationprocessor.metadata.Metadata;
-import org.springframework.boot.configurationsample.generic.AbstractGenericProperties;
-import org.springframework.boot.configurationsample.generic.ComplexGenericProperties;
-import org.springframework.boot.configurationsample.generic.GenericConfig;
-import org.springframework.boot.configurationsample.generic.SimpleGenericProperties;
-import org.springframework.boot.configurationsample.generic.UnresolvedGenericProperties;
-import org.springframework.boot.configurationsample.generic.UpperBoundGenericPojo;
-import org.springframework.boot.configurationsample.generic.WildcardConfig;
+import org.springframework.boot.configurationsample.generic.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -110,4 +104,15 @@ class GenericsMetadataGenerationTests extends AbstractMetadataGenerationTests {
 		assertThat(metadata.getItems()).hasSize(3);
 	}
 
+	@Test
+	void chainGenericProperties() {
+		ConfigurationMetadata metadata = compile(ChainGenericProperties.class);
+		assertThat(metadata).has(Metadata.withGroup("generic").fromSource(ChainGenericProperties.class));
+		assertThat(metadata).has(Metadata.withProperty("generic.config", ChainGenericConfig.class)
+				.fromSource(ChainGenericProperties.class).withDescription("Generic config.").withDefaultValue(null));
+		assertThat(metadata).has(Metadata
+				.withProperty("generic.config.ping-timeout", Integer.TYPE)
+				.fromSource(ChainGenericConfig.class).withDescription("Generic config pingTimeout.").withDefaultValue(null));
+		assertThat(metadata.getItems()).hasSize(1);
+	}
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/GenericsMetadataGenerationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/GenericsMetadataGenerationTests.java
@@ -116,12 +116,11 @@ class GenericsMetadataGenerationTests extends AbstractMetadataGenerationTests {
 	void chainGenericProperties() {
 		ConfigurationMetadata metadata = compile(ChainGenericProperties.class);
 		assertThat(metadata).has(Metadata.withGroup("generic").fromSource(ChainGenericProperties.class));
-		assertThat(metadata).has(Metadata.withProperty("generic.config", ChainGenericConfig.class)
-				.fromSource(ChainGenericProperties.class).withDescription("Generic config.").withDefaultValue(null));
-		assertThat(metadata).has(
-				Metadata.withProperty("generic.config.ping-timeout", Integer.TYPE).fromSource(ChainGenericConfig.class)
-						.withDescription("Generic config pingTimeout.").withDefaultValue(null));
-		assertThat(metadata.getItems()).hasSize(1);
+		assertThat(metadata).has(Metadata.withGroup("generic.config", ChainGenericConfig.class)
+				.fromSource(ChainGenericProperties.class));
+		assertThat(metadata).has(Metadata.withProperty("generic.config.ping-timeout", Integer.class)
+				.fromSource(ChainGenericConfig.class).withDefaultValue(null));
+		assertThat(metadata.getItems()).hasSize(3);
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericConfig.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericConfig.java
@@ -1,0 +1,21 @@
+package org.springframework.boot.configurationsample.generic;
+
+/**
+ * Chain Generic
+ *
+ * @author L.cm
+ * @param <T> name type
+ */
+public class ChainGenericConfig<T extends ChainGenericConfig> {
+
+	private Integer pingTimeout = 1000;
+
+	public int getPingTimeout() {
+		return pingTimeout;
+	}
+
+	public T setPingTimeout(int pingTimeout) {
+		this.pingTimeout = pingTimeout;
+		return (T) this;
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericConfig.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericConfig.java
@@ -1,17 +1,33 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.configurationsample.generic;
 
 /**
  * Chain Generic
  *
- * @author L.cm
  * @param <T> name type
+ * @author L.cm
  */
 public class ChainGenericConfig<T extends ChainGenericConfig> {
 
 	private Integer pingTimeout = 1000;
 
 	public int getPingTimeout() {
-		return pingTimeout;
+		return this.pingTimeout;
 	}
 
 	public T setPingTimeout(int pingTimeout) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericConfig.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericConfig.java
@@ -24,6 +24,9 @@ package org.springframework.boot.configurationsample.generic;
  */
 public class ChainGenericConfig<T extends ChainGenericConfig> {
 
+	/**
+	 * Generic config pingTimeout.
+	 */
 	private Integer pingTimeout = 1000;
 
 	public int getPingTimeout() {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericConfig.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericConfig.java
@@ -34,4 +34,5 @@ public class ChainGenericConfig<T extends ChainGenericConfig> {
 		this.pingTimeout = pingTimeout;
 		return (T) this;
 	}
+
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericProperties.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericProperties.java
@@ -1,0 +1,24 @@
+package org.springframework.boot.configurationsample.generic;
+
+import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+
+/**
+ * Chain Generic Properties
+ *
+ * @author L.cm
+ */
+@ConfigurationProperties("generic")
+public class ChainGenericProperties {
+
+	@NestedConfigurationProperty
+	private ChainGenericConfig config;
+
+	public ChainGenericConfig getConfig() {
+		return config;
+	}
+
+	public void setConfig(ChainGenericConfig config) {
+		this.config = config;
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericProperties.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericProperties.java
@@ -37,4 +37,5 @@ public class ChainGenericProperties {
 	public void setConfig(ChainGenericConfig config) {
 		this.config = config;
 	}
+
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericProperties.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericProperties.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.configurationsample.generic;
 
 import org.springframework.boot.configurationsample.ConfigurationProperties;
@@ -15,7 +31,7 @@ public class ChainGenericProperties {
 	private ChainGenericConfig config;
 
 	public ChainGenericConfig getConfig() {
-		return config;
+		return this.config;
 	}
 
 	public void setConfig(ChainGenericConfig config) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericProperties.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ChainGenericProperties.java
@@ -27,6 +27,9 @@ import org.springframework.boot.configurationsample.NestedConfigurationProperty;
 @ConfigurationProperties("generic")
 public class ChainGenericProperties {
 
+	/**
+	 * Generic config.
+	 */
 	@NestedConfigurationProperty
 	private ChainGenericConfig config;
 


### PR DESCRIPTION
I am writing a redisson starter. For the sake of simplicity, I have used the following this:

```java
@ConfigurationProperties(prefix = "redisson")
public class RedissonProperties {

	@NestedConfigurationProperty
	private ClusterServersConfig cluster = new ClusterServersConfig();

	public ClusterServersConfig getCluster() {
		return cluster;
	}

	public void setCluster(ClusterServersConfig cluster) {
		this.cluster = cluster;
	}
}
```

I found that the generated spring-configuration-metadata.json does not have [ClusterServersConfig](https://github.com/redisson/redisson/blob/master/redisson/src/main/java/org/redisson/config/ClusterServersConfig.java) parent [BaseMasterSlaveServersConfig](https://github.com/redisson/redisson/blob/master/redisson/src/main/java/org/redisson/config/BaseMasterSlaveServersConfig.java) and [BaseConfig](https://github.com/redisson/redisson/blob/master/redisson/src/main/java/org/redisson/config/BaseConfig.java) props!

```java
public class BaseMasterSlaveServersConfig<T extends BaseMasterSlaveServersConfig<T>> extends BaseConfig<T> {
    private ReadMode readMode = ReadMode.SLAVE;
	
    public T setReadMode(ReadMode readMode) {
        this.readMode = readMode;
        return (T) this;
    }
    public ReadMode getReadMode() {
        return readMode;
    }
}
```

setReadMode method returnType is generic type T.