### PR TITLE
Add micrometer-registry-stackdriver dependency for javadoc generation

### DIFF
--- a/spring-boot-project/spring-boot-docs/pom.xml
+++ b/spring-boot-project/spring-boot-docs/pom.xml
@@ -315,6 +315,11 @@
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-stackdriver</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-statsd</artifactId>
 			<optional>true</optional>
 		</dependency>


### PR DESCRIPTION
Hi,

this PR fixes the current failures caused by #19528 as the javadoc generation requires the new dependency as well.

Cheers,
Christoph