### PR TITLE
Auto-configure Spring Security SessionRegistry

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionAutoConfiguration.java
@@ -53,6 +53,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.web.authentication.RememberMeServices;
 import org.springframework.session.ReactiveSessionRepository;
 import org.springframework.session.Session;
@@ -125,6 +126,17 @@ public class SessionAutoConfiguration {
 
 		}
 
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass({FindByIndexNameSessionRepository.class, SessionRegistry.class, SpringSessionBackedSessionRegistry.class})
+	@ConditionalOnMissingBean(SessionRegistry.class)
+	static class SessionRegistryConfiguration<S extends Session> {
+
+		@Bean
+		SpringSessionBackedSessionRegistry<S> sessionRegistry(@Autowired FindByIndexNameSessionRepository<S> sessionRepository) {
+			return new SpringSessionBackedSessionRegistry<>(sessionRepository);
+		}
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
The SessionRegistry bean is useful to configure Spring Security session concurrency.

Combined with https://github.com/spring-projects/spring-security/pull/8548 Spring Session concurrency management would work automatically and as expected with Spring Session.

Right now, for Spring Session concurrency limits to work, one has to configure a bean and configure Spring Security to use it. In my experience, developers don't realize those two steps need to be taken, or simply forget to do them. So I've submitted a PR here to auto-confgure a SessionRegistry bean, and a PR to Spring Security to automatically use a SessionRegistry bean if one exists. Together, Things Just Work.

For the original report to Spring Session, see https://github.com/spring-projects/spring-session/issues/1629

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
