### PR TITLE
Links to Apache camel starter are broken

### DIFF
--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -22,8 +22,8 @@ do as they were designed before this was clarified.
 |===
 | Name | Location
 
-| https://camel.apache.org/spring-boot.html[Apache Camel]
-| https://github.com/apache/camel/tree/master/components/camel-spring-boot
+| https://camel.apache.org/camel-spring-boot/latest/spring-boot.html[Apache Camel]
+| https://github.com/apache/camel-spring-boot
 
 | https://cxf.apache.org/docs/springboot.html[Apache CXF]
 | https://github.com/apache/cxf


### PR DESCRIPTION
Hi

The links to the Apache Camel starter info both returned a 404 page not found.
With this merge the links are updated with the latest up to date links to the pages.
