### PR TITLE
Adds configuration for embedded Jetty max queue capacity

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -1034,6 +1034,11 @@ public class ServerProperties {
 		private Integer minThreads = 8;
 
 		/**
+		 * Maximum capacity of the thread pools backing queue.
+		 */
+		private Integer maxQueueCapacity;
+
+		/**
 		 * Maximum thread idle time.
 		 */
 		private Duration threadIdleTimeout = Duration.ofMillis(60000);
@@ -1096,6 +1101,14 @@ public class ServerProperties {
 
 		public Integer getMaxThreads() {
 			return this.maxThreads;
+		}
+
+		public void setMaxQueueCapacity(Integer maxQueueCapacity) {
+			this.maxQueueCapacity = maxQueueCapacity;
+		}
+
+		public Integer getMaxQueueCapacity() {
+			return this.maxQueueCapacity;
 		}
 
 		public void setThreadIdleTimeout(Duration threadIdleTimeout) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.undertow.UndertowOptions;
+import io.undertow.server.handlers.RequestLimitingHandler;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
@@ -1308,6 +1309,21 @@ public class ServerProperties {
 		private Integer workerThreads;
 
 		/**
+		 * Number of max concurrent requests. When specified will put a
+		 * {@link RequestLimitingHandler} in place. The default is null. Can only be
+		 * specified in Servlet environments.
+		 */
+		private Integer maxRequests;
+
+		/**
+		 * Maximum number of requests to queue up when running with a
+		 * {@link RequestLimitingHandler} and the {@link #maxRequests} is reached. The
+		 * default is -1 (unbounded). Can only be specified in Servlet environments and is
+		 * only used when {@link #maxRequests} is specified.
+		 */
+		private Integer maxQueueCapacity;
+
+		/**
 		 * Whether to allocate buffers outside the Java heap. The default is derived from
 		 * the maximum amount of memory that is available to the JVM.
 		 */
@@ -1401,6 +1417,22 @@ public class ServerProperties {
 
 		public void setWorkerThreads(Integer workerThreads) {
 			this.workerThreads = workerThreads;
+		}
+
+		public Integer getMaxRequests() {
+			return this.maxRequests;
+		}
+
+		public void setMaxRequests(Integer maxRequests) {
+			this.maxRequests = maxRequests;
+		}
+
+		public Integer getMaxQueueCapacity() {
+			return this.maxQueueCapacity;
+		}
+
+		public void setMaxQueueCapacity(Integer maxQueueCapacity) {
+			this.maxQueueCapacity = maxQueueCapacity;
 		}
 
 		public Boolean getDirectBuffers() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyConstrainedQueuedThreadPoolFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyConstrainedQueuedThreadPoolFactory.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.web.embedded;
+
+import java.time.Duration;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.SynchronousQueue;
+
+import org.eclipse.jetty.util.BlockingArrayQueue;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.ServerProperties.Jetty;
+import org.springframework.boot.web.embedded.jetty.JettyThreadPoolFactory;
+
+/**
+ * A {@link JettyThreadPoolFactory} that creates a thread pool that uses a backing queue
+ * with a max capacity if the {@link Jetty#maxQueueCapacity} is specified. If the max
+ * capacity is not specified then the factory will return null thus allowing the standard
+ * Jetty server thread pool to be used.
+ *
+ * @author Chris Bono
+ * @since 2.3.0
+ */
+public class JettyConstrainedQueuedThreadPoolFactory implements JettyThreadPoolFactory<QueuedThreadPool> {
+
+	private ServerProperties serverProperties;
+
+	public JettyConstrainedQueuedThreadPoolFactory(ServerProperties serverProperties) {
+		this.serverProperties = serverProperties;
+	}
+
+	/**
+	 * <p>
+	 * Creates a {@link QueuedThreadPool} with the following settings (if
+	 * {@link Jetty#maxQueueCapacity} is specified):
+	 * <ul>
+	 * <li>min threads set to {@link Jetty#minThreads} or {@code 8} if not specified.
+	 * <li>max threads set to {@link Jetty#maxThreads} or {@code 200} if not specified.
+	 * <li>idle timeout set to {@link Jetty#threadIdleTimeout} or {@code 60000} if not
+	 * specified.</li>
+	 * <li>if {@link Jetty#maxQueueCapacity} is zero its backing queue will be a
+	 * {@link SynchronousQueue} otherwise it will be a {@link BlockingArrayQueue} whose
+	 * max capacity is set to the max queue depth.
+	 * </ul>
+	 * @return thread pool as described above or {@code null} if
+	 * {@link Jetty#maxQueueCapacity} is not specified.
+	 */
+	@Override
+	public QueuedThreadPool create() {
+
+		Integer maxQueueCapacity = this.serverProperties.getJetty().getMaxQueueCapacity();
+
+		// Max depth is not specified - let Jetty server use its defaults in this case
+		if (maxQueueCapacity == null) {
+			return null;
+		}
+
+		BlockingQueue<Runnable> queue;
+		if (maxQueueCapacity == 0) {
+			/**
+			 * This queue will cause jetty to reject requests whenever there is no idle
+			 * thread available to handle them. If this queue is used, it is strongly
+			 * recommended to set _minThreads equal to _maxThreads. Jetty's
+			 * QueuedThreadPool class may not behave like a regular java thread pool and
+			 * may not add threads properly when a SynchronousQueue is used.
+			 */
+			queue = new SynchronousQueue<>();
+		}
+		else {
+			/**
+			 * Create a queue of fixed size. This queue will not grow. If a request
+			 * arrives and the queue is empty, the client will see an immediate
+			 * "connection reset" error.
+			 */
+			queue = new BlockingArrayQueue<>(maxQueueCapacity);
+		}
+
+		Integer maxThreadCount = this.serverProperties.getJetty().getMaxThreads();
+		Integer minThreadCount = this.serverProperties.getJetty().getMinThreads();
+		Duration threadIdleTimeout = this.serverProperties.getJetty().getThreadIdleTimeout();
+
+		return new QueuedThreadPool((maxThreadCount != null) ? maxThreadCount : 200,
+				(minThreadCount != null) ? minThreadCount : 8,
+				(threadIdleTimeout != null) ? (int) threadIdleTimeout.toMillis() : 60000, queue);
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryAutoConfiguration.java
@@ -79,6 +79,13 @@ public class ServletWebServerFactoryAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnClass(name = "io.undertow.Undertow")
+	public UndertowServletWebServerFactoryCustomizer undertowServletWebServerFactoryCustomizer(
+			ServerProperties serverProperties) {
+		return new UndertowServletWebServerFactoryCustomizer(serverProperties);
+	}
+
+	@Bean
 	@ConditionalOnMissingFilterBean(ForwardedHeaderFilter.class)
 	@ConditionalOnProperty(value = "server.forward-headers-strategy", havingValue = "framework")
 	public FilterRegistrationBean<ForwardedHeaderFilter> forwardedHeaderFilter() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/UndertowServletWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/UndertowServletWebServerFactoryCustomizer.java
@@ -16,6 +16,11 @@
 
 package org.springframework.boot.autoconfigure.web.servlet;
 
+import io.undertow.Handlers;
+import io.undertow.server.HandlerWrapper;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.handlers.RequestLimitingHandler;
+
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
@@ -25,6 +30,7 @@ import org.springframework.boot.web.server.WebServerFactoryCustomizer;
  * Servlet web servers.
  *
  * @author Andy Wilkinson
+ * @author Chris Bono
  * @since 2.1.7
  */
 public class UndertowServletWebServerFactoryCustomizer
@@ -36,10 +42,55 @@ public class UndertowServletWebServerFactoryCustomizer
 		this.serverProperties = serverProperties;
 	}
 
+	// TODO why was this not being used before now?
+
 	@Override
 	public void customize(UndertowServletWebServerFactory factory) {
+
 		factory.addDeploymentInfoCustomizers((deploymentInfo) -> deploymentInfo
 				.setEagerFilterInit(this.serverProperties.getUndertow().isEagerFilterInit()));
+
+		addRateLimiterIfMaxRequestsSet(factory);
+	}
+
+	/**
+	 * Installs a {@link RequestLimitingHandler} in the initial handler chain if
+	 * {@link ServerProperties.Undertow#maxRequests} is set. If installed, it will use
+	 * {@link ServerProperties.Undertow#maxQueueCapacity} to control the size of the queue
+	 * in the rate limting handler.
+	 * @param factory the factory to add the deployment info customizer on
+	 */
+	private void addRateLimiterIfMaxRequestsSet(UndertowServletWebServerFactory factory) {
+		Integer maxRequests = this.serverProperties.getUndertow().getMaxRequests();
+		if (maxRequests == null) {
+			return;
+		}
+		Integer maxQueueCapacity = this.serverProperties.getUndertow().getMaxQueueCapacity();
+		factory.addDeploymentInfoCustomizers((deploymentInfo) -> deploymentInfo.addInitialHandlerChainWrapper(
+				new RequestLimiterHandlerWrapper(maxRequests, (maxQueueCapacity != null) ? maxQueueCapacity : -1)));
+	}
+
+	/**
+	 * Explicit implementation of HandlerWrapper rather than Lambda to make it possible to
+	 * verify the handler wrappers at runtime during tests. This could be instead written
+	 * as a Lambda but then tests can not see what type of handler wrapper it is.
+	 */
+	static class RequestLimiterHandlerWrapper implements HandlerWrapper {
+
+		Integer maxRequests;
+
+		Integer maxQueueCapacity;
+
+		RequestLimiterHandlerWrapper(Integer maxRequests, Integer maxQueueCapacity) {
+			this.maxRequests = maxRequests;
+			this.maxQueueCapacity = maxQueueCapacity;
+		}
+
+		@Override
+		public HttpHandler wrap(HttpHandler handler) {
+			return Handlers.requestLimitingHandler(this.maxRequests, this.maxQueueCapacity, handler);
+		}
+
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -76,6 +76,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andrew McGhie
  * @author HaiTao Zhang
  * @author Rafiullah Hamedy
+ * @author Chris Bono
  */
 class ServerPropertiesTests {
 
@@ -236,6 +237,12 @@ class ServerPropertiesTests {
 	void testCustomizeJettyIdleTimeout() {
 		bind("server.jetty.thread-idle-timeout", "10s");
 		assertThat(this.properties.getJetty().getThreadIdleTimeout()).isEqualTo(Duration.ofSeconds(10));
+	}
+
+	@Test
+	void testCustomizeJettyMaxQueueCapacity() {
+		bind("server.jetty.max-queue-capacity", "5150");
+		assertThat(this.properties.getJetty().getMaxQueueCapacity()).isEqualTo(5150);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -260,6 +260,30 @@ class ServerPropertiesTests {
 	}
 
 	@Test
+	void testCustomizeUndertowWorkerThreads() {
+		bind("server.undertow.worker-threads", "150");
+		assertThat(this.properties.getUndertow().getWorkerThreads()).isEqualTo(150);
+	}
+
+	@Test
+	void testCustomizeUndertowIoThreads() {
+		bind("server.undertow.io-threads", "10");
+		assertThat(this.properties.getUndertow().getIoThreads()).isEqualTo(10);
+	}
+
+	@Test
+	void testCustomizeUndertowMaxRequests() {
+		bind("server.undertow.max-requests", "200");
+		assertThat(this.properties.getUndertow().getMaxRequests()).isEqualTo(200);
+	}
+
+	@Test
+	void testCustomizeUndertowMaxQueueCapacity() {
+		bind("server.undertow.max-queue-capacity", "100");
+		assertThat(this.properties.getUndertow().getMaxQueueCapacity()).isEqualTo(100);
+	}
+
+	@Test
 	void testCustomizeJettyAccessLog() {
 		Map<String, String> map = new HashMap<>();
 		map.put("server.jetty.accesslog.enabled", "true");

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyConstrainedQueuedThreadPoolFactoryTest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyConstrainedQueuedThreadPoolFactoryTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.web.embedded;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.SynchronousQueue;
+
+import org.eclipse.jetty.util.BlockingArrayQueue;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+import org.springframework.util.ReflectionUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link JettyConstrainedQueuedThreadPoolFactory}.
+ *
+ * @author Chris Bono
+ */
+class JettyConstrainedQueuedThreadPoolFactoryTest {
+
+	private MockEnvironment environment;
+
+	private ServerProperties serverProperties;
+
+	private JettyConstrainedQueuedThreadPoolFactory factory;
+
+	@BeforeEach
+	void setup() {
+		this.environment = new MockEnvironment();
+		this.serverProperties = new ServerProperties();
+		ConfigurationPropertySources.attach(this.environment);
+		this.factory = new JettyConstrainedQueuedThreadPoolFactory(this.serverProperties);
+	}
+
+	@Test
+	void factoryReturnsNullWhenMaxCapacityNotSpecified() {
+		bind("server.jetty.max-queue-capacity=");
+		assertThat(this.factory.create()).isNull();
+	}
+
+	@Test
+	void factoryReturnsSynchronousQueueWhenMaxCapacityIsZero() {
+		bind("server.jetty.max-queue-capacity=0");
+		QueuedThreadPool queuedThreadPool = this.factory.create();
+		assertThat(getQueue(queuedThreadPool, SynchronousQueue.class)).isNotNull();
+	}
+
+	@Test
+	void factoryReturnsBlockingArrayQueueWithDefaultsWhenOnlyMaxCapacityIsSet() {
+		bind("server.jetty.max-queue-capacity=5150");
+		QueuedThreadPool queuedThreadPool = this.factory.create();
+		assertThat(queuedThreadPool.getMinThreads()).isEqualTo(8);
+		assertThat(queuedThreadPool.getMaxThreads()).isEqualTo(200);
+		assertThat(queuedThreadPool.getIdleTimeout()).isEqualTo(60000);
+		assertThat(getQueue(queuedThreadPool, BlockingArrayQueue.class).getMaxCapacity()).isEqualTo(5150);
+	}
+
+	@Test
+	void factoryReturnsBlockingArrayQueueWithCustomValues() {
+		bind("server.jetty.max-queue-capacity=5150", "server.jetty.min-threads=200", "server.jetty.max-threads=1000",
+				"server.jetty.thread-idle-timeout=10000");
+		QueuedThreadPool queuedThreadPool = this.factory.create();
+		assertThat(queuedThreadPool.getMinThreads()).isEqualTo(200);
+		assertThat(queuedThreadPool.getMaxThreads()).isEqualTo(1000);
+		assertThat(queuedThreadPool.getIdleTimeout()).isEqualTo(10000);
+		assertThat(getQueue(queuedThreadPool, BlockingArrayQueue.class).getMaxCapacity()).isEqualTo(5150);
+	}
+
+	private void bind(String... inlinedProperties) {
+		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.environment, inlinedProperties);
+		new Binder(ConfigurationPropertySources.get(this.environment)).bind("server",
+				Bindable.ofInstance(this.serverProperties));
+	}
+
+	static <T extends BlockingQueue<Runnable>> T getQueue(QueuedThreadPool queuedThreadPool,
+			Class<T> expectedQueueClass) {
+		Method getQueue = ReflectionUtils.findMethod(QueuedThreadPool.class, "getQueue");
+		ReflectionUtils.makeAccessible(getQueue);
+		Object obj = ReflectionUtils.invokeMethod(getQueue, queuedThreadPool);
+		assertThat(obj).isInstanceOf(expectedQueueClass);
+		return expectedQueueClass.cast(obj);
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/ReactiveWebServerFactoryAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/ReactiveWebServerFactoryAutoConfigurationTests.java
@@ -22,14 +22,18 @@ import org.apache.catalina.Context;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ThreadPool;
 import org.junit.jupiter.api.Test;
 import reactor.netty.http.server.HttpServer;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.embedded.JettyConstrainedQueuedThreadPoolFactory;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
 import org.springframework.boot.web.embedded.jetty.JettyReactiveWebServerFactory;
 import org.springframework.boot.web.embedded.jetty.JettyServerCustomizer;
+import org.springframework.boot.web.embedded.jetty.JettyThreadPoolFactory;
 import org.springframework.boot.web.embedded.netty.NettyReactiveWebServerFactory;
 import org.springframework.boot.web.embedded.netty.NettyServerCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
@@ -53,6 +57,7 @@ import org.springframework.web.server.adapter.ForwardedHeaderTransformer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.when;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -63,6 +68,7 @@ import static org.mockito.Mockito.verify;
  * @author Brian Clozel
  * @author Raheela Aslam
  * @author Madhura Bhave
+ * @author Chris Bono
  */
 class ReactiveWebServerFactoryAutoConfigurationTests {
 
@@ -239,6 +245,36 @@ class ReactiveWebServerFactoryAutoConfigurationTests {
 					JettyServerCustomizer customizer = context.getBean("serverCustomizer", JettyServerCustomizer.class);
 					assertThat(factory.getServerCustomizers()).contains(customizer);
 					verify(customizer, times(1)).customize(any(Server.class));
+				});
+	}
+
+	@Test
+	void jettyDefaultThreadPoolFactoryUsedToCreateThreadPoolOnWebServerFactory() {
+		new ReactiveWebApplicationContextRunner(AnnotationConfigReactiveWebServerApplicationContext::new)
+				.withConfiguration(AutoConfigurations.of(ReactiveWebServerFactoryAutoConfiguration.class))
+				.withClassLoader(new FilteredClassLoader(Tomcat.class, HttpServer.class))
+				.withUserConfiguration(DoubleRegistrationJettyServerCustomizerConfiguration.class,
+						HttpHandlerConfiguration.class)
+				.withPropertyValues("server.port=0", "server.jetty.max-queue-capacity:5150").run((context) -> {
+					assertThat(context.getBean(JettyThreadPoolFactory.class))
+							.isInstanceOf(JettyConstrainedQueuedThreadPoolFactory.class);
+					JettyReactiveWebServerFactory factory = context.getBean(JettyReactiveWebServerFactory.class);
+					assertThat(factory.getThreadPool()).isNotNull();
+				});
+	}
+
+	@Test
+	void jettyCustomThreadPoolFactoryUsedToCreateThreadPoolOnWebServerFactory() {
+		new ReactiveWebApplicationContextRunner(AnnotationConfigReactiveWebServerApplicationContext::new)
+				.withConfiguration(AutoConfigurations.of(ReactiveWebServerFactoryAutoConfiguration.class))
+				.withClassLoader(new FilteredClassLoader(Tomcat.class, HttpServer.class))
+				.withUserConfiguration(JettyCustomThreadPoolFactoryConfiguration.class, HttpHandlerConfiguration.class)
+				.withPropertyValues("server.port=0").run((context) -> {
+					JettyReactiveWebServerFactory factory = context.getBean(JettyReactiveWebServerFactory.class);
+					JettyThreadPoolFactory threadPoolFactory = context.getBean("jettyCustomThreadPoolFactory",
+							JettyThreadPoolFactory.class);
+					verify(threadPoolFactory, times(1)).create();
+					assertThat(factory.getThreadPool()).isSameAs(JettyCustomThreadPoolFactoryConfiguration.threadPool);
 				});
 	}
 
@@ -464,6 +500,20 @@ class ReactiveWebServerFactoryAutoConfigurationTests {
 		@Bean
 		WebServerFactoryCustomizer<JettyReactiveWebServerFactory> jettyCustomizer() {
 			return (jetty) -> jetty.addServerCustomizers(this.customizer);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class JettyCustomThreadPoolFactoryConfiguration {
+
+		static ThreadPool threadPool = new QueuedThreadPool();
+
+		@Bean
+		JettyThreadPoolFactory jettyCustomThreadPoolFactory() {
+			JettyThreadPoolFactory threadPoolFactory = mock(JettyThreadPoolFactory.class);
+			when(threadPoolFactory.create()).thenReturn(threadPool);
+			return threadPoolFactory;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryAutoConfigurationTests.java
@@ -231,7 +231,7 @@ class ServletWebServerFactoryAutoConfigurationTests {
 						.withPropertyValues("server.port:0");
 		runner.run((context) -> {
 			UndertowServletWebServerFactory factory = context.getBean(UndertowServletWebServerFactory.class);
-			assertThat(factory.getDeploymentInfoCustomizers()).hasSize(1);
+			assertThat(factory.getDeploymentInfoCustomizers()).hasSize(2);
 		});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/UndertowServletWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/UndertowServletWebServerFactoryCustomizerTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.web.servlet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.servlet.UndertowServletWebServerFactoryCustomizer.RequestLimiterHandlerWrapper;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.web.embedded.undertow.UndertowServletWebServer;
+import org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link UndertowServletWebServerFactoryCustomizer}.
+ *
+ * @author Chris Bono
+ */
+class UndertowServletWebServerFactoryCustomizerTests {
+
+	private UndertowServletWebServerFactoryCustomizer customizer;
+
+	private MockEnvironment environment;
+
+	private ServerProperties serverProperties;
+
+	@BeforeEach
+	void setup() {
+		this.environment = new MockEnvironment();
+		this.serverProperties = new ServerProperties();
+		ConfigurationPropertySources.attach(this.environment);
+		this.customizer = new UndertowServletWebServerFactoryCustomizer(this.serverProperties);
+	}
+
+	@Test
+	void eagerFilterInitEnabled() {
+		bind("server.undertow.eager-filter-init=true");
+		UndertowServletWebServer server = customizeAndGetServer();
+		assertThat(server.getDeploymentManager().getDeployment().getDeploymentInfo().isEagerFilterInit()).isTrue();
+	}
+
+	@Test
+	void eagerFilterInitDisabled() {
+		bind("server.undertow.eager-filter-init=false");
+		UndertowServletWebServer server = customizeAndGetServer();
+		assertThat(server.getDeploymentManager().getDeployment().getDeploymentInfo().isEagerFilterInit()).isFalse();
+	}
+
+	@Test
+	void limiterNotAddedWhenMaxRequestsNotSet() {
+		bind("server.undertow.max-requests=");
+		UndertowServletWebServer server = customizeAndGetServer();
+		assertThat(server.getDeploymentManager().getDeployment().getDeploymentInfo().getInitialHandlerChainWrappers()
+				.stream().anyMatch(RequestLimiterHandlerWrapper.class::isInstance)).isFalse();
+	}
+
+	@Test
+	void limiterAddedWhenMaxRequestSetWithDefaultMaxQueueCapacity() {
+		bind("server.undertow.max-requests=200");
+		UndertowServletWebServer server = customizeAndGetServer();
+		RequestLimiterHandlerWrapper requestLimiter = server.getDeploymentManager().getDeployment().getDeploymentInfo()
+				.getInitialHandlerChainWrappers().stream().filter(RequestLimiterHandlerWrapper.class::isInstance)
+				.findFirst().map(RequestLimiterHandlerWrapper.class::cast).orElse(null);
+		assertThat(requestLimiter).isNotNull();
+		assertThat(requestLimiter.maxRequests).isEqualTo(200);
+		assertThat(requestLimiter.maxQueueCapacity).isEqualTo(-1);
+	}
+
+	@Test
+	void limiterAddedWhenMaxRequestSetWithCustomMaxQueueCapacity() {
+		bind("server.undertow.max-requests=200", "server.undertow.max-queue-capacity=100");
+		UndertowServletWebServer server = customizeAndGetServer();
+		RequestLimiterHandlerWrapper requestLimiter = server.getDeploymentManager().getDeployment().getDeploymentInfo()
+				.getInitialHandlerChainWrappers().stream().filter(RequestLimiterHandlerWrapper.class::isInstance)
+				.findFirst().map(RequestLimiterHandlerWrapper.class::cast).orElse(null);
+		assertThat(requestLimiter).isNotNull();
+		assertThat(requestLimiter.maxRequests).isEqualTo(200);
+		assertThat(requestLimiter.maxQueueCapacity).isEqualTo(100);
+	}
+
+	private void bind(String... inlinedProperties) {
+		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.environment, inlinedProperties);
+		new Binder(ConfigurationPropertySources.get(this.environment)).bind("server",
+				Bindable.ofInstance(this.serverProperties));
+	}
+
+	private UndertowServletWebServer customizeAndGetServer() {
+		UndertowServletWebServerFactory factory = customizeAndGetFactory();
+		return (UndertowServletWebServer) factory.getWebServer();
+	}
+
+	private UndertowServletWebServerFactory customizeAndGetFactory() {
+		UndertowServletWebServerFactory factory = new UndertowServletWebServerFactory(0);
+		this.customizer.customize(factory);
+		return factory;
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyThreadPoolFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyThreadPoolFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.embedded.jetty;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.thread.ThreadPool;
+
+/**
+ * Factory to create a thread pool for use by a Jetty {@link Server}.
+ *
+ * @author Chris Bono
+ * @since 2.3.0
+ * @param <T> type of ThreadPool that the factory returns
+ */
+@FunctionalInterface
+public interface JettyThreadPoolFactory<T extends ThreadPool> {
+
+	/**
+	 * Creates a thread pool.
+	 * @return a Jetty thread pool or null to use the default Jetty {@link Server} thread
+	 * pool.
+	 */
+	T create();
+
+}


### PR DESCRIPTION
Closes gh-19493

This is [that](https://github.com/spring-projects/spring-boot/issues/8662#issuecomment-287706410) pull request for Jetty. I think this property is Jetty specific and does not have a direct equivalent or current need in Tomcat or Undertow.

### Approach
Create a `JettyThreadPoolFactory` interface that is used to set the backing thread pool on the `Jetty[Servlet|Reactive]WebServerFactory`. 

This was needed because the thread pool's backing queue (which is where the max capacity is set) can not be safely modified in a customizer as by the time the customizer is called, the server has already had its `QueuedThreadPool` and its backing queue implementation set during construction - its immutable after that. 


<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
