### PR TITLE
Improve Binder performance slightly

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -367,7 +367,7 @@ public class Binder {
 	private <T> Object bindObject(ConfigurationPropertyName name, Bindable<T> target, BindHandler handler,
 			Context context, boolean allowRecursiveBinding) {
 		ConfigurationProperty property = findProperty(name, context);
-		if (property == null && containsNoDescendantOf(context.getSources(), name) && context.depth != 0) {
+		if (property == null && context.depth != 0 && containsNoDescendantOf(context.getSources(), name)) {
 			return null;
 		}
 		AggregateBinder<?> aggregateBinder = getAggregateBinder(target, context);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/IndexedElementsBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/IndexedElementsBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ abstract class IndexedElementsBinder<T> extends AggregateBinder<T> {
 
 	private void bindIndexed(ConfigurationPropertySource source, ConfigurationPropertyName root,
 			AggregateElementBinder elementBinder, IndexedCollectionSupplier collection, ResolvableType elementType) {
-		MultiValueMap<String, ConfigurationProperty> knownIndexedChildren = getKnownIndexedChildren(source, root);
+		MultiValueMap<String, ConfigurationPropertyName> knownIndexedChildren = getKnownIndexedChildren(source, root);
 		for (int i = 0; i < Integer.MAX_VALUE; i++) {
 			ConfigurationPropertyName name = root.append((i != 0) ? "[" + i + "]" : INDEX_ZERO);
 			Object value = elementBinder.bind(name, Bindable.of(elementType), source);
@@ -111,12 +111,12 @@ abstract class IndexedElementsBinder<T> extends AggregateBinder<T> {
 			knownIndexedChildren.remove(name.getLastElement(Form.UNIFORM));
 			collection.get().add(value);
 		}
-		assertNoUnboundChildren(knownIndexedChildren);
+		assertNoUnboundChildren(source, knownIndexedChildren);
 	}
 
-	private MultiValueMap<String, ConfigurationProperty> getKnownIndexedChildren(ConfigurationPropertySource source,
+	private MultiValueMap<String, ConfigurationPropertyName> getKnownIndexedChildren(ConfigurationPropertySource source,
 			ConfigurationPropertyName root) {
-		MultiValueMap<String, ConfigurationProperty> children = new LinkedMultiValueMap<>();
+		MultiValueMap<String, ConfigurationPropertyName> children = new LinkedMultiValueMap<>();
 		if (!(source instanceof IterableConfigurationPropertySource)) {
 			return children;
 		}
@@ -124,17 +124,17 @@ abstract class IndexedElementsBinder<T> extends AggregateBinder<T> {
 			ConfigurationPropertyName choppedName = name.chop(root.getNumberOfElements() + 1);
 			if (choppedName.isLastElementIndexed()) {
 				String key = choppedName.getLastElement(Form.UNIFORM);
-				ConfigurationProperty value = source.getConfigurationProperty(name);
-				children.add(key, value);
+				children.add(key, name);
 			}
 		}
 		return children;
 	}
 
-	private void assertNoUnboundChildren(MultiValueMap<String, ConfigurationProperty> children) {
+	private void assertNoUnboundChildren(ConfigurationPropertySource source,
+			MultiValueMap<String, ConfigurationPropertyName> children) {
 		if (!children.isEmpty()) {
-			throw new UnboundConfigurationPropertiesException(
-					children.values().stream().flatMap(List::stream).collect(Collectors.toCollection(TreeSet::new)));
+			throw new UnboundConfigurationPropertiesException(children.values().stream().flatMap(List::stream)
+					.map(source::getConfigurationProperty).collect(Collectors.toCollection(TreeSet::new)));
 		}
 	}
 


### PR DESCRIPTION
Hi,

I'm currently trying to improve the startup of a medium sized app and found a couple of minor optimization opportunities in the `Binder` logic:

1. Skip looking for descendants if `context.depth` is 0. (Was there before, but only as a subsequent condition)
2. Defer overhead of getting `ConfigurationProperty`s in `IndexedElementsBinder:: getKnownIndexedChildren ` until it's needed. The idea is that this is only really necessary if there are unbound properties - which should be the exception rather than the norm.

Applying this patch shows me the following results for the [initializr benchmarks](https://github.com/dsyer/initializr/tree/bench) we used in the past already:
```
2.3.0.M3
Benchmark                        (prof)   Mode  Cnt      Score      Error  Units
PropertiesBenchmarkIT.auto       medium  thrpt   10    238,644 ±  138,881  ops/s
PropertiesBenchmarkIT.auto:size  medium  thrpt   10   1340,000                 #
PropertiesBenchmarkIT.auto        small  thrpt   10  16863,321 ± 8881,464  ops/s
PropertiesBenchmarkIT.auto:size   small  thrpt   10     10,000                 #
PropertiesBenchmarkIT.auto        large  thrpt   10      4,492 ±    0,647  ops/s
PropertiesBenchmarkIT.auto:size   large  thrpt   10  10930,000                 #

Patch
Benchmark                        (prof)   Mode  Cnt      Score      Error  Units
PropertiesBenchmarkIT.auto       medium  thrpt   10    275,289 ±  144,481  ops/s
PropertiesBenchmarkIT.auto:size  medium  thrpt   10   1340,000                 #
PropertiesBenchmarkIT.auto        small  thrpt   10  20426,557 ± 4507,749  ops/s
PropertiesBenchmarkIT.auto:size   small  thrpt   10     10,000                 #
PropertiesBenchmarkIT.auto        large  thrpt   10      5,121 ±    0,428  ops/s
PropertiesBenchmarkIT.auto:size   large  thrpt   10  10930,000                 #
```

I also ran 2.3.0.M3 vs. this patch against the [config example](https://github.com/martinvisser/config-properties-example) which we used in the past to optimize the binding of large properties: 
|       | 2.3.0.M3 |  Patch  |
| ----- | -------: | ----: |
|       |    4.986 | 4.790 |
|       |    4.715 | 4.682 |
|       |    4.833 | 4.651 |
|       |    4.719 | 4.762 |
|       |    5.161 | 4.743 |
|       |    4.830 | 4.744 |
|       |    5.081 | 4.791 |
|       |    5.850 | 4.715 |
|       |    4.767 | 4.803 |
|       |    4.877 | 4.804 |
|  Mean |    4.982 | 4.749 |
| Range |    1.135 | 0.153 |

I should note that I see relatively volatile timings on my local machine, but always in favor of the new patched version. Nonetheless, I'd give it a try before merging this if I were you - even if the improvements seem relatively straight-forward ;-)

Let me know what you think.
Cheers,
Christoph