### PR TITLE
Aggregate TestExecutionListener orders

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/SpringBootAutoConfigureTestExecutionListenerOrder.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/SpringBootAutoConfigureTestExecutionListenerOrder.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure;
+
+import org.springframework.core.Ordered;
+import org.springframework.test.context.TestExecutionListener;
+
+/**
+ * Aggregates the orders of the {@link TestExecutionListener}s defined by Spring Boot Test
+ * AutoConfiguration.
+ *
+ * @author Andrei Dragnea
+ * @since 2.3.0
+ * @see org.springframework.core.Ordered
+ * @see TestExecutionListener
+ */
+public enum SpringBootAutoConfigureTestExecutionListenerOrder {
+
+	/**
+	 * Order of
+	 * {@link org.springframework.boot.test.autoconfigure.web.servlet.MockMvcPrintOnlyOnFailureTestExecutionListener}.
+	 */
+	MOCK_MVC_PRINT_ONLY_ON_FAILURE(Ordered.LOWEST_PRECEDENCE - 100),
+
+	/**
+	 * Order of
+	 * {@link org.springframework.boot.test.autoconfigure.web.client.MockRestServiceServerResetTestExecutionListener}.
+	 */
+	MOCK_REST_SERVICE_SERVER_RESET(Ordered.LOWEST_PRECEDENCE - 100),
+
+	/**
+	 * Order of
+	 * {@link org.springframework.boot.test.autoconfigure.web.servlet.WebDriverTestExecutionListener}.
+	 */
+	WEB_DRIVER(Ordered.LOWEST_PRECEDENCE - 100),
+
+	/**
+	 * Order of
+	 * {@link org.springframework.boot.test.autoconfigure.restdocs.RestDocsTestExecutionListener}.
+	 */
+	REST_DOCS(Ordered.LOWEST_PRECEDENCE - 100);
+
+	private final int value;
+
+	SpringBootAutoConfigureTestExecutionListenerOrder(int value) {
+		this.value = value;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/RestDocsTestExecutionListener.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/RestDocsTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.springframework.boot.test.autoconfigure.restdocs;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.core.Ordered;
+import org.springframework.boot.test.autoconfigure.SpringBootAutoConfigureTestExecutionListenerOrder;
 import org.springframework.restdocs.ManualRestDocumentation;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
@@ -37,7 +37,7 @@ public class RestDocsTestExecutionListener extends AbstractTestExecutionListener
 
 	@Override
 	public int getOrder() {
-		return Ordered.LOWEST_PRECEDENCE - 100;
+		return SpringBootAutoConfigureTestExecutionListenerOrder.REST_DOCS.getValue();
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/client/MockRestServiceServerResetTestExecutionListener.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/client/MockRestServiceServerResetTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.boot.test.autoconfigure.web.client;
 
+import org.springframework.boot.test.autoconfigure.SpringBootAutoConfigureTestExecutionListenerOrder;
 import org.springframework.context.ApplicationContext;
-import org.springframework.core.Ordered;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
@@ -32,7 +32,7 @@ class MockRestServiceServerResetTestExecutionListener extends AbstractTestExecut
 
 	@Override
 	public int getOrder() {
-		return Ordered.LOWEST_PRECEDENCE - 100;
+		return SpringBootAutoConfigureTestExecutionListenerOrder.MOCK_REST_SERVICE_SERVER_RESET.getValue();
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/MockMvcPrintOnlyOnFailureTestExecutionListener.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/MockMvcPrintOnlyOnFailureTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.boot.test.autoconfigure.web.servlet;
 
+import org.springframework.boot.test.autoconfigure.SpringBootAutoConfigureTestExecutionListenerOrder;
 import org.springframework.boot.test.autoconfigure.web.servlet.SpringBootMockMvcBuilderCustomizer.DeferredLinesWriter;
-import org.springframework.core.Ordered;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
@@ -31,7 +31,7 @@ class MockMvcPrintOnlyOnFailureTestExecutionListener extends AbstractTestExecuti
 
 	@Override
 	public int getOrder() {
-		return Ordered.LOWEST_PRECEDENCE - 100;
+		return SpringBootAutoConfigureTestExecutionListenerOrder.MOCK_MVC_PRINT_ONLY_ON_FAILURE.getValue();
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebDriverTestExecutionListener.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebDriverTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.test.autoconfigure.web.servlet;
 
-import org.springframework.core.Ordered;
+import org.springframework.boot.test.autoconfigure.SpringBootAutoConfigureTestExecutionListenerOrder;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
@@ -33,7 +33,7 @@ class WebDriverTestExecutionListener extends AbstractTestExecutionListener {
 
 	@Override
 	public int getOrder() {
-		return Ordered.LOWEST_PRECEDENCE - 100;
+		return SpringBootAutoConfigureTestExecutionListenerOrder.WEB_DRIVER.getValue();
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestExecutionListenerOrder.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestExecutionListenerOrder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.context;
+
+import org.springframework.core.Ordered;
+import org.springframework.test.context.TestExecutionListener;
+
+/**
+ * Aggregates the orders of the {@link TestExecutionListener}s defined by Spring Boot
+ * Test.
+ *
+ * @author Andrei Dragnea
+ * @since 2.3.0
+ * @see org.springframework.core.Ordered
+ * @see TestExecutionListener
+ */
+public enum SpringBootTestExecutionListenerOrder {
+
+	/**
+	 * Order of
+	 * {@link org.springframework.boot.test.mock.mockito.ResetMocksTestExecutionListener}.
+	 */
+	RESET_MOCKS(Ordered.LOWEST_PRECEDENCE - 100),
+
+	/**
+	 * Order of
+	 * {@link org.springframework.boot.test.mock.mockito.MockitoTestExecutionListener}.
+	 */
+	MOCKITO(1_950);
+
+	private final int value;
+
+	SpringBootTestExecutionListenerOrder(int value) {
+		this.value = value;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoTestExecutionListener.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.function.BiConsumer;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
 
+import org.springframework.boot.test.context.SpringBootTestExecutionListenerOrder;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
@@ -45,7 +46,7 @@ public class MockitoTestExecutionListener extends AbstractTestExecutionListener 
 
 	@Override
 	public final int getOrder() {
-		return 1950;
+		return SpringBootTestExecutionListenerOrder.MOCKITO.getValue();
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/ResetMocksTestExecutionListener.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/ResetMocksTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,9 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.test.context.SpringBootTestExecutionListenerOrder;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.core.Ordered;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
@@ -47,7 +47,7 @@ public class ResetMocksTestExecutionListener extends AbstractTestExecutionListen
 
 	@Override
 	public int getOrder() {
-		return Ordered.LOWEST_PRECEDENCE - 100;
+		return SpringBootTestExecutionListenerOrder.RESET_MOCKS.getValue();
 	}
 
 	@Override


### PR DESCRIPTION
Aggregated TestExecutionListener orders into:
- `SpringBootTestExecutionListenerOrder` for `spring-boot-test` module;
- `SpringBootAutoConfigureTestExecutionListenerOrder` for `spring-boot-test-autoconfigure` module.

This aggregation helps third-party integrators when choosing the order for a new listener.

I have done two similar PRs in [spring-framework](https://github.com/spring-projects/spring-framework/pull/24977) and [spring-security](https://github.com/spring-projects/spring-security/pull/8436) projects.