### PR TITLE
2.3.0.M1 accidentally reverted to using jersey-spring4 rather than jersey-spring5

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -119,7 +119,7 @@ dependencies {
 	testImplementation("org.aspectj:aspectjrt")
 	testImplementation("org.assertj:assertj-core")
 	testImplementation("org.eclipse.jetty:jetty-webapp")
-	testImplementation("org.glassfish.jersey.ext:jersey-spring4")
+	testImplementation("org.glassfish.jersey.ext:jersey-spring5")
 	testImplementation("org.glassfish.jersey.media:jersey-media-json-jackson")
 	testImplementation("org.hamcrest:hamcrest")
 	testImplementation("org.hsqldb:hsqldb")

--- a/spring-boot-project/spring-boot-actuator/build.gradle
+++ b/spring-boot-project/spring-boot-actuator/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 	testRuntimeOnly("io.projectreactor.netty:reactor-netty")
 	testRuntimeOnly("javax.xml.bind:jaxb-api")
 	testRuntimeOnly("org.apache.tomcat.embed:tomcat-embed-el")
-	testRuntimeOnly("org.glassfish.jersey.ext:jersey-spring4")
+	testRuntimeOnly("org.glassfish.jersey.ext:jersey-spring5")
 	testRuntimeOnly("org.hsqldb:hsqldb")
 }
 

--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-jersey/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-jersey/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 		exclude group: "jakarta.el", module: "jakarta.el-api"
 		exclude group: "org.glassfish", module: "jakarta.el"
 	}
-	api("org.glassfish.jersey.ext:jersey-spring4")
+	api("org.glassfish.jersey.ext:jersey-spring5")
 	api("org.glassfish.jersey.media:jersey-media-json-jackson")
 }
 


### PR DESCRIPTION
Hi,

apparently with the move to Gradle we're specifying `org.glassfish.jersey.ext:jersey-spring4` again, although we did switch already to `jersey-spring5` in #17412. It seems unintentional, so this PR reverts to `jersey-spring5`.

Let me know what you think.
Cheers,
Christoph