### PR TITLE
Upgrade to Elasticsearch 7.6.1

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/VersionOverridingElasticsearchContainer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/VersionOverridingElasticsearchContainer.java
@@ -32,7 +32,7 @@ public class VersionOverridingElasticsearchContainer extends ElasticsearchContai
 	/**
 	 * Elasticsearch version
 	 */
-	protected static final String ELASTICSEARCH_VERSION = "7.5.1";
+	protected static final String ELASTICSEARCH_VERSION = "7.6.1";
 
 	public VersionOverridingElasticsearchContainer() {
 		super(ELASTICSEARCH_IMAGE + ":" + ELASTICSEARCH_VERSION);

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -275,7 +275,7 @@ bom {
 			]
 		}
 	}
-	library("Elasticsearch", "7.5.2") {
+	library("Elasticsearch", "7.6.1") {
 		group("org.elasticsearch") {
 			modules = [
 				"elasticsearch"


### PR DESCRIPTION
Hi,

the current builds seem to fail, probably because of an upgrade to Elasticsearch 7.6.1 in https://github.com/spring-projects/spring-data-elasticsearch/commit/9258cdde8438845f8a4730394873aeb4199b2979 . When upgrading Spring-Boot accordingly the failing tests are green again.

Cheers,
Christoph