### PR TITLE
DataSource url property is ignored when there is no connection pool

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
 /**
@@ -73,8 +74,9 @@ public class DataSourceAutoConfiguration {
 	}
 
 	/**
-	 * {@link AnyNestedCondition} that checks that either {@code spring.datasource.type}
-	 * is set or {@link PooledDataSourceAvailableCondition} applies.
+	 * {@link AnyNestedCondition} that checks that either one of
+	 * {@code spring.datasource.type}, {@code spring.datasource.url} properties is set or
+	 * {@link PooledDataSourceAvailableCondition} applies.
 	 */
 	static class PooledDataSourceCondition extends AnyNestedCondition {
 
@@ -84,6 +86,12 @@ public class DataSourceAutoConfiguration {
 
 		@ConditionalOnProperty(prefix = "spring.datasource", name = "type")
 		static class ExplicitType {
+
+		}
+
+		@ConditionalOnProperty(prefix = "spring.datasource", name = "url")
+		@ConditionalOnClass(SimpleDriverDataSource.class)
+		static class ExplicitUrl {
 
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,6 +159,16 @@ class DataSourceAutoConfigurationTests {
 	}
 
 	@Test
+	void createDataSourceExplicitUrlPresentAndNoPoolDataSourceAvailable() {
+		this.contextRunner
+				.withClassLoader(new FilteredClassLoader("org.apache.tomcat", "com.zaxxer.hikari",
+						"org.apache.commons.dbcp", "org.apache.commons.dbcp2"))
+				.withPropertyValues("spring.datasource.driverClassName:org.hsqldb.jdbcDriver",
+						"spring.datasource.url:jdbc:hsqldb:mem:testdb")
+				.run(this::containsOnlySimpleDriverDataSource);
+	}
+
+	@Test
 	void explicitTypeSupportedDataSource() {
 		this.contextRunner
 				.withPropertyValues("spring.datasource.driverClassName:org.hsqldb.jdbcDriver",
@@ -169,7 +179,8 @@ class DataSourceAutoConfigurationTests {
 
 	private void containsOnlySimpleDriverDataSource(AssertableApplicationContext context) {
 		assertThat(context).hasSingleBean(DataSource.class);
-		assertThat(context).getBean(DataSource.class).isExactlyInstanceOf(SimpleDriverDataSource.class);
+		assertThat(context).getBean(DataSource.class).isExactlyInstanceOf(SimpleDriverDataSource.class)
+				.extracting("driver").isNotNull();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DataSourceBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DataSourceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,7 @@ public final class DataSourceBuilder<T extends DataSource> {
 		ConfigurationPropertyNameAliases aliases = new ConfigurationPropertyNameAliases();
 		aliases.addAliases("url", "jdbc-url");
 		aliases.addAliases("username", "user");
+		aliases.addAliases("driver-class-name", "driver-class");
 		Binder binder = new Binder(source.withAliases(aliases));
 		binder.bind(ConfigurationPropertyName.EMPTY, Bindable.ofInstance(result));
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DataSourceBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DataSourceBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ import com.zaxxer.hikari.HikariDataSource;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -66,6 +68,13 @@ class DataSourceBuilderTests {
 				.create(new HidePackagesClassLoader("com.zaxxer.hikari", "org.apache.tomcat.jdbc.pool"))
 				.url("jdbc:h2:test").build();
 		assertThat(this.dataSource).isInstanceOf(BasicDataSource.class);
+	}
+
+	@Test
+	void simpleDriverDataSource() {
+		this.dataSource = DataSourceBuilder.create().url("jdbc:h2:test").type(SimpleDriverDataSource.class).build();
+		assertThat(this.dataSource).isInstanceOf(SimpleDriverDataSource.class);
+		assertThat(this.dataSource).extracting("driver").isNotNull();
 	}
 
 	@Test


### PR DESCRIPTION
see gh-19192

Btw, I found an issue in `DataSourceBuilder`, the builder does not support `SimpleDriverDataSource` without alias `aliases.addAliases("driver-class-name", "driver-class")`

Here is a test to reproduce:
```java

	@Test
	void simpleDriverDataSource() {
		this.dataSource = DataSourceBuilder.create().url("jdbc:h2:test").type(SimpleDriverDataSource.class).build();
		assertThat(this.dataSource).isInstanceOf(SimpleDriverDataSource.class);
		assertThat(this.dataSource).extracting("driver").isNotNull();
	}
```
`


**UPDATE**

My first approach was incorrect. Sorry for the inconvenience.

