### PR TITLE
Proposal, give indication of timing for health check execution.

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/hazelcast/HazelcastHealthContributorAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/hazelcast/HazelcastHealthContributorAutoConfigurationIntegrationTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
 import org.springframework.boot.actuate.hazelcast.HazelcastHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Health.Builder;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.hazelcast.HazelcastAutoConfiguration;
@@ -47,7 +48,8 @@ class HazelcastHealthContributorAutoConfigurationIntegrationTests {
 			HazelcastInstance hazelcast = context.getBean(HazelcastInstance.class);
 			Health health = context.getBean(HazelcastHealthIndicator.class).health();
 			assertThat(health.getStatus()).isEqualTo(Status.UP);
-			assertThat(health.getDetails()).containsOnlyKeys("name", "uuid").containsEntry("name", hazelcast.getName())
+			assertThat(health.getDetails()).containsOnlyKeys("name", "uuid", Builder.DURATION_LABEL)
+					.containsEntry("name", hazelcast.getName())
 					.containsEntry("uuid", hazelcast.getLocalEndpoint().getUuid());
 		});
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/neo4j/Neo4jHealthContributorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/neo4j/Neo4jHealthContributorAutoConfigurationTests.java
@@ -22,6 +22,7 @@ import org.neo4j.ogm.session.SessionFactory;
 
 import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
 import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Health.Builder;
 import org.springframework.boot.actuate.neo4j.Neo4jHealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -60,7 +61,8 @@ class Neo4jHealthContributorAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(CustomIndicatorConfiguration.class).run((context) -> {
 			assertThat(context).hasSingleBean(Neo4jHealthIndicator.class);
 			Health health = context.getBean(Neo4jHealthIndicator.class).health();
-			assertThat(health.getDetails()).containsOnly(entry("test", true));
+			assertThat(health.getDetails()).contains(entry("test", true));
+			assertThat(health.getDetails()).containsOnlyKeys("test", Builder.DURATION_LABEL);
 		});
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/cassandra/CassandraReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/cassandra/CassandraReactiveHealthIndicatorTests.java
@@ -21,6 +21,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Health.Builder;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.data.cassandra.CassandraInternalException;
 import org.springframework.data.cassandra.core.ReactiveCassandraOperations;
@@ -52,7 +53,7 @@ class CassandraReactiveHealthIndicatorTests {
 		Mono<Health> health = cassandraReactiveHealthIndicator.health();
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
-			assertThat(h.getDetails()).containsOnlyKeys("version");
+			assertThat(h.getDetails()).containsOnlyKeys("version", Builder.DURATION_LABEL);
 			assertThat(h.getDetails().get("version")).isEqualTo("6.0.0");
 		}).verifyComplete();
 	}
@@ -68,7 +69,7 @@ class CassandraReactiveHealthIndicatorTests {
 		Mono<Health> health = cassandraReactiveHealthIndicator.health();
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.DOWN);
-			assertThat(h.getDetails()).containsOnlyKeys("error");
+			assertThat(h.getDetails()).containsOnlyKeys("error", Builder.DURATION_LABEL);
 			assertThat(h.getDetails().get("error"))
 					.isEqualTo(CassandraInternalException.class.getName() + ": Connection failed");
 		}).verifyComplete();

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/hazelcast/HazelcastHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/hazelcast/HazelcastHealthIndicatorTests.java
@@ -23,6 +23,7 @@ import com.hazelcast.transaction.TransactionalTask;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Health.Builder;
 import org.springframework.boot.actuate.health.Status;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,8 +53,8 @@ class HazelcastHealthIndicatorTests {
 		});
 		Health health = new HazelcastHealthIndicator(this.hazelcast).health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails()).containsOnlyKeys("name", "uuid").containsEntry("name", "hz0-instance")
-				.containsEntry("uuid", "7581bb2f-879f-413f-b574-0071d7519eb0");
+		assertThat(health.getDetails()).containsOnlyKeys("name", "uuid", Builder.DURATION_LABEL)
+				.containsEntry("name", "hz0-instance").containsEntry("uuid", "7581bb2f-879f-413f-b574-0071d7519eb0");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/CompositeHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/CompositeHealthIndicatorTests.java
@@ -64,7 +64,7 @@ class CompositeHealthIndicatorTests {
 		indicators.put("two", this.two);
 		CompositeHealthIndicator composite = new CompositeHealthIndicator(this.healthAggregator, indicators);
 		Health result = composite.health();
-		assertThat(result.getDetails()).hasSize(2);
+		assertThat(result.getDetails()).hasSize(3);
 		assertThat(result.getDetails()).containsEntry("one",
 				new Health.Builder().unknown().withDetail("1", "1").build());
 		assertThat(result.getDetails()).containsEntry("two",
@@ -82,9 +82,10 @@ class CompositeHealthIndicatorTests {
 		Health result = composite.health();
 		ObjectMapper mapper = new ObjectMapper();
 		assertThat(mapper.writeValueAsString(result))
-				.isEqualTo("{\"status\":\"UNKNOWN\",\"details\":{\"db\":{\"status\":\"UNKNOWN\""
-						+ ",\"details\":{\"db1\":{\"status\":\"UNKNOWN\",\"details\""
-						+ ":{\"1\":\"1\"}},\"db2\":{\"status\":\"UNKNOWN\",\"details\":{\"2\":\"2\"}}}}}}");
+				.containsPattern("\\{\"status\":\"UNKNOWN\",\"details\":\\{\"db\":\\{\"status\":\"UNKNOWN\""
+						+ ",\"details\":\\{\"db1\":\\{\"status\":\"UNKNOWN\",\"details\""
+						+ ":\\{\"1\":\"1\",\"durationNanos\":[0-9].*}},\"db2\":\\{\"status\":\"UNKNOWN\""
+						+ ",\"details\":\\{\"2\":\"2\",\"durationNanos\":[0-9].*}},\"durationNanos\":[0-9].*}},\"durationNanos\":[0-9].*}}");
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/CompositeHealthTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/CompositeHealthTests.java
@@ -64,8 +64,9 @@ class CompositeHealthTests {
 		CompositeHealth health = new CompositeHealth(ApiVersion.V3, Status.UP, components);
 		ObjectMapper mapper = new ObjectMapper();
 		String json = mapper.writeValueAsString(health);
-		assertThat(json).isEqualTo("{\"status\":\"UP\",\"components\":{\"db1\":{\"status\":\"UP\"},"
-				+ "\"db2\":{\"status\":\"DOWN\",\"details\":{\"a\":\"b\"}}}}");
+		assertThat(json).containsPattern(
+				"\\{\"status\":\"UP\",\"components\":\\{\"db1\":\\{\"status\":\"UP\",\"details\":\\{\"durationNanos\":[0-9].*},"
+						+ "\"db2\":\\{\"status\":\"DOWN\",\"details\":\\{\"a\":\"b\",\"durationNanos\":[0-9].*}}}}");
 	}
 
 	@Test
@@ -76,8 +77,9 @@ class CompositeHealthTests {
 		CompositeHealth health = new CompositeHealth(ApiVersion.V2, Status.UP, components);
 		ObjectMapper mapper = new ObjectMapper();
 		String json = mapper.writeValueAsString(health);
-		assertThat(json).isEqualTo("{\"status\":\"UP\",\"details\":{\"db1\":{\"status\":\"UP\"},"
-				+ "\"db2\":{\"status\":\"DOWN\",\"details\":{\"a\":\"b\"}}}}");
+		assertThat(json).containsPattern(
+				"\\{\"status\":\"UP\",\"details\":\\{\"db1\":\\{\"status\":\"UP\",\"details\":\\{\"durationNanos\":[0-9].*},"
+						+ "\"db2\":\\{\"status\":\"DOWN\",\"details\":\\{\"a\":\"b\",\"durationNanos\":[0-9].*}}}}");
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/CompositeReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/CompositeReactiveHealthIndicatorTests.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import org.springframework.boot.actuate.health.Health.Builder;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -47,7 +49,7 @@ class CompositeReactiveHealthIndicatorTests {
 				new DefaultReactiveHealthIndicatorRegistry(Collections.singletonMap("test", () -> Mono.just(HEALTHY))));
 		StepVerifier.create(indicator.health()).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
-			assertThat(h.getDetails()).containsOnlyKeys("test");
+			assertThat(h.getDetails()).containsOnlyKeys("test", Builder.DURATION_LABEL);
 			assertThat(h.getDetails().get("test")).isEqualTo(HEALTHY);
 		}).verifyComplete();
 	}
@@ -63,7 +65,7 @@ class CompositeReactiveHealthIndicatorTests {
 		StepVerifier.withVirtualTime(indicator::health).expectSubscription().thenAwait(Duration.ofMillis(10000))
 				.consumeNextWith((h) -> {
 					assertThat(h.getStatus()).isEqualTo(Status.UP);
-					assertThat(h.getDetails()).hasSize(50);
+					assertThat(h.getDetails()).hasSize(51);
 				}).verifyComplete();
 
 	}
@@ -77,7 +79,7 @@ class CompositeReactiveHealthIndicatorTests {
 				new DefaultReactiveHealthIndicatorRegistry(indicators)).timeoutStrategy(100, UNKNOWN_HEALTH);
 		StepVerifier.create(indicator.health()).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
-			assertThat(h.getDetails()).containsOnlyKeys("slow", "fast");
+			assertThat(h.getDetails()).containsOnlyKeys("slow", "fast", Builder.DURATION_LABEL);
 			assertThat(h.getDetails().get("slow")).isEqualTo(UNKNOWN_HEALTH);
 			assertThat(h.getDetails().get("fast")).isEqualTo(HEALTHY);
 		}).verifyComplete();
@@ -93,7 +95,7 @@ class CompositeReactiveHealthIndicatorTests {
 		StepVerifier.withVirtualTime(indicator::health).expectSubscription().thenAwait(Duration.ofMillis(10000))
 				.consumeNextWith((h) -> {
 					assertThat(h.getStatus()).isEqualTo(Status.UP);
-					assertThat(h.getDetails()).containsOnlyKeys("slow", "fast");
+					assertThat(h.getDetails()).containsOnlyKeys("slow", "fast", Builder.DURATION_LABEL);
 					assertThat(h.getDetails().get("slow")).isEqualTo(HEALTHY);
 					assertThat(h.getDetails().get("fast")).isEqualTo(HEALTHY);
 				}).verifyComplete();

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthTests.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.actuate.health.Health.Builder;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.entry;
@@ -47,14 +49,15 @@ class HealthTests {
 	void createWithStatus() {
 		Health health = Health.status(Status.UP).build();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails()).isEmpty();
+		assertThat(health.getDetails()).containsOnlyKeys(Builder.DURATION_LABEL);
 	}
 
 	@Test
 	void createWithDetails() {
 		Health health = new Health.Builder(Status.UP, Collections.singletonMap("a", "b")).build();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails()).containsOnly(entry("a", "b"));
+		assertThat(health.getDetails()).contains(entry("a", "b"));
+		assertThat(health.getDetails()).containsKey(Builder.DURATION_LABEL);
 	}
 
 	@Test
@@ -74,14 +77,21 @@ class HealthTests {
 	void withException() {
 		RuntimeException ex = new RuntimeException("bang");
 		Health health = new Health.Builder(Status.UP, Collections.singletonMap("a", "b")).withException(ex).build();
-		assertThat(health.getDetails()).containsOnly(entry("a", "b"),
-				entry("error", "java.lang.RuntimeException: bang"));
+		assertThat(health.getDetails()).contains(entry("a", "b"), entry("error", "java.lang.RuntimeException: bang"));
+		assertThat(health.getDetails()).containsOnlyKeys("a", "error", Builder.DURATION_LABEL);
 	}
 
 	@Test
 	void withDetails() {
 		Health health = new Health.Builder(Status.UP, Collections.singletonMap("a", "b")).withDetail("c", "d").build();
-		assertThat(health.getDetails()).containsOnly(entry("a", "b"), entry("c", "d"));
+		assertThat(health.getDetails()).contains(entry("a", "b"), entry("c", "d"));
+		assertThat(health.getDetails()).containsOnlyKeys("a", "c", Builder.DURATION_LABEL);
+	}
+
+	@Test
+	void withoutDetails() {
+		Health health = new Health.Builder(Status.UP, Collections.singletonMap("a", "b")).build();
+		assertThat(health.withoutDetails().getDetails()).doesNotContainKeys("a", Builder.DURATION_LABEL);
 	}
 
 	@Test
@@ -90,7 +100,8 @@ class HealthTests {
 		details.put("a", "b");
 		details.put("c", "d");
 		Health health = Health.up().withDetails(details).build();
-		assertThat(health.getDetails()).containsOnly(entry("a", "b"), entry("c", "d"));
+		assertThat(health.getDetails()).contains(entry("a", "b"), entry("c", "d"));
+		assertThat(health.getDetails()).containsOnlyKeys("a", "c", Builder.DURATION_LABEL);
 	}
 
 	@Test
@@ -99,7 +110,8 @@ class HealthTests {
 		details.put("c", "d");
 		details.put("a", "e");
 		Health health = Health.up().withDetail("a", "b").withDetails(details).build();
-		assertThat(health.getDetails()).containsOnly(entry("a", "e"), entry("c", "d"));
+		assertThat(health.getDetails()).contains(entry("a", "e"), entry("c", "d"));
+		assertThat(health.getDetails()).containsOnlyKeys("a", "c", Builder.DURATION_LABEL);
 	}
 
 	@Test
@@ -111,35 +123,38 @@ class HealthTests {
 		details1.put("a", "e");
 		details1.put("1", "2");
 		Health health = Health.up().withDetails(details1).withDetails(details2).build();
-		assertThat(health.getDetails()).containsOnly(entry("a", "e"), entry("c", "d"), entry("1", "2"));
+		assertThat(health.getDetails()).contains(entry("a", "e"), entry("c", "d"), entry("1", "2"));
+		assertThat(health.getDetails()).containsOnlyKeys("a", "c", "1", Builder.DURATION_LABEL);
 	}
 
 	@Test
 	void unknownWithDetails() {
 		Health health = new Health.Builder().unknown().withDetail("a", "b").build();
 		assertThat(health.getStatus()).isEqualTo(Status.UNKNOWN);
-		assertThat(health.getDetails()).containsOnly(entry("a", "b"));
+		assertThat(health.getDetails()).contains(entry("a", "b"));
+		assertThat(health.getDetails()).containsOnlyKeys("a", Builder.DURATION_LABEL);
 	}
 
 	@Test
 	void unknown() {
 		Health health = new Health.Builder().unknown().build();
 		assertThat(health.getStatus()).isEqualTo(Status.UNKNOWN);
-		assertThat(health.getDetails()).isEmpty();
+		assertThat(health.getDetails()).containsOnlyKeys(Builder.DURATION_LABEL);
 	}
 
 	@Test
 	void upWithDetails() {
 		Health health = new Health.Builder().up().withDetail("a", "b").build();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails()).containsOnly(entry("a", "b"));
+		assertThat(health.getDetails()).contains(entry("a", "b"));
+		assertThat(health.getDetails()).containsOnlyKeys("a", Builder.DURATION_LABEL);
 	}
 
 	@Test
 	void up() {
 		Health health = new Health.Builder().up().build();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails()).isEmpty();
+		assertThat(health.getDetails()).containsOnlyKeys(Builder.DURATION_LABEL);
 	}
 
 	@Test
@@ -147,35 +162,36 @@ class HealthTests {
 		RuntimeException ex = new RuntimeException("bang");
 		Health health = Health.down(ex).build();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
-		assertThat(health.getDetails()).containsOnly(entry("error", "java.lang.RuntimeException: bang"));
+		assertThat(health.getDetails()).contains(entry("error", "java.lang.RuntimeException: bang"));
+		assertThat(health.getDetails()).containsOnlyKeys("error", Builder.DURATION_LABEL);
 	}
 
 	@Test
 	void down() {
 		Health health = Health.down().build();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
-		assertThat(health.getDetails()).isEmpty();
+		assertThat(health.getDetails()).containsOnlyKeys(Builder.DURATION_LABEL);
 	}
 
 	@Test
 	void outOfService() {
 		Health health = Health.outOfService().build();
 		assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
-		assertThat(health.getDetails()).isEmpty();
+		assertThat(health.getDetails()).containsOnlyKeys(Builder.DURATION_LABEL);
 	}
 
 	@Test
 	void statusCode() {
 		Health health = Health.status("UP").build();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails()).isEmpty();
+		assertThat(health.getDetails()).containsOnlyKeys(Builder.DURATION_LABEL);
 	}
 
 	@Test
 	void status() {
 		Health health = Health.status(Status.UP).build();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails()).isEmpty();
+		assertThat(health.getDetails()).containsOnlyKeys(Builder.DURATION_LABEL);
 	}
 
 	@Test
@@ -183,7 +199,8 @@ class HealthTests {
 		Health health = Health.down().withDetail("a", "b").build();
 		ObjectMapper mapper = new ObjectMapper();
 		String json = mapper.writeValueAsString(health);
-		assertThat(json).isEqualTo("{\"status\":\"DOWN\",\"details\":{\"a\":\"b\"}}");
+		assertThat(json)
+				.containsPattern("\\{\"status\":\"DOWN\",\"details\":\\{\"a\":\"b\",\"durationNanos\":[0-9].*}}");
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/ReactiveHealthIndicatorRegistryFactoryTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/ReactiveHealthIndicatorRegistryFactoryTests.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import org.springframework.boot.actuate.health.Health.Builder;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -52,7 +54,7 @@ class ReactiveHealthIndicatorRegistryFactoryTests {
 		assertThat(registry.getAll()).containsOnlyKeys("test", "regular");
 		StepVerifier.create(registry.get("regular").health()).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.DOWN);
-			assertThat(h.getDetails()).isEmpty();
+			assertThat(h.getDetails()).containsOnlyKeys(Builder.DURATION_LABEL);
 		}).verifyComplete();
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/SystemHealthTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/SystemHealthTests.java
@@ -45,9 +45,10 @@ class SystemHealthTests {
 		CompositeHealth health = new SystemHealth(ApiVersion.V3, Status.UP, components, groups);
 		ObjectMapper mapper = new ObjectMapper();
 		String json = mapper.writeValueAsString(health);
-		assertThat(json).isEqualTo("{\"status\":\"UP\",\"components\":{\"db1\":{\"status\":\"UP\"},"
-				+ "\"db2\":{\"status\":\"DOWN\",\"details\":{\"a\":\"b\"}}},"
-				+ "\"groups\":[\"liveness\",\"readiness\"]}");
+		assertThat(json).containsPattern(
+				"\\{\"status\":\"UP\",\"components\":\\{\"db1\":\\{\"status\":\"UP\",\"details\":\\{\"durationNanos\":[0-9].*}},"
+						+ "\"db2\":\\{\"status\":\"DOWN\",\"details\":\\{\"a\":\"b\",\"durationNanos\":[0-9].*}}},"
+						+ "\"groups\":\\[\"liveness\",\"readiness\"]}");
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicatorTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Health.Builder;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -69,8 +70,9 @@ class DataSourceHealthIndicatorTests {
 		this.indicator.setDataSource(this.dataSource);
 		Health health = this.indicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails()).containsOnly(entry("database", "HSQL Database Engine"),
+		assertThat(health.getDetails()).contains(entry("database", "HSQL Database Engine"),
 				entry("validationQuery", "isValid()"));
+		assertThat(health.getDetails()).containsOnlyKeys("database", "validationQuery", Builder.DURATION_LABEL);
 	}
 
 	@Test
@@ -81,8 +83,10 @@ class DataSourceHealthIndicatorTests {
 		this.indicator.setQuery(customValidationQuery);
 		Health health = this.indicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails()).containsOnly(entry("database", "HSQL Database Engine"), entry("result", 0L),
+		assertThat(health.getDetails()).contains(entry("database", "HSQL Database Engine"), entry("result", 0L),
 				entry("validationQuery", customValidationQuery));
+		assertThat(health.getDetails()).containsOnlyKeys("database", "result", "validationQuery",
+				Builder.DURATION_LABEL);
 	}
 
 	@Test
@@ -94,7 +98,8 @@ class DataSourceHealthIndicatorTests {
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
 		assertThat(health.getDetails()).contains(entry("database", "HSQL Database Engine"),
 				entry("validationQuery", invalidValidationQuery));
-		assertThat(health.getDetails()).containsOnlyKeys("database", "error", "validationQuery");
+		assertThat(health.getDetails()).containsOnlyKeys("database", "error", "validationQuery",
+				Builder.DURATION_LABEL);
 	}
 
 	@Test
@@ -119,8 +124,9 @@ class DataSourceHealthIndicatorTests {
 		this.indicator.setDataSource(dataSource);
 		Health health = this.indicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
-		assertThat(health.getDetails()).containsOnly(entry("database", "HSQL Database Engine"),
+		assertThat(health.getDetails()).contains(entry("database", "HSQL Database Engine"),
 				entry("validationQuery", "isValid()"));
+		assertThat(health.getDetails()).containsOnlyKeys("database", "validationQuery", Builder.DURATION_LABEL);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/mongo/MongoReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/mongo/MongoReactiveHealthIndicatorTests.java
@@ -23,6 +23,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Health.Builder;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 
@@ -48,7 +49,7 @@ class MongoReactiveHealthIndicatorTests {
 		Mono<Health> health = mongoReactiveHealthIndicator.health();
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
-			assertThat(h.getDetails()).containsOnlyKeys("version");
+			assertThat(h.getDetails()).containsOnlyKeys("version", Builder.DURATION_LABEL);
 			assertThat(h.getDetails().get("version")).isEqualTo("2.6.4");
 		}).verifyComplete();
 	}
@@ -63,7 +64,7 @@ class MongoReactiveHealthIndicatorTests {
 		Mono<Health> health = mongoReactiveHealthIndicator.health();
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.DOWN);
-			assertThat(h.getDetails()).containsOnlyKeys("error");
+			assertThat(h.getDetails()).containsOnlyKeys("error", Builder.DURATION_LABEL);
 			assertThat(h.getDetails().get("error")).isEqualTo(MongoException.class.getName() + ": Connection failed");
 		}).verifyComplete();
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/r2dbc/ConnectionFactoryHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/r2dbc/ConnectionFactoryHealthIndicatorTests.java
@@ -31,6 +31,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import org.springframework.boot.actuate.health.Health.Builder;
 import org.springframework.boot.actuate.health.ReactiveHealthIndicator;
 import org.springframework.boot.actuate.health.Status;
 
@@ -54,8 +55,9 @@ class ConnectionFactoryHealthIndicatorTests {
 			ConnectionFactoryHealthIndicator healthIndicator = new ConnectionFactoryHealthIndicator(connectionFactory);
 			healthIndicator.health().as(StepVerifier::create).assertNext((actual) -> {
 				assertThat(actual.getStatus()).isEqualTo(Status.UP);
-				assertThat(actual.getDetails()).containsOnly(entry("database", "H2"),
+				assertThat(actual.getDetails()).contains(entry("database", "H2"),
 						entry("validationQuery", "validate(REMOTE)"));
+				assertThat(actual.getDetails()).containsOnlyKeys("database", "validationQuery", Builder.DURATION_LABEL);
 			}).verifyComplete();
 		}
 		finally {
@@ -72,8 +74,10 @@ class ConnectionFactoryHealthIndicatorTests {
 		ConnectionFactoryHealthIndicator healthIndicator = new ConnectionFactoryHealthIndicator(connectionFactory);
 		healthIndicator.health().as(StepVerifier::create).assertNext((actual) -> {
 			assertThat(actual.getStatus()).isEqualTo(Status.DOWN);
-			assertThat(actual.getDetails()).containsOnly(entry("database", "mock"),
+			assertThat(actual.getDetails()).contains(entry("database", "mock"),
 					entry("validationQuery", "validate(REMOTE)"), entry("error", "java.lang.RuntimeException: test"));
+			assertThat(actual.getDetails()).containsOnlyKeys("database", "validationQuery", "error",
+					Builder.DURATION_LABEL);
 		}).verifyComplete();
 	}
 
@@ -88,8 +92,9 @@ class ConnectionFactoryHealthIndicatorTests {
 		ConnectionFactoryHealthIndicator healthIndicator = new ConnectionFactoryHealthIndicator(connectionFactory);
 		healthIndicator.health().as(StepVerifier::create).assertNext((actual) -> {
 			assertThat(actual.getStatus()).isEqualTo(Status.DOWN);
-			assertThat(actual.getDetails()).containsOnly(entry("database", "mock"),
+			assertThat(actual.getDetails()).contains(entry("database", "mock"),
 					entry("validationQuery", "validate(REMOTE)"));
+			assertThat(actual.getDetails()).containsOnlyKeys("database", "validationQuery", Builder.DURATION_LABEL);
 		}).verifyComplete();
 	}
 
@@ -105,8 +110,10 @@ class ConnectionFactoryHealthIndicatorTests {
 					customValidationQuery);
 			healthIndicator.health().as(StepVerifier::create).assertNext((actual) -> {
 				assertThat(actual.getStatus()).isEqualTo(Status.UP);
-				assertThat(actual.getDetails()).containsOnly(entry("database", "H2"), entry("result", 0L),
+				assertThat(actual.getDetails()).contains(entry("database", "H2"), entry("result", 0L),
 						entry("validationQuery", customValidationQuery));
+				assertThat(actual.getDetails()).containsOnlyKeys("database", "result", "validationQuery",
+						Builder.DURATION_LABEL);
 			}).verifyComplete();
 		}
 		finally {
@@ -126,7 +133,8 @@ class ConnectionFactoryHealthIndicatorTests {
 				assertThat(actual.getStatus()).isEqualTo(Status.DOWN);
 				assertThat(actual.getDetails()).contains(entry("database", "H2"),
 						entry("validationQuery", invalidValidationQuery));
-				assertThat(actual.getDetails()).containsOnlyKeys("database", "error", "validationQuery");
+				assertThat(actual.getDetails()).containsOnlyKeys("database", "validationQuery", "error",
+						Builder.DURATION_LABEL);
 			}).verifyComplete();
 		}
 		finally {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicatorTests.java
@@ -24,6 +24,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Health.Builder;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.connection.ReactiveRedisConnection;
@@ -57,7 +58,7 @@ class RedisReactiveHealthIndicatorTests {
 		Mono<Health> health = healthIndicator.health();
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
-			assertThat(h.getDetails()).containsOnlyKeys("version");
+			assertThat(h.getDetails()).containsOnlyKeys("version", Builder.DURATION_LABEL);
 			assertThat(h.getDetails().get("version")).isEqualTo("2.8.9");
 		}).verifyComplete();
 		verify(redisConnection).closeLater();


### PR DESCRIPTION
I'm submitting this PR as a proposal to provide a mechanism for tracking the duration any given health check implementation took, providing the information in the `details` of the `Health` object. 

In reality, this tracks the nanoseconds between the `Health.Builder` construction time and when the builder's `build()` method is invoked. Though this may blur the execution time very slightly from that of the `doHealthCheck()` method, it would be negligible.

The reason that timing would be beneficial (at least for me) is that in some boot applications the time it takes for the overall health check to return (based on monitoring metrics on the actuator endpoint) continuously increases to a point at which kubernetes will begin to restart our services. I am attempting to identify which individual health check may be responsible, but also feel that this is nice information to have for anyone showing the details of the health endpoint.

This may not be a desired solution, so do please let me know your thoughts. I did attempt to catch these timings with an `@Around` aspect, but was unable to successfully get granular enough for items like the `DataSourceHealthIndicator` which was (for me) just 1 of 4 such health indicators wrapped in a `CompositeHealthIndicator` based on my particular app having 4 DataSources.

I look forward to any and all feedback. If this is accepted, I would back port this at least to 2.1.x, but would go farther back based on guidance and suggestions from contributing members.  