### PR TITLE
Fix of the issue #10886 Incremental compilation does not keep metadata...

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java
@@ -40,7 +40,7 @@ import javax.lang.model.util.ElementFilter;
  */
 class TypeElementMembers {
 
-	private static final String OBJECT_CLASS_NAME = Object.class.getName();
+	private static final String OBJECT_CLASS_NAME = Object.class.getCanonicalName();
 
 	private final MetadataGenerationEnvironment env;
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
@@ -68,7 +68,7 @@ class TypeUtils {
 
 	static {
 		Map<String, TypeKind> primitives = new HashMap<>();
-		PRIMITIVE_WRAPPERS.forEach((kind, wrapperClass) -> primitives.put(wrapperClass.getName(), kind));
+		PRIMITIVE_WRAPPERS.forEach((kind, wrapperClass) -> primitives.put(wrapperClass.getCanonicalName(), kind));
 		WRAPPER_TO_PRIMITIVE = primitives;
 	}
 
@@ -95,7 +95,7 @@ class TypeUtils {
 	private TypeMirror getDeclaredType(Types types, Class<?> typeClass, int numberOfTypeArgs) {
 		TypeMirror[] typeArgs = new TypeMirror[numberOfTypeArgs];
 		Arrays.setAll(typeArgs, (i) -> types.getWildcardType(null, null));
-		TypeElement typeElement = this.env.getElementUtils().getTypeElement(typeClass.getName());
+		TypeElement typeElement = this.env.getElementUtils().getTypeElement(typeClass.getCanonicalName());
 		try {
 			return types.getDeclaredType(typeElement, typeArgs);
 		}
@@ -199,7 +199,7 @@ class TypeUtils {
 	TypeMirror getWrapperOrPrimitiveFor(TypeMirror typeMirror) {
 		Class<?> candidate = getWrapperFor(typeMirror);
 		if (candidate != null) {
-			return this.env.getElementUtils().getTypeElement(candidate.getName()).asType();
+			return this.env.getElementUtils().getTypeElement(candidate.getCanonicalName()).asType();
 		}
 		TypeKind primitiveKind = getPrimitiveFor(typeMirror);
 		if (primitiveKind != null) {
@@ -275,7 +275,7 @@ class TypeUtils {
 
 		private String determineQualifiedName(DeclaredType type, TypeElement enclosingElement) {
 			if (enclosingElement != null) {
-				return getQualifiedName(enclosingElement) + "$" + type.asElement().getSimpleName();
+				return getQualifiedName(enclosingElement) + "." + type.asElement().getSimpleName();
 			}
 			return getQualifiedName(type.asElement());
 		}
@@ -330,7 +330,7 @@ class TypeUtils {
 			}
 			TypeElement enclosingElement = getEnclosingTypeElement(element.asType());
 			if (enclosingElement != null) {
-				return getQualifiedName(enclosingElement) + "$"
+				return getQualifiedName(enclosingElement) + "."
 						+ ((DeclaredType) element.asType()).asElement().getSimpleName();
 			}
 			if (element instanceof TypeElement) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/fieldvalues/javac/JavaCompilerFieldValuesParser.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/fieldvalues/javac/JavaCompilerFieldValuesParser.java
@@ -64,15 +64,15 @@ public class JavaCompilerFieldValuesParser implements FieldValuesParser {
 		static {
 			Map<String, Class<?>> types = new HashMap<>();
 			types.put("boolean", Boolean.class);
-			types.put(Boolean.class.getName(), Boolean.class);
+			types.put(Boolean.class.getCanonicalName(), Boolean.class);
 			types.put("byte", Byte.class);
-			types.put(Byte.class.getName(), Byte.class);
+			types.put(Byte.class.getCanonicalName(), Byte.class);
 			types.put("short", Short.class);
-			types.put(Short.class.getName(), Short.class);
+			types.put(Short.class.getCanonicalName(), Short.class);
 			types.put("int", Integer.class);
-			types.put(Integer.class.getName(), Integer.class);
+			types.put(Integer.class.getCanonicalName(), Integer.class);
 			types.put("long", Long.class);
-			types.put(Long.class.getName(), Long.class);
+			types.put(Long.class.getCanonicalName(), Long.class);
 			WRAPPER_TYPES = Collections.unmodifiableMap(types);
 		}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -213,7 +213,7 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 		assertThat(metadata).has(Metadata.withProperty("collection.bytes", "java.util.Collection<java.lang.Byte>"));
 		assertThat(metadata).has(Metadata.withProperty("collection.doubles", "java.util.List<java.lang.Double>"));
 		assertThat(metadata).has(Metadata.withProperty("collection.names-to-holders",
-				"java.util.Map<java.lang.String,org.springframework.boot.configurationsample.simple.SimpleCollectionProperties$Holder<java.lang.String>>"));
+				"java.util.Map<java.lang.String,org.springframework.boot.configurationsample.simple.SimpleCollectionProperties.Holder<java.lang.String>>"));
 	}
 
 	@Test
@@ -223,7 +223,7 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 		assertThat(metadata).has(Metadata.withProperty("array.primitive", "java.lang.Integer[]"));
 		assertThat(metadata).has(Metadata.withProperty("array.simple", "java.lang.String[]"));
 		assertThat(metadata).has(Metadata.withProperty("array.inner",
-				"org.springframework.boot.configurationsample.simple.SimpleArrayProperties$Holder[]"));
+				"org.springframework.boot.configurationsample.simple.SimpleArrayProperties.Holder[]"));
 		assertThat(metadata).has(
 				Metadata.withProperty("array.name-to-integer", "java.util.Map<java.lang.String,java.lang.Integer>[]"));
 		assertThat(metadata.getItems()).hasSize(5);

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConstructorParameterPropertyDescriptorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConstructorParameterPropertyDescriptorTests.java
@@ -112,7 +112,7 @@ class ConstructorParameterPropertyDescriptorTests extends PropertyDescriptorTest
 			TypeElement ownerElement = roundEnv.getRootElement(ImmutableInnerClassProperties.class);
 			ConstructorParameterPropertyDescriptor property = createPropertyDescriptor(ownerElement, "first");
 			assertItemMetadata(metadataEnv, property).isGroup().hasName("test.first")
-					.hasType("org.springframework.boot.configurationsample.immutable.ImmutableInnerClassProperties$Foo")
+					.hasType("org.springframework.boot.configurationsample.immutable.ImmutableInnerClassProperties.Foo")
 					.hasSourceType(ImmutableInnerClassProperties.class).hasSourceMethod("getFirst()").hasNoDescription()
 					.isNotDeprecated();
 		});

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/GenericsMetadataGenerationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/GenericsMetadataGenerationTests.java
@@ -81,15 +81,15 @@ class GenericsMetadataGenerationTests extends AbstractMetadataGenerationTests {
 		assertThat(metadata).has(Metadata.withGroup("generic")
 				.ofType("org.springframework.boot.configurationsample.generic.GenericConfig"));
 		assertThat(metadata).has(Metadata.withGroup("generic.foo")
-				.ofType("org.springframework.boot.configurationsample.generic.GenericConfig$Foo"));
+				.ofType("org.springframework.boot.configurationsample.generic.GenericConfig.Foo"));
 		assertThat(metadata).has(Metadata.withGroup("generic.foo.bar")
-				.ofType("org.springframework.boot.configurationsample.generic.GenericConfig$Bar"));
+				.ofType("org.springframework.boot.configurationsample.generic.GenericConfig.Bar"));
 		assertThat(metadata).has(Metadata.withGroup("generic.foo.bar.biz")
-				.ofType("org.springframework.boot.configurationsample.generic.GenericConfig$Bar$Biz"));
+				.ofType("org.springframework.boot.configurationsample.generic.GenericConfig.Bar.Biz"));
 		assertThat(metadata).has(
 				Metadata.withProperty("generic.foo.name").ofType(String.class).fromSource(GenericConfig.Foo.class));
 		assertThat(metadata).has(Metadata.withProperty("generic.foo.string-to-bar").ofType(
-				"java.util.Map<java.lang.String,org.springframework.boot.configurationsample.generic.GenericConfig$Bar<java.lang.Integer>>")
+				"java.util.Map<java.lang.String,org.springframework.boot.configurationsample.generic.GenericConfig.Bar<java.lang.Integer>>")
 				.fromSource(GenericConfig.Foo.class));
 		assertThat(metadata).has(Metadata.withProperty("generic.foo.string-to-integer")
 				.ofType("java.util.Map<java.lang.String,java.lang.Integer>").fromSource(GenericConfig.Foo.class));

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/JavaBeanPropertyDescriptorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/JavaBeanPropertyDescriptorTests.java
@@ -152,7 +152,7 @@ class JavaBeanPropertyDescriptorTests extends PropertyDescriptorTests {
 			TypeElement ownerElement = roundEnv.getRootElement(InnerClassProperties.class);
 			JavaBeanPropertyDescriptor property = createPropertyDescriptor(ownerElement, "first");
 			assertItemMetadata(metadataEnv, property).isGroup().hasName("test.first")
-					.hasType("org.springframework.boot.configurationsample.specific.InnerClassProperties$Foo")
+					.hasType("org.springframework.boot.configurationsample.specific.InnerClassProperties.Foo")
 					.hasSourceType(InnerClassProperties.class).hasSourceMethod("getFirst()").hasNoDescription()
 					.isNotDeprecated();
 		});

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/LombokPropertyDescriptorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/LombokPropertyDescriptorTests.java
@@ -176,7 +176,7 @@ class LombokPropertyDescriptorTests extends PropertyDescriptorTests {
 			TypeElement ownerElement = roundEnv.getRootElement(LombokInnerClassProperties.class);
 			LombokPropertyDescriptor property = createPropertyDescriptor(ownerElement, "first");
 			assertItemMetadata(metadataEnv, property).isGroup().hasName("test.first")
-					.hasType("org.springframework.boot.configurationsample.lombok.LombokInnerClassProperties$Foo")
+					.hasType("org.springframework.boot.configurationsample.lombok.LombokInnerClassProperties.Foo")
 					.hasSourceType(LombokInnerClassProperties.class).hasSourceMethod(null).hasNoDescription()
 					.isNotDeprecated();
 		});

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/MergeMetadataGenerationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/MergeMetadataGenerationTests.java
@@ -52,7 +52,7 @@ class MergeMetadataGenerationTests extends AbstractMetadataGenerationTests {
 	@Test
 	void mergingOfAdditionalProperty() throws Exception {
 		ItemMetadata property = ItemMetadata.newProperty(null, "foo", "java.lang.String",
-				AdditionalMetadata.class.getName(), null, null, null, null);
+				AdditionalMetadata.class.getCanonicalName(), null, null, null, null);
 		writeAdditionalMetadata(property);
 		ConfigurationMetadata metadata = compile(SimpleProperties.class);
 		assertThat(metadata).has(Metadata.withProperty("simple.comparator"));
@@ -81,25 +81,25 @@ class MergeMetadataGenerationTests extends AbstractMetadataGenerationTests {
 
 	@Test
 	void mergeExistingPropertyWithSeveralCandidates() throws Exception {
-		ItemMetadata property = ItemMetadata.newProperty("simple", "flag", Boolean.class.getName(), null, null, null,
-				true, null);
+		ItemMetadata property = ItemMetadata.newProperty("simple", "flag", Boolean.class.getCanonicalName(), null, null,
+				null, true, null);
 		writeAdditionalMetadata(property);
 		ConfigurationMetadata metadata = compile(SimpleProperties.class, SimpleConflictingProperties.class);
 		assertThat(metadata.getItems()).hasSize(6);
 		List<ItemMetadata> items = metadata.getItems().stream().filter((item) -> item.getName().equals("simple.flag"))
 				.collect(Collectors.toList());
 		assertThat(items).hasSize(2);
-		ItemMetadata matchingProperty = items.stream().filter((item) -> item.getType().equals(Boolean.class.getName()))
-				.findFirst().orElse(null);
+		ItemMetadata matchingProperty = items.stream()
+				.filter((item) -> item.getType().equals(Boolean.class.getCanonicalName())).findFirst().orElse(null);
 		assertThat(matchingProperty).isNotNull();
 		assertThat(matchingProperty.getDefaultValue()).isEqualTo(true);
-		assertThat(matchingProperty.getSourceType()).isEqualTo(SimpleProperties.class.getName());
+		assertThat(matchingProperty.getSourceType()).isEqualTo(SimpleProperties.class.getCanonicalName());
 		assertThat(matchingProperty.getDescription()).isEqualTo("A simple flag.");
 		ItemMetadata nonMatchingProperty = items.stream()
-				.filter((item) -> item.getType().equals(String.class.getName())).findFirst().orElse(null);
+				.filter((item) -> item.getType().equals(String.class.getCanonicalName())).findFirst().orElse(null);
 		assertThat(nonMatchingProperty).isNotNull();
 		assertThat(nonMatchingProperty.getDefaultValue()).isEqualTo("hello");
-		assertThat(nonMatchingProperty.getSourceType()).isEqualTo(SimpleConflictingProperties.class.getName());
+		assertThat(nonMatchingProperty.getSourceType()).isEqualTo(SimpleConflictingProperties.class.getCanonicalName());
 		assertThat(nonMatchingProperty.getDescription()).isNull();
 	}
 
@@ -132,7 +132,7 @@ class MergeMetadataGenerationTests extends AbstractMetadataGenerationTests {
 				new ItemDeprecation("Don't use this.", "single.name"));
 		writeAdditionalMetadata(property);
 		ConfigurationMetadata metadata = compile(DeprecatedSingleProperty.class);
-		assertThat(metadata).has(Metadata.withProperty("singledeprecated.name", String.class.getName())
+		assertThat(metadata).has(Metadata.withProperty("singledeprecated.name", String.class.getCanonicalName())
 				.fromSource(DeprecatedSingleProperty.class).withDeprecation("Don't use this.", "single.name"));
 		assertThat(metadata.getItems()).hasSize(3);
 	}
@@ -143,7 +143,7 @@ class MergeMetadataGenerationTests extends AbstractMetadataGenerationTests {
 				new ItemDeprecation(null, null, "error"));
 		writeAdditionalMetadata(property);
 		ConfigurationMetadata metadata = compile(DeprecatedSingleProperty.class);
-		assertThat(metadata).has(Metadata.withProperty("singledeprecated.name", String.class.getName())
+		assertThat(metadata).has(Metadata.withProperty("singledeprecated.name", String.class.getCanonicalName())
 				.fromSource(DeprecatedSingleProperty.class)
 				.withDeprecation("renamed", "singledeprecated.new-name", "error"));
 		assertThat(metadata.getItems()).hasSize(3);
@@ -210,7 +210,7 @@ class MergeMetadataGenerationTests extends AbstractMetadataGenerationTests {
 		JSONObject property = new JSONObject();
 		property.put("name", "foo");
 		property.put("type", "java.lang.String");
-		property.put("sourceType", AdditionalMetadata.class.getName());
+		property.put("sourceType", AdditionalMetadata.class.getCanonicalName());
 		JSONArray properties = new JSONArray();
 		properties.put(property);
 		JSONObject additionalMetadata = new JSONObject();

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/TypeUtilsTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/TypeUtilsTests.java
@@ -51,9 +51,9 @@ class TypeUtilsTests {
 					.resolveTypeDescriptor(roundEnv.getRootElement(SimpleGenericProperties.class));
 			assertThat(typeDescriptor.getGenerics().keySet().stream().map(Object::toString)).containsOnly("A", "B",
 					"C");
-			assertThat(typeDescriptor.resolveGeneric("A")).hasToString(String.class.getName());
-			assertThat(typeDescriptor.resolveGeneric("B")).hasToString(Integer.class.getName());
-			assertThat(typeDescriptor.resolveGeneric("C")).hasToString(Duration.class.getName());
+			assertThat(typeDescriptor.resolveGeneric("A")).hasToString(String.class.getCanonicalName());
+			assertThat(typeDescriptor.resolveGeneric("B")).hasToString(Integer.class.getCanonicalName());
+			assertThat(typeDescriptor.resolveGeneric("C")).hasToString(Duration.class.getCanonicalName());
 
 		});
 	}
@@ -65,8 +65,8 @@ class TypeUtilsTests {
 					.resolveTypeDescriptor(roundEnv.getRootElement(AbstractIntermediateGenericProperties.class));
 			assertThat(typeDescriptor.getGenerics().keySet().stream().map(Object::toString)).containsOnly("A", "B",
 					"C");
-			assertThat(typeDescriptor.resolveGeneric("A")).hasToString(String.class.getName());
-			assertThat(typeDescriptor.resolveGeneric("B")).hasToString(Integer.class.getName());
+			assertThat(typeDescriptor.resolveGeneric("A")).hasToString(String.class.getCanonicalName());
+			assertThat(typeDescriptor.resolveGeneric("B")).hasToString(Integer.class.getCanonicalName());
 			assertThat(typeDescriptor.resolveGeneric("C")).hasToString("C");
 		});
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/JsonMarshallerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/JsonMarshallerTests.java
@@ -38,8 +38,9 @@ class JsonMarshallerTests {
 	@Test
 	void marshallAndUnmarshal() throws Exception {
 		ConfigurationMetadata metadata = new ConfigurationMetadata();
-		metadata.add(ItemMetadata.newProperty("a", "b", StringBuffer.class.getName(), InputStream.class.getName(),
-				"sourceMethod", "desc", "x", new ItemDeprecation("Deprecation comment", "b.c.d")));
+		metadata.add(ItemMetadata.newProperty("a", "b", StringBuffer.class.getCanonicalName(),
+				InputStream.class.getCanonicalName(), "sourceMethod", "desc", "x",
+				new ItemDeprecation("Deprecation comment", "b.c.d")));
 		metadata.add(ItemMetadata.newProperty("b.c.d", null, null, null, null, null, null, null));
 		metadata.add(ItemMetadata.newProperty("c", null, null, null, null, null, 123, null));
 		metadata.add(ItemMetadata.newProperty("d", null, null, null, null, null, true, null));

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/Metadata.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/Metadata.java
@@ -138,7 +138,7 @@ public final class Metadata {
 			if (this.type != null && !this.type.equals(itemMetadata.getType())) {
 				return false;
 			}
-			if (this.sourceType != null && !this.sourceType.getName().equals(itemMetadata.getSourceType())) {
+			if (this.sourceType != null && !this.sourceType.getCanonicalName().equals(itemMetadata.getSourceType())) {
 				return false;
 			}
 			if (this.sourceMethod != null && !this.sourceMethod.equals(itemMetadata.getSourceMethod())) {
@@ -164,7 +164,7 @@ public final class Metadata {
 		}
 
 		public MetadataItemCondition ofType(Class<?> dataType) {
-			return new MetadataItemCondition(this.itemType, this.name, dataType.getName(), this.sourceType,
+			return new MetadataItemCondition(this.itemType, this.name, dataType.getCanonicalName(), this.sourceType,
 					this.sourceMethod, this.description, this.defaultValue, this.deprecation);
 		}
 


### PR DESCRIPTION
Hi!

This PR fixes issue #10886 "Incremental compilation does not keep metadata for `NestedConfigurationProperty`".

Proposed changes make use type canonical name instead of class name to populate "sourceType" metadata.

Regards,
Boris