### PR TITLE
Map NewRelicProperties Connect and Read Timeouts To NewRelicConfig

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/newrelic/NewRelicMetricsExportAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/newrelic/NewRelicMetricsExportAutoConfiguration.java
@@ -17,8 +17,11 @@
 package org.springframework.boot.actuate.autoconfigure.metrics.export.newrelic;
 
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.ipc.http.HttpUrlConnectionSender;
+import io.micrometer.newrelic.ClientProviderType;
 import io.micrometer.newrelic.NewRelicClientProvider;
 import io.micrometer.newrelic.NewRelicConfig;
+import io.micrometer.newrelic.NewRelicInsightsApiClientProvider;
 import io.micrometer.newrelic.NewRelicMeterRegistry;
 import io.micrometer.newrelic.NewRelicMeterRegistry.Builder;
 
@@ -73,6 +76,13 @@ public class NewRelicMetricsExportAutoConfiguration {
 			ObjectProvider<NewRelicClientProvider> newRelicClientProvider) {
 		Builder builder = NewRelicMeterRegistry.builder(newRelicConfig).clock(clock);
 		newRelicClientProvider.ifUnique(builder::clientProvider);
+
+		if (!newRelicClientProvider.iterator().hasNext()
+				&& ClientProviderType.INSIGHTS_API.equals(newRelicConfig.clientProviderType())) {
+			builder.clientProvider(new NewRelicInsightsApiClientProvider(newRelicConfig, new HttpUrlConnectionSender(
+					this.properties.getConnectTimeout(), this.properties.getReadTimeout())));
+		}
+
 		return builder.build();
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/newrelic/NewRelicPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/newrelic/NewRelicPropertiesConfigAdapter.java
@@ -16,8 +16,6 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.newrelic;
 
-import java.time.Duration;
-
 import io.micrometer.newrelic.ClientProviderType;
 import io.micrometer.newrelic.NewRelicConfig;
 
@@ -70,18 +68,6 @@ public class NewRelicPropertiesConfigAdapter extends StepRegistryPropertiesConfi
 	@Override
 	public String uri() {
 		return get(NewRelicProperties::getUri, NewRelicConfig.super::uri);
-	}
-
-	@SuppressWarnings("deprecation")
-	@Override
-	public Duration connectTimeout() {
-		return get(NewRelicProperties::getConnectTimeout, NewRelicConfig.super::connectTimeout);
-	}
-
-	@SuppressWarnings("deprecation")
-	@Override
-	public Duration readTimeout() {
-		return get(NewRelicProperties::getReadTimeout, NewRelicConfig.super::readTimeout);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/newrelic/NewRelicPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/newrelic/NewRelicPropertiesConfigAdapter.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.newrelic;
 
+import java.time.Duration;
+
 import io.micrometer.newrelic.ClientProviderType;
 import io.micrometer.newrelic.NewRelicConfig;
 
@@ -68,6 +70,18 @@ public class NewRelicPropertiesConfigAdapter extends StepRegistryPropertiesConfi
 	@Override
 	public String uri() {
 		return get(NewRelicProperties::getUri, NewRelicConfig.super::uri);
+	}
+
+	@SuppressWarnings("deprecation")
+	@Override
+	public Duration connectTimeout() {
+		return get(NewRelicProperties::getConnectTimeout, NewRelicConfig.super::connectTimeout);
+	}
+
+	@SuppressWarnings("deprecation")
+	@Override
+	public Duration readTimeout() {
+		return get(NewRelicProperties::getReadTimeout, NewRelicConfig.super::readTimeout);
 	}
 
 }


### PR DESCRIPTION
Add connect/readTimout property mapping so overridden values are propagated.

See related PR conversation:  https://github.com/micrometer-metrics/micrometer/pull/1961
