### PR TITLE
Add support for configuring Liquibase's clearCheckSums

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -64,6 +64,7 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
  * @author Dominic Gunn
  * @author Dan Zheng
  * @author András Deák
+ * @author Ferenc Gratzer
  * @since 1.1.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -107,6 +108,7 @@ public class LiquibaseAutoConfiguration {
 			liquibase.setDatabaseChangeLogTable(this.properties.getDatabaseChangeLogTable());
 			liquibase.setDatabaseChangeLogLockTable(this.properties.getDatabaseChangeLogLockTable());
 			liquibase.setDropFirst(this.properties.isDropFirst());
+			liquibase.setClearCheckSums(this.properties.isClearCheckSums());
 			liquibase.setShouldRun(this.properties.isEnabled());
 			liquibase.setLabels(this.properties.getLabels());
 			liquibase.setChangeLogParameters(this.properties.getParameters());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
  *
  * @author Marcel Overdijk
  * @author Eddú Meléndez
+ * @author Ferenc Gratzer
  * @since 1.1.0
  */
 @ConfigurationProperties(prefix = "spring.liquibase", ignoreUnknownFields = false)
@@ -73,6 +74,12 @@ public class LiquibaseProperties {
 	 * Whether to first drop the database schema.
 	 */
 	private boolean dropFirst;
+
+	/**
+	 * Whether to clear all checksums in the current changelog, so they will be
+	 * recalculated next update.
+	 */
+	private boolean clearCheckSums;
 
 	/**
 	 * Whether to enable Liquibase support.
@@ -185,6 +192,14 @@ public class LiquibaseProperties {
 
 	public void setDropFirst(boolean dropFirst) {
 		this.dropFirst = dropFirst;
+	}
+
+	public boolean isClearCheckSums() {
+		return this.clearCheckSums;
+	}
+
+	public void setClearCheckSums(boolean clearCheckSums) {
+		this.clearCheckSums = clearCheckSums;
 	}
 
 	public boolean isEnabled() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
@@ -69,6 +69,7 @@ import static org.assertj.core.api.Assertions.contentOf;
  * @author Dominic Gunn
  * @author András Deák
  * @author Andrii Hrytsiuk
+ * @author Ferenc Gratzer
  */
 @ExtendWith(OutputCaptureExtension.class)
 class LiquibaseAutoConfigurationTests {
@@ -106,6 +107,7 @@ class LiquibaseAutoConfigurationTests {
 					assertThat(liquibase.getContexts()).isNull();
 					assertThat(liquibase.getDefaultSchema()).isNull();
 					assertThat(liquibase.isDropFirst()).isFalse();
+					assertThat(liquibase.isClearCheckSums()).isFalse();
 				}));
 	}
 
@@ -143,6 +145,7 @@ class LiquibaseAutoConfigurationTests {
 					assertThat(liquibase.getDatabaseChangeLogLockTable())
 							.isEqualTo(properties.getDatabaseChangeLogLockTable());
 					assertThat(liquibase.isDropFirst()).isEqualTo(properties.isDropFirst());
+					assertThat(liquibase.isClearCheckSums()).isEqualTo(properties.isClearCheckSums());
 					assertThat(liquibase.isTestRollbackOnUpdate()).isEqualTo(properties.isTestRollbackOnUpdate());
 				}));
 	}
@@ -187,6 +190,13 @@ class LiquibaseAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
 				.withPropertyValues("spring.liquibase.drop-first:true")
 				.run(assertLiquibase((liquibase) -> assertThat(liquibase.isDropFirst()).isTrue()));
+	}
+
+	@Test
+	void overrideClearCheckSums() {
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+				.withPropertyValues("spring.liquibase.clear-check-sums:true")
+				.run(assertLiquibase((liquibase) -> assertThat(liquibase.isClearCheckSums()).isTrue()));
 	}
 
 	@Test


### PR DESCRIPTION
Liquibase auto configuration is extended with clearCheckSums to allow to clear all checksums in the current changelog, so they will be recalculated next update. SpringLiquibase supports it since 3.7.0.

The clearCheckSums is a pretty useful feature of Liquibase in the development phase. For instance if you just added a comment or some cosmetic changes to your changeset, Liquibase will break the startup of your application based on the changed checksum values. So if your changeset is already deployed to QA / UAT, this flag makes it possible to make those small changes, without a new changeset. Sometimes even a new changeset doesn't solve your problem, like in my project.
In my case I want to make the existing Liquibase scripts run on H2 database for some integration tests, but those scripts contain some Oracle default values (CREATE SEQUENCE with NOORDER) - which could be removed without any effect -, and unfortunately those script are already deployed to QA. So either this flag or clear the checksums in the table DATABASECHANGELOG on QA database, which is more difficult.

It'd be nice if you cherry-pick this change to spring-boot 2.2.