### PR TITLE
Invalid variable reference in maven-shade-plugin configuration

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
@@ -191,7 +191,7 @@ publishing.publications.withType(MavenPublication) {
 								dependency {
 									delegate.groupId('org.springframework.boot')
 									delegate.artifactId('spring-boot-maven-plugin')
-									delegate.version('${project.version}')
+									delegate.version('${version}')
 								}
 							}
 							executions {


### PR DESCRIPTION
This should fix my prior PR #20052. I am pretty sure this is correct, but sadly I seem to be unable to fully build the project to verify for sure. Might need a couple eyes from build masters to ensure. I am so sorry for the bad fix in #20052.

History:
1) after the Gradle migration it was incorrectly left as `${revision}`
2) I blindly used Maven conventions to set it to `${project.version}`
3) After trying to `2.3.0.BUILD-SNAPSHOT` build with my change I discovered ${project.version} always resolves to `0.0.1-SNAPSHOT`.
4) Here is where I think I found the rest of the Gradle setup uses `${version}` for the current SpringBoot build version. So I used that. :)

In order to know for sure a simple child project inheriting from the spring-boot-starter-parent 2.3.0.BUILD-SNAPSHOT must use the `shade` plugin like so:

```
<build>
    <plugins>
        <plugin>
            <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-shade-plugin</artifactId>
            <configuration>
                <createDependencyReducedPom>false</createDependencyReducedPom>
            </configuration>
            <executions>
                <execution>
                    <phase>package</phase>
                    <goals>
                        <goal>shade</goal>
                    </goals>
                </execution>
            </executions>
        </plugin>
    </plugins>
</build>
```

Then simply execute `./mvnw package` to see the error.

