### PR TITLE
Upgrade CI to Docker 19.03.7

### DIFF
--- a/ci/images/setup.sh
+++ b/ci/images/setup.sh
@@ -29,7 +29,7 @@ test -f /opt/openjdk/bin/javac
 ###########################################################
 
 cd /
-curl -L https://download.docker.com/linux/static/stable/x86_64/docker-19.03.5.tgz | tar zx
+curl -L https://download.docker.com/linux/static/stable/x86_64/docker-19.03.7.tgz | tar zx
 mv /docker/* /bin/
 chmod +x /bin/docker*
 


### PR DESCRIPTION
Hi,

this upgrades the Docker version for the CI environment to 19.03.7.

Cheers,
Christoph

P.S.: I could offer to create a similar automation process that we use for detecting jdk or ubuntu image upgrades. Let me know if I should invest a bit of time for that.