### PR TITLE
Restore disabled tests in TomcatReactiveWebServerFactoryTests

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/TomcatReactiveWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/TomcatReactiveWebServerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/TomcatReactiveWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/TomcatReactiveWebServerFactoryTests.java
@@ -33,7 +33,6 @@ import org.apache.catalina.startup.Tomcat;
 import org.apache.catalina.valves.RemoteIpValve;
 import org.apache.coyote.ProtocolHandler;
 import org.apache.coyote.http11.AbstractHttp11Protocol;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
@@ -64,16 +63,6 @@ class TomcatReactiveWebServerFactoryTests extends AbstractReactiveWebServerFacto
 	@Override
 	protected TomcatReactiveWebServerFactory getFactory() {
 		return new TomcatReactiveWebServerFactory(0);
-	}
-
-	@Test
-	@Disabled("gh-19702")
-	void compressionOfResponseToGetRequest() {
-	}
-
-	@Test
-	@Disabled("gh-19702")
-	void compressionOfResponseToPostRequest() {
 	}
 
 	@Test


### PR DESCRIPTION
Hi,

given that the publishing of Gradle module metadata was disabled again for now and we're back on using enforced platforms #19702 I think we can restore the tests in `TomcatReactiveWebServerFactoryTests`. What do you think?

Cheers,
Christoph