### PR TITLE
Exclude jcl-over-slf4j also on Reactive Cassandra starter

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-data-cassandra-reactive/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-data-cassandra-reactive/build.gradle
@@ -8,6 +8,8 @@ dependencies {
 	api(platform(project(":spring-boot-project:spring-boot-dependencies")))
 	api(project(":spring-boot-project:spring-boot-starters:spring-boot-starter"))
 	api("org.springframework:spring-tx")
-	api("org.springframework.data:spring-data-cassandra")
+	api("org.springframework.data:spring-data-cassandra") {
+		exclude group: "org.slf4j", module: "jcl-over-slf4j"
+	}
 	api("io.projectreactor:reactor-core")
 }


### PR DESCRIPTION
Hi,

the missing exclude for `jcl-over-slf4j` is currently failing the build.

Cheers,
Christoph