### PR TITLE
Use ServerHttpResponse.getRawStatusCode() in WebFluxTags

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTags.java
@@ -22,7 +22,6 @@ import io.micrometer.core.instrument.Tag;
 
 import org.springframework.boot.actuate.metrics.http.Outcome;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.server.reactive.AbstractServerHttpResponse;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.HandlerMapping;
@@ -164,11 +163,9 @@ public final class WebFluxTags {
 
 	private static Integer extractStatusCode(ServerWebExchange exchange) {
 		ServerHttpResponse response = exchange.getResponse();
-		if (response instanceof AbstractServerHttpResponse) {
-			Integer statusCode = ((AbstractServerHttpResponse) response).getStatusCodeValue();
-			if (statusCode != null) {
-				return statusCode;
-			}
+		Integer statusCode = response.getRawStatusCode();
+		if (statusCode != null) {
+			return statusCode;
 		}
 		HttpStatus status = response.getStatusCode();
 		return (status != null) ? status.value() : null;

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTagsTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTagsTests.java
@@ -21,8 +21,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.server.reactive.AbstractServerHttpResponse;
 import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.reactive.HandlerMapping;
@@ -123,9 +123,9 @@ class WebFluxTagsTests {
 	void outcomeTagIsSuccessWhenResponseStatusIsAvailableFromUnderlyingServer() {
 		ServerWebExchange exchange = mock(ServerWebExchange.class);
 		ServerHttpRequest request = mock(ServerHttpRequest.class);
-		AbstractServerHttpResponse response = mock(AbstractServerHttpResponse.class);
+		ServerHttpResponse response = mock(ServerHttpResponse.class);
 		given(response.getStatusCode()).willReturn(HttpStatus.OK);
-		given(response.getStatusCodeValue()).willReturn(null);
+		given(response.getRawStatusCode()).willReturn(null);
 		given(exchange.getRequest()).willReturn(request);
 		given(exchange.getResponse()).willReturn(response);
 		Tag tag = WebFluxTags.outcome(exchange);

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1608,7 +1608,7 @@ bom {
 			]
 		}
 	}
-	library("Spring Framework", "5.2.3.RELEASE") {
+	library("Spring Framework", "5.2.4.BUILD-SNAPSHOT") {
 		group("org.springframework") {
 			imports = [
 				"spring-framework-bom"


### PR DESCRIPTION
This PR changes to use `ServerHttpResponse.getRawStatusCode()` in `WebFluxTags`.

This PR also changes Spring Framework version to 5.2.4.BUILD-SNAPSHOT for the necessary upstream change.

See https://github.com/spring-projects/spring-boot/issues/19367#issuecomment-580182069

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
