### PR TITLE
Added log capturing library to assert logging messages

### DIFF
--- a/spring-boot-project/spring-boot-test/build.gradle
+++ b/spring-boot-project/spring-boot-test/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	optional("org.springframework:spring-web")
 	optional("org.springframework:spring-webflux")
 	optional("net.sourceforge.htmlunit:htmlunit")
+	optional("io.github.hakky54:logcaptor:1.0.1")
 
 	testImplementation(project(":spring-boot-project:spring-boot-tools:spring-boot-test-support"))
 	testImplementation("io.mockk:mockk")

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/bootstrap/SpringBootTestContextBootstrapperTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/bootstrap/SpringBootTestContextBootstrapperTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.test.context.bootstrap;
 
+import nl.altindag.log.LogCaptor;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,6 +26,7 @@ import org.springframework.test.context.BootstrapContext;
 import org.springframework.test.context.CacheAwareContextLoaderDelegate;
 import org.springframework.test.context.web.WebAppConfiguration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -47,7 +49,13 @@ class SpringBootTestContextBootstrapperTests {
 
 	@Test
 	void springBootTestWithAMockWebEnvironmentCanBeUsedWithWebAppConfiguration() {
+		LogCaptor<?> logCaptor = LogCaptor.forClass(SpringBootTestContextBootstrapper.class);
+
 		buildTestContext(SpringBootTestMockWebEnvironmentAndWebAppConfiguration.class);
+
+		assertThat(logCaptor.getLogs()).contains("Found @SpringBootConfiguration "
+				+ "org.springframework.boot.test.context.bootstrap.SpringBootTestContextBootstrapperExampleConfig for test class "
+				+ "org.springframework.boot.test.context.bootstrap.SpringBootTestContextBootstrapperTests$SpringBootTestMockWebEnvironmentAndWebAppConfiguration");
 	}
 
 	@SuppressWarnings("rawtypes")


### PR DESCRIPTION
**Context:**
Spring-boot-test provides a lot of libraries which you could use without direct depending on other libraries. It provides a lot of tools which will enable you easily test your web application or any other application. As it provide junit, assertj and much more.

**Challenges:**
Within our application we can create log messages for different use cases. You will see this more often within back-end application. Unfortunately these logging messages are quite tough to test. Spring-boot-test does not provide a tool which will enable you to unit test your log messages.

**Solution**
By adding an additional library to spring-boot-test this use case will be possible:
# Usage
To be tested class
```java
import org.apache.logging.log4j.LogManager;
import org.apache.logging.log4j.Logger;

public class FooService {

    private static final Logger LOGGER = LogManager.getLogger(FooService.class);

    public void sayHello() {
        LOGGER.info("Keyboard not responding. Press any key to continue...");
        LOGGER.warn("Congratulations, you are pregnant!");
    }

}
```
Unit test:
```java
import static org.assertj.core.api.Assertions.assertThat;
import org.junit.Test;
import ch.qos.logback.classic.Level;
import nl.altindag.log.LogCaptor;

public class FooServiceShould {

    @Test
    public void logInfoAndWarnMessages() {
        String expectedInfoMessage = "Keyboard not responding. Press any key to continue...";
        String expectedWarnMessage = "Congratulations, you are pregnant!";

        LogCaptor<FooService> logCaptor = LogCaptor.forClass(FooService.class);

        FooService fooService = new FooService();
        fooService.sayHello();

        // Option 1 to assert logging entries
        assertThat(logCaptor.getLogs(Level.INFO)).containsExactly(expectedInfoMessage);
        assertThat(logCaptor.getLogs(Level.WARN)).containsExactly(expectedWarnMessage);

        // Option 2 to assert logging entries
        assertThat(logCaptor.getLogs("INFO").containsExactly(expectedInfoMessage);
        assertThat(logCaptor.getLogs("WARN").containsExactly(expectedWarnMessage);

        // Option 3 to assert logging entries
        assertThat(logCaptor.getLogs())
                .hasSize(2)
                .containsExactly(expectedInfoMessage, expectedWarnMessage);
    }
}
```

What do you think, would this be a good contribute to spring-boot-test library?