### PR TITLE
Simplify validation pattern of EndpointId

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/EndpointId.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/EndpointId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,9 +41,9 @@ public final class EndpointId {
 
 	private static final Set<String> loggedWarnings = new HashSet<>();
 
-	private static final Pattern VALID_PATTERN = Pattern.compile("[a-zA-Z0-9\\.\\-]+");
+	private static final Pattern VALID_PATTERN = Pattern.compile("[a-zA-Z0-9.-]+");
 
-	private static final Pattern WARNING_PATTERN = Pattern.compile("[\\.\\-]+");
+	private static final Pattern WARNING_PATTERN = Pattern.compile("[.-]+");
 
 	private static final String MIGRATE_LEGACY_NAMES_PROPERTY = "management.endpoints.migrate-legacy-ids";
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/EndpointIdTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/EndpointIdTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,12 @@ class EndpointIdTests {
 	@Test
 	void ofWhenContainsSlashThrowsException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> EndpointId.of("foo/bar"))
+				.withMessage("Value must only contain valid chars");
+	}
+
+	@Test
+	void ofWhenContainsBackslashThrowsException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> EndpointId.of("foo\\bar"))
 				.withMessage("Value must only contain valid chars");
 	}
 


### PR DESCRIPTION
The literals `.` (dot) and `-` (hyphen) are escaped within the character classes. While a dot is not a meta character within a character class, a hyphen does not need to be escaped unless it can be interpreted as a meta character (usually at the end).

These changes do not change the behavior, but improve readability and understandability. I have added an explicit test only to avoid uncertainties for possible future escape characters.