### PR TITLE
Print the java version being used on startup

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
@@ -70,6 +70,7 @@ class StartupInfoLogger {
 		appendOn(message);
 		appendPid(message);
 		appendContext(message);
+		appendJavaVersion(message);
 		return message;
 	}
 
@@ -145,6 +146,10 @@ class StartupInfoLogger {
 			message.append(context);
 			message.append(")");
 		}
+	}
+
+	private void appendJavaVersion(StringBuilder message) {
+		append(message, "on Java ", () -> System.getProperty("java.version"));
 	}
 
 	private void append(StringBuilder message, String prefix, Callable<Object> call) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
@@ -67,10 +67,10 @@ class StartupInfoLogger {
 		message.append("Starting ");
 		appendApplicationName(message);
 		appendVersion(message, this.sourceClass);
+		appendJavaVersion(message);
 		appendOn(message);
 		appendPid(message);
 		appendContext(message);
-		appendJavaVersion(message);
 		return message;
 	}
 
@@ -149,7 +149,7 @@ class StartupInfoLogger {
 	}
 
 	private void appendJavaVersion(StringBuilder message) {
-		append(message, "on Java ", () -> System.getProperty("java.version"));
+		append(message, "using Java ", () -> System.getProperty("java.version"));
 	}
 
 	private void append(StringBuilder message, String prefix, Callable<Object> call) {


### PR DESCRIPTION
Hi,

this PR closes #21553 by using `System.getProperty("java.version")`. Alternatively, we could check for `Runtime.version()` being available (which is the case for JDK 9+) and use that.

Cheers,
Christoph