### PR TITLE
Upgrade CI to Docker 19.03.5

### DIFF
--- a/ci/images/setup.sh
+++ b/ci/images/setup.sh
@@ -29,7 +29,7 @@ test -f /opt/openjdk/bin/javac
 ###########################################################
 
 cd /
-curl -L https://download.docker.com/linux/static/stable/x86_64/docker-19.03.2.tgz | tar zx
+curl -L https://download.docker.com/linux/static/stable/x86_64/docker-19.03.5.tgz | tar zx
 mv /docker/* /bin/
 chmod +x /bin/docker*
 


### PR DESCRIPTION
Hi,

this PR upgrades to Docker 19.03.5 in the CI setup. It's almost impossible for me to test this locally in a proper way, so feel free to decline the PR.

Cheers,
Christoph