### PR TITLE
Update validation of Micrometer configuration

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/elastic/ElasticProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/elastic/ElasticProperties.java
@@ -62,17 +62,17 @@ public class ElasticProperties extends StepRegistryProperties {
 	/**
 	 * Login user of the Elastic server.
 	 */
-	private String userName = "";
+	private String userName;
 
 	/**
 	 * Login password of the Elastic server.
 	 */
-	private String password = "";
+	private String password;
 
 	/**
 	 * Ingest pipeline name. By default, events are not pre-processed.
 	 */
-	private String pipeline = "";
+	private String pipeline;
 
 	public String getHost() {
 		return this.host;

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/ganglia/GangliaProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/ganglia/GangliaProperties.java
@@ -46,8 +46,11 @@ public class GangliaProperties {
 
 	/**
 	 * Base time unit used to report rates.
+	 *
+	 * @deprecated No longer used by Micrometer.
 	 */
-	private TimeUnit rateUnits = TimeUnit.SECONDS;
+	@Deprecated
+	private TimeUnit rateUnits;
 
 	/**
 	 * Base time unit used to report durations.
@@ -56,8 +59,11 @@ public class GangliaProperties {
 
 	/**
 	 * Ganglia protocol version. Must be either 3.1 or 3.0.
+	 *
+	 * @deprecated No longer used by Micrometer.
 	 */
-	private String protocolVersion = "3.1";
+	@Deprecated
+	private String protocolVersion;
 
 	/**
 	 * UDP addressing mode, either unicast or multicast.

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -105,4 +105,4 @@ org.springframework.boot.actuate.autoconfigure.web.servlet.ServletManagementChil
 org.springframework.boot.actuate.autoconfigure.web.servlet.WebMvcEndpointChildContextConfiguration
 
 org.springframework.boot.diagnostics.FailureAnalyzer=\
-org.springframework.boot.actuate.autoconfigure.metrics.MissingRequiredConfigurationFailureAnalyzer
+org.springframework.boot.actuate.autoconfigure.metrics.ValidationFailureAnalyzer

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/ValidationFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/ValidationFailureAnalyzerTests.java
@@ -30,18 +30,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * Tests for {@link MissingRequiredConfigurationFailureAnalyzer}.
+ * Tests for {@link ValidationFailureAnalyzer}.
  *
  * @author Andy Wilkinson
  */
-class MissingRequiredConfigurationFailureAnalyzerTests {
+class ValidationFailureAnalyzerTests {
 
 	@Test
 	void analyzesMissingRequiredConfiguration() {
-		FailureAnalysis analysis = new MissingRequiredConfigurationFailureAnalyzer()
+		FailureAnalysis analysis = new ValidationFailureAnalyzer()
 				.analyze(createFailure(MissingAccountIdConfiguration.class));
 		assertThat(analysis).isNotNull();
-		assertThat(analysis.getDescription()).isEqualTo("accountId must be set to report metrics to New Relic.");
+		assertThat(analysis.getDescription()).isEqualTo(
+				"management.metrics.export.newrelic.apiKey was 'null' but it is required when publishing to Insights API.\n" +
+				"management.metrics.export.newrelic.accountId was 'null' but it is required when publishing to Insights API.");
 		assertThat(analysis.getAction()).isEqualTo("Update your application to provide the missing configuration.");
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontPropertiesTests.java
@@ -16,12 +16,14 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.wavefront;
 
+import io.micrometer.core.instrument.config.validate.ValidationException;
 import io.micrometer.wavefront.WavefrontConfig;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.PushRegistryPropertiesTests;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link WavefrontProperties}.
@@ -36,8 +38,6 @@ class WavefrontPropertiesTests extends PushRegistryPropertiesTests {
 		WavefrontConfig config = WavefrontConfig.DEFAULT_DIRECT;
 		assertStepRegistryDefaultValues(properties, config);
 		assertThat(properties.getUri().toString()).isEqualTo(config.uri());
-		// source has no static default value
-		assertThat(properties.getApiToken()).isEqualTo(config.apiToken());
 		assertThat(properties.getGlobalPrefix()).isEqualTo(config.globalPrefix());
 	}
 


### PR DESCRIPTION
This updates Spring Boot tests to accomodate a few deprecated properties in Micrometer 1.5.0 and the new validation API in https://github.com/micrometer-metrics/micrometer/issues/2011.

Fixes test failure seen from the latest Micrometer snapshot in https://ge.spring.io/s/5avby2vzce5qm/tests/failed

cc / @shakuzen @snicoll @wilkinsona