### PR TITLE
Reinstate Cassandra smoke tests

### DIFF
--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/build.gradle
@@ -1,9 +1,3 @@
-buildscript {
-	dependencies {
-		classpath "org.springframework:spring-core:5.2.2.RELEASE"
-	}
-}
-
 plugins {
 	id "java"
 	id "org.springframework.boot.conventions"

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/build.gradle
@@ -11,30 +11,15 @@ plugins {
 
 description = "Spring Boot Data Cassandra smoke test"
 
+ext {
+	testcontainersVersion = "1.12.5"
+}
+
 dependencies {
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-data-cassandra"))
 
 	testImplementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-test"))
-	testImplementation("org.cassandraunit:cassandra-unit-spring:3.5.0.1") {
-		exclude group: "org.slf4j", module: "jcl-over-slf4j"
-	}
-}
-
-test {
-	jvmArgumentProviders.add new CassandraPortsProvider()
-	enabled = !JavaVersion.current().java9Compatible
-}
-
-class CassandraPortsProvider implements CommandLineArgumentProvider {
-
-	@Override
-	Iterable<String> asArguments() {
-		def ports = org.springframework.util.SocketUtils.findAvailableTcpPorts(2)
-		return [
-				"-Dspring.data.cassandra.port=${ports[0]}",
-				"-Dcassandra.native_transport_port=${ports[0]}",
-				"-Dcassandra.port.storage=${ports[1]}"
-		]
-	}
-
+	testImplementation "org.testcontainers:cassandra:${testcontainersVersion}"
+	testImplementation "org.testcontainers:testcontainers:${testcontainersVersion}"
+	testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/src/main/java/smoketest/data/cassandra/Customer.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/src/main/java/smoketest/data/cassandra/Customer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.data.cassandra;
+
+import java.util.UUID;
+
+import org.springframework.data.cassandra.core.mapping.PrimaryKey;
+import org.springframework.data.cassandra.core.mapping.Table;
+
+@Table
+public class Customer {
+
+	@PrimaryKey
+	private UUID id;
+
+	private String firstName;
+
+	private String lastName;
+
+	public Customer() {
+	}
+
+	public Customer(UUID id, String firstName, String lastName) {
+		this.id = id;
+		this.firstName = firstName;
+		this.lastName = lastName;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("Customer[id=%s, firstName='%s', lastName='%s']", this.id, this.firstName, this.lastName);
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/src/main/java/smoketest/data/cassandra/CustomerRepository.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/src/main/java/smoketest/data/cassandra/CustomerRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.data.cassandra;
+
+import java.util.List;
+
+import org.springframework.data.cassandra.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+public interface CustomerRepository extends CrudRepository<Customer, String> {
+
+	@Query("Select * from customer where firstname=?0")
+	Customer findByFirstName(String firstName);
+
+	@Query("Select * from customer where lastname=?0")
+	List<Customer> findByLastName(String lastName);
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/src/main/java/smoketest/data/cassandra/SampleCassandraApplication.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/src/main/java/smoketest/data/cassandra/SampleCassandraApplication.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.data.cassandra;
+
+import com.datastax.oss.driver.api.core.uuid.Uuids;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SampleCassandraApplication implements CommandLineRunner {
+
+	@Autowired
+	private CustomerRepository repository;
+
+	@Override
+	public void run(String... args) throws Exception {
+		this.repository.deleteAll();
+
+		// save a couple of customers
+		this.repository.save(new Customer(Uuids.timeBased(), "Alice", "Smith"));
+		this.repository.save(new Customer(Uuids.timeBased(), "Bob", "Smith"));
+
+		// fetch all customers
+		System.out.println("Customers found with findAll():");
+		System.out.println("-------------------------------");
+		for (Customer customer : this.repository.findAll()) {
+			System.out.println(customer);
+		}
+		System.out.println();
+
+		// fetch an individual customer
+		System.out.println("Customer found with findByFirstName('Alice'):");
+		System.out.println("--------------------------------");
+		System.out.println(this.repository.findByFirstName("Alice"));
+
+		System.out.println("Customers found with findByLastName('Smith'):");
+		System.out.println("--------------------------------");
+		for (Customer customer : this.repository.findByLastName("Smith")) {
+			System.out.println(customer);
+		}
+	}
+
+	public static void main(String[] args) {
+		SpringApplication.run(SampleCassandraApplication.class, args);
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/src/main/resources/application.properties
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.data.cassandra.keyspace-name=mykeyspace

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/src/test/java/smoketest/data/cassandra/SampleCassandraApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/src/test/java/smoketest/data/cassandra/SampleCassandraApplicationTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.data.cassandra;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SampleCassandraApplication}.
+ */
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest
+@ContextConfiguration(initializers = SampleCassandraApplicationTests.Initializer.class)
+@Testcontainers(disabledWithoutDocker = true)
+class SampleCassandraApplicationTests {
+
+	@Container
+	static final CassandraContainer<?> container = new CassandraContainer<>().withStartupAttempts(5)
+			.withStartupTimeout(Duration.ofMinutes(10)).withInitScript("setup.cql");
+
+	@Test
+	@DisabledOnOs(OS.WINDOWS)
+	void testDefaultSettings(CapturedOutput output) {
+		assertThat(output).contains("firstName='Alice', lastName='Smith'");
+	}
+
+	static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+		@Override
+		public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+			TestPropertyValues
+					.of("spring.data.cassandra.contact-points:localhost:" + container.getFirstMappedPort(),
+							"spring.data.cassandra.local-datacenter=datacenter1",
+							"spring.data.cassandra.read-timeout=20s", "spring.data.cassandra.connect-timeout=10s")
+					.applyTo(configurableApplicationContext.getEnvironment());
+		}
+
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/src/test/resources/setup.cql
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/src/test/resources/setup.cql
@@ -1,0 +1,4 @@
+CREATE KEYSPACE IF NOT EXISTS mykeyspace WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1};
+CREATE TABLE mykeyspace.customer (id TimeUUID PRIMARY KEY, firstname text, lastname text);
+CREATE INDEX customerfistnameindex ON mykeyspace.customer (firstname);
+CREATE INDEX customersecondnameindex ON mykeyspace.customer (lastname);


### PR DESCRIPTION
Hi,

I just noticed that `spring-boot-smoke-test-data-cassandra` is doing nothing. I traced this back to ca1710ee56d327e46a76f028f7bbc12dc974ee5e, but wasn't sure if the removal was intentional.

Reinstating the tests required some changes as they didn't work anymore as they were. While working on it, I noticed that this should effectively fix #10453 as we're on a version that works with Java 9 now and my PR makes use of `testcontainers` instead of the old `cassandra-unit-spring` approach.

If you think, they shouldn't be brought back at all, I'm also happy to simply remove the complete folder.

Let me know what you think.
Cheers,
Christoph