### PR TITLE
Upgrade to Ivy 2.5.0

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-antlib/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-antlib/build.gradle
@@ -18,7 +18,7 @@ configurations {
 
 dependencies {
 	antUnit "org.apache.ant:ant-antunit:1.3"
-	antIvy "org.apache.ivy:ivy:2.4.0"
+	antIvy "org.apache.ivy:ivy:2.5.0"
 
 	api(platform(project(":spring-boot-project:spring-boot-dependencies")))
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-ant/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-ant/build.gradle
@@ -23,7 +23,7 @@ plugins.withType(EclipsePlugin) {
 }
 
 dependencies {
-	antDependencies "org.apache.ivy:ivy:2.4.0"
+	antDependencies "org.apache.ivy:ivy:2.5.0"
 	antDependencies project(path: ":spring-boot-project:spring-boot-tools:spring-boot-antlib")
 	antDependencies "org.apache.ant:ant-launcher:1.10.7"
 	antDependencies "org.apache.ant:ant:1.10.7"


### PR DESCRIPTION
Hi,

this PR upgrades Ivy to 2.5.0. That should get rid of the warnings in the JDK11 & JDK13 builds:

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.apache.ivy.util.url.IvyAuthenticator (file:/tmp/build/6da1d659/gradle/caches/modules-2/files-2.1/org.apache.ivy/ivy/2.4.0/5abe4c24bbe992a9ac07ca563d5bd3e8d569e9ed/ivy-2.4.0.jar) to field java.net.Authenticator.theAuthenticator
WARNING: Please consider reporting this to the maintainers of org.apache.ivy.util.url.IvyAuthenticator
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

Cheers,
Christoph