### PR TITLE
Fix link to Spring Integration Graph documentation

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -154,6 +154,21 @@ test {
 	outputs.dir("${buildDir}/generated-snippets")
 }
 
+task dependencyVersions(type: org.springframework.boot.build.constraints.ExtractVersionConstraints) {
+	enforcedPlatform(":spring-boot-project:spring-boot-dependencies")
+}
+
+tasks.withType(org.asciidoctor.gradle.jvm.AbstractAsciidoctorTask) {
+	dependsOn dependencyVersions
+	baseDirFollowsSourceDir()
+	doFirst {
+		def versionConstraints = dependencyVersions.versionConstraints
+		def integrationVersion = versionConstraints["org.springframework.integration:spring-integration-core"]
+		def integrationDocs = String.format("https://docs.spring.io/spring-integration/docs/%s/reference/html/", integrationVersion)
+		attributes "spring-integration-docs": integrationDocs
+	}
+}
+
 asciidoctor {
 	configurations "asciidoctorExtensions"
 	dependsOn test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/docs/asciidoc/endpoints/integrationgraph.adoc
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/docs/asciidoc/endpoints/integrationgraph.adoc
@@ -20,7 +20,7 @@ include::{snippets}/integrationgraph/graph/http-response.adoc[]
 [[integrationgraph-retrieving-response-structure]]
 === Response Structure
 The response contains all Spring Integration components used within the application, as well as the links between them.
-More information about the structure can be found in the https://docs.spring.io/spring-integration/reference/html/index-single.html#integration-graph[reference documentation].
+More information about the structure can be found in the {spring-integration-docs}index-single.html#integration-graph[reference documentation].
 
 
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/docs/asciidoc/endpoints/integrationgraph.adoc
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/docs/asciidoc/endpoints/integrationgraph.adoc
@@ -20,7 +20,7 @@ include::{snippets}/integrationgraph/graph/http-response.adoc[]
 [[integrationgraph-retrieving-response-structure]]
 === Response Structure
 The response contains all Spring Integration components used within the application, as well as the links between them.
-More information about the structure can be found in the https://docs.spring.io/spring-integration/reference/html/#integration-graph[reference documentation].
+More information about the structure can be found in the https://docs.spring.io/spring-integration/reference/html/index-single.html#integration-graph[reference documentation].
 
 
 


### PR DESCRIPTION
Hi,

this PR fixes another tiny link problem in the docs.

Cheers,
Christoph