### PR TITLE
Remove deprecated usage of WebTestClientBuilderCustomizer

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/RestDocsWebTestClientBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/RestDocsWebTestClientBuilderCustomizer.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.test.autoconfigure.restdocs;
 
-import org.springframework.boot.test.autoconfigure.web.reactive.WebTestClientBuilderCustomizer;
+import org.springframework.boot.test.web.reactive.server.WebTestClientBuilderCustomizer;
 import org.springframework.restdocs.webtestclient.WebTestClientRestDocumentationConfigurer;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.util.StringUtils;


### PR DESCRIPTION
Hi,

this PR removes a remaining usage of  the deprecated `org.springframework.boot.test.autoconfigure.web.reactive.WebTestClientBuilderCustomizer` in favor of using `org.springframework.boot.test.web.reactive.server.WebTestClientBuilderCustomizer`.

Cheers,
Christoph