### PR TITLE
Proper ordering of metrics auto-configurations

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.java
@@ -37,7 +37,7 @@ import org.springframework.context.annotation.Configuration;
  * @since 2.1.0
  */
 @Configuration(proxyBeanMethods = false)
-@AutoConfigureAfter(MetricsAutoConfiguration.class)
+@AutoConfigureAfter(CompositeMeterRegistryAutoConfiguration.class)
 @ConditionalOnClass(MeterRegistry.class)
 @ConditionalOnBean(MeterRegistry.class)
 public class JvmMetricsAutoConfiguration {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/KafkaMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/KafkaMetricsAutoConfiguration.java
@@ -43,7 +43,7 @@ import org.springframework.kafka.core.ProducerFactory;
  */
 @Configuration(proxyBeanMethods = false)
 @AutoConfigureBefore(KafkaAutoConfiguration.class)
-@AutoConfigureAfter(MetricsAutoConfiguration.class)
+@AutoConfigureAfter(CompositeMeterRegistryAutoConfiguration.class)
 @ConditionalOnClass({ KafkaClientMetrics.class, ProducerFactory.class })
 @ConditionalOnBean(MeterRegistry.class)
 public class KafkaMetricsAutoConfiguration {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/Log4J2MetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/Log4J2MetricsAutoConfiguration.java
@@ -41,7 +41,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
  * @since 2.1.0
  */
 @Configuration(proxyBeanMethods = false)
-@AutoConfigureAfter(MetricsAutoConfiguration.class)
+@AutoConfigureAfter(CompositeMeterRegistryAutoConfiguration.class)
 @ConditionalOnClass(value = { Log4j2Metrics.class, LogManager.class },
 		name = "org.apache.logging.log4j.core.LoggerContext")
 @ConditionalOnBean(MeterRegistry.class)

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/LogbackMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/LogbackMetricsAutoConfiguration.java
@@ -44,7 +44,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
  * @since 2.1.0
  */
 @Configuration(proxyBeanMethods = false)
-@AutoConfigureAfter(MetricsAutoConfiguration.class)
+@AutoConfigureAfter(CompositeMeterRegistryAutoConfiguration.class)
 @ConditionalOnClass({ MeterRegistry.class, LoggerContext.class, LoggerFactory.class })
 @ConditionalOnBean(MeterRegistry.class)
 @Conditional(LogbackLoggingCondition.class)

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/SystemMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/SystemMetricsAutoConfiguration.java
@@ -36,7 +36,7 @@ import org.springframework.context.annotation.Configuration;
  * @since 2.1.0
  */
 @Configuration(proxyBeanMethods = false)
-@AutoConfigureAfter(MetricsAutoConfiguration.class)
+@AutoConfigureAfter(CompositeMeterRegistryAutoConfiguration.class)
 @ConditionalOnClass(MeterRegistry.class)
 @ConditionalOnBean(MeterRegistry.class)
 public class SystemMetricsAutoConfiguration {


### PR DESCRIPTION
Metrics auto-configurations that depend on a `MeterRegistry` bean
should be configured AFTER configurations that create the
`MeterRegistry`. However, `@AutoConfigureAfter(MetricsAutoConfiguration.class)`
is not sufficient. `MetricsAutoConfiguration` does not export a `MeterRegistry`.

This commit changes the `@AutoConfigureAfter` annotations so that the
proper ordering of configurations in ensured.

#### The long story:
I ran into issues in one of my spring-boot services when trying to fix [a Micrometer bug](https://github.com/micrometer-metrics/micrometer/issues/2028). After adding a simple custom auto-configuration with dependency on `MeterRegistry` and `LogbackMetrics`, the application failed to start because of a missing `LogbackMetrics` dependency. Debug output showed that the `LogbackMetricsAutoConfiguration` is disabled because the condition `@ConditionalOnBean(MeterRegistry.class)` is not met. After more debugging I found out that `LogbackMetricsAutoConfiguration` was evaluated before `PrometheusMetricsExportAutoConfiguration`.

I created [a sample project](https://github.com/bendiscz/logback-metrics-bug) that demonstrates this issue.

A simple workaround that I currently use in my projects is a dummy auto-configuration that inserts itself between `LogbackMetricsAutoConfiguration` and configurations that create the `MeterRegistry`:
```java
@Configuration
@AutoConfigureAfter({ CompositeMeterRegistryAutoConfiguration.class, SimpleMetricsExportAutoConfiguration.class })
@AutoConfigureBefore({
        JvmMetricsAutoConfiguration.class,
        KafkaMetricsAutoConfiguration.class,
        Log4J2MetricsAutoConfiguration.class,
        LogbackMetricsAutoConfiguration.class,
        SystemMetricsAutoConfiguration.class
})
public class ProperMetricsOrderingAutoConfiguration {
    // empty
}
```
