### PR TITLE
Support additional R2DBC pool properties

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryConfigurations.java
@@ -68,7 +68,6 @@ abstract class ConnectionFactoryConfigurations {
 				ObjectProvider<ConnectionFactoryOptionsBuilderCustomizer> customizers) {
 			ConnectionFactory connectionFactory = createConnectionFactory(properties, resourceLoader.getClassLoader(),
 					customizers.orderedStream().collect(Collectors.toList()));
-
 			R2dbcProperties.Pool pool = properties.getPool();
 			ConnectionPoolConfiguration.Builder builder = ConnectionPoolConfiguration.builder(connectionFactory)
 					.initialSize(pool.getInitialSize()).maxSize(pool.getMaxSize()).maxIdleTime(pool.getMaxIdleTime())
@@ -79,7 +78,6 @@ abstract class ConnectionFactoryConfigurations {
 			if (StringUtils.hasText(pool.getValidationQuery())) {
 				builder.validationQuery(pool.getValidationQuery());
 			}
-
 			return new ConnectionPool(builder.build());
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryConfigurations.java
@@ -43,6 +43,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Paluch
  * @author Stephane Nicoll
+ * @author Rodolpho S. Couto
  */
 abstract class ConnectionFactoryConfigurations {
 
@@ -67,12 +68,22 @@ abstract class ConnectionFactoryConfigurations {
 				ObjectProvider<ConnectionFactoryOptionsBuilderCustomizer> customizers) {
 			ConnectionFactory connectionFactory = createConnectionFactory(properties, resourceLoader.getClassLoader(),
 					customizers.orderedStream().collect(Collectors.toList()));
+
 			R2dbcProperties.Pool pool = properties.getPool();
-			ConnectionPoolConfiguration.Builder builder = ConnectionPoolConfiguration.builder(connectionFactory)
-					.maxSize(pool.getMaxSize()).initialSize(pool.getInitialSize()).maxIdleTime(pool.getMaxIdleTime());
+			ConnectionPoolConfiguration.Builder builder = ConnectionPoolConfiguration
+					.builder(connectionFactory)
+					.initialSize(pool.getInitialSize())
+					.maxSize(pool.getMaxSize())
+					.maxIdleTime(pool.getMaxIdleTime())
+					.maxLifeTime(pool.getMaxLifeTime())
+					.maxAcquireTime(pool.getMaxAcquireTime())
+					.maxCreateConnectionTime(pool.getMaxCreateConnectionTime())
+					.validationDepth(pool.getValidationDepth());
+
 			if (StringUtils.hasText(pool.getValidationQuery())) {
 				builder.validationQuery(pool.getValidationQuery());
 			}
+
 			return new ConnectionPool(builder.build());
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryConfigurations.java
@@ -70,13 +70,9 @@ abstract class ConnectionFactoryConfigurations {
 					customizers.orderedStream().collect(Collectors.toList()));
 
 			R2dbcProperties.Pool pool = properties.getPool();
-			ConnectionPoolConfiguration.Builder builder = ConnectionPoolConfiguration
-					.builder(connectionFactory)
-					.initialSize(pool.getInitialSize())
-					.maxSize(pool.getMaxSize())
-					.maxIdleTime(pool.getMaxIdleTime())
-					.maxLifeTime(pool.getMaxLifeTime())
-					.maxAcquireTime(pool.getMaxAcquireTime())
+			ConnectionPoolConfiguration.Builder builder = ConnectionPoolConfiguration.builder(connectionFactory)
+					.initialSize(pool.getInitialSize()).maxSize(pool.getMaxSize()).maxIdleTime(pool.getMaxIdleTime())
+					.maxLifeTime(pool.getMaxLifeTime()).maxAcquireTime(pool.getMaxAcquireTime())
 					.maxCreateConnectionTime(pool.getMaxCreateConnectionTime())
 					.validationDepth(pool.getValidationDepth());
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcProperties.java
@@ -238,6 +238,7 @@ public class R2dbcProperties {
 		public void setValidationDepth(ValidationDepth validationDepth) {
 			this.validationDepth = validationDepth;
 		}
+
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcProperties.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import io.r2dbc.spi.ValidationDepth;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -29,6 +30,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Mark Paluch
  * @author Andreas Killaitis
  * @author Stephane Nicoll
+ * @author Rodolpho S. Couto
  * @since 2.3.0
  */
 @ConfigurationProperties(prefix = "spring.r2dbc")
@@ -139,6 +141,21 @@ public class R2dbcProperties {
 		private Duration maxIdleTime = Duration.ofMinutes(30);
 
 		/**
+		 * Max lifetime.
+		 */
+		private Duration maxLifeTime = Duration.ZERO;
+
+		/**
+		 * Max acquire time.
+		 */
+		private Duration maxAcquireTime = Duration.ZERO;
+
+		/**
+		 * Max create connection time.
+		 */
+		private Duration maxCreateConnectionTime = Duration.ZERO;
+
+		/**
 		 * Initial connection pool size.
 		 */
 		private int initialSize = 10;
@@ -153,12 +170,41 @@ public class R2dbcProperties {
 		 */
 		private String validationQuery;
 
+		/**
+		 * Validation depth.
+		 */
+		private ValidationDepth validationDepth = ValidationDepth.LOCAL;
+
 		public Duration getMaxIdleTime() {
 			return this.maxIdleTime;
 		}
 
 		public void setMaxIdleTime(Duration maxIdleTime) {
 			this.maxIdleTime = maxIdleTime;
+		}
+
+		public Duration getMaxLifeTime() {
+			return maxLifeTime;
+		}
+
+		public void setMaxLifeTime(Duration maxLifeTime) {
+			this.maxLifeTime = maxLifeTime;
+		}
+
+		public Duration getMaxAcquireTime() {
+			return maxAcquireTime;
+		}
+
+		public void setMaxAcquireTime(Duration maxAcquireTime) {
+			this.maxAcquireTime = maxAcquireTime;
+		}
+
+		public Duration getMaxCreateConnectionTime() {
+			return maxCreateConnectionTime;
+		}
+
+		public void setMaxCreateConnectionTime(Duration maxCreateConnectionTime) {
+			this.maxCreateConnectionTime = maxCreateConnectionTime;
 		}
 
 		public int getInitialSize() {
@@ -185,6 +231,13 @@ public class R2dbcProperties {
 			this.validationQuery = validationQuery;
 		}
 
+		public ValidationDepth getValidationDepth() {
+			return validationDepth;
+		}
+
+		public void setValidationDepth(ValidationDepth validationDepth) {
+			this.validationDepth = validationDepth;
+		}
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcProperties.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import io.r2dbc.spi.ValidationDepth;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -184,7 +185,7 @@ public class R2dbcProperties {
 		}
 
 		public Duration getMaxLifeTime() {
-			return maxLifeTime;
+			return this.maxLifeTime;
 		}
 
 		public void setMaxLifeTime(Duration maxLifeTime) {
@@ -192,7 +193,7 @@ public class R2dbcProperties {
 		}
 
 		public Duration getMaxAcquireTime() {
-			return maxAcquireTime;
+			return this.maxAcquireTime;
 		}
 
 		public void setMaxAcquireTime(Duration maxAcquireTime) {
@@ -200,7 +201,7 @@ public class R2dbcProperties {
 		}
 
 		public Duration getMaxCreateConnectionTime() {
-			return maxCreateConnectionTime;
+			return this.maxCreateConnectionTime;
 		}
 
 		public void setMaxCreateConnectionTime(Duration maxCreateConnectionTime) {
@@ -232,7 +233,7 @@ public class R2dbcProperties {
 		}
 
 		public ValidationDepth getValidationDepth() {
-			return validationDepth;
+			return this.validationDepth;
 		}
 
 		public void setValidationDepth(ValidationDepth validationDepth) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcProperties.java
@@ -144,17 +144,17 @@ public class R2dbcProperties {
 		/**
 		 * Max lifetime.
 		 */
-		private Duration maxLifeTime = Duration.ZERO;
+		private Duration maxLifeTime = Duration.ofMinutes(0L);
 
 		/**
 		 * Max acquire time.
 		 */
-		private Duration maxAcquireTime = Duration.ZERO;
+		private Duration maxAcquireTime = Duration.ofMinutes(0L);
 
 		/**
 		 * Max create connection time.
 		 */
-		private Duration maxCreateConnectionTime = Duration.ZERO;
+		private Duration maxCreateConnectionTime = Duration.ofMinutes(0L);
 
 		/**
 		 * Initial connection pool size.

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1472,6 +1472,10 @@
       "description": "Whether pooling is enabled. Enabled automatically if \"r2dbc-pool\" is on the classpath."
     },
     {
+      "name": "spring.r2dbc.pool.validationDepth",
+      "defaultValue": "local"
+    },
+    {
       "name": "spring.rabbitmq.cache.connection.mode",
       "defaultValue": "channel"
     },

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcAutoConfigurationTests.java
@@ -63,16 +63,13 @@ class R2dbcAutoConfigurationTests {
 
 	@Test
 	void configureWithUrlAndPoolPropertiesApplyProperties() {
-		this.contextRunner.withPropertyValues("spring.r2dbc.url:r2dbc:h2:mem:///" + randomDatabaseName(),
-				"spring.r2dbc.pool.initial-size=5",
-				"spring.r2dbc.pool.max-size=15",
-				"spring.r2dbc.pool.max-idle-time=1ms",
-				"spring.r2dbc.pool.max-life-time=2s",
-				"spring.r2dbc.pool.max-acquire-time=3m",
-				"spring.r2dbc.pool.max-create-connection-time=4h",
-				"spring.r2dbc.pool.validation-query=SELECT 1",
-				"spring.r2dbc.pool.validation-depth=remote"
-				).run((context) -> {
+		this.contextRunner
+				.withPropertyValues("spring.r2dbc.url:r2dbc:h2:mem:///" + randomDatabaseName(),
+						"spring.r2dbc.pool.initial-size=5", "spring.r2dbc.pool.max-size=15",
+						"spring.r2dbc.pool.max-idle-time=1ms", "spring.r2dbc.pool.max-life-time=2s",
+						"spring.r2dbc.pool.max-acquire-time=3m", "spring.r2dbc.pool.max-create-connection-time=4h",
+						"spring.r2dbc.pool.validation-query=SELECT 1", "spring.r2dbc.pool.validation-depth=remote")
+				.run((context) -> {
 					assertThat(context).hasSingleBean(ConnectionFactory.class).hasSingleBean(ConnectionPool.class)
 							.hasSingleBean(R2dbcProperties.class);
 					PoolMetrics poolMetrics = context.getBean(ConnectionPool.class).getMetrics().get();

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcAutoConfigurationTests.java
@@ -18,6 +18,7 @@ package org.springframework.boot.autoconfigure.r2dbc;
 
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -28,6 +29,7 @@ import io.r2dbc.pool.ConnectionPool;
 import io.r2dbc.pool.PoolMetrics;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.Option;
+import io.r2dbc.spi.ValidationDepth;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.BeanCreationException;
@@ -62,10 +64,29 @@ class R2dbcAutoConfigurationTests {
 	@Test
 	void configureWithUrlAndPoolPropertiesApplyProperties() {
 		this.contextRunner.withPropertyValues("spring.r2dbc.url:r2dbc:h2:mem:///" + randomDatabaseName(),
-				"spring.r2dbc.pool.max-size=15").run((context) -> {
-					assertThat(context).hasSingleBean(ConnectionFactory.class).hasSingleBean(ConnectionPool.class);
+				"spring.r2dbc.pool.initial-size=5",
+				"spring.r2dbc.pool.max-size=15",
+				"spring.r2dbc.pool.max-idle-time=1ms",
+				"spring.r2dbc.pool.max-life-time=2s",
+				"spring.r2dbc.pool.max-acquire-time=3m",
+				"spring.r2dbc.pool.max-create-connection-time=4h",
+				"spring.r2dbc.pool.validation-query=SELECT 1",
+				"spring.r2dbc.pool.validation-depth=remote"
+				).run((context) -> {
+					assertThat(context).hasSingleBean(ConnectionFactory.class).hasSingleBean(ConnectionPool.class)
+							.hasSingleBean(R2dbcProperties.class);
 					PoolMetrics poolMetrics = context.getBean(ConnectionPool.class).getMetrics().get();
 					assertThat(poolMetrics.getMaxAllocatedSize()).isEqualTo(15);
+
+					R2dbcProperties properties = context.getBean(R2dbcProperties.class);
+					assertThat(properties.getPool().getInitialSize()).isEqualTo(5);
+					assertThat(properties.getPool().getMaxSize()).isEqualTo(15);
+					assertThat(properties.getPool().getMaxIdleTime()).isEqualTo(Duration.ofMillis(1));
+					assertThat(properties.getPool().getMaxLifeTime()).isEqualTo(Duration.ofSeconds(2));
+					assertThat(properties.getPool().getMaxAcquireTime()).isEqualTo(Duration.ofMinutes(3));
+					assertThat(properties.getPool().getMaxCreateConnectionTime()).isEqualTo(Duration.ofHours(4));
+					assertThat(properties.getPool().getValidationQuery()).isEqualTo("SELECT 1");
+					assertThat(properties.getPool().getValidationDepth()).isEqualTo(ValidationDepth.REMOTE);
 				});
 	}
 


### PR DESCRIPTION
This PR adds some missing properties from R2DBC pool:

* max-life-time
* max-acquire-time
* max-create-connection-time
* validation-depth