### PR TITLE
CassandraHealthIndicator runs a query that fails on some Consistency Levels

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/cassandra/CassandraHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/cassandra/CassandraHealthIndicator.java
@@ -35,8 +35,8 @@ import org.springframework.util.Assert;
  */
 public class CassandraHealthIndicator extends AbstractHealthIndicator {
 
-	private static final SimpleStatement SELECT = SimpleStatement.newInstance("SELECT release_version FROM system.local")
-			.setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
+	private static final SimpleStatement SELECT = SimpleStatement
+			.newInstance("SELECT release_version FROM system.local").setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
 
 	private CassandraOperations cassandraOperations;
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/cassandra/CassandraHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/cassandra/CassandraHealthIndicator.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.cassandra;
 
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 
@@ -33,6 +34,9 @@ import org.springframework.util.Assert;
  * @since 2.0.0
  */
 public class CassandraHealthIndicator extends AbstractHealthIndicator {
+
+	private static final SimpleStatement SELECT = SimpleStatement.newInstance("SELECT release_version FROM system.local")
+			.setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
 
 	private CassandraOperations cassandraOperations;
 
@@ -52,8 +56,7 @@ public class CassandraHealthIndicator extends AbstractHealthIndicator {
 
 	@Override
 	protected void doHealthCheck(Health.Builder builder) throws Exception {
-		SimpleStatement select = SimpleStatement.newInstance("SELECT release_version FROM system.local");
-		ResultSet results = this.cassandraOperations.getCqlOperations().queryForResultSet(select);
+		ResultSet results = this.cassandraOperations.getCqlOperations().queryForResultSet(SELECT);
 		if (results.isFullyFetched()) {
 			builder.up();
 			return;


### PR DESCRIPTION
The system keyspace has a replication factor of 1 and is local to each node; it is therefore recommended to query system.local with a consistency level of ONE or LOCAL_ONE.

Stronger consistency levels may result in an Unavailable error, but this does not mean that the node is down.

This patch does not include additional tests because it is hard to test the change in a stubbed environment; obviously, the existing tests still pass. Let me know if I can contribute an integration test for that.