### PR TITLE
Fix ClientHttpConnectorConfigurationTests.shouldApplyHttpClientMapper()

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/function/client/ClientHttpConnectorConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/function/client/ClientHttpConnectorConfigurationTests.java
@@ -76,8 +76,10 @@ class ClientHttpConnectorConfigurationTests {
 	void shouldApplyHttpClientMapper() {
 		new ReactiveWebApplicationContextRunner()
 				.withConfiguration(AutoConfigurations.of(ClientHttpConnectorConfiguration.ReactorNetty.class))
-				.withUserConfiguration(CustomHttpClientMapper.class)
-				.run((context) -> assertThat(CustomHttpClientMapper.called).isTrue());
+				.withUserConfiguration(CustomHttpClientMapper.class).run((context) -> {
+					context.getBean("reactorClientHttpConnector");
+					assertThat(CustomHttpClientMapper.called).isTrue();
+				});
 	}
 
 	static class CustomHttpClientMapper {
@@ -86,8 +88,10 @@ class ClientHttpConnectorConfigurationTests {
 
 		@Bean
 		ReactorNettyHttpClientMapper clientMapper() {
-			called = true;
-			return (client) -> client.baseUrl("/test");
+			return (client) -> {
+				called = true;
+				return client.baseUrl("/test");
+			};
 		}
 
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR fixes `ClientHttpConnectorConfigurationTests.shouldApplyHttpClientMapper()` as it doesn't test that the mapper is called as intended.