### PR TITLE
Add reference to Mule 4 starter

### DIFF
--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -133,6 +133,9 @@ do as they were designed before this was clarified.
 | https://logback.qos.ch/access.html[Logback-access]
 | https://github.com/akihyro/logback-access-spring-boot-starter
 
+| Mule 4
+| https://github.com/hawkore/mule4-spring-boot-starter
+
 | https://github.com/mybatis/mybatis-3[MyBatis]
 | https://github.com/mybatis/mybatis-spring-boot
 


### PR DESCRIPTION
A 'Bootiful' approach to run Mule 4 embedded into a Spring Boot application.