### PR TITLE
Use DateTimeFormatter in favor of SimpleDateFormat

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/management/HeapDumpWebEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/management/HeapDumpWebEndpoint.java
@@ -27,8 +27,8 @@ import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -106,7 +106,7 @@ public class HeapDumpWebEndpoint {
 	}
 
 	private File createTempFile(boolean live) throws IOException {
-		String date = new SimpleDateFormat("yyyy-MM-dd-HH-mm").format(new Date());
+		String date = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm").format(LocalDateTime.now());
 		File file = File.createTempFile("heapdump" + date + (live ? "-live" : ""), ".hprof");
 		file.delete();
 		return file;

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/management/PlainTextThreadDumpFormatter.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/management/PlainTextThreadDumpFormatter.java
@@ -23,8 +23,8 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MonitorInfo;
 import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadInfo;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -47,8 +47,8 @@ class PlainTextThreadDumpFormatter {
 	}
 
 	private void writePreamble(PrintWriter writer) {
-		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-		writer.println(dateFormat.format(new Date()));
+		DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+		writer.println(dateFormat.format(LocalDateTime.now()));
 		RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
 		writer.printf("Full thread dump %s (%s %s):%n", runtime.getVmName(), runtime.getVmVersion(),
 				System.getProperty("java.vm.info"));

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/GitProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/GitProperties.java
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.info;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Properties;
 
 /**
@@ -108,11 +108,11 @@ public class GitProperties extends InfoProperties {
 		if (epoch != null) {
 			return String.valueOf(epoch);
 		}
-		SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+		DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ");
 		try {
-			return String.valueOf(format.parse(s).getTime());
+			return String.valueOf(format.parse(s, Instant::from).toEpochMilli());
 		}
-		catch (ParseException ex) {
+		catch (DateTimeParseException ex) {
 			return s;
 		}
 	}


### PR DESCRIPTION
Hi,

this PR replaces usages of `SimpleDateFormat` with  `DateTimeFormatter` where possible in order to reduce usages of the old Date API in favor of the "new" date/time API.

Cheers,
Christoph