### PR TITLE
Change call to createClassLoader(URL) from 'super' to 'this'

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/ExecutableArchiveLauncher.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/ExecutableArchiveLauncher.java
@@ -89,7 +89,7 @@ public abstract class ExecutableArchiveLauncher extends Launcher {
 		if (this.classPathIndex != null) {
 			urls.addAll(this.classPathIndex.getUrls());
 		}
-		return super.createClassLoader(urls.toArray(new URL[0]));
+		return this.createClassLoader(urls.toArray(new URL[0]));
 	}
 
 	private int guessClassPathSize() {


### PR DESCRIPTION
ExecutableArchiveLauncher.createClassLoader(Iterator) calls createClassLoader(URL) method with 'super' effectively removing any chance the later method could be overriden and successfully called without overriding both methods.
