### PR TITLE
Upgrade to JUnit Jupiter 5.6.0

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 	implementation("io.spring.javaformat:spring-javaformat-gradle-plugin:${javaFormatVersion}")
 	testImplementation("org.assertj:assertj-core:3.11.1")
 	testImplementation("org.apache.logging.log4j:log4j-core:2.12.1")
-	testImplementation("org.junit.jupiter:junit-jupiter:5.5.2")
+	testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
 }
 
 checkstyle {

--- a/buildSrc/src/test/java/org/springframework/boot/build/testing/TestFailuresPluginIntegrationTests.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/testing/TestFailuresPluginIntegrationTests.java
@@ -149,7 +149,7 @@ class TestFailuresPluginIntegrationTests {
 			writer.println("}");
 			writer.println();
 			writer.println("dependencies {");
-			writer.println("	testImplementation 'org.junit.jupiter:junit-jupiter:5.5.2'");
+			writer.println("	testImplementation 'org.junit.jupiter:junit-jupiter:5.6.0'");
 			writer.println("	testImplementation 'org.assertj:assertj-core:3.11.1'");
 			writer.println("}");
 			writer.println();

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -942,7 +942,7 @@ bom {
 			]
 		}
 	}
-	library("JUnit Jupiter", "5.5.2") {
+	library("JUnit Jupiter", "5.6.0") {
 		group("org.junit") {
 			imports = [
 				"junit-bom"

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/docs/RunningDocumentationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/docs/RunningDocumentationTests.java
@@ -20,7 +20,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -41,7 +41,7 @@ class RunningDocumentationTests {
 	GradleBuild gradleBuild;
 
 	@TestTemplate
-	@DisabledOnJre(JRE.JAVA_13)
+	@DisabledForJreRange(min = JRE.JAVA_13)
 	void bootRunMain() throws IOException {
 		// Testing of convention mappings is flakey between 5.2 and 6.0 inclusive
 		// https://github.com/gradle/gradle/issues/11323

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/SpringBootPluginIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/SpringBootPluginIntegrationTests.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -47,13 +47,13 @@ class SpringBootPluginIntegrationTests {
 				.contains("Spring Boot plugin requires Gradle 5.6 or later. The current version is Gradle 5.5.1");
 	}
 
-	@DisabledOnJre(JRE.JAVA_13)
+	@DisabledForJreRange(min = JRE.JAVA_13)
 	@Test
 	void succeedWithVersionOfGradleHigherThanRequired() {
 		this.gradleBuild.gradleVersion("5.6.1").build();
 	}
 
-	@DisabledOnJre(JRE.JAVA_13)
+	@DisabledForJreRange(min = JRE.JAVA_13)
 	@Test
 	void succeedWithVersionOfGradleMatchingWhatIsRequired() {
 		this.gradleBuild.gradleVersion("5.6").build();

--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/classpath/ModifiedClassPathExtension.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/classpath/ModifiedClassPathExtension.java
@@ -16,10 +16,8 @@
 
 package org.springframework.boot.testsupport.classpath;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URLClassLoader;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -76,7 +74,7 @@ class ModifiedClassPathExtension implements InvocationInterceptor {
 			invocation.proceed();
 			return;
 		}
-		fakeInvocation(invocation);
+		invocation.skip();
 		runTestWithModifiedClassPath(invocationContext, extensionContext);
 	}
 
@@ -129,17 +127,7 @@ class ModifiedClassPathExtension implements InvocationInterceptor {
 			invocation.proceed();
 			return;
 		}
-		fakeInvocation(invocation);
-	}
-
-	private void fakeInvocation(Invocation<Void> invocation) {
-		try {
-			Field field = ReflectionUtils.findField(invocation.getClass(), "invoked");
-			ReflectionUtils.makeAccessible(field);
-			ReflectionUtils.setField(field, invocation, new AtomicBoolean(true));
-		}
-		catch (Throwable ex) {
-		}
+		invocation.skip();
 	}
 
 	private boolean isModifiedClassPathClassLoader(ExtensionContext extensionContext) {


### PR DESCRIPTION
Hi,

this PR upgrades JUnit Jupiter to version 5.6.0. There was a field renamed in the internals that broke the reflection calls in `ModifiedClassPathExtension`, but luckily there as a new `Invocation.skip()` that makes the reflection obsolete.

I also used the new `@DisabledForJreRange` annotation already in order to disable some tests from JDK 13 onwards. That should make an eventual upgrade to JDK 14 smoother.

Let me know what you think.
Cheers,
Christoph 