### PR TITLE
Include version and edition of neo4j database in health details

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicator.java
@@ -40,7 +40,8 @@ public class Neo4jHealthIndicator extends AbstractHealthIndicator {
 	/**
 	 * The Cypher statement used to verify Neo4j is up.
 	 */
-	static final String CYPHER = "match (n) return count(n) as nodes";
+	static final String CYPHER = "CALL dbms.components() YIELD versions, edition"
+			+ " UNWIND versions as version return version, edition";
 
 	private final SessionFactory sessionFactory;
 
@@ -69,7 +70,7 @@ public class Neo4jHealthIndicator extends AbstractHealthIndicator {
 	 */
 	protected void extractResult(Session session, Health.Builder builder) throws Exception {
 		Result result = session.query(CYPHER, Collections.emptyMap());
-		builder.up().withDetail("nodes", result.queryResults().iterator().next().get("nodes"));
+		builder.up().withDetails(result.queryResults().iterator().next());
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicatorTests.java
@@ -61,17 +61,21 @@ class Neo4jHealthIndicatorTests {
 	void neo4jUp() {
 		Result result = mock(Result.class);
 		given(this.session.query(Neo4jHealthIndicator.CYPHER, Collections.emptyMap())).willReturn(result);
-		int nodeCount = 500;
 		Map<String, Object> expectedCypherDetails = new HashMap<>();
-		expectedCypherDetails.put("nodes", nodeCount);
+		String edition = "community";
+		String version = "4.0.0";
+		expectedCypherDetails.put("edition", edition);
+		expectedCypherDetails.put("version", version);
 		List<Map<String, Object>> queryResults = new ArrayList<>();
 		queryResults.add(expectedCypherDetails);
 		given(result.queryResults()).willReturn(queryResults);
 		Health health = this.neo4jHealthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
 		Map<String, Object> details = health.getDetails();
-		int nodeCountFromDetails = (int) details.get("nodes");
-		assertThat(nodeCountFromDetails).isEqualTo(nodeCount);
+		String editionFromDetails = details.get("edition").toString();
+		String versionFromDetails = details.get("version").toString();
+		assertThat(editionFromDetails).isEqualTo(edition);
+		assertThat(versionFromDetails).isEqualTo(version);
 	}
 
 	@Test


### PR DESCRIPTION
Actually heath indicator details for **Neo4j** returns the number of nodes witch makes one database hit  

```javascript
  neo4j: {
  status: "UP",
  details: {
      nodes: 0
    }
  }
```

Comparing to other database vendors, I found more useful to show technical details (version and edition)  about the database rather then returning the number of nodes in the database

With this pull request the **Neo4j** heath details will be as follow 

```javascript
  neo4j: {
  status: "UP",
  details: {
      edition: "community",
      version: "4.0.0"
    }
  }
```

Notice that the new request will make 0 hits to the database, and I guess less time consuming then counting the total number of nodes

