### PR TITLE
Test the Gradle Plugin against Gradle 6.2.2

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleCompatibilityExtension.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleCompatibilityExtension.java
@@ -39,7 +39,7 @@ import org.springframework.boot.gradle.testkit.GradleBuildExtension;
 public final class GradleCompatibilityExtension implements TestTemplateInvocationContextProvider {
 
 	private static final List<String> GRADLE_VERSIONS = Arrays.asList("default", "5.0", "5.1.1", "5.2.1", "5.3.1",
-			"5.4.1", "5.5.1", "5.6.4", "6.0.1", "6.1.1", "6.2.1");
+			"5.4.1", "5.5.1", "5.6.4", "6.0.1", "6.1.1", "6.2.2");
 
 	@Override
 	public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {


### PR DESCRIPTION
Hi,

this PR tests the Gradle Plugin against 6.2.2 in the 2.2.x mainline.

Cheers,
Christoph