### PR TITLE
Link consistently to Tomcat 9.0 docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/pom.xml
+++ b/spring-boot-project/spring-boot-docs/pom.xml
@@ -1188,7 +1188,7 @@
 										<link>https://docs.oracle.com/javaee/7/api</link>
 										<link>https://docs.spring.io/spring-framework/docs/${spring-framework.version}/javadoc-api</link>
 										<link>https://docs.spring.io/spring-security/site/docs/${spring-security.version}/api</link>
-										<link>https://tomcat.apache.org/tomcat-8.5-doc/api</link>
+										<link>https://tomcat.apache.org/tomcat-9.0-doc/api</link>
 										<link>https://www.eclipse.org/jetty/javadoc/${jetty.version}</link>
 										<link>https://www.thymeleaf.org/apidocs/thymeleaf/${thymeleaf.version}</link>
 									</links>

--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -3407,7 +3407,7 @@ These are the standard options that work regardless of the actual implementation
 It is also possible to fine-tune implementation-specific settings by using their respective prefix (`+spring.datasource.hikari.*+`, `+spring.datasource.tomcat.*+`, and `+spring.datasource.dbcp2.*+`).
 Refer to the documentation of the connection pool implementation you are using for more details.
 
-For instance, if you use the https://tomcat.apache.org/tomcat-8.0-doc/jdbc-pool.html#Common_Attributes[Tomcat connection pool], you could customize many additional settings, as shown in the following example:
+For instance, if you use the {tomcat-docs}/jdbc-pool.html#Common_Attributes[Tomcat connection pool], you could customize many additional settings, as shown in the following example:
 
 [source,properties,indent=0,configprops]
 ----


### PR DESCRIPTION
Hi,

this PR fixes two places where the links to the Tomcat docs point to a version that Spring Boot isn't using.

Cheers,
Christoph