### PR TITLE
Add properties to control exceptions ignored by LdapTemplate

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfiguration.java
@@ -64,8 +64,16 @@ public class LdapAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(LdapOperations.class)
-	public LdapTemplate ldapTemplate(ContextSource contextSource) {
-		return new LdapTemplate(contextSource);
+	public LdapTemplate ldapTemplate(LdapProperties properties, ContextSource contextSource) {
+		PropertyMapper propertyMapper = PropertyMapper.get().alwaysApplyingWhenNonNull();
+		LdapTemplate ldapTemplate = new LdapTemplate(contextSource);
+		propertyMapper.from(properties.isIgnorePartialResultException())
+				.to(ldapTemplate::setIgnorePartialResultException);
+		propertyMapper.from(properties.isIgnoreNameNotFoundException())
+				.to(ldapTemplate::setIgnoreNameNotFoundException);
+		propertyMapper.from(properties.isIgnoreSizeLimitExceededException())
+				.to(ldapTemplate::setIgnoreSizeLimitExceededException);
+		return ldapTemplate;
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapProperties.java
@@ -65,6 +65,22 @@ public class LdapProperties {
 	 */
 	private final Map<String, String> baseEnvironment = new HashMap<>();
 
+	/**
+	 * Whether PartialResultException should be ignored in searches via the LdapTemplate.
+	 */
+	private boolean ignorePartialResultException = false;
+
+	/**
+	 * Whether NameNotFoundException should be ignored in searches via the LdapTemplate.
+	 */
+	private boolean ignoreNameNotFoundException = false;
+
+	/**
+	 * Whether SizeLimitExceededException should be ignored in searches via the
+	 * LdapTemplate.
+	 */
+	private boolean ignoreSizeLimitExceededException = true;
+
 	public String[] getUrls() {
 		return this.urls;
 	}
@@ -107,6 +123,30 @@ public class LdapProperties {
 
 	public Map<String, String> getBaseEnvironment() {
 		return this.baseEnvironment;
+	}
+
+	public boolean isIgnorePartialResultException() {
+		return this.ignorePartialResultException;
+	}
+
+	public void setIgnorePartialResultException(boolean ignorePartialResultException) {
+		this.ignorePartialResultException = ignorePartialResultException;
+	}
+
+	public boolean isIgnoreNameNotFoundException() {
+		return this.ignoreNameNotFoundException;
+	}
+
+	public void setIgnoreNameNotFoundException(boolean ignoreNameNotFoundException) {
+		this.ignoreNameNotFoundException = ignoreNameNotFoundException;
+	}
+
+	public boolean isIgnoreSizeLimitExceededException() {
+		return this.ignoreSizeLimitExceededException;
+	}
+
+	public void setIgnoreSizeLimitExceededException(Boolean ignoreSizeLimitExceededException) {
+		this.ignoreSizeLimitExceededException = ignoreSizeLimitExceededException;
 	}
 
 	public String[] determineUrls(Environment environment) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfigurationTests.java
@@ -29,7 +29,6 @@ import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.ldap.core.support.SimpleDirContextAuthenticationStrategy;
 import org.springframework.ldap.pool2.factory.PoolConfig;
 import org.springframework.ldap.pool2.factory.PooledContextSource;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfigurationTests.java
@@ -29,6 +29,7 @@ import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.ldap.core.support.SimpleDirContextAuthenticationStrategy;
 import org.springframework.ldap.pool2.factory.PoolConfig;
 import org.springframework.ldap.pool2.factory.PooledContextSource;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -103,8 +104,26 @@ class LdapAutoConfigurationTests {
 
 	@Test
 	void templateExists() {
-		this.contextRunner.withPropertyValues("spring.ldap.urls:ldap://localhost:389")
-				.run((context) -> assertThat(context).hasSingleBean(LdapTemplate.class));
+		this.contextRunner.withPropertyValues("spring.ldap.urls:ldap://localhost:389").run((context) -> {
+			assertThat(context).hasSingleBean(LdapTemplate.class);
+			LdapTemplate ldapTemplate = context.getBean(LdapTemplate.class);
+			assertThat(ldapTemplate).hasFieldOrPropertyWithValue("ignorePartialResultException", false);
+			assertThat(ldapTemplate).hasFieldOrPropertyWithValue("ignoreNameNotFoundException", false);
+			assertThat(ldapTemplate).hasFieldOrPropertyWithValue("ignoreSizeLimitExceededException", true);
+		});
+	}
+
+	@Test
+	void templateWithCustomConfigurationExists() {
+		this.contextRunner.withPropertyValues("spring.ldap.urls:ldap://localhost:389",
+				"spring.ldap.ignorePartialResultException=true", "spring.ldap.ignoreNameNotFoundException=true",
+				"spring.ldap.ignoreSizeLimitExceededException=false").run((context) -> {
+					assertThat(context).hasSingleBean(LdapTemplate.class);
+					LdapTemplate ldapTemplate = context.getBean(LdapTemplate.class);
+					assertThat(ldapTemplate).hasFieldOrPropertyWithValue("ignorePartialResultException", true);
+					assertThat(ldapTemplate).hasFieldOrPropertyWithValue("ignoreNameNotFoundException", true);
+					assertThat(ldapTemplate).hasFieldOrPropertyWithValue("ignoreSizeLimitExceededException", false);
+				});
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapPropertiesTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.ldap;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ldap.core.LdapTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link LdapProperties}
+ *
+ * @author Filip Hrisafov
+ */
+class LdapPropertiesTests {
+
+	private final LdapProperties properties = new LdapProperties();
+
+	@Test
+	void ldapTemplatePropertiesUseConsistentLdapTemplateDefaultValues() {
+		LdapTemplate ldapTemplate = new LdapTemplate();
+
+		assertThat(ldapTemplate).hasFieldOrPropertyWithValue("ignorePartialResultException",
+				properties.isIgnorePartialResultException());
+		assertThat(ldapTemplate).hasFieldOrPropertyWithValue("ignoreNameNotFoundException",
+				properties.isIgnoreNameNotFoundException());
+		assertThat(ldapTemplate).hasFieldOrPropertyWithValue("ignoreSizeLimitExceededException",
+				properties.isIgnoreSizeLimitExceededException());
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapPropertiesTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.ldap;
 
 import org.junit.jupiter.api.Test;
+
 import org.springframework.ldap.core.LdapTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,11 +36,11 @@ class LdapPropertiesTests {
 		LdapTemplate ldapTemplate = new LdapTemplate();
 
 		assertThat(ldapTemplate).hasFieldOrPropertyWithValue("ignorePartialResultException",
-				properties.isIgnorePartialResultException());
+				this.properties.isIgnorePartialResultException());
 		assertThat(ldapTemplate).hasFieldOrPropertyWithValue("ignoreNameNotFoundException",
-				properties.isIgnoreNameNotFoundException());
+				this.properties.isIgnoreNameNotFoundException());
 		assertThat(ldapTemplate).hasFieldOrPropertyWithValue("ignoreSizeLimitExceededException",
-				properties.isIgnoreSizeLimitExceededException());
+				this.properties.isIgnoreSizeLimitExceededException());
 	}
 
 }


### PR DESCRIPTION
Added properties:

* `ignorePartialResultException` - For ignoring `PartialResultException` when searching with the `LdapTemplate`
* `ignoreNameNotFoundException` - For ignoring `NameNotFoundException` when searching with the `LdapTemplate`
* `ignoreSizeLimitExceededException` - For ignoring `SizeLimitExceededException` when searching with the `LdapTemplate`

I was not sure whether you prefer setting the defaults in the properties as they are done in the target class or use `null` and only set them when they are explicitly set. I can change it if you prefer to have the defaults in the `LdapProperties`
