### PR TITLE
Add missing icon to daily CI build

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -140,6 +140,7 @@ resources:
     days: [Wednesday]
 - name: daily
   type: time
+  icon: clock-outline
   source: { interval: "24h" }
 jobs:
 - name: build-spring-boot-ci-images


### PR DESCRIPTION
Hi,

I just noticed that the daily windows pipeline is missing an icon.
![image](https://user-images.githubusercontent.com/6304496/70709363-08d8d680-1cdd-11ea-8932-094deffe4a50.png)

Cheers,
Christoph
