### PR TITLE
Remove superfluous useJUnit()

### DIFF
--- a/spring-boot-project/spring-boot-test/build.gradle
+++ b/spring-boot-project/spring-boot-test/build.gradle
@@ -57,6 +57,5 @@ dependencies {
 }
 
 test {
-	useJUnit()
 	useJUnitPlatform()
 }


### PR DESCRIPTION
Hi,

as @sbrannen [pointed out](https://github.com/spring-projects/spring-boot/pull/19826#issuecomment-581850662), the `useJUnit()` isn't really needed.

Cheers,
Christoph
