### PR TITLE
Add DeferredImportSelector that runs before/after auto configuration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AbstractImportBeforeAndAfterAutoConfigurationDeferredImportSelector.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AbstractImportBeforeAndAfterAutoConfigurationDeferredImportSelector.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.context.annotation.DeferredImportSelector;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+/**
+ * {@link DeferredImportSelector} implementation that works with
+ * {@link ImportBeforeAutoConfiguration} and {@link ImportAfterAutoConfiguration}.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 2.3.0
+ */
+public abstract class AbstractImportBeforeAndAfterAutoConfigurationDeferredImportSelector
+		implements DeferredImportSelector, Ordered {
+
+	// ImportAutoConfigurationImportSelector is a child of AutoConfigurationImportSelector
+	// and getOrder() subtracts 1 from parent; therefore, use it as a lower bound.
+	protected static final int ORDER_BEFORE_AUTO_CONFIGURATION = new ImportAutoConfigurationImportSelector().getOrder()
+			- 1;
+
+	protected static final int ORDER_AFTER_AUTO_CONFIGURATION = new AutoConfigurationImportSelector().getOrder() + 1;
+
+	@Override
+	public String[] selectImports(AnnotationMetadata metadata) {
+		Class<?> annotationClass = getAnnotationClass();
+		AnnotationAttributes attributes = getAttributes(metadata, annotationClass, true);
+		String[] imports = attributes.getStringArray("classes");
+		Assert.notNull(imports,
+				() -> "Attribute \"classes\" should exist on " + ClassUtils.getShortName(annotationClass));
+		return imports;
+	}
+
+	/**
+	 * Return the source annotation class used by the selector.
+	 * @return the annotation class
+	 */
+	protected abstract Class<?> getAnnotationClass();
+
+	private static AnnotationAttributes getAttributes(AnnotationMetadata metadata, Class<?> annotationClass,
+			boolean classValuesAsString) {
+		String annotationName = annotationClass.getName();
+		AnnotationAttributes attributes = AnnotationAttributes
+				.fromMap(metadata.getAnnotationAttributes(annotationName, classValuesAsString));
+		Assert.notNull(attributes, () -> "No annotation attributes found. Is " + metadata.getClassName()
+				+ " annotated with " + ClassUtils.getShortName(annotationName) + "?");
+		return attributes;
+	}
+
+	/**
+	 * {@link DeferredImportSelector.Group} implementation for
+	 * {@link ImportBeforeAutoConfigurationDeferredImportSelector} and
+	 * {@link ImportAfterAutoConfigurationDeferredImportSelector}.
+	 */
+	protected abstract static class AbstractBeforeAndAfterAutoConfigurationGroup
+			implements DeferredImportSelector.Group {
+
+		private static final Comparator<ConfigurationEntry> CONFIGURATION_CLASS_COMPARATOR = (o1,
+				o2) -> AnnotationAwareOrderComparator.INSTANCE.compare(o1.getImportingConfigClass(),
+						o2.getImportingConfigClass());
+
+		private List<ConfigurationEntry> entries = new ArrayList<>();
+
+		@Override
+		public void process(AnnotationMetadata metadata, DeferredImportSelector selector) {
+			Assert.state(selector instanceof AbstractImportBeforeAndAfterAutoConfigurationDeferredImportSelector,
+					() -> String.format("Only %s implementations are supported, got %s",
+							AbstractImportBeforeAndAfterAutoConfigurationDeferredImportSelector.class.getSimpleName(),
+							selector.getClass().getName()));
+			Class<?> annotationClass = ((AbstractImportBeforeAndAfterAutoConfigurationDeferredImportSelector) selector)
+					.getAnnotationClass();
+			AnnotationAttributes attributes = getAttributes(metadata, annotationClass, false);
+			Class<?>[] configurationClasses = attributes.getClassArray("classes");
+			for (Class<?> configurationClass : configurationClasses) {
+				ConfigurationEntry entry = new ConfigurationEntry(configurationClass, metadata);
+				this.entries.add(entry);
+			}
+			this.entries.sort(CONFIGURATION_CLASS_COMPARATOR);
+		}
+
+		@Override
+		public Iterable<Entry> selectImports() {
+			return new ArrayList<>(this.entries);
+		}
+
+		private static class ConfigurationEntry extends Entry {
+
+			private final Class<?> importingConfigClass;
+
+			ConfigurationEntry(Class<?> importingConfigClass, AnnotationMetadata metadata) {
+				super(metadata, importingConfigClass.getName());
+				this.importingConfigClass = importingConfigClass;
+			}
+
+			Class<?> getImportingConfigClass() {
+				return this.importingConfigClass;
+			}
+
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ImportAfterAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ImportAfterAutoConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * Import and apply the specified configuration classes after auto-configuration classes.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 2.3.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(ImportAfterAutoConfigurationDeferredImportSelector.class)
+public @interface ImportAfterAutoConfiguration {
+
+	/**
+	 * The configuration classes that should be imported after auto-configurations. This
+	 * is an alias for {@link #classes()}.
+	 * @return the classes to import
+	 */
+	@AliasFor("classes")
+	Class<?>[] value() default {};
+
+	/**
+	 * The configuration classes that should be imported after auto-configurations.
+	 * @return the classes to import
+	 */
+	@AliasFor("value")
+	Class<?>[] classes() default {};
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ImportAfterAutoConfigurationDeferredImportSelector.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ImportAfterAutoConfigurationDeferredImportSelector.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure;
+
+/**
+ * {@link org.springframework.context.annotation.DeferredImportSelector} that is used by
+ * {@link ImportAfterAutoConfiguration}.
+ * <p>
+ * This deferred import selector makes sure specified configurations to run AFTER auto
+ * configurations.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 2.3.0
+ */
+public class ImportAfterAutoConfigurationDeferredImportSelector
+		extends AbstractImportBeforeAndAfterAutoConfigurationDeferredImportSelector {
+
+	@Override
+	public int getOrder() {
+		return ORDER_AFTER_AUTO_CONFIGURATION;
+	}
+
+	@Override
+	protected Class<?> getAnnotationClass() {
+		return ImportAfterAutoConfiguration.class;
+	}
+
+	@Override
+	public Class<? extends Group> getImportGroup() {
+		return AfterAutoConfigurationGroup.class;
+	}
+
+	/**
+	 * {@link org.springframework.context.annotation.DeferredImportSelector.Group} for
+	 * {@link ImportAfterAutoConfigurationDeferredImportSelector}.
+	 */
+	private static class AfterAutoConfigurationGroup extends AbstractBeforeAndAfterAutoConfigurationGroup {
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ImportBeforeAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ImportBeforeAutoConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * Import and apply the specified configuration classes before auto-configuration classes
+ * but after normal configuration classes.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 2.3.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(ImportBeforeAutoConfigurationDeferredImportSelector.class)
+public @interface ImportBeforeAutoConfiguration {
+
+	/**
+	 * The configuration classes that should be imported before auto-configurations but
+	 * after normal configuration classes. This is an alias for {@link #classes()}.
+	 * @return the classes to import
+	 */
+	@AliasFor("classes")
+	Class<?>[] value() default {};
+
+	/**
+	 * The configuration classes that should be imported before auto-configurations but
+	 * after normal configuration classes.
+	 * @return the classes to import
+	 */
+	@AliasFor("value")
+	Class<?>[] classes() default {};
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ImportBeforeAutoConfigurationDeferredImportSelector.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ImportBeforeAutoConfigurationDeferredImportSelector.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure;
+
+/**
+ * {@link org.springframework.context.annotation.DeferredImportSelector} that is used by
+ * {@link ImportBeforeAutoConfiguration}.
+ * <p>
+ * This deferred import selector makes sure specified configurations to run BEFORE auto
+ * configurations.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 2.3.0
+ */
+public class ImportBeforeAutoConfigurationDeferredImportSelector
+		extends AbstractImportBeforeAndAfterAutoConfigurationDeferredImportSelector {
+
+	@Override
+	public int getOrder() {
+		return ORDER_BEFORE_AUTO_CONFIGURATION;
+	}
+
+	@Override
+	protected Class<?> getAnnotationClass() {
+		return ImportBeforeAutoConfiguration.class;
+	}
+
+	@Override
+	public Class<? extends Group> getImportGroup() {
+		return BeforeAutoConfigurationGroup.class;
+	}
+
+	/**
+	 * {@link org.springframework.context.annotation.DeferredImportSelector.Group} for
+	 * {@link ImportBeforeAutoConfigurationDeferredImportSelector}.
+	 */
+	private static class BeforeAutoConfigurationGroup extends AbstractBeforeAndAfterAutoConfigurationGroup {
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ImportBeforeAndAfterAutoConfigurationGroupOrderTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ImportBeforeAndAfterAutoConfigurationGroupOrderTests.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.logging.ConditionEvaluationReportLoggingListener;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for configuration group used by
+ * {@link ImportBeforeAutoConfigurationDeferredImportSelector} and
+ * {@link ImportAfterAutoConfigurationDeferredImportSelector}.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+class ImportBeforeAndAfterAutoConfigurationGroupOrderTests {
+
+	// NOTE: cannot use "AutoConfigurations" since it is NOT a deferred import selector
+	private ApplicationContextRunner runner = new ApplicationContextRunner()
+			.withInitializer(new ConditionEvaluationReportLoggingListener());
+
+	@Test
+	void order() {
+		this.runner.withUserConfiguration(Import_10_20_30_Config.class)
+				.run((context) -> assertThat(context).hasNotFailed().getBean("myBean").isEqualTo("Config Order 10"));
+
+		this.runner.withUserConfiguration(Import_20_30_40_Config.class)
+				.run((context) -> assertThat(context).hasNotFailed().getBean("myBean").isEqualTo("Config Order 20"));
+	}
+
+	@Test
+	void noOrder() {
+		this.runner.withUserConfiguration(Import_NoOrder_20_30_Config.class)
+				.run((context) -> assertThat(context).hasNotFailed().getBean("myBean").isEqualTo("Config Order 20"));
+
+		this.runner.withUserConfiguration(Import_NoOrder_Config.class)
+				.run((context) -> assertThat(context).hasNotFailed().getBean("myBean").isEqualTo("Config No Order"));
+	}
+
+	@Test
+	void importAfterOnly() {
+		this.runner.withUserConfiguration(ImportAfterOnlyConfig.class)
+				.run((context) -> assertThat(context).hasNotFailed().getBean("myBean").isEqualTo("Config Order 10"));
+	}
+
+	@Test
+	void importAfterAndAutoConfig() {
+		this.runner.withUserConfiguration(ImportAfterAndAutoConfig.class)
+				.run((context) -> assertThat(context).hasNotFailed().getBean("myBean").isEqualTo("Auto Config"));
+	}
+
+	@Test
+	void userConfig() {
+		// UserConfig always takes precedence
+		this.runner.withUserConfiguration(Import_10_20_30_Config.class, UserConfig.class)
+				.run((context) -> assertThat(context).hasNotFailed().getBean("myBean").isEqualTo("User Config"));
+
+		this.runner.withUserConfiguration(Import_NoOrder_Config.class, UserConfig.class)
+				.run((context) -> assertThat(context).hasNotFailed().getBean("myBean").isEqualTo("User Config"));
+	}
+
+	@Test
+	void importBeforeAndAfter() {
+		this.runner.withUserConfiguration(ImportBeforeAndAfterAndAfterConfig.class)
+				.run((context) -> assertThat(context).hasNotFailed().getBean("myBean").isEqualTo("Config Order 10"));
+	}
+
+	@Test
+	void importBothBeforeAndAfterWithAfterHasHigherPriority() {
+		this.runner.withUserConfiguration(ImportBeforeAndAfterWithAfterHasHigherPriorityConfig.class)
+				.run((context) -> assertThat(context).hasNotFailed().getBean("myBean")
+						.as("@EnableConfigurationBeforeAutoConfiguration should be resolved first")
+						.isEqualTo("Config Order 20"));
+	}
+
+	@Test
+	void importFooAndBarAndAutoConfig() {
+		this.runner.withUserConfiguration(ImportFooAndBarAndAutoConfig.class)
+				.run((context) -> assertThat(context).hasNotFailed().hasBean("foo").hasBean("bar").hasBean("baz"));
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Order(10)
+	static class ConfigOrder10 {
+
+		@Bean
+		@ConditionalOnMissingBean
+		String myBean() {
+			return "Config Order 10";
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Order(20)
+	static class ConfigOrder20 {
+
+		@Bean
+		@ConditionalOnMissingBean
+		String myBean() {
+			return "Config Order 20";
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Order(30)
+	static class ConfigOrder30 {
+
+		@Bean
+		@ConditionalOnMissingBean
+		String myBean() {
+			return "Config Order 30";
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Order(40)
+	static class ConfigOrder40 {
+
+		@Bean
+		@ConditionalOnMissingBean
+		String myBean() {
+			return "Config Order 40";
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigNoOrder {
+
+		@Bean
+		@ConditionalOnMissingBean
+		String myBean() {
+			return "Config No Order";
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class AutoConfig {
+
+		@Bean
+		@ConditionalOnMissingBean
+		String myBean() {
+			return "Auto Config";
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class UserConfig {
+
+		@Bean
+		String myBean() {
+			return "User Config";
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportBeforeAutoConfiguration({ ConfigOrder10.class, ConfigOrder20.class, ConfigOrder30.class })
+	@ImportAutoConfiguration(AutoConfig.class)
+	static class Import_10_20_30_Config {
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportBeforeAutoConfiguration({ ConfigOrder20.class, ConfigOrder30.class, ConfigOrder40.class })
+	@ImportAutoConfiguration(AutoConfig.class)
+	static class Import_20_30_40_Config {
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportBeforeAutoConfiguration({ ConfigNoOrder.class, ConfigOrder20.class, ConfigOrder30.class })
+	@ImportAutoConfiguration(AutoConfig.class)
+	static class Import_NoOrder_20_30_Config {
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportBeforeAutoConfiguration(ConfigNoOrder.class)
+	@ImportAutoConfiguration(AutoConfig.class)
+	static class Import_NoOrder_Config {
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportAfterAutoConfiguration(ConfigOrder20.class)
+	@ImportAutoConfiguration(AutoConfig.class)
+	static class ImportAfterAndAutoConfig {
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportAfterAutoConfiguration({ ConfigOrder10.class, ConfigOrder20.class })
+	static class ImportAfterOnlyConfig {
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportBeforeAutoConfiguration(ConfigOrder10.class)
+	@ImportAfterAutoConfiguration(ConfigOrder20.class)
+	@ImportAutoConfiguration(AutoConfig.class)
+	static class ImportBeforeAndAfterAndAfterConfig {
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportBeforeAutoConfiguration(ConfigOrder20.class)
+	@ImportAfterAutoConfiguration(ConfigOrder10.class) // after has higher priority
+	@ImportAutoConfiguration(AutoConfig.class)
+	static class ImportBeforeAndAfterWithAfterHasHigherPriorityConfig {
+
+	}
+
+	// -------
+
+	@Configuration(proxyBeanMethods = false)
+	static class FooConfig {
+
+		@Bean
+		String foo() {
+			return "FOO";
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class BarConfig {
+
+		@Bean
+		String bar() {
+			return "BAR";
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class BazConfig {
+
+		@Bean
+		String baz() {
+			return "BAZ";
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportBeforeAutoConfiguration(FooConfig.class)
+	@ImportAfterAutoConfiguration(BarConfig.class)
+	@ImportAutoConfiguration(BazConfig.class) // BazConfig as AutoConfiguration
+	static class ImportFooAndBarAndAutoConfig {
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ImportBeforeAndAfterAutoConfigurationOrderTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ImportBeforeAndAfterAutoConfigurationOrderTests.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ImportBeforeAutoConfiguration} and
+ * {@link ImportAfterAutoConfiguration}
+ *
+ * @author Tadaya Tsuyukubo
+ */
+class ImportBeforeAndAfterAutoConfigurationOrderTests {
+
+	@Nested
+	@SpringBootTest(classes = MyAppConfigEnableBefore.class)
+	@ImportAutoConfiguration(MyAutoConfig.class)
+	class BeforeAutoConfigurationTest {
+
+		@Autowired
+		String bean;
+
+		@Test
+		void check() {
+			assertThat(this.bean).isEqualTo("From my config");
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(classes = MyAppConfigEnableBeforeWithBean.class)
+	@ImportAutoConfiguration(MyAutoConfig.class)
+	class BeforeAutoConfigurationWithBeanTest {
+
+		@Autowired
+		String bean;
+
+		@Test
+		void check() {
+			assertThat(this.bean).isEqualTo("From app config");
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(classes = MyAppConfigEnableAfter.class)
+	@ImportAutoConfiguration(MyAutoConfig.class)
+	class AfterAutoConfigurationTest {
+
+		@Autowired
+		String bean;
+
+		@Test
+		void check() {
+			assertThat(this.bean).isEqualTo("From auto config");
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(classes = MyAppConfigEnableAfterWithBean.class)
+	@ImportAutoConfiguration(MyAutoConfig.class)
+	class AfterAutoConfigurationWithBeanTest {
+
+		@Autowired
+		String bean;
+
+		@Test
+		void check() {
+			assertThat(this.bean).isEqualTo("From app config");
+		}
+
+	}
+
+	// my configuration
+	@Configuration(proxyBeanMethods = false)
+	static class MyConfig {
+
+		@Bean
+		@ConditionalOnMissingBean
+		String bean() {
+			return "From my config";
+		}
+
+	}
+
+	// pretend to be auto configuration (used by @ImportAutoConfiguration)
+	@Configuration(proxyBeanMethods = false)
+	static class MyAutoConfig {
+
+		@Bean
+		@ConditionalOnMissingBean
+		String bean() {
+			return "From auto config";
+		}
+
+	}
+
+	// @EnableX to apply MyConfig BEFORE auto configurations
+	@Target(ElementType.TYPE)
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	@ImportBeforeAutoConfiguration(MyConfig.class)
+	@interface EnableBeforeAutoConfiguration {
+
+	}
+
+	// @EnableX to apply MyConfig AFTER auto configurations
+	@Target(ElementType.TYPE)
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	@ImportAfterAutoConfiguration(MyConfig.class)
+	@interface EnableAfterAutoConfiguration {
+
+	}
+
+	// test configuration that enables my configuration BEFORE auto configs
+	@Configuration(proxyBeanMethods = false)
+	@EnableBeforeAutoConfiguration
+	static class MyAppConfigEnableBefore {
+
+	}
+
+	// test configuration that enables my configuration BEFORE auto configs but has
+	// defined a bean
+	@Configuration(proxyBeanMethods = false)
+	@EnableBeforeAutoConfiguration
+	static class MyAppConfigEnableBeforeWithBean {
+
+		@Bean
+		String bean() {
+			return "From app config";
+		}
+
+	}
+
+	// test configuration that enables my configuration AFTER auto configs
+	@Configuration(proxyBeanMethods = false)
+	@EnableAfterAutoConfiguration
+	static class MyAppConfigEnableAfter {
+
+	}
+
+	// test configuration that enables my configuration AFTER auto configs but has defined
+	// a bean
+	@Configuration(proxyBeanMethods = false)
+	@EnableAfterAutoConfiguration
+	static class MyAppConfigEnableAfterWithBean {
+
+		@Bean
+		String bean() {
+			return "From app config";
+		}
+
+	}
+
+}


### PR DESCRIPTION
Hi,

I wrote custom `DeferredImportSelectors` and corresponding annotations that run before/after auto configurations for my library.
- _`Import[Before|After]AutoConfigurationDeferredImportSelector`:_
  `DeferedImportSelector`  implementation that runs before/after auto configuration
- _`@Import[Before|After]AutoConfiguration`:_
  Use the above deferred selector to specify which configurations to run before/after auto configuration


The background is we have shared library on top of spring-boot and provides shared configurations. Applications will pick some of the shared configurations to enable features.
Since those shared configurations are not autoconfigurations, because of our preference to explicitly enable each feature, I had some problems with configuration orders especially with `@ConditionalOn[Missing]Bean`.
By using these `DeferredImportSelectors`, I have better control for my library's configurations to run  after user's configurations, and then before/after auto configurations.

Sample usage are:

In library:
```java
// Make this configuration runs after user config but before autoconfig
@Configuration(proxyBeanMethods = false)
class MyFeatureConfig {
  // @Bean to enable some feature
}

// annotation to enable my feature(config)
@Target(ElementType.TYPE)
@Retention(RetentionPolicy.RUNTIME)
@Documented
@ImportBeforeAutoConfiguration(MyFeatureConfig.class)  // <=== meta annotate
@interface EnableMyFeature {
}
```

In application:
```java
@EnableMyFeature
@SpringBootApplication
class Application {
}
```

I am going to apply these import selectors to our library.
At the same time, I think this is also beneficial if exists in spring-boot itself, hence the PR here.

Thanks,


Relates to: #18228, #19343
