### PR TITLE
URI tag for WebMvc and WebFlux metrics is empty, rather than "root", when the path pattern is empty

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTags.java
@@ -110,6 +110,9 @@ public final class WebFluxTags {
 			if (ignoreTrailingSlash && patternString.length() > 1) {
 				patternString = TRAILING_SLASH_PATTERN.matcher(patternString).replaceAll("");
 			}
+			if (patternString.isEmpty()) {
+				return URI_ROOT;
+			}
 			return Tag.of("uri", patternString);
 		}
 		HttpStatus status = exchange.getResponse().getStatusCode();

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcTags.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcTags.java
@@ -115,6 +115,9 @@ public final class WebMvcTags {
 				if (ignoreTrailingSlash && pattern.length() > 1) {
 					pattern = TRAILING_SLASH_PATTERN.matcher(pattern).replaceAll("");
 				}
+				if (pattern.isEmpty()) {
+					return URI_ROOT;
+				}
 				return Tag.of("uri", pattern);
 			}
 			if (response != null) {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcTagsTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcTagsTests.java
@@ -59,6 +59,14 @@ class WebMvcTagsTests {
 	}
 
 	@Test
+	void uriTagValueIsRootWhenBestMatchingPatternIsEmpty() {
+		this.request.setAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, "");
+		this.response.setStatus(301);
+		Tag tag = WebMvcTags.uri(this.request, this.response);
+		assertThat(tag.getValue()).isEqualTo("root");
+	}
+
+	@Test
 	void uriTagValueWithBestMatchingPatternAndIgnoreTrailingSlashRemoveTrailingSlash() {
 		this.request.setAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, "/spring/");
 		Tag tag = WebMvcTags.uri(this.request, this.response, true);

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTagsTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTagsTests.java
@@ -62,6 +62,15 @@ class WebFluxTagsTests {
 	}
 
 	@Test
+	void uriTagValueIsRootWhenBestMatchingPatternIsEmpty() {
+		this.exchange.getAttributes().put(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE,
+				this.parser.parse(""));
+		this.exchange.getResponse().setStatusCode(HttpStatus.MOVED_PERMANENTLY);
+		Tag tag = WebFluxTags.uri(this.exchange);
+		assertThat(tag.getValue()).isEqualTo("root");
+	}
+
+	@Test
 	void uriTagValueWithBestMatchingPatternAndIgnoreTrailingSlashRemoveTrailingSlash() {
 		this.exchange.getAttributes().put(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE,
 				this.parser.parse("/spring/"));


### PR DESCRIPTION
This handles the case where you have an empty path in `@GetMapping`, which yields an empty string for the uri tag.

```
# HELP http_server_requests_seconds  
# TYPE http_server_requests_seconds summary
http_server_requests_seconds_count{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 48764.0
http_server_requests_seconds_sum{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 1460.28618
http_server_requests_seconds_count{exception="None",method="GET",outcome="SUCCESS",status="200",uri="",} 1.0
http_server_requests_seconds_sum{exception="None",method="GET",outcome="SUCCESS",status="200",uri="",} 0.055319
# HELP http_server_requests_seconds_max  
# TYPE http_server_requests_seconds_max gauge
http_server_requests_seconds_max{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 0.0599019
http_server_requests_seconds_max{exception="None",method="GET",outcome="SUCCESS",status="200",uri="",} 0.055319
```