### PR TITLE
Dirty changes when using CqlSessionBuilder to create several sessions

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraAutoConfiguration.java
@@ -44,6 +44,7 @@ import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Scope;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Cassandra.
@@ -69,6 +70,7 @@ public class CassandraAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
+	@Scope("prototype")
 	public CqlSessionBuilder cassandraSessionBuilder(CassandraProperties properties,
 			DriverConfigLoader driverConfigLoader, ObjectProvider<CqlSessionBuilderCustomizer> builderCustomizers) {
 		CqlSessionBuilder builder = CqlSession.builder().withConfigLoader(driverConfigLoader);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cassandra/CassandraAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cassandra/CassandraAutoConfigurationTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.autoconfigure.cassandra;
 
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
@@ -41,6 +43,17 @@ class CassandraAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(CassandraAutoConfiguration.class));
+
+	@Test
+	void cqlSessionBuilderThreadSafe() {
+		this.contextRunner.run((context) -> {
+			CqlIdentifier keyspace = CqlIdentifier.fromCql("test");
+			assertThat(context).hasSingleBean(CqlSessionBuilder.class);
+			assertThat(context.getBean(CqlSessionBuilder.class).withKeyspace(keyspace))
+					.hasFieldOrPropertyWithValue("keyspace", keyspace);
+			assertThat(context.getBean(CqlSessionBuilder.class)).hasFieldOrPropertyWithValue("keyspace", null);
+		});
+	}
 
 	@Test
 	void driverConfigLoaderWithDefaultConfiguration() {


### PR DESCRIPTION
`CqlSessionBuilder` is a mutable builder, hence this may lead to unexpected situations.
 Here is a configuration that shows a problem:
```java
@Configuration(proxyBeanMethods = false)
class CassandraConfiguration {

	@Bean
	@DependsOn("session2")
	public CqlSession session1(CqlSessionBuilder builder) {
		return builder.build();
	}

	@Bean
	public CqlSession session2(CqlSessionBuilder builder) {
		return builder.withKeyspace("test").build();
	}

}

```

This PR adds `@Scope(prototype)` to avoid such problems 😃 