### PR TITLE
Explicitly set java home in CommandLineInvoker

### DIFF
--- a/spring-boot-project/spring-boot-cli/src/intTest/java/org/springframework/boot/cli/infrastructure/CommandLineInvoker.java
+++ b/spring-boot-project/spring-boot-cli/src/intTest/java/org/springframework/boot/cli/infrastructure/CommandLineInvoker.java
@@ -76,6 +76,7 @@ public final class CommandLineInvoker {
 		command.addAll(Arrays.asList(args));
 		ProcessBuilder processBuilder = new ProcessBuilder(command).directory(this.workingDirectory);
 		processBuilder.environment().put("JAVA_OPTS", "-Duser.home=" + this.temp);
+		processBuilder.environment().put("JAVA_HOME", System.getProperty("java.home"));
 		return processBuilder.start();
 	}
 


### PR DESCRIPTION
Hi,

similar to #20193 I found that `JarCommandIT.jarCreationWithGrabResolver()` fails if the java version in the console is different to the one used in IDEA, which is used to run the test.

Setting it explicitly in the `CommandLineInvoker` or more specifically in the `ProcessBuilder` seems to fix that.

Cheers,
Christoph