### PR TITLE
Set includeantruntime in Ant smoke tests

### DIFF
--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-ant/build.xml
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-ant/build.xml
@@ -29,7 +29,7 @@
 	</target>
 
 	<target name="compile" depends="init" description="compile">
-		<javac srcdir="src/main/java" destdir="build/ant/classes" classpathref="compile.classpath" fork="true" />
+		<javac srcdir="src/main/java" destdir="build/ant/classes" classpathref="compile.classpath" fork="true" includeantruntime="false" />
 	</target>
 
 	<target name="clean" description="cleans all created files/dirs">


### PR DESCRIPTION
Hi,

this PR is an attempt to get rid of a warning inside `spring-boot-smoke-test-ant`:

```
compile:
    [javac] /path/to/spring-boot-smoke-test-ant/build.xml:32: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
```

Cheers,
Christoph