### PR TITLE
Remove redundant jar task configuration

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
@@ -55,12 +55,6 @@ gradlePlugin {
 	}
 }
 
-jar {
-	manifest {
-		attributes "Implementation-Version": project.version
-	}
-}
-
 task dependencyVersions(type: org.springframework.boot.build.constraints.ExtractVersionConstraints) {
 	enforcedPlatform(":spring-boot-project:spring-boot-dependencies")
 }


### PR DESCRIPTION
Hi,

I just noticed that we have a jar configuration in `spring-boot-gradle-plugin` that seems redundant given that we apply the conventions plugin, which should add this. Am I missing something?

Cheers,
Christoph