### PR TITLE
Increase cache ttl in CachingOperationInvokerTests

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvokerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvokerTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.actuate.endpoint.invoker.cache;
 
 import java.security.Principal;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,6 +50,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  */
 class CachingOperationInvokerTests {
 
+	private static final long CACHE_TTL = Duration.ofHours(1).toMillis();
+
 	@Test
 	void createInstanceWithTtlSetToZero() {
 		assertThatIllegalArgumentException()
@@ -74,7 +77,7 @@ class CachingOperationInvokerTests {
 		MonoOperationInvoker.invocations = 0;
 		MonoOperationInvoker target = new MonoOperationInvoker();
 		InvocationContext context = new InvocationContext(mock(SecurityContext.class), Collections.emptyMap());
-		CachingOperationInvoker invoker = new CachingOperationInvoker(target, 500L);
+		CachingOperationInvoker invoker = new CachingOperationInvoker(target, CACHE_TTL);
 		Object response = ((Mono<?>) invoker.invoke(context)).block();
 		Object cachedResponse = ((Mono<?>) invoker.invoke(context)).block();
 		assertThat(MonoOperationInvoker.invocations).isEqualTo(1);
@@ -86,7 +89,7 @@ class CachingOperationInvokerTests {
 		FluxOperationInvoker.invocations = 0;
 		FluxOperationInvoker target = new FluxOperationInvoker();
 		InvocationContext context = new InvocationContext(mock(SecurityContext.class), Collections.emptyMap());
-		CachingOperationInvoker invoker = new CachingOperationInvoker(target, 500L);
+		CachingOperationInvoker invoker = new CachingOperationInvoker(target, CACHE_TTL);
 		Object response = ((Flux<?>) invoker.invoke(context)).blockLast();
 		Object cachedResponse = ((Flux<?>) invoker.invoke(context)).blockLast();
 		assertThat(FluxOperationInvoker.invocations).isEqualTo(1);
@@ -98,7 +101,7 @@ class CachingOperationInvokerTests {
 		Object expected = new Object();
 		InvocationContext context = new InvocationContext(mock(SecurityContext.class), parameters);
 		given(target.invoke(context)).willReturn(expected);
-		CachingOperationInvoker invoker = new CachingOperationInvoker(target, 500L);
+		CachingOperationInvoker invoker = new CachingOperationInvoker(target, CACHE_TTL);
 		Object response = invoker.invoke(context);
 		assertThat(response).isSameAs(expected);
 		verify(target, times(1)).invoke(context);
@@ -115,7 +118,7 @@ class CachingOperationInvokerTests {
 		parameters.put("something", null);
 		InvocationContext context = new InvocationContext(mock(SecurityContext.class), parameters);
 		given(target.invoke(context)).willReturn(new Object());
-		CachingOperationInvoker invoker = new CachingOperationInvoker(target, 500L);
+		CachingOperationInvoker invoker = new CachingOperationInvoker(target, CACHE_TTL);
 		invoker.invoke(context);
 		invoker.invoke(context);
 		invoker.invoke(context);
@@ -130,7 +133,7 @@ class CachingOperationInvokerTests {
 		given(securityContext.getPrincipal()).willReturn(mock(Principal.class));
 		InvocationContext context = new InvocationContext(securityContext, parameters);
 		given(target.invoke(context)).willReturn(new Object());
-		CachingOperationInvoker invoker = new CachingOperationInvoker(target, 500L);
+		CachingOperationInvoker invoker = new CachingOperationInvoker(target, CACHE_TTL);
 		invoker.invoke(context);
 		invoker.invoke(context);
 		invoker.invoke(context);
@@ -164,7 +167,7 @@ class CachingOperationInvokerTests {
 				Collections.emptyMap());
 		given(target.invoke(contextV2)).willReturn(expectedV2);
 		given(target.invoke(contextV3)).willReturn(expectedV3);
-		CachingOperationInvoker invoker = new CachingOperationInvoker(target, 500L);
+		CachingOperationInvoker invoker = new CachingOperationInvoker(target, CACHE_TTL);
 		Object response = invoker.invoke(contextV2);
 		assertThat(response).isSameAs(expectedV2);
 		verify(target, times(1)).invoke(contextV2);


### PR DESCRIPTION
Hi,

I just saw that the latest pipeline [(Build # 49)](https://ci.spring.io/teams/spring-boot/pipelines/spring-boot-2.3.x/jobs/build/builds/49) failed. It seems that this is caused by the test code not running fast enough and not meeting the specified TTL parameter of 500 milliseconds. This PR increases the cache TTL to a much higher value as it's actually not really needed to set this to a low value.

Let me know what you think.
Cheers,
Christoph