### PR TITLE
Optimize SystemEnvironmentPropertyMapper

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SystemEnvironmentPropertyMapper.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SystemEnvironmentPropertyMapper.java
@@ -58,7 +58,7 @@ final class SystemEnvironmentPropertyMapper implements PropertyMapper {
 		StringBuilder result = new StringBuilder();
 		for (int i = 0; i < numberOfElements; i++) {
 			if (result.length() > 0) {
-				result.append("_");
+				result.append('_');
 			}
 			result.append(name.getElement(i, Form.UNIFORM).toUpperCase(Locale.ENGLISH));
 		}
@@ -69,7 +69,7 @@ final class SystemEnvironmentPropertyMapper implements PropertyMapper {
 		StringBuilder result = new StringBuilder();
 		for (int i = 0; i < name.getNumberOfElements(); i++) {
 			if (result.length() > 0) {
-				result.append("_");
+				result.append('_');
 			}
 			result.append(convertLegacyNameElement(name.getElement(i, Form.ORIGINAL)));
 		}
@@ -116,13 +116,24 @@ final class SystemEnvironmentPropertyMapper implements PropertyMapper {
 		if (!hasDashedEntries(name)) {
 			return false;
 		}
+		StringBuilder legacyCompatibleName = buildLegacyCompatibleName(name);
+		try {
+			return ConfigurationPropertyName.of(legacyCompatibleName).isAncestorOf(candidate);
+		}
+		catch (Exception ex) {
+			return false;
+		}
+	}
+
+	private StringBuilder buildLegacyCompatibleName(ConfigurationPropertyName name) {
 		StringBuilder legacyCompatibleName = new StringBuilder();
 		for (int i = 0; i < name.getNumberOfElements(); i++) {
-			legacyCompatibleName.append((i != 0) ? "." : "");
+			if (i != 0) {
+				legacyCompatibleName.append('.');
+			}
 			legacyCompatibleName.append(name.getElement(i, Form.DASHED).replace('-', '.'));
 		}
-		return ConfigurationPropertyName.isValid(legacyCompatibleName)
-				&& ConfigurationPropertyName.of(legacyCompatibleName).isAncestorOf(candidate);
+		return legacyCompatibleName;
 	}
 
 	boolean hasDashedEntries(ConfigurationPropertyName name) {


### PR DESCRIPTION
Hi,

I just noticed a couple of minor performance tweaks in `SystemEnvironmentPropertyMapper`. The biggest one is probably to avoid creating `ConfigurationPropertyName` instances twice for every `isAncestorOf` check (once for the normal `of()` call and once for the `isValid()` check).

Cheers,
Christoph