### PR TITLE
Make ActiveMQConnectionFactoryFactory public

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQConnectionFactoryFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQConnectionFactoryFactory.java
@@ -33,7 +33,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @author Venil Noronha
  */
-class ActiveMQConnectionFactoryFactory {
+public class ActiveMQConnectionFactoryFactory {
 
 	private static final String DEFAULT_EMBEDDED_BROKER_URL = "vm://localhost?broker.persistent=false";
 
@@ -43,14 +43,14 @@ class ActiveMQConnectionFactoryFactory {
 
 	private final List<ActiveMQConnectionFactoryCustomizer> factoryCustomizers;
 
-	ActiveMQConnectionFactoryFactory(ActiveMQProperties properties,
+	public ActiveMQConnectionFactoryFactory(ActiveMQProperties properties,
 			List<ActiveMQConnectionFactoryCustomizer> factoryCustomizers) {
 		Assert.notNull(properties, "Properties must not be null");
 		this.properties = properties;
 		this.factoryCustomizers = (factoryCustomizers != null) ? factoryCustomizers : Collections.emptyList();
 	}
 
-	<T extends ActiveMQConnectionFactory> T createConnectionFactory(Class<T> factoryClass) {
+	public <T extends ActiveMQConnectionFactory> T createConnectionFactory(Class<T> factoryClass) {
 		try {
 			return doCreateConnectionFactory(factoryClass);
 		}


### PR DESCRIPTION
As SSL ActiveMQ is not currently supported for autoconfiguration (https://github.com/spring-projects/spring-boot/pull/17373, https://github.com/spring-projects/spring-boot/issues/17589), this helps provide a low-cost stop-gap measure for autoconfiguring with SSL. This could be used in a way similar to [ActiveMQConnectionFactoryConfiguration's usage of ActiveMQConnectionFactoryFactory](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/activemq/ActiveMQConnectionFactoryConfiguration.java#L64):


```java

@Bean
public ActiveMQProperties properties() {
    return new ActiveMQProperties();
}

@Bean
@ConfigurationProperties(prefix = "javax.net.ssl") //standard ssl prefix that also fits ActiveMQSslConnectionFactory method naming, allowing easy SSL property injection
public ActiveMqSslConnectionFactory connectionFactory(ActiveMQProperties properties,
				ObjectProvider<ActiveMQConnectionFactoryCustomizer> factoryCustomizers) {
    new ActiveMQConnectionFactoryFactory(properties,
					factoryCustomizers.orderedStream().collect(Collectors.toList()))
							.createConnectionFactory(ActiveMQSslConnectionFactory.class);
}

```

Right now, with this class being package-private, wiring spring.active.x and spring.jms.x properties into an ActiveMQSslConnectionFactory is a bit of a hassle.