### PR TITLE
Improve messages in case of DataSource health check failure.

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicator.java
@@ -82,7 +82,18 @@ public class DataSourceHealthIndicator extends AbstractHealthIndicator implement
 	 * @param query the validation query to use (can be {@code null})
 	 */
 	public DataSourceHealthIndicator(DataSource dataSource, String query) {
-		super("DataSource health check failed");
+		this(null, dataSource, query);
+	}
+
+	/**
+	 * Create a new {@link DataSourceHealthIndicator} using the specified
+	 * {@link DataSource} and validation query.
+	 * @param name the name of the data source
+	 * @param dataSource the data source
+	 * @param query the validation query to use (can be {@code null})
+	 */
+	public DataSourceHealthIndicator(String name, DataSource dataSource, String query) {
+		super(ex -> "DataSource " + name + " health check failed : " + ex.getMessage());
 		this.dataSource = dataSource;
 		this.query = query;
 		this.jdbcTemplate = (dataSource != null) ? new JdbcTemplate(dataSource) : null;


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
My application is running on several data sources.
I have a monitoring that raise alerts based on the logs, but do not allow to view the related stack trace easily.
One of the database was failing from time to time, and I had to dig in my logs to find which one.
Adding those logs will allow to find out which data source have a problem and get the error message without having to dig into the stack trace.