### PR TITLE
Fix links in Maven Plugin documentation

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/mavenplugin/DocumentPluginGoals.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/mavenplugin/DocumentPluginGoals.java
@@ -109,7 +109,7 @@ public class DocumentPluginGoals extends DefaultTask {
 				writer.println();
 				writer.printf("[[%s-required]]%n", parametersSectionId);
 				writer.println("=== Required parameters");
-				writeParametersTable(writer, mojo.getGoal(), requiredParameters);
+				writeParametersTable(writer, detailsSectionId, requiredParameters);
 			}
 			List<Parameter> optionalParameters = parameters.stream().filter((parameter) -> !parameter.isRequired())
 					.collect(Collectors.toList());

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging.adoc
@@ -332,7 +332,7 @@ Spring Boot repackages the jar file for this project using a custom layout facto
 The layout factory is provided as an implementation of `LayoutFactory` (from `spring-boot-loader-tools`) explicitly specified in the pom.
 If there is only one custom `LayoutFactory` on the plugin classpath and it is listed in `META-INF/spring.factories` then it is unnecessary to explicitly set it in the plugin configuration.
 
-Layout factories are always ignored if an explicit <<goals-repackage-optional-parameters-layout,layout>> is set.
+Layout factories are always ignored if an explicit <<goals-repackage-parameters-details-layoutFactory,layout>> is set.
 
 
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/running.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/running.adoc
@@ -10,7 +10,7 @@ The plugin includes a run goal which can be used to launch your application from
 
 By default the application is executed in a forked process and setting properties on the command-line will not affect the application.
 If you need to specify some JVM arguments (i.e. for debugging purposes), you can use the `jvmArguments` parameter, see <<run-example-debug,Debug the application>> for more details.
-There is also explicit support for <<run-example-system-properties,system properties>> and <<run-example-environment-variable,environment variables>>.
+There is also explicit support for <<run-example-system-properties,system properties>> and <<run-example-environment-variables,environment variables>>.
 
 As enabling a profile is quite common, there is dedicated `profiles` property that offers a shortcut for `-Dspring-boot.run.jvmArguments="-Dspring.profiles.active=dev"`, see <<run-example-active-profiles,Specify active profiles>>.
 
@@ -71,7 +71,7 @@ It is also a helpful way of allowing your front end developers to work without n
 NOTE: A side effect of using this feature is that filtering of resources at build time will not work.
 
 In order to be consistent with the `repackage` goal, the `run` goal builds the classpath in such a way that any dependency that is excluded in the plugin's configuration gets excluded from the classpath as well.
-For more details, see <<run-example-exclude-dependency,the dedicated example>>.
+For more details, see <<repackage-example-exclude-dependency,the dedicated example>>.
 
 Sometimes it is useful to include test dependencies when running the application.
 For example, if you want to run your application in a test mode that uses stub classes.


### PR DESCRIPTION
Hi,

@snicoll's work on the Maven Plugin documentation sparked a thought to check for broken links inside the documentation like I did it for the normal Spring-Boot docs in #19936 and I indeed found some links that do not work. 

Cheers,
Christoph