### PR TITLE
Add UTF-8 encoding to spring-boot-starter-parent POM

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
@@ -23,6 +23,8 @@ publishing.publications.withType(MavenPublication) {
 				delegate.'resource.delimiter'('@')
 				delegate.'maven.compiler.source'('${java.version}')
 				delegate.'maven.compiler.target'('${java.version}')
+				delegate.'project.build.sourceEncoding'('UTF-8')
+				delegate.'project.reporting.outputEncoding'('UTF-8')
 			}
 		}
 		root.issueManagement.plus {


### PR DESCRIPTION
Hi,

this is an attempt to fix #19815 by adding `project.build.sourceEncoding` with UTF-8 to the generated `spring-boot-starter-parent` POM again.

Let me know what you think.
Cheers,
Christoph