### PR TITLE
Remove redundant useJUnitPlatform declarations

### DIFF
--- a/spring-boot-project/spring-boot-cli/build.gradle
+++ b/spring-boot-project/spring-boot-cli/build.gradle
@@ -98,7 +98,6 @@ sourceSets {
 
 test {
 	dependsOn syncTestRepository
-	useJUnitPlatform()
 }
 
 task fullJar(type: Jar) {

--- a/spring-boot-project/spring-boot-test/build.gradle
+++ b/spring-boot-project/spring-boot-test/build.gradle
@@ -56,6 +56,3 @@ dependencies {
 	testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 }
 
-test {
-	useJUnitPlatform()
-}


### PR DESCRIPTION
Hi,

this PR removes two usages of `useJUnitPlatform` that should be redundant as they're applied via the `ConventionsPlugin` already (one of which I introduced myself :/ ).

Cheers,
Christoph