### PR TITLE
Add an example for setting a custom image name on the command line with Gradle

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging-oci-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging-oci-image.adoc
@@ -153,7 +153,7 @@ include::../gradle/packaging/boot-build-image-name.gradle.kts[tags=image-name]
 Note that this configuration does not provide an explicit tag so `latest` is used.
 It is possible to specify a tag as well, either using `${project.version}`, any property available in the build or a hardcoded version.
 
-The builder can be specified on the command line as well, as shown in this example:
+The image name can be specified on the command line as well, as shown in this example:
 
 [indent=0]
 ----

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging-oci-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging-oci-image.adoc
@@ -152,3 +152,10 @@ include::../gradle/packaging/boot-build-image-name.gradle.kts[tags=image-name]
 
 Note that this configuration does not provide an explicit tag so `latest` is used.
 It is possible to specify a tag as well, either using `${project.version}`, any property available in the build or a hardcoded version.
+
+The builder can be specified on the command line as well, as shown in this example:
+
+[indent=0]
+----
+$ gradle bootBuildImage --imageName=example.com/library/v1
+----


### PR DESCRIPTION
The Maven docs have an example, so it seems like a good idea to have one here too.