### PR TITLE
Replace deprecated Concourse resource for pull requests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -7,7 +7,7 @@ resource_types:
 - name: pull-request
   type: docker-image
   source:
-    repository: jtarchie/pr
+    repository: teliaoss/github-pr-resource
 - name: github-status-resource
   type: docker-image
   source:
@@ -43,8 +43,8 @@ resources:
   icon: source-pull
   source:
     access_token: ((github-ci-pull-request-token))
-    repo: ((github-repo-name))
-    base: ((branch))
+    repository: ((github-repo-name))
+    base_branch: ((branch))
     ignore_paths: ["ci/*"]
 - name: github-pre-release
   type: github-release


### PR DESCRIPTION
Hi,

apparently https://github.com/jtarchie/github-pullrequest-resource has been replaced by https://github.com/telia-oss/github-pr-resource since the end of 2018 already.

I don't know if this is a problem for the Concourse setup when we switch resources. I remember https://github.com/concourse/concourse/issues/145 but that should be solved.

Let me know what you think.
Cheers,
Christoph