### PR TITLE
Default for spring.kafka.listener.missing-topics-fatal is no longer aligned with Spring Kafka's default

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
@@ -52,6 +52,7 @@ import org.springframework.util.unit.DataSize;
  * @author Stephane Nicoll
  * @author Artem Bilan
  * @author Nakul Mishra
+ * @author Dhiren Mathur
  * @since 1.5.0
  */
 @ConfigurationProperties(prefix = "spring.kafka")
@@ -906,7 +907,7 @@ public class KafkaProperties {
 		 * Whether the container should fail to start if at least one of the configured
 		 * topics are not present on the broker.
 		 */
-		private boolean missingTopicsFatal = true;
+		private boolean missingTopicsFatal = false;
 
 		public Type getType() {
 			return this.type;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfigurationTests.java
@@ -87,6 +87,7 @@ import static org.mockito.Mockito.verify;
  * @author Stephane Nicoll
  * @author Eddú Meléndez
  * @author Nakul Mishra
+ * @author Dhiren Mathur
  */
 class KafkaAutoConfigurationTests {
 
@@ -370,7 +371,7 @@ class KafkaAutoConfigurationTests {
 						"spring.kafka.listener.no-poll-threshold=2.5", "spring.kafka.listener.type=batch",
 						"spring.kafka.listener.idle-event-interval=1s", "spring.kafka.listener.monitor-interval=45",
 						"spring.kafka.listener.log-container-config=true",
-						"spring.kafka.listener.missing-topics-fatal=false", "spring.kafka.jaas.enabled=true",
+						"spring.kafka.listener.missing-topics-fatal=true", "spring.kafka.jaas.enabled=true",
 						"spring.kafka.producer.transaction-id-prefix=foo", "spring.kafka.jaas.login-module=foo",
 						"spring.kafka.jaas.control-flag=REQUISITE", "spring.kafka.jaas.options.useKeyTab=true")
 				.run((context) -> {
@@ -395,7 +396,7 @@ class KafkaAutoConfigurationTests {
 					assertThat(containerProperties.getIdleEventInterval()).isEqualTo(1000L);
 					assertThat(containerProperties.getMonitorInterval()).isEqualTo(45);
 					assertThat(containerProperties.isLogContainerConfig()).isTrue();
-					assertThat(containerProperties.isMissingTopicsFatal()).isFalse();
+					assertThat(containerProperties.isMissingTopicsFatal()).isTrue();
 					assertThat(kafkaListenerContainerFactory).extracting("concurrency").isEqualTo(3);
 					assertThat(kafkaListenerContainerFactory.isBatchListener()).isTrue();
 					assertThat(context.getBeansOfType(KafkaJaasLoginModuleInitializer.class)).hasSize(1);
@@ -583,6 +584,17 @@ class KafkaAutoConfigurationTests {
 					.getBean(ConcurrentKafkaListenerContainerFactory.class);
 			assertThat(kafkaListenerContainerFactory.getConsumerFactory())
 					.isNotSameAs(context.getBean(ConsumerFactoryConfiguration.class).consumerFactory);
+		});
+	}
+
+	@Test
+	void testConcurrentKafkaListenerContainerFactoryMatchesDefaults() {
+		Listener listenerProperties = new KafkaProperties().getListener();
+		this.contextRunner.withUserConfiguration(ConsumerFactoryConfiguration.class).run((context) -> {
+			ConcurrentKafkaListenerContainerFactory<?, ?> kafkaListenerContainerFactory = context
+					.getBean(ConcurrentKafkaListenerContainerFactory.class);
+			assertThat(kafkaListenerContainerFactory.getContainerProperties().isMissingTopicsFatal())
+					.isEqualTo(listenerProperties.isMissingTopicsFatal());
 		});
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Related to: 
[ISSUE -20828](https://github.com/spring-projects/spring-boot/issues/20828)

Issue Explanation:
[Spring-Kafka configuration change](https://docs.spring.io/spring-kafka/docs/2.4.5.RELEASE/reference/html/#configuration-changes) - Starting with version 2.3.4, the missingTopicsFatal container property is false by default. (Previously) When this is true, the application fails to start if the broker is down; many users were affected by this change; 
After this S-K config change, default for spring.kafka.listener.missing-topics-fatal is no longer aligned with Spring Kafka's default. 

AIM: 
Update the `missingTopicsFatal` default value to be consistent with above referenced Spring-Kafka change

This commit contains:
* In `KafkaProperties.java` update `missingTopicsFatal` default value to `false`.
* Unit test to assert that new default is consistent