### PR TITLE
Upgrade CI to Artifactory Resource 0.0.10

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -3,7 +3,7 @@ resource_types:
   type: docker-image
   source:
     repository: springio/artifactory-resource
-    tag: 0.0.5
+    tag: 0.0.10
 - name: pull-request
   type: docker-image
   source:


### PR DESCRIPTION
Hi,

I just noticed that the `artifactory-resource` seems to be still on version 0.0.5 while there is 0.0.10 available. As I don't have a way to test this and don't know if there is a reason for this, please feel free to decline the PR.

Cheers,
Christoph