### PR TITLE
Fix typo in NoSuchBeanDefinitionFailureAnalyzer exception

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/diagnostics/analyzer/NoSuchBeanDefinitionFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/diagnostics/analyzer/NoSuchBeanDefinitionFailureAnalyzer.java
@@ -123,7 +123,7 @@ class NoSuchBeanDefinitionFailureAnalyzer extends AbstractInjectionFailureAnalyz
 			if (configurationProperties.isPresent()) {
 				if (KotlinDetector.isKotlinType(declaringClass) && !KotlinDetector.isKotlinReflectPresent()) {
 					action = String.format(
-							"%s%nConsider adding a dependency on kotlin-reflect so that the contructor used for @%s can be located. Also, ensure that @%s is present on '%s' if you intended to use constructor-based "
+							"%s%nConsider adding a dependency on kotlin-reflect so that the constructor used for @%s can be located. Also, ensure that @%s is present on '%s' if you intended to use constructor-based "
 									+ "configuration property binding.",
 							action, ConstructorBinding.class.getSimpleName(), ConstructorBinding.class.getSimpleName(),
 							constructor.getName());

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/kotlin/org/springframework/boot/autoconfigure/diagnostics/analyzer/KotlinNoSuchBeanFailureAnalyzerNoKotlinReflectTests.kt
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/kotlin/org/springframework/boot/autoconfigure/diagnostics/analyzer/KotlinNoSuchBeanFailureAnalyzerNoKotlinReflectTests.kt
@@ -31,7 +31,7 @@ class KotlinNoSuchBeanFailureAnalyzerNoKotlinReflectTests {
 		assertThat(analysis!!.getAction()).startsWith(
 				java.lang.String.format("Consider defining a bean of type '%s' in your configuration.", String::class.java!!.getName()))
 		assertThat(analysis!!.getAction()).contains(java.lang.String.format(
-				"Consider adding a dependency on kotlin-reflect so that the contructor used for @ConstructorBinding can be located. Also, ensure that @ConstructorBinding is present on '%s' ", ConstructorBoundProperties::class.java!!.getName()))
+				"Consider adding a dependency on kotlin-reflect so that the constructor used for @ConstructorBinding can be located. Also, ensure that @ConstructorBinding is present on '%s' ", ConstructorBoundProperties::class.java!!.getName()))
 	}
 
 	private fun createFailure(config: Class<*>, vararg environment: String): FatalBeanException? {


### PR DESCRIPTION
Hi,

I just noticed a typo in `NoSuchBeanDefinitionFailureAnalyzer` that seems to have been introduced with https://github.com/spring-projects/spring-boot/commit/437941cc518bcd740f6685e38ae01881777aa73e. As the commit was done in 2.2.x I took the freedom to target 2.2.x.

Cheers,
Christoph