### PR TITLE
Disable failing Gradle tests on Java 13

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/SpringBootPluginIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/SpringBootPluginIntegrationTests.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.boot.gradle.testkit.GradleBuild;
@@ -45,11 +47,13 @@ class SpringBootPluginIntegrationTests {
 				.contains("Spring Boot plugin requires Gradle 5.6 or later. The current version is Gradle 5.5.1");
 	}
 
+	@DisabledOnJre(JRE.JAVA_13)
 	@Test
 	void succeedWithVersionOfGradleHigherThanRequired() {
 		this.gradleBuild.gradleVersion("5.6.1").build();
 	}
 
+	@DisabledOnJre(JRE.JAVA_13)
 	@Test
 	void succeedWithVersionOfGradleMatchingWhatIsRequired() {
 		this.gradleBuild.gradleVersion("5.6").build();


### PR DESCRIPTION
Hi,

apparently raising the new minimum version for Gradle via #18777 breaks the build on JDK 13. I actually don't have a clue why this worked with 4.10 previously, but as 5.6 isn't supporting JDK 13 we can maybe disable the tests under Java 13?

Maybe you have more insights on why this worked previously, in which case feel free to decline the PR.

Cheers,
Christoph 