### PR TITLE
Upgrade group("com.squareup.okhttp3") to 4.4.1 and start using bom.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/influx/InfluxDbProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/influx/InfluxDbProperties.java
@@ -36,12 +36,16 @@ public class InfluxDbProperties {
 	/**
 	 * Login user.
 	 */
-	private String user;
+	// null value leads invalid basic auth setup and RuntimeException until
+	// https://github.com/influxdata/influxdb-java/pull/644 released.
+	private String user = "";
 
 	/**
 	 * Login password.
 	 */
-	private String password;
+	// null value leads invalid basic auth setup and RuntimeException until
+	// https://github.com/influxdata/influxdb-java/pull/644 released.
+	private String password = "";
 
 	public String getUrl() {
 		return this.url;

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -566,7 +566,7 @@ bom {
 			]
 		}
 	}
-	library("InfluxDB Java", "2.17") {
+	library("InfluxDB Java", "2.17") { // Maybe we can refactor InfluxDbProperties.java when update it.
 		group("org.influxdb") {
 			modules = [
 				"influxdb-java"
@@ -1295,18 +1295,10 @@ bom {
 			]
 		}
 	}
-	library("OkHttp3", "3.14.7") {
+	library("OkHttp", "4.4.1") {
 		group("com.squareup.okhttp3") {
-			modules = [
-				"logging-interceptor",
-				"mockwebserver",
-				"okcurl",
-				"okhttp",
-				"okhttp-dnsoverhttps",
-				"okhttp-sse",
-				"okhttp-testing-support",
-				"okhttp-tls",
-				"okhttp-urlconnection"
+			imports = [
+				"okhttp-bom"
 			]
 		}
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/RestTemplateBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/RestTemplateBuilderTests.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import okhttp3.OkHttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -532,16 +533,16 @@ class RestTemplateBuilderTests {
 	void connectTimeoutCanBeConfiguredOnOkHttp3RequestFactory() {
 		ClientHttpRequestFactory requestFactory = this.builder.requestFactory(OkHttp3ClientHttpRequestFactory.class)
 				.setConnectTimeout(Duration.ofMillis(1234)).build().getRequestFactory();
-		assertThat(
-				ReflectionTestUtils.getField(ReflectionTestUtils.getField(requestFactory, "client"), "connectTimeout"))
-						.isEqualTo(1234);
+		assertThat(((OkHttpClient) ReflectionTestUtils.getField(requestFactory, "client")).connectTimeoutMillis())
+				.isEqualTo(1234);
 	}
 
 	@Test
 	void readTimeoutCanBeConfiguredOnOkHttp3RequestFactory() {
 		ClientHttpRequestFactory requestFactory = this.builder.requestFactory(OkHttp3ClientHttpRequestFactory.class)
 				.setReadTimeout(Duration.ofMillis(1234)).build().getRequestFactory();
-		assertThat(requestFactory).extracting("client").extracting("readTimeout").isEqualTo(1234);
+		assertThat(((OkHttpClient) ReflectionTestUtils.getField(requestFactory, "client")).readTimeoutMillis())
+				.isEqualTo(1234);
 	}
 
 	@Test


### PR DESCRIPTION
First: I don't know if there are any reason to avoid upgrade OkHttp to 4.x. Sorry if I'm sending PR about already rejected topic.

----

* Upgrade OkHttp to 4.4.1

According to https://square.github.io/okhttp/upgrading_to_okhttp_4/, 4.x has strict compatibility for 3.x. So upgrade to 4.x by dependency management is safer than typical major upgrade.

> Binary compatibility is the ability to compile a program against OkHttp 3.x, and then to run it against OkHttp 4.x. We’re using the excellent japicmp library via its Gradle plugin to enforce binary compatibility.
> https://square.github.io/okhttp/upgrading_to_okhttp_4/

* 2 test cases are updated due to OkHttp's internal field name is changed. (RestTemplateBuilderTests.java)

* Also InfluxDbProperties is changed due to issue in influxdb-java.
  * Under OkHttp3, influxdb-java sends "Authorization: encode(null:null"
  * Under new version of OkHttp, null username & password not leads illegal BasicAuth configuration but throws NullPointer exception.
  * Anyway, if user don't use auth, nothing affected I think.

This issue fixed in https://github.com/influxdata/influxdb-java/pull/644/files#diff-23360835991a654afd56314b41590521L150-R155, but not released yet.