### PR TITLE
Reinstate running of OutputCaptureRuleTests

### DIFF
--- a/spring-boot-project/spring-boot-test/build.gradle
+++ b/spring-boot-project/spring-boot-test/build.gradle
@@ -52,4 +52,10 @@ dependencies {
 	testImplementation 'org.testng:testng'
 
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
+}
+
+test {
+	useJUnit()
+	useJUnitPlatform()
 }


### PR DESCRIPTION
Hi,

I just noticed that `OutputCaptureRuleTests` were not running due to the fact that they need to be run with JUnit4. This PR is an attempt to fix this.

Let me know if there's maybe a smarter way to achieve this in Gradle.

Cheers,
Christoph