### PR TITLE
Delete useless judgment 

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/deployment.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/deployment.adoc
@@ -41,8 +41,8 @@ For example, using a `Dockerfile` you could express it in this form:
 ----
 	FROM openjdk:8-jdk-alpine AS builder
 	WORKDIR target/dependency
-	ARG appjar
-	COPY ${appjar} app.jar
+	ARG APPJAR=target/*.jar
+	COPY ${APPJAR} app.jar
 	RUN jar -xf ./app.jar
 
 	FROM openjdk:8-jre-alpine
@@ -54,13 +54,12 @@ For example, using a `Dockerfile` you could express it in this form:
 	ENTRYPOINT ["java","-cp","app:app/lib/*","com.example.MyApplication"]
 ----
 
-Assuming the above `Dockerfile` is the current directory, your docker image can be built specifying the path to your application jar, as show in the following example:
+Assuming the above `Dockerfile` is the current directory, your docker image can be built with `docker build .`, or optionally specifying the path to your application jar, as show in the following example:
 
 [indent=0]
 ----
 	docker build --build-arg appjar=path/to/myapp.jar .
 ----
-
 
 
 [[cloud-deployment]]


### PR DESCRIPTION
# 1.old code
`
if (StringUtils.hasText(validationQuery)) { try { // Avoid calling getObject as it breaks MySQL on Java 7 List<Object> results = this.jdbcTemplate.query(validationQuery, new SingleColumnRowMapper()); Object result = DataAccessUtils.requiredSingleResult(results); builder.withDetail("result", result); } finally { builder.withDetail("validationQuery", validationQuery); } } }
`
# 2. After updating the code
Delete useless judgment，Because validationQuery must not be null or “” or “ ”
`
try { // Avoid calling getObject as it breaks MySQL on Java 7 List<Object> results = this.jdbcTemplate.query(validationQuery, new SingleColumnRowMapper()); Object result = DataAccessUtils.requiredSingleResult(results); builder.withDetail("result", result); } finally { builder.withDetail("validationQuery", validationQuery); }
`