### PR TITLE
Links to CLI binaries are broken for non-snapshot builds

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/AsciidoctorConventions.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/AsciidoctorConventions.java
@@ -156,7 +156,7 @@ class AsciidoctorConventions {
 
 	private String determineArtifactoryRepo(Project project) {
 		String version = project.getVersion().toString();
-		String type = version.substring(version.lastIndexOf('.'));
+		String type = version.substring(version.lastIndexOf('.') + 1);
 		if (type.equals("RELEASE")) {
 			return "release";
 		}


### PR DESCRIPTION
Hi,

I just noticed that the link to the CLI-binary in the latest milestone builds is not working. Essentially it's always pointing to the `snapshot` repo in Artifactory instead of the appropriate one. See https://docs.spring.io/spring-boot/docs/2.3.0.M4/reference/htmlsingle/#getting-started-manual-cli-installation

As this is also affecting release builds & release candidates, it's probably good to have this one merged before the next release is done.

Cheers,
Christoph