### PR TITLE
Use Dropwizard metrics BOM to manage dependencies

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -250,25 +250,10 @@ bom {
 			]
 		}
 	}
-	library("Dropwizard Metrics", "4.1.1") {
+	library("Dropwizard Metrics", "4.1.2") {
 		group("io.dropwizard.metrics") {
-			modules = [
-				"metrics-annotation",
-				"metrics-core",
-				"metrics-ehcache",
-				"metrics-graphite",
-				"metrics-healthchecks",
-				"metrics-httpasyncclient",
-				"metrics-jdbi",
-				"metrics-jersey2",
-				"metrics-jetty9",
-				"metrics-jmx",
-				"metrics-json",
-				"metrics-jvm",
-				"metrics-log4j2",
-				"metrics-logback",
-				"metrics-servlet",
-				"metrics-servlets"
+			imports = [
+				"metrics-bom"
 			]
 		}
 	}


### PR DESCRIPTION
Hi,

I just noticed that we could make use of Dropwizard's `metrics-bom` to manage the dependencies. While doing so, I upgraded to 4.1.2 directly, because it adds dependency management for `metrics-collectd`.

Let me know what you think.
Cheers,
Christoph