### PR TITLE
Pass CI branch parameter to build scan

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -210,6 +210,7 @@ jobs:
       image: spring-boot-ci-image
       file: git-repo/ci/tasks/build-project.yml
       params:
+        BRANCH: ((branch))
         GRADLE_ENTERPRISE_CACHE_USERNAME: ((gradle-enterprise-cache-username))
         GRADLE_ENTERPRISE_CACHE_PASSWORD: ((gradle-enterprise-cache-password))
     on_failure:
@@ -298,6 +299,7 @@ jobs:
       image: spring-boot-jdk11-ci-image
       file: git-repo/ci/tasks/build-project.yml
       params:
+        BRANCH: ((branch))
         GRADLE_ENTERPRISE_CACHE_USERNAME: ((gradle-enterprise-cache-username))
         GRADLE_ENTERPRISE_CACHE_PASSWORD: ((gradle-enterprise-cache-password))
     on_failure:
@@ -334,6 +336,7 @@ jobs:
         image: spring-boot-jdk13-ci-image
         file: git-repo/ci/tasks/build-project.yml
         params:
+          BRANCH: ((branch))
           GRADLE_ENTERPRISE_CACHE_USERNAME: ((gradle-enterprise-cache-username))
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ((gradle-enterprise-cache-password))
       on_failure:

--- a/ci/tasks/build-project.yml
+++ b/ci/tasks/build-project.yml
@@ -9,6 +9,7 @@ caches:
 - path: gradle
 - path: embedmongo
 params:
+  BRANCH:
   CI: true
   GRADLE_ENTERPRISE_CACHE_USERNAME:
   GRADLE_ENTERPRISE_CACHE_PASSWORD:

--- a/gradle/build-scan-user-data.gradle
+++ b/gradle/build-scan-user-data.gradle
@@ -27,7 +27,7 @@ void tagCiOrLocal() {
 void addGitMetadata() {
 	gradleEnterprise.buildScan.background {
 		def gitCommitId = execAndGetStdout('git', 'rev-parse', '--short=8', '--verify', 'HEAD')
-		def gitBranchName = execAndGetStdout('git', 'rev-parse', '--abbrev-ref', 'HEAD')
+		def gitBranchName = getBranch()
 		def gitStatus = execAndGetStdout('git', 'status', '--porcelain')
 
 		if(gitCommitId) {
@@ -48,6 +48,14 @@ void addGitMetadata() {
 
 boolean isCi() {
 	System.getenv('CI')
+}
+
+String getBranch() {
+	def branch = System.getenv('BRANCH')
+	if (branch != null && !branch.isEmpty()) {
+		return branch
+	}
+	return execAndGetStdout('git', 'rev-parse', '--abbrev-ref', 'HEAD')
 }
 
 String execAndGetStdout(String... args) {


### PR DESCRIPTION
Hi,

this is an attempt to fix #19614 by passing the Concourse branch parameter to the build scan directly and only fallback to the current mechanism if it isn't set (e.g. in local builds).

As the Concourse stuff is hard to test for me, feel free to decline the PR. Let me know what you think.

Cheers,
Christoph