### PR TITLE
Custom redis client configuration builder add param "RedisProperties"

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/JedisClientConfigurationBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/JedisClientConfigurationBuilderCustomizer.java
@@ -26,6 +26,7 @@ import org.springframework.data.redis.connection.jedis.JedisClientConfiguration.
  * auto-configuration.
  *
  * @author Mark Paluch
+ * @author Zmapleshine
  * @since 2.0.0
  */
 @FunctionalInterface

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/JedisClientConfigurationBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/JedisClientConfigurationBuilderCustomizer.java
@@ -33,8 +33,9 @@ public interface JedisClientConfigurationBuilderCustomizer {
 
 	/**
 	 * Customize the {@link JedisClientConfigurationBuilder}.
+	 * @param properties                 The configuration file to which the current build belongs.
 	 * @param clientConfigurationBuilder the builder to customize
 	 */
-	void customize(JedisClientConfigurationBuilder clientConfigurationBuilder);
+	void customize(RedisProperties properties, JedisClientConfigurationBuilder clientConfigurationBuilder);
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/JedisClientConfigurationBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/JedisClientConfigurationBuilderCustomizer.java
@@ -34,7 +34,7 @@ public interface JedisClientConfigurationBuilderCustomizer {
 
 	/**
 	 * Customize the {@link JedisClientConfigurationBuilder}.
-	 * @param properties                 The configuration file to which the current build belongs.
+	 * @param properties the configuration file to which the current build belongs
 	 * @param clientConfigurationBuilder the builder to customize
 	 */
 	void customize(RedisProperties properties, JedisClientConfigurationBuilder clientConfigurationBuilder);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/JedisConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/JedisConnectionConfiguration.java
@@ -82,7 +82,7 @@ class JedisConnectionConfiguration extends RedisConnectionConfiguration {
 		if (StringUtils.hasText(getProperties().getUrl())) {
 			customizeConfigurationFromUrl(builder);
 		}
-		builderCustomizers.orderedStream().forEach((customizer) -> customizer.customize(builder));
+		builderCustomizers.orderedStream().forEach((customizer) -> customizer.customize(getProperties(), builder));
 		return builder.build();
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceClientConfigurationBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceClientConfigurationBuilderCustomizer.java
@@ -26,6 +26,7 @@ import org.springframework.data.redis.connection.lettuce.LettuceClientConfigurat
  * auto-configuration.
  *
  * @author Mark Paluch
+ * @author Zmapleshine
  * @since 2.0.0
  */
 @FunctionalInterface
@@ -33,8 +34,9 @@ public interface LettuceClientConfigurationBuilderCustomizer {
 
 	/**
 	 * Customize the {@link LettuceClientConfigurationBuilder}.
+	 * @param properties                 The configuration file to which the current build belongs.
 	 * @param clientConfigurationBuilder the builder to customize
 	 */
-	void customize(LettuceClientConfigurationBuilder clientConfigurationBuilder);
+	void customize(RedisProperties properties, LettuceClientConfigurationBuilder clientConfigurationBuilder);
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceClientConfigurationBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceClientConfigurationBuilderCustomizer.java
@@ -34,7 +34,7 @@ public interface LettuceClientConfigurationBuilderCustomizer {
 
 	/**
 	 * Customize the {@link LettuceClientConfigurationBuilder}.
-	 * @param properties                 The configuration file to which the current build belongs.
+	 * @param properties the configuration file to which the current build belongs
 	 * @param clientConfigurationBuilder the builder to customize
 	 */
 	void customize(RedisProperties properties, LettuceClientConfigurationBuilder clientConfigurationBuilder);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
@@ -96,7 +96,7 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 		}
 		builder.clientOptions(initializeClientOptionsBuilder().timeoutOptions(TimeoutOptions.enabled()).build());
 		builder.clientResources(clientResources);
-		builderCustomizers.orderedStream().forEach((customizer) -> customizer.customize(getProperties(),builder));
+		builderCustomizers.orderedStream().forEach((customizer) -> customizer.customize(getProperties(), builder));
 		return builder.build();
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
@@ -96,7 +96,7 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 		}
 		builder.clientOptions(initializeClientOptionsBuilder().timeoutOptions(TimeoutOptions.enabled()).build());
 		builder.clientResources(clientResources);
-		builderCustomizers.orderedStream().forEach((customizer) -> customizer.customize(builder));
+		builderCustomizers.orderedStream().forEach((customizer) -> customizer.customize(getProperties(),builder));
 		return builder.build();
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationJedisTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationJedisTests.java
@@ -25,7 +25,6 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisClientConfigurationBuilder;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -176,7 +175,10 @@ class RedisAutoConfigurationJedisTests {
 
 		@Bean
 		JedisClientConfigurationBuilderCustomizer customizer() {
-			return JedisClientConfigurationBuilder::useSsl;
+			return (properties, clientConfigurationBuilder) -> {
+				//ignore properties config
+				clientConfigurationBuilder.useSsl();
+			};
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationJedisTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationJedisTests.java
@@ -175,10 +175,7 @@ class RedisAutoConfigurationJedisTests {
 
 		@Bean
 		JedisClientConfigurationBuilderCustomizer customizer() {
-			return (properties, clientConfigurationBuilder) -> {
-				//ignore properties config
-				clientConfigurationBuilder.useSsl();
-			};
+			return (properties, clientConfigurationBuilder) -> clientConfigurationBuilder.useSsl();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -301,10 +301,7 @@ class RedisAutoConfigurationTests {
 
 		@Bean
 		LettuceClientConfigurationBuilderCustomizer customizer() {
-			return (properties, clientConfigurationBuilder) -> {
-				//ignore properties config
-				clientConfigurationBuilder.useSsl();
-			};
+			return (properties, clientConfigurationBuilder) -> clientConfigurationBuilder.useSsl();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -38,7 +38,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisNode;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration;
 import org.springframework.data.redis.core.RedisOperations;
@@ -302,7 +301,10 @@ class RedisAutoConfigurationTests {
 
 		@Bean
 		LettuceClientConfigurationBuilderCustomizer customizer() {
-			return LettuceClientConfigurationBuilder::useSsl;
+			return (properties, clientConfigurationBuilder) -> {
+				//ignore properties config
+				clientConfigurationBuilder.useSsl();
+			};
 		}
 
 	}


### PR DESCRIPTION
(original text from #21120)

I have implemented a dynamic Redis data source, I find a interface named `LettuceClientConfigurationBuilderCustomizer`  that can help me build `LettuceConnectionFactory` using custom  configuration.

However, there is an obvious disadvantage of this interface. 
When I try to use the method of `setClientResource()`, I cannot get the context information of the `LettuceConnectionFactory`.

This prevents me from creating Tracing(`TracingContext` needs tags such as `hostname`, database... ) in `ClientResources` based on the current context (such as `RedisProperties`).

I can submit a pull request that contains the builder interface that has been modified to add the `redisProperties` parameter