### PR TITLE
Improve Elasticsearch RestClient customization capabilities

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/RestClientBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/RestClientBuilderCustomizer.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.autoconfigure.elasticsearch;
 
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.elasticsearch.client.RestClientBuilder;
 
 /**
@@ -24,6 +26,7 @@ import org.elasticsearch.client.RestClientBuilder;
  * retaining default auto-configuration.
  *
  * @author Brian Clozel
+ * @author Vedran Pavic
  * @since 2.1.0
  */
 @FunctionalInterface
@@ -34,5 +37,19 @@ public interface RestClientBuilderCustomizer {
 	 * @param builder the builder to customize
 	 */
 	void customize(RestClientBuilder builder);
+
+	/**
+	 * Customize the {@link HttpAsyncClientBuilder}.
+	 * @param builder the builder
+	 */
+	default void customize(HttpAsyncClientBuilder builder) {
+	}
+
+	/**
+	 * Customize the {@link RequestConfig.Builder}.
+	 * @param builder the builder
+	 */
+	default void customize(RequestConfig.Builder builder) {
+	}
 
 }


### PR DESCRIPTION
At present, `RestClientBuilderCustomizer` allows general customization of `RestClientBuilder`. This is troublesome for users that want to customize `HttpAsyncClientBuilder` and `RequestConfig.Builder` since those are set on the `RestClientBuilder`. By customizing those two builders users lose out on Spring Boot's support for binding `username`, `password`, `connection-timeout` and `read-timeout` properties from `spring.elasticsearch.rest` namespace.

To illustrate the problem, attempting to customize aspects of `HttpAsyncClientBuilder` like this:

```java
@Bean
public RestClientBuilderCustomizer restClientBuilderCustomizer() throws Exception {
    SSLContext sslContext; // configure custom sslContext
    SchemeIOSessionStrategy sessionStrategy; // configure custom sessionStrategy
    return builder -> builder.setHttpClientConfigCallback(
            httpClientBuilder -> httpClientBuilder.setSSLStrategy(sessionStrategy).setSSLContext(sslContext));
    });
}
```

Will disable the binding of `username` and `password` properties applied here:
https://github.com/spring-projects/spring-boot/blob/70d4994502c848b3db82845c97a033448356c938/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java#L57-L62

To work around this, users need to replicate Spring Boot's configuration logic using something like:

```java
@Bean
public RestClientBuilderCustomizer restClientBuilderCustomizer(RestClientProperties properties) throws Exception {
    SSLContext sslContext; // configure custom sslContext
    SchemeIOSessionStrategy sessionStrategy; // configure custom sessionStrategy
    return builder -> builder.setHttpClientConfigCallback(httpClientBuilder -> {
        httpClientBuilder.setSSLStrategy(sessionStrategy).setSSLContext(sslContext);
        PropertyMapper.get().from(properties::getUsername).whenHasText().to(username -> {
            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
            Credentials credentials = new UsernamePasswordCredentials(properties.getUsername(),
                    properties.getPassword());
            credentialsProvider.setCredentials(AuthScope.ANY, credentials);
            httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
        });
        return httpClientBuilder;
    });
}
```

This PR enhances the `RestClientBuilderCustomizer` with support for customizing `HttpAsyncClientBuilder` and `RequestConfig.Builder` by providing additional `#customize` methods that accept the aforementioned builders. Both new methods are optional as they have no-op default implementations.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
