### PR TITLE
Harmonize issue title for auto-created Docker upgrade issues

### DIFF
--- a/ci/parameters.yml
+++ b/ci/parameters.yml
@@ -1,4 +1,3 @@
-docker-upgrade-issue-title: "Upgrade Docker version in CI"
 email-server: "smtp.svc.pivotal.io"
 email-from: "ci@spring.io"
 email-to: ["spring-boot-dev@pivotal.io"]

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -230,7 +230,6 @@ jobs:
       params:
         GITHUB_REPO: spring-boot
         GITHUB_ORGANIZATION: spring-projects
-        ISSUE_TITLE: ((docker-upgrade-issue-title))
       image: spring-boot-ci-image
     - put: git-repo-ci-docker
       params:
@@ -245,7 +244,6 @@ jobs:
         GITHUB_ORGANIZATION: spring-projects
         GITHUB_PASSWORD: ((github-password))
         GITHUB_USERNAME: ((github-username))
-        ISSUE_TITLE: ((docker-upgrade-issue-title))
       image: spring-boot-ci-image
 - name: build
   serial: true

--- a/ci/scripts/create-pull-request.sh
+++ b/ci/scripts/create-pull-request.sh
@@ -2,6 +2,7 @@
 set -e
 
 if [[ -f commit-details/message ]]; then
+	ISSUE_TITLE="$(cat commit-details/message)"
 	curl \
 	  -s \
 		-u ${GITHUB_USERNAME}:${GITHUB_PASSWORD} \

--- a/ci/tasks/create-pull-request.yml
+++ b/ci/tasks/create-pull-request.yml
@@ -10,6 +10,5 @@ params:
   GITHUB_ORGANIZATION:
   GITHUB_PASSWORD:
   GITHUB_USERNAME:
-  ISSUE_TITLE:
 run:
   path: git-repo/ci/scripts/create-pull-request.sh

--- a/ci/tasks/detect-docker-updates.yml
+++ b/ci/tasks/detect-docker-updates.yml
@@ -9,6 +9,5 @@ outputs:
 params:
   GITHUB_REPO:
   GITHUB_ORGANIZATION:
-  ISSUE_TITLE:
 run:
   path: git-repo/ci/scripts/detect-docker-updates.sh


### PR DESCRIPTION
Hi,

this PR closes #20760 as discussed. To fix this I needed to fix some related quirks around fetching already existing issues:

- The GitHub `/pulls` API is not having feature-parity with the `/issues` API when it comes to filtering and caused the API to return quite a lot of issues (e.g. all open ones instead of just open ones by the specific creator). I switched to the `/issues` API again + a corresponding `jq` selection filter for the `pull_request` key.
- Apparently there are some control characters in the response that cause the intermediate echo to fail on my local machine. I think I haven't noticed this before because it seems to be related to the milestone description (I'm guessing newlines) that wasn't assigned previously all the time. Inlining the `curl` and `jq` commands fixes this. Or at least makes it more stable.

Cheers,
Christoph