### PR TITLE
Fix some tests that fail with JDK 14

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/diagnostics/analyzer/NoSuchBeanDefinitionFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/diagnostics/analyzer/NoSuchBeanDefinitionFailureAnalyzerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.diagnostics.FailureAnalysis;
 import org.springframework.boot.diagnostics.LoggingFailureAnalysisReporter;
+import org.springframework.boot.system.JavaVersion;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -153,8 +154,11 @@ class NoSuchBeanDefinitionFailureAnalyzerTests {
 	@Test
 	void failureAnalysisForUnmatchedQualifier() {
 		FailureAnalysis analysis = analyzeFailure(createFailure(QualifiedBeanConfiguration.class));
-		assertThat(analysis.getDescription())
-				.containsPattern("@org.springframework.beans.factory.annotation.Qualifier\\(value=\"*alpha\"*\\)");
+		String pattern = "@org.springframework.beans.factory.annotation.Qualifier\\(value=\"*alpha\"*\\)";
+		if (JavaVersion.getJavaVersion().isEqualOrNewerThan(JavaVersion.FOURTEEN)) {
+			pattern = "@org.springframework.beans.factory.annotation.Qualifier\\(\"*alpha\"*\\)";
+		}
+		assertThat(analysis.getDescription()).containsPattern(pattern);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/TestJarCreator.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/TestJarCreator.java
@@ -98,6 +98,7 @@ public abstract class TestJarCreator {
 			writeEntry(jarOutputStream, "META-INF/versions/11/multi-release.dat", 11);
 			writeEntry(jarOutputStream, "META-INF/versions/12/multi-release.dat", 12);
 			writeEntry(jarOutputStream, "META-INF/versions/13/multi-release.dat", 13);
+			writeEntry(jarOutputStream, "META-INF/versions/14/multi-release.dat", 14);
 		}
 		else {
 			writeEntry(jarOutputStream, "3.dat", 3);


### PR DESCRIPTION
Hi,

this PR fixes two tests that break when running with JDK 14 as discussed in #20147 .

There are obviously more build failures, but these were quick wins.

Cheers,
Christoph