### PR TITLE
Fix deprecations in spring-boot-smoke-test-hateoas

### DIFF
--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-hateoas/src/main/java/smoketest/hateoas/web/CustomerController.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-hateoas/src/main/java/smoketest/hateoas/web/CustomerController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,14 +48,14 @@ public class CustomerController {
 
 	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
 	HttpEntity<CollectionModel<Customer>> showCustomers() {
-		CollectionModel<Customer> resources = new CollectionModel<>(this.repository.findAll());
+		CollectionModel<Customer> resources = CollectionModel.of(this.repository.findAll());
 		resources.add(this.entityLinks.linkToCollectionResource(Customer.class));
 		return new ResponseEntity<>(resources, HttpStatus.OK);
 	}
 
 	@GetMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	HttpEntity<EntityModel<Customer>> showCustomer(@PathVariable Long id) {
-		EntityModel<Customer> resource = new EntityModel<>(this.repository.findOne(id));
+		EntityModel<Customer> resource = EntityModel.of(this.repository.findOne(id));
 		resource.add(this.entityLinks.linkToItemResource(Customer.class, id));
 		return new ResponseEntity<>(resource, HttpStatus.OK);
 	}


### PR DESCRIPTION
Hi,

this PR fixes two deprecations in `spring-boot-smoke-test-hateoas` that were introduced by building against Spring HATEOAS 1.1.0 snapshots.

Cheers,
Christoph