### PR TITLE
Upgrade to Groovy 2.5.10

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -367,7 +367,7 @@ bom {
 			]
 		}
 	}
-	library("Groovy", "2.5.9") {
+	library("Groovy", "2.5.10") {
 		group("org.codehaus.groovy") {
 			modules = [
 				"groovy",


### PR DESCRIPTION
Hi,

this PR upgrades to Groovy 2.5.10. I know this sort of upgrade is usually handled via bomr, but this is relevant for the JDK 14 setup which I'm currently working on.

In a separate PR I'd eventually use the new BOM if that's okay for you.

Cheers,
Christoph