### PR TITLE
Upgrade to Kafka to 2.4.0 and Spring Kafka 2.4.1

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -996,7 +996,7 @@ bom {
 			]
 		}
 	}
-	library('Kafka', '2.3.1') {
+	library('Kafka', '2.4.0') {
 		group('org.apache.kafka') {
 			modules = [
 				'connect-api',
@@ -1010,10 +1010,12 @@ bom {
 				'kafka-streams',
 				'kafka-streams-scala_2.11',
 				'kafka-streams-scala_2.12',
+				'kafka-streams-scala_2.13',
 				'kafka-streams-test-utils',
 				'kafka-tools',
 				'kafka_2.11',
-				'kafka_2.12'
+				'kafka_2.12',
+				'kafka_2.13'
 			]
 		}
 	}
@@ -1690,7 +1692,7 @@ bom {
 			]
 		}
 	}
-	library('Spring Kafka', '2.3.4.RELEASE') {
+	library('Spring Kafka', '2.4.1.RELEASE') {
 		group('org.springframework.kafka') {
 			modules = [
 				'spring-kafka',


### PR DESCRIPTION
Closes #19612 and #19633

The `kafka_2.11`, `kafka_2.12`, and `kafka_2.13` managed dependencies refer to versions of the Kafka broker, which are compiled with Scala 2.11, 2.12, and 2.13 respectively. These dependencies are only used when running an embedded Kafka broker. 

`kafka_2.13` is new with Kafka `2.4.0`. 

`kafka_2.12` has been the recommended version since [Kafka 2.0.1 in November 2018](https://kafka.apache.org/downloads#2.0.1). `kafka_2.11` was removed at the recommendation of @garyrussell . 
