### PR TITLE
Remove redundant code

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/SessionsEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/SessionsEndpointDocumentationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,10 +93,6 @@ class SessionsEndpointDocumentationTests extends MockMvcEndpointDocumentationTes
 
 	@Test
 	void sessionWithId() throws Exception {
-		Map<String, Session> sessions = new HashMap<>();
-		sessions.put(sessionOne.getId(), sessionOne);
-		sessions.put(sessionTwo.getId(), sessionTwo);
-		sessions.put(sessionThree.getId(), sessionThree);
 		given(this.sessionRepository.findById(sessionTwo.getId())).willReturn(sessionTwo);
 		this.mockMvc.perform(get("/actuator/sessions/{id}", sessionTwo.getId())).andExpect(status().isOk())
 				.andDo(document("sessions/id", responseFields(sessionFields)));


### PR DESCRIPTION
Hi,

I just noticed a few lines of unused code in `SessionsEndpointDocumentationTests` that can be removed.

Cheers,
Christoph