### PR TITLE
Fix typos in packaging docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -8051,7 +8051,7 @@ For Gradle, refer to the {spring-boot-gradle-plugin-docs}/#packaging-layered-jar
 
 === Writing the Dockerfile
 
-When you create a layered jar, the `spring-boot-layertools` jar will be added as a dependency to your jar.
+When you create a layered jar, the `spring-boot-jarmode-layertools` jar will be added as a dependency to your jar.
 With this jar on the classpath, you can launch your application in a special mode which allows the bootstrap code to run something entirely different from your application, for example, something that extracts the layers.
 Here’s how you can launch your jar with a `layertools` jar mode:
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging.adoc
@@ -290,7 +290,7 @@ The layers order is important as it determines how likely previous layers can be
 The default order is `dependencies`, `snapshot-dependencies`, and `application`.
 Content that is least likely to change should be added first, followed by layers that are more likely to change.
 
-When you create a layered jar, the `spring-boot-layertools` jar will be added as a dependency to your jar.
+When you create a layered jar, the `spring-boot-jarmode-layertools` jar will be added as a dependency to your jar.
 With this jar on the classpath, you can launch your application in a special mode which allows the bootstrap code to run something entirely different from your application, for example, something that extracts the layers.
 If you wish to exclude this dependency, you can do so in the following manner:
 
@@ -335,4 +335,4 @@ The content of a `libraries` layer can be customized using filters to `include` 
 The format is `groupId:artifactId[:version]`.
 In the example above, any artifact whose version ends with `SNAPSHOT` is going to be included in the `snapshot-dependencies` layer.
 
-The content of a `application` layer can be customized using filters to `includ` or `exclude` based on location of the entry using Ant-style pattern matching.
+The content of an `application` layer can be customized using filters to `include` or `exclude` based on location of the entry using Ant-style pattern matching.

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging.adoc
@@ -180,7 +180,7 @@ The content of a `libraries` layer can be customized using filters to `include` 
 The format is `groupId:artifactId[:version]`.
 In the example above, any artifact whose version ends with `SNAPSHOT` is going to be included in the `snapshot-dependencies` layer.
 
-The content of a `application` layer can be customized using filters to `include` or `exclude` based on location of the entry using Ant-style pattern matching.
+The content of an `application` layer can be customized using filters to `include` or `exclude` based on location of the entry using Ant-style pattern matching.
 
 
 
@@ -516,7 +516,7 @@ This example excludes any artifact belonging to the `com.foo` group:
 [[repackage-layered-jars-tools]]
 ==== Layered jar tools
 
-When you create a layered jar, the `spring-boot-layertools` jar will be added as a dependency to your jar.
+When you create a layered jar, the `spring-boot-jarmode-layertools` jar will be added as a dependency to your jar.
 With this jar on the classpath, you can launch your application in a special mode which allows the bootstrap code to run something entirely different from your application, for example, something that extracts the layers.
 If you wish to exclude this dependency, you can do so in the following manner:
 


### PR DESCRIPTION
Hi,

7444306d0b2dfe89fe4f33ea197e0c670aba81d4 introduced a couple of typos. While fixing them I noticed that the docs were still referring to `spring-boot-layertools` instead `spring-boot-jarmode-layertools` so I fixed that as well while being on it.

Cheers,
Christoph