### PR TITLE
Upgrade to Gradle 6.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleCompatibilityExtension.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleCompatibilityExtension.java
@@ -43,10 +43,10 @@ public final class GradleCompatibilityExtension implements TestTemplateInvocatio
 
 	static {
 		if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_13)) {
-			GRADLE_VERSIONS = Arrays.asList("6.0.1", "default");
+			GRADLE_VERSIONS = Arrays.asList("6.0.1", "6.1.1", "default");
 		}
 		else {
-			GRADLE_VERSIONS = Arrays.asList("5.6.4", "6.0.1", "default");
+			GRADLE_VERSIONS = Arrays.asList("5.6.4", "6.0.1", "6.1.1", "default");
 		}
 	}
 


### PR DESCRIPTION
Hi,

this PR updates the project to Gradle 6.2 and updates the Gradle Plugin accordingly to test against 6.1.1 in addition to the new default.

Cheers,
Christoph