### PR TITLE
Explicitly set java home in Maven Plugin integration tests

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/MavenBuild.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/MavenBuild.java
@@ -166,6 +166,7 @@ class MavenBuild {
 			Files.write(destination.resolve("settings.xml"), settingsXml.getBytes(StandardCharsets.UTF_8),
 					StandardOpenOption.CREATE_NEW);
 			request.setBaseDirectory(this.temp);
+			request.setJavaHome(new File(System.getProperty("java.home")));
 			request.setProperties(this.properties);
 			request.setGoals(this.goals.isEmpty() ? Collections.singletonList("package") : this.goals);
 			request.setUserSettingsFile(new File(this.temp, "settings.xml"));


### PR DESCRIPTION
Hi,

I'm regularly switching between JDKs at the moment and noticed that `RunIntegrationTests` fails if IDEA is setup with JDK 13+ while the actual Java home (e.g. inside the terminal) is set to something lower. 

This PR sets the Java home explicitly on the `InvocationRequest` in `MavenBuild`, so the Java version for the maven invocation matches the one that actually runs the test.

Cheers,
Christoph