### PR TITLE
Fix link to Vaadin Spring Boot starter

### DIFF
--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -200,7 +200,7 @@ do as they were designed before this was clarified.
 | https://github.com/Catalysts/structurizr-extensions
 
 | https://vaadin.com/[Vaadin]
-| https://github.com/vaadin/spring/tree/master/vaadin-spring-boot-starter
+| https://github.com/vaadin/platform/tree/master/vaadin-spring-boot-starter
 
 | https://github.com/valiktor/valiktor[Valiktor]
 | https://github.com/valiktor/valiktor/tree/master/valiktor-spring/valiktor-spring-boot-starter


### PR DESCRIPTION
Hi,

I just noticed the Vaadin Spring-Boot starter has moved. This PR updates the link in the documentation accordingly.

Cheers,
Christoph