### PR TITLE
Upgrade to AssertJ 3.15.0

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/properties/PushRegistryPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/properties/PushRegistryPropertiesConfigAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public abstract class PushRegistryPropertiesConfigAdapterTests<P extends PushReg
 	void whenPropertiesStepIsSetAdapterStepReturnsIt() {
 		P properties = createProperties();
 		properties.setStep(Duration.ofSeconds(42));
-		assertThat(createConfigAdapter(properties).step()).isEqualTo(Duration.ofSeconds(42));
+		assertThat(createConfigAdapter(properties).step()).hasSeconds(42);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ class JmsPropertiesTests {
 	@Test
 	void defaultReceiveTimeoutMatchesListenerContainersDefault() {
 		assertThat(new JmsProperties().getListener().getReceiveTimeout())
-				.isEqualTo(Duration.ofMillis(AbstractPollingMessageListenerContainer.DEFAULT_RECEIVE_TIMEOUT));
+				.hasMinutes(AbstractPollingMessageListenerContainer.DEFAULT_RECEIVE_TIMEOUT);
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsPropertiesTests.java
@@ -83,7 +83,7 @@ class JmsPropertiesTests {
 	@Test
 	void defaultReceiveTimeoutMatchesListenerContainersDefault() {
 		assertThat(new JmsProperties().getListener().getReceiveTimeout())
-				.hasMinutes(AbstractPollingMessageListenerContainer.DEFAULT_RECEIVE_TIMEOUT);
+				.hasMillis(AbstractPollingMessageListenerContainer.DEFAULT_RECEIVE_TIMEOUT);
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.autoconfigure.session;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.EnumSet;
 
@@ -98,8 +97,7 @@ class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurationTest
 		this.contextRunner
 				.withUserConfiguration(ServerPropertiesConfiguration.class, SessionRepositoryConfiguration.class)
 				.withPropertyValues("server.servlet.session.timeout=1", "spring.session.timeout=3")
-				.run((context) -> assertThat(context.getBean(SessionProperties.class).getTimeout())
-						.isEqualTo(Duration.ofSeconds(3)));
+				.run((context) -> assertThat(context.getBean(SessionProperties.class).getTimeout()).hasSeconds(3));
 	}
 
 	@Test
@@ -107,8 +105,7 @@ class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurationTest
 		this.contextRunner
 				.withUserConfiguration(ServerPropertiesConfiguration.class, SessionRepositoryConfiguration.class)
 				.withPropertyValues("server.servlet.session.timeout=3")
-				.run((context) -> assertThat(context.getBean(SessionProperties.class).getTimeout())
-						.isEqualTo(Duration.ofSeconds(3)));
+				.run((context) -> assertThat(context.getBean(SessionProperties.class).getTimeout()).hasSeconds(3));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -107,7 +106,7 @@ class ServerPropertiesTests {
 	@Test
 	void testConnectionTimeout() {
 		bind("server.connection-timeout", "60s");
-		assertThat(this.properties.getConnectionTimeout()).isEqualTo(Duration.ofMillis(60000));
+		assertThat(this.properties.getConnectionTimeout()).hasMillis(60000);
 	}
 
 	@Test
@@ -149,7 +148,7 @@ class ServerPropertiesTests {
 		assertThat(tomcat.getRemoteIpHeader()).isEqualTo("Remote-Ip");
 		assertThat(tomcat.getProtocolHeader()).isEqualTo("X-Forwarded-Protocol");
 		assertThat(tomcat.getInternalProxies()).isEqualTo("10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
-		assertThat(tomcat.getBackgroundProcessorDelay()).isEqualTo(Duration.ofSeconds(10));
+		assertThat(tomcat.getBackgroundProcessorDelay()).hasSeconds(10);
 		assertThat(tomcat.getRelaxedPathChars()).containsExactly('|', '<');
 		assertThat(tomcat.getRelaxedQueryChars()).containsExactly('^', '|');
 	}
@@ -235,7 +234,7 @@ class ServerPropertiesTests {
 	@Test
 	void testCustomizeJettyIdleTimeout() {
 		bind("server.jetty.thread-idle-timeout", "10s");
-		assertThat(this.properties.getJetty().getThreadIdleTimeout()).isEqualTo(Duration.ofSeconds(10));
+		assertThat(this.properties.getJetty().getThreadIdleTimeout()).hasSeconds(10);
 	}
 
 	@Test
@@ -308,7 +307,7 @@ class ServerPropertiesTests {
 	@Test
 	void tomcatBackgroundProcessorDelayMatchesEngineDefault() {
 		assertThat(this.properties.getTomcat().getBackgroundProcessorDelay())
-				.isEqualTo(Duration.ofSeconds((new StandardEngine().getBackgroundProcessorDelay())));
+				.hasSeconds((new StandardEngine().getBackgroundProcessorDelay()));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryCustomizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.boot.autoconfigure.web.servlet;
 
 import java.io.File;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -106,14 +105,14 @@ class ServletWebServerFactoryCustomizerTests {
 		this.customizer.customize(factory);
 		ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
 		verify(factory).setSession(sessionCaptor.capture());
-		assertThat(sessionCaptor.getValue().getTimeout()).isEqualTo(Duration.ofSeconds(123));
+		assertThat(sessionCaptor.getValue().getTimeout()).hasSeconds(123);
 		Cookie cookie = sessionCaptor.getValue().getCookie();
 		assertThat(cookie.getName()).isEqualTo("testname");
 		assertThat(cookie.getDomain()).isEqualTo("testdomain");
 		assertThat(cookie.getPath()).isEqualTo("/testpath");
 		assertThat(cookie.getComment()).isEqualTo("testcomment");
 		assertThat(cookie.getHttpOnly()).isTrue();
-		assertThat(cookie.getMaxAge()).isEqualTo(Duration.ofSeconds(60));
+		assertThat(cookie.getMaxAge()).hasSeconds(60);
 
 	}
 

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -101,7 +101,7 @@ bom {
 			]
 		}
 	}
-	library("AssertJ", "3.14.0") {
+	library("AssertJ", "3.15.0") {
 		group("org.assertj") {
 			modules = [
 				"assertj-core"

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.boot.devtools.autoconfigure;
 
 import java.io.File;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -115,7 +114,7 @@ class LocalDevToolsAutoConfigurationTests {
 	void resourceCachePeriodIsZero() throws Exception {
 		this.context = getContext(() -> initializeAndRun(WebResourcesConfig.class));
 		ResourceProperties properties = this.context.getBean(ResourceProperties.class);
-		assertThat(properties.getCache().getPeriod()).isEqualTo(Duration.ZERO);
+		assertThat(properties.getCache().getPeriod()).isZero();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/context/properties/bind/AppSystemPropertiesTests.java
+++ b/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/context/properties/bind/AppSystemPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.docs.context.properties.bind;
 
-import java.time.Duration;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
@@ -43,8 +42,8 @@ class AppSystemPropertiesTests {
 	void bindWithDefaultUnit() {
 		this.contextRunner.withPropertyValues("app.system.session-timeout=40", "app.system.read-timeout=5000")
 				.run(assertBinding((properties) -> {
-					assertThat(properties.getSessionTimeout()).isEqualTo(Duration.ofSeconds(40));
-					assertThat(properties.getReadTimeout()).isEqualTo(Duration.ofMillis(5000));
+					assertThat(properties.getSessionTimeout()).hasSeconds(40);
+					assertThat(properties.getReadTimeout()).hasMillis(5000);
 				}));
 	}
 
@@ -52,8 +51,8 @@ class AppSystemPropertiesTests {
 	void bindWithExplicitUnit() {
 		this.contextRunner.withPropertyValues("app.system.session-timeout=1h", "app.system.read-timeout=5s")
 				.run(assertBinding((properties) -> {
-					assertThat(properties.getSessionTimeout()).isEqualTo(Duration.ofMinutes(60));
-					assertThat(properties.getReadTimeout()).isEqualTo(Duration.ofMillis(5000));
+					assertThat(properties.getSessionTimeout()).hasMinutes(60);
+					assertThat(properties.getReadTimeout()).hasMillis(5000);
 				}));
 	}
 
@@ -61,8 +60,8 @@ class AppSystemPropertiesTests {
 	void bindWithIso8601Format() {
 		this.contextRunner.withPropertyValues("app.system.session-timeout=PT15S", "app.system.read-timeout=PT0.5S")
 				.run(assertBinding((properties) -> {
-					assertThat(properties.getSessionTimeout()).isEqualTo(Duration.ofSeconds(15));
-					assertThat(properties.getReadTimeout()).isEqualTo(Duration.ofMillis(500));
+					assertThat(properties.getSessionTimeout()).hasSeconds(15);
+					assertThat(properties.getReadTimeout()).hasMillis(500);
 				}));
 	}
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/reactive/WebTestClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/reactive/WebTestClientAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.boot.test.autoconfigure.web.reactive;
 
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -75,8 +74,8 @@ class WebTestClientAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(BaseConfiguration.class)
 				.withPropertyValues("spring.test.webtestclient.timeout=15m").run((context) -> {
 					WebTestClient webTestClient = context.getBean(WebTestClient.class);
-					Object duration = ReflectionTestUtils.getField(webTestClient, "timeout");
-					assertThat(duration).isEqualTo(Duration.of(15, ChronoUnit.MINUTES));
+					Duration duration = (Duration) ReflectionTestUtils.getField(webTestClient, "timeout");
+					assertThat(duration).hasMinutes(15);
 				});
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/DurationStyleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/DurationStyleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,72 +51,72 @@ class DurationStyleTests {
 
 	@Test
 	void detectAndParseWhenSimpleNanosShouldReturnDuration() {
-		assertThat(DurationStyle.detectAndParse("10ns")).isEqualTo(Duration.ofNanos(10));
-		assertThat(DurationStyle.detectAndParse("10NS")).isEqualTo(Duration.ofNanos(10));
-		assertThat(DurationStyle.detectAndParse("+10ns")).isEqualTo(Duration.ofNanos(10));
-		assertThat(DurationStyle.detectAndParse("-10ns")).isEqualTo(Duration.ofNanos(-10));
+		assertThat(DurationStyle.detectAndParse("10ns")).hasNanos(10);
+		assertThat(DurationStyle.detectAndParse("10NS")).hasNanos(10);
+		assertThat(DurationStyle.detectAndParse("+10ns")).hasNanos(10);
+		assertThat(DurationStyle.detectAndParse("-10ns")).hasNanos(-10);
 	}
 
 	@Test
 	void detectAndParseWhenSimpleMicrosShouldReturnDuration() {
-		assertThat(DurationStyle.detectAndParse("10us")).isEqualTo(Duration.ofNanos(10000));
-		assertThat(DurationStyle.detectAndParse("10US")).isEqualTo(Duration.ofNanos(10000));
-		assertThat(DurationStyle.detectAndParse("+10us")).isEqualTo(Duration.ofNanos(10000));
-		assertThat(DurationStyle.detectAndParse("-10us")).isEqualTo(Duration.ofNanos(-10000));
+		assertThat(DurationStyle.detectAndParse("10us")).hasNanos(10000);
+		assertThat(DurationStyle.detectAndParse("10US")).hasNanos(10000);
+		assertThat(DurationStyle.detectAndParse("+10us")).hasNanos(10000);
+		assertThat(DurationStyle.detectAndParse("-10us")).hasNanos(-10000);
 	}
 
 	@Test
 	void detectAndParseWhenSimpleMillisShouldReturnDuration() {
-		assertThat(DurationStyle.detectAndParse("10ms")).isEqualTo(Duration.ofMillis(10));
-		assertThat(DurationStyle.detectAndParse("10MS")).isEqualTo(Duration.ofMillis(10));
-		assertThat(DurationStyle.detectAndParse("+10ms")).isEqualTo(Duration.ofMillis(10));
-		assertThat(DurationStyle.detectAndParse("-10ms")).isEqualTo(Duration.ofMillis(-10));
+		assertThat(DurationStyle.detectAndParse("10ms")).hasMillis(10);
+		assertThat(DurationStyle.detectAndParse("10MS")).hasMillis(10);
+		assertThat(DurationStyle.detectAndParse("+10ms")).hasMillis(10);
+		assertThat(DurationStyle.detectAndParse("-10ms")).hasMillis(-10);
 	}
 
 	@Test
 	void detectAndParseWhenSimpleSecondsShouldReturnDuration() {
-		assertThat(DurationStyle.detectAndParse("10s")).isEqualTo(Duration.ofSeconds(10));
-		assertThat(DurationStyle.detectAndParse("10S")).isEqualTo(Duration.ofSeconds(10));
-		assertThat(DurationStyle.detectAndParse("+10s")).isEqualTo(Duration.ofSeconds(10));
-		assertThat(DurationStyle.detectAndParse("-10s")).isEqualTo(Duration.ofSeconds(-10));
+		assertThat(DurationStyle.detectAndParse("10s")).hasSeconds(10);
+		assertThat(DurationStyle.detectAndParse("10S")).hasSeconds(10);
+		assertThat(DurationStyle.detectAndParse("+10s")).hasSeconds(10);
+		assertThat(DurationStyle.detectAndParse("-10s")).hasSeconds(-10);
 	}
 
 	@Test
 	void detectAndParseWhenSimpleMinutesShouldReturnDuration() {
-		assertThat(DurationStyle.detectAndParse("10m")).isEqualTo(Duration.ofMinutes(10));
-		assertThat(DurationStyle.detectAndParse("10M")).isEqualTo(Duration.ofMinutes(10));
-		assertThat(DurationStyle.detectAndParse("+10m")).isEqualTo(Duration.ofMinutes(10));
-		assertThat(DurationStyle.detectAndParse("-10m")).isEqualTo(Duration.ofMinutes(-10));
+		assertThat(DurationStyle.detectAndParse("10m")).hasMinutes(10);
+		assertThat(DurationStyle.detectAndParse("10M")).hasMinutes(10);
+		assertThat(DurationStyle.detectAndParse("+10m")).hasMinutes(10);
+		assertThat(DurationStyle.detectAndParse("-10m")).hasMinutes(-10);
 	}
 
 	@Test
 	void detectAndParseWhenSimpleHoursShouldReturnDuration() {
-		assertThat(DurationStyle.detectAndParse("10h")).isEqualTo(Duration.ofHours(10));
-		assertThat(DurationStyle.detectAndParse("10H")).isEqualTo(Duration.ofHours(10));
-		assertThat(DurationStyle.detectAndParse("+10h")).isEqualTo(Duration.ofHours(10));
-		assertThat(DurationStyle.detectAndParse("-10h")).isEqualTo(Duration.ofHours(-10));
+		assertThat(DurationStyle.detectAndParse("10h")).hasHours(10);
+		assertThat(DurationStyle.detectAndParse("10H")).hasHours(10);
+		assertThat(DurationStyle.detectAndParse("+10h")).hasHours(10);
+		assertThat(DurationStyle.detectAndParse("-10h")).hasHours(-10);
 	}
 
 	@Test
 	void detectAndParseWhenSimpleDaysShouldReturnDuration() {
-		assertThat(DurationStyle.detectAndParse("10d")).isEqualTo(Duration.ofDays(10));
-		assertThat(DurationStyle.detectAndParse("10D")).isEqualTo(Duration.ofDays(10));
-		assertThat(DurationStyle.detectAndParse("+10d")).isEqualTo(Duration.ofDays(10));
-		assertThat(DurationStyle.detectAndParse("-10d")).isEqualTo(Duration.ofDays(-10));
+		assertThat(DurationStyle.detectAndParse("10d")).hasDays(10);
+		assertThat(DurationStyle.detectAndParse("10D")).hasDays(10);
+		assertThat(DurationStyle.detectAndParse("+10d")).hasDays(10);
+		assertThat(DurationStyle.detectAndParse("-10d")).hasDays(-10);
 	}
 
 	@Test
 	void detectAndParseWhenSimpleWithoutSuffixShouldReturnDuration() {
-		assertThat(DurationStyle.detectAndParse("10")).isEqualTo(Duration.ofMillis(10));
-		assertThat(DurationStyle.detectAndParse("+10")).isEqualTo(Duration.ofMillis(10));
-		assertThat(DurationStyle.detectAndParse("-10")).isEqualTo(Duration.ofMillis(-10));
+		assertThat(DurationStyle.detectAndParse("10")).hasMillis(10);
+		assertThat(DurationStyle.detectAndParse("+10")).hasMillis(10);
+		assertThat(DurationStyle.detectAndParse("-10")).hasMillis(-10);
 	}
 
 	@Test
 	void detectAndParseWhenSimpleWithoutSuffixButWithChronoUnitShouldReturnDuration() {
-		assertThat(DurationStyle.detectAndParse("10", ChronoUnit.SECONDS)).isEqualTo(Duration.ofSeconds(10));
-		assertThat(DurationStyle.detectAndParse("+10", ChronoUnit.SECONDS)).isEqualTo(Duration.ofSeconds(10));
-		assertThat(DurationStyle.detectAndParse("-10", ChronoUnit.SECONDS)).isEqualTo(Duration.ofSeconds(-10));
+		assertThat(DurationStyle.detectAndParse("10", ChronoUnit.SECONDS)).hasSeconds(10);
+		assertThat(DurationStyle.detectAndParse("+10", ChronoUnit.SECONDS)).hasSeconds(10);
+		assertThat(DurationStyle.detectAndParse("-10", ChronoUnit.SECONDS)).hasSeconds(-10);
 	}
 
 	@Test
@@ -191,13 +191,13 @@ class DurationStyleTests {
 
 	@Test
 	void parseSimpleShouldParse() {
-		assertThat(DurationStyle.SIMPLE.parse("10m")).isEqualTo(Duration.ofMinutes(10));
+		assertThat(DurationStyle.SIMPLE.parse("10m")).hasMinutes(10);
 	}
 
 	@Test
 	void parseSimpleWithUnitShouldUseUnitAsFallback() {
-		assertThat(DurationStyle.SIMPLE.parse("10m", ChronoUnit.SECONDS)).isEqualTo(Duration.ofMinutes(10));
-		assertThat(DurationStyle.SIMPLE.parse("10", ChronoUnit.MINUTES)).isEqualTo(Duration.ofMinutes(10));
+		assertThat(DurationStyle.SIMPLE.parse("10m", ChronoUnit.SECONDS)).hasMinutes(10);
+		assertThat(DurationStyle.SIMPLE.parse("10", ChronoUnit.MINUTES)).hasMinutes(10);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/NumberToDurationConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/NumberToDurationConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,16 +40,16 @@ class NumberToDurationConverterTests {
 
 	@ConversionServiceTest
 	void convertWhenSimpleWithoutSuffixShouldReturnDuration(ConversionService conversionService) {
-		assertThat(convert(conversionService, 10)).isEqualTo(Duration.ofMillis(10));
-		assertThat(convert(conversionService, +10)).isEqualTo(Duration.ofMillis(10));
-		assertThat(convert(conversionService, -10)).isEqualTo(Duration.ofMillis(-10));
+		assertThat(convert(conversionService, 10)).hasMillis(10);
+		assertThat(convert(conversionService, +10)).hasMillis(10);
+		assertThat(convert(conversionService, -10)).hasMillis(-10);
 	}
 
 	@ConversionServiceTest
 	void convertWhenSimpleWithoutSuffixButWithAnnotationShouldReturnDuration(ConversionService conversionService) {
-		assertThat(convert(conversionService, 10, ChronoUnit.SECONDS)).isEqualTo(Duration.ofSeconds(10));
-		assertThat(convert(conversionService, +10, ChronoUnit.SECONDS)).isEqualTo(Duration.ofSeconds(10));
-		assertThat(convert(conversionService, -10, ChronoUnit.SECONDS)).isEqualTo(Duration.ofSeconds(-10));
+		assertThat(convert(conversionService, 10, ChronoUnit.SECONDS)).hasSeconds(10);
+		assertThat(convert(conversionService, +10, ChronoUnit.SECONDS)).hasSeconds(10);
+		assertThat(convert(conversionService, -10, ChronoUnit.SECONDS)).hasSeconds(-10);
 	}
 
 	private Duration convert(ConversionService conversionService, Integer source) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/StringToDurationConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/StringToDurationConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,72 +50,72 @@ class StringToDurationConverterTests {
 
 	@ConversionServiceTest
 	void convertWhenSimpleNanosShouldReturnDuration(ConversionService conversionService) {
-		assertThat(convert(conversionService, "10ns")).isEqualTo(Duration.ofNanos(10));
-		assertThat(convert(conversionService, "10NS")).isEqualTo(Duration.ofNanos(10));
-		assertThat(convert(conversionService, "+10ns")).isEqualTo(Duration.ofNanos(10));
-		assertThat(convert(conversionService, "-10ns")).isEqualTo(Duration.ofNanos(-10));
+		assertThat(convert(conversionService, "10ns")).hasNanos(10);
+		assertThat(convert(conversionService, "10NS")).hasNanos(10);
+		assertThat(convert(conversionService, "+10ns")).hasNanos(10);
+		assertThat(convert(conversionService, "-10ns")).hasNanos(-10);
 	}
 
 	@ConversionServiceTest
 	void convertWhenSimpleMicrosShouldReturnDuration(ConversionService conversionService) {
-		assertThat(convert(conversionService, "10us")).isEqualTo(Duration.ofNanos(10000));
-		assertThat(convert(conversionService, "10US")).isEqualTo(Duration.ofNanos(10000));
-		assertThat(convert(conversionService, "+10us")).isEqualTo(Duration.ofNanos(10000));
-		assertThat(convert(conversionService, "-10us")).isEqualTo(Duration.ofNanos(-10000));
+		assertThat(convert(conversionService, "10us")).hasNanos(10000);
+		assertThat(convert(conversionService, "10US")).hasNanos(10000);
+		assertThat(convert(conversionService, "+10us")).hasNanos(10000);
+		assertThat(convert(conversionService, "-10us")).hasNanos(-10000);
 	}
 
 	@ConversionServiceTest
 	void convertWhenSimpleMillisShouldReturnDuration(ConversionService conversionService) {
-		assertThat(convert(conversionService, "10ms")).isEqualTo(Duration.ofMillis(10));
-		assertThat(convert(conversionService, "10MS")).isEqualTo(Duration.ofMillis(10));
-		assertThat(convert(conversionService, "+10ms")).isEqualTo(Duration.ofMillis(10));
-		assertThat(convert(conversionService, "-10ms")).isEqualTo(Duration.ofMillis(-10));
+		assertThat(convert(conversionService, "10ms")).hasMillis(10);
+		assertThat(convert(conversionService, "10MS")).hasMillis(10);
+		assertThat(convert(conversionService, "+10ms")).hasMillis(10);
+		assertThat(convert(conversionService, "-10ms")).hasMillis(-10);
 	}
 
 	@ConversionServiceTest
 	void convertWhenSimpleSecondsShouldReturnDuration(ConversionService conversionService) {
-		assertThat(convert(conversionService, "10s")).isEqualTo(Duration.ofSeconds(10));
-		assertThat(convert(conversionService, "10S")).isEqualTo(Duration.ofSeconds(10));
-		assertThat(convert(conversionService, "+10s")).isEqualTo(Duration.ofSeconds(10));
-		assertThat(convert(conversionService, "-10s")).isEqualTo(Duration.ofSeconds(-10));
+		assertThat(convert(conversionService, "10s")).hasSeconds(10);
+		assertThat(convert(conversionService, "10S")).hasSeconds(10);
+		assertThat(convert(conversionService, "+10s")).hasSeconds(10);
+		assertThat(convert(conversionService, "-10s")).hasSeconds(-10);
 	}
 
 	@ConversionServiceTest
 	void convertWhenSimpleMinutesShouldReturnDuration(ConversionService conversionService) {
-		assertThat(convert(conversionService, "10m")).isEqualTo(Duration.ofMinutes(10));
-		assertThat(convert(conversionService, "10M")).isEqualTo(Duration.ofMinutes(10));
-		assertThat(convert(conversionService, "+10m")).isEqualTo(Duration.ofMinutes(10));
-		assertThat(convert(conversionService, "-10m")).isEqualTo(Duration.ofMinutes(-10));
+		assertThat(convert(conversionService, "10m")).hasMinutes(10);
+		assertThat(convert(conversionService, "10M")).hasMinutes(10);
+		assertThat(convert(conversionService, "+10m")).hasMinutes(10);
+		assertThat(convert(conversionService, "-10m")).hasMinutes(-10);
 	}
 
 	@ConversionServiceTest
 	void convertWhenSimpleHoursShouldReturnDuration(ConversionService conversionService) {
-		assertThat(convert(conversionService, "10h")).isEqualTo(Duration.ofHours(10));
-		assertThat(convert(conversionService, "10H")).isEqualTo(Duration.ofHours(10));
-		assertThat(convert(conversionService, "+10h")).isEqualTo(Duration.ofHours(10));
-		assertThat(convert(conversionService, "-10h")).isEqualTo(Duration.ofHours(-10));
+		assertThat(convert(conversionService, "10h")).hasHours(10);
+		assertThat(convert(conversionService, "10H")).hasHours(10);
+		assertThat(convert(conversionService, "+10h")).hasHours(10);
+		assertThat(convert(conversionService, "-10h")).hasHours(-10);
 	}
 
 	@ConversionServiceTest
 	void convertWhenSimpleDaysShouldReturnDuration(ConversionService conversionService) {
-		assertThat(convert(conversionService, "10d")).isEqualTo(Duration.ofDays(10));
-		assertThat(convert(conversionService, "10D")).isEqualTo(Duration.ofDays(10));
-		assertThat(convert(conversionService, "+10d")).isEqualTo(Duration.ofDays(10));
-		assertThat(convert(conversionService, "-10d")).isEqualTo(Duration.ofDays(-10));
+		assertThat(convert(conversionService, "10d")).hasDays(10);
+		assertThat(convert(conversionService, "10D")).hasDays(10);
+		assertThat(convert(conversionService, "+10d")).hasDays(10);
+		assertThat(convert(conversionService, "-10d")).hasDays(-10);
 	}
 
 	@ConversionServiceTest
 	void convertWhenSimpleWithoutSuffixShouldReturnDuration(ConversionService conversionService) {
-		assertThat(convert(conversionService, "10")).isEqualTo(Duration.ofMillis(10));
-		assertThat(convert(conversionService, "+10")).isEqualTo(Duration.ofMillis(10));
-		assertThat(convert(conversionService, "-10")).isEqualTo(Duration.ofMillis(-10));
+		assertThat(convert(conversionService, "10")).hasMillis(10);
+		assertThat(convert(conversionService, "+10")).hasMillis(10);
+		assertThat(convert(conversionService, "-10")).hasMillis(-10);
 	}
 
 	@ConversionServiceTest
 	void convertWhenSimpleWithoutSuffixButWithAnnotationShouldReturnDuration(ConversionService conversionService) {
-		assertThat(convert(conversionService, "10", ChronoUnit.SECONDS, null)).isEqualTo(Duration.ofSeconds(10));
-		assertThat(convert(conversionService, "+10", ChronoUnit.SECONDS, null)).isEqualTo(Duration.ofSeconds(10));
-		assertThat(convert(conversionService, "-10", ChronoUnit.SECONDS, null)).isEqualTo(Duration.ofSeconds(-10));
+		assertThat(convert(conversionService, "10", ChronoUnit.SECONDS, null)).hasSeconds(10);
+		assertThat(convert(conversionService, "+10", ChronoUnit.SECONDS, null)).hasSeconds(10);
+		assertThat(convert(conversionService, "-10", ChronoUnit.SECONDS, null)).hasSeconds(-10);
 	}
 
 	@ConversionServiceTest

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
@@ -676,7 +676,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 
 	@Test
 	void defaultSessionTimeout() {
-		assertThat(getFactory().getSession().getTimeout()).isEqualTo(Duration.ofMinutes(30));
+		assertThat(getFactory().getSession().getTimeout()).hasMinutes(30);
 	}
 
 	@Test


### PR DESCRIPTION
Hi,

this PR upgrades to AssertJ 3.15.0 and already makes use of the new duration assertions (in separate commits though).

Let me know what you think.
Cheers,
Christoph