### PR TITLE
Polish ConditionMessage#because()

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionMessage.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionMessage.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionMessage.java
@@ -300,7 +300,7 @@ public final class ConditionMessage {
 				return new ConditionMessage(ConditionMessage.this, this.condition);
 			}
 			return new ConditionMessage(ConditionMessage.this,
-					this.condition + (StringUtils.isEmpty(this.condition) ? "" : " ") + reason);
+					StringUtils.isEmpty(this.condition) ? reason : this.condition + " " + reason);
 		}
 
 	}


### PR DESCRIPTION
Hi,

I just noticed a tiny optimization opportunity in `ConditionMessage#because` to avoid unnecessary string concatenations when the `condition` is empty.

Cheers,
Christoph