### PR TITLE
Add support for setting DirContextAuthenticationStrategy on the LdapContextSource

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.boot.autoconfigure.ldap;
 
 import java.util.Collections;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -29,6 +30,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.ldap.core.ContextSource;
 import org.springframework.ldap.core.LdapOperations;
 import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.core.support.DirContextAuthenticationStrategy;
 import org.springframework.ldap.core.support.LdapContextSource;
 
 /**
@@ -45,7 +47,8 @@ public class LdapAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public LdapContextSource ldapContextSource(LdapProperties properties, Environment environment) {
+	public LdapContextSource ldapContextSource(LdapProperties properties, Environment environment,
+			ObjectProvider<DirContextAuthenticationStrategy> authenticationStrategy) {
 		LdapContextSource source = new LdapContextSource();
 		PropertyMapper propertyMapper = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		propertyMapper.from(properties.getUsername()).to(source::setUserDn);
@@ -55,6 +58,8 @@ public class LdapAutoConfiguration {
 		propertyMapper.from(properties.determineUrls(environment)).to(source::setUrls);
 		propertyMapper.from(properties.getBaseEnvironment()).to(
 				(baseEnvironment) -> source.setBaseEnvironmentProperties(Collections.unmodifiableMap(baseEnvironment)));
+
+		authenticationStrategy.ifUnique(source::setAuthenticationStrategy);
 		return source;
 	}
 


### PR DESCRIPTION
Set `DirContextAuthenticationStrategy` on the `LdapContextSource`
if there is a unique `DirContextAuthenticationStrategy` bean in the `ApplicationContext`

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
