### PR TITLE
Only suggest Ubuntu versions available in the Docker registry

### DIFF
--- a/ci/scripts/detect-ubuntu-image-updates.sh
+++ b/ci/scripts/detect-ubuntu-image-updates.sh
@@ -3,7 +3,7 @@
 ISSUE_TITLE="Upgrade Ubuntu version in CI images"
 
 ubuntu="bionic"
-latest=$( curl -s "https://partner-images.canonical.com/core/$ubuntu/current/unpacked/build-info.txt" | awk '{split($0, parts, "="); print parts[2]}' )
+latest=$( curl -s "https://hub.docker.com/v2/repositories/library/ubuntu/tags/?page_size=1&page=1&name=$ubuntu" | jq -c -r '.results[0].name' | awk '{split($0, parts, "-"); print parts[2]}' )
 current=$( grep "ubuntu:$ubuntu" git-repo/ci/images/spring-boot-ci-image/Dockerfile | awk '{split($0, parts, "-"); print parts[2]}' )
 
 if [[ $current = $latest ]]; then


### PR DESCRIPTION
Hi,

unfortunately the current Ubuntu upgrade task suggested to upgrade to a version that wasn't available in the Docker registry yet. See #20566 . This PR should fix that.

Sorry for the inconveniences this has caused.

Cheers,
Christoph