### PR TITLE
Fix for issue #10886 "Incremental compilation does not keep metadata…"

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessor.java
@@ -195,7 +195,8 @@ public class ConfigurationMetadataAnnotationProcessor extends AbstractProcessor 
 
 	private void processAnnotatedTypeElement(String prefix, TypeElement element, Stack<TypeElement> seen) {
 		String type = this.metadataEnv.getTypeUtils().getQualifiedName(element);
-		this.metadataCollector.add(ItemMetadata.newGroup(prefix, type, type, null));
+		String canonicalType = this.metadataEnv.getTypeUtils().getQualifiedCanonicalName(element);
+		this.metadataCollector.add(ItemMetadata.newGroup(prefix, type, type, canonicalType, null));
 		processTypeElement(prefix, element, null, seen);
 	}
 
@@ -207,6 +208,7 @@ public class ConfigurationMetadataAnnotationProcessor extends AbstractProcessor 
 				ItemMetadata group = ItemMetadata.newGroup(prefix,
 						this.metadataEnv.getTypeUtils().getQualifiedName(returns),
 						this.metadataEnv.getTypeUtils().getQualifiedName(element.getEnclosingElement()),
+						this.metadataEnv.getTypeUtils().getQualifiedCanonicalName(element.getEnclosingElement()),
 						element.toString());
 				if (this.metadataCollector.hasSimilarGroup(group)) {
 					this.processingEnv.getMessager().printMessage(Kind.ERROR,
@@ -259,13 +261,15 @@ public class ConfigurationMetadataAnnotationProcessor extends AbstractProcessor 
 		String endpointKey = ItemMetadata.newItemMetadataPrefix("management.endpoint.", endpointId);
 		Boolean enabledByDefault = (Boolean) elementValues.get("enableByDefault");
 		String type = this.metadataEnv.getTypeUtils().getQualifiedName(element);
-		this.metadataCollector.add(ItemMetadata.newGroup(endpointKey, type, type, null));
-		this.metadataCollector.add(ItemMetadata.newProperty(endpointKey, "enabled", Boolean.class.getName(), type, null,
-				String.format("Whether to enable the %s endpoint.", endpointId),
+		String canonicalType = this.metadataEnv.getTypeUtils().getQualifiedCanonicalName(element);
+		this.metadataCollector.add(ItemMetadata.newGroup(endpointKey, type, type, canonicalType, null));
+		this.metadataCollector.add(ItemMetadata.newProperty(endpointKey, "enabled", Boolean.class.getName(), type,
+				canonicalType, null, String.format("Whether to enable the %s endpoint.", endpointId),
 				(enabledByDefault != null) ? enabledByDefault : true, null));
 		if (hasMainReadOperation(element)) {
-			this.metadataCollector.add(ItemMetadata.newProperty(endpointKey, "cache.time-to-live",
-					Duration.class.getName(), type, null, "Maximum time that a response can be cached.", "0ms", null));
+			this.metadataCollector
+					.add(ItemMetadata.newProperty(endpointKey, "cache.time-to-live", Duration.class.getName(), type,
+							canonicalType, null, "Maximum time that a response can be cached.", "0ms", null));
 		}
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataCollector.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataCollector.java
@@ -68,8 +68,12 @@ public class MetadataCollector {
 
 	private void markAsProcessed(Element element) {
 		if (element instanceof TypeElement) {
-			this.processedSourceTypes.add(this.typeUtils.getQualifiedName(element));
+			this.processedSourceTypes.add(this.typeUtils.getQualifiedCanonicalName(element));
 		}
+	}
+
+	private void markAsProcessed(ItemMetadata itemMetadata) {
+		this.processedSourceTypes.add(itemMetadata.getSourceCanonicalTypeFallback());
 	}
 
 	public void add(ItemMetadata metadata) {
@@ -93,6 +97,7 @@ public class MetadataCollector {
 		ConfigurationMetadata metadata = new ConfigurationMetadata();
 		for (ItemMetadata item : this.metadataItems) {
 			metadata.add(item);
+			markAsProcessed(item);
 		}
 		if (this.previousMetadata != null) {
 			List<ItemMetadata> items = this.previousMetadata.getItems();
@@ -106,8 +111,7 @@ public class MetadataCollector {
 	}
 
 	private boolean shouldBeMerged(ItemMetadata itemMetadata) {
-		String sourceType = (itemMetadata.getSourceCanonicalType() != null) ? itemMetadata.getSourceCanonicalType()
-				: itemMetadata.getSourceType();
+		String sourceType = itemMetadata.getSourceCanonicalTypeFallback();
 		return (sourceType != null && !deletedInCurrentBuild(sourceType) && !processedInCurrentBuild(sourceType));
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataCollector.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataCollector.java
@@ -106,7 +106,8 @@ public class MetadataCollector {
 	}
 
 	private boolean shouldBeMerged(ItemMetadata itemMetadata) {
-		String sourceType = itemMetadata.getSourceType();
+		String sourceType = (itemMetadata.getSourceCanonicalType() != null) ? itemMetadata.getSourceCanonicalType()
+				: itemMetadata.getSourceType();
 		return (sourceType != null && !deletedInCurrentBuild(sourceType) && !processedInCurrentBuild(sourceType));
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptor.java
@@ -135,11 +135,12 @@ abstract class PropertyDescriptor<S extends Element> {
 	private ItemMetadata resolveItemMetadataProperty(String prefix, MetadataGenerationEnvironment environment) {
 		String dataType = resolveType(environment);
 		String ownerType = environment.getTypeUtils().getQualifiedName(getOwnerElement());
+		String ownerCanonicalType = environment.getTypeUtils().getQualifiedCanonicalName(getOwnerElement());
 		String description = resolveDescription(environment);
 		Object defaultValue = resolveDefaultValue(environment);
 		ItemDeprecation deprecation = resolveItemDeprecation(environment);
-		return ItemMetadata.newProperty(prefix, getName(), dataType, ownerType, null, description, defaultValue,
-				deprecation);
+		return ItemMetadata.newProperty(prefix, getName(), dataType, ownerType, ownerCanonicalType, null, description,
+				defaultValue, deprecation);
 	}
 
 	private ItemMetadata resolveItemMetadataGroup(String prefix, MetadataGenerationEnvironment environment) {
@@ -147,8 +148,9 @@ abstract class PropertyDescriptor<S extends Element> {
 		String nestedPrefix = ConfigurationMetadata.nestedPrefix(prefix, getName());
 		String dataType = environment.getTypeUtils().getQualifiedName(propertyElement);
 		String ownerType = environment.getTypeUtils().getQualifiedName(getOwnerElement());
+		String ownerCanonicalType = environment.getTypeUtils().getQualifiedCanonicalName(getOwnerElement());
 		String sourceMethod = (getGetter() != null) ? getGetter().toString() : null;
-		return ItemMetadata.newGroup(nestedPrefix, dataType, ownerType, sourceMethod);
+		return ItemMetadata.newGroup(nestedPrefix, dataType, ownerType, ownerCanonicalType, sourceMethod);
 	}
 
 	private String resolveType(MetadataGenerationEnvironment environment) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java
@@ -40,7 +40,7 @@ import javax.lang.model.util.ElementFilter;
  */
 class TypeElementMembers {
 
-	private static final String OBJECT_CLASS_NAME = Object.class.getName();
+	private static final String OBJECT_CLASS_NAME = Object.class.getCanonicalName();
 
 	private final MetadataGenerationEnvironment env;
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/ItemMetadata.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/ItemMetadata.java
@@ -121,6 +121,10 @@ public final class ItemMetadata implements Comparable<ItemMetadata> {
 		return this.sourceCanonicalType;
 	}
 
+	public String getSourceCanonicalTypeFallback() {
+		return (this.sourceCanonicalType != null) ? this.sourceCanonicalType : this.sourceType;
+	}
+
 	public void setSourceCanonicalType(String sourceCanonicalType) {
 		this.sourceCanonicalType = sourceCanonicalType;
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/ItemMetadata.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/ItemMetadata.java
@@ -38,18 +38,22 @@ public final class ItemMetadata implements Comparable<ItemMetadata> {
 
 	private String sourceType;
 
+	private String sourceCanonicalType;
+
 	private String sourceMethod;
 
 	private Object defaultValue;
 
 	private ItemDeprecation deprecation;
 
-	ItemMetadata(ItemType itemType, String prefix, String name, String type, String sourceType, String sourceMethod,
-			String description, Object defaultValue, ItemDeprecation deprecation) {
+	ItemMetadata(ItemType itemType, String prefix, String name, String type, String sourceType,
+			String sourceCanonicalType, String sourceMethod, String description, Object defaultValue,
+			ItemDeprecation deprecation) {
 		this.itemType = itemType;
 		this.name = buildName(prefix, name);
 		this.type = type;
 		this.sourceType = sourceType;
+		this.sourceCanonicalType = sourceCanonicalType;
 		this.sourceMethod = sourceMethod;
 		this.description = description;
 		this.defaultValue = defaultValue;
@@ -113,6 +117,14 @@ public final class ItemMetadata implements Comparable<ItemMetadata> {
 		this.sourceType = sourceType;
 	}
 
+	public String getSourceCanonicalType() {
+		return this.sourceCanonicalType;
+	}
+
+	public void setSourceCanonicalType(String sourceCanonicalType) {
+		this.sourceCanonicalType = sourceCanonicalType;
+	}
+
 	public String getSourceMethod() {
 		return this.sourceMethod;
 	}
@@ -152,6 +164,7 @@ public final class ItemMetadata implements Comparable<ItemMetadata> {
 		result = result && nullSafeEquals(this.type, other.type);
 		result = result && nullSafeEquals(this.description, other.description);
 		result = result && nullSafeEquals(this.sourceType, other.sourceType);
+		result = result && nullSafeEquals(this.sourceCanonicalType, other.sourceCanonicalType);
 		result = result && nullSafeEquals(this.sourceMethod, other.sourceMethod);
 		result = result && nullSafeEquals(this.defaultValue, other.defaultValue);
 		result = result && nullSafeEquals(this.deprecation, other.deprecation);
@@ -165,6 +178,7 @@ public final class ItemMetadata implements Comparable<ItemMetadata> {
 		result = 31 * result + nullSafeHashCode(this.type);
 		result = 31 * result + nullSafeHashCode(this.description);
 		result = 31 * result + nullSafeHashCode(this.sourceType);
+		result = 31 * result + nullSafeHashCode(this.sourceCanonicalType);
 		result = 31 * result + nullSafeHashCode(this.sourceMethod);
 		result = 31 * result + nullSafeHashCode(this.defaultValue);
 		result = 31 * result + nullSafeHashCode(this.deprecation);
@@ -190,6 +204,7 @@ public final class ItemMetadata implements Comparable<ItemMetadata> {
 		StringBuilder string = new StringBuilder(this.name);
 		buildToStringProperty(string, "type", this.type);
 		buildToStringProperty(string, "sourceType", this.sourceType);
+		buildToStringProperty(string, "sourceCanonicalType", this.sourceCanonicalType);
 		buildToStringProperty(string, "description", this.description);
 		buildToStringProperty(string, "defaultValue", this.defaultValue);
 		buildToStringProperty(string, "deprecation", this.deprecation);
@@ -207,14 +222,17 @@ public final class ItemMetadata implements Comparable<ItemMetadata> {
 		return getName().compareTo(o.getName());
 	}
 
-	public static ItemMetadata newGroup(String name, String type, String sourceType, String sourceMethod) {
-		return new ItemMetadata(ItemType.GROUP, name, null, type, sourceType, sourceMethod, null, null, null);
+	public static ItemMetadata newGroup(String name, String type, String sourceType, String sourceCanonicalType,
+			String sourceMethod) {
+		return new ItemMetadata(ItemType.GROUP, name, null, type, sourceType, sourceCanonicalType, sourceMethod, null,
+				null, null);
 	}
 
 	public static ItemMetadata newProperty(String prefix, String name, String type, String sourceType,
-			String sourceMethod, String description, Object defaultValue, ItemDeprecation deprecation) {
-		return new ItemMetadata(ItemType.PROPERTY, prefix, name, type, sourceType, sourceMethod, description,
-				defaultValue, deprecation);
+			String sourceCanonicalType, String sourceMethod, String description, Object defaultValue,
+			ItemDeprecation deprecation) {
+		return new ItemMetadata(ItemType.PROPERTY, prefix, name, type, sourceType, sourceCanonicalType, sourceMethod,
+				description, defaultValue, deprecation);
 	}
 
 	public static String newItemMetadataPrefix(String prefix, String suffix) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/JsonConverter.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/JsonConverter.java
@@ -63,6 +63,7 @@ class JsonConverter {
 		jsonObject.putOpt("type", item.getType());
 		jsonObject.putOpt("description", item.getDescription());
 		jsonObject.putOpt("sourceType", item.getSourceType());
+		jsonObject.putOpt("sourceCanonicalType", item.getSourceCanonicalType());
 		jsonObject.putOpt("sourceMethod", item.getSourceMethod());
 		Object defaultValue = item.getDefaultValue();
 		if (defaultValue != null) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/JsonMarshaller.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/JsonMarshaller.java
@@ -91,11 +91,12 @@ public class JsonMarshaller {
 		String type = object.optString("type", null);
 		String description = object.optString("description", null);
 		String sourceType = object.optString("sourceType", null);
+		String sourceCanonicalType = object.optString("sourceCanonicalType", null);
 		String sourceMethod = object.optString("sourceMethod", null);
 		Object defaultValue = readItemValue(object.opt("defaultValue"));
 		ItemDeprecation deprecation = toItemDeprecation(object);
-		return new ItemMetadata(itemType, name, null, type, sourceType, sourceMethod, description, defaultValue,
-				deprecation);
+		return new ItemMetadata(itemType, name, null, type, sourceType, sourceCanonicalType, sourceMethod, description,
+				defaultValue, deprecation);
 	}
 
 	private ItemDeprecation toItemDeprecation(JSONObject object) throws Exception {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/IncrementalBuildMetadataGenerationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/IncrementalBuildMetadataGenerationTests.java
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.configurationprocessor.metadata.ConfigurationMetadata;
 import org.springframework.boot.configurationprocessor.metadata.Metadata;
-import org.springframework.boot.configurationsample.incremental.BazProperties;
 import org.springframework.boot.configurationsample.incremental.BarProperties;
+import org.springframework.boot.configurationsample.incremental.BazProperties;
 import org.springframework.boot.configurationsample.incremental.FooProperties;
 import org.springframework.boot.configurationsample.incremental.RenamedBarProperties;
 import org.springframework.boot.configurationsample.incremental.RenamedBazProperties;

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/JsonMarshallerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/JsonMarshallerTests.java
@@ -39,13 +39,16 @@ class JsonMarshallerTests {
 	void marshallAndUnmarshal() throws Exception {
 		ConfigurationMetadata metadata = new ConfigurationMetadata();
 		metadata.add(ItemMetadata.newProperty("a", "b", StringBuffer.class.getName(), InputStream.class.getName(),
-				"sourceMethod", "desc", "x", new ItemDeprecation("Deprecation comment", "b.c.d")));
-		metadata.add(ItemMetadata.newProperty("b.c.d", null, null, null, null, null, null, null));
-		metadata.add(ItemMetadata.newProperty("c", null, null, null, null, null, 123, null));
-		metadata.add(ItemMetadata.newProperty("d", null, null, null, null, null, true, null));
-		metadata.add(ItemMetadata.newProperty("e", null, null, null, null, null, new String[] { "y", "n" }, null));
-		metadata.add(ItemMetadata.newProperty("f", null, null, null, null, null, new Boolean[] { true, false }, null));
-		metadata.add(ItemMetadata.newGroup("d", null, null, null));
+				InputStream.class.getCanonicalName(), "sourceMethod", "desc", "x",
+				new ItemDeprecation("Deprecation comment", "b.c.d")));
+		metadata.add(ItemMetadata.newProperty("b.c.d", null, null, null, null, null, null, null, null));
+		metadata.add(ItemMetadata.newProperty("c", null, null, null, null, null, null, 123, null));
+		metadata.add(ItemMetadata.newProperty("d", null, null, null, null, null, null, true, null));
+		metadata.add(
+				ItemMetadata.newProperty("e", null, null, null, null, null, null, new String[] { "y", "n" }, null));
+		metadata.add(
+				ItemMetadata.newProperty("f", null, null, null, null, null, null, new Boolean[] { true, false }, null));
+		metadata.add(ItemMetadata.newGroup("d", null, null, null, null));
 		metadata.add(ItemHint.newHint("a.b"));
 		metadata.add(ItemHint.newHint("c", new ItemHint.ValueHint(123, "hey"), new ItemHint.ValueHint(456, null)));
 		metadata.add(new ItemHint("d", null,
@@ -73,12 +76,12 @@ class JsonMarshallerTests {
 		ConfigurationMetadata metadata = new ConfigurationMetadata();
 		metadata.add(ItemHint.newHint("fff"));
 		metadata.add(ItemHint.newHint("eee"));
-		metadata.add(ItemMetadata.newProperty("com.example.bravo", "bbb", null, null, null, null, null, null));
-		metadata.add(ItemMetadata.newProperty("com.example.bravo", "aaa", null, null, null, null, null, null));
-		metadata.add(ItemMetadata.newProperty("com.example.alpha", "ddd", null, null, null, null, null, null));
-		metadata.add(ItemMetadata.newProperty("com.example.alpha", "ccc", null, null, null, null, null, null));
-		metadata.add(ItemMetadata.newGroup("com.acme.bravo", "com.example.AnotherTestProperties", null, null));
-		metadata.add(ItemMetadata.newGroup("com.acme.alpha", "com.example.TestProperties", null, null));
+		metadata.add(ItemMetadata.newProperty("com.example.bravo", "bbb", null, null, null, null, null, null, null));
+		metadata.add(ItemMetadata.newProperty("com.example.bravo", "aaa", null, null, null, null, null, null, null));
+		metadata.add(ItemMetadata.newProperty("com.example.alpha", "ddd", null, null, null, null, null, null, null));
+		metadata.add(ItemMetadata.newProperty("com.example.alpha", "ccc", null, null, null, null, null, null, null));
+		metadata.add(ItemMetadata.newGroup("com.acme.bravo", "com.example.AnotherTestProperties", null, null, null));
+		metadata.add(ItemMetadata.newGroup("com.acme.alpha", "com.example.TestProperties", null, null, null));
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 		JsonMarshaller marshaller = new JsonMarshaller();
 		marshaller.write(metadata, outputStream);
@@ -91,11 +94,11 @@ class JsonMarshallerTests {
 	@Test
 	void marshallPutDeprecatedItemsAtTheEnd() throws IOException {
 		ConfigurationMetadata metadata = new ConfigurationMetadata();
-		metadata.add(ItemMetadata.newProperty("com.example.bravo", "bbb", null, null, null, null, null, null));
-		metadata.add(ItemMetadata.newProperty("com.example.bravo", "aaa", null, null, null, null, null,
+		metadata.add(ItemMetadata.newProperty("com.example.bravo", "bbb", null, null, null, null, null, null, null));
+		metadata.add(ItemMetadata.newProperty("com.example.bravo", "aaa", null, null, null, null, null, null,
 				new ItemDeprecation(null, null, "warning")));
-		metadata.add(ItemMetadata.newProperty("com.example.alpha", "ddd", null, null, null, null, null, null));
-		metadata.add(ItemMetadata.newProperty("com.example.alpha", "ccc", null, null, null, null, null,
+		metadata.add(ItemMetadata.newProperty("com.example.alpha", "ddd", null, null, null, null, null, null, null));
+		metadata.add(ItemMetadata.newProperty("com.example.alpha", "ccc", null, null, null, null, null, null,
 				new ItemDeprecation(null, null, "warning")));
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 		JsonMarshaller marshaller = new JsonMarshaller();

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/Metadata.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/Metadata.java
@@ -141,6 +141,10 @@ public final class Metadata {
 			if (this.sourceType != null && !this.sourceType.getName().equals(itemMetadata.getSourceType())) {
 				return false;
 			}
+			if (this.sourceType != null
+					&& !this.sourceType.getCanonicalName().equals(itemMetadata.getSourceCanonicalType())) {
+				return false;
+			}
 			if (this.sourceMethod != null && !this.sourceMethod.equals(itemMetadata.getSourceMethod())) {
 				return false;
 			}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/test/ItemMetadataAssert.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/test/ItemMetadataAssert.java
@@ -77,8 +77,13 @@ public class ItemMetadataAssert extends AbstractAssert<ItemMetadataAssert, ItemM
 		return this;
 	}
 
+	public ItemMetadataAssert hasSourceCanonicalType(String type) {
+		objects.assertEqual(this.info, this.actual.getSourceCanonicalType(), type);
+		return this;
+	}
+
 	public ItemMetadataAssert hasSourceType(Class<?> type) {
-		return hasSourceType(type.getName());
+		return hasSourceType(type.getName()).hasSourceCanonicalType(type.getCanonicalName());
 	}
 
 	public ItemMetadataAssert hasSourceMethod(String type) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/incremental/BazProperties.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/incremental/BazProperties.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.configurationsample.incremental;
+
+import org.springframework.boot.configurationsample.ConfigurationProperties;
+
+@ConfigurationProperties("baz")
+public class BazProperties {
+
+	private String name;
+
+	private String description;
+
+	/**
+	 * A nice counter description.
+	 */
+	private Integer counter = 0;
+
+	public String getName() {
+		return this.name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getDescription() {
+		return this.description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public Integer getCounter() {
+		return this.counter;
+	}
+
+	public void setCounter(Integer counter) {
+		this.counter = counter;
+	}
+
+
+	@ConfigurationProperties("quux")
+	public static class QuuxProperties {
+
+		private String name;
+
+		private String description;
+
+		/**
+		 * A nice counter description.
+		 */
+		private Integer counter = 0;
+
+		public String getName() {
+			return this.name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getDescription() {
+			return this.description;
+		}
+
+		public void setDescription(String description) {
+			this.description = description;
+		}
+
+		public Integer getCounter() {
+			return this.counter;
+		}
+
+		public void setCounter(Integer counter) {
+			this.counter = counter;
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/incremental/BazProperties.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/incremental/BazProperties.java
@@ -54,7 +54,6 @@ public class BazProperties {
 		this.counter = counter;
 	}
 
-
 	@ConfigurationProperties("quux")
 	public static class QuuxProperties {
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/incremental/RenamedBazProperties.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/incremental/RenamedBazProperties.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.configurationsample.incremental;
+
+import org.springframework.boot.configurationsample.ConfigurationProperties;
+
+@ConfigurationProperties("baz")
+public class RenamedBazProperties {
+
+	private String name;
+
+	private String description;
+
+	/**
+	 * A nice counter description.
+	 */
+	private Integer counter = 0;
+
+	public String getName() {
+		return this.name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getDescription() {
+		return this.description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public Integer getCounter() {
+		return this.counter;
+	}
+
+	public void setCounter(Integer counter) {
+		this.counter = counter;
+	}
+
+	@ConfigurationProperties("quux")
+	public static class RenamedQuuxProperties {
+
+		private String name;
+
+		private String description;
+
+		/**
+		 * A nice counter description.
+		 */
+		private Integer counter = 0;
+
+		public String getName() {
+			return this.name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getDescription() {
+			return this.description;
+		}
+
+		public void setDescription(String description) {
+			this.description = description;
+		}
+
+		public Integer getCounter() {
+			return this.counter;
+		}
+
+		public void setCounter(Integer counter) {
+			this.counter = counter;
+		}
+
+	}
+
+}


### PR DESCRIPTION
Hi!

Proposed changes introduce additional metadata property "sourceCanonicalType" holding the canonical name of the source type. Existing property "sourceType" remains unchanged for backward compatibility.

Fixes #10886.

Regards,
Boris