### PR TITLE
Do not auto-create IMDG instance when Jet is present

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfiguration.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.HazelcastInstance;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -36,6 +37,7 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(HazelcastInstance.class)
+@ConditionalOnMissingClass("com.hazelcast.jet.JetInstance")
 @EnableConfigurationProperties(HazelcastProperties.class)
 @Import({ HazelcastClientConfiguration.class, HazelcastServerConfiguration.class })
 public class HazelcastAutoConfiguration {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationJetTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationJetTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.hazelcast;
+
+import com.hazelcast.core.HazelcastInstance;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.testsupport.classpath.ClassPathOverrides;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link HazelcastAutoConfiguration} when Hazelcast Jet is present. Spring Boot
+ * should not auto-create Hazelcast IMDG instances when Jet is present.
+ *
+ * @author Jaromir Hamala
+ */
+@ClassPathOverrides("com.hazelcast.jet:hazelcast-jet:3.2.1")
+public class HazelcastAutoConfigurationJetTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(HazelcastAutoConfiguration.class));
+
+	@Test
+	void testHazelcastInstanceNotCreatedWhenJetIsPresent() {
+		this.contextRunner.run((context) -> assertThat(context).doesNotHaveBean(HazelcastInstance.class));
+	}
+
+}


### PR DESCRIPTION
Spring Boot automatically creates a Hazelcast instance when either Config bean exist or when it finds a configuration file.

This makes Hazelcast Jet hard to use in the Spring Boot container: Spring will try to create a new IMDG instance when it detects hazelcast.xml (or any other config file), but you probably want to start Jet instance.

It's actually even worst when you explicitly create a new Jet instance then it will try to create join with the IMDG instance created by Spring and this will fail with:

```
com.hazelcast.core.HazelcastException: Service with name 'hz:impl:jetService' not found!
	at com.hazelcast.spi.impl.NodeEngineImpl.getService(NodeEngineImpl.java:367) ~[hazelcast-jet-3.2.1.jar:3.2.1]
	at com.hazelcast.spi.Operation.getService(Operation.java:395) ~[hazelcast-jet-3.2.1.jar:3.2.1]
	at com.hazelcast.jet.impl.operation.GetClusterMetadataOperation.run(GetClusterMetadataOperation.java:41) ~[hazelcast-jet-3.2.1.jar:3.2.1]
	at com.hazelcast.spi.Operation.call(Operation.java:170) ~[hazelcast-jet-3.2.1.jar:3.2.1]
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.call(OperationRunnerImpl.java:210) [hazelcast-jet-3.2.1.jar:3.2.1]
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:199) [hazelcast-jet-3.2.1.jar:3.2.1]
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:416) [hazelcast-jet-3.2.1.jar:3.2.1]
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:153) [hazelcast-jet-3.2.1.jar:3.2.1]
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:123) [hazelcast-jet-3.2.1.jar:3.2.1]
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.run(OperationThread.java:110) [hazelcast-jet-3.2.1.jar:3.2.1]
Caused by: com.hazelcast.spi.exception.ServiceNotFoundException: Service with name 'hz:impl:jetService' not found!
	... 10 common frames omitted
```

Related issue in the Hazelcast Jet repo: https://github.com/hazelcast/hazelcast-jet/issues/1835