### PR TITLE
Add branch information to build scans on Windows

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -390,6 +390,7 @@ jobs:
         - WIN64
         timeout: ((task-timeout))
         params:
+          BRANCH: ((branch))
           GRADLE_ENTERPRISE_ACCESS_KEY: ((gradle_enterprise_secret_access_key))
           GRADLE_ENTERPRISE_CACHE_USERNAME: ((gradle_enterprise_cache_user.username))
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ((gradle_enterprise_cache_user.password))

--- a/ci/tasks/build-project-windows.yml
+++ b/ci/tasks/build-project-windows.yml
@@ -3,6 +3,7 @@ platform: windows
 inputs:
 - name: git-repo
 params:
+  BRANCH:
   CI: true
   GRADLE_ENTERPRISE_ACCESS_KEY:
   GRADLE_ENTERPRISE_CACHE_USERNAME:


### PR DESCRIPTION
Hi,

I just noticed that the build scans for Windows builds seem to be missing the branch tag. E.g. https://ge.spring.io/s/ij4xsjian2fjy

The Windows builds seem to be also marked as "dirty" all the time. I wonder if there is a problem with line-endings still, but I can't really verify that.

Cheers,
Christoph