### PR TITLE
Fix Actuator API PDF name

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -194,6 +194,7 @@ task zip(type: Zip) {
 	duplicatesStrategy "fail"
 	from(asciidoctorPdf.outputDir) {
 		into "pdf"
+		rename { "spring-boot-actuator-web-api.pdf" }
 	}
 	from(asciidoctor.outputDir) {
 		into "html"


### PR DESCRIPTION
Hi,

I found another broken link in the docs pointing to the actuator api PDF. An alternative solution to what I've done in this PR is obviously renaming the link in the docs, but that is a bit inconsistent to the other PDFs we have. (And I kind of like to switch between versions in the docs, which is easier if it's the same file name, but that's just personal).

Slightly related, I've noticed that the actuator-api doesn't have a `reference` folder, but directly contains the `pdf` and `html` folder. I was wondering if this should be harmonized maybe. I didn't do it here because it's not part of the bug really.

Cheers,
Christoph