### PR TITLE
Align TestRestTemplate Javadoc with documentation

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplate.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplate.java
@@ -65,10 +65,14 @@ import org.springframework.web.util.UriTemplateHandler;
  * {@link #getRestTemplate()}.
  * <p>
  * If you are using the
- * {@link org.springframework.boot.test.context.SpringBootTest @SpringBootTest}
- * annotation, a {@link TestRestTemplate} is automatically available and can be
- * {@code @Autowired} into your test. If you need customizations (for example to adding
- * additional message converters) use a {@link RestTemplateBuilder} {@code @Bean}.
+ * {@link org.springframework.boot.test.context.SpringBootTest @SpringBootTest} annotation
+ * with
+ * {@link org.springframework.boot.test.context.SpringBootTest.WebEnvironment#RANDOM_PORT
+ * WebEnvironment.RANDOM_PORT} or
+ * {@link org.springframework.boot.test.context.SpringBootTest.WebEnvironment#DEFINED_PORT
+ * WebEnvironment.DEFINED_PORT}, a {@link TestRestTemplate} is automatically available and
+ * can be {@code @Autowired} into your test. If you need customizations (for example to
+ * adding additional message converters) use a {@link RestTemplateBuilder} {@code @Bean}.
  *
  * @author Dave Syer
  * @author Phillip Webb


### PR DESCRIPTION
Aligned `TestRestTemplate` Javadoc with documentation.
To make it more clear that it will be autoconfigured only if SpringBoot test is running is embedded mode, eg `@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)` or `@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)`

Documentation: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-rest-templates-test-utility