### PR TITLE
Use isEmpty() where possible

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/mavenplugin/PluginXmlParser.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/mavenplugin/PluginXmlParser.java
@@ -60,7 +60,7 @@ class PluginXmlParser {
 
 	private String textAt(String path, Node source) throws XPathExpressionException {
 		String text = this.xpath.evaluate(path + "/text()", source);
-		return (text.length() == 0) ? null : text;
+		return text.isEmpty() ? null : text;
 	}
 
 	private List<Mojo> parseMojos(Node plugin) throws XPathExpressionException {
@@ -81,12 +81,12 @@ class PluginXmlParser {
 		Map<String, String> userProperties = new HashMap<>();
 		for (Node parameterConfigurationNode : nodesAt("configuration/*", mojoNode)) {
 			String userProperty = parameterConfigurationNode.getTextContent();
-			if (userProperty != null && userProperty.length() > 0) {
+			if (userProperty != null && !userProperty.isEmpty()) {
 				userProperties.put(parameterConfigurationNode.getNodeName(),
 						userProperty.replace("${", "`").replace("}", "`"));
 			}
 			Node defaultValueAttribute = parameterConfigurationNode.getAttributes().getNamedItem("default-value");
-			if (defaultValueAttribute != null && defaultValueAttribute.getTextContent().length() > 0) {
+			if (defaultValueAttribute != null && !defaultValueAttribute.getTextContent().isEmpty()) {
 				defaultValues.put(parameterConfigurationNode.getNodeName(), defaultValueAttribute.getTextContent());
 			}
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/TotalProgressBar.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/TotalProgressBar.java
@@ -63,7 +63,7 @@ public class TotalProgressBar implements Consumer<TotalProgressEvent> {
 	public TotalProgressBar(String prefix, char progressChar, boolean bookend, PrintStream out) {
 		this.progressChar = progressChar;
 		this.bookend = bookend;
-		if (prefix != null && prefix.length() > 0) {
+		if (prefix != null && !prefix.isEmpty()) {
 			out.print(prefix);
 			out.print(" ");
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -154,7 +154,7 @@ class TypeUtils {
 		if (((TypeElement) this.types.asElement(type)).getQualifiedName().contentEquals(Collection.class.getName())) {
 			DeclaredType declaredType = (DeclaredType) type;
 			// raw type, just "Collection"
-			if (declaredType.getTypeArguments().size() == 0) {
+			if (declaredType.getTypeArguments().isEmpty()) {
 				return this.types.getDeclaredType(this.env.getElementUtils().getTypeElement(Object.class.getName()));
 			}
 			// return type argument to Collection<...>

--- a/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/main/java/org/springframework/boot/jarmode/layertools/Context.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/main/java/org/springframework/boot/jarmode/layertools/Context.java
@@ -62,7 +62,7 @@ class Context {
 			return null;
 		}
 		String relativePath = sourcePath.substring(workingPath.length() + 1);
-		return (relativePath.length() > 0) ? relativePath : null;
+		return !relativePath.isEmpty() ? relativePath : null;
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiPropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -162,7 +162,7 @@ public class AnsiPropertySource extends PropertySource<AnsiElement> {
 					return false;
 				}
 			}
-			return postfix.length() > 0;
+			return !postfix.isEmpty();
 		}
 
 	}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-integration/src/test/java/smoketest/integration/producer/ProducerApplication.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-integration/src/test/java/smoketest/integration/producer/ProducerApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public class ProducerApplication implements ApplicationRunner {
 	@Override
 	public void run(ApplicationArguments args) throws Exception {
 		this.serviceProperties.getInputDir().mkdirs();
-		if (args.getNonOptionArgs().size() > 0) {
+		if (!args.getNonOptionArgs().isEmpty()) {
 			FileOutputStream stream = new FileOutputStream(
 					new File(this.serviceProperties.getInputDir(), "data" + System.currentTimeMillis() + ".txt"));
 			for (String arg : args.getNonOptionArgs()) {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-parent-context/src/test/java/smoketest/parent/producer/ProducerApplication.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-parent-context/src/test/java/smoketest/parent/producer/ProducerApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public class ProducerApplication implements ApplicationRunner {
 	@Override
 	public void run(ApplicationArguments args) throws Exception {
 		this.serviceProperties.getInputDir().mkdirs();
-		if (args.getNonOptionArgs().size() > 0) {
+		if (!args.getNonOptionArgs().isEmpty()) {
 			FileOutputStream stream = new FileOutputStream(
 					new File(this.serviceProperties.getInputDir(), "data" + System.currentTimeMillis() + ".txt"));
 			for (String arg : args.getNonOptionArgs()) {


### PR DESCRIPTION
Hi,

this PR polishes cases where `isEmpty()` could be used in favor of doing `size()/length() == 0` checks.

Cheers,
Christoph