### PR TITLE
Requests are auto-timed when autotime.enabled is set to false

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/TestController.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/TestController.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.web;
 
+import io.micrometer.core.annotation.Timed;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author Dmytro Nosan
  * @author Stephane Nicoll
+ * @author Chanhyeong LEE
  */
 @RestController
 public class TestController {
@@ -40,6 +43,12 @@ public class TestController {
 
 	@GetMapping("test2")
 	public String test2() {
+		return "test2";
+	}
+
+	@Timed
+	@GetMapping("test3")
+	public String test3() {
 		return "test2";
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsAutoConfigurationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.web.servlet;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 
@@ -24,6 +25,7 @@ import javax.servlet.Filter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
@@ -64,6 +66,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Dmytro Nosan
  * @author Tadaya Tsuyukubo
  * @author Madhura Bhave
+ * @author Chanhyeong LEE
  */
 @ExtendWith(OutputCaptureExtension.class)
 class WebMvcMetricsAutoConfigurationTests {
@@ -158,6 +161,19 @@ class WebMvcMetricsAutoConfigurationTests {
 	}
 
 	@Test
+	void timerWorksWithTimedAnnotationsWhenAutoTimeRequestsIsFalse() {
+		this.contextRunner.withUserConfiguration(TestController.class)
+				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, WebMvcAutoConfiguration.class))
+				.withPropertyValues("management.metrics.web.server.request.autotime.enabled=false").run((context) -> {
+					MeterRegistry registry = getInitializedMeterRegistry(context, "/test3");
+					Collection<Meter> meters = registry.get("http.server.requests").meters();
+					assertThat(meters).hasSize(1);
+					Meter meter = meters.iterator().next();
+					assertThat(meter.getId().getTag("uri")).isEqualTo("/test3");
+				});
+	}
+
+	@Test
 	@SuppressWarnings("rawtypes")
 	void longTaskTimingInterceptorIsRegistered() {
 		this.contextRunner.withUserConfiguration(TestController.class)
@@ -167,13 +183,17 @@ class WebMvcMetricsAutoConfigurationTests {
 						.contains(LongTaskTimingHandlerInterceptor.class));
 	}
 
-	private MeterRegistry getInitializedMeterRegistry(AssertableWebApplicationContext context) throws Exception {
+	private MeterRegistry getInitializedMeterRegistry(AssertableWebApplicationContext context, String... urls)
+			throws Exception {
+		if (urls.length == 0) {
+			urls = new String[] { "/test0", "/test1", "/test2" };
+		}
 		assertThat(context).hasSingleBean(FilterRegistrationBean.class);
 		Filter filter = context.getBean(FilterRegistrationBean.class).getFilter();
 		assertThat(filter).isInstanceOf(WebMvcMetricsFilter.class);
 		MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(context).addFilters(filter).build();
-		for (int i = 0; i < 3; i++) {
-			mockMvc.perform(MockMvcRequestBuilders.get("/test" + i)).andExpect(status().isOk());
+		for (String url : urls) {
+			mockMvc.perform(MockMvcRequestBuilders.get(url)).andExpect(status().isOk());
 		}
 		return context.getBean(MeterRegistry.class);
 	}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilter.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilter.java
@@ -48,6 +48,7 @@ import org.springframework.web.util.NestedServletException;
  *
  * @author Jon Schneider
  * @author Phillip Webb
+ * @author Chanhyeong LEE
  * @since 2.0.0
  */
 public class WebMvcMetricsFilter extends OncePerRequestFilter {
@@ -123,8 +124,10 @@ public class WebMvcMetricsFilter extends OncePerRequestFilter {
 		Set<Timed> annotations = getTimedAnnotations(handler);
 		Timer.Sample timerSample = timingContext.getTimerSample();
 		if (annotations.isEmpty()) {
-			Builder builder = this.autoTimer.builder(this.metricName);
-			timerSample.stop(getTimer(builder, handler, request, response, exception));
+			if (this.autoTimer.isEnabled()) {
+				Builder builder = this.autoTimer.builder(this.metricName);
+				timerSample.stop(getTimer(builder, handler, request, response, exception));
+			}
 			return;
 		}
 		for (Timed annotation : annotations) {


### PR DESCRIPTION
### Background
According to [this doc](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-metrics-spring-mvc), it says `Alternatively, when set to false, you can enable instrumentation by adding @Timed to a request-handling method`. However our current actuator doesn't recognize the `management.metrics.web.server.request.autotime.enabled`'s value in `record(timingContext, request, response, exception)` of `WebMvcMetricsFilter.java` and the actuator's metric doesn't work properly.

### Changes
- Added a testcase for it
- Checked `this.autoTimer.isEnabled()`

### References
- https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-metrics-spring-mvc