### PR TITLE
Add support for reactive Elasticsearch healthcheck

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -99,6 +99,7 @@ dependencies {
 	optional("org.springframework.data:spring-data-mongodb")
 	optional("org.springframework.data:spring-data-neo4j")
 	optional("org.springframework.data:spring-data-redis")
+	optional("org.springframework.data:spring-data-elasticsearch")
 	optional("org.springframework.data:spring-data-solr")
 	optional("org.springframework.integration:spring-integration-core")
 	optional("org.springframework.kafka:spring-kafka")

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticSearchReactiveHealthContributorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticSearchReactiveHealthContributorAutoConfiguration.java
@@ -18,39 +18,41 @@ package org.springframework.boot.actuate.autoconfigure.elasticsearch;
 
 import java.util.Map;
 
-import org.elasticsearch.client.RestClient;
+import reactor.core.publisher.Flux;
 
-import org.springframework.boot.actuate.autoconfigure.health.CompositeHealthContributorConfiguration;
+import org.springframework.boot.actuate.autoconfigure.health.CompositeReactiveHealthContributorConfiguration;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
-import org.springframework.boot.actuate.elasticsearch.ElasticsearchRestHealthIndicator;
-import org.springframework.boot.actuate.health.HealthContributor;
+import org.springframework.boot.actuate.elasticsearch.ElasticsearchReactiveHealthIndicator;
+import org.springframework.boot.actuate.health.ReactiveHealthContributor;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ReactiveElasticsearchRestClientAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for
- * {@link ElasticsearchRestHealthIndicator} using the {@link RestClient}.
+ * {@link ElasticsearchReactiveHealthIndicator} using the
+ * {@link ReactiveElasticsearchClient}.
  *
- * @author Artsiom Yudovin
- * @since 2.1.1
+ * @author Aleksander Lech
+ * @since 2.3
  */
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass(RestClient.class)
-@ConditionalOnBean(RestClient.class)
+@ConditionalOnClass({ ReactiveElasticsearchClient.class, Flux.class })
+@ConditionalOnBean(ReactiveElasticsearchClient.class)
 @ConditionalOnEnabledHealthIndicator("elasticsearch")
-@AutoConfigureAfter(ElasticsearchRestClientAutoConfiguration.class)
-public class ElasticSearchRestHealthContributorAutoConfiguration
-		extends CompositeHealthContributorConfiguration<ElasticsearchRestHealthIndicator, RestClient> {
+@AutoConfigureAfter(ReactiveElasticsearchRestClientAutoConfiguration.class)
+public class ElasticSearchReactiveHealthContributorAutoConfiguration extends
+		CompositeReactiveHealthContributorConfiguration<ElasticsearchReactiveHealthIndicator, ReactiveElasticsearchClient> {
 
 	@Bean
 	@ConditionalOnMissingBean(name = { "elasticsearchHealthIndicator", "elasticsearchHealthContributor" })
-	public HealthContributor elasticsearchHealthContributor(Map<String, RestClient> clients) {
+	public ReactiveHealthContributor elasticsearchHealthContributor(Map<String, ReactiveElasticsearchClient> clients) {
 		return createContributor(clients);
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -15,6 +15,7 @@ org.springframework.boot.actuate.autoconfigure.context.ShutdownEndpointAutoConfi
 org.springframework.boot.actuate.autoconfigure.couchbase.CouchbaseHealthContributorAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.couchbase.CouchbaseReactiveHealthContributorAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.elasticsearch.ElasticSearchRestHealthContributorAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.elasticsearch.ElasticSearchReactiveHealthContributorAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.endpoint.jmx.JmxEndpointAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration,\

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticsearchReactiveHealthContributorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticsearchReactiveHealthContributorAutoConfigurationTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.elasticsearch;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
+import org.springframework.boot.actuate.elasticsearch.ElasticsearchReactiveHealthIndicator;
+import org.springframework.boot.actuate.elasticsearch.ElasticsearchRestHealthIndicator;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ReactiveElasticsearchRestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ElasticSearchReactiveHealthContributorAutoConfiguration}.
+ *
+ * @author Aleksander Lech
+ */
+class ElasticsearchReactiveHealthContributorAutoConfigurationTests {
+
+	private ApplicationContextRunner contextRunner = new ApplicationContextRunner().withConfiguration(AutoConfigurations
+			.of(ElasticsearchDataAutoConfiguration.class, ReactiveElasticsearchRestClientAutoConfiguration.class,
+					ElasticsearchRestClientAutoConfiguration.class,
+					ElasticSearchReactiveHealthContributorAutoConfiguration.class,
+					HealthContributorAutoConfiguration.class));
+
+	@Test
+	void runShouldCreateIndicator() {
+		this.contextRunner.run((context) -> assertThat(context)
+				.hasSingleBean(ElasticsearchReactiveHealthIndicator.class).hasBean("elasticsearchHealthContributor"));
+	}
+
+	@Test
+	void runWithRegularIndicatorShouldOnlyCreateReactiveIndicator() {
+		this.contextRunner
+				.withConfiguration(AutoConfigurations.of(ElasticSearchRestHealthContributorAutoConfiguration.class))
+				.run((context) -> assertThat(context).hasSingleBean(ElasticsearchReactiveHealthIndicator.class)
+						.hasBean("elasticsearchHealthContributor")
+						.doesNotHaveBean(ElasticsearchRestHealthIndicator.class));
+	}
+
+	@Test
+	void runWhenDisabledShouldNotCreateIndicator() {
+		this.contextRunner.withPropertyValues("management.health.elasticsearch.enabled:false")
+				.run((context) -> assertThat(context).doesNotHaveBean(ElasticsearchReactiveHealthIndicator.class)
+						.doesNotHaveBean("elasticsearchHealthContributor"));
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/build.gradle
+++ b/spring-boot-project/spring-boot-actuator/build.gradle
@@ -60,6 +60,7 @@ dependencies {
 	optional("org.springframework.data:spring-data-neo4j")
 	optional("org.springframework.data:spring-data-redis")
 	optional("org.springframework.data:spring-data-rest-webmvc")
+	optional("org.springframework.data:spring-data-elasticsearch")
 	optional("org.springframework.data:spring-data-solr")
 	optional("org.springframework.integration:spring-integration-core")
 	optional("org.springframework.security:spring-security-core")

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/elasticsearch/ElasticsearchReactiveHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/elasticsearch/ElasticsearchReactiveHealthIndicator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.elasticsearch;
+
+import java.util.stream.Collectors;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.boot.actuate.health.AbstractReactiveHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient;
+
+/**
+ * {@link HealthIndicator} for an Elasticsearch cluster using a
+ * {@link ReactiveElasticsearchClient}.
+ *
+ * @author Aleksander Lech
+ * @since 2.3
+ */
+public class ElasticsearchReactiveHealthIndicator extends AbstractReactiveHealthIndicator {
+
+	private final ReactiveElasticsearchClient client;
+
+	public ElasticsearchReactiveHealthIndicator(ReactiveElasticsearchClient client) {
+		super("Elasticsearch health check failed");
+		this.client = client;
+	}
+
+	@Override
+	protected Mono<Health> doHealthCheck(Health.Builder builder) {
+		return this.client.status().map((status) -> {
+			if (status.isOk()) {
+				builder.up();
+			}
+			else {
+				builder.down();
+			}
+
+			builder.withDetails(status.hosts().stream().collect(Collectors
+					.toMap((host) -> host.getEndpoint().getHostString(), (host) -> host.getState().toString())));
+
+			return builder.build();
+		});
+	}
+
+}


### PR DESCRIPTION
Hello,

I am working a lot with spring-data-elasticsearch using reactive repositories. I noticed that even the newest version still supports only healthchecks for ReactiveElasticsearchClient. More over the default healthcheck still wants to run even if all of the clients are reactive - it uses the default one created by autoconfiguration that fails.

I checked how it was done for Mongo that supports reactive indicators as well as basing on the existing ElasticSearch health indicator I implemented a simple proposal. The generated output would be as follows:


```json
"elasticsearch": {
            "status": "UP",
            "components": {
                "reactiveElasticsearchClient": {
                    "status": "UP",
                    "details": {
                        "192.168.78.150": "ONLINE",
                        "192.168.78.160": "OFFLINE"
                    }
                }
            }
        }
```

This is my first contribution to the project so please forgive me any mistakes, I tried my best to follow the guidelines. Any comments appreciated. Thank you.