### PR TITLE
Upgrade to Ant 1.10.7

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-antlib/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-antlib/build.gradle
@@ -8,7 +8,7 @@ plugins {
 description = "Spring Boot Antlib"
 
 ext {
-	antVersion = "1.9.3"
+	antVersion = "1.10.7"
 }
 
 configurations {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-ant/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-ant/build.gradle
@@ -25,8 +25,8 @@ plugins.withType(EclipsePlugin) {
 dependencies {
 	antDependencies "org.apache.ivy:ivy:2.4.0"
 	antDependencies project(path: ":spring-boot-project:spring-boot-tools:spring-boot-antlib")
-	antDependencies "org.apache.ant:ant-launcher:1.9.3"
-	antDependencies "org.apache.ant:ant:1.9.3"
+	antDependencies "org.apache.ant:ant-launcher:1.10.7"
+	antDependencies "org.apache.ant:ant:1.10.7"
 
 	testRepository(project(path: ":spring-boot-project:spring-boot-tools:spring-boot-loader", configuration: "mavenRepository"))
 	testRepository(project(path: ":spring-boot-project:spring-boot-starters:spring-boot-starter", configuration: "mavenRepository"))


### PR DESCRIPTION
Hi,

this PR upgrades `spring-boot-antlib` and  `spring-boot-smoke-test-ant` to Ant 1.10.7.

Cheers,
Christoph