### PR TITLE
Adapt file rotation documentation to logging's maxHistory default change to 7 days

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/main/asciidoc/spring-boot-features.adoc
@@ -1634,7 +1634,7 @@ The following table shows how the `logging.*` properties can be used together:
 
 Log files rotate when they reach 10 MB and, as with console output, `ERROR`-level, `WARN`-level, and `INFO`-level messages are logged by default.
 Size limits can be changed using the configprop:logging.file.max-size[] property.
-Previously rotated files are archived indefinitely unless the configprop:logging.file.max-history[] property has been set.
+Last 7 previously rotated log files are kept by default unless the configprop:logging.file.max-history[] property has been set.
 The total size of log archives can be capped using configprop:logging.file.total-size-cap[].
 When the total size of log archives exceeds that threshold, backups will be deleted.
 To force log archive cleanup on application startup, use the configprop:logging.file.clean-history-on-start[] property.


### PR DESCRIPTION
Documentation is corrected to reflect the changes made to change the default `logging.file.max-history` to 7 instead of indefinite.