### PR TITLE
Fix TestFailuresPlugin.TestFailure.compareTo()

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/testing/TestFailuresPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/testing/TestFailuresPlugin.java
@@ -56,7 +56,7 @@ public class TestFailuresPlugin implements Plugin<Project> {
 
 	private final class FailureRecordingTestListener implements TestListener {
 
-		private List<TestFailure> failures = new ArrayList<>();
+		private final List<TestFailure> failures = new ArrayList<>();
 
 		private final TestResultsExtension testResults;
 
@@ -106,7 +106,7 @@ public class TestFailuresPlugin implements Plugin<Project> {
 		public int compareTo(TestFailure other) {
 			int comparison = this.descriptor.getClassName().compareTo(other.descriptor.getClassName());
 			if (comparison == 0) {
-				comparison = this.descriptor.getName().compareTo(other.descriptor.getClassName());
+				comparison = this.descriptor.getName().compareTo(other.descriptor.getName());
 			}
 			return comparison;
 		}

--- a/buildSrc/src/test/java/org/springframework/boot/build/testing/TestFailuresPluginIntegrationTests.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/testing/TestFailuresPluginIntegrationTests.java
@@ -22,9 +22,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringReader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
@@ -169,17 +169,12 @@ class TestFailuresPluginIntegrationTests {
 	}
 
 	private List<String> readLines(String output) {
-		List<String> lines = new ArrayList<>();
 		try (BufferedReader reader = new BufferedReader(new StringReader(output))) {
-			String line;
-			while ((line = reader.readLine()) != null) {
-				lines.add(line);
-			}
+			return reader.lines().collect(Collectors.toList());
 		}
 		catch (IOException ex) {
 			throw new RuntimeException(ex);
 		}
-		return lines;
 	}
 
 }


### PR DESCRIPTION
This PR fixes `TestFailuresPlugin.TestFailure.compareTo()` as it seems that `getName()` was meant to be used.

This PR also polishes around it a bit.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
