### PR TITLE
Support for webAdminPassword property of H2 Console

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleAutoConfiguration.java
@@ -62,13 +62,7 @@ public class H2ConsoleAutoConfiguration {
 		String path = properties.getPath();
 		String urlMapping = path + (path.endsWith("/") ? "*" : "/*");
 		ServletRegistrationBean<WebServlet> registration = new ServletRegistrationBean<>(new WebServlet(), urlMapping);
-		H2ConsoleProperties.Settings settings = properties.getSettings();
-		if (settings.isTrace()) {
-			registration.addInitParameter("trace", "");
-		}
-		if (settings.isWebAllowOthers()) {
-			registration.addInitParameter("webAllowOthers", "");
-		}
+		configureSettings(properties.getSettings(), registration);
 		dataSource.ifAvailable((available) -> {
 			try (Connection connection = available.getConnection()) {
 				logger.info("H2 console available at '" + path + "'. Database available at '"
@@ -79,6 +73,20 @@ public class H2ConsoleAutoConfiguration {
 			}
 		});
 		return registration;
+	}
+
+	private void configureSettings(H2ConsoleProperties.Settings settings,
+			ServletRegistrationBean<WebServlet> registration) {
+		if (settings.isTrace()) {
+			registration.addInitParameter("trace", "");
+		}
+		if (settings.isWebAllowOthers()) {
+			registration.addInitParameter("webAllowOthers", "");
+		}
+
+		if (settings.getWebAdminPassword() != null) {
+			registration.addInitParameter("webAdminPassword", settings.getWebAdminPassword());
+		}
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/h2/H2ConsoleProperties.java
@@ -77,6 +77,8 @@ public class H2ConsoleProperties {
 		 */
 		private boolean webAllowOthers = false;
 
+		private String webAdminPassword;
+
 		public boolean isTrace() {
 			return this.trace;
 		}
@@ -91,6 +93,14 @@ public class H2ConsoleProperties {
 
 		public void setWebAllowOthers(boolean webAllowOthers) {
 			this.webAllowOthers = webAllowOthers;
+		}
+
+		public String getWebAdminPassword() {
+			return this.webAdminPassword;
+		}
+
+		public void setWebAdminPassword(String webAdminPassword) {
+			this.webAdminPassword = webAdminPassword;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/h2/H2ConsoleAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/h2/H2ConsoleAutoConfigurationTests.java
@@ -79,6 +79,7 @@ class H2ConsoleAutoConfigurationTests {
 		assertThat(registrationBean.getUrlMappings()).contains("/h2-console/*");
 		assertThat(registrationBean.getInitParameters()).doesNotContainKey("trace");
 		assertThat(registrationBean.getInitParameters()).doesNotContainKey("webAllowOthers");
+		assertThat(registrationBean.getInitParameters()).doesNotContainKey("webAdminPassword");
 	}
 
 	@Test
@@ -114,13 +115,15 @@ class H2ConsoleAutoConfigurationTests {
 	void customInitParameters() {
 		this.context.register(H2ConsoleAutoConfiguration.class);
 		TestPropertyValues.of("spring.h2.console.enabled:true", "spring.h2.console.settings.trace=true",
-				"spring.h2.console.settings.webAllowOthers=true").applyTo(this.context);
+				"spring.h2.console.settings.webAllowOthers=true", "spring.h2.console.settings.webAdminPassword=abcd")
+				.applyTo(this.context);
 		this.context.refresh();
 		assertThat(this.context.getBeansOfType(ServletRegistrationBean.class)).hasSize(1);
 		ServletRegistrationBean<?> registrationBean = this.context.getBean(ServletRegistrationBean.class);
 		assertThat(registrationBean.getUrlMappings()).contains("/h2-console/*");
 		assertThat(registrationBean.getInitParameters()).containsEntry("trace", "");
 		assertThat(registrationBean.getInitParameters()).containsEntry("webAllowOthers", "");
+		assertThat(registrationBean.getInitParameters()).containsEntry("webAdminPassword", "abcd");
 	}
 
 	@Test


### PR DESCRIPTION
Hi,
I was trying to log in to the "Preferences" or "Tools" page in H2 console, but this operation requires H2 console password that cannot be set from Spring Boot, thus I am not able to log in to the H2 Console, providing an empty password string does not work.

Please read the whole scenario with solution bellow:

I have running Spring Boot application with embedded H2 database and H2 console.

When I want to go to the "Preferences" or "Tools" page in H2 console, I am asked for a password which is the `webAdminPassword` property of [H2 console](http://www.h2database.com/html/tutorial.html#console_settings) settings.

The problem is that `application.properties` does not support the `webAdminPassword` property, thus I am not able to log in to the "Preferences" or "Tools" page, providing an empty password string does not work.

I have added this property to the `H2ConsoleAutoConfiguration` class, the property can be configured in `application.properties` like this:
```
spring.h2.console.settings.web-admin-password=abcd
```

I have tested this implementation with my modified Spring Boot `2.2.6.RELEASE` build and H2 `h2-1.4.200`. I was able to log in to the "Preferences" or "Tools" page with provided password in `application.properties`

This is a similar H2 configuration change to https://github.com/spring-projects/spring-boot/pull/5417
