### PR TITLE
Remove '.' and '-' reference in the EndpointId javadoc

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/EndpointId.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/EndpointId.java
@@ -27,8 +27,8 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.util.Assert;
 
 /**
- * An identifier for an actuator endpoint. Endpoint IDs may contain only letters, numbers
- * {@code '.'} and {@code '-'}. They must begin with a lower-case letter. Case and syntax
+ * An identifier for an actuator endpoint. Endpoint IDs may contain only letters and numbers.
+ * They must begin with a lower-case letter. Case and syntax
  * characters are ignored when comparing endpoint IDs.
  *
  * @author Phillip Webb


### PR DESCRIPTION
Endpoint ID's which contain '-' or '.' cause a deprecation warning.
Therefore they shouldn't be doumented as valid characters.

see  #14840