### PR TITLE
Creation of DiskSpaceHealthIndicatorProperties should not fail for a non-existent path

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/system/DiskSpaceHealthIndicatorProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/system/DiskSpaceHealthIndicatorProperties.java
@@ -48,8 +48,6 @@ public class DiskSpaceHealthIndicatorProperties {
 	}
 
 	public void setPath(File path) {
-		Assert.isTrue(path.exists(), () -> "Path '" + path + "' does not exist");
-		Assert.isTrue(path.canRead(), () -> "Path '" + path + "' cannot be read");
 		this.path = path;
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/system/DiskSpaceHealthContributorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/system/DiskSpaceHealthContributorAutoConfigurationTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.actuate.autoconfigure.system;
 
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
@@ -56,6 +58,13 @@ class DiskSpaceHealthContributorAutoConfigurationTests {
 			assertThat(context.getBean(DiskSpaceHealthIndicator.class)).hasFieldOrPropertyWithValue("threshold",
 					DataSize.ofMegabytes(20));
 		});
+	}
+
+	@Test
+	void pathIsNotRequiredToExist() {
+		String randomPath = "IDoNOTeXiST" + UUID.randomUUID().toString();
+		this.contextRunner.withPropertyValues("management.health.diskspace.path=" + randomPath)
+				.run((context) -> assertThat(context).hasSingleBean(DiskSpaceHealthIndicator.class));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/system/DiskSpaceHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/system/DiskSpaceHealthIndicator.java
@@ -68,7 +68,9 @@ public class DiskSpaceHealthIndicator extends AbstractHealthIndicator {
 			builder.down();
 		}
 		builder.withDetail("total", this.path.getTotalSpace()).withDetail("free", diskFreeInBytes)
-				.withDetail("threshold", this.threshold.toBytes());
+				.withDetail("threshold", this.threshold.toBytes()).withDetail("exists", this.path.exists())
+				.withDetail("canRead", this.path.canRead()).withDetail("canWrite", this.path.canWrite())
+				.withDetail("canExecute", this.path.canExecute());
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/system/DiskSpaceHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/system/DiskSpaceHealthIndicator.java
@@ -59,7 +59,9 @@ public class DiskSpaceHealthIndicator extends AbstractHealthIndicator {
 	@Override
 	protected void doHealthCheck(Health.Builder builder) throws Exception {
 		long diskFreeInBytes = this.path.getUsableSpace();
-		if (diskFreeInBytes >= this.threshold.toBytes()) {
+		// return value of 0L means "the abstract pathname does not name a
+		// partition" which for our purposes means it's not usable i.e DOWN
+		if (diskFreeInBytes >= this.threshold.toBytes() && diskFreeInBytes != 0L) {
 			builder.up();
 		}
 		else {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/system/DiskSpaceHealthIndicatorPathTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/system/DiskSpaceHealthIndicatorPathTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.system;
+
+import java.io.File;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.util.unit.DataSize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Tests for the {@link DiskSpaceHealthIndicator} {@code path} parameter.
+ *
+ * @author Andreas Born
+ */
+class DiskSpaceHealthIndicatorPathTests {
+
+	private static final DataSize THRESHOLD = DataSize.ofKilobytes(1);
+
+	private static final DataSize TOTAL_SPACE = DataSize.ofKilobytes(10);
+
+	@Mock
+	private File fileMock;
+
+	private HealthIndicator healthIndicator;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.initMocks(this);
+		given(this.fileMock.exists()).willReturn(false);
+		given(this.fileMock.canRead()).willReturn(false);
+		given(this.fileMock.canWrite()).willReturn(false);
+		given(this.fileMock.canExecute()).willReturn(false);
+		this.healthIndicator = new DiskSpaceHealthIndicator(this.fileMock, THRESHOLD);
+	}
+
+	@Test
+	void diskSpaceIsDown() {
+		Health health = this.healthIndicator.health();
+		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+		assertThat(health.getDetails().get("threshold")).isEqualTo(THRESHOLD.toBytes());
+		assertThat(health.getDetails().get("free")).isEqualTo(0L);
+		assertThat(health.getDetails().get("total")).isEqualTo(0L);
+		assertThat(health.getDetails().get("exists")).isEqualTo(false);
+		assertThat(health.getDetails().get("canRead")).isEqualTo(false);
+		assertThat(health.getDetails().get("canWrite")).isEqualTo(false);
+		assertThat(health.getDetails().get("canExecute")).isEqualTo(false);
+	}
+
+	@Test
+	void diskSpaceIsUpWhenPathOnlyExists() {
+		long freeSpace = THRESHOLD.toBytes() + 10;
+		given(this.fileMock.getUsableSpace()).willReturn(freeSpace);
+		given(this.fileMock.getTotalSpace()).willReturn(TOTAL_SPACE.toBytes());
+		given(this.fileMock.exists()).willReturn(true);
+		Health health = this.healthIndicator.health();
+		assertThat(health.getStatus()).isEqualTo(Status.UP);
+		assertThat(health.getDetails().get("threshold")).isEqualTo(THRESHOLD.toBytes());
+		assertThat(health.getDetails().get("free")).isEqualTo(freeSpace);
+		assertThat(health.getDetails().get("total")).isEqualTo(TOTAL_SPACE.toBytes());
+		assertThat(health.getDetails().get("exists")).isEqualTo(true);
+		assertThat(health.getDetails().get("canRead")).isEqualTo(false);
+		assertThat(health.getDetails().get("canWrite")).isEqualTo(false);
+		assertThat(health.getDetails().get("canExecute")).isEqualTo(false);
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/system/DiskSpaceHealthIndicatorPathTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/system/DiskSpaceHealthIndicatorPathTests.java
@@ -40,6 +40,8 @@ class DiskSpaceHealthIndicatorPathTests {
 
 	private static final DataSize THRESHOLD = DataSize.ofKilobytes(1);
 
+	private static final DataSize ZERO_THRESHOLD = DataSize.ofBytes(0);
+
 	private static final DataSize TOTAL_SPACE = DataSize.ofKilobytes(10);
 
 	@Mock
@@ -62,6 +64,20 @@ class DiskSpaceHealthIndicatorPathTests {
 		Health health = this.healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
 		assertThat(health.getDetails().get("threshold")).isEqualTo(THRESHOLD.toBytes());
+		assertThat(health.getDetails().get("free")).isEqualTo(0L);
+		assertThat(health.getDetails().get("total")).isEqualTo(0L);
+		assertThat(health.getDetails().get("exists")).isEqualTo(false);
+		assertThat(health.getDetails().get("canRead")).isEqualTo(false);
+		assertThat(health.getDetails().get("canWrite")).isEqualTo(false);
+		assertThat(health.getDetails().get("canExecute")).isEqualTo(false);
+	}
+
+	@Test
+	void diskSpaceIsDownWhenThresholdIsZero() {
+		this.healthIndicator = new DiskSpaceHealthIndicator(this.fileMock, ZERO_THRESHOLD);
+		Health health = this.healthIndicator.health();
+		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+		assertThat(health.getDetails().get("threshold")).isEqualTo(ZERO_THRESHOLD.toBytes());
 		assertThat(health.getDetails().get("free")).isEqualTo(0L);
 		assertThat(health.getDetails().get("total")).isEqualTo(0L);
 		assertThat(health.getDetails().get("exists")).isEqualTo(false);

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/system/DiskSpaceHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/system/DiskSpaceHealthIndicatorTests.java
@@ -53,6 +53,8 @@ class DiskSpaceHealthIndicatorTests {
 		MockitoAnnotations.initMocks(this);
 		given(this.fileMock.exists()).willReturn(true);
 		given(this.fileMock.canRead()).willReturn(true);
+		given(this.fileMock.canWrite()).willReturn(true);
+		given(this.fileMock.canExecute()).willReturn(true);
 		this.healthIndicator = new DiskSpaceHealthIndicator(this.fileMock, THRESHOLD);
 	}
 
@@ -66,6 +68,10 @@ class DiskSpaceHealthIndicatorTests {
 		assertThat(health.getDetails().get("threshold")).isEqualTo(THRESHOLD.toBytes());
 		assertThat(health.getDetails().get("free")).isEqualTo(freeSpace);
 		assertThat(health.getDetails().get("total")).isEqualTo(TOTAL_SPACE.toBytes());
+		assertThat(health.getDetails().get("exists")).isEqualTo(true);
+		assertThat(health.getDetails().get("canRead")).isEqualTo(true);
+		assertThat(health.getDetails().get("canWrite")).isEqualTo(true);
+		assertThat(health.getDetails().get("canExecute")).isEqualTo(true);
 	}
 
 	@Test
@@ -78,6 +84,10 @@ class DiskSpaceHealthIndicatorTests {
 		assertThat(health.getDetails().get("threshold")).isEqualTo(THRESHOLD.toBytes());
 		assertThat(health.getDetails().get("free")).isEqualTo(freeSpace);
 		assertThat(health.getDetails().get("total")).isEqualTo(TOTAL_SPACE.toBytes());
+		assertThat(health.getDetails().get("exists")).isEqualTo(true);
+		assertThat(health.getDetails().get("canRead")).isEqualTo(true);
+		assertThat(health.getDetails().get("canWrite")).isEqualTo(true);
+		assertThat(health.getDetails().get("canExecute")).isEqualTo(true);
 	}
 
 }


### PR DESCRIPTION
## Problem
When the path referenced by `management.health.diskspace.path` does not exist before a Spring Boot application with the actuator autoconfiguration is started, there is no possibility to create the path during application startup. This is sort of a chicken & egg problem. If I want to create the path during startup, I need to get it from the configuration. But to access the configuration the creation of `DiskSpaceHealthIndicatorProperties` must not fail. However, this is the case when that path does not exist (or is not readable) before application startup.

## Use Case
My application has a data directory and I want the autoconfigured DiskSpaceHealthIndicator to monitor that directory. Let's say the configuration is like that:
~~~
myapp.data.path=myapp/data/
management.health.diskspace.path=${myapp.data.path}
~~~
I do not want to tell every user (or developer) that he needs to create the `myapp/data/` directory first. So the application will create the directory itself when necessary. However, once I add the second line above this mechanism stops working and application startup fails until the directories are created outside the scope of the Spring Boot application and before its startup (e.g. manually).

## Proposed Solution
Do not check mutable aspects of the system environment when binding the configuration properties. That is, move the existence & readability assertions from `DiskSpaceHealthIndicatorProperties` to `DiskSpaceHealthContributorAutoconfiguration`. This allows in my use case to access the configuration and to create the directories during startup before the autoconfiguration runs.

I picked this solution because the behavior of `DiskSpaceHealthContributorAutoconfiguration` would remain largely unchanged as indicated by the test case I added. I did not move the assertions to `DiskSpaceHealthIndicator` because that would affect users that directly use it and that might for some reason rely on being able to create it with a nonexistent or unreadable path.

Please let me know if you would prefer a different approach.