### PR TITLE
Add 'threads' configuration group for embedded containers

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -65,6 +65,7 @@ import org.springframework.util.unit.DataSize;
  * @author Dirk Deyne
  * @author HaiTao Zhang
  * @author Victor Mandujano
+ * @author Chris Bono
  * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = true)
@@ -309,6 +310,11 @@ public class ServerProperties {
 		private final Accesslog accesslog = new Accesslog();
 
 		/**
+		 * Thread related configuration.
+		 */
+		private final Threads threads = new Threads();
+
+		/**
 		 * Tomcat base directory. If not specified, a temporary directory is used.
 		 */
 		private File basedir;
@@ -319,16 +325,6 @@ public class ServerProperties {
 		 */
 		@DurationUnit(ChronoUnit.SECONDS)
 		private Duration backgroundProcessorDelay = Duration.ofSeconds(10);
-
-		/**
-		 * Maximum amount of worker threads.
-		 */
-		private int maxThreads = 200;
-
-		/**
-		 * Minimum amount of worker threads.
-		 */
-		private int minSpareThreads = 10;
 
 		/**
 		 * Maximum size of the form content in any HTTP post request.
@@ -417,20 +413,26 @@ public class ServerProperties {
 		 */
 		private final Remoteip remoteip = new Remoteip();
 
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "server.tomcat.threads.max")
 		public int getMaxThreads() {
-			return this.maxThreads;
+			return this.getThreads().getMax();
 		}
 
+		@Deprecated
 		public void setMaxThreads(int maxThreads) {
-			this.maxThreads = maxThreads;
+			this.getThreads().setMax(maxThreads);
 		}
 
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "server.tomcat.threads.min-spare")
 		public int getMinSpareThreads() {
-			return this.minSpareThreads;
+			return this.getThreads().getMinSpare();
 		}
 
+		@Deprecated
 		public void setMinSpareThreads(int minSpareThreads) {
-			this.minSpareThreads = minSpareThreads;
+			this.getThreads().setMinSpare(minSpareThreads);
 		}
 
 		@Deprecated
@@ -454,6 +456,10 @@ public class ServerProperties {
 
 		public Accesslog getAccesslog() {
 			return this.accesslog;
+		}
+
+		public Threads getThreads() {
+			return this.threads;
 		}
 
 		public Duration getBackgroundProcessorDelay() {
@@ -863,6 +869,39 @@ public class ServerProperties {
 		}
 
 		/**
+		 * Tomcat thread properties.
+		 */
+		public static class Threads {
+
+			/**
+			 * Maximum amount of worker threads.
+			 */
+			private int max = 200;
+
+			/**
+			 * Minimum amount of worker threads.
+			 */
+			private int minSpare = 10;
+
+			public int getMax() {
+				return this.max;
+			}
+
+			public void setMax(int max) {
+				this.max = max;
+			}
+
+			public int getMinSpare() {
+				return this.minSpare;
+			}
+
+			public void setMinSpare(int minSpare) {
+				this.minSpare = minSpare;
+			}
+
+		}
+
+		/**
 		 * Tomcat static resource properties.
 		 */
 		public static class Resource {
@@ -1015,42 +1054,14 @@ public class ServerProperties {
 		private final Accesslog accesslog = new Accesslog();
 
 		/**
+		 * Thread related configuration.
+		 */
+		private final Threads threads = new Threads();
+
+		/**
 		 * Maximum size of the form content in any HTTP post request.
 		 */
 		private DataSize maxHttpFormPostSize = DataSize.ofBytes(200000);
-
-		/**
-		 * Number of acceptor threads to use. When the value is -1, the default, the
-		 * number of acceptors is derived from the operating environment.
-		 */
-		private Integer acceptors = -1;
-
-		/**
-		 * Number of selector threads to use. When the value is -1, the default, the
-		 * number of selectors is derived from the operating environment.
-		 */
-		private Integer selectors = -1;
-
-		/**
-		 * Minimum number of threads.
-		 */
-		private int minThreads = 8;
-
-		/**
-		 * Maximum number of threads.
-		 */
-		private int maxThreads = 200;
-
-		/**
-		 * Maximum capacity of the thread pool's backing queue. A default is computed
-		 * based on the threading configuration.
-		 */
-		private Integer maxQueueCapacity;
-
-		/**
-		 * Maximum thread idle time.
-		 */
-		private Duration threadIdleTimeout = Duration.ofMillis(60000);
 
 		/**
 		 * Time that the connection can be idle before it is closed.
@@ -1059,6 +1070,10 @@ public class ServerProperties {
 
 		public Accesslog getAccesslog() {
 			return this.accesslog;
+		}
+
+		public Threads getThreads() {
+			return this.threads;
 		}
 
 		@Deprecated
@@ -1080,52 +1095,68 @@ public class ServerProperties {
 			this.maxHttpFormPostSize = maxHttpFormPostSize;
 		}
 
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "server.jetty.threads.acceptors")
 		public Integer getAcceptors() {
-			return this.acceptors;
+			return this.getThreads().getAcceptors();
 		}
 
 		public void setAcceptors(Integer acceptors) {
-			this.acceptors = acceptors;
+			this.getThreads().setAcceptors(acceptors);
 		}
 
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "server.jetty.threads.selectors")
 		public Integer getSelectors() {
-			return this.selectors;
+			return this.getThreads().getSelectors();
 		}
 
 		public void setSelectors(Integer selectors) {
-			this.selectors = selectors;
+			this.getThreads().setSelectors(selectors);
 		}
 
-		public void setMinThreads(int minThreads) {
-			this.minThreads = minThreads;
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "server.jetty.threads.min")
+		public Integer getMinThreads() {
+			return this.getThreads().getMin();
 		}
 
-		public int getMinThreads() {
-			return this.minThreads;
+		@Deprecated
+		public void setMinThreads(Integer minThreads) {
+			this.getThreads().setMin(minThreads);
 		}
 
-		public void setMaxThreads(int maxThreads) {
-			this.maxThreads = maxThreads;
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "server.jetty.threads.max")
+		public Integer getMaxThreads() {
+			return this.getThreads().getMax();
 		}
 
-		public int getMaxThreads() {
-			return this.maxThreads;
+		@Deprecated
+		public void setMaxThreads(Integer maxThreads) {
+			this.getThreads().setMax(maxThreads);
 		}
 
-		public void setMaxQueueCapacity(Integer maxQueueCapacity) {
-			this.maxQueueCapacity = maxQueueCapacity;
-		}
-
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "server.jetty.threads.maxQueueCapacity")
 		public Integer getMaxQueueCapacity() {
-			return this.maxQueueCapacity;
+			return this.getThreads().getMaxQueueCapacity();
 		}
 
-		public void setThreadIdleTimeout(Duration threadIdleTimeout) {
-			this.threadIdleTimeout = threadIdleTimeout;
+		@Deprecated
+		public void setMaxQueueCapacity(Integer maxQueueCapacity) {
+			this.getThreads().setMaxQueueCapacity(maxQueueCapacity);
 		}
 
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "server.jetty.threads.idle-timeout")
 		public Duration getThreadIdleTimeout() {
-			return this.threadIdleTimeout;
+			return this.getThreads().getIdleTimeout();
+		}
+
+		@Deprecated
+		public void setThreadIdleTimeout(Duration threadIdleTimeout) {
+			this.getThreads().setIdleTimeout(threadIdleTimeout);
 		}
 
 		public Duration getConnectionIdleTimeout() {
@@ -1266,6 +1297,94 @@ public class ServerProperties {
 
 		}
 
+		/**
+		 * Jetty thread properties.
+		 */
+		public static class Threads {
+
+			/**
+			 * Number of acceptor threads to use. When the value is -1, the default, the
+			 * number of acceptors is derived from the operating environment.
+			 */
+			private Integer acceptors = -1;
+
+			/**
+			 * Number of selector threads to use. When the value is -1, the default, the
+			 * number of selectors is derived from the operating environment.
+			 */
+			private Integer selectors = -1;
+
+			/**
+			 * Maximum number of threads.
+			 */
+			private Integer max = 200;
+
+			/**
+			 * Minimum number of threads.
+			 */
+			private Integer min = 8;
+
+			/**
+			 * Maximum capacity of the thread pool's backing queue. A default is computed
+			 * based on the threading configuration.
+			 */
+			private Integer maxQueueCapacity;
+
+			/**
+			 * Maximum thread idle time.
+			 */
+			private Duration idleTimeout = Duration.ofMillis(60000);
+
+			public Integer getAcceptors() {
+				return this.acceptors;
+			}
+
+			public void setAcceptors(Integer acceptors) {
+				this.acceptors = acceptors;
+			}
+
+			public Integer getSelectors() {
+				return this.selectors;
+			}
+
+			public void setSelectors(Integer selectors) {
+				this.selectors = selectors;
+			}
+
+			public void setMin(Integer min) {
+				this.min = min;
+			}
+
+			public Integer getMin() {
+				return this.min;
+			}
+
+			public void setMax(Integer max) {
+				this.max = max;
+			}
+
+			public Integer getMax() {
+				return this.max;
+			}
+
+			public Integer getMaxQueueCapacity() {
+				return this.maxQueueCapacity;
+			}
+
+			public void setMaxQueueCapacity(Integer maxQueueCapacity) {
+				this.maxQueueCapacity = maxQueueCapacity;
+			}
+
+			public void setIdleTimeout(Duration idleTimeout) {
+				this.idleTimeout = idleTimeout;
+			}
+
+			public Duration getIdleTimeout() {
+				return this.idleTimeout;
+			}
+
+		}
+
 	}
 
 	/**
@@ -1304,17 +1423,6 @@ public class ServerProperties {
 		 * that is available to the JVM.
 		 */
 		private DataSize bufferSize;
-
-		/**
-		 * Number of I/O threads to create for the worker. The default is derived from the
-		 * number of available processors.
-		 */
-		private Integer ioThreads;
-
-		/**
-		 * Number of worker threads. The default is 8 times the number of I/O threads.
-		 */
-		private Integer workerThreads;
 
 		/**
 		 * Whether to allocate buffers outside the Java heap. The default is derived from
@@ -1378,6 +1486,11 @@ public class ServerProperties {
 
 		private final Accesslog accesslog = new Accesslog();
 
+		/**
+		 * Thread related configuration.
+		 */
+		private final Threads threads = new Threads();
+
 		private final Options options = new Options();
 
 		public DataSize getMaxHttpPostSize() {
@@ -1396,20 +1509,26 @@ public class ServerProperties {
 			this.bufferSize = bufferSize;
 		}
 
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "server.undertow.threads.io")
 		public Integer getIoThreads() {
-			return this.ioThreads;
+			return this.getThreads().getIo();
 		}
 
+		@Deprecated
 		public void setIoThreads(Integer ioThreads) {
-			this.ioThreads = ioThreads;
+			this.getThreads().setIo(ioThreads);
 		}
 
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "server.undertow.threads.worker")
 		public Integer getWorkerThreads() {
-			return this.workerThreads;
+			return this.getThreads().getWorker();
 		}
 
+		@Deprecated
 		public void setWorkerThreads(Integer workerThreads) {
-			this.workerThreads = workerThreads;
+			this.getThreads().setWorker(workerThreads);
 		}
 
 		public Boolean getDirectBuffers() {
@@ -1494,6 +1613,10 @@ public class ServerProperties {
 
 		public Accesslog getAccesslog() {
 			return this.accesslog;
+		}
+
+		public Threads getThreads() {
+			return this.threads;
 		}
 
 		public Options getOptions() {
@@ -1581,6 +1704,40 @@ public class ServerProperties {
 
 			public void setRotate(boolean rotate) {
 				this.rotate = rotate;
+			}
+
+		}
+
+		/**
+		 * Undertow thread properties.
+		 */
+		public static class Threads {
+
+			/**
+			 * Number of I/O threads to create for the worker. The default is derived from
+			 * the number of available processors.
+			 */
+			private Integer io;
+
+			/**
+			 * Number of worker threads. The default is 8 times the number of I/O threads.
+			 */
+			private Integer worker;
+
+			public Integer getIo() {
+				return this.io;
+			}
+
+			public void setIo(Integer io) {
+				this.io = io;
+			}
+
+			public Integer getWorker() {
+				return this.worker;
+			}
+
+			public void setWorker(Integer worker) {
+				this.worker = worker;
 			}
 
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
@@ -79,14 +79,15 @@ public class TomcatWebServerFactoryCustomizer
 	public void customize(ConfigurableTomcatWebServerFactory factory) {
 		ServerProperties properties = this.serverProperties;
 		ServerProperties.Tomcat tomcatProperties = properties.getTomcat();
+		ServerProperties.Tomcat.Threads threadProperties = tomcatProperties.getThreads();
 		PropertyMapper propertyMapper = PropertyMapper.get();
 		propertyMapper.from(tomcatProperties::getBasedir).whenNonNull().to(factory::setBaseDirectory);
 		propertyMapper.from(tomcatProperties::getBackgroundProcessorDelay).whenNonNull().as(Duration::getSeconds)
 				.as(Long::intValue).to(factory::setBackgroundProcessorDelay);
 		customizeRemoteIpValve(factory);
-		propertyMapper.from(tomcatProperties::getMaxThreads).when(this::isPositive)
-				.to((maxThreads) -> customizeMaxThreads(factory, tomcatProperties.getMaxThreads()));
-		propertyMapper.from(tomcatProperties::getMinSpareThreads).when(this::isPositive)
+		propertyMapper.from(threadProperties::getMax).when(this::isPositive)
+				.to((maxThreads) -> customizeMaxThreads(factory, threadProperties.getMax()));
+		propertyMapper.from(threadProperties::getMinSpare).when(this::isPositive)
 				.to((minSpareThreads) -> customizeMinThreads(factory, minSpareThreads));
 		propertyMapper.from(this.serverProperties.getMaxHttpHeaderSize()).whenNonNull().asInt(DataSize::toBytes)
 				.when(this::isPositive)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/UndertowWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/UndertowWebServerFactoryCustomizer.java
@@ -88,9 +88,10 @@ public class UndertowWebServerFactoryCustomizer
 	private void mapUndertowProperties(ConfigurableUndertowWebServerFactory factory, FactoryOptions options) {
 		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		Undertow properties = this.serverProperties.getUndertow();
+		ServerProperties.Undertow.Threads threadProperties = properties.getThreads();
 		map.from(properties::getBufferSize).whenNonNull().asInt(DataSize::toBytes).to(factory::setBufferSize);
-		map.from(properties::getIoThreads).to(factory::setIoThreads);
-		map.from(properties::getWorkerThreads).to(factory::setWorkerThreads);
+		map.from(threadProperties::getIo).to(factory::setIoThreads);
+		map.from(threadProperties::getWorker).to(factory::setWorkerThreads);
 		map.from(properties::getDirectBuffers).to(factory::setUseDirectBuffers);
 		map.from(properties::getMaxHttpPostSize).as(DataSize::toBytes).when(this::isPositive)
 				.to(options.server(UndertowOptions.MAX_ENTITY_SIZE));

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -75,6 +76,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andrew McGhie
  * @author HaiTao Zhang
  * @author Rafiullah Hamedy
+ * @author Chris Bono
  */
 class ServerPropertiesTests {
 
@@ -208,39 +210,131 @@ class ServerPropertiesTests {
 	}
 
 	@Test
+	void testCustomizeTomcatMaxThreads() {
+		bind("server.tomcat.threads.max", "10");
+		assertThat(this.properties.getTomcat().getThreads().getMax()).isEqualTo(10);
+	}
+
+	@Deprecated
+	@Test
+	void testCustomizeTomcatMaxThreadsDeprecated() {
+		bind("server.tomcat.maxThreads", "10");
+		assertThat(this.properties.getTomcat().getMaxThreads()).isEqualTo(10);
+		// Verify they are locked on same backing props to avoid further downstream
+		// deprecated testing
+		assertThat(this.properties.getTomcat().getThreads().getMax()).isEqualTo(10);
+	}
+
+	@Test
+	void testCustomizeTomcatMinSpareThreads() {
+		bind("server.tomcat.threads.min-spare", "10");
+		assertThat(this.properties.getTomcat().getThreads().getMinSpare()).isEqualTo(10);
+	}
+
+	@Deprecated
+	@Test
+	void testCustomizeTomcatMinSpareThreadsDeprecated() {
+		bind("server.tomcat.min-spare-threads", "10");
+		assertThat(this.properties.getTomcat().getMinSpareThreads()).isEqualTo(10);
+		// Verify they are locked on same backing props to avoid further downstream
+		// deprecated testing
+		assertThat(this.properties.getTomcat().getThreads().getMinSpare()).isEqualTo(10);
+	}
+
+	@Test
 	void testCustomizeJettyAcceptors() {
+		bind("server.jetty.threads.acceptors", "10");
+		assertThat(this.properties.getJetty().getThreads().getAcceptors()).isEqualTo(10);
+	}
+
+	@Deprecated
+	@Test
+	void testCustomizeJettyAcceptorsDeprecated() {
 		bind("server.jetty.acceptors", "10");
 		assertThat(this.properties.getJetty().getAcceptors()).isEqualTo(10);
+		// Verify they are locked on same backing props to avoid further downstream
+		// deprecated testing
+		assertThat(this.properties.getJetty().getThreads().getAcceptors()).isEqualTo(10);
 	}
 
 	@Test
 	void testCustomizeJettySelectors() {
+		bind("server.jetty.threads.selectors", "10");
+		assertThat(this.properties.getJetty().getThreads().getSelectors()).isEqualTo(10);
+	}
+
+	@Deprecated
+	@Test
+	void testCustomizeJettySelectorsDeprecated() {
 		bind("server.jetty.selectors", "10");
 		assertThat(this.properties.getJetty().getSelectors()).isEqualTo(10);
+		// Verify they are locked on same backing props to avoid further downstream
+		// deprecated testing
+		assertThat(this.properties.getJetty().getThreads().getSelectors()).isEqualTo(10);
 	}
 
 	@Test
 	void testCustomizeJettyMaxThreads() {
-		bind("server.jetty.max-threads", "10");
+		bind("server.jetty.threads.max", "10");
+		assertThat(this.properties.getJetty().getThreads().getMax()).isEqualTo(10);
+	}
+
+	@Deprecated
+	@Test
+	void testCustomizeJettyMaxThreadsDeprecated() {
+		bind("server.jetty.maxThreads", "10");
 		assertThat(this.properties.getJetty().getMaxThreads()).isEqualTo(10);
+		// Verify they are locked on same backing props to avoid further downstream
+		// deprecated testing
+		assertThat(this.properties.getJetty().getThreads().getMax()).isEqualTo(10);
 	}
 
 	@Test
 	void testCustomizeJettyMinThreads() {
-		bind("server.jetty.min-threads", "10");
+		bind("server.jetty.threads.min", "10");
+		assertThat(this.properties.getJetty().getThreads().getMin()).isEqualTo(10);
+	}
+
+	@Deprecated
+	@Test
+	void testCustomizeJettyMinThreadsDeprecated() {
+		bind("server.jetty.minThreads", "10");
 		assertThat(this.properties.getJetty().getMinThreads()).isEqualTo(10);
+		// Verify they are locked on same backing props to avoid further downstream
+		// deprecated testing
+		assertThat(this.properties.getJetty().getThreads().getMin()).isEqualTo(10);
 	}
 
 	@Test
 	void testCustomizeJettyIdleTimeout() {
+		bind("server.jetty.threads.idle-timeout", "10s");
+		assertThat(this.properties.getJetty().getThreads().getIdleTimeout()).isEqualTo(Duration.ofSeconds(10));
+	}
+
+	@Deprecated
+	@Test
+	void testCustomizeJettyIdleTimeoutDeprecated() {
 		bind("server.jetty.thread-idle-timeout", "10s");
-		assertThat(this.properties.getJetty().getThreadIdleTimeout()).hasSeconds(10);
+		assertThat(this.properties.getJetty().getThreadIdleTimeout()).isEqualTo(Duration.ofSeconds(10));
+		// Verify they are locked on same backing props to avoid further downstream
+		// deprecated testing
+		assertThat(this.properties.getJetty().getThreads().getIdleTimeout()).hasSeconds(10);
 	}
 
 	@Test
 	void testCustomizeJettyMaxQueueCapacity() {
+		bind("server.jetty.threads.max-queue-capacity", "5150");
+		assertThat(this.properties.getJetty().getThreads().getMaxQueueCapacity()).isEqualTo(5150);
+	}
+
+	@Deprecated
+	@Test
+	void testCustomizeJettyMaxQueueCapacityDeprecated() {
 		bind("server.jetty.max-queue-capacity", "5150");
 		assertThat(this.properties.getJetty().getMaxQueueCapacity()).isEqualTo(5150);
+		// Verify they are locked on same backing props to avoid further downstream
+		// deprecated testing
+		assertThat(this.properties.getJetty().getThreads().getMaxQueueCapacity()).isEqualTo(5150);
 	}
 
 	@Test
@@ -255,6 +349,38 @@ class ServerPropertiesTests {
 		bind("server.undertow.options.socket.ALWAYS_SET_KEEP_ALIVE", "true");
 		assertThat(this.properties.getUndertow().getOptions().getSocket()).containsEntry("ALWAYS_SET_KEEP_ALIVE",
 				"true");
+	}
+
+	@Test
+	void testCustomizeUndertowIoThreads() {
+		bind("server.undertow.threads.io", "4");
+		assertThat(this.properties.getUndertow().getThreads().getIo()).isEqualTo(4);
+	}
+
+	@Deprecated
+	@Test
+	void testCustomizeUndertowIoThreadsDeprecated() {
+		bind("server.undertow.ioThreads", "4");
+		assertThat(this.properties.getUndertow().getIoThreads()).isEqualTo(4);
+		// Verify they are locked on same backing props to avoid further downstream
+		// deprecated testing
+		assertThat(this.properties.getUndertow().getThreads().getIo()).isEqualTo(4);
+	}
+
+	@Test
+	void testCustomizeUndertowWorkerThreads() {
+		bind("server.undertow.threads.worker", "10");
+		assertThat(this.properties.getUndertow().getThreads().getWorker()).isEqualTo(10);
+	}
+
+	@Deprecated
+	@Test
+	void testCustomizeUndertowWorkerThreadsDeprecated() {
+		bind("server.undertow.workerThreads", "10");
+		assertThat(this.properties.getUndertow().getWorkerThreads()).isEqualTo(10);
+		// Verify they are locked on same backing props to avoid further downstream
+		// deprecated testing
+		assertThat(this.properties.getUndertow().getThreads().getWorker()).isEqualTo(10);
 	}
 
 	@Test
@@ -295,12 +421,12 @@ class ServerPropertiesTests {
 
 	@Test
 	void tomcatMaxThreadsMatchesProtocolDefault() throws Exception {
-		assertThat(this.properties.getTomcat().getMaxThreads()).isEqualTo(getDefaultProtocol().getMaxThreads());
+		assertThat(this.properties.getTomcat().getThreads().getMax()).isEqualTo(getDefaultProtocol().getMaxThreads());
 	}
 
 	@Test
 	void tomcatMinSpareThreadsMatchesProtocolDefault() throws Exception {
-		assertThat(this.properties.getTomcat().getMinSpareThreads())
+		assertThat(this.properties.getTomcat().getThreads().getMinSpare())
 				.isEqualTo(getDefaultProtocol().getMinSpareThreads());
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizerTests.java
@@ -345,8 +345,8 @@ class TomcatWebServerFactoryCustomizerTests {
 
 	@Test
 	void testCustomizeMinSpareThreads() {
-		bind("server.tomcat.min-spare-threads=10");
-		assertThat(this.serverProperties.getTomcat().getMinSpareThreads()).isEqualTo(10);
+		bind("server.tomcat.threads.min-spare=10");
+		assertThat(this.serverProperties.getTomcat().getThreads().getMinSpare()).isEqualTo(10);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/UndertowWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/UndertowWebServerFactoryCustomizerTests.java
@@ -133,6 +133,22 @@ class UndertowWebServerFactoryCustomizerTests {
 	}
 
 	@Test
+	void customizeIoThreads() {
+		bind("server.undertow.threads.io=4");
+		ConfigurableUndertowWebServerFactory factory = mock(ConfigurableUndertowWebServerFactory.class);
+		this.customizer.customize(factory);
+		verify(factory).setIoThreads(4);
+	}
+
+	@Test
+	void customizeWorkerThreads() {
+		bind("server.undertow.threads.worker=10");
+		ConfigurableUndertowWebServerFactory factory = mock(ConfigurableUndertowWebServerFactory.class);
+		this.customizer.customize(factory);
+		verify(factory).setWorkerThreads(10);
+	}
+
+	@Test
 	void allowEncodedSlashes() {
 		bind("server.undertow.allow-encoded-slash=true");
 		assertThat(boundServerOption(UndertowOptions.ALLOW_ENCODED_SLASH)).isTrue();

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryCustomizerTests.java
@@ -137,9 +137,9 @@ class ServletWebServerFactoryCustomizerTests {
 	@Test
 	void testCustomizeTomcatMinSpareThreads() {
 		Map<String, String> map = new HashMap<>();
-		map.put("server.tomcat.min-spare-threads", "10");
+		map.put("server.tomcat.threads.min-spare", "10");
 		bindProperties(map);
-		assertThat(this.properties.getTomcat().getMinSpareThreads()).isEqualTo(10);
+		assertThat(this.properties.getTomcat().getThreads().getMinSpare()).isEqualTo(10);
 	}
 
 	@Test


### PR DESCRIPTION
Moves all thread related server properties under a "threads" group for each server implementation that has thread related properties (`tomcat|jetty|undertow`).

The existing property accessors have been marked as deprecated. The old impl just delegates to the new one which allows us to test that fact in a deprecated test and then all subsequent downstream tests can rely on the new api (ie have deprecate test in a single place for each property).

@snicoll do the Boot docs get auto-generated from the `@DeprecatedConfigurationProperty`s? 

Closes gh-18620
