### PR TITLE
Fix broken documentation links

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/attributes.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/attributes.adoc
@@ -27,12 +27,12 @@
 :spring-boot-api: https://docs.spring.io/spring-boot/docs/{spring-boot-version}/api/
 :spring-boot-docs: https://docs.spring.io/spring-boot/docs/{spring-boot-version}/reference
 :spring-boot-master-code: https://github.com/{github-repo}/tree/master
-:spring-boot-current-docs: https://docs.spring.io/spring-boot/docs/current/reference
+:spring-boot-current-docs: https://docs.spring.io/spring-boot/docs/current/reference/
 :spring-boot-actuator-restapi: https://docs.spring.io/spring-boot/docs/{spring-boot-version}/actuator-api/
 :spring-boot-maven-plugin-docs: https://docs.spring.io/spring-boot/docs/{spring-boot-version}/maven-plugin/html/
 :spring-boot-gradle-plugin-docs: https://docs.spring.io/spring-boot/docs/{spring-boot-version}/gradle-plugin/reference/html/
 :spring-boot-gradle-plugin-pdfdocs: https://docs.spring.io/spring-boot/docs/{spring-boot-version}/gradle-plugin/reference/pdf/spring-boot-gradle-plugin-reference.pdf
-:spring-boot-gradle-plugin-api: https://docs.spring.io/spring-boot/docs/{spring-boot-version}/gradle-plugin/reference/api/
+:spring-boot-gradle-plugin-api: https://docs.spring.io/spring-boot/docs/{spring-boot-version}/gradle-plugin/api/
 
 :spring-boot-module-code: {spring-boot-code}/spring-boot-project/spring-boot/src/main/java/org/springframework/boot
 :spring-boot-module-api: {spring-boot-api}/org/springframework/boot

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/documentation-overview.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/documentation-overview.adoc
@@ -11,8 +11,8 @@ It serves as a map for the rest of the document.
 == About the Documentation
 The Spring Boot reference guide is available as:
 
-* {spring-boot-docs}/html[Multi-page HTML]
-* {spring-boot-docs}/htmlsingle[Single page HTML]
+* {spring-boot-docs}/html/[Multi-page HTML]
+* {spring-boot-docs}/htmlsingle/[Single page HTML]
 * {spring-boot-docs}/pdf/spring-boot-reference.pdf[PDF]
 
 The latest copy is available at {spring-boot-current-docs}.
@@ -88,4 +88,4 @@ Finally, we have a few topics for more advanced users:
 
 * *Spring Boot Applications Deployment:* <<deployment.adoc#cloud-deployment, Cloud Deployment>> | <<deployment.adoc#deployment-service, OS Service>>
 * *Build tool plugins:* <<build-tool-plugins.adoc#build-tool-plugins-maven-plugin, Maven>> | <<build-tool-plugins.adoc#build-tool-plugins-gradle-plugin, Gradle>>
-* *Appendix:* <<appendix-application-properties.adoc#common-application-properties,Application Properties>> | <<appendix-configuration-metadata.adoc#configuration-metadata,Configuration Metadata>> | <<appendix-auto-configuration-classes.adoc#auto-configuration-classes,Auto-configuration Classes>> | <<appendix-test-auto-configuration.adoc#test-auto-configuration,Test Auto-configuration Annotations>> | <<appendix-executable-jar-format.adoc#executable-jar,Executable Jars>> | <<appendix-dependency-versions.adoc#appendex-dependency-versions,Dependency Versions>>
+* *Appendix:* <<appendix-application-properties.adoc#common-application-properties,Application Properties>> | <<appendix-configuration-metadata.adoc#configuration-metadata,Configuration Metadata>> | <<appendix-auto-configuration-classes.adoc#auto-configuration-classes,Auto-configuration Classes>> | <<appendix-test-auto-configuration.adoc#test-auto-configuration,Test Auto-configuration Annotations>> | <<appendix-executable-jar-format.adoc#executable-jar,Executable Jars>> | <<appendix-dependency-versions.adoc#dependency-versions,Dependency Versions>>

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/getting-started.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/getting-started.adoc
@@ -703,7 +703,7 @@ To do so, insert the following lines just below the `dependencies` section:
 
 NOTE: The `spring-boot-starter-parent` POM includes `<executions>` configuration to bind the `repackage` goal.
 If you do not use the parent POM, you need to declare this configuration yourself.
-See the {spring-boot-maven-plugin-docs}/usage.html[plugin documentation] for details.
+See the {spring-boot-maven-plugin-docs}#getting-started[plugin documentation] for details.
 
 Save your `pom.xml` and run `mvn package` from the command line, as follows:
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto.adoc
@@ -156,7 +156,7 @@ NOTE: Only production configuration is filtered that way (in other words, no fil
 TIP: If you enable the `addResources` flag, the `spring-boot:run` goal can add `src/main/resources` directly to the classpath (for hot reloading purposes).
 Doing so circumvents the resource filtering and this feature.
 Instead, you can use the `exec:java` goal or customize the plugin's configuration.
-See the {spring-boot-maven-plugin-docs}/usage.html[plugin usage page] for more details.
+See the {spring-boot-maven-plugin-docs}#getting-started[plugin usage page] for more details.
 
 If you do not use the starter parent, you need to include the following  element inside the `<build/>` element of your `pom.xml`:
 
@@ -2224,7 +2224,7 @@ If you define a `@Configuration` with a `WebSecurityConfigurerAdapter` in your a
 [[howto-change-the-user-details-service-and-add-user-accounts]]
 === Change the UserDetailsService and Add User Accounts
 If you provide a `@Bean` of type `AuthenticationManager`, `AuthenticationProvider`, or `UserDetailsService`, the default `@Bean` for `InMemoryUserDetailsManager` is not created.
-This means you have the full feature set of Spring Security available (such as {spring-security-docs}#jc-authentication[various authentication options]).
+This means you have the full feature set of Spring Security available (such as {spring-security-docs}#servlet-authentication[various authentication options]).
 
 The easiest way to add user accounts is to provide your own `UserDetailsService` bean.
 
@@ -2320,7 +2320,7 @@ See {spring-boot-autoconfigure-module-code}/groovy/template/GroovyTemplateAutoCo
 [[howto-reload-fast-restart]]
 === Fast Application Restarts
 The `spring-boot-devtools` module includes support for automatic application restarts.
-While not as fast as technologies such as https://jrebel.com/software/jrebel/[JRebel] it is usually significantly faster than a "`cold start`".
+While not as fast as technologies such as https://www.jrebel.com/products/jrebel[JRebel] it is usually significantly faster than a "`cold start`".
 You should probably give it a try before investigating some of the more complex reload options discussed later in this document.
 
 For more details, see the <<using-spring-boot.adoc#using-boot-devtools>> section.
@@ -2369,7 +2369,7 @@ To generate build information with Maven, add an execution for the `build-info` 
 	</build>
 ----
 
-TIP: See the {spring-boot-maven-plugin-docs}/#build-info[Spring Boot Maven Plugin documentation] for more details.
+TIP: See the {spring-boot-maven-plugin-docs}#goals-build-info[Spring Boot Maven Plugin documentation] for more details.
 
 The following example does the same with Gradle:
 
@@ -2481,7 +2481,7 @@ However, you must additionally add an `<executions>` section, as follows:
 	</build>
 ----
 
-See the {spring-boot-maven-plugin-docs}/usage.html[plugin documentation] for full usage details.
+See the {spring-boot-maven-plugin-docs}#getting-started[plugin documentation] for full usage details.
 
 
 
@@ -2595,7 +2595,7 @@ In Maven, the executable jar must be the main artifact and you can add a classif
 === Remote Debug a Spring Boot Application Started with Maven
 To attach a remote debugger to a Spring Boot application that was started with Maven, you can use the `jvmArguments` property of the {spring-boot-maven-plugin-docs}[maven plugin].
 
-See {spring-boot-maven-plugin-docs}/examples/run-debug.html[this example] for more details.
+See {spring-boot-maven-plugin-docs}#run-example-debug[this example] for more details.
 
 
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/index.htmladoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/index.htmladoc
@@ -25,4 +25,4 @@ The reference documentation has the following appendices:
 <<appendix-auto-configuration-classes.adoc#auto-configuration-classes,Auto-configuration Classes>> :: Auto-configuration classes provided by Spring Boot.
 <<appendix-test-auto-configuration.adoc#test-auto-configuration,Test Auto-configuration Annotations>> :: Test-autoconfiguration annotations used to test slices of your application.
 <<appendix-executable-jar-format.adoc#executable-jar,Executable Jars>> :: Spring Boot's executable jars, their launchers, and their format.
-<<appendix-dependency-versions.adoc#appendix-dependency-versions,Dependency Versions>> :: Details of the dependencies that are managed by Spring Boot.
+<<appendix-dependency-versions.adoc#dependency-versions,Dependency Versions>> :: Details of the dependencies that are managed by Spring Boot.

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
@@ -147,7 +147,7 @@ If your application is a web application (Spring MVC, Spring WebFlux, or Jersey)
   Requires a dependency on `micrometer-registry-prometheus`.
 |===
 
-To learn more about the Actuator's endpoints and their request and response formats, please refer to the separate API documentation ({spring-boot-actuator-restapi}/html/[HTML] or {spring-boot-actuator-restapi}/pdf/spring-boot-actuator-web-api.pdf[PDF]).
+To learn more about the Actuator's endpoints and their request and response formats, please refer to the separate API documentation ({spring-boot-actuator-restapi}html/[HTML] or {spring-boot-actuator-restapi}pdf/spring-boot-actuator-web-api.pdf[PDF]).
 
 
 
@@ -363,7 +363,7 @@ A typical Spring Security configuration might look something like the following 
 
 The preceding example uses `EndpointRequest.toAnyEndpoint()` to match a request to any endpoint and then ensures that all have the `ENDPOINT_ADMIN` role.
 Several other matcher methods are also available on `EndpointRequest`.
-See the API documentation ({spring-boot-actuator-restapi}/html[HTML] or {spring-boot-actuator-restapi}/pdf/spring-boot-actuator-web-api.pdf[PDF]) for details.
+See the API documentation ({spring-boot-actuator-restapi}html[HTML] or {spring-boot-actuator-restapi}pdf/spring-boot-actuator-web-api.pdf[PDF]) for details.
 
 If you deploy applications behind a firewall, you may prefer that all your actuator endpoints can be accessed without requiring authentication.
 You can do so by changing the configprop:management.endpoints.web.exposure.include[] property, as follows:

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-cli.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-cli.adoc
@@ -171,7 +171,7 @@ Doing so consults Spring Boot's default dependency metadata to deduce the artifa
 
 NOTE: The default metadata is tied to the version of the CLI that you use.
 It changes only when you move to a new version of the CLI, putting you in control of when the versions of your dependencies may change.
-A table showing the dependencies and their versions that are included in the default metadata can be found in the <<appendix-dependency-versions.adoc#appendix-dependency-versions,appendix>>.
+A table showing the dependencies and their versions that are included in the default metadata can be found in the <<appendix-dependency-versions.adoc#dependency-versions,appendix>>.
 
 
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -3249,7 +3249,7 @@ Alternatively, you can define your own `OpaqueTokenIntrospector` bean for servle
 ==== Authorization Server
 Currently, Spring Security does not provide support for implementing an OAuth 2.0 Authorization Server.
 However, this functionality is available from the {spring-security-oauth2}[Spring Security OAuth] project, which will eventually be superseded by Spring Security completely.
-Until then, you can use the `spring-security-oauth2-autoconfigure` module to easily set up an OAuth 2.0 authorization server; see its https://docs.spring.io/spring-security-oauth2-boot[documentation] for instructions.
+Until then, you can use the `spring-security-oauth2-autoconfigure` module to easily set up an OAuth 2.0 authorization server; see its https://docs.spring.io/spring-security-oauth2-boot/[documentation] for instructions.
 
 
 [[boot-features-security-saml]]
@@ -4393,7 +4393,7 @@ TIP: If you want to fully bypass the auto-configuration for Spring Data Couchbas
 [[boot-features-ldap]]
 === LDAP
 https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol[LDAP] (Lightweight Directory Access Protocol) is an open, vendor-neutral, industry standard application protocol for accessing and maintaining distributed directory information services over an IP network.
-Spring Boot offers auto-configuration for any compliant LDAP server as well as support for the embedded in-memory LDAP server from https://www.ldap.com/unboundid-ldap-sdk-for-java[UnboundID].
+Spring Boot offers auto-configuration for any compliant LDAP server as well as support for the embedded in-memory LDAP server from https://ldap.com/unboundid-ldap-sdk-for-java/[UnboundID].
 
 LDAP abstractions are provided by https://github.com/spring-projects/spring-data-ldap[Spring Data LDAP].
 There is a `spring-boot-starter-data-ldap` "`Starter`" for collecting the dependencies in a convenient way.
@@ -4449,7 +4449,7 @@ You can also inject an auto-configured `LdapTemplate` instance as you would with
 
 [[boot-features-ldap-embedded]]
 ==== Embedded In-memory LDAP Server
-For testing purposes, Spring Boot supports auto-configuration of an in-memory LDAP server from https://www.ldap.com/unboundid-ldap-sdk-for-java[UnboundID].
+For testing purposes, Spring Boot supports auto-configuration of an in-memory LDAP server from https://ldap.com/unboundid-ldap-sdk-for-java/[UnboundID].
 To configure the server, add a dependency to `com.unboundid:unboundid-ldapsdk` and declare a configprop:spring.ldap.embedded.base-dn[] property, as follows:
 
 [source,properties,indent=0,configprops]
@@ -4872,7 +4872,7 @@ By default, ActiveMQ creates a destination if it does not yet exist so that dest
 
 [[boot-features-artemis]]
 ==== Artemis Support
-Spring Boot can auto-configure a `ConnectionFactory` when it detects that https://activemq.apache.org/artemis/[Artemis] is available on the classpath.
+Spring Boot can auto-configure a `ConnectionFactory` when it detects that https://activemq.apache.org/components/artemis/[Artemis] is available on the classpath.
 If the broker is present, an embedded broker is automatically started and configured (unless the mode property has been explicitly set).
 The supported modes are `embedded` (to make explicit that an embedded broker is required and that an error should occur if the broker is not available on the classpath) and `native` (to connect to a broker using the `netty` transport protocol).
 When the latter is configured, Spring Boot configures a `ConnectionFactory` that connects to a broker running on the local machine with the default settings.
@@ -5880,11 +5880,11 @@ If you have migrated your tests to JUnit 5, you should exclude JUnit 4 support, 
 === Test Scope Dependencies
 The `spring-boot-starter-test` "`Starter`" (in the `test` `scope`) contains the following provided libraries:
 
-* https://junit.org/junit5[JUnit 5] (including the vintage engine for backward compatibility with JUnit 4): The de-facto standard for unit testing Java applications.
+* https://junit.org/junit5/[JUnit 5] (including the vintage engine for backward compatibility with JUnit 4): The de-facto standard for unit testing Java applications.
 * {spring-framework-docs}testing.html#integration-testing[Spring Test] & Spring Boot Test: Utilities and integration test support for Spring Boot applications.
-* https://joel-costigliola.github.io/assertj/[AssertJ]: A fluent assertion library.
+* https://assertj.github.io/doc/[AssertJ]: A fluent assertion library.
 * https://github.com/hamcrest/JavaHamcrest[Hamcrest]: A library of matcher objects (also known as constraints or predicates).
-* https://mockito.github.io[Mockito]: A Java mocking framework.
+* https://site.mockito.org/[Mockito]: A Java mocking framework.
 * https://github.com/skyscreamer/JSONassert[JSONassert]: An assertion library for JSON.
 * https://github.com/jayway/JsonPath[JsonPath]: XPath for JSON.
 
@@ -7234,7 +7234,7 @@ These annotations include:
 [[boot-features-class-conditions]]
 ==== Class Conditions
 The `@ConditionalOnClass` and `@ConditionalOnMissingClass` annotations let `@Configuration` classes be included based on the presence or absence of specific classes.
-Due to the fact that annotation metadata is parsed by using https://asm.ow2.org/[ASM], you can use the `value` attribute to refer to the real class, even though that class might not actually appear on the running application classpath.
+Due to the fact that annotation metadata is parsed by using https://asm.ow2.io/[ASM], you can use the `value` attribute to refer to the real class, even though that class might not actually appear on the running application classpath.
 You can also use the `name` attribute if you prefer to specify the class name by using a `String` value.
 
 This mechanism does not apply the same way to `@Bean` methods where typically the return type is the target of the condition: before the condition on the method applies, the JVM will have loaded the class and potentially processed method references which will fail if the class is not present.
@@ -7675,7 +7675,7 @@ If you need the `Mockk` equivalent of the Mockito specific <<boot-features-testi
 [[boot-features-kotlin-resources-further-reading]]
 ==== Further reading
 * {kotlin-docs}[Kotlin language reference]
-* https://slack.kotlinlang.org/[Kotlin Slack] (with a dedicated #spring channel)
+* https://kotlinlang.slack.com/[Kotlin Slack] (with a dedicated #spring channel)
 * https://stackoverflow.com/questions/tagged/spring+kotlin[Stackoverflow with `spring` and `kotlin` tags]
 * https://try.kotlinlang.org/[Try Kotlin in your browser]
 * https://blog.jetbrains.com/kotlin/[Kotlin blog]

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/using-spring-boot.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/using-spring-boot.adoc
@@ -44,7 +44,7 @@ The parent project provides the following features:
 * UTF-8 source encoding.
 * A <<using-boot-dependency-management,Dependency Management section>>, inherited from the spring-boot-dependencies pom, that manages the versions of common dependencies.
 This dependency management lets you omit <version> tags for those dependencies when used in your own pom.
-* An execution of the {spring-boot-maven-plugin-docs}/repackage-mojo.html[`repackage` goal] with a `repackage` execution id.
+* An execution of the {spring-boot-maven-plugin-docs}#goals-repackage[`repackage` goal] with a `repackage` execution id.
 * Sensible https://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html[resource filtering].
 * Sensible plugin configuration (https://www.mojohaus.org/exec-maven-plugin/[exec plugin], https://github.com/ktoso/maven-git-commit-id-plugin[Git commit ID], and https://maven.apache.org/plugins/maven-shade-plugin/[shade]).
 * Sensible resource filtering for `application.properties` and `application.yml` including profile-specific files (for example, `application-dev.properties` and `application-dev.yml`)
@@ -622,7 +622,7 @@ You might also want to use the `JAVA_OPTS` operating system environment variable
 === Hot Swapping
 Since Spring Boot applications are just plain Java applications, JVM hot-swapping should work out of the box.
 JVM hot swapping is somewhat limited with the bytecode that it can replace.
-For a more complete solution, https://jrebel.com/software/jrebel/[JRebel] can be used.
+For a more complete solution, https://www.jrebel.com/products/jrebel[JRebel] can be used.
 
 The `spring-boot-devtools` module also includes support for quick application restarts.
 See the <<using-boot-devtools>> section later in this chapter and the <<howto.adoc#howto-hotswapping, Hot swapping "`How-to`">> for details.


### PR DESCRIPTION
Hi,

this PR fixes a variety of issues related to documentation links on the current master:

- 404 errors (e.g. for the reworked Maven/Gradle plugin docs)
- Some wrong fragments (e.g. pointing to the "Dependency versions" appendix)
- Permanent redirects

Cheers,
Christoph