### PR TITLE
Harmonize naming of Elasticsearch auto-configuration classes

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticSearchRestHealthContributorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticSearchRestHealthContributorAutoConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.elasticsearch.rest.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -44,7 +44,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass(RestClient.class)
 @ConditionalOnBean(RestClient.class)
 @ConditionalOnEnabledHealthIndicator("elasticsearch")
-@AutoConfigureAfter(RestClientAutoConfiguration.class)
+@AutoConfigureAfter(ElasticsearchRestClientAutoConfiguration.class)
 public class ElasticSearchRestHealthContributorAutoConfiguration
 		extends CompositeHealthContributorConfiguration<ElasticsearchRestHealthIndicator, RestClient> {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchDataAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchDataAutoConfiguration.java
@@ -19,7 +19,7 @@ package org.springframework.boot.autoconfigure.data.elasticsearch;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.elasticsearch.rest.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
@@ -39,7 +39,8 @@ import org.springframework.data.elasticsearch.repository.config.EnableReactiveEl
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass({ ElasticsearchTemplate.class })
-@AutoConfigureAfter({ RestClientAutoConfiguration.class, ReactiveRestClientAutoConfiguration.class })
+@AutoConfigureAfter({ ElasticsearchRestClientAutoConfiguration.class,
+		ReactiveElasticsearchRestClientAutoConfiguration.class })
 @Import({ ElasticsearchDataConfiguration.BaseConfiguration.class,
 		ElasticsearchDataConfiguration.RestClientConfiguration.class,
 		ElasticsearchDataConfiguration.ReactiveRestClientConfiguration.class })

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/elasticsearch/ReactiveElasticsearchRestClientAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/elasticsearch/ReactiveElasticsearchRestClientAutoConfiguration.java
@@ -42,12 +42,12 @@ import org.springframework.web.reactive.function.client.WebClient;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass({ ReactiveRestClients.class, WebClient.class, HttpClient.class })
-@EnableConfigurationProperties(ReactiveRestClientProperties.class)
-public class ReactiveRestClientAutoConfiguration {
+@EnableConfigurationProperties(ReactiveElasticsearchRestClientProperties.class)
+public class ReactiveElasticsearchRestClientAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ClientConfiguration clientConfiguration(ReactiveRestClientProperties properties) {
+	public ClientConfiguration clientConfiguration(ReactiveElasticsearchRestClientProperties properties) {
 		ClientConfiguration.MaybeSecureClientConfigurationBuilder builder = ClientConfiguration.builder()
 				.connectedTo(properties.getEndpoints().toArray(new String[0]));
 		if (properties.isUseSsl()) {
@@ -59,7 +59,7 @@ public class ReactiveRestClientAutoConfiguration {
 	}
 
 	private void configureTimeouts(ClientConfiguration.TerminalClientConfigurationBuilder builder,
-			ReactiveRestClientProperties properties) {
+			ReactiveElasticsearchRestClientProperties properties) {
 		PropertyMapper map = PropertyMapper.get();
 		map.from(properties.getConnectionTimeout()).whenNonNull().to(builder::withConnectTimeout);
 		map.from(properties.getSocketTimeout()).whenNonNull().to(builder::withSocketTimeout);
@@ -71,7 +71,7 @@ public class ReactiveRestClientAutoConfiguration {
 	}
 
 	private void configureExchangeStrategies(ClientConfiguration.TerminalClientConfigurationBuilder builder,
-			ReactiveRestClientProperties properties) {
+			ReactiveElasticsearchRestClientProperties properties) {
 		PropertyMapper map = PropertyMapper.get();
 		builder.withWebClientConfigurer((webClient) -> {
 			ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/elasticsearch/ReactiveElasticsearchRestClientProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/elasticsearch/ReactiveElasticsearchRestClientProperties.java
@@ -31,7 +31,7 @@ import org.springframework.util.unit.DataSize;
  * @since 2.2.0
  */
 @ConfigurationProperties(prefix = "spring.data.elasticsearch.client.reactive")
-public class ReactiveRestClientProperties {
+public class ReactiveElasticsearchRestClientProperties {
 
 	/**
 	 * Comma-separated list of the Elasticsearch endpoints to connect to.

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.autoconfigure.elasticsearch.rest;
+package org.springframework.boot.autoconfigure.elasticsearch;
 
 import org.elasticsearch.client.RestClient;
 
@@ -33,10 +33,10 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(RestClient.class)
-@EnableConfigurationProperties(RestClientProperties.class)
-@Import({ RestClientConfigurations.RestClientBuilderConfiguration.class,
-		RestClientConfigurations.RestHighLevelClientConfiguration.class,
-		RestClientConfigurations.RestClientFallbackConfiguration.class })
-public class RestClientAutoConfiguration {
+@EnableConfigurationProperties(ElasticsearchRestClientProperties.class)
+@Import({ ElasticsearchRestClientConfigurations.RestClientBuilderConfiguration.class,
+		ElasticsearchRestClientConfigurations.RestHighLevelClientConfiguration.class,
+		ElasticsearchRestClientConfigurations.RestClientFallbackConfiguration.class })
+public class ElasticsearchRestClientAutoConfiguration {
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.autoconfigure.elasticsearch.rest;
+package org.springframework.boot.autoconfigure.elasticsearch;
 
 import java.time.Duration;
 
@@ -41,14 +41,14 @@ import org.springframework.context.annotation.Configuration;
  * @author Brian Clozel
  * @author Stephane Nicoll
  */
-class RestClientConfigurations {
+class ElasticsearchRestClientConfigurations {
 
 	@Configuration(proxyBeanMethods = false)
 	static class RestClientBuilderConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		RestClientBuilder elasticsearchRestClientBuilder(RestClientProperties properties,
+		RestClientBuilder elasticsearchRestClientBuilder(ElasticsearchRestClientProperties properties,
 				ObjectProvider<RestClientBuilderCustomizer> builderCustomizers) {
 			HttpHost[] hosts = properties.getUris().stream().map(HttpHost::create).toArray(HttpHost[]::new);
 			RestClientBuilder builder = RestClient.builder(hosts);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.autoconfigure.elasticsearch.rest;
+package org.springframework.boot.autoconfigure.elasticsearch;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -30,7 +30,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @since 2.1.0
  */
 @ConfigurationProperties(prefix = "spring.elasticsearch.rest")
-public class RestClientProperties {
+public class ElasticsearchRestClientProperties {
 
 	/**
 	 * Comma-separated list of the Elasticsearch instances to use.

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/RestClientBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/RestClientBuilderCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.autoconfigure.elasticsearch.rest;
+package org.springframework.boot.autoconfigure.elasticsearch;
 
 import org.elasticsearch.client.RestClientBuilder;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/package-info.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,6 @@
  */
 
 /**
- * Auto-configuration for Elasticsearch REST clients.
+ * Auto-configuration for Elasticsearch client.
  */
-package org.springframework.boot.autoconfigure.elasticsearch.rest;
+package org.springframework.boot.autoconfigure.elasticsearch;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -41,7 +41,7 @@ org.springframework.boot.autoconfigure.data.couchbase.CouchbaseRepositoriesAutoC
 org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.elasticsearch.ReactiveElasticsearchRepositoriesAutoConfiguration,\
-org.springframework.boot.autoconfigure.data.elasticsearch.ReactiveRestClientAutoConfiguration,\
+org.springframework.boot.autoconfigure.data.elasticsearch.ReactiveElasticsearchRestClientAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.jdbc.JdbcRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.ldap.LdapRepositoriesAutoConfiguration,\
@@ -60,7 +60,7 @@ org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration
 org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoConfiguration,\
 org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration,\
-org.springframework.boot.autoconfigure.elasticsearch.rest.RestClientAutoConfiguration,\
+org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration,\
 org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration,\
 org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration,\
 org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration,\

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchDataAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchDataAutoConfigurationTests.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.autoconfigure.elasticsearch.rest.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -44,8 +44,8 @@ import static org.mockito.Mockito.mock;
 class ElasticsearchDataAutoConfigurationTests {
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(RestClientAutoConfiguration.class,
-					ReactiveRestClientAutoConfiguration.class, ElasticsearchDataAutoConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(ElasticsearchRestClientAutoConfiguration.class,
+					ReactiveElasticsearchRestClientAutoConfiguration.class, ElasticsearchDataAutoConfiguration.class));
 
 	@BeforeEach
 	void setUp() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchRepositoriesAutoConfigurationTests.java
@@ -29,7 +29,7 @@ import org.springframework.boot.autoconfigure.data.alt.elasticsearch.CityElastic
 import org.springframework.boot.autoconfigure.data.elasticsearch.city.City;
 import org.springframework.boot.autoconfigure.data.elasticsearch.city.CityRepository;
 import org.springframework.boot.autoconfigure.data.empty.EmptyDataPackage;
-import org.springframework.boot.autoconfigure.elasticsearch.rest.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
@@ -52,7 +52,7 @@ class ElasticsearchRepositoriesAutoConfigurationTests {
 			.withStartupAttempts(5).withStartupTimeout(Duration.ofMinutes(10));
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(RestClientAutoConfiguration.class,
+			.withConfiguration(AutoConfigurations.of(ElasticsearchRestClientAutoConfiguration.class,
 					ElasticsearchRepositoriesAutoConfiguration.class, ElasticsearchDataAutoConfiguration.class))
 			.withPropertyValues("spring.elasticsearch.rest.uris=" + elasticsearch.getHttpHostAddress());
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ReactiveElasticsearchRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ReactiveElasticsearchRepositoriesAutoConfigurationTests.java
@@ -51,7 +51,7 @@ public class ReactiveElasticsearchRepositoriesAutoConfigurationTests {
 			.withStartupTimeout(Duration.ofMinutes(10));
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(ReactiveRestClientAutoConfiguration.class,
+			.withConfiguration(AutoConfigurations.of(ReactiveElasticsearchRestClientAutoConfiguration.class,
 					ReactiveElasticsearchRepositoriesAutoConfiguration.class, ElasticsearchDataAutoConfiguration.class))
 			.withPropertyValues("spring.data.elasticsearch.client.reactive.endpoints="
 					+ elasticsearch.getContainerIpAddress() + ":" + elasticsearch.getFirstMappedPort());

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ReactiveElasticsearchRestClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ReactiveElasticsearchRestClientAutoConfigurationTests.java
@@ -39,19 +39,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
- * Tests for {@link ReactiveRestClientAutoConfiguration}
+ * Tests for {@link ReactiveElasticsearchRestClientAutoConfiguration}.
  *
  * @author Brian Clozel
  */
 @Testcontainers(disabledWithoutDocker = true)
-public class ReactiveRestClientAutoConfigurationTests {
+public class ReactiveElasticsearchRestClientAutoConfigurationTests {
 
 	@Container
 	static ElasticsearchContainer elasticsearch = new VersionOverridingElasticsearchContainer().withStartupAttempts(5)
 			.withStartupTimeout(Duration.ofMinutes(10));
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(ReactiveRestClientAutoConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(ReactiveElasticsearchRestClientAutoConfiguration.class));
 
 	@Test
 	void configureShouldCreateDefaultBeans() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfigurationTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.autoconfigure.elasticsearch.rest;
+package org.springframework.boot.autoconfigure.elasticsearch;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -42,19 +42,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
- * Tests for {@link RestClientAutoConfiguration}
+ * Tests for {@link ElasticsearchRestClientAutoConfiguration}.
  *
  * @author Brian Clozel
  */
 @Testcontainers(disabledWithoutDocker = true)
-class RestClientAutoConfigurationTests {
+class ElasticsearchRestClientAutoConfigurationTests {
 
 	@Container
 	static final ElasticsearchContainer elasticsearch = new ElasticsearchContainer().withStartupAttempts(5)
 			.withStartupTimeout(Duration.ofMinutes(10));
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(RestClientAutoConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(ElasticsearchRestClientAutoConfiguration.class));
 
 	@Test
 	void configureShouldCreateBothRestClientVariants() {


### PR DESCRIPTION
This PR harmonizes the naming of Elasticsearch auto-configuration components by including _Elasticsearch_ in class names.

I've found the current naming to be very inconvenient to work with, since searching for Elasticsearch related auto-configuration components by entering _ElasticsearchConfiguration_ or _ElasticsearchProperties_ in IDEA's doesn't return some of vital components like `RestClientAutoConfiguration` and `RestClientProperties` - those two are especially harder to find this way since they're not in the same package as components that currently do have _Elasticsearch_ in their name (`org.springframework.boot.autoconfigure.elasticsearch.rest` vs `org.springframework.boot.autoconfigure.data.elasticsearch`).

A good example of well-named (and therefore easily discoverable) auto-configuration components is [`org.springframework.boot.autoconfigure.session`](https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session), where all components contain _Session_ in their names.

Additionally, one further point of harmonization (that I didn't apply to this PR yet) could be to move components from `org.springframework.boot.autoconfigure.elasticsearch.rest` to simply `org.springframework.boot.autoconfigure.elasticsearch` - as reactive client components in `org.springframework.boot.autoconfigure.data.elasticsearch` aren't nested in `rest` subpackage.