### PR TITLE
Migrate off deprecated Spring Data Cassandra API

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfiguration.java
@@ -80,8 +80,7 @@ public class CassandraDataAutoConfiguration {
 		if (!packages.isEmpty()) {
 			context.setInitialEntitySet(CassandraEntityClassScanner.scan(packages));
 		}
-		context.setUserTypeResolver(new SimpleUserTypeResolver(this.session));
-		context.setCustomConversions(conversions);
+		context.setSimpleTypeHolder(conversions.getSimpleTypeHolder());
 		return context;
 	}
 
@@ -90,7 +89,9 @@ public class CassandraDataAutoConfiguration {
 	public CassandraConverter cassandraConverter(CassandraMappingContext mapping,
 			CassandraCustomConversions conversions) {
 		MappingCassandraConverter converter = new MappingCassandraConverter(mapping);
+		converter.setCodecRegistry(this.session.getContext().getCodecRegistry());
 		converter.setCustomConversions(conversions);
+		converter.setUserTypeResolver(new SimpleUserTypeResolver(this.session));
 		return converter;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraReactiveDataAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraReactiveDataAutoConfigurationTests.java
@@ -19,6 +19,8 @@ package org.springframework.boot.autoconfigure.data.cassandra;
 import java.util.Set;
 
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,11 +32,13 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.cassandra.core.ReactiveCassandraTemplate;
+import org.springframework.data.cassandra.core.convert.CassandraConverter;
 import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
 import org.springframework.data.cassandra.core.mapping.SimpleUserTypeResolver;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.when;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -74,8 +78,8 @@ class CassandraReactiveDataAutoConfigurationTests {
 	@Test
 	void userTypeResolverShouldBeSet() {
 		load("spring.data.cassandra.keyspaceName:boot_test");
-		CassandraMappingContext mappingContext = this.context.getBean(CassandraMappingContext.class);
-		assertThat(mappingContext).extracting("userTypeResolver").isInstanceOf(SimpleUserTypeResolver.class);
+		CassandraConverter cassandraConverter = this.context.getBean(CassandraConverter.class);
+		assertThat(cassandraConverter).extracting("userTypeResolver").isInstanceOf(SimpleUserTypeResolver.class);
 	}
 
 	private void load(String... environment) {
@@ -99,7 +103,12 @@ class CassandraReactiveDataAutoConfigurationTests {
 
 		@Bean
 		CqlSession cqlSession() {
-			return mock(CqlSession.class);
+			CodecRegistry codecRegistry = mock(CodecRegistry.class);
+			DriverContext context = mock(DriverContext.class);
+			CqlSession cqlSession = mock(CqlSession.class);
+			when(context.getCodecRegistry()).thenReturn(codecRegistry);
+			when(cqlSession.getContext()).thenReturn(context);
+			return cqlSession;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraReactiveRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraReactiveRepositoriesAutoConfigurationTests.java
@@ -20,6 +20,8 @@ import java.util.Set;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -40,6 +42,7 @@ import org.springframework.data.cassandra.repository.config.EnableReactiveCassan
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.when;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -107,7 +110,12 @@ class CassandraReactiveRepositoriesAutoConfigurationTests {
 
 		@Bean
 		CqlSession cqlSession() {
-			return mock(CqlSession.class);
+			CodecRegistry codecRegistry = mock(CodecRegistry.class);
+			DriverContext context = mock(DriverContext.class);
+			CqlSession cqlSession = mock(CqlSession.class);
+			when(context.getCodecRegistry()).thenReturn(codecRegistry);
+			when(cqlSession.getContext()).thenReturn(context);
+			return cqlSession;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraRepositoriesAutoConfigurationTests.java
@@ -20,6 +20,8 @@ import java.util.Set;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -40,6 +42,7 @@ import org.springframework.data.cassandra.repository.config.EnableCassandraRepos
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.when;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -105,7 +108,12 @@ class CassandraRepositoriesAutoConfigurationTests {
 
 		@Bean
 		CqlSession cqlSession() {
-			return mock(CqlSession.class);
+			CodecRegistry codecRegistry = mock(CodecRegistry.class);
+			DriverContext context = mock(DriverContext.class);
+			CqlSession cqlSession = mock(CqlSession.class);
+			when(context.getCodecRegistry()).thenReturn(codecRegistry);
+			when(cqlSession.getContext()).thenReturn(context);
+			return cqlSession;
 		}
 
 	}


### PR DESCRIPTION
Configure `UserTypeResolver` and `CodecRegistry` on `MappingCassandraConverter`. Configure on `CassandraMappingContext` only the simple type holder instead of custom conversions.

Applies only to Spring Data Cassandra 3.0 (Neumann Release Train).

Related ticket: https://jira.spring.io/browse/DATACASS-470