### PR TITLE
upgrade netty to 4.1.47.Final

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1255,7 +1255,7 @@ bom {
 			]
 		}
 	}
-	library("Netty", "4.1.43.Final") {
+	library("Netty", "4.1.47.Final") {
 		group("io.netty") {
 			imports = [
 				"netty-bom"


### PR DESCRIPTION
refer: [Netty 4.1.47.Final released](https://netty.io/news/2020/03/09/4-1-47-Final.html)