### PR TITLE
Add support for customizing Spring Session's cookie serializer

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/CookieSerializerCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/CookieSerializerCustomizer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.session;
+
+import org.springframework.session.web.http.DefaultCookieSerializer;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize the
+ * {@link DefaultCookieSerializer} configuration.
+ *
+ * @author Vedran Pavic
+ * @since 2.3.0
+ */
+@FunctionalInterface
+public interface CookieSerializerCustomizer {
+
+	/**
+	 * Customize the cookie serializer.
+	 * @param cookieSerializer the {@code CookieSerializer} to customize
+	 */
+	void customize(DefaultCookieSerializer cookieSerializer);
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionAutoConfiguration.java
@@ -53,6 +53,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.security.web.authentication.RememberMeServices;
 import org.springframework.session.ReactiveSessionRepository;
 import org.springframework.session.Session;
 import org.springframework.session.SessionRepository;
@@ -61,7 +62,6 @@ import org.springframework.session.web.http.CookieHttpSessionIdResolver;
 import org.springframework.session.web.http.CookieSerializer;
 import org.springframework.session.web.http.DefaultCookieSerializer;
 import org.springframework.session.web.http.HttpSessionIdResolver;
-import org.springframework.util.ClassUtils;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Spring Session.
@@ -83,8 +83,6 @@ import org.springframework.util.ClassUtils;
 @AutoConfigureBefore(HttpHandlerAutoConfiguration.class)
 public class SessionAutoConfiguration {
 
-	private static final String REMEMBER_ME_SERVICES_CLASS = "org.springframework.security.web.authentication.RememberMeServices";
-
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnWebApplication(type = Type.SERVLET)
 	@Import({ ServletSessionRepositoryValidator.class, SessionRepositoryFilterConfiguration.class })
@@ -92,7 +90,8 @@ public class SessionAutoConfiguration {
 
 		@Bean
 		@Conditional(DefaultCookieSerializerCondition.class)
-		DefaultCookieSerializer cookieSerializer(ServerProperties serverProperties) {
+		DefaultCookieSerializer cookieSerializer(ServerProperties serverProperties,
+				ObjectProvider<CookieSerializerCustomizer> cookieSerializerCustomizers) {
 			Cookie cookie = serverProperties.getServlet().getSession().getCookie();
 			DefaultCookieSerializer cookieSerializer = new DefaultCookieSerializer();
 			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
@@ -102,10 +101,19 @@ public class SessionAutoConfiguration {
 			map.from(cookie::getHttpOnly).to(cookieSerializer::setUseHttpOnlyCookie);
 			map.from(cookie::getSecure).to(cookieSerializer::setUseSecureCookie);
 			map.from(cookie::getMaxAge).to((maxAge) -> cookieSerializer.setCookieMaxAge((int) maxAge.getSeconds()));
-			if (ClassUtils.isPresent(REMEMBER_ME_SERVICES_CLASS, getClass().getClassLoader())) {
-				new RememberMeServicesCookieSerializerCustomizer().apply(cookieSerializer);
-			}
+			cookieSerializerCustomizers.orderedStream().forEach((customizer) -> customizer.customize(cookieSerializer));
 			return cookieSerializer;
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		@ConditionalOnClass(RememberMeServices.class)
+		static class RememberMeServicesConfiguration {
+
+			@Bean
+			RememberMeServicesCookieSerializerCustomizer rememberMeServicesCookieSerializerCustomizer() {
+				return new RememberMeServicesCookieSerializerCustomizer();
+			}
+
 		}
 
 		@Configuration(proxyBeanMethods = false)
@@ -137,9 +145,10 @@ public class SessionAutoConfiguration {
 	 * Customization for {@link SpringSessionRememberMeServices} that is only instantiated
 	 * when Spring Security is on the classpath.
 	 */
-	static class RememberMeServicesCookieSerializerCustomizer {
+	static class RememberMeServicesCookieSerializerCustomizer implements CookieSerializerCustomizer {
 
-		void apply(DefaultCookieSerializer cookieSerializer) {
+		@Override
+		public void customize(DefaultCookieSerializer cookieSerializer) {
 			cookieSerializer.setRememberMeRequestAttribute(SpringSessionRememberMeServices.REMEMBER_ME_LOGIN_ATTR);
 		}
 


### PR DESCRIPTION
This PR introduces `CookieSerializerCustomizer` as callback that allows the customization of auto-configured `DefaultCookieSerializer` bean. This is particularly useful for configuring cookie serializer's capabilities that are not supported by Servlet API and therefore not exposed via `server.servlet.session.cookie.*` properties, such as SameSite.

The existing `RememberMeServicesCookieSerializerCustomizer` has also been refactored to leverage the new callback.