### PR TITLE
Make Tomcat javadoc link version dependent

### DIFF
--- a/spring-boot-project/spring-boot-docs/build.gradle
+++ b/spring-boot-project/spring-boot-docs/build.gradle
@@ -58,12 +58,14 @@ task javadoc(type: Javadoc) {
 		}
 		doFirst {
 			def versionConstraints = dependencyVersions.versionConstraints
+			def tomcatVersion = "${versionConstraints['org.apache.tomcat:tomcat-annotations-api']}"
+			def tomcatDocsVersion = tomcatVersion.substring(0, tomcatVersion.lastIndexOf('.'));
 			options.links = [
 				'https://docs.oracle.com/javase/8/docs/api/',
 				'https://docs.oracle.com/javaee/7/api/',
 				"https://docs.spring.io/spring-framework/docs/${versionConstraints['org.springframework:spring-core']}/javadoc-api/",
 				"https://docs.spring.io/spring-security/site/docs/${versionConstraints['org.springframework.security:spring-security-core']}/api/",
-				'https://tomcat.apache.org/tomcat-9.0-doc/api/',
+				"https://tomcat.apache.org/tomcat-${tomcatDocsVersion}-doc/api/",
 				"https://www.eclipse.org/jetty/javadoc/${versionConstraints['org.eclipse.jetty:jetty-server']}/",
 				"https://www.thymeleaf.org/apidocs/thymeleaf/${versionConstraints['org.thymeleaf:thymeleaf']}/"
 			] as String[]


### PR DESCRIPTION
Hi,

the move to Gradle allows us to have a bit more flexible Javadoc links. Tomcat is only using the MAJOR.MINOR part of the version and achieving this wasn't really possible with Maven without introducing another (somewhat duplicated) property.

This PR makes the Tomcat links dependent on the Tomcat version instead of hardcoding the link. If we upgrade eventually to a newer version of Tomcat there is no need to update the link anymore.

Let me know what you think.
Cheers,
Christoph