### PR TITLE
Improve property name in thrown Micrometer ValidationException

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/ValidationFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/ValidationFailureAnalyzer.java
@@ -34,7 +34,7 @@ class ValidationFailureAnalyzer extends AbstractFailureAnalyzer<ValidationExcept
 	protected FailureAnalysis analyze(Throwable rootFailure, ValidationException cause) {
 		StringBuilder description = new StringBuilder(String.format("Invalid Micrometer configuration detected:%n"));
 		for (Invalid<?> failure : cause.getValidation().failures()) {
-			description.append(String.format("%n  - management.metrics.export.%s was '%s' but it %s",
+			description.append(String.format("%n  - %s was '%s' but it %s",
 					failure.getProperty(), failure.getValue(), failure.getMessage()));
 		}
 		return new FailureAnalysis(description.toString(),

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/appoptics/AppOpticsPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/appoptics/AppOpticsPropertiesConfigAdapter.java
@@ -33,6 +33,11 @@ class AppOpticsPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapt
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.appoptics";
+	}
+
+	@Override
 	public String uri() {
 		return get(AppOpticsProperties::getUri, AppOpticsConfig.super::uri);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogPropertiesConfigAdapter.java
@@ -34,6 +34,11 @@ class DatadogPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.datadog";
+	}
+
+	@Override
 	public String apiKey() {
 		return get(DatadogProperties::getApiKey, DatadogConfig.super::apiKey);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/dynatrace/DynatracePropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/dynatrace/DynatracePropertiesConfigAdapter.java
@@ -33,6 +33,11 @@ class DynatracePropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapt
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.dynatrace";
+	}
+
+	@Override
 	public String apiToken() {
 		return get(DynatraceProperties::getApiToken, DynatraceConfig.super::apiToken);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/elastic/ElasticPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/elastic/ElasticPropertiesConfigAdapter.java
@@ -33,6 +33,11 @@ class ElasticPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.elastic";
+	}
+
+	@Override
 	public String host() {
 		return get(ElasticProperties::getHost, ElasticConfig.super::host);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/ganglia/GangliaPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/ganglia/GangliaPropertiesConfigAdapter.java
@@ -37,6 +37,11 @@ class GangliaPropertiesConfigAdapter extends PropertiesConfigAdapter<GangliaProp
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.ganglia";
+	}
+
+	@Override
 	public String get(String k) {
 		return null;
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphitePropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphitePropertiesConfigAdapter.java
@@ -37,6 +37,11 @@ class GraphitePropertiesConfigAdapter extends PropertiesConfigAdapter<GraphitePr
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.graphite";
+	}
+
+	@Override
 	public String get(String k) {
 		return null;
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/humio/HumioPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/humio/HumioPropertiesConfigAdapter.java
@@ -34,6 +34,11 @@ class HumioPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<H
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.humio";
+	}
+
+	@Override
 	public String get(String k) {
 		return null;
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxPropertiesConfigAdapter.java
@@ -35,6 +35,11 @@ class InfluxPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.influx";
+	}
+
+	@Override
 	public String db() {
 		return get(InfluxProperties::getDb, InfluxConfig.super::db);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/jmx/JmxPropertiesConfigAdapter.java
@@ -35,6 +35,11 @@ class JmxPropertiesConfigAdapter extends PropertiesConfigAdapter<JmxProperties> 
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.jmx";
+	}
+
+	@Override
 	public String get(String key) {
 		return null;
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/kairos/KairosPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/kairos/KairosPropertiesConfigAdapter.java
@@ -33,6 +33,11 @@ class KairosPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.kairos";
+	}
+
+	@Override
 	public String uri() {
 		return get(KairosProperties::getUri, KairosConfig.super::uri);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/newrelic/NewRelicPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/newrelic/NewRelicPropertiesConfigAdapter.java
@@ -36,6 +36,11 @@ public class NewRelicPropertiesConfigAdapter extends StepRegistryPropertiesConfi
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.newrelic";
+	}
+
+	@Override
 	public boolean meterNameEventTypeEnabled() {
 		return get(NewRelicProperties::isMeterNameEventTypeEnabled, NewRelicConfig.super::meterNameEventTypeEnabled);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/prometheus/PrometheusPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/prometheus/PrometheusPropertiesConfigAdapter.java
@@ -37,6 +37,11 @@ class PrometheusPropertiesConfigAdapter extends PropertiesConfigAdapter<Promethe
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.prometheus";
+	}
+
+	@Override
 	public String get(String key) {
 		return null;
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/signalfx/SignalFxPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/signalfx/SignalFxPropertiesConfigAdapter.java
@@ -35,6 +35,11 @@ public class SignalFxPropertiesConfigAdapter extends StepRegistryPropertiesConfi
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.signalfx";
+	}
+
+	@Override
 	public String accessToken() {
 		return get(SignalFxProperties::getAccessToken, SignalFxConfig.super::accessToken);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimplePropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimplePropertiesConfigAdapter.java
@@ -36,6 +36,11 @@ public class SimplePropertiesConfigAdapter extends PropertiesConfigAdapter<Simpl
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.simple";
+	}
+
+	@Override
 	public String get(String k) {
 		return null;
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverPropertiesConfigAdapter.java
@@ -34,6 +34,11 @@ public class StackdriverPropertiesConfigAdapter extends StepRegistryPropertiesCo
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.stackdriver";
+	}
+
+	@Override
 	public String projectId() {
 		return get(StackdriverProperties::getProjectId, StackdriverConfig.super::projectId);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapter.java
@@ -41,6 +41,11 @@ public class StatsdPropertiesConfigAdapter extends PropertiesConfigAdapter<Stats
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.statsd";
+	}
+
+	@Override
 	public StatsdFlavor flavor() {
 		return get(StatsdProperties::getFlavor, StatsdConfig.super::flavor);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontPropertiesConfigAdapter.java
@@ -34,6 +34,11 @@ public class WavefrontPropertiesConfigAdapter extends PushRegistryPropertiesConf
 	}
 
 	@Override
+	public String prefix() {
+		return "management.metrics.export.wavefront";
+	}
+
+	@Override
 	public String get(String k) {
 		return null;
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/ValidationFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/ValidationFailureAnalyzerTests.java
@@ -20,11 +20,14 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.newrelic.NewRelicMeterRegistry;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.actuate.autoconfigure.metrics.export.newrelic.NewRelicProperties;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.newrelic.NewRelicPropertiesConfigAdapter;
 import org.springframework.boot.diagnostics.FailureAnalysis;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -40,6 +43,7 @@ class ValidationFailureAnalyzerTests {
 	void analyzesMissingRequiredConfiguration() {
 		FailureAnalysis analysis = new ValidationFailureAnalyzer()
 				.analyze(createFailure(MissingAccountIdAndApiKeyConfiguration.class));
+		assertThat(analysis.getCause().getMessage()).contains("management.metrics.export.newrelic.apiKey was 'null'");
 		assertThat(analysis).isNotNull();
 		assertThat(analysis.getDescription()).isEqualTo(String.format("Invalid Micrometer configuration detected:%n%n"
 				+ "  - management.metrics.export.newrelic.apiKey was 'null' but it is required when publishing to Insights API%n"
@@ -57,11 +61,11 @@ class ValidationFailureAnalyzerTests {
 	}
 
 	@Configuration(proxyBeanMethods = false)
+	@Import(NewRelicProperties.class)
 	static class MissingAccountIdAndApiKeyConfiguration {
-
 		@Bean
-		NewRelicMeterRegistry meterRegistry() {
-			return new NewRelicMeterRegistry((key) -> null, Clock.SYSTEM);
+		NewRelicMeterRegistry meterRegistry(NewRelicProperties newRelicProperties) {
+			return new NewRelicMeterRegistry(new NewRelicPropertiesConfigAdapter(newRelicProperties), Clock.SYSTEM);
 		}
 
 	}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1697736/79899066-3ac01f00-83da-11ea-9ed5-703a6962339a.png)

This change makes the message for `ValidationException` include the Spring config property prefix for each registry implementation.

cc / @wilkinsona 