### PR TITLE
Add a way to customize Hazelcast's Client/Server configs

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientConfigCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientConfigCustomizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.hazelcast;
+
+import com.hazelcast.client.config.ClientConfig;
+
+/**
+ * Callback interface that can be used to customize a {@link ClientConfig}.
+ *
+ * @author Dmytro Nosan
+ * @since 2.3.0
+ */
+@FunctionalInterface
+public interface HazelcastClientConfigCustomizer {
+
+	/**
+	 * Customize the Hazelcast {@link ClientConfig}.
+	 * @param clientConfig the config to customize
+	 */
+	void customize(ClientConfig clientConfig);
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.HazelcastInstance;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
@@ -49,12 +50,15 @@ class HazelcastClientConfiguration {
 	static class HazelcastClientConfigFileConfiguration {
 
 		@Bean
-		HazelcastInstance hazelcastInstance(HazelcastProperties properties) throws IOException {
+		HazelcastInstance hazelcastInstance(HazelcastProperties properties,
+				ObjectProvider<HazelcastClientConfigCustomizer> hazelcastClientConfigCustomizers) throws IOException {
+			HazelcastClientConfigCustomizer[] customizers = hazelcastClientConfigCustomizers.orderedStream()
+					.toArray(HazelcastClientConfigCustomizer[]::new);
 			Resource config = properties.resolveConfigLocation();
 			if (config != null) {
-				return new HazelcastClientFactory(config).getHazelcastInstance();
+				return new HazelcastClientFactory(config, customizers).getHazelcastInstance();
 			}
-			return HazelcastClient.newHazelcastClient();
+			return new HazelcastClientFactory(customizers).getHazelcastInstance();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastConfigCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastConfigCustomizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.hazelcast;
+
+import com.hazelcast.config.Config;
+
+/**
+ * Callback interface that can be used to customize a {@link Config}.
+ *
+ * @author Dmytro Nosan
+ * @since 2.3.0
+ */
+@FunctionalInterface
+public interface HazelcastConfigCustomizer {
+
+	/**
+	 * Customize the Hazelcast {@link Config}.
+	 * @param config the config to customize
+	 */
+	void customize(Config config);
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastServerConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ package org.springframework.boot.autoconfigure.hazelcast;
 import java.io.IOException;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.context.annotation.Bean;
@@ -47,12 +47,15 @@ class HazelcastServerConfiguration {
 	static class HazelcastServerConfigFileConfiguration {
 
 		@Bean
-		HazelcastInstance hazelcastInstance(HazelcastProperties properties) throws IOException {
+		HazelcastInstance hazelcastInstance(HazelcastProperties properties,
+				ObjectProvider<HazelcastConfigCustomizer> hazelcastConfigCustomizers) throws IOException {
+			HazelcastConfigCustomizer[] customizers = hazelcastConfigCustomizers.orderedStream()
+					.toArray(HazelcastConfigCustomizer[]::new);
 			Resource config = properties.resolveConfigLocation();
 			if (config != null) {
-				return new HazelcastInstanceFactory(config).getHazelcastInstance();
+				return new HazelcastInstanceFactory(config, customizers).getHazelcastInstance();
 			}
-			return Hazelcast.newHazelcastInstance();
+			return new HazelcastInstanceFactory(customizers).getHazelcastInstance();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationServerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -154,6 +154,24 @@ class HazelcastAutoConfigurationServerTests {
 					Map<String, QueueConfig> queueConfigs = config.getQueueConfigs();
 					assertThat(queueConfigs.keySet()).containsOnly("another-queue");
 				});
+	}
+
+	@Test
+	void configureConfigUsingCustomizer() {
+		this.contextRunner.withUserConfiguration(HazelcastCustomizerConfiguration.class).run((context) -> {
+			HazelcastInstance hazelcast = context.getBean(HazelcastInstance.class);
+			assertThat(hazelcast.getConfig().getInstanceName()).isEqualTo("spring-boot-instance");
+		});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class HazelcastCustomizerConfiguration {
+
+		@Bean
+		HazelcastConfigCustomizer hazelcastConfigInstanceNameCustomizer() {
+			return (config) -> config.setInstanceName("spring-boot-instance");
+		}
+
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -5675,6 +5675,14 @@ Otherwise, Spring Boot tries to find the Hazelcast configuration from the defaul
 We also check if the `hazelcast.config` system property is set.
 See the https://docs.hazelcast.org/docs/latest/manual/html-single/[Hazelcast documentation] for more details.
 
+You can also customize `com.hazelcast.config.Config` programmatically by declaring `HazelcastConfigCustomizer` bean(s)
+as shown in the following example:
+
+[source,java,indent=0]
+----
+include::{code-examples}/hazelcast/HazelcastConfigCustomizerConfiguration.java[tag=configuration]
+----
+
 If `hazelcast-client` is present on the classpath, Spring Boot first attempts to create a client by checking the following configuration options:
 
 * The presence of a `com.hazelcast.client.config.ClientConfig` bean.
@@ -5683,8 +5691,17 @@ If `hazelcast-client` is present on the classpath, Spring Boot first attempts to
 * A `hazelcast-client.xml` in the working directory or at the root of the classpath.
 * A `hazelcast-client.yaml` in the working directory or at the root of the classpath.
 
+If you require more control over `com.hazelcast.client.config.ClientConfig`, you can customize `com.hazelcast.client.config.ClientConfig`
+programmatically by declaring `HazelcastClientConfigCustomizer` bean(s) as shown in the following example:
+
+[source,java,indent=0]
+----
+include::{code-examples}/hazelcast/HazelcastClientConfigCustomizerConfiguration.java[tag=configuration]
+----
+
 NOTE: Spring Boot also has <<boot-features-caching-provider-hazelcast,explicit caching support for Hazelcast>>.
 If caching is enabled, the `HazelcastInstance` is automatically wrapped in a `CacheManager` implementation.
+
 
 
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/hazelcast/HazelcastClientConfigCustomizerConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/hazelcast/HazelcastClientConfigCustomizerConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docs.hazelcast;
+
+import com.hazelcast.spring.context.SpringManagedContext;
+
+import org.springframework.boot.autoconfigure.hazelcast.HazelcastClientConfigCustomizer;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * An example configuration for customizing Hazelcast Client Config.
+ *
+ * @author Dmytro Nosan
+ */
+// tag::configuration[]
+@Configuration(proxyBeanMethods = false)
+public class HazelcastClientConfigCustomizerConfiguration {
+
+	@Bean
+	public HazelcastClientConfigCustomizer hazelcastClientConfigCustomizer(ApplicationContext applicationContext) {
+		return (clientConfig) -> {
+			SpringManagedContext managedContext = new SpringManagedContext();
+			managedContext.setApplicationContext(applicationContext);
+			clientConfig.setManagedContext(managedContext);
+		};
+	}
+
+}
+// end::configuration[]

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/hazelcast/HazelcastConfigCustomizerConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/hazelcast/HazelcastConfigCustomizerConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.docs.hazelcast;
+
+import com.hazelcast.spring.context.SpringManagedContext;
+
+import org.springframework.boot.autoconfigure.hazelcast.HazelcastConfigCustomizer;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * An example configuration for customizing Hazelcast Config.
+ *
+ * @author Dmytro Nosan
+ */
+// tag::configuration[]
+@Configuration(proxyBeanMethods = false)
+public class HazelcastConfigCustomizerConfiguration {
+
+	@Bean
+	public HazelcastConfigCustomizer hazelcastInstanceConfigCustomizer(ApplicationContext applicationContext) {
+		return (config) -> {
+			SpringManagedContext managedContext = new SpringManagedContext();
+			managedContext.setApplicationContext(applicationContext);
+			config.setManagedContext(managedContext);
+		};
+	}
+
+}
+// end::configuration[]


### PR DESCRIPTION
This PR provides a way to customize Hazelcast's Client/Server configs before `HazelcastInstance` is created.  At the moment there is no way to do this except creating your own config.


Here is a small example of a configuration, that shows how to set `SpringManagedContext` using the `HazelcastConfigCustomizer`

```java

@Configuration(proxyBeanMethods = false)
static class HazelcastConfiguration {

	@Bean
	HazelcastConfigCustomizer hazelcastConfigCustomizer(ApplicationContext applicationContext) {
		return (config) -> {
			SpringManagedContext managedContext = new SpringManagedContext();
			managedContext.setApplicationContext(applicationContext);
			config.setManagedContext(managedContext);
		};
	}

}

```
