### PR TITLE
Fix MustacheEnvironmentCollector to not ignore native fetcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .#*
 .*.md.html
 .DS_Store
+.attach_pid*
 .classpath
 .factorypath
 .gradle

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheEnvironmentCollector.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheEnvironmentCollector.java
@@ -67,8 +67,8 @@ public class MustacheEnvironmentCollector extends DefaultCollector implements En
 
 		@Override
 		public Object get(Object ctx, String name) {
+			Object result;
 			if (this.nativeFetcher != null) {
-				Object result;
 				try {
 					result = this.nativeFetcher.get(ctx, name);
 					if (result != null && result != Template.NO_FETCHER_FOUND) {
@@ -79,7 +79,11 @@ public class MustacheEnvironmentCollector extends DefaultCollector implements En
 					// fall through
 				}
 			}
-			return MustacheEnvironmentCollector.this.environment.getProperty(name);
+			result = MustacheEnvironmentCollector.this.environment.getProperty(name);
+			if (result == null) {
+				return Template.NO_FETCHER_FOUND;
+			}
+			return result;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheEnvironmentCollector.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheEnvironmentCollector.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.mustache;
 import com.samskivert.mustache.DefaultCollector;
 import com.samskivert.mustache.Mustache.Collector;
 import com.samskivert.mustache.Mustache.VariableFetcher;
+import com.samskivert.mustache.Template;
 
 import org.springframework.context.EnvironmentAware;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -35,8 +36,6 @@ public class MustacheEnvironmentCollector extends DefaultCollector implements En
 
 	private ConfigurableEnvironment environment;
 
-	private final VariableFetcher propertyFetcher = new PropertyVariableFetcher();
-
 	@Override
 	public void setEnvironment(Environment environment) {
 		this.environment = (ConfigurableEnvironment) environment;
@@ -46,18 +45,40 @@ public class MustacheEnvironmentCollector extends DefaultCollector implements En
 	public VariableFetcher createFetcher(Object ctx, String name) {
 		VariableFetcher fetcher = super.createFetcher(ctx, name);
 		if (fetcher != null) {
-			return fetcher;
+			return new PropertyVariableFetcher(fetcher);
 		}
 		if (this.environment.containsProperty(name)) {
-			return this.propertyFetcher;
+			return new PropertyVariableFetcher();
 		}
 		return null;
 	}
 
 	private class PropertyVariableFetcher implements VariableFetcher {
 
+		private final VariableFetcher nativeFetcher;
+
+		PropertyVariableFetcher() {
+			this.nativeFetcher = null;
+		}
+
+		PropertyVariableFetcher(VariableFetcher nativeFetcher) {
+			this.nativeFetcher = nativeFetcher;
+		}
+
 		@Override
 		public Object get(Object ctx, String name) {
+			if (this.nativeFetcher != null) {
+				Object result;
+				try {
+					result = this.nativeFetcher.get(ctx, name);
+					if (result != null && result != Template.NO_FETCHER_FOUND) {
+						return result;
+					}
+				}
+				catch (Exception ex) {
+					// fall through
+				}
+			}
 			return MustacheEnvironmentCollector.this.environment.getProperty(name);
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mustache/MustacheStandaloneIntegrationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mustache/MustacheStandaloneIntegrationTests.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Dave Syer
  */
 @DirtiesContext
-@SpringBootTest(webEnvironment = WebEnvironment.NONE, properties = { "env.FOO=There", "foo=World" })
+@SpringBootTest(webEnvironment = WebEnvironment.NONE, properties = { "env.FOO=There", "foo=World", "bar.name=Bar" })
 class MustacheStandaloneIntegrationTests {
 
 	@Autowired
@@ -67,6 +67,18 @@ class MustacheStandaloneIntegrationTests {
 	}
 
 	@Test
+	void environmentCollectorCompoundKeyWithBean() {
+		assertThat(this.compiler.compile("Hello: {{foo.name}}")
+				.execute(Collections.singletonMap("foo", new Foo()))).isEqualTo("Hello: Foo");
+	}
+
+	@Test
+	void environmentCollectorCompoundKeyWithBeanPrefersEnvironment() {
+		assertThat(this.compiler.compile("Hello: {{bar.name}}")
+				.execute(Collections.singletonMap("bar", new Foo()))).isEqualTo("Hello: Bar");
+	}
+
+	@Test
 	void environmentCollectorSimpleKey() {
 		assertThat(this.compiler.compile("Hello: {{foo}}").execute(new Object())).isEqualTo("Hello: World");
 	}
@@ -81,6 +93,18 @@ class MustacheStandaloneIntegrationTests {
 	@Import({ MustacheAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class })
 	static class Application {
 
+	}
+	
+	static class Foo {
+		private String name = "Foo";
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mustache/MustacheStandaloneIntegrationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mustache/MustacheStandaloneIntegrationTests.java
@@ -61,8 +61,20 @@ class MustacheStandaloneIntegrationTests {
 	}
 
 	@Test
+	void environmentCollectorCompoundKeyStandardMap() {
+		assertThat(this.compiler.standardsMode(true).compile("Hello: {{env.foo}}")
+				.execute(Collections.singletonMap("world", "World"))).isEqualTo("Hello: There");
+	}
+
+	@Test
 	void environmentCollectorSimpleKey() {
 		assertThat(this.compiler.compile("Hello: {{foo}}").execute(new Object())).isEqualTo("Hello: World");
+	}
+
+	@Test
+	void environmentCollectorSimpleKeyMap() {
+		assertThat(this.compiler.compile("Hello: {{foo}}").execute(Collections.singletonMap("world", "Foo")))
+				.isEqualTo("Hello: World");
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
When the context is a map (as it is in a web View for instance) you can't
assume a non-null fetcher actually contains the property you are searching
for. This change alters the logic so that the native fetcher is always
consulted if it exists, but there is always a fallback.

Fixes gh-21045