### PR TITLE
Add support for auto-configuration of Hazelcast Jet

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	optional("com.github.ben-manes.caffeine:caffeine")
 	optional("com.hazelcast:hazelcast")
 	optional("com.hazelcast:hazelcast-spring")
+	optional("com.hazelcast.jet:hazelcast-jet")
 	optional("com.sun.mail:jakarta.mail")
 	optional("com.zaxxer:HikariCP")
 	optional("io.dropwizard.metrics:metrics-jmx")

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/jet/HazelcastJetHealthContributorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/jet/HazelcastJetHealthContributorAutoConfiguration.java
@@ -49,7 +49,7 @@ public class HazelcastJetHealthContributorAutoConfiguration
 		extends CompositeHealthContributorConfiguration<HazelcastJetHealthIndicator, JetInstance> {
 
 	@Bean
-	@ConditionalOnMissingBean(name = {"hazelcastJetHealthIndicator", "hazelcastJetHealthContributor"})
+	@ConditionalOnMissingBean(name = { "hazelcastJetHealthIndicator", "hazelcastJetHealthContributor" })
 	public HealthContributor hazelcastHealthContributor(Map<String, JetInstance> jetInstances) {
 		return createContributor(jetInstances);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/jet/HazelcastJetHealthContributorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/jet/HazelcastJetHealthContributorAutoConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.jet;
+
+import java.util.Map;
+
+import com.hazelcast.jet.JetInstance;
+
+import org.springframework.boot.actuate.autoconfigure.health.CompositeHealthContributorConfiguration;
+import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.actuate.health.HealthContributor;
+import org.springframework.boot.actuate.jet.HazelcastJetHealthIndicator;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.jet.HazelcastJetAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for
+ * {@link HazelcastJetHealthIndicator}.
+ *
+ * @author Ali Gurbuz
+ * @since 2.3.0
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(JetInstance.class)
+@ConditionalOnBean(JetInstance.class)
+@ConditionalOnEnabledHealthIndicator("hazelcast.jet")
+@AutoConfigureAfter(HazelcastJetAutoConfiguration.class)
+public class HazelcastJetHealthContributorAutoConfiguration
+		extends CompositeHealthContributorConfiguration<HazelcastJetHealthIndicator, JetInstance> {
+
+	@Bean
+	@ConditionalOnMissingBean(name = {"hazelcastJetHealthIndicator", "hazelcastJetHealthContributor"})
+	public HealthContributor hazelcastHealthContributor(Map<String, JetInstance> jetInstances) {
+		return createContributor(jetInstances);
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/jet/package-info.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/jet/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for actuator Hazelcast Jet concerns.
+ */
+package org.springframework.boot.actuate.autoconfigure.jet;

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -20,6 +20,7 @@ org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfi
 org.springframework.boot.actuate.autoconfigure.env.EnvironmentEndpointAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.flyway.FlywayEndpointAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.hazelcast.HazelcastHealthContributorAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.jet.HazelcastJetHealthContributorAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.health.HealthEndpointAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.influx.InfluxDbHealthContributorAutoConfiguration,\

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/integrationtest/WebEndpointsAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/integrationtest/WebEndpointsAutoConfigurationIntegrationTests.java
@@ -36,6 +36,7 @@ import org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoCon
 import org.springframework.boot.autoconfigure.data.solr.SolrRepositoriesAutoConfiguration;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 import org.springframework.boot.autoconfigure.hazelcast.HazelcastAutoConfiguration;
+import org.springframework.boot.autoconfigure.jet.HazelcastJetAutoConfiguration;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoReactiveAutoConfiguration;
@@ -82,7 +83,7 @@ class WebEndpointsAutoConfigurationIntegrationTests {
 			RepositoryRestMvcAutoConfiguration.class, HazelcastAutoConfiguration.class,
 			ElasticsearchDataAutoConfiguration.class, SolrRepositoriesAutoConfiguration.class,
 			SolrAutoConfiguration.class, RedisAutoConfiguration.class, RedisRepositoriesAutoConfiguration.class,
-			MetricsAutoConfiguration.class })
+			MetricsAutoConfiguration.class, HazelcastJetAutoConfiguration.class })
 	@SpringBootConfiguration
 	static class WebEndpointTestApplication {
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/jet/HazelcastJetHealthContributorAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/jet/HazelcastJetHealthContributorAutoConfigurationIntegrationTests.java
@@ -14,52 +14,50 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.actuate.autoconfigure.hazelcast;
+package org.springframework.boot.actuate.autoconfigure.jet;
 
-import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.JetInstance;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
-import org.springframework.boot.actuate.hazelcast.HazelcastHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.actuate.jet.HazelcastJetHealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.autoconfigure.hazelcast.HazelcastAutoConfiguration;
+import org.springframework.boot.autoconfigure.jet.HazelcastJetAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration tests for {@link HazelcastHealthContributorAutoConfiguration}.
+ * Integration tests for {@link HazelcastJetHealthContributorAutoConfiguration}.
  *
- * @author Dmytro Nosan
+ * @author Ali Gurbuz
  */
-@ClassPathExclusions({ "hazelcast-jet*.jar" })
-class HazelcastHealthContributorAutoConfigurationIntegrationTests {
+class HazelcastJetHealthContributorAutoConfigurationIntegrationTests {
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(HazelcastHealthContributorAutoConfiguration.class,
-					HazelcastAutoConfiguration.class, HealthContributorAutoConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(HazelcastJetHealthContributorAutoConfiguration.class,
+					HazelcastJetAutoConfiguration.class, HealthContributorAutoConfiguration.class));
 
 	@Test
 	void hazelcastUp() {
 		this.contextRunner.run((context) -> {
-			assertThat(context).hasSingleBean(HazelcastInstance.class).hasSingleBean(HazelcastHealthIndicator.class);
-			HazelcastInstance hazelcast = context.getBean(HazelcastInstance.class);
-			Health health = context.getBean(HazelcastHealthIndicator.class).health();
+			assertThat(context).hasSingleBean(JetInstance.class).hasSingleBean(HazelcastJetHealthIndicator.class);
+			JetInstance jet = context.getBean(JetInstance.class);
+			Health health = context.getBean(HazelcastJetHealthIndicator.class).health();
 			assertThat(health.getStatus()).isEqualTo(Status.UP);
-			assertThat(health.getDetails()).containsOnlyKeys("name", "uuid").containsEntry("name", hazelcast.getName())
-					.containsEntry("uuid", hazelcast.getLocalEndpoint().getUuid());
+			assertThat(health.getDetails()).containsOnlyKeys("name", "uuid").containsEntry("name", jet.getName())
+					.containsEntry("uuid", jet.getHazelcastInstance().getLocalEndpoint().getUuid());
 		});
 	}
 
 	@Test
 	void hazelcastDown() {
 		this.contextRunner.run((context) -> {
-			context.getBean(HazelcastInstance.class).shutdown();
-			assertThat(context).hasSingleBean(HazelcastHealthIndicator.class);
-			Health health = context.getBean(HazelcastHealthIndicator.class).health();
+			context.getBean(JetInstance.class).shutdown();
+			assertThat(context).hasSingleBean(HazelcastJetHealthIndicator.class);
+			Health health = context.getBean(HazelcastJetHealthIndicator.class).health();
 			assertThat(health.getStatus()).isEqualTo(Status.DOWN);
 		});
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/jet/HazelcastJetHealthContributorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/jet/HazelcastJetHealthContributorAutoConfigurationTests.java
@@ -14,40 +14,38 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.actuate.autoconfigure.hazelcast;
+package org.springframework.boot.actuate.autoconfigure.jet;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
-import org.springframework.boot.actuate.hazelcast.HazelcastHealthIndicator;
+import org.springframework.boot.actuate.jet.HazelcastJetHealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.autoconfigure.hazelcast.HazelcastAutoConfiguration;
+import org.springframework.boot.autoconfigure.jet.HazelcastJetAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link HazelcastHealthContributorAutoConfiguration}.
+ * Tests for {@link HazelcastJetHealthContributorAutoConfiguration}.
  *
- * @author Dmytro Nosan
+ * @author Ali Gurbuz
  */
-@ClassPathExclusions({ "hazelcast-jet*.jar" })
-class HazelcastHealthContributorAutoConfigurationTests {
+class HazelcastJetHealthContributorAutoConfigurationTests {
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(HazelcastAutoConfiguration.class,
-					HazelcastHealthContributorAutoConfiguration.class, HealthContributorAutoConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(HazelcastJetAutoConfiguration.class,
+					HazelcastJetHealthContributorAutoConfiguration.class, HealthContributorAutoConfiguration.class));
 
 	@Test
 	void runShouldCreateIndicator() {
-		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(HazelcastHealthIndicator.class));
+		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(HazelcastJetHealthIndicator.class));
 	}
 
 	@Test
 	void runWhenDisabledShouldNotCreateIndicator() {
-		this.contextRunner.withPropertyValues("management.health.hazelcast.enabled:false")
-				.run((context) -> assertThat(context).doesNotHaveBean(HazelcastHealthIndicator.class));
+		this.contextRunner.withPropertyValues("management.health.hazelcast.jet.enabled:false")
+				.run((context) -> assertThat(context).doesNotHaveBean(HazelcastJetHealthIndicator.class));
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/resources/hazelcast-jet.yaml
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/resources/hazelcast-jet.yaml
@@ -1,0 +1,10 @@
+hazelcast-jet:
+  edge-defaults:
+    queue-size: 2048
+
+  hazelcast:
+    instance-name: default-instance
+    network:
+      join:
+        multicast:
+          enabled: false

--- a/spring-boot-project/spring-boot-actuator/build.gradle
+++ b/spring-boot-project/spring-boot-actuator/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	optional("com.github.ben-manes.caffeine:caffeine")
 	optional("com.hazelcast:hazelcast")
 	optional("com.hazelcast:hazelcast-spring")
+	optional("com.hazelcast.jet:hazelcast-jet")
 	optional("com.sun.mail:jakarta.mail")
 	optional("com.zaxxer:HikariCP")
 	optional("io.lettuce:lettuce-core")

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/jet/HazelcastJetHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/jet/HazelcastJetHealthIndicator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.jet;
+
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.Job;
+import com.hazelcast.jet.core.DAG;
+import com.hazelcast.jet.core.processor.Processors;
+
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.util.Assert;
+
+/**
+ * {@link HealthIndicator} for Hazelcast Jet.
+ *
+ * @author Ali Gurbuz
+ * @since 2.3.0
+ */
+public class HazelcastJetHealthIndicator extends AbstractHealthIndicator {
+
+	private final JetInstance jetInstance;
+
+	public HazelcastJetHealthIndicator(JetInstance jetInstance) {
+		super("Hazelcast Jet health check failed");
+		Assert.notNull(jetInstance, "JetInstance must not be null");
+		this.jetInstance = jetInstance;
+	}
+
+	@Override
+	protected void doHealthCheck(Health.Builder builder) {
+		submitJob();
+		builder.up().withDetail("name", this.jetInstance.getName()).withDetail("uuid",
+				this.jetInstance.getHazelcastInstance().getLocalEndpoint().getUuid());
+	}
+
+	/**
+	 * Submits a noop {@link Job} to the Hazelcast Jet cluster and waits for it to finish
+	 * without any exception. This should indicate that the Hazelcast Jet cluster is up
+	 * and running.
+	 */
+	private void submitJob() {
+		DAG dag = new DAG();
+		dag.newVertex("noopSource", Processors.noopP());
+		this.jetInstance.newJob(dag).join();
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/jet/package-info.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/jet/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Actuator support for Hazelcast Jet.
+ */
+package org.springframework.boot.actuate.jet;

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jet/HazelcastJetHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jet/HazelcastJetHealthIndicatorTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.jet;
+
+import com.hazelcast.core.Endpoint;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.Job;
+import com.hazelcast.jet.core.DAG;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.when;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link HazelcastJetHealthIndicator}.
+ *
+ * @author Ali Gurbuz
+ */
+class HazelcastJetHealthIndicatorTests {
+
+	private final JetInstance jet = mock(JetInstance.class);
+
+	@Test
+	void hazelcastUp() {
+		HazelcastInstance hazelcast = mock(HazelcastInstance.class);
+		Endpoint endpoint = mock(Endpoint.class);
+		Job job = mock(Job.class);
+		when(this.jet.getHazelcastInstance()).thenReturn(hazelcast);
+		when(this.jet.getName()).thenReturn("jet0-instance");
+		when(hazelcast.getLocalEndpoint()).thenReturn(endpoint);
+		when(endpoint.getUuid()).thenReturn("7581bb2f-879f-413f-b574-0071d7519eb0");
+		when(this.jet.newJob(any(DAG.class))).thenReturn(job);
+		Health health = new HazelcastJetHealthIndicator(this.jet).health();
+		assertThat(health.getStatus()).isEqualTo(Status.UP);
+		assertThat(health.getDetails()).containsOnlyKeys("name", "uuid").containsEntry("name", "jet0-instance")
+				.containsEntry("uuid", "7581bb2f-879f-413f-b574-0071d7519eb0");
+	}
+
+	@Test
+	void hazelcastDown() {
+		HazelcastInstance hazelcast = mock(HazelcastInstance.class);
+		when(this.jet.getHazelcastInstance()).thenReturn(hazelcast);
+		when(hazelcast.executeTransaction(any())).thenThrow(new HazelcastException());
+		Health health = new HazelcastJetHealthIndicator(this.jet).health();
+		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/resources/hazelcast-jet.yaml
+++ b/spring-boot-project/spring-boot-actuator/src/test/resources/hazelcast-jet.yaml
@@ -1,0 +1,10 @@
+hazelcast-jet:
+  edge-defaults:
+    queue-size: 2048
+
+  hazelcast:
+    instance-name: default-instance
+    network:
+      join:
+        multicast:
+          enabled: false

--- a/spring-boot-project/spring-boot-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-autoconfigure/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	optional("com.fasterxml.jackson.module:jackson-module-parameter-names")
 	optional("com.google.code.gson:gson")
 	optional("com.hazelcast:hazelcast")
+	optional("com.hazelcast.jet:hazelcast-jet")
 	optional("com.hazelcast:hazelcast-client")
 	optional("com.hazelcast:hazelcast-spring")
 	optional("com.h2database:h2")

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/HazelcastJetAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/HazelcastJetAutoConfiguration.java
@@ -14,34 +14,27 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.autoconfigure.hazelcast;
+package org.springframework.boot.autoconfigure.jet;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.JetInstance;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
- * {@link EnableAutoConfiguration Auto-configuration} for Hazelcast. Creates a
- * {@link HazelcastInstance} based on explicit configuration or when a default
- * configuration file is found in the environment unless {@link JetInstance} is on the
- * classpath.
+ * {@link EnableAutoConfiguration Auto-configuration} for Hazelcast Jet. Creates a
+ * {@link JetInstance} based on explicit configuration or when a default configuration
+ * file is found in the environment.
  *
- * @author Stephane Nicoll
- * @author Vedran Pavic
- * @since 1.3.0
- * @see HazelcastConfigResourceCondition
+ * @author Ali Gurbuz
+ * @see HazelcastJetConfigResourceCondition
+ * @since 2.3.0
  */
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass(HazelcastInstance.class)
-@ConditionalOnMissingClass("com.hazelcast.jet.JetInstance")
-@EnableConfigurationProperties(HazelcastProperties.class)
-@Import({ HazelcastClientConfiguration.class, HazelcastServerConfiguration.class })
-public class HazelcastAutoConfiguration {
+@ConditionalOnClass(JetInstance.class)
+@Import({ HazelcastJetServerConfiguration.class, HazelcastJetClientConfiguration.class })
+public class HazelcastJetAutoConfiguration {
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/HazelcastJetClientConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/HazelcastJetClientConfiguration.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jet;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.client.config.YamlClientConfigBuilder;
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.JetInstance;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+
+/**
+ * Configuration for Hazelcast Jet client.
+ *
+ * @author Ali Gurbuz
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(HazelcastJetClientProperties.class)
+@ConditionalOnMissingBean(JetInstance.class)
+class HazelcastJetClientConfiguration {
+
+	public static final String CONFIG_ENVIRONMENT_PROPERTY = "spring.hazelcast.jet.client.config";
+
+	public static final String CONFIG_SYSTEM_PROPERTY = "hazelcast.client.config";
+
+	private static ClientConfig getClientConfig(Resource clientConfigLocation) throws IOException {
+		URL configUrl = clientConfigLocation.getURL();
+		String configFileName = configUrl.getPath();
+		if (configFileName.endsWith(".yaml") || configFileName.endsWith("yml")) {
+			return new YamlClientConfigBuilder(configUrl).build();
+		}
+		return new XmlClientConfigBuilder(configUrl).build();
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnMissingBean(ClientConfig.class)
+	@Conditional(ConfigAvailableCondition.class)
+	static class HazelcastJetClientConfigFileConfiguration {
+
+		@Bean
+		JetInstance jetInstance(HazelcastJetClientProperties properties) throws IOException {
+			Resource configLocation = properties.resolveConfigLocation();
+			if (configLocation == null) {
+				return Jet.newJetClient();
+			}
+			return Jet.newJetClient(getClientConfig(configLocation));
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnSingleCandidate(ClientConfig.class)
+	static class HazelcastJetClientConfigConfiguration {
+
+		@Bean
+		JetInstance jetInstance(ClientConfig clientConfig) {
+			return Jet.newJetClient(clientConfig);
+		}
+
+	}
+
+	/**
+	 * {@link HazelcastJetConfigResourceCondition} that checks if the
+	 * {@code spring.hazelcast.jet.config} configuration key is defined.
+	 */
+	static class ConfigAvailableCondition extends HazelcastJetConfigResourceCondition {
+
+		ConfigAvailableCondition() {
+			super("HazelcastJetClient", CONFIG_ENVIRONMENT_PROPERTY, CONFIG_SYSTEM_PROPERTY,
+					"file:./hazelcast-client.xml", "classpath:/hazelcast-client.xml", "file:./hazelcast-client.yaml",
+					"classpath:/hazelcast-client.yaml", "file:./hazelcast-client.yml",
+					"classpath:/hazelcast-client.yml");
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/HazelcastJetClientProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/HazelcastJetClientProperties.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jet;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.Resource;
+import org.springframework.util.Assert;
+
+/**
+ * Configuration properties for the hazelcast jet integration.
+ *
+ * @author Ali Gurbuz
+ * @since 2.3.0
+ */
+@ConfigurationProperties(prefix = "spring.hazelcast.jet.client")
+public class HazelcastJetClientProperties {
+
+	/**
+	 * The location of the configuration file to use to initialize Hazelcast Jet.
+	 */
+	private Resource config;
+
+	public Resource getConfig() {
+		return this.config;
+	}
+
+	public void setConfig(Resource config) {
+		this.config = config;
+	}
+
+	/**
+	 * Resolve the config location if set.
+	 * @return the location or {@code null} if it is not set
+	 * @throws IllegalArgumentException if the config attribute is set to an unknown
+	 * location
+	 */
+	public Resource resolveConfigLocation() {
+		if (this.config == null) {
+			return null;
+		}
+		Assert.isTrue(this.config.exists(),
+				() -> "Hazelcast Jet client configuration does not exist '" + this.config.getDescription() + "'");
+		return this.config;
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/HazelcastJetConfigResourceCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/HazelcastJetConfigResourceCondition.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jet;
+
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.ResourceCondition;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.Assert;
+
+/**
+ * {@link SpringBootCondition} used to check if the Hazelcast Jet configuration is
+ * available. This either kicks in if a default configuration has been found or if
+ * configurable property referring to the resource to use has been set.
+ *
+ * @author Ali Gurbuz
+ * @since 2.3.0
+ */
+public abstract class HazelcastJetConfigResourceCondition extends ResourceCondition {
+
+	private final String configSystemProperty;
+
+	protected HazelcastJetConfigResourceCondition(String name, String property, String configSystemProperty,
+			String... resourceLocations) {
+		super(name, property, resourceLocations);
+		Assert.notNull(configSystemProperty, "ConfigSystemProperty must not be null");
+		this.configSystemProperty = configSystemProperty;
+	}
+
+	@Override
+	public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		if (System.getProperty(this.configSystemProperty) != null) {
+			return ConditionOutcome
+					.match(startConditionMessage().because("System property '" + this.configSystemProperty + "' is set."));
+		}
+		return super.getMatchOutcome(context, metadata);
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/HazelcastJetConfigResourceCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/HazelcastJetConfigResourceCondition.java
@@ -45,8 +45,8 @@ public abstract class HazelcastJetConfigResourceCondition extends ResourceCondit
 	@Override
 	public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
 		if (System.getProperty(this.configSystemProperty) != null) {
-			return ConditionOutcome
-					.match(startConditionMessage().because("System property '" + this.configSystemProperty + "' is set."));
+			return ConditionOutcome.match(
+					startConditionMessage().because("System property '" + this.configSystemProperty + "' is set."));
 		}
 		return super.getMatchOutcome(context, metadata);
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/HazelcastJetProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/HazelcastJetProperties.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jet;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.Resource;
+import org.springframework.util.Assert;
+
+/**
+ * Configuration properties for the hazelcast jet integration.
+ *
+ * @author Ali Gurbuz
+ * @since 2.3.0
+ */
+@ConfigurationProperties(prefix = "spring.hazelcast.jet")
+public class HazelcastJetProperties {
+
+	/**
+	 * The location of the configuration file to use to initialize Hazelcast Jet.
+	 */
+	private Resource config;
+
+	public Resource getConfig() {
+		return this.config;
+	}
+
+	public void setConfig(Resource config) {
+		this.config = config;
+	}
+
+	/**
+	 * Resolve the config location if set.
+	 * @return the location or {@code null} if it is not set
+	 * @throws IllegalArgumentException if the config attribute is set to an unknown
+	 * location
+	 */
+	public Resource resolveConfigLocation() {
+		if (this.config == null) {
+			return null;
+		}
+		Assert.isTrue(this.config.exists(),
+				() -> "Hazelcast Jet configuration does not exist '" + this.config.getDescription() + "'");
+		return this.config;
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/HazelcastJetServerConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/HazelcastJetServerConfiguration.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jet;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.impl.config.ConfigProvider;
+import com.hazelcast.jet.impl.config.XmlJetConfigBuilder;
+import com.hazelcast.jet.impl.config.YamlJetConfigBuilder;
+import com.hazelcast.spring.context.SpringManagedContext;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Hazelcast Jet. Creates a
+ * {@link JetInstance} based on explicit configuration or when a default configuration
+ * file is found in the environment.
+ *
+ * @author Ali Gurbuz
+ * @since 2.3.0
+ * @see HazelcastJetConfigResourceCondition
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(HazelcastJetProperties.class)
+@ConditionalOnMissingBean(JetInstance.class)
+public class HazelcastJetServerConfiguration {
+
+	public static final String CONFIG_SYSTEM_PROPERTY = "hazelcast.jet.config";
+
+	public static final String CONFIG_ENVIRONMENT_PROPERTY = "spring.hazelcast.jet.config";
+
+	private static JetConfig getJetConfig(Resource configLocation) throws IOException {
+		URL configUrl = configLocation.getURL();
+		String configFileName = configUrl.getPath();
+		InputStream inputStream = configUrl.openStream();
+		if (configFileName.endsWith(".yaml") || configFileName.endsWith("yml")) {
+			return new YamlJetConfigBuilder(inputStream).build();
+		}
+		return new XmlJetConfigBuilder(inputStream).build();
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnMissingBean(JetConfig.class)
+	@Conditional(JetConfigAvailableCondition.class)
+	static class HazelcastJetServerConfigFileConfiguration {
+
+		@Autowired
+		private ApplicationContext applicationContext;
+
+		@Bean
+		JetInstance jetInstance(HazelcastJetProperties properties) throws IOException {
+			Resource configLocation = properties.resolveConfigLocation();
+			JetConfig jetConfig = (configLocation != null) ? getJetConfig(configLocation)
+					: ConfigProvider.locateAndGetJetConfig();
+			injectSpringManagedContext(jetConfig);
+			return Jet.newJetInstance(jetConfig);
+		}
+
+		private void injectSpringManagedContext(JetConfig jetConfig) {
+			SpringManagedContext springManagedContext = new SpringManagedContext();
+			springManagedContext.setApplicationContext(this.applicationContext);
+			jetConfig.getHazelcastConfig().setManagedContext(springManagedContext);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnSingleCandidate(JetConfig.class)
+	static class HazelcastJetServerConfigConfiguration {
+
+		@Bean
+		JetInstance jetInstance(JetConfig jetConfig) {
+			return Jet.newJetInstance(jetConfig);
+		}
+
+	}
+
+	/**
+	 * {@link HazelcastJetConfigResourceCondition} that checks if the
+	 * {@code spring.hazelcast.jet.config} configuration key is defined.
+	 */
+	static class JetConfigAvailableCondition extends HazelcastJetConfigResourceCondition {
+
+		JetConfigAvailableCondition() {
+			super("HazelcastJet", CONFIG_ENVIRONMENT_PROPERTY, CONFIG_SYSTEM_PROPERTY, "file:./hazelcast-jet.xml",
+					"classpath:/hazelcast-jet.xml", "file:./hazelcast-jet.yaml", "classpath:/hazelcast-jet.yaml",
+					"file:./hazelcast-jet.yml", "classpath:/hazelcast-jet.yml");
+		}
+
+		@Override
+		protected ConditionOutcome getResourceOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+			if (System.getProperty(HazelcastJetClientConfiguration.CONFIG_SYSTEM_PROPERTY) != null) {
+				return ConditionOutcome.noMatch(startConditionMessage().because(
+						"System property '" + HazelcastJetClientConfiguration.CONFIG_SYSTEM_PROPERTY + "' is set."));
+			}
+			if (context.getEnvironment()
+					.containsProperty(HazelcastJetClientConfiguration.CONFIG_ENVIRONMENT_PROPERTY)) {
+				return ConditionOutcome.noMatch(startConditionMessage().because("Environment property '"
+						+ HazelcastJetClientConfiguration.CONFIG_ENVIRONMENT_PROPERTY + "' is set."));
+			}
+			return super.getResourceOutcome(context, metadata);
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/package-info.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jet/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Hazelcast Jet.
+ */
+package org.springframework.boot.autoconfigure.jet;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -79,6 +79,7 @@ org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration,\
 org.springframework.boot.autoconfigure.jdbc.JndiDataSourceAutoConfiguration,\
 org.springframework.boot.autoconfigure.jdbc.XADataSourceAutoConfiguration,\
 org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration,\
+org.springframework.boot.autoconfigure.jet.HazelcastJetAutoConfiguration,\
 org.springframework.boot.autoconfigure.jms.JmsAutoConfiguration,\
 org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration,\
 org.springframework.boot.autoconfigure.jms.JndiConnectionFactoryAutoConfiguration,\

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
@@ -85,7 +85,7 @@ import static org.mockito.Mockito.verify;
  * @author Mark Paluch
  * @author Ryon Day
  */
-@ClassPathExclusions("hazelcast-client-*.jar")
+@ClassPathExclusions({ "hazelcast-client-*.jar", "hazelcast-jet-*.jar" })
 class CacheAutoConfigurationTests extends AbstractCacheAutoConfigurationTests {
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationClientTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationClientTests.java
@@ -32,6 +32,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.ContextConsumer;
+import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -43,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Vedran Pavic
  * @author Stephane Nicoll
  */
+@ClassPathExclusions({ "hazelcast-jet*.jar" })
 class HazelcastAutoConfigurationClientTests {
 
 	/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationServerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationServerTests.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Stephane Nicoll
  */
-@ClassPathExclusions("hazelcast-client-*.jar")
+@ClassPathExclusions({ "hazelcast-client-*.jar", "hazelcast-jet*.jar" })
 class HazelcastAutoConfigurationServerTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
 import org.springframework.core.io.ClassPathResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Stephane Nicoll
  */
+@ClassPathExclusions({ "hazelcast-jet*.jar" })
 class HazelcastAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jet/HazelcastJetAutoConfigurationClientTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jet/HazelcastJetAutoConfigurationClientTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jet;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.impl.JetClientInstanceImpl;
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.ContextConsumer;
+import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link HazelcastJetServerConfiguration} specific to the client.
+ *
+ * @author Ali Gurbuz
+ */
+@ClassPathExclusions({ "hazelcast-client*.jar" })
+class HazelcastJetAutoConfigurationClientTests {
+
+	/**
+	 * Servers the test clients will connect to.
+	 */
+	private static JetInstance jetServer;
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(HazelcastJetAutoConfiguration.class));
+
+	@BeforeAll
+	static void init() {
+		JetConfig jetConfig = new JetConfig();
+		Config hazelcastConfig = jetConfig.getHazelcastConfig();
+		hazelcastConfig.getGroupConfig().setName("boot").setPassword("test");
+		hazelcastConfig.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+		jetServer = Jet.newJetInstance(jetConfig);
+	}
+
+	@AfterAll
+	static void close() {
+		if (jetServer != null) {
+			jetServer.shutdown();
+		}
+	}
+
+	@Test
+	void systemPropertyWithXml() {
+		this.contextRunner
+				.withSystemProperties(HazelcastJetClientConfiguration.CONFIG_SYSTEM_PROPERTY
+						+ "=classpath:org/springframework/boot/autoconfigure/jet/hazelcast-jet-client-specific.xml")
+				.run(assertSpecificHazelcastJetClient("explicit-xml"));
+	}
+
+	@Test
+	void systemPropertyWithYaml() {
+		this.contextRunner
+				.withSystemProperties(HazelcastJetClientConfiguration.CONFIG_SYSTEM_PROPERTY
+						+ "=classpath:org/springframework/boot/autoconfigure/jet/hazelcast-jet-client-specific.yaml")
+				.run(assertSpecificHazelcastJetClient("explicit-yaml"));
+	}
+
+	@Test
+	void explicitConfigFileWithXml() {
+		this.contextRunner
+				.withPropertyValues("spring.hazelcast.jet.client.config=org/springframework/boot/autoconfigure/"
+						+ "jet/hazelcast-jet-client-specific.xml")
+				.run(assertSpecificHazelcastJetClient("explicit-xml"));
+	}
+
+	@Test
+	void explicitConfigFileWithYaml() {
+		this.contextRunner
+				.withPropertyValues("spring.hazelcast.jet.client.config=org/springframework/boot/autoconfigure/"
+						+ "jet/hazelcast-jet-client-specific.yaml")
+				.run(assertSpecificHazelcastJetClient("explicit-yaml"));
+	}
+
+	@Test
+	void explicitConfigUrlWithXml() {
+		this.contextRunner
+				.withPropertyValues("spring.hazelcast.jet.client.config=classpath:org/springframework/"
+						+ "boot/autoconfigure/jet/hazelcast-jet-client-specific.xml")
+				.run(assertSpecificHazelcastJetClient("explicit-xml"));
+	}
+
+	@Test
+	void explicitConfigUrlWithYaml() {
+		this.contextRunner
+				.withPropertyValues("spring.hazelcast.jet.client.config=classpath:org/springframework/"
+						+ "boot/autoconfigure/jet/hazelcast-jet-client-specific.yaml")
+				.run(assertSpecificHazelcastJetClient("explicit-yaml"));
+	}
+
+	@Test
+	void unknownConfigFile() {
+		this.contextRunner.withPropertyValues("spring.hazelcast.jet.client.config=foo/bar/unknown.xml")
+				.run((context) -> assertThat(context).getFailure().isInstanceOf(BeanCreationException.class)
+						.hasMessageContaining("foo/bar/unknown.xml"));
+	}
+
+	private static ContextConsumer<AssertableApplicationContext> assertSpecificHazelcastJetClient(String label) {
+		return (context) -> assertThat(context).getBean(JetInstance.class).isInstanceOf(JetInstance.class)
+				.has(labelEqualTo(label));
+	}
+
+	private static Condition<JetInstance> labelEqualTo(String label) {
+		return new Condition<>((o) -> ((JetClientInstanceImpl) o).getHazelcastClient().getClientConfig().getLabels()
+				.stream().anyMatch((e) -> e.equals(label)), "Label equals to " + label);
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jet/HazelcastJetAutoConfigurationServerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jet/HazelcastJetAutoConfigurationServerTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jet;
+
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.EdgeConfig;
+import com.hazelcast.jet.config.JetConfig;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.ContextConsumer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link HazelcastJetServerConfiguration}.
+ *
+ * @author Ali Gurbuz
+ */
+class HazelcastJetAutoConfigurationServerTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(HazelcastJetAutoConfiguration.class));
+
+	@Test
+	void defaultConfigFile() {
+		// hazelcast-jet.xml present in root classpath
+		this.contextRunner.run((context) -> {
+			JetConfig jetConfig = context.getBean(JetInstance.class).getConfig();
+			EdgeConfig defaultEdgeConfig = jetConfig.getDefaultEdgeConfig();
+			assertThat(defaultEdgeConfig.getQueueSize()).isEqualTo(2048);
+		});
+	}
+
+	@Test
+	void systemPropertyWithXml() {
+		this.contextRunner
+				.withSystemProperties(HazelcastJetServerConfiguration.CONFIG_SYSTEM_PROPERTY
+						+ "=classpath:org/springframework/boot/autoconfigure/jet/hazelcast-jet-specific.xml")
+				.run(assertSpecificJetServer("xml"));
+	}
+
+	@Test
+	void systemPropertyWithYaml() {
+		this.contextRunner
+				.withSystemProperties(HazelcastJetServerConfiguration.CONFIG_SYSTEM_PROPERTY
+						+ "=classpath:org/springframework/boot/autoconfigure/jet/hazelcast-jet-specific.yaml")
+				.run(assertSpecificJetServer("yaml"));
+	}
+
+	@Test
+	void explicitConfigFileWithXml() {
+		this.contextRunner.withPropertyValues("spring.hazelcast.jet.config=org/springframework/boot/autoconfigure/jet/"
+				+ "hazelcast-jet-specific.xml").run(assertSpecificJetServer("xml"));
+	}
+
+	@Test
+	void explicitConfigFileWithYaml() {
+		this.contextRunner.withPropertyValues("spring.hazelcast.jet.config=org/springframework/boot/autoconfigure/jet/"
+				+ "hazelcast-jet-specific.yaml").run(assertSpecificJetServer("yaml"));
+	}
+
+	@Test
+	void explicitConfigUrlWithXml() {
+		this.contextRunner.withPropertyValues("spring.hazelcast.jet.config=classpath:org/springframework/"
+				+ "boot/autoconfigure/jet/hazelcast-jet-specific.xml").run(assertSpecificJetServer("xml"));
+	}
+
+	@Test
+	void explicitConfigUrlWithYaml() {
+		this.contextRunner.withPropertyValues("spring.hazelcast.jet.config=classpath:org/springframework/"
+				+ "boot/autoconfigure/jet/hazelcast-jet-specific.yaml").run(assertSpecificJetServer("yaml"));
+	}
+
+	@Test
+	void unknownConfigFile() {
+		this.contextRunner.withPropertyValues("spring.hazelcast.jet.config=foo/bar/unknown.xml")
+				.run((context) -> assertThat(context).getFailure().isInstanceOf(BeanCreationException.class)
+						.hasMessageContaining("foo/bar/unknown.xml"));
+	}
+
+	@Test
+	void configInstanceWithoutName() {
+		this.contextRunner.withUserConfiguration(HazelcastJetConfig.class)
+				.withPropertyValues("spring.hazelcast.jet.config=this-is-ignored.xml")
+				.run(assertSpecificJetServer("configAsBean"));
+	}
+
+	private static ContextConsumer<AssertableApplicationContext> assertSpecificJetServer(String suffix) {
+		return (context) -> {
+			JetConfig jetConfig = context.getBean(JetInstance.class).getConfig();
+			assertThat(jetConfig.getProperties().getProperty("foo")).isEqualTo("bar-" + suffix);
+		};
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class HazelcastJetConfig {
+
+		@Bean
+		JetConfig anotherHazelcastJetConfig() {
+			JetConfig jetConfig = new JetConfig();
+			jetConfig.getHazelcastConfig().getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+			jetConfig.setProperty("foo", "bar-configAsBean");
+			return jetConfig;
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/hazelcast-jet.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/hazelcast-jet.xml
@@ -1,0 +1,7 @@
+<hazelcast-jet xsi:schemaLocation="http://www.hazelcast.com/schema/jet-config hazelcast-jet-config-3.2.xsd"
+			   xmlns="http://www.hazelcast.com/schema/jet-config"
+			   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<edge-defaults>
+		<queue-size>2048</queue-size>
+	</edge-defaults>
+</hazelcast-jet>

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/hazelcast-jet.yaml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/hazelcast-jet.yaml
@@ -1,0 +1,10 @@
+hazelcast-jet:
+  edge-defaults:
+    queue-size: 2048
+
+  hazelcast:
+    instance-name: default-instance
+    network:
+      join:
+        multicast:
+          enabled: false

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/jet/hazelcast-jet-client-specific.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/jet/hazelcast-jet-client-specific.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.12.xsd">
+	<group>
+		<name>boot</name>
+		<password>test</password>
+	</group>
+	<client-labels>
+		<label>explicit-xml</label>
+	</client-labels>
+
+</hazelcast-client>

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/jet/hazelcast-jet-client-specific.yaml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/jet/hazelcast-jet-client-specific.yaml
@@ -1,0 +1,6 @@
+hazelcast-client:
+  group:
+    name: boot
+    password: test
+  client-labels:
+    - explicit-yaml

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/jet/hazelcast-jet-specific.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/jet/hazelcast-jet-specific.xml
@@ -1,0 +1,8 @@
+<hazelcast-jet xsi:schemaLocation="http://www.hazelcast.com/schema/jet-config hazelcast-jet-config-3.2.xsd"
+			   xmlns="http://www.hazelcast.com/schema/jet-config"
+			   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<properties>
+		<property name="foo">bar-xml</property>
+	</properties>
+
+</hazelcast-jet>

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/jet/hazelcast-jet-specific.yaml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/jet/hazelcast-jet-specific.yaml
@@ -1,0 +1,9 @@
+hazelcast-jet:
+  properties:
+    foo: bar-yaml
+
+  hazelcast:
+    network:
+      join:
+        multicast:
+          enabled: false

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -434,6 +434,13 @@ bom {
 			]
 		}
 	}
+	library("HazelcastJet", "3.2.2") {
+		group("com.hazelcast.jet") {
+			modules = [
+					"hazelcast-jet"
+			]
+		}
+	}
 	library("Hazelcast Hibernate5", "1.3.2") {
 		group("com.hazelcast") {
 			modules = [

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
@@ -675,6 +675,9 @@ The following `HealthIndicators` are auto-configured by Spring Boot when appropr
 | {spring-boot-actuator-module-code}/hazelcast/HazelcastHealthIndicator.java[`HazelcastHealthIndicator`]
 | Checks that a Hazelcast server is up.
 
+| {spring-boot-actuator-module-code}/jet/HazelcastJetHealthIndicator.java[`HazelcastJetHealthIndicator`]
+| Checks that a Hazelcast Jet server is up.
+
 | {spring-boot-actuator-module-code}/influx/InfluxDbHealthIndicator.java[`InfluxDbHealthIndicator`]
 | Checks that an InfluxDB server is up.
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -5805,7 +5805,7 @@ The {spring-boot-module-code}/jta/bitronix/BitronixXAConnectionFactoryWrapper.ja
 
 [[boot-features-hazelcast]]
 == Hazelcast
-If https://hazelcast.com/[Hazelcast] is on the classpath and a suitable configuration is found, Spring Boot auto-configures a `HazelcastInstance` that you can inject in your application.
+If https://hazelcast.com/[Hazelcast] is on the classpath and a suitable configuration is found, Spring Boot auto-configures a `HazelcastInstance` that you can inject in your application. If there is <<boot-features-hazelcast-jet,Hazelcast Jet>> on the classpath Spring Boot does not try to auto-configure Hazelcast, instead tries to auto-configure Hazelcast Jet.
 
 If you define a `com.hazelcast.config.Config` bean, Spring Boot uses that.
 If your configuration defines an instance name, Spring Boot tries to locate an existing instance rather than creating a new one.
@@ -5832,6 +5832,40 @@ If `hazelcast-client` is present on the classpath, Spring Boot first attempts to
 NOTE: Spring Boot also has <<boot-features-caching-provider-hazelcast,explicit caching support for Hazelcast>>.
 If caching is enabled, the `HazelcastInstance` is automatically wrapped in a `CacheManager` implementation.
 
+[[boot-features-hazelcast-jet]]
+== Hazelcast Jet
+If https://jet.hazelcast.org/[Hazelcast Jet] is on the classpath and a suitable configuration is found, Spring Boot auto-configures a `JetInstance` that you can inject in your application
+
+If you define a `com.hazelcast.jet.config.JetConfig` bean, Spring Boot uses that.
+
+You could also specify the Hazelcast Jet server configuration file to use through configuration, as shown in the following example:
+
+[source,properties,indent=0,configprops]
+----
+	spring.hazelcast.jet.config=classpath:config/my-hazelcast-jet.xml
+----
+
+Or you could specify Hazelcast Jet client configuration as shown in the following example:
+
+[source,properties,indent=0,configprops]
+----
+	spring.hazelcast.jet.client.config=classpath:config/my-hazelcast-client.xml
+----
+
+Otherwise, Spring Boot tries to find the Hazelcast Jet configuration from the default locations: `hazelcast-jet.xml` in the working directory or at the root of the classpath, or a `.yaml`/`.yml` counterpart in the same locations.
+We also check if the `hazelcast.jet.config` system property set for server configuration and `hazelcast.client.config` system property set for client configuration.
+See the https://docs.hazelcast.org/docs/jet/latest/manual/#declarative-configuration[Hazelcast Jet documentation] for more details.
+
+Spring Boot attempts to create a `JetInstance` by checking following configuration options:
+
+* The presence of a `com.hazelcast.jet.config.JetConfig` bean (a Jet member will be created).
+* The presence of the `hazelcast.jet.config` system property (a Jet member will be created).
+* A configuration file defined by the configprop:spring.hazelcast.jet.config[] property (a Jet member will be created).
+* The presence of a `com.hazelcast.client.config.ClientConfig` bean (a Jet client will be created).
+* The presence of the `hazelcast.client.config` system property (a Jet client will be created).
+* A configuration file defined by the configprop:spring.hazelcast.jet.client.config[] property (a Jet client will be created).
+* `hazelcast-jet.yaml`, `hazelcast-jet.yml` or `hazelcast-jet.xml` in the working directory or at the root of the classpath. (a Jet member will be created).
+* `hazelcast-client.yaml`, `hazelcast-client.yml` or `hazelcast-client.xml` in the working directory or at the root of the classpath. (a Jet client will be created).
 
 
 [[boot-features-quartz]]


### PR DESCRIPTION
This commit adds support for auto-configuration of Hazelcast Jet server
and client and auto-configuration of Hazelcast Jet Health Contributor.

Since Hazelcast Jet is shading Hazelcast classes and using Hazelcast specific
configuration files, Hazelcast Jet auto-configuration should disable the Hazelcast
auto-configuration if Hazelcast Jet found on the classpath. I've achieved this using 
`@ConditionalOnMissingClass("com.hazelcast.jet.JetInstance")` annotation on to
Hazelcast auto-configuration class. 

