### PR TITLE
Optimize AutoConfigurationImportSelector.filter()

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelector.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -239,14 +239,12 @@ public class AutoConfigurationImportSelector implements DeferredImportSelector, 
 	private List<String> filter(List<String> configurations, AutoConfigurationMetadata autoConfigurationMetadata) {
 		long startTime = System.nanoTime();
 		String[] candidates = StringUtils.toStringArray(configurations);
-		boolean[] skip = new boolean[candidates.length];
 		boolean skipped = false;
 		for (AutoConfigurationImportFilter filter : getAutoConfigurationImportFilters()) {
 			invokeAwareMethods(filter);
 			boolean[] match = filter.match(candidates, autoConfigurationMetadata);
 			for (int i = 0; i < match.length; i++) {
 				if (!match[i]) {
-					skip[i] = true;
 					candidates[i] = null;
 					skipped = true;
 				}
@@ -257,7 +255,7 @@ public class AutoConfigurationImportSelector implements DeferredImportSelector, 
 		}
 		List<String> result = new ArrayList<>(candidates.length);
 		for (int i = 0; i < candidates.length; i++) {
-			if (!skip[i]) {
+			if (candidates[i] != null) {
 				result.add(candidates[i]);
 			}
 		}
@@ -266,7 +264,7 @@ public class AutoConfigurationImportSelector implements DeferredImportSelector, 
 			logger.trace("Filtered " + numberFiltered + " auto configuration class in "
 					+ TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) + " ms");
 		}
-		return new ArrayList<>(result);
+		return result;
 	}
 
 	protected List<AutoConfigurationImportFilter> getAutoConfigurationImportFilters() {


### PR DESCRIPTION
Hi,

I just found two tiny optimization opportunities in `AutoConfigurationImportSelector.filter()` that this PR addresses:

- `skipped` candidates are set to null, so there seems to be no need to explicitly hold a `skip` array for this purpose.
- the `result` ArrayList is copied to a new ArrayList, which seems redundant.

Let me know if I'm missing something.

Cheers,
Christoph
