### PR TITLE
Outdated reference in ArtemisConfigurationCustomizer javadoc

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisConfigurationCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisConfigurationCustomizer.java
@@ -17,12 +17,12 @@
 package org.springframework.boot.autoconfigure.jms.artemis;
 
 import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.jms.server.embedded.EmbeddedJMS;
+import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the Artemis
  * JMS server {@link Configuration} before it is used by an auto-configured
- * {@link EmbeddedJMS} instance.
+ * {@link EmbeddedActiveMQ} instance.
  *
  * @author Eddú Meléndez
  * @author Phillip Webb


### PR DESCRIPTION
## Description of Issue
The Javadoc of `ArtemisConfigurationCustomizer` references a deprecated `EmbeddedJMS` import.

## Solution
Replaced deprecated `EmbeddedJMS` import with `EmbeddedActiveMQ`.

#19502 