### PR TITLE
Upgrade to Infinispan 10.1.1.Final

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 	optional 'org.hibernate.validator:hibernate-validator'
 	optional 'org.influxdb:influxdb-java'
 	optional 'org.jolokia:jolokia-core'
-	optional 'org.infinispan:infinispan-spring4-embedded'
+	optional 'org.infinispan:infinispan-spring5-embedded'
 	optional 'org.liquibase:liquibase-core'
 	optional 'org.mongodb:mongodb-driver-async'
 	optional 'org.mongodb:mongodb-driver-reactivestreams'

--- a/spring-boot-project/spring-boot-actuator/build.gradle
+++ b/spring-boot-project/spring-boot-actuator/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	optional 'org.glassfish.jersey.core:jersey-server'
 	optional 'org.glassfish.jersey.containers:jersey-container-servlet-core'
 	optional 'org.hibernate.validator:hibernate-validator'
-	optional 'org.infinispan:infinispan-spring4-embedded'
+	optional 'org.infinispan:infinispan-spring5-embedded'
 	optional 'org.influxdb:influxdb-java'
 	optional 'org.liquibase:liquibase-core'
 	optional 'org.mongodb:mongodb-driver-async'

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -534,12 +534,12 @@ bom {
 			]
 		}
 	}
-	library('Infinispan', '9.4.16.Final') {
+	library('Infinispan', '10.1.0.Final') {
 		group('org.infinispan') {
 			modules = [
+				'infinispan-api',
 				'infinispan-cachestore-jdbc',
 				'infinispan-cachestore-jpa',
-				'infinispan-cachestore-leveldb',
 				'infinispan-cachestore-remote',
 				'infinispan-cachestore-rest',
 				'infinispan-cachestore-rocksdb',
@@ -547,22 +547,25 @@ bom {
 				'infinispan-cdi-embedded',
 				'infinispan-cdi-remote',
 				'infinispan-client-hotrod',
-				'infinispan-cloud',
+				'infinispan-client-rest',
 				'infinispan-clustered-counter',
 				'infinispan-clustered-lock',
 				'infinispan-commons',
+				'infinispan-component-annotations',
 				'infinispan-core',
 				'infinispan-directory-provider',
 				'infinispan-hibernate-cache-v53',
+				'infinispan-jboss-marshalling',
 				'infinispan-jcache',
 				'infinispan-jcache-commons',
 				'infinispan-jcache-remote',
+				'infinispan-key-value-store-client',
 				'infinispan-lucene-directory',
 				'infinispan-objectfilter',
 				'infinispan-osgi',
-				'infinispan-persistence-cli',
 				'infinispan-persistence-soft-index',
 				'infinispan-query',
+				'infinispan-query-core',
 				'infinispan-query-dsl',
 				'infinispan-remote-query-client',
 				'infinispan-remote-query-server',
@@ -570,17 +573,14 @@ bom {
 				'infinispan-server-core',
 				'infinispan-server-hotrod',
 				'infinispan-server-memcached',
+				'infinispan-server-rest',
 				'infinispan-server-router',
-				'infinispan-spring4-common',
-				'infinispan-spring4-embedded',
-				'infinispan-spring4-remote',
 				'infinispan-spring5-common',
 				'infinispan-spring5-embedded',
 				'infinispan-spring5-remote',
 				'infinispan-tasks',
 				'infinispan-tasks-api',
-				'infinispan-tools',
-				'infinispan-tree'
+				'infinispan-tools'
 			]
 			plugins = [
 				'infinispan-protocol-parser-generator-maven-plugin'


### PR DESCRIPTION
This includes removing modules that were made obsolete (notably `infinispan-spring4-*`) and adding modules that are new in 10.1.0.