### PR TITLE
Recommend configuring compileJava's inputs to include processResources' output when generating configuration metadata

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/appendix-configuration-metadata.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/appendix-configuration-metadata.adoc
@@ -730,7 +730,7 @@ If you are using an `additional-spring-configuration-metadata.json` file, the `c
 
 [source,groovy,indent=0,subs="verbatim,quotes,attributes"]
 ----
-	compileJava.dependsOn(processResources)
+	compileJava.inputs.files(processResources)
 ----
 
 This dependency ensures that the additional metadata is available when the annotation processor runs during compilation.


### PR DESCRIPTION
`compileJava.dependsOn(processResources)` is not enough to ensure the correct behavior.

Using `dependsOn` only affects the execution order (`processResources` before `compileJava`) but not the up-to-date check of `compileJava`: After modifying `META-INF/additional-spring-configuration-metadata.json` the `processResouces` task will considered out-of-date and will be re-executed, but after that `compileJava` will still be considered up-to-date which causes the changes not to be merged into `META-INF/spring-configuration-metadata.json`

With this change the up-do-date check of `compileJava` is affected, too. Therefore it will correctly re-execute the configuration-processor when `META-INF/additional-spring-configuration-metadata.json` was changed.

Related Issues:

#9758
#9732
