### PR TITLE
server.ssl.key-alias is ignored when configuring Netty

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/SslServerCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/SslServerCustomizer.java
@@ -16,12 +16,27 @@
 
 package org.springframework.boot.web.embedded.netty;
 
+import java.net.Socket;
 import java.net.URL;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.stream.Collectors;
 
+import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.KeyManagerFactorySpi;
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedKeyManager;
 
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -92,8 +107,10 @@ public class SslServerCustomizer implements NettyServerCustomizer {
 	protected KeyManagerFactory getKeyManagerFactory(Ssl ssl, SslStoreProvider sslStoreProvider) {
 		try {
 			KeyStore keyStore = getKeyStore(ssl, sslStoreProvider);
-			KeyManagerFactory keyManagerFactory = KeyManagerFactory
-					.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+			KeyManagerFactory keyManagerFactory = (ssl.getKeyAlias() == null)
+					? KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
+					: ConfigurableAliasKeyManagerFactory.instance(ssl.getKeyAlias(),
+							KeyManagerFactory.getDefaultAlgorithm());
 			char[] keyPassword = (ssl.getKeyPassword() != null) ? ssl.getKeyPassword().toCharArray() : null;
 			if (keyPassword == null && ssl.getKeyStorePassword() != null) {
 				keyPassword = ssl.getKeyStorePassword().toCharArray();
@@ -157,6 +174,122 @@ public class SslServerCustomizer implements NettyServerCustomizer {
 		}
 		catch (Exception ex) {
 			throw new WebServerException("Could not load key store '" + resource + "'", ex);
+		}
+
+	}
+
+	/**
+	 * A {@link KeyManagerFactory} that allows a configurable key alias to be used. Due to
+	 * the fact that the actual calls to retrieve the key by alias are done at request
+	 * time the approach is to wrap the actual key managers with a
+	 * {@link ConfigurableAliasKeyManager}. The actual SPI has to be wrapped as well due
+	 * to the fact that {@link KeyManagerFactory#getKeyManagers()} is final.
+	 */
+	private static class ConfigurableAliasKeyManagerFactory extends KeyManagerFactory {
+
+		static final ConfigurableAliasKeyManagerFactory instance(String alias, String algorithm)
+				throws NoSuchAlgorithmException {
+			KeyManagerFactory originalFactory = KeyManagerFactory.getInstance(algorithm);
+			ConfigurableAliasKeyManagerFactorySpi spi = new ConfigurableAliasKeyManagerFactorySpi(originalFactory,
+					alias);
+			return new ConfigurableAliasKeyManagerFactory(spi, originalFactory.getProvider(), algorithm);
+		}
+
+		ConfigurableAliasKeyManagerFactory(ConfigurableAliasKeyManagerFactorySpi spi, Provider provider,
+				String algorithm) {
+			super(spi, provider, algorithm);
+		}
+
+	}
+
+	private static class ConfigurableAliasKeyManagerFactorySpi extends KeyManagerFactorySpi {
+
+		private KeyManagerFactory originalFactory;
+
+		private String alias;
+
+		ConfigurableAliasKeyManagerFactorySpi(KeyManagerFactory originalFactory, String alias) {
+			this.originalFactory = originalFactory;
+			this.alias = alias;
+		}
+
+		@Override
+		protected void engineInit(KeyStore keyStore, char[] chars)
+				throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
+			this.originalFactory.init(keyStore, chars);
+		}
+
+		@Override
+		protected void engineInit(ManagerFactoryParameters managerFactoryParameters)
+				throws InvalidAlgorithmParameterException {
+			throw new InvalidAlgorithmParameterException("Unsupported ManagerFactoryParameters");
+		}
+
+		@Override
+		protected KeyManager[] engineGetKeyManagers() {
+			return Arrays.stream(this.originalFactory.getKeyManagers()).filter(X509ExtendedKeyManager.class::isInstance)
+					.map(X509ExtendedKeyManager.class::cast).map(this::wrapKeyManager).collect(Collectors.toList())
+					.toArray(new KeyManager[0]);
+		}
+
+		private ConfigurableAliasKeyManager wrapKeyManager(X509ExtendedKeyManager km) {
+			return new ConfigurableAliasKeyManager(km, this.alias);
+		}
+
+	}
+
+	private static class ConfigurableAliasKeyManager extends X509ExtendedKeyManager {
+
+		private final X509ExtendedKeyManager keyManager;
+
+		private final String alias;
+
+		ConfigurableAliasKeyManager(X509ExtendedKeyManager keyManager, String alias) {
+			this.keyManager = keyManager;
+			this.alias = alias;
+		}
+
+		@Override
+		public String chooseEngineClientAlias(String[] strings, Principal[] principals, SSLEngine sslEngine) {
+			return this.keyManager.chooseEngineClientAlias(strings, principals, sslEngine);
+		}
+
+		@Override
+		public String chooseEngineServerAlias(String s, Principal[] principals, SSLEngine sslEngine) {
+			if (this.alias == null) {
+				return this.keyManager.chooseEngineServerAlias(s, principals, sslEngine);
+			}
+			return this.alias;
+		}
+
+		@Override
+		public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+			return this.keyManager.chooseClientAlias(keyType, issuers, socket);
+		}
+
+		@Override
+		public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+			return this.keyManager.chooseServerAlias(keyType, issuers, socket);
+		}
+
+		@Override
+		public X509Certificate[] getCertificateChain(String alias) {
+			return this.keyManager.getCertificateChain(alias);
+		}
+
+		@Override
+		public String[] getClientAliases(String keyType, Principal[] issuers) {
+			return this.keyManager.getClientAliases(keyType, issuers);
+		}
+
+		@Override
+		public PrivateKey getPrivateKey(String alias) {
+			return this.keyManager.getPrivateKey(alias);
+		}
+
+		@Override
+		public String[] getServerAliases(String keyType, Principal[] issuers) {
+			return this.keyManager.getServerAliases(keyType, issuers);
 		}
 
 	}


### PR DESCRIPTION
Closes gh-17944

Followed similar approach as in `org.springframework.boot.web.embedded.jetty.SslServerCustomizer` by wrapping the returned key managers with a version that supports looking up by alias. It was one level deeper as Netty passes the KeyManagerFactory, not the KeyManagers down into the bowels of SSL. With this change, the KeyManagerFactory actually returns the wrapped KeyManagers via its SPI. 

Verified that an invalid alias name does the same exception at runtime as reported by #16168. They are in parity w/ this change.