### PR TITLE
Remove redundant exclusions

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/CheckBom.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/CheckBom.java
@@ -69,9 +69,14 @@ public class CheckBom extends DefaultTask {
 				.collect(Collectors.toSet());
 		Set<String> unused = new TreeSet<>();
 		for (String exclusion : exclusions) {
-			if (!resolved.contains(exclusion) && exclusion.endsWith(":*")) {
-				String group = exclusion.substring(0, exclusion.indexOf(':') + 1);
-				if (resolved.stream().noneMatch((candidate) -> candidate.startsWith(group))) {
+			if (!resolved.contains(exclusion)) {
+				if (exclusion.endsWith(":*")) {
+					String group = exclusion.substring(0, exclusion.indexOf(':') + 1);
+					if (resolved.stream().noneMatch((candidate) -> candidate.startsWith(group))) {
+						unused.add(exclusion);
+					}
+				}
+				else {
 					unused.add(exclusion);
 				}
 			}

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1524,13 +1524,9 @@ bom {
 				"selenium-ie-driver",
 				"selenium-java",
 				"selenium-opera-driver",
-				"selenium-remote-driver" {
-					exclude group: "commons-logging", module: "commons-logging"
-				},
+				"selenium-remote-driver",
 				"selenium-safari-driver",
-				"selenium-support" {
-					exclude group: "commons-logging", module: "commons-logging"
-				}
+				"selenium-support"
 			]
 		}
 	}
@@ -1641,12 +1637,6 @@ bom {
 	}
 	library("Spring Integration", "5.3.0.M2") {
 		group("org.springframework.integration") {
-			modules = [
-				"spring-integration-http" {
-					exclude group: "commons-logging", module: "commons-logging"
-					exclude group: "commons-logging", module: "commons-logging-api"
-				}
-			]
 			imports = [
 				"spring-integration-bom"
 			]
@@ -1707,18 +1697,10 @@ bom {
 	library("Spring WS", "3.0.8.RELEASE") {
 		group("org.springframework.ws") {
 			modules = [
-				"spring-ws-core" {
-					exclude group: "commons-logging", module: "commons-logging"
-				},
-				"spring-ws-security" {
-					exclude group: "commons-logging", module: "commons-logging"
-				},
-				"spring-ws-support" {
-					exclude group: "commons-logging", module: "commons-logging"
-				},
-				"spring-ws-test" {
-					exclude group: "commons-logging", module: "commons-logging"
-				},
+				"spring-ws-core",
+				"spring-ws-security",
+				"spring-ws-support",
+				"spring-ws-test",
 				"spring-xml"
 			]
 		}


### PR DESCRIPTION
Hi,

I just noticed some dependency exclusions in `spring-boot-dependencies` that seem redundant. E.g. compare [selenium-remote-driver:3.14.0](https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-remote-driver/3.14.0) with [selenium-remote-driver:3.141.0](https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-remote-driver/3.141.0). On the latter, `commons-logging` is not a dependency anymore, while it is one in the former.

If I understood `CheckBom` correctly, it misses to check for non-wildcard excludes at the moment. This PR removes the redundant exclusions and handles non-wildcard ones inside `CheckBom` now.

Let me know what you think.
Cheers,
Christoph