### PR TITLE
Favor exec-maven-plugin shorthand property over redefinition

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
@@ -25,6 +25,7 @@ publishing.publications.withType(MavenPublication) {
 				delegate."maven.compiler.target"('${java.version}')
 				delegate."project.build.sourceEncoding"('UTF-8')
 				delegate."project.reporting.outputEncoding"('UTF-8')
+				delegate."exec.mainClass"('${start-class}')
 			}
 		}
 		root.issueManagement.plus {
@@ -124,9 +125,6 @@ publishing.publications.withType(MavenPublication) {
 						plugin {
 							delegate.groupId('org.codehaus.mojo')
 							delegate.artifactId('exec-maven-plugin')
-							configuration {
-								delegate.mainClass('${start-class}')
-							}
 						}
 						plugin {
 							delegate.groupId('org.apache.maven.plugins')


### PR DESCRIPTION
With this change, users can now rely on the standard
`exec.mainClass` property when executing the exec-maven-plugin.
Users of the `start-class` property are unaffected.

Thanks @hboutemy for the initial diagnosis and suggestion for the
fix.
