### PR TITLE
Spring Boot 2.2 Tomcat 8.5.53 compatibility

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/pom.xml
+++ b/spring-boot-project/spring-boot-dependencies/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -3517,4 +3517,32 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>tomcat85</id>
+			<properties>
+				<tomcat.version>8.5.53</tomcat.version>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-jar-plugin</artifactId>
+						<executions>
+							<!-- Create the production jar with files inside target/filtered-classes/prod  -->
+							<execution>
+								<id>prod-jar</id>
+								<phase>package</phase>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+								<configuration>
+									<classifier>tomcat-${tomcat.version}</classifier>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatCompatibilityUtils.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatCompatibilityUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.embedded.tomcat;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.apache.tomcat.util.compat.JreCompat;
+import org.apache.tomcat.util.modeler.Registry;
+
+import org.springframework.util.ReflectionUtils;
+
+final class TomcatCompatibilityUtils {
+
+	private TomcatCompatibilityUtils() {
+	}
+
+	static boolean isGraalAvailable() {
+		Optional<Method> optionalMethod = Optional
+				.ofNullable(ReflectionUtils.findMethod(JreCompat.class, "isGraalAvailable"));
+		return optionalMethod.map((method) -> ReflectionUtils.invokeMethod(method, null)).map(Boolean.class::cast)
+				.orElse(false);
+	}
+
+	static void disableRegistry() {
+		Optional<Method> optionalMethod = Optional
+				.ofNullable(ReflectionUtils.findMethod(Registry.class, "disableRegistry"));
+		optionalMethod.map((method) -> ReflectionUtils.invokeMethod(method, null));
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatEmbeddedWebappClassLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatEmbeddedWebappClassLoader.java
@@ -24,7 +24,6 @@ import java.util.Enumeration;
 import org.apache.catalina.loader.ParallelWebappClassLoader;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.tomcat.util.compat.JreCompat;
 
 /**
  * Extension of Tomcat's {@link ParallelWebappClassLoader} that does not consider the
@@ -40,8 +39,9 @@ public class TomcatEmbeddedWebappClassLoader extends ParallelWebappClassLoader {
 
 	private static final Log logger = LogFactory.getLog(TomcatEmbeddedWebappClassLoader.class);
 
+	private static final Boolean IS_GRAAL_AVAILABLE = TomcatCompatibilityUtils.isGraalAvailable();
 	static {
-		if (!JreCompat.isGraalAvailable()) {
+		if (!IS_GRAAL_AVAILABLE) {
 			ClassLoader.registerAsParallelCapable();
 		}
 	}
@@ -65,7 +65,7 @@ public class TomcatEmbeddedWebappClassLoader extends ParallelWebappClassLoader {
 
 	@Override
 	public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-		synchronized (JreCompat.isGraalAvailable() ? this : getClassLoadingLock(name)) {
+		synchronized (IS_GRAAL_AVAILABLE ? this : getClassLoadingLock(name)) {
 			Class<?> result = findExistingLoadedClass(name);
 			result = (result != null) ? result : doLoadClass(name);
 			if (result == null) {
@@ -77,7 +77,7 @@ public class TomcatEmbeddedWebappClassLoader extends ParallelWebappClassLoader {
 
 	private Class<?> findExistingLoadedClass(String name) {
 		Class<?> resultClass = findLoadedClass0(name);
-		resultClass = (resultClass != null || JreCompat.isGraalAvailable()) ? resultClass : findLoadedClass(name);
+		resultClass = (resultClass != null || IS_GRAAL_AVAILABLE) ? resultClass : findLoadedClass(name);
 		return resultClass;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatReactiveWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatReactiveWebServerFactory.java
@@ -38,7 +38,6 @@ import org.apache.catalina.startup.Tomcat;
 import org.apache.coyote.AbstractProtocol;
 import org.apache.coyote.ProtocolHandler;
 import org.apache.coyote.http2.Http2Protocol;
-import org.apache.tomcat.util.modeler.Registry;
 import org.apache.tomcat.util.scan.StandardJarScanFilter;
 
 import org.springframework.boot.util.LambdaSafe;
@@ -114,7 +113,7 @@ public class TomcatReactiveWebServerFactory extends AbstractReactiveWebServerFac
 	@Override
 	public WebServer getWebServer(HttpHandler httpHandler) {
 		if (this.disableMBeanRegistry) {
-			Registry.disableRegistry();
+			TomcatCompatibilityUtils.disableRegistry();
 		}
 		Tomcat tomcat = new Tomcat();
 		File baseDir = (this.baseDirectory != null) ? this.baseDirectory : createTempDir("tomcat");

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
@@ -61,7 +61,6 @@ import org.apache.catalina.webresources.StandardRoot;
 import org.apache.coyote.AbstractProtocol;
 import org.apache.coyote.ProtocolHandler;
 import org.apache.coyote.http2.Http2Protocol;
-import org.apache.tomcat.util.modeler.Registry;
 import org.apache.tomcat.util.scan.StandardJarScanFilter;
 
 import org.springframework.boot.util.LambdaSafe;
@@ -172,7 +171,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	@Override
 	public WebServer getWebServer(ServletContextInitializer... initializers) {
 		if (this.disableMBeanRegistry) {
-			Registry.disableRegistry();
+			TomcatCompatibilityUtils.disableRegistry();
 		}
 		Tomcat tomcat = new Tomcat();
 		File baseDir = (this.baseDirectory != null) ? this.baseDirectory : createTempDir("tomcat");


### PR DESCRIPTION
Context
=======

We have some applications that would like to move to Spring Boot 2.2 but their clients depend on some of the features that are available in Tomcat 8, specifically the response phrase. Ideally they should be moving the clients to a state where they can upgrade to Tomcat 9. In the mean time we could also make some additional changes to the _Embedded Tomcat_ integration such that it doesn't fail if used with Tomcat 8.5.53.

Proposed Changes
================

The `JreCompat.isGraalAvailable` as well as `Registry.disableRegistry` methods were added in Tomcat 9. Their usage on TomcatEmbeddedWebappClassLoader, TomcatReactiveWebServerFactory, and TomcatServletWebServerFactory prevents users from pinning their tomcat dependencies to 8.5.53 and still be able to use Spring Boot 2.2.x.

This commit adds the TomcatCompatibilityUtil class that isolates those APIs and handles the case where the methods are not available. It also adds a Maven Profile that can be used to build and test spring-boot with Tomcat 8.5.53.

e.g.
```
./mvnw clean package -P tomcat85
```