### PR TITLE
Disable Jackson SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS by default

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
@@ -88,6 +88,7 @@ public class JacksonAutoConfiguration {
 	static {
 		Map<Object, Boolean> featureDefaults = new HashMap<>();
 		featureDefaults.put(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+		featureDefaults.put(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false);
 		FEATURE_DEFAULTS = Collections.unmodifiableMap(featureDefaults);
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfigurationTests.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.jackson;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -375,6 +376,15 @@ class JacksonAutoConfigurationTests {
 			String expected = FormatConfig.DEFAULT_DATETIME_PRINTER.rawFormatter().withZone(DateTimeZone.UTC)
 					.print(dateTime);
 			assertThat(mapper.writeValueAsString(dateTime)).isEqualTo("\"" + expected + "\"");
+		});
+	}
+
+	@Test
+	void writeDurationAsTimestampsDefault() {
+		this.contextRunner.run((context) -> {
+			ObjectMapper mapper = context.getBean(ObjectMapper.class);
+			Duration duration = Duration.ofHours(2);
+			assertThat(mapper.writeValueAsString(duration)).isEqualTo("\"PT2H\"");
 		});
 	}
 


### PR DESCRIPTION

Jackson added a breaking change in 2.10 for the way `Duration` is serialized.
Before that the `DurationSerializer` was using `SerializationFeature.WRITE_DATES_AS_TIMESTAMPS`
to check whether Duration should be serialized as a timestamp or not.

Since 2.10 Jackson uses `SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS`
to check whether `Duration` should be serialized as a timestamp or not.

This commit aligns the default for `SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS`
with the default for `SerializationFeature.WRITE_DATES_AS_TIMESTAMPS`

The change in Jackson was done in https://github.com/FasterXML/jackson-modules-java8/pull/75

fixes gh-19345