### PR TITLE
Prevent shaded imports from Datastax

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/servlet/DefaultWebMvcTagsProviderTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/servlet/DefaultWebMvcTagsProviderTests.java
@@ -19,13 +19,13 @@ package org.springframework.boot.actuate.endpoint.web.servlet;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.datastax.oss.driver.shaded.guava.common.base.Functions;
 import io.micrometer.core.instrument.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -72,7 +72,7 @@ public class DefaultWebMvcTagsProviderTests {
 
 	private Map<String, Tag> asMap(Iterable<Tag> tags) {
 		return StreamSupport.stream(tags.spliterator(), false)
-				.collect(Collectors.toMap(Tag::getKey, Functions.identity()));
+				.collect(Collectors.toMap(Tag::getKey, Function.identity()));
 	}
 
 	private static final class TestWebMvcTagsContributor implements WebMvcTagsContributor {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/DefaultWebFluxTagsProviderTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/DefaultWebFluxTagsProviderTests.java
@@ -19,10 +19,10 @@ package org.springframework.boot.actuate.metrics.web.reactive.server;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import com.datastax.oss.driver.shaded.guava.common.base.Functions;
 import io.micrometer.core.instrument.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +58,7 @@ public class DefaultWebFluxTagsProviderTests {
 
 	private Map<String, Tag> asMap(Iterable<Tag> tags) {
 		return StreamSupport.stream(tags.spliterator(), false)
-				.collect(Collectors.toMap(Tag::getKey, Functions.identity()));
+				.collect(Collectors.toMap(Tag::getKey, Function.identity()));
 	}
 
 	private static final class TestWebFluxTagsContributor implements WebFluxTagsContributor {

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -16,7 +16,7 @@
 			name="com.puppycrawl.tools.checkstyle.checks.imports.IllegalImportCheck">
 			<property name="regexp" value="true" />
 			<property name="illegalPkgs"
-				value="^sun.*, ^org\.apache\.commons\.(?!compress|dbcp2|lang|lang3|logging|pool2).*, ^com\.google\.common.*, ^io\.micrometer\.shaded.*, ^org\.flywaydb\.core\.internal.*, ^org\.testcontainers\.shaded.*" />
+				value="^sun.*, ^org\.apache\.commons\.(?!compress|dbcp2|lang|lang3|logging|pool2).*, ^com\.datastax\.oss\.driver\.shaded.*, ^com\.google\.common.*, ^io\.micrometer\.shaded.*, ^org\.flywaydb\.core\.internal.*, ^org\.testcontainers\.shaded.*" />
 			<property name="illegalClasses"
 				value="^com\.hazelcast\.util\.Base64, ^org\.junit\.rules\.ExpectedException, ^org\.mockito\.InjectMocks, ^org\.slf4j\.LoggerFactory, ^org.springframework.context.annotation.ScannedGenericBeanDefinition, ^reactor\.core\.support\.Assert" />
 		</module>


### PR DESCRIPTION
Hi,

I just noticed two imports of `com.datastax.oss.driver.shaded.guava.common.base.Functions` that could be replaced with Java's `java.util.function.Function`.

I also added the shaded package to the checkstyle rules, so accidental imports are prevented in the future.

Cheers,
Christoph