### PR TITLE
Use Supplier variants of Assert

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSystemWatcher.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSystemWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,7 +124,7 @@ public class FileSystemWatcher {
 	 */
 	public void addSourceFolder(File folder) {
 		Assert.notNull(folder, "Folder must not be null");
-		Assert.isTrue(!folder.isFile(), "Folder '" + folder + "' must not be a file");
+		Assert.isTrue(!folder.isFile(), () -> "Folder '" + folder + "' must not be a file");
 		synchronized (this.monitor) {
 			checkNotStarted();
 			this.folders.put(folder, null);

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FolderSnapshot.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FolderSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ class FolderSnapshot {
 	 */
 	FolderSnapshot(File folder) {
 		Assert.notNull(folder, "Folder must not be null");
-		Assert.isTrue(!folder.isFile(), "Folder '" + folder + "' must not be a file");
+		Assert.isTrue(!folder.isFile(), () -> "Folder '" + folder + "' must not be a file");
 		this.folder = folder;
 		this.time = new Date();
 		Set<FileSnapshot> files = new LinkedHashSet<>();

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/ApiVersion.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/ApiVersion.java
@@ -121,7 +121,7 @@ final class ApiVersion {
 	static ApiVersion parse(String value) {
 		Assert.hasText(value, "Value must not be empty");
 		Matcher matcher = PATTERN.matcher(value);
-		Assert.isTrue(matcher.matches(), "Malformed version number '" + value + "'");
+		Assert.isTrue(matcher.matches(), () -> "Malformed version number '" + value + "'");
 		try {
 			int major = Integer.parseInt(matcher.group(1));
 			int minor = Integer.parseInt(matcher.group(2));

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildOwner.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildOwner.java
@@ -49,7 +49,7 @@ class BuildOwner implements Owner {
 
 	private long getValue(Map<String, String> env, String name) {
 		String value = env.get(name);
-		Assert.state(StringUtils.hasText(value), "Missing '" + name + "' value from the builder environment");
+		Assert.state(StringUtils.hasText(value), () -> "Missing '" + name + "' value from the builder environment");
 		try {
 			return Long.parseLong(value);
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuilderMetadata.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuilderMetadata.java
@@ -123,7 +123,7 @@ class BuilderMetadata extends MappedObject {
 		Assert.notNull(imageConfig, "ImageConfig must not be null");
 		Map<String, String> labels = imageConfig.getLabels();
 		String json = (labels != null) ? labels.get(LABEL_NAME) : null;
-		Assert.notNull(json, "No '" + LABEL_NAME + "' label found in image config");
+		Assert.notNull(json, () -> "No '" + LABEL_NAME + "' label found in image config");
 		return fromJson(json);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/StackId.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/StackId.java
@@ -77,7 +77,7 @@ class StackId {
 	private static StackId fromImageConfig(ImageConfig imageConfig) {
 		Map<String, String> labels = imageConfig.getLabels();
 		String value = (labels != null) ? labels.get(LABEL_NAME) : null;
-		Assert.state(StringUtils.hasText(value), "Missing '" + LABEL_NAME + "' stack label");
+		Assert.state(StringUtils.hasText(value), () -> "Missing '" + LABEL_NAME + "' stack label");
 		return new StackId(value);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/ImageReference.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/ImageReference.java
@@ -151,7 +151,7 @@ public final class ImageReference {
 	 * @throws IllegalStateException if the image reference contains a digest
 	 */
 	public ImageReference inTaggedForm() {
-		Assert.state(this.digest == null, "Image reference '" + this + "' cannot contain a digest");
+		Assert.state(this.digest == null, () -> "Image reference '" + this + "' cannot contain a digest");
 		return new ImageReference(this.name, (this.tag != null) ? this.tag : LATEST, this.digest);
 	}
 
@@ -163,7 +163,7 @@ public final class ImageReference {
 	 */
 	public static ImageReference forJarFile(File jarFile) {
 		String filename = jarFile.getName();
-		Assert.isTrue(filename.toLowerCase().endsWith(".jar"), "File '" + jarFile + "' is not a JAR");
+		Assert.isTrue(filename.toLowerCase().endsWith(".jar"), () -> "File '" + jarFile + "' is not a JAR");
 		filename = filename.substring(0, filename.length() - 4);
 		int firstDot = filename.indexOf('.');
 		if (firstDot == -1) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/LayerId.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/LayerId.java
@@ -85,7 +85,7 @@ public final class LayerId {
 	public static LayerId of(String value) {
 		Assert.hasText(value, "Value must not be empty");
 		int i = value.indexOf(':');
-		Assert.isTrue(i >= 0, "Invalid layer ID '" + value + "'");
+		Assert.isTrue(i >= 0, () -> "Invalid layer ID '" + value + "'");
 		return new LayerId(value, value.substring(0, i), value.substring(i + 1));
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/VolumeName.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/VolumeName.java
@@ -124,7 +124,8 @@ public final class VolumeName {
 	}
 
 	private static String asHexString(byte[] digest, int digestLength) {
-		Assert.isTrue(digestLength <= digest.length, "DigestLength must be less than or equal to " + digest.length);
+		Assert.isTrue(digestLength <= digest.length,
+				() -> "DigestLength must be less than or equal to " + digest.length);
 		byte[] shortDigest = new byte[6];
 		System.arraycopy(digest, 0, shortDigest, 0, shortDigest.length);
 		return String.format("%0" + digestLength + "x", new BigInteger(1, shortDigest));

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/json/MappedObject.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/json/MappedObject.java
@@ -200,7 +200,7 @@ public class MappedObject {
 			if (declaringClass == Object.class) {
 				method.invoke(proxy, args);
 			}
-			Assert.state(args == null || args.length == 0, "Unsupported method " + method);
+			Assert.state(args == null || args.length == 0, () -> "Unsupported method " + method);
 			String name = getName(method.getName());
 			Class<?> type = method.getReturnType();
 			return valueForProperty(name, type);

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/socket/BsdDomainSocket.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/socket/BsdDomainSocket.java
@@ -65,7 +65,7 @@ class BsdDomainSocket extends DomainSocket {
 		public byte[] sunPath = new byte[MAX_PATH_LENGTH];
 
 		private SockaddrUn(byte sunFamily, byte[] path) {
-			Assert.isTrue(path.length < MAX_PATH_LENGTH, "Path cannot exceed " + MAX_PATH_LENGTH + " bytes");
+			Assert.isTrue(path.length < MAX_PATH_LENGTH, () -> "Path cannot exceed " + MAX_PATH_LENGTH + " bytes");
 			System.arraycopy(path, 0, this.sunPath, 0, path.length);
 			this.sunPath[path.length] = 0;
 			this.sunLen = (byte) (fieldOffset("sunPath") + path.length);

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/socket/LinuxDomainSocket.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/socket/LinuxDomainSocket.java
@@ -63,7 +63,7 @@ class LinuxDomainSocket extends DomainSocket {
 		public byte[] sunPath = new byte[MAX_PATH_LENGTH];
 
 		private SockaddrUn(byte sunFamily, byte[] path) {
-			Assert.isTrue(path.length < MAX_PATH_LENGTH, "Path cannot exceed " + MAX_PATH_LENGTH + " bytes");
+			Assert.isTrue(path.length < MAX_PATH_LENGTH, () -> "Path cannot exceed " + MAX_PATH_LENGTH + " bytes");
 			System.arraycopy(path, 0, this.sunPath, 0, path.length);
 			this.sunPath[path.length] = 0;
 			this.sunFamily = sunFamily;

--- a/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/main/java/org/springframework/boot/jarmode/layertools/IndexedLayers.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/main/java/org/springframework/boot/jarmode/layertools/IndexedLayers.java
@@ -69,7 +69,7 @@ class IndexedLayers implements Layers {
 		Matcher matcher = LAYER_PATTERN.matcher(name);
 		if (matcher.matches()) {
 			String layer = matcher.group(1);
-			Assert.state(this.layers.contains(layer), "Unexpected layer '" + layer + "'");
+			Assert.state(this.layers.contains(layer), () -> "Unexpected layer '" + layer + "'");
 			return layer;
 		}
 		return this.layers.contains(APPLICATION_LAYER) ? APPLICATION_LAYER : SPRING_BOOT_APPLICATION_LAYER;

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/ImagePackager.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/ImagePackager.java
@@ -52,8 +52,8 @@ public class ImagePackager extends Packager {
 
 	private void packageImage(Libraries libraries, AbstractJarWriter writer) throws IOException {
 		File source = isAlreadyPackaged() ? getBackupFile() : getSource();
-		Assert.state(source.exists() && source.isFile(), "Unable to read jar file " + source);
-		Assert.state(!isAlreadyPackaged(source), "Repackaged jar file " + source + " cannot be exported");
+		Assert.state(source.exists() && source.isFile(), () -> "Unable to read jar file " + source);
+		Assert.state(!isAlreadyPackaged(source), () -> "Repackaged jar file " + source + " cannot be exported");
 		try (JarFile sourceJar = new JarFile(source)) {
 			write(sourceJar, libraries, writer);
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Layer.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Layer.java
@@ -40,9 +40,9 @@ public class Layer {
 	 */
 	public Layer(String name) {
 		Assert.hasText(name, "Name must not be empty");
-		Assert.isTrue(PATTERN.matcher(name).matches(), "Malformed layer name '" + name + "'");
+		Assert.isTrue(PATTERN.matcher(name).matches(), () -> "Malformed layer name '" + name + "'");
 		Assert.isTrue(!name.equalsIgnoreCase("ext") && !name.toLowerCase().startsWith("springboot"),
-				"Layer name '" + name + "' is reserved");
+				() -> "Layer name '" + name + "' is reserved");
 		this.name = name;
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Packager.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Packager.java
@@ -403,7 +403,7 @@ public abstract class Packager {
 		private String transformName(String name) {
 			if (this.layout instanceof LayeredLayout) {
 				Layer layer = this.layers.getLayer(name);
-				Assert.state(layer != null, "Invalid 'null' layer from " + this.layers.getClass().getName());
+				Assert.state(layer != null, () -> "Invalid 'null' layer from " + this.layers.getClass().getName());
 				return ((LayeredLayout) this.layout).getRepackagedClassesLocation(layer) + name;
 			}
 			return this.layout.getRepackagedClassesLocation() + name;
@@ -433,7 +433,7 @@ public abstract class Packager {
 					String location = getLocation(library);
 					if (location != null) {
 						Library existing = this.libraryEntryNames.putIfAbsent(location + library.getName(), library);
-						Assert.state(existing == null, "Duplicate library " + library.getName());
+						Assert.state(existing == null, () -> "Duplicate library " + library.getName());
 					}
 				}
 			});
@@ -444,7 +444,7 @@ public abstract class Packager {
 			if (layout instanceof LayeredLayout) {
 				Layers layers = Packager.this.layers;
 				Layer layer = layers.getLayer(library);
-				Assert.state(layer != null, "Invalid 'null' library layer from " + layers.getClass().getName());
+				Assert.state(layer != null, () -> "Invalid 'null' library layer from " + layers.getClass().getName());
 				return ((LayeredLayout) layout).getLibraryLocation(library.getName(), library.getScope(), layer);
 			}
 			return layout.getLibraryLocation(library.getName(), library.getScope());
@@ -459,7 +459,7 @@ public abstract class Packager {
 		@Override
 		public String sha1Hash(String name) throws IOException {
 			Library library = this.libraryEntryNames.get(name);
-			Assert.notNull(library, "No library found for entry name '" + name + "'");
+			Assert.notNull(library, () -> "No library found for entry name '" + name + "'");
 			return FileUtils.sha1Hash(library.getFile());
 		}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/PropertiesLauncher.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/PropertiesLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -371,7 +371,7 @@ public class PropertiesLauncher extends Launcher {
 		if (classLoader == null) {
 			classLoader = newClassLoader(type, NO_PARAMS);
 		}
-		Assert.notNull(classLoader, "Unable to create class loader for " + className);
+		Assert.notNull(classLoader, () -> "Unable to create class loader for " + className);
 		return classLoader;
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/classpath/ModifiedClassPathExtension.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/classpath/ModifiedClassPathExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ class ModifiedClassPathExtension implements InvocationInterceptor {
 				}
 			}
 		}
-		Assert.state(method != null, "Unable to find " + testClass + "." + testMethodName);
+		Assert.state(method != null, () -> "Unable to find " + testClass + "." + testMethodName);
 		return method;
 	}
 


### PR DESCRIPTION
Hi,

this PR changes some `Assert` calls to make use of their `Supplier` variants in order to save the overhead of String construction in case the assertion passes.

Cheers,
Christoph