### PR TITLE
Add Java 14 CI

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/ConventionsPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/ConventionsPlugin.java
@@ -144,6 +144,7 @@ public class ConventionsPlugin implements Plugin<Project> {
 			});
 			project.getTasks().withType(Test.class, (test) -> {
 				withOptionalBuildJavaHome(project, (javaHome) -> test.setExecutable(javaHome + "/bin/java"));
+				withOptionalTestJavaHome(project, (javaHome) -> test.setExecutable(javaHome + "/bin/java"));
 				test.useJUnitPlatform();
 				test.setMaxHeapSize("1024M");
 			});
@@ -202,7 +203,15 @@ public class ConventionsPlugin implements Plugin<Project> {
 	}
 
 	private void withOptionalBuildJavaHome(Project project, Consumer<String> consumer) {
-		String buildJavaHome = (String) project.findProperty("buildJavaHome");
+		withOptionalJavaHome(project, consumer, "buildJavaHome");
+	}
+
+	private void withOptionalTestJavaHome(Project project, Consumer<String> consumer) {
+		withOptionalJavaHome(project, consumer, "testJavaHome");
+	}
+
+	private void withOptionalJavaHome(Project project, Consumer<String> consumer, String javaHome) {
+		String buildJavaHome = (String) project.findProperty(javaHome);
 		if (buildJavaHome != null && !buildJavaHome.isEmpty()) {
 			consumer.accept(buildJavaHome);
 		}

--- a/ci/images/get-jdk-url.sh
+++ b/ci/images/get-jdk-url.sh
@@ -11,6 +11,9 @@ case "$1" in
 	java13)
 		 echo "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_x64_linux_hotspot_13.0.2_8.tar.gz"
 	;;
+	java14)
+		 echo "https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14-2020-03-05-04-06/OpenJDK14-jdk_x64_linux_hotspot_2020-03-05-04-06.tar.gz"
+	;;
   *)
 		echo $"Unknown java version"
 		exit 1

--- a/ci/images/get-jdk-url.sh
+++ b/ci/images/get-jdk-url.sh
@@ -12,7 +12,7 @@ case "$1" in
 		 echo "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_x64_linux_hotspot_13.0.2_8.tar.gz"
 	;;
 	java14)
-		 echo "https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14-2020-03-05-04-06/OpenJDK14-jdk_x64_linux_hotspot_2020-03-05-04-06.tar.gz"
+		 echo "https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14%2B36/OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz"
 	;;
   *)
 		echo $"Unknown java version"

--- a/ci/images/setup.sh
+++ b/ci/images/setup.sh
@@ -23,6 +23,16 @@ curl -L ${JDK_URL} | tar zx --strip-components=1
 test -f /opt/openjdk/bin/java
 test -f /opt/openjdk/bin/javac
 
+if [[ $1 != $2 ]]; then
+	SECONDARY_JDK_URL=$( ./get-jdk-url.sh $2 )
+
+	mkdir -p /opt/openjdk-secondary
+	cd /opt/openjdk-secondary
+	curl -L ${SECONDARY_JDK_URL} | tar zx --strip-components=1
+	test -f /opt/openjdk-secondary/bin/java
+	test -f /opt/openjdk-secondary/bin/javac
+fi
+
 
 ###########################################################
 # DOCKER

--- a/ci/images/spring-boot-ci-image/Dockerfile
+++ b/ci/images/spring-boot-ci-image/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:bionic-20200219
 
 ADD setup.sh /setup.sh
 ADD get-jdk-url.sh /get-jdk-url.sh
-RUN ./setup.sh java8
+RUN ./setup.sh java8 java8
 
 ENV JAVA_HOME /opt/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/ci/images/spring-boot-jdk13-ci-image/Dockerfile
+++ b/ci/images/spring-boot-jdk13-ci-image/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:bionic-20200219
 
 ADD setup.sh /setup.sh
 ADD get-jdk-url.sh /get-jdk-url.sh
-RUN ./setup.sh java13
+RUN ./setup.sh java13 java13
 
 ENV JAVA_HOME /opt/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/ci/images/spring-boot-jdk14-ci-image/Dockerfile
+++ b/ci/images/spring-boot-jdk14-ci-image/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:bionic-20200219
 
 ADD setup.sh /setup.sh
 ADD get-jdk-url.sh /get-jdk-url.sh
-RUN ./setup.sh java11 java11
+RUN ./setup.sh java8 java14
 
 ENV JAVA_HOME /opt/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -94,6 +94,14 @@ resources:
     username: ((docker-hub-username))
     password: ((docker-hub-password))
     tag: 2.3.x
+- name: spring-boot-jdk14-ci-image
+  type: docker-image
+  icon: docker
+  source:
+    repository: ((docker-hub-organization))/spring-boot-jdk14-ci-image
+    username: ((docker-hub-username))
+    password: ((docker-hub-password))
+    tag: 2.3.x
 - name: artifactory-repo
   type: artifactory-resource
   icon: package-variant
@@ -126,6 +134,14 @@ resources:
     access_token: ((github-ci-status-token))
     branch: ((branch))
     context: jdk13-build
+- name: repo-status-jdk14-build
+  type: github-status-resource
+  icon: eye-check-outline
+  source:
+    repository: ((github-repo-name))
+    access_token: ((github-ci-status-token))
+    branch: ((branch))
+    context: jdk14-build
 - name: slack-alert
   type: slack-notification
   icon: slack
@@ -160,6 +176,10 @@ jobs:
       params:
         build: ci-images-git-repo/ci/images
         dockerfile: ci-images-git-repo/ci/images/spring-boot-jdk13-ci-image/Dockerfile
+    - put: spring-boot-jdk14-ci-image
+      params:
+        build: ci-images-git-repo/ci/images
+        dockerfile: ci-images-git-repo/ci/images/spring-boot-jdk14-ci-image/Dockerfile
 - name: detect-jdk-updates
   plan:
   - get: git-repo
@@ -193,6 +213,15 @@ jobs:
         GITHUB_PASSWORD: ((github-password))
         GITHUB_USERNAME: ((github-username))
         JDK_VERSION: java13
+      image: spring-boot-ci-image
+    - task: detect-jdk14-update
+      file: git-repo/ci/tasks/detect-jdk-updates.yml
+      params:
+        GITHUB_REPO: spring-boot
+        GITHUB_ORGANIZATION: spring-projects
+        GITHUB_PASSWORD: ((github-password))
+        GITHUB_USERNAME: ((github-username))
+        JDK_VERSION: java14
       image: spring-boot-ci-image
 - name: detect-ubuntu-image-updates
   plan:
@@ -368,6 +397,44 @@ jobs:
               icon_emoji: ":concourse:"
               username: concourse-ci
     - put: repo-status-jdk13-build
+      params: { state: "success", commit: "git-repo" }
+    - put: slack-alert
+      params:
+        text: ":concourse-succeeded: <https://ci.spring.io/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}|${BUILD_PIPELINE_NAME} ${BUILD_JOB_NAME} was successful!>"
+        silent: true
+        icon_emoji: ":concourse:"
+        username: concourse-ci
+- name: jdk14-build
+  serial: true
+  public: true
+  plan:
+    - get: spring-boot-jdk14-ci-image
+    - get: git-repo
+      trigger: false
+    - put: repo-status-jdk14-build
+      params: { state: "pending", commit: "git-repo" }
+    - do:
+      - task: build-project
+        privileged: true
+        timeout: ((task-timeout))
+        image: spring-boot-jdk14-ci-image
+        file: git-repo/ci/tasks/build-project.yml
+        params:
+          BRANCH: ((branch))
+          GRADLE_ENTERPRISE_ACCESS_KEY: ((gradle_enterprise_secret_access_key))
+          GRADLE_ENTERPRISE_CACHE_USERNAME: ((gradle_enterprise_cache_user.username))
+          GRADLE_ENTERPRISE_CACHE_PASSWORD: ((gradle_enterprise_cache_user.password))
+      on_failure:
+        do:
+          - put: repo-status-jdk14-build
+            params: { state: "failure", commit: "git-repo" }
+          - put: slack-alert
+            params:
+              text: ":concourse-failed: <https://ci.spring.io/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}|${BUILD_PIPELINE_NAME} ${BUILD_JOB_NAME} failed!>"
+              silent: true
+              icon_emoji: ":concourse:"
+              username: concourse-ci
+    - put: repo-status-jdk14-build
       params: { state: "success", commit: "git-repo" }
     - put: slack-alert
       params:
@@ -591,7 +658,7 @@ jobs:
       body: generated-release-notes/release-notes.md
 groups:
 - name: "Build"
-  jobs: ["build", "jdk11-build", "jdk13-build", "windows-build"]
+  jobs: ["build", "jdk11-build", "jdk13-build", "jdk14-build", "windows-build"]
 - name: "Release"
   jobs: ["stage-milestone", "stage-rc", "stage-release", "promote-milestone", "promote-rc", "promote-release", "sync-to-maven-central"]
 - name: "CI Images"

--- a/ci/scripts/build-project.sh
+++ b/ci/scripts/build-project.sh
@@ -5,5 +5,14 @@ source $(dirname $0)/common.sh
 repository=$(pwd)/distribution-repository
 
 pushd git-repo > /dev/null
-./gradlew -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false --no-daemon --max-workers=4 -PdeploymentRepository=${repository} build publishAllPublicationsToDeploymentRepository
+if [[ -d /opt/openjdk-secondary ]]; then
+  java_version=$( ./$(dirname $0)/get-secondary-java-version.sh )
+  if [[ ${java_version} = "14" ]]; then
+	  ./gradlew -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false --no-daemon --max-workers=4 -PtestJavaHome=/opt/openjdk-secondary -PdeploymentRepository=${repository} build publishAllPublicationsToDeploymentRepository -x :spring-boot-project:spring-boot-tools:spring-boot-gradle-plugin:test
+  else
+	  ./gradlew -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false --no-daemon --max-workers=4 -PtestJavaHome=/opt/openjdk-secondary -PdeploymentRepository=${repository} build publishAllPublicationsToDeploymentRepository
+  fi
+else
+	./gradlew -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false --no-daemon --max-workers=4 -PdeploymentRepository=${repository} build publishAllPublicationsToDeploymentRepository
+fi
 popd > /dev/null

--- a/ci/scripts/detect-jdk-updates.sh
+++ b/ci/scripts/detect-jdk-updates.sh
@@ -2,23 +2,27 @@
 
 case "$JDK_VERSION" in
 	java8)
-		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/8"
+		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ga"
 		 ISSUE_TITLE="Upgrade Java 8 version in CI image"
 	;;
 	java11)
-		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/11"
+		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga"
 		 ISSUE_TITLE="Upgrade Java 11 version in CI image"
 	;;
 	java13)
-		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/13"
+		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/13/ga"
 		 ISSUE_TITLE="Upgrade Java 13 version in CI image"
+	;;
+	java14)
+		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ea"
+		 ISSUE_TITLE="Upgrade Java 14 version in CI image"
 	;;
 	*)
 		echo $"Unknown java version"
 		exit 1;
 esac
 
-response=$( curl -s ${BASE_URL}\/ga\?architecture\=x64\&heap_size\=normal\&image_type\=jdk\&jvm_impl\=hotspot\&os\=linux\&sort_order\=DESC\&vendor\=adoptopenjdk )
+response=$( curl -s ${BASE_URL}\?architecture\=x64\&heap_size\=normal\&image_type\=jdk\&jvm_impl\=hotspot\&os\=linux\&sort_order\=DESC\&vendor\=adoptopenjdk )
 latest=$( jq -r '.[0].binaries[0].package.link' <<< "$response" )
 
 current=$( git-repo/ci/images/get-jdk-url.sh ${JDK_VERSION} )

--- a/ci/scripts/detect-jdk-updates.sh
+++ b/ci/scripts/detect-jdk-updates.sh
@@ -14,7 +14,7 @@ case "$JDK_VERSION" in
 		 ISSUE_TITLE="Upgrade Java 13 version in CI image"
 	;;
 	java14)
-		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ea"
+		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga"
 		 ISSUE_TITLE="Upgrade Java 14 version in CI image"
 	;;
 	*)

--- a/ci/scripts/get-secondary-java-version.sh
+++ b/ci/scripts/get-secondary-java-version.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+/opt/openjdk-secondary/bin/java -XshowSettings:properties -version 2>&1 | grep "java.specification.version" | awk '{split($0,parts,"="); print parts[2]}' | awk '{$1=$1;print}'


### PR DESCRIPTION
Hi,

this PR should add a CI job for Java 14 and therefore closes #20147 . Again - as the CI topics are extremely hard to test for me locally, feel free to decline the PR or forgive me if things are not working as they were intended.

Eventually, when there is a Gradle version that works with JDK 14, we can clean things up again. For the time being, the spring-boot-gradle-plugin tests are excluded from the build.

In order to have a green build, the following two prior PRs need to be merged:
- #20180 
- #20411 

Let me know what you think.
Cheers,
Christoph