### PR TITLE
Optimize StringSequence.startsWith

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/StringSequence.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/StringSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,14 +98,18 @@ final class StringSequence implements CharSequence {
 		return this.source.indexOf(str, this.start + fromIndex) - this.start;
 	}
 
-	boolean startsWith(CharSequence prefix) {
+	boolean startsWith(String prefix) {
 		return startsWith(prefix, 0);
 	}
 
-	boolean startsWith(CharSequence prefix, int offset) {
+	boolean startsWith(String prefix, int offset) {
 		int prefixLength = prefix.length();
-		if (length() - prefixLength - offset < 0) {
+		int length = length();
+		if (length - prefixLength - offset < 0) {
 			return false;
+		}
+		if (length == this.source.length()) {
+			return this.source.startsWith(prefix, offset);
 		}
 		int prefixOffset = 0;
 		int sourceOffset = offset;


### PR DESCRIPTION
Hi,

I noticed that a vanilla Boot app spends some time in `StringSequence.startsWith` or respectively `StringSequence.charAt`:
![image](https://user-images.githubusercontent.com/6304496/80636825-553f6b80-8a5e-11ea-85f1-2da06be0f3de.png)

This PR optimizes `startsWith` in cases where the length doesn't differ from the source length, which essentially means that StringSequence is "equal" to the source. In those cases, we can use `startsWith` on the actual source and by that avoid the repeated boundary checks inside charAt. A little benchmark of old vs. new approach shows the following results.

```
Benchmark                                Mode  Cnt   Score    Error   Units
MyBenchmark.testNew                      avgt   10   6,270 ±  0,255   ns/op
MyBenchmark.testNew:·gc.alloc.rate       avgt   10  ≈ 10⁻⁴           MB/sec
MyBenchmark.testNew:·gc.alloc.rate.norm  avgt   10  ≈ 10⁻⁶             B/op
MyBenchmark.testNew:·gc.count            avgt   10     ≈ 0           counts
MyBenchmark.testOld                      avgt   10   9,029 ±  0,330   ns/op
MyBenchmark.testOld:·gc.alloc.rate       avgt   10  ≈ 10⁻⁴           MB/sec
MyBenchmark.testOld:·gc.alloc.rate.norm  avgt   10  ≈ 10⁻⁶             B/op
MyBenchmark.testOld:·gc.count            avgt   10     ≈ 0           counts

```

Let me know what you think.
Cheers,
Christoph