### PR TITLE
Fix Linkage error when using the build cache

### DIFF
--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-ant/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-ant/build.gradle
@@ -53,8 +53,16 @@ ant.properties['projectDir'] = project.layout.projectDirectory
 antresolve {
 	dependsOn syncTestRepository, configurations.antDependencies
 	doFirst {
-		ClassLoader antClassLoader = org.apache.tools.ant.Project.class.classLoader
-		configurations.antDependencies.each { antClassLoader.addURL it.toURI().toURL() }
+		ant.taskdef(
+				resource: "org/apache/ivy/ant/antlib.xml",
+				uri: "antlib:org.apache.ivy.ant",
+				classpath: configurations.antDependencies.asPath
+		)
+		ant.taskdef(
+				resource: "org/springframework/boot/ant/antlib.xml",
+				uri: "antlib:org.springframework.boot.ant",
+				classpath: configurations.antDependencies.asPath
+		)
 	}
 }
 


### PR DESCRIPTION
The error should be fixed now by adding explicit taskdefs
instead of changing the classpath of the classloader which
did load org.apache.tools.ant.Project.
This classloader is owned by Gradle and is probably a parent
of the one which is used for `TarBuildCacheEntryPacker`.

See https://github.com/gradle/gradle/issues/11914