### PR TITLE
Clarify the type to which connection-pool-specific `spring.datasource` properties are bound

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/context/properties/DocumentConfigurationProperties.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/context/properties/DocumentConfigurationProperties.java
@@ -81,8 +81,9 @@ public class DocumentConfigurationProperties extends AbstractTask {
 						"spring.jooq", "spring.jdbc", "spring.jpa", "spring.r2dbc")
 				.addOverride("spring.datasource.dbcp2", "Commons DBCP2 specific settings")
 				.addOverride("spring.datasource.tomcat", "Tomcat datasource specific settings")
-				.addOverride("spring.datasource.hikari", "Hikari specific settings").addSection("transaction")
-				.withKeyPrefixes("spring.jta", "spring.transaction").addSection("integration")
+				.addOverride("spring.datasource.hikari",
+						"Hikari specific settings bound to an instance of Hikari datasource")
+				.addSection("transaction").withKeyPrefixes("spring.jta", "spring.transaction").addSection("integration")
 				.withKeyPrefixes("spring.activemq", "spring.artemis", "spring.batch", "spring.integration",
 						"spring.jms", "spring.kafka", "spring.rabbitmq", "spring.hazelcast", "spring.webservices")
 				.addSection("actuator").withKeyPrefixes("management").addSection("devtools")

--- a/buildSrc/src/main/java/org/springframework/boot/build/context/properties/DocumentConfigurationProperties.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/context/properties/DocumentConfigurationProperties.java
@@ -82,7 +82,7 @@ public class DocumentConfigurationProperties extends AbstractTask {
 				.addOverride("spring.datasource.dbcp2", "Commons DBCP2 specific settings")
 				.addOverride("spring.datasource.tomcat", "Tomcat datasource specific settings")
 				.addOverride("spring.datasource.hikari",
-						"Hikari specific settings bound to an instance of HikariDataSource")
+						"Hikari specific settings bound to an instance of `HikariDataSource`")
 				.addSection("transaction").withKeyPrefixes("spring.jta", "spring.transaction").addSection("integration")
 				.withKeyPrefixes("spring.activemq", "spring.artemis", "spring.batch", "spring.integration",
 						"spring.jms", "spring.kafka", "spring.rabbitmq", "spring.hazelcast", "spring.webservices")

--- a/buildSrc/src/main/java/org/springframework/boot/build/context/properties/DocumentConfigurationProperties.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/context/properties/DocumentConfigurationProperties.java
@@ -82,7 +82,7 @@ public class DocumentConfigurationProperties extends AbstractTask {
 				.addOverride("spring.datasource.dbcp2", "Commons DBCP2 specific settings")
 				.addOverride("spring.datasource.tomcat", "Tomcat datasource specific settings")
 				.addOverride("spring.datasource.hikari",
-						"Hikari specific settings bound to an instance of Hikari datasource")
+						"Hikari specific settings bound to an instance of HikariDataSource")
 				.addSection("transaction").withKeyPrefixes("spring.jta", "spring.transaction").addSection("integration")
 				.withKeyPrefixes("spring.activemq", "spring.artemis", "spring.batch", "spring.integration",
 						"spring.jms", "spring.kafka", "spring.rabbitmq", "spring.hazelcast", "spring.webservices")


### PR DESCRIPTION
For issue: #20688, Minor change to description of Hikari Datasource properties in documentation

Fixes gh-20688

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
