### PR TITLE
Updated HazelcastClientConfiguration to support Hazelcast 4.0

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientConfiguration.java
@@ -112,8 +112,9 @@ class HazelcastClientConfiguration {
 			String configFileName = configUrl.getPath();
 			if (configFileName.endsWith(".yaml")) {
 				new YamlClientConfigBuilder(configUrl).build();
+			} else if (configFileName.endsWith(".xml")) {
+				new XmlClientConfigBuilder(configUrl).build();
 			}
-			new XmlClientConfigBuilder(configUrl).build();
 		}
 	}
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientConfiguration.java
@@ -123,9 +123,8 @@ class HazelcastClientConfiguration {
 					MethodType.methodType(void.class, InputStream.class, int.class));
 			MethodHandle configRecognizerConstructor = MethodHandles.publicLookup()
 					.findConstructor(configRecognizerClass, MethodType.methodType(void.class));
-			MethodHandle isRecognizedMethod = MethodHandles.publicLookup().findVirtual(
-					abstractConfigRecognizerClass, "isRecognized",
-					MethodType.methodType(boolean.class, configStreamClass));
+			MethodHandle isRecognizedMethod = MethodHandles.publicLookup().findVirtual(abstractConfigRecognizerClass,
+					"isRecognized", MethodType.methodType(boolean.class, configStreamClass));
 
 			Object configStream = configStreamConstructor.invoke(resource.getInputStream(), 4096);
 			Object configRecognizer = configRecognizerConstructor.invoke();


### PR DESCRIPTION
Fixes #20856.

Added a validation for Hazelcast client configuration on `HazelcastClientConfiguration.ConfigAvailableCondition` when `spring.hazelcast.config` property is available. If the configured config is a valid Hazelcast client configuration, then the client instance bean is initialized. 

The validation is done by building the `ClientConfig` object from the configuration file for now, since there are no public API for client file validation in Hazelcast. When it is exposed, it can be updated to use this validation API. 