### PR TITLE
Remove this keyword on member method invocations

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/BomExtension.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/BomExtension.java
@@ -107,12 +107,12 @@ public class BomExtension {
 		this.properties.put(library.getVersionProperty(), library.getVersion());
 		for (Group group : library.getGroups()) {
 			for (Module module : group.getModules()) {
-				this.putArtifactVersionProperty(group.getId(), module.getName(), library.getVersionProperty());
+				putArtifactVersionProperty(group.getId(), module.getName(), library.getVersionProperty());
 				this.dependencyHandler.getConstraints().add(JavaPlatformPlugin.API_CONFIGURATION_NAME,
 						createDependencyNotation(group.getId(), module.getName(), library.getVersion()));
 			}
 			for (String bomImport : group.getBoms()) {
-				this.putArtifactVersionProperty(group.getId(), bomImport, library.getVersionProperty());
+				putArtifactVersionProperty(group.getId(), bomImport, library.getVersionProperty());
 				String bomDependency = createDependencyNotation(group.getId(), bomImport, library.getVersion());
 				this.dependencyHandler.add(JavaPlatformPlugin.API_CONFIGURATION_NAME,
 						this.dependencyHandler.platform(bomDependency));

--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/bomr/version/UnstructuredDependencyVersion.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/bomr/version/UnstructuredDependencyVersion.java
@@ -35,17 +35,17 @@ final class UnstructuredDependencyVersion extends AbstractDependencyVersion impl
 
 	@Override
 	public boolean isNewerThan(DependencyVersion other) {
-		return this.compareTo(other) > 0;
+		return compareTo(other) > 0;
 	}
 
 	@Override
 	public boolean isSameMajorAndNewerThan(DependencyVersion other) {
-		return this.compareTo(other) > 0;
+		return compareTo(other) > 0;
 	}
 
 	@Override
 	public boolean isSameMinorAndNewerThan(DependencyVersion other) {
-		return this.compareTo(other) > 0;
+		return compareTo(other) > 0;
 	}
 
 	@Override

--- a/buildSrc/src/main/java/org/springframework/boot/build/test/IntegrationTestPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/test/IntegrationTestPlugin.java
@@ -46,7 +46,7 @@ public class IntegrationTestPlugin implements Plugin<Project> {
 
 	@Override
 	public void apply(Project project) {
-		project.getPlugins().withType(JavaPlugin.class, (javaPlugin) -> this.configureIntegrationTesting(project));
+		project.getPlugins().withType(JavaPlugin.class, (javaPlugin) -> configureIntegrationTesting(project));
 	}
 
 	private void configureIntegrationTesting(Project project) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/CloudFoundryWebEndpointDiscovererTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/CloudFoundryWebEndpointDiscovererTests.java
@@ -79,7 +79,7 @@ class CloudFoundryWebEndpointDiscovererTests {
 	}
 
 	private void load(Class<?> configuration, Consumer<CloudFoundryWebEndpointDiscoverer> consumer) {
-		this.load((id) -> null, EndpointId::toString, configuration, consumer);
+		load((id) -> null, EndpointId::toString, configuration, consumer);
 	}
 
 	private void load(Function<EndpointId, Long> timeToLive, PathMapper endpointPathMapper, Class<?> configuration,

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/mappings/servlet/FilterRegistrationMappingDescription.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/mappings/servlet/FilterRegistrationMappingDescription.java
@@ -42,7 +42,7 @@ public class FilterRegistrationMappingDescription extends RegistrationMappingDes
 	 * @return the mappings
 	 */
 	public Collection<String> getServletNameMappings() {
-		return this.getRegistration().getServletNameMappings();
+		return getRegistration().getServletNameMappings();
 	}
 
 	/**
@@ -50,7 +50,7 @@ public class FilterRegistrationMappingDescription extends RegistrationMappingDes
 	 * @return the mappings
 	 */
 	public Collection<String> getUrlPatternMappings() {
-		return this.getRegistration().getUrlPatternMappings();
+		return getRegistration().getUrlPatternMappings();
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/annotation/WebEndpointDiscovererTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/annotation/WebEndpointDiscovererTests.java
@@ -217,7 +217,7 @@ class WebEndpointDiscovererTests {
 	}
 
 	private void load(Class<?> configuration, Consumer<WebEndpointDiscoverer> consumer) {
-		this.load((id) -> null, EndpointId::toString, configuration, consumer);
+		load((id) -> null, EndpointId::toString, configuration, consumer);
 	}
 
 	private void load(Function<EndpointId, Long> timeToLive, PathMapper endpointPathMapper, Class<?> configuration,

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jProperties.java
@@ -145,7 +145,7 @@ public class Neo4jProperties implements ApplicationContextAware {
 		if (this.username != null && this.password != null) {
 			builder.credentials(this.username, this.password);
 		}
-		builder.autoIndex(this.getAutoIndex().getName());
+		builder.autoIndex(getAutoIndex().getName());
 		if (this.useNativeTypes) {
 			builder.useNativeTypes();
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/logging/ConditionEvaluationReportLoggingListener.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/logging/ConditionEvaluationReportLoggingListener.java
@@ -113,7 +113,7 @@ public class ConditionEvaluationReportLoggingListener
 			this.report = ConditionEvaluationReport.get(this.applicationContext.getBeanFactory());
 		}
 		if (!this.report.getConditionAndOutcomesBySource().isEmpty()) {
-			if (this.getLogLevelForReport().equals(LogLevel.INFO)) {
+			if (getLogLevelForReport().equals(LogLevel.INFO)) {
 				if (this.logger.isInfoEnabled()) {
 					this.logger.info(new ConditionEvaluationReportMessage(this.report));
 				}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2ClientProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2ClientProperties.java
@@ -57,7 +57,7 @@ public class OAuth2ClientProperties {
 
 	@PostConstruct
 	public void validate() {
-		this.getRegistration().values().forEach(this::validateRegistration);
+		getRegistration().values().forEach(this::validateRegistration);
 	}
 
 	private void validateRegistration(Registration registration) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -424,23 +424,23 @@ public class ServerProperties {
 		@Deprecated
 		@DeprecatedConfigurationProperty(replacement = "server.tomcat.threads.max")
 		public int getMaxThreads() {
-			return this.getThreads().getMax();
+			return getThreads().getMax();
 		}
 
 		@Deprecated
 		public void setMaxThreads(int maxThreads) {
-			this.getThreads().setMax(maxThreads);
+			getThreads().setMax(maxThreads);
 		}
 
 		@Deprecated
 		@DeprecatedConfigurationProperty(replacement = "server.tomcat.threads.min-spare")
 		public int getMinSpareThreads() {
-			return this.getThreads().getMinSpare();
+			return getThreads().getMinSpare();
 		}
 
 		@Deprecated
 		public void setMinSpareThreads(int minSpareThreads) {
-			this.getThreads().setMinSpare(minSpareThreads);
+			getThreads().setMinSpare(minSpareThreads);
 		}
 
 		@Deprecated
@@ -1106,65 +1106,65 @@ public class ServerProperties {
 		@Deprecated
 		@DeprecatedConfigurationProperty(replacement = "server.jetty.threads.acceptors")
 		public Integer getAcceptors() {
-			return this.getThreads().getAcceptors();
+			return getThreads().getAcceptors();
 		}
 
 		public void setAcceptors(Integer acceptors) {
-			this.getThreads().setAcceptors(acceptors);
+			getThreads().setAcceptors(acceptors);
 		}
 
 		@Deprecated
 		@DeprecatedConfigurationProperty(replacement = "server.jetty.threads.selectors")
 		public Integer getSelectors() {
-			return this.getThreads().getSelectors();
+			return getThreads().getSelectors();
 		}
 
 		public void setSelectors(Integer selectors) {
-			this.getThreads().setSelectors(selectors);
+			getThreads().setSelectors(selectors);
 		}
 
 		@Deprecated
 		@DeprecatedConfigurationProperty(replacement = "server.jetty.threads.min")
 		public Integer getMinThreads() {
-			return this.getThreads().getMin();
+			return getThreads().getMin();
 		}
 
 		@Deprecated
 		public void setMinThreads(Integer minThreads) {
-			this.getThreads().setMin(minThreads);
+			getThreads().setMin(minThreads);
 		}
 
 		@Deprecated
 		@DeprecatedConfigurationProperty(replacement = "server.jetty.threads.max")
 		public Integer getMaxThreads() {
-			return this.getThreads().getMax();
+			return getThreads().getMax();
 		}
 
 		@Deprecated
 		public void setMaxThreads(Integer maxThreads) {
-			this.getThreads().setMax(maxThreads);
+			getThreads().setMax(maxThreads);
 		}
 
 		@Deprecated
 		@DeprecatedConfigurationProperty(replacement = "server.jetty.threads.max-queue-capacity")
 		public Integer getMaxQueueCapacity() {
-			return this.getThreads().getMaxQueueCapacity();
+			return getThreads().getMaxQueueCapacity();
 		}
 
 		@Deprecated
 		public void setMaxQueueCapacity(Integer maxQueueCapacity) {
-			this.getThreads().setMaxQueueCapacity(maxQueueCapacity);
+			getThreads().setMaxQueueCapacity(maxQueueCapacity);
 		}
 
 		@Deprecated
 		@DeprecatedConfigurationProperty(replacement = "server.jetty.threads.idle-timeout")
 		public Duration getThreadIdleTimeout() {
-			return this.getThreads().getIdleTimeout();
+			return getThreads().getIdleTimeout();
 		}
 
 		@Deprecated
 		public void setThreadIdleTimeout(Duration threadIdleTimeout) {
-			this.getThreads().setIdleTimeout(threadIdleTimeout);
+			getThreads().setIdleTimeout(threadIdleTimeout);
 		}
 
 		public Duration getConnectionIdleTimeout() {
@@ -1520,23 +1520,23 @@ public class ServerProperties {
 		@Deprecated
 		@DeprecatedConfigurationProperty(replacement = "server.undertow.threads.io")
 		public Integer getIoThreads() {
-			return this.getThreads().getIo();
+			return getThreads().getIo();
 		}
 
 		@Deprecated
 		public void setIoThreads(Integer ioThreads) {
-			this.getThreads().setIo(ioThreads);
+			getThreads().setIo(ioThreads);
 		}
 
 		@Deprecated
 		@DeprecatedConfigurationProperty(replacement = "server.undertow.threads.worker")
 		public Integer getWorkerThreads() {
-			return this.getThreads().getWorker();
+			return getThreads().getWorker();
 		}
 
 		@Deprecated
 		public void setWorkerThreads(Integer workerThreads) {
-			this.getThreads().setWorker(workerThreads);
+			getThreads().setWorker(workerThreads);
 		}
 
 		public Boolean getDirectBuffers() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/AbstractErrorController.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/AbstractErrorController.java
@@ -78,7 +78,7 @@ public abstract class AbstractErrorController implements ErrorController {
 	 */
 	@Deprecated
 	protected Map<String, Object> getErrorAttributes(HttpServletRequest request, boolean includeStackTrace) {
-		return this.getErrorAttributes(request, includeStackTrace, false);
+		return getErrorAttributes(request, includeStackTrace, false);
 	}
 
 	protected Map<String, Object> getErrorAttributes(HttpServletRequest request, boolean includeStackTrace,

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/sendgrid/SendGridAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/sendgrid/SendGridAutoConfigurationTests.java
@@ -79,7 +79,7 @@ class SendGridAutoConfigurationTests {
 	}
 
 	private void loadContext(String... environment) {
-		this.loadContext(null, environment);
+		loadContext(null, environment);
 	}
 
 	private void loadContext(Class<?> additionalConfiguration, String... environment) {

--- a/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/run/RunCommand.java
+++ b/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/run/RunCommand.java
@@ -55,8 +55,8 @@ public class RunCommand extends OptionParsingCommand {
 	}
 
 	public void stop() {
-		if (this.getHandler() != null) {
-			((RunOptionHandler) this.getHandler()).stop();
+		if (getHandler() != null) {
+			((RunOptionHandler) getHandler()).stop();
 		}
 	}
 

--- a/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/grape/AetherGrapeEngine.java
+++ b/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/grape/AetherGrapeEngine.java
@@ -266,7 +266,7 @@ public class AetherGrapeEngine implements GrapeEngine {
 
 	@Override
 	public URI[] resolve(Map args, Map... dependencyMaps) {
-		return this.resolve(args, null, dependencyMaps);
+		return resolve(args, null, dependencyMaps);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-cli/src/test/java/org/springframework/boot/cli/compiler/grape/AetherGrapeEngineTests.java
+++ b/spring-boot-project/spring-boot-cli/src/test/java/org/springframework/boot/cli/compiler/grape/AetherGrapeEngineTests.java
@@ -139,7 +139,7 @@ class AetherGrapeEngineTests {
 	@Test
 	void resolutionWithCustomResolver() {
 		Map<String, Object> args = new HashMap<>();
-		AetherGrapeEngine grapeEngine = this.createGrapeEngine();
+		AetherGrapeEngine grapeEngine = createGrapeEngine();
 		grapeEngine.addResolver(createResolver("spring-releases", "https://repo.spring.io/release"));
 		Map<String, Object> dependency = createDependency("io.spring.docresources", "spring-doc-resources",
 				"0.1.1.RELEASE");

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/AbstractDevToolsDataSourceAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/AbstractDevToolsDataSourceAutoConfigurationTests.java
@@ -101,11 +101,11 @@ abstract class AbstractDevToolsDataSourceAutoConfigurationTests {
 	}
 
 	protected final ConfigurableApplicationContext createContext(Class<?>... classes) {
-		return this.createContext(null, classes);
+		return createContext(null, classes);
 	}
 
 	protected final ConfigurableApplicationContext createContext(String driverClassName, Class<?>... classes) {
-		return this.createContext(driverClassName, null, classes);
+		return createContext(driverClassName, null, classes);
 	}
 
 	protected final ConfigurableApplicationContext createContext(String driverClassName, String url,

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/BasicJsonTester.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/BasicJsonTester.java
@@ -81,7 +81,7 @@ public class BasicJsonTester {
 	 * resources
 	 */
 	protected final void initialize(Class<?> resourceLoadClass) {
-		this.initialize(resourceLoadClass, null);
+		initialize(resourceLoadClass, null);
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/JacksonTester.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/json/JacksonTester.java
@@ -165,7 +165,7 @@ public class JacksonTester<T> extends AbstractJsonMarshalTester<T> {
 	 * @return the new instance
 	 */
 	public JacksonTester<T> forView(Class<?> view) {
-		return new JacksonTester<>(this.getResourceLoadClass(), this.getType(), this.objectMapper, view);
+		return new JacksonTester<>(getResourceLoadClass(), getType(), this.objectMapper, view);
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyDefinition.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyDefinition.java
@@ -97,7 +97,7 @@ class SpyDefinition extends Definition {
 		}
 		settings.spiedInstance(instance);
 		settings.defaultAnswer(Mockito.CALLS_REAL_METHODS);
-		if (this.isProxyTargetAware()) {
+		if (isProxyTargetAware()) {
 			settings.verificationStartedListeners(new SpringAopBypassingVerificationStartedListener());
 		}
 		return (T) mock(instance.getClass(), settings);

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/LifecycleVersion.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/LifecycleVersion.java
@@ -80,7 +80,7 @@ class LifecycleVersion implements Comparable<LifecycleVersion> {
 	 * version
 	 */
 	boolean isEqualOrGreaterThan(LifecycleVersion other) {
-		return this.compareTo(other) >= 0;
+		return compareTo(other) >= 0;
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/ErrorsTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/ErrorsTests.java
@@ -34,7 +34,7 @@ class ErrorsTests extends AbstractJsonTests {
 
 	@Test
 	void readValueDeserializesJson() throws Exception {
-		Errors errors = this.getObjectMapper().readValue(getContent("errors.json"), Errors.class);
+		Errors errors = getObjectMapper().readValue(getContent("errors.json"), Errors.class);
 		Iterator<Error> iterator = errors.iterator();
 		Error error1 = iterator.next();
 		Error error2 = iterator.next();
@@ -47,7 +47,7 @@ class ErrorsTests extends AbstractJsonTests {
 
 	@Test
 	void toStringHasErrorDetails() throws Exception {
-		Errors errors = this.getObjectMapper().readValue(getContent("errors.json"), Errors.class);
+		Errors errors = getObjectMapper().readValue(getContent("errors.json"), Errors.class);
 		assertThat(errors.toString()).isEqualTo("[TEST1: Test One, TEST2: Test Two]");
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/dsl/SpringBootExtension.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/dsl/SpringBootExtension.java
@@ -78,7 +78,7 @@ public class SpringBootExtension {
 	 * artifact will be the base name of the {@code bootWar} or {@code bootJar} task.
 	 */
 	public void buildInfo() {
-		this.buildInfo(null);
+		buildInfo(null);
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/run/BootRun.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/run/BootRun.java
@@ -78,7 +78,7 @@ public class BootRun extends JavaExec {
 		}
 		if (System.console() != null) {
 			// Record that the console is available here for AnsiOutput to detect later
-			this.getEnvironment().put("spring.output.ansi.console-available", true);
+			getEnvironment().put("spring.output.ansi.console-available", true);
 		}
 		super.exec();
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/AbstractJarWriter.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/AbstractJarWriter.java
@@ -76,7 +76,7 @@ public abstract class AbstractJarWriter implements LoaderClassesWriter {
 	 * @throws IOException if the entries cannot be written
 	 */
 	public void writeEntries(JarFile jarFile) throws IOException {
-		this.writeEntries(jarFile, EntryTransformer.NONE, UnpackHandler.NEVER);
+		writeEntries(jarFile, EntryTransformer.NONE, UnpackHandler.NEVER);
 	}
 
 	final void writeEntries(JarFile jarFile, EntryTransformer entryTransformer, UnpackHandler unpackHandler)

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Repackager.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Repackager.java
@@ -84,7 +84,7 @@ public class Repackager extends Packager {
 	 * @since 1.3.0
 	 */
 	public void repackage(File destination, Libraries libraries, LaunchScript launchScript) throws IOException {
-		this.repackage(destination, libraries, launchScript, null);
+		repackage(destination, libraries, launchScript, null);
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/ExecutableArchiveLauncher.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/ExecutableArchiveLauncher.java
@@ -89,7 +89,7 @@ public abstract class ExecutableArchiveLauncher extends Launcher {
 		if (this.classPathIndex != null) {
 			urls.addAll(this.classPathIndex.getUrls());
 		}
-		return this.createClassLoader(urls.toArray(new URL[0]));
+		return createClassLoader(urls.toArray(new URL[0]));
 	}
 
 	private int guessClassPathSize() {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
@@ -149,7 +149,7 @@ public enum CloudPlatform {
 	 */
 	public boolean isEnforced(Environment environment) {
 		String platform = environment.getProperty("spring.main.cloud-platform");
-		return (platform != null) ? this.name().equalsIgnoreCase(platform) : false;
+		return (platform != null) ? name().equalsIgnoreCase(platform) : false;
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -213,7 +213,7 @@ public final class ConfigurationPropertyName implements Comparable<Configuration
 	 */
 	public boolean isParentOf(ConfigurationPropertyName name) {
 		Assert.notNull(name, "Name must not be null");
-		if (this.getNumberOfElements() != name.getNumberOfElements() - 1) {
+		if (getNumberOfElements() != name.getNumberOfElements() - 1) {
 			return false;
 		}
 		return isAncestorOf(name);
@@ -227,7 +227,7 @@ public final class ConfigurationPropertyName implements Comparable<Configuration
 	 */
 	public boolean isAncestorOf(ConfigurationPropertyName name) {
 		Assert.notNull(name, "Name must not be null");
-		if (this.getNumberOfElements() >= name.getNumberOfElements()) {
+		if (getNumberOfElements() >= name.getNumberOfElements()) {
 			return false;
 		}
 		return elementsEqual(name);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
@@ -246,7 +246,7 @@ public enum DatabaseDriver {
 	}
 
 	protected Collection<String> getUrlPrefixes() {
-		return Collections.singleton(this.name().toLowerCase(Locale.ENGLISH));
+		return Collections.singleton(name().toLowerCase(Locale.ENGLISH));
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyServletWebServerFactory.java
@@ -260,7 +260,7 @@ public class JettyServletWebServerFactory extends AbstractServletWebServerFactor
 			Resource rootResource = (docBase.isDirectory() ? Resource.newResource(docBase.getCanonicalFile())
 					: JarResource.newJarResource(Resource.newResource(docBase)));
 			resources.add((root != null) ? new LoaderHidingResource(rootResource) : rootResource);
-			for (URL resourceJarUrl : this.getUrlsOfJarsWithMetaInfResources()) {
+			for (URL resourceJarUrl : getUrlsOfJarsWithMetaInfResources()) {
 				Resource resource = createResource(resourceJarUrl);
 				if (resource.exists() && resource.isDirectory()) {
 					resources.add(resource);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatReactiveWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatReactiveWebServerFactory.java
@@ -178,8 +178,8 @@ public class TomcatReactiveWebServerFactory extends AbstractReactiveWebServerFac
 	protected void customizeConnector(Connector connector) {
 		int port = Math.max(getPort(), 0);
 		connector.setPort(port);
-		if (StringUtils.hasText(this.getServerHeader())) {
-			connector.setAttribute("server", this.getServerHeader());
+		if (StringUtils.hasText(getServerHeader())) {
+			connector.setAttribute("server", getServerHeader());
 		}
 		if (connector.getProtocolHandler() instanceof AbstractProtocol) {
 			customizeProtocol((AbstractProtocol<?>) connector.getProtocolHandler());

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
@@ -301,8 +301,8 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	protected void customizeConnector(Connector connector) {
 		int port = Math.max(getPort(), 0);
 		connector.setPort(port);
-		if (StringUtils.hasText(this.getServerHeader())) {
-			connector.setAttribute("server", this.getServerHeader());
+		if (StringUtils.hasText(getServerHeader())) {
+			connector.setAttribute("server", getServerHeader());
 		}
 		if (connector.getProtocolHandler() instanceof AbstractProtocol) {
 			customizeProtocol((AbstractProtocol<?>) connector.getProtocolHandler());

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/context/AnnotationConfigReactiveWebServerApplicationContext.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/context/AnnotationConfigReactiveWebServerApplicationContext.java
@@ -144,8 +144,7 @@ public class AnnotationConfigReactiveWebServerApplicationContext extends Reactiv
 	public void setBeanNameGenerator(BeanNameGenerator beanNameGenerator) {
 		this.reader.setBeanNameGenerator(beanNameGenerator);
 		this.scanner.setBeanNameGenerator(beanNameGenerator);
-		this.getBeanFactory().registerSingleton(AnnotationConfigUtils.CONFIGURATION_BEAN_NAME_GENERATOR,
-				beanNameGenerator);
+		getBeanFactory().registerSingleton(AnnotationConfigUtils.CONFIGURATION_BEAN_NAME_GENERATOR, beanNameGenerator);
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/context/FilteredReactiveWebContextResource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/context/FilteredReactiveWebContextResource.java
@@ -60,7 +60,7 @@ class FilteredReactiveWebContextResource extends AbstractResource {
 
 	@Override
 	public InputStream getInputStream() throws IOException {
-		throw new FileNotFoundException(this.getDescription() + " cannot be opened because it does not exist");
+		throw new FileNotFoundException(getDescription() + " cannot be opened because it does not exist");
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributes.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributes.java
@@ -82,7 +82,7 @@ public class DefaultErrorAttributes implements ErrorAttributes {
 	@Override
 	@Deprecated
 	public Map<String, Object> getErrorAttributes(ServerRequest request, boolean includeStackTrace) {
-		return this.getErrorAttributes(request, includeStackTrace, false);
+		return getErrorAttributes(request, includeStackTrace, false);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/ErrorPage.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/ErrorPage.java
@@ -129,7 +129,7 @@ public class ErrorPage {
 		int result = 1;
 		result = prime * result + ObjectUtils.nullSafeHashCode(getExceptionName());
 		result = prime * result + ObjectUtils.nullSafeHashCode(this.path);
-		result = prime * result + this.getStatusCode();
+		result = prime * result + getStatusCode();
 		return result;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/AnnotationConfigServletWebApplicationContext.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/AnnotationConfigServletWebApplicationContext.java
@@ -143,8 +143,7 @@ public class AnnotationConfigServletWebApplicationContext extends GenericWebAppl
 	public void setBeanNameGenerator(BeanNameGenerator beanNameGenerator) {
 		this.reader.setBeanNameGenerator(beanNameGenerator);
 		this.scanner.setBeanNameGenerator(beanNameGenerator);
-		this.getBeanFactory().registerSingleton(AnnotationConfigUtils.CONFIGURATION_BEAN_NAME_GENERATOR,
-				beanNameGenerator);
+		getBeanFactory().registerSingleton(AnnotationConfigUtils.CONFIGURATION_BEAN_NAME_GENERATOR, beanNameGenerator);
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/AnnotationConfigServletWebServerApplicationContext.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/AnnotationConfigServletWebServerApplicationContext.java
@@ -141,8 +141,7 @@ public class AnnotationConfigServletWebServerApplicationContext extends ServletW
 	public void setBeanNameGenerator(BeanNameGenerator beanNameGenerator) {
 		this.reader.setBeanNameGenerator(beanNameGenerator);
 		this.scanner.setBeanNameGenerator(beanNameGenerator);
-		this.getBeanFactory().registerSingleton(AnnotationConfigUtils.CONFIGURATION_BEAN_NAME_GENERATOR,
-				beanNameGenerator);
+		getBeanFactory().registerSingleton(AnnotationConfigUtils.CONFIGURATION_BEAN_NAME_GENERATOR, beanNameGenerator);
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/XmlServletWebServerApplicationContext.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/XmlServletWebServerApplicationContext.java
@@ -47,7 +47,7 @@ public class XmlServletWebServerApplicationContext extends ServletWebServerAppli
 	 * {@linkplain #load loaded} and then manually {@link #refresh refreshed}.
 	 */
 	public XmlServletWebServerApplicationContext() {
-		this.reader.setEnvironment(this.getEnvironment());
+		this.reader.setEnvironment(getEnvironment());
 	}
 
 	/**
@@ -101,7 +101,7 @@ public class XmlServletWebServerApplicationContext extends ServletWebServerAppli
 	@Override
 	public void setEnvironment(ConfigurableEnvironment environment) {
 		super.setEnvironment(environment);
-		this.reader.setEnvironment(this.getEnvironment());
+		this.reader.setEnvironment(getEnvironment());
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/error/DefaultErrorAttributes.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/error/DefaultErrorAttributes.java
@@ -103,7 +103,7 @@ public class DefaultErrorAttributes implements ErrorAttributes, HandlerException
 	@Override
 	@Deprecated
 	public Map<String, Object> getErrorAttributes(WebRequest webRequest, boolean includeStackTrace) {
-		return this.getErrorAttributes(webRequest, includeStackTrace, false);
+		return getErrorAttributes(webRequest, includeStackTrace, false);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/view/MustacheView.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/view/MustacheView.java
@@ -68,14 +68,14 @@ public class MustacheView extends AbstractTemplateView {
 
 	@Override
 	public boolean checkResource(Locale locale) throws Exception {
-		Resource resource = getApplicationContext().getResource(this.getUrl());
+		Resource resource = getApplicationContext().getResource(getUrl());
 		return (resource != null && resource.exists());
 	}
 
 	@Override
 	protected void renderMergedTemplateModel(Map<String, Object> model, HttpServletRequest request,
 			HttpServletResponse response) throws Exception {
-		Template template = createTemplate(getApplicationContext().getResource(this.getUrl()));
+		Template template = createTemplate(getApplicationContext().getResource(getUrl()));
 		if (template != null) {
 			template.execute(model, response.getWriter());
 		}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/jetty/AbstractJettyServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/jetty/AbstractJettyServletWebServerFactoryTests.java
@@ -88,7 +88,7 @@ abstract class AbstractJettyServletWebServerFactoryTests extends AbstractServlet
 
 	@Override
 	protected void handleExceptionCausedByBlockedPortOnSecondaryConnector(RuntimeException ex, int blockedPort) {
-		this.handleExceptionCausedByBlockedPortOnPrimaryConnector(ex, blockedPort);
+		handleExceptionCausedByBlockedPortOnPrimaryConnector(ex, blockedPort);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactoryTests.java
@@ -307,7 +307,7 @@ class UndertowServletWebServerFactoryTests extends AbstractServletWebServerFacto
 
 	@Override
 	protected void handleExceptionCausedByBlockedPortOnSecondaryConnector(RuntimeException ex, int blockedPort) {
-		this.handleExceptionCausedByBlockedPortOnPrimaryConnector(ex, blockedPort);
+		handleExceptionCausedByBlockedPortOnPrimaryConnector(ex, blockedPort);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/server/AbstractReactiveWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/server/AbstractReactiveWebServerFactoryTests.java
@@ -485,7 +485,7 @@ public abstract class AbstractReactiveWebServerFactoryTests {
 	}
 
 	protected void awaitInGracefulShutdown() {
-		while (!this.inGracefulShutdown()) {
+		while (!inGracefulShutdown()) {
 			try {
 				Thread.sleep(100);
 			}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
@@ -1162,7 +1162,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 	}
 
 	protected void awaitInGracefulShutdown() {
-		while (!this.inGracefulShutdown()) {
+		while (!inGracefulShutdown()) {
 			try {
 				Thread.sleep(100);
 			}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR removes `this` keyword on member method invocations for consistency as most of them don't have `this` keyword.