### PR TITLE
Fixes wrong prints of @ConditionalOnBean for negative matches

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnBeanCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnBeanCondition.java
@@ -67,6 +67,7 @@ import org.springframework.util.StringUtils;
  * @author Jakub Kubrynski
  * @author Stephane Nicoll
  * @author Andy Wilkinson
+ * @author Jorge Cordoba
  * @see ConditionalOnBean
  * @see ConditionalOnMissingBean
  * @see ConditionalOnSingleCandidate
@@ -387,7 +388,7 @@ class OnBeanCondition extends FilteringSpringBootCondition implements Configurat
 
 		private final ClassLoader classLoader;
 
-		private final Class<?> annotationType;
+		private final Class<? extends Annotation> annotationType;
 
 		private final Set<String> names;
 
@@ -581,11 +582,11 @@ class OnBeanCondition extends FilteringSpringBootCondition implements Configurat
 		}
 
 		ConditionMessage.Builder message() {
-			return ConditionMessage.forCondition(ConditionalOnBean.class, this);
+			return ConditionMessage.forCondition(this.annotationType, this);
 		}
 
 		ConditionMessage.Builder message(ConditionMessage message) {
-			return message.andCondition(ConditionalOnBean.class, this);
+			return message.andCondition(this.annotationType, this);
 		}
 
 		@Override

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnMissingBeanTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnMissingBeanTests.java
@@ -21,6 +21,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Collection;
 import java.util.Date;
 import java.util.function.Consumer;
 
@@ -57,6 +58,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Phillip Webb
  * @author Jakub Kubrynski
  * @author Andy Wilkinson
+ * @author Jorge Cordoba
  */
 @SuppressWarnings("resource")
 public class ConditionalOnMissingBeanTests {
@@ -134,6 +136,16 @@ public class ConditionalOnMissingBeanTests {
 					assertThat(context).hasBean("example");
 					assertThat(context.getBean("foo")).isEqualTo("foo");
 				});
+	}
+	@Test
+	void testOnMissingBeanConditionOutputShouldNotContainConditionalOnBeanClassInMessage() {
+		this.contextRunner.withUserConfiguration(ConditionalOnMissingBeanTests.OnBeanNameConfiguration.class).run((context) -> {
+			Collection<ConditionEvaluationReport.ConditionAndOutcomes> conditionAndOutcomes = ConditionEvaluationReport
+					.get(context.getSourceApplicationContext().getBeanFactory()).getConditionAndOutcomesBySource()
+					.values();
+			String message = conditionAndOutcomes.iterator().next().iterator().next().getOutcome().getMessage();
+			assertThat(message).doesNotContain("@ConditionalOnBean (names: foo; SearchStrategy: all) did not find any beans");
+		});
 	}
 
 	@Test


### PR DESCRIPTION
 Fixes wrong prints of @ConditionalOnBean for negative matches in Conditions Evaluation Report by changing a hardcoded ConditionalOnBean.class for annotationType in `org.springframework.boot.autoconfigure.condition.OnBeanCondition.Spec<A>` message methods.

It also changes `Class<?> annotationType` for `Class<? extends Annotation> annotationType` for type safety and to be able to use `org.springframework.boot.autoconfigure.condition.ConditionMessage` forCondition method.

Fixes #19169 
