### PR TITLE
Upgrade to Testcontainers 1.12.5

### DIFF
--- a/spring-boot-project/spring-boot-parent/build.gradle
+++ b/spring-boot-project/spring-boot-parent/build.gradle
@@ -12,7 +12,7 @@ javaPlatform {
 
 dependencies {
 	api(enforcedPlatform(project(":spring-boot-project:spring-boot-dependencies")))
-	api(enforcedPlatform("org.testcontainers:testcontainers-bom:1.12.4"))
+	api(enforcedPlatform("org.testcontainers:testcontainers-bom:1.12.5"))
 	
 	constraints {
 		api("com.vaadin.external.google:android-json:0.0.20131108.vaadin1")


### PR DESCRIPTION
Hi,

this PR upgrades the testcontainers-java library to version 1.12.5.

Cheers,
Christoph