### PR TITLE
Clarify that configuring a custom health HTTP status mapping replaces the default mappings

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
@@ -764,6 +764,9 @@ For example, the following property maps `FATAL` to 503 (service unavailable):
 	management.endpoint.health.status.http-mapping.fatal=503
 ----
 
+WARNING: A custom status mapping replaces whole of the default status mappings.
+That means the above example has only one mapping to `FATAL` and any other statuses will return the http status 200 as `UNKNOWN` health status.
+
 TIP: If you need more control, you can define your own `HttpCodeStatusMapper` bean.
 
 The following table shows the default status mappings for the built-in statuses:


### PR DESCRIPTION
Clarify that configuring a custom health HTTP status mapping replaces the default mappings. (#20334)

Fixes gh-20334

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
