### PR TITLE
Add configuration property for RabbitMQ client requestedChannelMax

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -140,7 +140,7 @@ public class RabbitAutoConfiguration {
 			}
 			map.from(properties::getConnectionTimeout).whenNonNull().asInt(Duration::toMillis)
 					.to(factory::setConnectionTimeout);
-			map.from(properties::getRequestedChannelMax).to(factory::setRequestedChannelMax);
+			map.from(properties::getRequestedChannelMax).whenNonNull().to(factory::setRequestedChannelMax);
 			factory.afterPropertiesSet();
 			return factory;
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -140,6 +140,7 @@ public class RabbitAutoConfiguration {
 			}
 			map.from(properties::getConnectionTimeout).whenNonNull().asInt(Duration::toMillis)
 					.to(factory::setConnectionTimeout);
+			map.from(properties::getRequestedChannelMax).to(factory::setRequestedChannelMax);
 			factory.afterPropertiesSet();
 			return factory;
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -104,8 +104,9 @@ public class RabbitProperties {
 	private Duration connectionTimeout;
 
 	/**
-	 * Requested Channel Max. Set it to zero for unlimited. Default is 2047 from RabbitMQ
-	 * java client versions 4.7.0 and 5.3.0.
+	 * Requested Channel Max; zero for unlimited. Number of channels per connection client
+	 * will request from server, actual maximum will be negotiated between client and
+	 * server for lowest value (excluding zero as it represents unlimited).
 	 */
 	private int requestedChannelMax = 2047;
 
@@ -305,10 +306,6 @@ public class RabbitProperties {
 		return this.connectionTimeout;
 	}
 
-	public int getRequestedChannelMax() {
-		return this.requestedChannelMax;
-	}
-
 	public void setPublisherConfirmType(ConfirmType publisherConfirmType) {
 		this.publisherConfirmType = publisherConfirmType;
 	}
@@ -321,7 +318,11 @@ public class RabbitProperties {
 		this.connectionTimeout = connectionTimeout;
 	}
 
-	public void setConnectionTimeout(int requestedChannelMax) {
+	public int getRequestedChannelMax() {
+		return this.requestedChannelMax;
+	}
+
+	public void setRequestedChannelMax(int requestedChannelMax) {
 		this.requestedChannelMax = requestedChannelMax;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -40,6 +40,7 @@ import org.springframework.util.StringUtils;
  * @author Josh Thornhill
  * @author Gary Russell
  * @author Artsiom Yudovin
+ * @author Franjo Zilic
  * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "spring.rabbitmq")
@@ -101,6 +102,12 @@ public class RabbitProperties {
 	 * Connection timeout. Set it to zero to wait forever.
 	 */
 	private Duration connectionTimeout;
+
+	/**
+	 * Requested Channel Max. Set it to zero for unlimited. Default is 2047 from RabbitMQ
+	 * java client versions 4.7.0 and 5.3.0.
+	 */
+	private int requestedChannelMax = 2047;
 
 	/**
 	 * Cache configuration.
@@ -298,6 +305,10 @@ public class RabbitProperties {
 		return this.connectionTimeout;
 	}
 
+	public int getRequestedChannelMax() {
+		return this.requestedChannelMax;
+	}
+
 	public void setPublisherConfirmType(ConfirmType publisherConfirmType) {
 		this.publisherConfirmType = publisherConfirmType;
 	}
@@ -308,6 +319,10 @@ public class RabbitProperties {
 
 	public void setConnectionTimeout(Duration connectionTimeout) {
 		this.connectionTimeout = connectionTimeout;
+	}
+
+	public void setConnectionTimeout(int requestedChannelMax) {
+		this.requestedChannelMax = requestedChannelMax;
 	}
 
 	public Cache getCache() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -108,7 +108,7 @@ public class RabbitProperties {
 	 * will request from server, actual maximum will be negotiated between client and
 	 * server for lowest value (excluding zero as it represents unlimited).
 	 */
-	private int requestedChannelMax = 2047;
+	private Integer requestedChannelMax;
 
 	/**
 	 * Cache configuration.
@@ -318,11 +318,11 @@ public class RabbitProperties {
 		this.connectionTimeout = connectionTimeout;
 	}
 
-	public int getRequestedChannelMax() {
+	public Integer getRequestedChannelMax() {
 		return this.requestedChannelMax;
 	}
 
-	public void setRequestedChannelMax(int requestedChannelMax) {
+	public void setRequestedChannelMax(Integer requestedChannelMax) {
 		this.requestedChannelMax = requestedChannelMax;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -725,6 +725,15 @@ class RabbitAutoConfigurationTests {
 				});
 	}
 
+	@Test
+	void testKeepDefaultRequestedChannelMax() throws Exception {
+		this.contextRunner.withUserConfiguration(TestConfiguration.class).run((context) -> {
+			com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory = getTargetConnectionFactory(context);
+			assertThat(rabbitConnectionFactory.getRequestedChannelMax())
+					.isEqualTo(com.rabbitmq.client.ConnectionFactory.DEFAULT_CHANNEL_MAX);
+		});
+	}
+
 	private com.rabbitmq.client.ConnectionFactory getTargetConnectionFactory(AssertableApplicationContext context) {
 		CachingConnectionFactory connectionFactory = context.getBean(CachingConnectionFactory.class);
 		return connectionFactory.getRabbitConnectionFactory();

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -81,6 +81,7 @@ import static org.mockito.Mockito.verify;
  * @author Stephane Nicoll
  * @author Gary Russell
  * @author HaiTao Zhang
+ * @author Franjo Zilic
  */
 class RabbitAutoConfigurationTests {
 
@@ -713,6 +714,15 @@ class RabbitAutoConfigurationTests {
 			trustManager = ReflectionTestUtils.getField(trustManager, "tm");
 		}
 		return (TrustManager) trustManager;
+	}
+
+	@Test
+	void testChangeDefaultRequestedChannelMax() throws Exception {
+		this.contextRunner.withUserConfiguration(TestConfiguration.class)
+				.withPropertyValues("spring.rabbitmq.requestedChannelMax:12").run((context) -> {
+					com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory = getTargetConnectionFactory(context);
+					assertThat(rabbitConnectionFactory.getRequestedChannelMax()).isEqualTo(12);
+				});
 	}
 
 	private com.rabbitmq.client.ConnectionFactory getTargetConnectionFactory(AssertableApplicationContext context) {


### PR DESCRIPTION
According to changes in RabbitMQ Java client library 4.7.0 and 5.3.0 com.rabbitmq.client.ConnectionFactory sets its property requestedChannelMax to 2047 to align itself with changes to RabbitMQ server.

Spring Boot autoconfiguration for RabbitMQ does not expose any configuration properties that would allow developers to change this limit if required by their project.

Limit of 2047 channels per connection is reasonable, but in some cases changing this is required.

Logic for determining negotiated channel_max limit for RabbitMQ is as follows:
- if channel_max >0 (server) and channel_max > 0 (clinet) take smaller version
- if any channel_max is 0, and either server or client have it to non zero, take non zero value
- if all channel_max are 0, set to unlimited

This is negotiated on RabbitMQ server and would not impact existing users.

GitHub issue for RabbitMQ Java client
rabbitmq/rabbitmq-java-client#366

And RabbitMQ server GitHub issue
rabbitmq/rabbitmq-server#1593

Working on pull request.