### PR TITLE
Update copyright in legal doc section

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/legal.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/legal.adoc
@@ -3,7 +3,7 @@
 
 {spring-boot-version}
 
-Copyright &#169; 2012-2019
+Copyright &#169; 2012-2020
 
 Copies of this document may be made for your own use and for distribution to
 others, provided that you do not charge any fee for such copies and further


### PR DESCRIPTION
Hi.

this PR updates the copyright to 2020 under the Legal section in the [HTML reference](https://docs.spring.io/spring-boot/docs/2.3.0.BUILD-SNAPSHOT/reference/htmlsingle/#legal).

Cheers,
Christoph