### PR TITLE
Fix links to external types in javadoc

### DIFF
--- a/spring-boot-project/spring-boot-docs/pom.xml
+++ b/spring-boot-project/spring-boot-docs/pom.xml
@@ -1002,13 +1002,13 @@
 									<quiet>true</quiet>
 									<stylesheetfile>${basedir}/src/main/javadoc/spring-javadoc.css</stylesheetfile>
 									<links>
-										<link>https://docs.oracle.com/javase/8/docs/api</link>
-										<link>https://docs.oracle.com/javaee/7/api</link>
-										<link>https://docs.spring.io/spring-framework/docs/${spring-framework.version}/javadoc-api</link>
-										<link>https://docs.spring.io/spring-security/site/docs/${spring-security.version}/api</link>
-										<link>https://tomcat.apache.org/tomcat-9.0-doc/api</link>
-										<link>https://www.eclipse.org/jetty/javadoc/${jetty.version}</link>
-										<link>https://www.thymeleaf.org/apidocs/thymeleaf/${thymeleaf.version}</link>
+										<link>https://docs.oracle.com/javase/8/docs/api/</link>
+										<link>https://docs.oracle.com/javaee/7/api/</link>
+										<link>https://docs.spring.io/spring-framework/docs/${spring-framework.version}/javadoc-api/</link>
+										<link>https://docs.spring.io/spring-security/site/docs/${spring-security.version}/api/</link>
+										<link>https://tomcat.apache.org/tomcat-9.0-doc/api/</link>
+										<link>https://www.eclipse.org/jetty/javadoc/${jetty.version}/</link>
+										<link>https://www.thymeleaf.org/apidocs/thymeleaf/${thymeleaf.version}/</link>
 									</links>
 								</configuration>
 							</execution>


### PR DESCRIPTION
Hi,

I took the freedom to add trailing slashes to the Javadoc links again as [MJAVADOC-532](https://issues.apache.org/jira/browse/MJAVADOC-532) seems to be fixed and the current redirects for the Spring-Framework docs seem to not work. See  #19573 for more information.

The PR is already targeting 2.1.x - hope that's okay.

Cheers,
Christoph