### PR TITLE
Upgrade to Gradle 6.3 RC4

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-rc-3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-rc-4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Hi,

this PR upgrades to Gradle 6.3 RC4 until we hopefully get a GA release next week.

Cheers,
Christoph