### PR TITLE
Allow custom url in @AutoConfigureTestDatabase

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jdbc/AutoConfigureTestDatabase.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jdbc/AutoConfigureTestDatabase.java
@@ -61,6 +61,13 @@ public @interface AutoConfigureTestDatabase {
 	EmbeddedDatabaseConnection connection() default EmbeddedDatabaseConnection.NONE;
 
 	/**
+	 * The custom connection URL options to use. If specified it will replace the options
+	 * on the default URL string in the embedded datasource.
+	 */
+	@PropertyMapping(skip = SkipPropertyMapping.ON_DEFAULT_VALUE)
+	String urlOptions() default "";
+
+	/**
 	 * What the test database can replace.
 	 */
 	enum Replace {

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jdbc/JdbcTestWithAutoConfigureTestDatabaseAnnotationPropertiesIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jdbc/JdbcTestWithAutoConfigureTestDatabaseAnnotationPropertiesIntegrationTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.jdbc;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link JdbcTest @JdbcTest}.
+ *
+ * @author Chris Bono
+ */
+@JdbcTest
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.HSQL, replace = Replace.ANY,
+		urlOptions = "DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MYSQL")
+class JdbcTestWithAutoConfigureTestDatabaseAnnotationPropertiesIntegrationTests {
+
+	@Autowired
+	private DataSource dataSource;
+
+	@Test
+	void replacesDataSource() throws Exception {
+		SimpleDriverDataSource actualDatasource = this.dataSource.unwrap(SimpleDriverDataSource.class);
+		String url = actualDatasource.getUrl();
+		assertThat(url).matches("jdbc:hsqldb:mem:[a-zA-Z0-9-]*;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MYSQL");
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableAutoConfiguration // Will auto-configure H2
+	static class Config {
+
+	}
+
+}


### PR DESCRIPTION
This allows a custom URL to specified in `@AutoConfigureTestDatabase`.

### It was not straightforward:

We leverage `org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder` in `org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration` which ultimately delegates to 
```java
org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseFactory 
-> 
org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseConfigurer#configureConnectionProperties
```
which in turn each configurer impl has the hardcoded URL it uses and sets the properties on the datasource. It is these configurers that have the last say in what the url is. 

The `EmbeddedDatabaseBuilder` does not expose a setter for its `EmbeddedDatabaseFactory` so getting a "custom url respecting" configurer in this call chain is not straightforward and may not be possible w/o modification to Spring Framework `EmbeddedDatabaseBuilder`.
Those configurers are all package protected as well so copying some code was not an option either. 

### Another note:
The hardcoding is in multiple places, the `EmbeddedDatabaseConnection` and in `EmbeddedDatabaseConfigurer` impls.  For the purposes of this change I believe its fine just modifying the latter as the former is not used by any test code AFAICT.

