### PR TITLE
Profile with comma in name does not work in tests

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootContextLoader.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootContextLoader.java
@@ -28,7 +28,6 @@ import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
 import org.springframework.boot.test.mock.web.SpringBootMockServletContext;
-import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.boot.web.reactive.context.GenericReactiveWebApplicationContext;
 import org.springframework.boot.web.servlet.support.ServletContextApplicationContextInitializer;
 import org.springframework.context.ApplicationContext;
@@ -73,6 +72,7 @@ import org.springframework.web.context.support.GenericWebApplicationContext;
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  * @author Madhura Bhave
+ * @author Scott Frederick
  * @since 1.4.0
  * @see SpringBootTest
  */
@@ -92,7 +92,7 @@ public class SpringBootContextLoader extends AbstractContextLoader {
 		application.getSources().addAll(Arrays.asList(configLocations));
 		ConfigurableEnvironment environment = getEnvironment();
 		if (!ObjectUtils.isEmpty(config.getActiveProfiles())) {
-			setActiveProfiles(environment, config.getActiveProfiles());
+			environment.setActiveProfiles(config.getActiveProfiles());
 		}
 		ResourceLoader resourceLoader = (application.getResourceLoader() != null) ? application.getResourceLoader()
 				: new DefaultResourceLoader(getClass().getClassLoader());
@@ -136,11 +136,6 @@ public class SpringBootContextLoader extends AbstractContextLoader {
 	 */
 	protected ConfigurableEnvironment getEnvironment() {
 		return new StandardEnvironment();
-	}
-
-	private void setActiveProfiles(ConfigurableEnvironment environment, String[] profiles) {
-		TestPropertyValues.of("spring.profiles.active=" + StringUtils.arrayToCommaDelimitedString(profiles))
-				.applyTo(environment);
 	}
 
 	protected String[] getInlinedProperties(MergedContextConfiguration config) {

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootContextLoaderTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootContextLoaderTests.java
@@ -22,6 +22,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.MergedContextConfiguration;
 import org.springframework.test.context.TestContext;
@@ -35,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link SpringBootContextLoader}
  *
  * @author Stephane Nicoll
+ * @author Scott Frederick
  */
 public class SpringBootContextLoaderTests {
 
@@ -88,11 +91,38 @@ public class SpringBootContextLoaderTests {
 		assertKey(config, "variables", "foo=FOO\n bar=BAR");
 	}
 
+	@Test
+	public void noActiveProfiles() {
+		Environment environment = getApplicationEnvironment(SimpleConfig.class);
+		assertThat(environment.getActiveProfiles()).isEmpty();
+	}
+
+	@Test
+	public void multipleActiveProfiles() {
+		Environment environment = getApplicationEnvironment(MultipleActiveProfiles.class);
+		assertThat(environment.getActiveProfiles()).containsExactly("profile1", "profile2");
+	}
+
+	@Test
+	public void activeProfileWithComma() {
+		Environment environment = getApplicationEnvironment(ActiveProfileWithComma.class);
+		assertThat(environment.getActiveProfiles()).containsExactly("profile1,2");
+	}
+
 	private Map<String, Object> getEnvironmentProperties(Class<?> testClass) {
-		TestContext context = new ExposedTestContextManager(testClass).getExposedTestContext();
+		TestContext context = getTestContext(testClass);
 		MergedContextConfiguration config = (MergedContextConfiguration) ReflectionTestUtils.getField(context,
 				"mergedContextConfiguration");
 		return TestPropertySourceUtils.convertInlinedPropertiesToMap(config.getPropertySourceProperties());
+	}
+
+	private Environment getApplicationEnvironment(Class<?> testClass) {
+		TestContext context = getTestContext(testClass);
+		return context.getApplicationContext().getEnvironment();
+	}
+
+	private TestContext getTestContext(Class<?> testClass) {
+		return new ExposedTestContextManager(testClass).getExposedTestContext();
 	}
 
 	private void assertKey(Map<String, Object> actual, String key, Object value) {
@@ -139,6 +169,20 @@ public class SpringBootContextLoaderTests {
 	@SpringBootTest({ "key=myValue", "variables=foo=FOO\n bar=BAR" })
 	@ContextConfiguration(classes = Config.class)
 	static class NewLineInValue {
+
+	}
+
+	@SpringBootTest
+	@ActiveProfiles({ "profile1", "profile2" })
+	@ContextConfiguration(classes = Config.class)
+	static class MultipleActiveProfiles {
+
+	}
+
+	@SpringBootTest
+	@ActiveProfiles({ "profile1,2" })
+	@ContextConfiguration(classes = Config.class)
+	static class ActiveProfileWithComma {
 
 	}
 


### PR DESCRIPTION
Prior to this commit, active profiles were being added to the Spring Boot application environment by setting the `spring.profiles.active` property. This could result in profiles getting parsed differently than other uses of `@ActiveProfiles`. Setting the profiles directly in the `Environment` prevents this parsing.

Fixes #19537
