### PR TITLE
Fix some deprecations

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/PropertiesMeterFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/PropertiesMeterFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -240,7 +240,7 @@ class PropertiesMeterFilterTests {
 		PropertiesMeterFilter filter = new PropertiesMeterFilter(
 				createProperties("distribution.minimum-expected-value.spring.boot=10"));
 		assertThat(filter.configure(createMeterId("spring.boot"), DistributionStatisticConfig.DEFAULT)
-				.getMinimumExpectedValue()).isEqualTo(Duration.ofMillis(10).toNanos());
+				.getMinimumExpectedValueAsDouble()).isEqualTo(Duration.ofMillis(10).toNanos());
 	}
 
 	@Test
@@ -248,7 +248,7 @@ class PropertiesMeterFilterTests {
 		PropertiesMeterFilter filter = new PropertiesMeterFilter(
 				createProperties("distribution.minimum-expected-value.spring=10"));
 		assertThat(filter.configure(createMeterId("spring.boot"), DistributionStatisticConfig.DEFAULT)
-				.getMinimumExpectedValue()).isEqualTo(Duration.ofMillis(10).toNanos());
+				.getMinimumExpectedValueAsDouble()).isEqualTo(Duration.ofMillis(10).toNanos());
 	}
 
 	@Test
@@ -256,7 +256,7 @@ class PropertiesMeterFilterTests {
 		PropertiesMeterFilter filter = new PropertiesMeterFilter(createProperties(
 				"distribution.minimum-expected-value.spring=10", "distribution.minimum-expected-value.spring.boot=50"));
 		assertThat(filter.configure(createMeterId("spring.boot"), DistributionStatisticConfig.DEFAULT)
-				.getMinimumExpectedValue()).isEqualTo(Duration.ofMillis(50).toNanos());
+				.getMinimumExpectedValueAsDouble()).isEqualTo(Duration.ofMillis(50).toNanos());
 	}
 
 	@Test
@@ -264,7 +264,7 @@ class PropertiesMeterFilterTests {
 		PropertiesMeterFilter filter = new PropertiesMeterFilter(
 				createProperties("distribution.maximum-expected-value.spring.boot=5000"));
 		assertThat(filter.configure(createMeterId("spring.boot"), DistributionStatisticConfig.DEFAULT)
-				.getMaximumExpectedValue()).isEqualTo(Duration.ofMillis(5000).toNanos());
+				.getMaximumExpectedValueAsDouble()).isEqualTo(Duration.ofMillis(5000).toNanos());
 	}
 
 	@Test
@@ -272,7 +272,7 @@ class PropertiesMeterFilterTests {
 		PropertiesMeterFilter filter = new PropertiesMeterFilter(
 				createProperties("distribution.maximum-expected-value.spring=5000"));
 		assertThat(filter.configure(createMeterId("spring.boot"), DistributionStatisticConfig.DEFAULT)
-				.getMaximumExpectedValue()).isEqualTo(Duration.ofMillis(5000).toNanos());
+				.getMaximumExpectedValueAsDouble()).isEqualTo(Duration.ofMillis(5000).toNanos());
 	}
 
 	@Test
@@ -281,7 +281,7 @@ class PropertiesMeterFilterTests {
 				createProperties("distribution.maximum-expected-value.spring=5000",
 						"distribution.maximum-expected-value.spring.boot=10000"));
 		assertThat(filter.configure(createMeterId("spring.boot"), DistributionStatisticConfig.DEFAULT)
-				.getMaximumExpectedValue()).isEqualTo(Duration.ofMillis(10000).toNanos());
+				.getMaximumExpectedValueAsDouble()).isEqualTo(Duration.ofMillis(10000).toNanos());
 	}
 
 	private Id createMeterId(String name) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfigurationTests.java
@@ -214,7 +214,7 @@ class KafkaAutoConfigurationTests {
 						"spring.kafka.admin.ssl.trust-store-type=PKCS12", "spring.kafka.admin.ssl.protocol=TLSv1.2")
 				.run((context) -> {
 					KafkaAdmin admin = context.getBean(KafkaAdmin.class);
-					Map<String, Object> configs = admin.getConfig();
+					Map<String, Object> configs = admin.getConfigurationProperties();
 					// common
 					assertThat(configs.get(AdminClientConfig.CLIENT_ID_CONFIG)).isEqualTo("cid");
 					// admin
@@ -583,7 +583,7 @@ class KafkaAutoConfigurationTests {
 					Map<String, Object> producerConfigs = producerFactory.getConfigurationProperties();
 					assertThat(producerConfigs.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)).isEqualTo("SSL");
 					KafkaAdmin admin = context.getBean(KafkaAdmin.class);
-					Map<String, Object> configs = admin.getConfig();
+					Map<String, Object> configs = admin.getConfigurationProperties();
 					assertThat(configs.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)).isEqualTo("PLAINTEXT");
 				});
 	}


### PR DESCRIPTION
Hi,

this PR fixes some deprecations in tests. The `KafkaAdmin#getConfig()` deprecation was introduced in 2.5.x only, which is currently still a snapshot version in Boot. So feel free to hold this PR back or decline it or revert the Kafka part only.

Cheers,
Christoph