### PR TITLE
Fix capitalization of Testcontainers in Howto docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto.adoc
@@ -2951,11 +2951,11 @@ The following example shows how to do so in Gradle:
 
 
 [[howto-testcontainers]]
-===  Use TestContainers for integration testing
-The https://www.testcontainers.org/[TestContainers] library provides a way to manage services running inside Docker containers.
+===  Use Testcontainers for integration testing
+The https://www.testcontainers.org/[Testcontainers] library provides a way to manage services running inside Docker containers.
 It integrates with JUnit, allowing you to write a test class that can start up a container before any of the tests run.
-TestContainers is especially useful for writing integration tests that talk to a real backend service such as MySQL, MongoDB, Cassandra etc.
-TestContainers can be used in a Spring Boot test as follows:
+Testcontainers is especially useful for writing integration tests that talk to a real backend service such as MySQL, MongoDB, Cassandra etc.
+Testcontainers can be used in a Spring Boot test as follows:
 
 [source,java,indent=0,subs="verbatim,quotes,attributes"]
 ----


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Unfortunately 3e3ff26 included a minor capitalization issue. `TestContainers` is incorrect; `Testcontainers` is the correct way to write the name.

Refs #20734