### PR TITLE
Invalid variable reference in maven-shade-plugin configuration

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
@@ -191,7 +191,7 @@ publishing.publications.withType(MavenPublication) {
 								dependency {
 									delegate.groupId('org.springframework.boot')
 									delegate.artifactId('spring-boot-maven-plugin')
-									delegate.version('${revision}')
+									delegate.version('${project.version}')
 								}
 							}
 							executions {


### PR DESCRIPTION
When trying to use the `maven-shade-plugin` plugin in a project using the latest 2.3.0.M1 milestone release we encounter this error:

```
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] 'build.plugins.plugin[org.apache.maven.plugins:maven-shade-plugin].dependencies.dependency.version' for org.springframework.boot:spring-boot-maven-plugin:jar must be a valid version but is '${revision}'. @ org.springframework.boot:spring-boot-starter-parent:2.3.0.M1, /Users/demo/.m2/repository/org/springframework/boot/spring-boot-starter-parent/2.3.0.M1/spring-boot-starter-parent-2.3.0.M1.pom, line 211, column 24
```

Build Settings:
```
<build>
    <plugins>
        <plugin>
            <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-shade-plugin</artifactId>
            <configuration>
                <createDependencyReducedPom>false</createDependencyReducedPom>
            </configuration>
            <executions>
                <execution>
                    <phase>package</phase>
                    <goals>
                        <goal>shade</goal>
                    </goals>
                </execution>
            </executions>
        </plugin>
    </plugins>
</build>
```

I believe this PR fixes what seems to be a very slight oversight during the Gradle migration.