### PR TITLE
Added Apache commons-pool2 dependency to spring-boot-starter-data-redis

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-data-redis/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-data-redis/build.gradle
@@ -9,4 +9,5 @@ dependencies {
 	api(project(":spring-boot-project:spring-boot-starters:spring-boot-starter"))
 	api("org.springframework.data:spring-data-redis")
 	api("io.lettuce:lettuce-core")
+	api("org.apache.commons:commons-pool2")
 }


### PR DESCRIPTION
This is to resolve issues when constructing a `LettucePoolingClientConfiguration` pool config.
I was trying to establish a connection pool with the Lettuce driver using `spring-boot-starter-data-redis`, but ran into compilation issues as the `commons-pool2` was not a dependency in `build.gradle`. 

Sample code [here](https://github.com/spring-cloud/spring-cloud-connectors/blob/4cbee67434fddc0aa488c38215259db38ed5380a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/keyval/RedisLettuceClientConfigurer.java#L42) 

Resolves: https://github.com/spring-projects/spring-boot/issues/12843#issuecomment-380738137

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
