### PR TITLE
Fix deprecation info in CompositeHealthIndicatorConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/health/CompositeHealthIndicatorConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/health/CompositeHealthIndicatorConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.core.ResolvableType;
  * @param <S> the bean source type
  * @author Stephane Nicoll
  * @since 2.0.0
- * @deprecated since 2.0.0 in favor of {@link CompositeHealthContributorConfiguration}
+ * @deprecated since 2.2.0 in favor of {@link CompositeHealthContributorConfiguration}
  */
 @Deprecated
 public abstract class CompositeHealthIndicatorConfiguration<H extends HealthIndicator, S> {


### PR DESCRIPTION
Hi,

I wanted to do a PR that removes code marked as deprecated since 2.0.x and 2.1.x when I found one occurrence in `CompositeHealthIndicatorConfiguration` that seems to state the wrong release in its deprecation info.

Cheers,
Christoph

P.S.: Are you generally okay with one single follow up PR that removes the 3 places that seem to be deprecated since 2.1.x? 

- [ReactiveStreamsMongoClientDependsOnBeanFactoryPostProcessor#L47](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/mongo/ReactiveStreamsMongoClientDependsOnBeanFactoryPostProcessor.java#L47)
- [MongoClientDependsOnBeanFactoryPostProcessor#L47](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoClientDependsOnBeanFactoryPostProcessor.java#L47)
- [JerseyRequestMatcherProvider](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/JerseyRequestMatcherProvider.java)