### PR TITLE
Calculate hashCode only once in ConfigurationPropertyName

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -444,6 +444,7 @@ public final class ConfigurationPropertyName implements Comparable<Configuration
 				}
 				hashCode = 31 * hashCode + elementHashCode;
 			}
+			this.hashCode = hashCode;
 		}
 		return hashCode;
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/ConfigurationPropertyNameTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/ConfigurationPropertyNameTests.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName.Form;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -617,6 +618,14 @@ class ConfigurationPropertyNameTests {
 		assertThat(ConfigurationPropertyName.isValid("-foo")).isFalse();
 		assertThat(ConfigurationPropertyName.isValid("FooBar")).isFalse();
 		assertThat(ConfigurationPropertyName.isValid("foo!bar")).isFalse();
+	}
+
+	@Test
+	void hashCodeIsOnlyCalculatedOnce() {
+		ConfigurationPropertyName name = ConfigurationPropertyName.of("hash.code");
+		int hashCode = name.hashCode();
+		int hashCodeField = (int) ReflectionTestUtils.getField(name, "hashCode");
+		assertThat(hashCodeField).isEqualTo(hashCode);
 	}
 
 }


### PR DESCRIPTION
Hi,

I just noticed that the new hashCode logic in `ConfigurationPropertyName` doesn't set the new `hashCode` field. Seems to be an oversight that might lead to performance issues, (although I haven't benchmarked anything).

Cheers,
Christoph