### PR TITLE
Add reference to XChange starter

### DIFF
--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -217,4 +217,7 @@ do as they were designed before this was clarified.
 | https://alexo.github.io/wro4j/[Wro4j]
 | https://github.com/michael-simons/wro4j-spring-boot-starter
 
+| https://github.com/knowm/XChange[XChange]
+| https://github.com/cassandre-tech/cassandre-trading-bot
+
 |===


### PR DESCRIPTION
I updated to spring boot starter list to add a spring boot starter we made for [XChange](https://github.com/knowm/XChange).

Our project : [https://github.com/cassandre-tech/cassandre-trading-bot](https://github.com/cassandre-tech/cassandre-trading-bot)
