### PR TITLE
Unnecessary use of / in classpath:/db/changelog/db.changelog-master.yaml prevents Liquibase from identifying that a change set has already been applied when run from the command line

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/liquibase/LiquibaseEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/liquibase/LiquibaseEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,10 +104,10 @@ class LiquibaseEndpointTests {
 							.liquibaseBeans().getContexts().get(context.getId()).getLiquibaseBeans();
 					assertThat(liquibaseBeans.get("liquibase").getChangeSets()).hasSize(1);
 					assertThat(liquibaseBeans.get("liquibase").getChangeSets().get(0).getChangeLog())
-							.isEqualTo("classpath:/db/changelog/db.changelog-master.yaml");
+							.isEqualTo("classpath:db/changelog/db.changelog-master.yaml");
 					assertThat(liquibaseBeans.get("liquibaseBackup").getChangeSets()).hasSize(1);
 					assertThat(liquibaseBeans.get("liquibaseBackup").getChangeSets().get(0).getChangeLog())
-							.isEqualTo("classpath:/db/changelog/db.changelog-master-backup.yaml");
+							.isEqualTo("classpath:db/changelog/db.changelog-master-backup.yaml");
 				});
 	}
 
@@ -157,7 +157,7 @@ class LiquibaseEndpointTests {
 
 		private SpringLiquibase createSpringLiquibase(String changeLog, DataSource dataSource) {
 			SpringLiquibase liquibase = new SpringLiquibase();
-			liquibase.setChangeLog("classpath:/db/changelog/" + changeLog);
+			liquibase.setChangeLog("classpath:db/changelog/" + changeLog);
 			liquibase.setShouldRun(true);
 			liquibase.setDataSource(dataSource);
 			return liquibase;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public class LiquibaseProperties {
 	/**
 	 * Change log configuration path.
 	 */
-	private String changeLog = "classpath:/db/changelog/db.changelog-master.yaml";
+	private String changeLog = "classpath:db/changelog/db.changelog-master.yaml";
 
 	/**
 	 * Comma-separated list of runtime contexts to use.

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1088,7 +1088,7 @@
       "name": "liquibase.change-log",
       "type": "java.lang.String",
       "description": "Change log configuration path.",
-      "defaultValue": "classpath:/db/changelog/db.changelog-master.yaml",
+      "defaultValue": "classpath:db/changelog/db.changelog-master.yaml",
       "deprecation": {
         "replacement": "spring.liquibase.change-log",
         "level": "error"

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,7 +102,7 @@ class LiquibaseAutoConfigurationTests {
 	void defaultSpringLiquibase() {
 		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
 				.run(assertLiquibase((liquibase) -> {
-					assertThat(liquibase.getChangeLog()).isEqualTo("classpath:/db/changelog/db.changelog-master.yaml");
+					assertThat(liquibase.getChangeLog()).isEqualTo("classpath:db/changelog/db.changelog-master.yaml");
 					assertThat(liquibase.getContexts()).isNull();
 					assertThat(liquibase.getDefaultSchema()).isNull();
 					assertThat(liquibase.isDropFirst()).isFalse();
@@ -112,26 +112,26 @@ class LiquibaseAutoConfigurationTests {
 	@Test
 	void changelogXml() {
 		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
-				.withPropertyValues("spring.liquibase.change-log:classpath:/db/changelog/db.changelog-override.xml")
+				.withPropertyValues("spring.liquibase.change-log:classpath:db/changelog/db.changelog-override.xml")
 				.run(assertLiquibase((liquibase) -> assertThat(liquibase.getChangeLog())
-						.isEqualTo("classpath:/db/changelog/db.changelog-override.xml")));
+						.isEqualTo("classpath:db/changelog/db.changelog-override.xml")));
 	}
 
 	@Test
 	void changelogJson() {
 		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
-				.withPropertyValues("spring.liquibase.change-log:classpath:/db/changelog/db.changelog-override.json")
+				.withPropertyValues("spring.liquibase.change-log:classpath:db/changelog/db.changelog-override.json")
 				.run(assertLiquibase((liquibase) -> assertThat(liquibase.getChangeLog())
-						.isEqualTo("classpath:/db/changelog/db.changelog-override.json")));
+						.isEqualTo("classpath:db/changelog/db.changelog-override.json")));
 	}
 
 	@Test
 	@EnabledOnJre(JRE.JAVA_8)
 	void changelogSql() {
 		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
-				.withPropertyValues("spring.liquibase.change-log:classpath:/db/changelog/db.changelog-override.sql")
+				.withPropertyValues("spring.liquibase.change-log:classpath:db/changelog/db.changelog-override.sql")
 				.run(assertLiquibase((liquibase) -> assertThat(liquibase.getChangeLog())
-						.isEqualTo("classpath:/db/changelog/db.changelog-override.sql")));
+						.isEqualTo("classpath:db/changelog/db.changelog-override.sql")));
 	}
 
 	@Test
@@ -374,7 +374,7 @@ class LiquibaseAutoConfigurationTests {
 		@Bean
 		SpringLiquibase springLiquibase(DataSource dataSource) {
 			SpringLiquibase liquibase = new SpringLiquibase();
-			liquibase.setChangeLog("classpath:/db/changelog/db.changelog-master.yaml");
+			liquibase.setChangeLog("classpath:db/changelog/db.changelog-master.yaml");
 			liquibase.setShouldRun(true);
 			liquibase.setDataSource(dataSource);
 			return liquibase;

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-liquibase/src/test/java/smoketest/liquibase/SampleLiquibaseApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-liquibase/src/test/java/smoketest/liquibase/SampleLiquibaseApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,10 +59,10 @@ class SampleLiquibaseApplicationTests {
 		assertThat(output).contains("Successfully acquired change log lock")
 				.contains("Creating database history table with name: PUBLIC.DATABASECHANGELOG")
 				.contains("Table person created")
-				.contains("ChangeSet classpath:/db/changelog/db.changelog-master.yaml::1::"
+				.contains("ChangeSet classpath:db/changelog/db.changelog-master.yaml::1::"
 						+ "marceloverdijk ran successfully")
 				.contains("New row inserted into person")
-				.contains("ChangeSet classpath:/db/changelog/"
+				.contains("ChangeSet classpath:db/changelog/"
 						+ "db.changelog-master.yaml::2::marceloverdijk ran successfully")
 				.contains("Successfully released change log lock");
 	}


### PR DESCRIPTION
Liquibase computes identity of ChangeSet using three field:

* id
* author
* filename

Where `filename` is changelog path.

When spring-boot runs liquibase migrations at startup, it by default (and usually) reads changelog file from classpath (not from local filesystem).

This makes liquibase to fill it's `DATABASECHANGELOG.FILENAME` field with this value: `classpath:/db/changelog/db.changelog-master.yaml` (the default value of `LiquibaseProperties.changeLog` field).

Then, if you try to run liquibase as maven plugin, you can't pass `liquibase.changeLogFile` property with `classpath:` prefix. You must pass it without prefix and without a leading slash. This way liquibase uses right classpath location.

```
mvn process-resources liquibase:updateSQL \
    -Dliquibase.url=jdbc:mysql://localhost:3306/db \
    -Dliquibase.username=user -Dliquibase.password=password \
    -Dliquibase.changeLogFile=db/changelog/db.changelog-master.yaml \
    -Dliquibase.verbose=true
```

But, this doesn't work for the following reason:

Liquibase creates the identity of each ChangeSet based on `id`, `author` and `filename`. And when you run liquibase as maven plugin, the `filename` of each ChangeSet is `db/changelog/db.changelog-master.yaml`, while filename in already existent rows of `DATABASECHANGELOG` is `classpath:/db/changelog/db.changelog-master.yaml`. **These strings are not equal.**

**This makes liquibase to consider all ChangeSets as new, not yet applied, and try to reapply them.**

**The good news:** it's already handled by Liquibase (see this PR https://github.com/liquibase/liquibase/pull/187). To handle this, Liquibase removes `classpath:` prefix, when compares changelog filenames.

**The bad news:** it only strips `classpath:` prefix, but not the leading slash. See https://github.com/liquibase/liquibase/blob/bc49461eb63e45fcf6bda0a15c7b41ef44936457/liquibase-core/src/main/java/liquibase/changelog/filter/ShouldRunChangeSetFilter.java#L69

So, it actually compares `db/changelog/db.changelog-master.yaml` to `/db/changelog/db.changelog-master.yaml`. These strings are almost equal. :)

### So, back to this PR:

This patch just removes the leading slash from default `changeLog` property, as it is redundant anyway (See https://github.com/spring-projects/spring-framework/blob/e66e41029ccb31df18e2cc56c9fc87119cc90bd2/spring-core/src/main/java/org/springframework/core/io/ClassPathResource.java#L81).

With this small change liquibase is happy and understands that these are the same changesets, when you run liquibase as maven plugin.

This is useful, for example, to rollback changesets or to inspect changesets generated SQL.