### PR TITLE
Add reference to OptaPlanner starter

### DIFF
--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -154,6 +154,9 @@ do as they were designed before this was clarified.
 | https://developer.okta.com/[Okta]
 | https://github.com/okta/okta-spring-boot
 
+| https://www.optaplanner.org/[OptaPlanner]
+| https://github.com/kiegroup/optaplanner/tree/master/optaplanner-integration/optaplanner-spring-boot-starter
+
 | https://orika-mapper.github.io/orika-docs/[Orika]
 | https://github.com/akihyro/orika-spring-boot-starter
 


### PR DESCRIPTION
This PR adds the Spring Boot starter for OptaPlanner.

OptaPlanner is the open source constraint solver AI in Java. It is used across the globe for TSP, VRP, Employee rostering, school timetabling, task assignment and conference scheduling (including Devoxx Belgium!).
