### PR TITLE
@DataJpaTest using H2 with schema.sql and spring.datasource.schema-username fails

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-test-autoconfigure/pom.xml
@@ -250,6 +250,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>de.flapdoodle.embed</groupId>
 			<artifactId>de.flapdoodle.embed.mongo</artifactId>
 			<scope>test</scope>

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/resources/org/springframework/boot/test/autoconfigure/jdbc/data.sql
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/resources/org/springframework/boot/test/autoconfigure/jdbc/data.sql
@@ -1,0 +1,1 @@
+insert into example values (1, 'example1');


### PR DESCRIPTION
Currently, `jdbcUrl` is determined when `spring.datasource.schema-username`
and `spring.datasource.schema-password` configuration properties are set.
This behaviour causes an issue trying to perform sql scripts in the
wrong database. This commit introduces to get the right `url` from the
`dataSource` bean.

See gh-19321

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
