### PR TITLE
Switch FilteringSpringBootCondition to use Class.forName

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/FilteringSpringBootCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/FilteringSpringBootCondition.java
@@ -97,7 +97,7 @@ abstract class FilteringSpringBootCondition extends SpringBootCondition
 
 	/**
 	 * Slightly faster variant of {@link ClassUtils#forName(String, ClassLoader)} that
-	 * doesn't deal with primitives, arrays or innter types.
+	 * doesn't deal with primitives, arrays or inner types.
 	 * @param className the class name to resolve
 	 * @param classLoader the class loader to use
 	 * @return a resolved class
@@ -105,7 +105,7 @@ abstract class FilteringSpringBootCondition extends SpringBootCondition
 	 */
 	protected static Class<?> resolve(String className, ClassLoader classLoader) throws ClassNotFoundException {
 		if (classLoader != null) {
-			return classLoader.loadClass(className);
+			return Class.forName(className, false, classLoader);
 		}
 		return Class.forName(className);
 	}


### PR DESCRIPTION
See gh-19342

Applied suggested changes so FilteringSpringBootCondition uses Class.forName instead of the passed classLoader argument, which prevented a GraalVM interceptor to work properly.

