### PR TITLE
Fix link in new Maven Plugin docs

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/asciidoc/integration-tests.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/asciidoc/integration-tests.adoc
@@ -31,7 +31,7 @@ To make sure that the lifecycle of your Spring Boot application is properly mana
 </build>
 ----
 
-Such setup can now use the https://maven.apache.org/surefire/maven-failsafe-plugin[failsafe-plugi to run your integration tests as you would expect.
+Such setup can now use the https://maven.apache.org/surefire/maven-failsafe-plugin[failsafe-plugin] to run your integration tests as you would expect.
 
 You could also configure a more advanced setup to skip the integration tests when a specific property has been set, see <<integration-tests-example-skip,the dedicated example>>.
 


### PR DESCRIPTION
Hi,

I just noticed a broken link formatting in https://docs.spring.io/spring-boot/docs/2.3.0.BUILD-SNAPSHOT/maven-plugin/html/#integration-tests.

(I really like the asciidoc approach btw ;-) )

Cheers,
Christoph