### PR TITLE
Upgrade to Testcontainers 1.14.2

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfigurationIntegrationTests.java
@@ -55,7 +55,7 @@ class CassandraDataAutoConfigurationIntegrationTests {
 			.withConfiguration(
 					AutoConfigurations.of(CassandraAutoConfiguration.class, CassandraDataAutoConfiguration.class))
 			.withPropertyValues(
-					"spring.data.cassandra.contact-points:" + cassandra.getContainerIpAddress() + ":"
+					"spring.data.cassandra.contact-points:" + cassandra.getHost() + ":"
 							+ cassandra.getFirstMappedPort(),
 					"spring.data.cassandra.local-datacenter=datacenter1", "spring.data.cassandra.read-timeout=20s",
 					"spring.data.cassandra.connect-timeout=10s")

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ReactiveElasticsearchRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ReactiveElasticsearchRepositoriesAutoConfigurationTests.java
@@ -53,8 +53,8 @@ public class ReactiveElasticsearchRepositoriesAutoConfigurationTests {
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(ReactiveElasticsearchRestClientAutoConfiguration.class,
 					ReactiveElasticsearchRepositoriesAutoConfiguration.class, ElasticsearchDataAutoConfiguration.class))
-			.withPropertyValues("spring.data.elasticsearch.client.reactive.endpoints="
-					+ elasticsearch.getContainerIpAddress() + ":" + elasticsearch.getFirstMappedPort());
+			.withPropertyValues("spring.data.elasticsearch.client.reactive.endpoints=" + elasticsearch.getHost() + ":"
+					+ elasticsearch.getFirstMappedPort());
 
 	@Test
 	void testDefaultRepositoryConfiguration() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ReactiveElasticsearchRestClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/elasticsearch/ReactiveElasticsearchRestClientAutoConfigurationTests.java
@@ -75,7 +75,7 @@ public class ReactiveElasticsearchRestClientAutoConfigurationTests {
 	@Test
 	void restClientCanQueryElasticsearchNode() {
 		this.contextRunner.withPropertyValues(
-				"spring.data.elasticsearch.client.reactive.endpoints=" + elasticsearch.getContainerIpAddress() + ":"
+				"spring.data.elasticsearch.client.reactive.endpoints=" + elasticsearch.getHost() + ":"
 						+ elasticsearch.getFirstMappedPort(),
 				"spring.data.elasticsearch.client.reactive.connection-timeout=120s",
 				"spring.data.elasticsearch.client.reactive.socket-timeout=120s").run((context) -> {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisRepositoriesAutoConfigurationTests.java
@@ -54,8 +54,8 @@ class RedisRepositoriesAutoConfigurationTests {
 
 	@BeforeEach
 	void setUp() {
-		TestPropertyValues.of("spring.redis.host=" + redis.getContainerIpAddress(),
-				"spring.redis.port=" + redis.getFirstMappedPort()).applyTo(this.context.getEnvironment());
+		TestPropertyValues.of("spring.redis.host=" + redis.getHost(), "spring.redis.port=" + redis.getFirstMappedPort())
+				.applyTo(this.context.getEnvironment());
 	}
 
 	@AfterEach

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationRedisTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationRedisTests.java
@@ -63,8 +63,9 @@ class SessionAutoConfigurationRedisTests extends AbstractSessionAutoConfiguratio
 
 	@Test
 	void defaultConfig() {
-		this.contextRunner.withPropertyValues("spring.session.store-type=redis",
-				"spring.redis.host=" + redis.getContainerIpAddress(), "spring.redis.port=" + redis.getFirstMappedPort())
+		this.contextRunner
+				.withPropertyValues("spring.session.store-type=redis", "spring.redis.host=" + redis.getHost(),
+						"spring.redis.port=" + redis.getFirstMappedPort())
 				.withConfiguration(AutoConfigurations.of(RedisAutoConfiguration.class))
 				.run(validateSpringSessionUsesRedis("spring:session:event:0:created:", FlushMode.ON_SAVE,
 						SaveMode.ON_SET_ATTRIBUTE, "0 * * * * *"));
@@ -76,7 +77,7 @@ class SessionAutoConfigurationRedisTests extends AbstractSessionAutoConfiguratio
 				.withClassLoader(new FilteredClassLoader(HazelcastIndexedSessionRepository.class,
 						JdbcIndexedSessionRepository.class, MongoIndexedSessionRepository.class))
 				.withConfiguration(AutoConfigurations.of(RedisAutoConfiguration.class))
-				.withPropertyValues("spring.redis.host=" + redis.getContainerIpAddress(),
+				.withPropertyValues("spring.redis.host=" + redis.getHost(),
 						"spring.redis.port=" + redis.getFirstMappedPort())
 				.run(validateSpringSessionUsesRedis("spring:session:event:0:created:", FlushMode.ON_SAVE,
 						SaveMode.ON_SET_ATTRIBUTE, "0 * * * * *"));
@@ -87,8 +88,7 @@ class SessionAutoConfigurationRedisTests extends AbstractSessionAutoConfiguratio
 		this.contextRunner.withConfiguration(AutoConfigurations.of(RedisAutoConfiguration.class))
 				.withPropertyValues("spring.session.store-type=redis", "spring.session.redis.namespace=foo",
 						"spring.session.redis.flush-mode=immediate", "spring.session.redis.save-mode=on-get-attribute",
-						"spring.session.redis.cleanup-cron=0 0 12 * * *",
-						"spring.redis.host=" + redis.getContainerIpAddress(),
+						"spring.session.redis.cleanup-cron=0 0 12 * * *", "spring.redis.host=" + redis.getHost(),
 						"spring.redis.port=" + redis.getFirstMappedPort())
 				.run(validateSpringSessionUsesRedis("foo:event:0:created:", FlushMode.IMMEDIATE,
 						SaveMode.ON_GET_ATTRIBUTE, "0 0 12 * * *"));
@@ -98,16 +98,14 @@ class SessionAutoConfigurationRedisTests extends AbstractSessionAutoConfiguratio
 	void redisSessionWithConfigureActionNone() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(RedisAutoConfiguration.class))
 				.withPropertyValues("spring.session.store-type=redis", "spring.session.redis.configure-action=none",
-						"spring.redis.host=" + redis.getContainerIpAddress(),
-						"spring.redis.port=" + redis.getFirstMappedPort())
+						"spring.redis.host=" + redis.getHost(), "spring.redis.port=" + redis.getFirstMappedPort())
 				.run(validateStrategy(ConfigureRedisAction.NO_OP.getClass()));
 	}
 
 	@Test
 	void redisSessionWithDefaultConfigureActionNone() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(RedisAutoConfiguration.class))
-				.withPropertyValues("spring.session.store-type=redis",
-						"spring.redis.host=" + redis.getContainerIpAddress(),
+				.withPropertyValues("spring.session.store-type=redis", "spring.redis.host=" + redis.getHost(),
 						"spring.redis.port=" + redis.getFirstMappedPort())
 				.run(validateStrategy(ConfigureNotifyKeyspaceEventsAction.class,
 						entry("notify-keyspace-events", "gxE")));
@@ -117,8 +115,7 @@ class SessionAutoConfigurationRedisTests extends AbstractSessionAutoConfiguratio
 	void redisSessionWithCustomConfigureRedisActionBean() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(RedisAutoConfiguration.class))
 				.withUserConfiguration(MaxEntriesRedisAction.class)
-				.withPropertyValues("spring.session.store-type=redis",
-						"spring.redis.host=" + redis.getContainerIpAddress(),
+				.withPropertyValues("spring.session.store-type=redis", "spring.redis.host=" + redis.getHost(),
 						"spring.redis.port=" + redis.getFirstMappedPort())
 				.run(validateStrategy(MaxEntriesRedisAction.class, entry("set-max-intset-entries", "1024")));
 

--- a/spring-boot-project/spring-boot-parent/build.gradle
+++ b/spring-boot-project/spring-boot-parent/build.gradle
@@ -13,7 +13,7 @@ javaPlatform {
 
 dependencies {
 	api(platform(project(":spring-boot-project:spring-boot-dependencies")))
-	api(platform("org.testcontainers:testcontainers-bom:1.14.1"))
+	api(platform("org.testcontainers:testcontainers-bom:1.14.2"))
 
 	constraints {
 		api("com.vaadin.external.google:android-json:0.0.20131108.vaadin1")

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestIntegrationTests.java
@@ -60,7 +60,7 @@ class DataRedisTestIntegrationTests {
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.redis.host", redis::getContainerIpAddress);
+		registry.add("spring.redis.host", redis::getHost);
 		registry.add("spring.redis.port", redis::getFirstMappedPort);
 	}
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestPropertiesIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestPropertiesIntegrationTests.java
@@ -46,7 +46,7 @@ class DataRedisTestPropertiesIntegrationTests {
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.redis.host", redis::getContainerIpAddress);
+		registry.add("spring.redis.host", redis::getHost);
 		registry.add("spring.redis.port", redis::getFirstMappedPort);
 	}
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestWithIncludeFilterIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestWithIncludeFilterIntegrationTests.java
@@ -49,7 +49,7 @@ class DataRedisTestWithIncludeFilterIntegrationTests {
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.redis.host", redis::getContainerIpAddress);
+		registry.add("spring.redis.host", redis::getHost);
 		registry.add("spring.redis.port", redis::getFirstMappedPort);
 	}
 

--- a/spring-boot-tests/spring-boot-deployment-tests/src/intTest/java/sample/DeploymentIntegrationTests.java
+++ b/spring-boot-tests/spring-boot-deployment-tests/src/intTest/java/sample/DeploymentIntegrationTests.java
@@ -103,8 +103,8 @@ class DeploymentIntegrationTests {
 					this.port)) {
 				container.start();
 				TestRestTemplate rest = new TestRestTemplate(new RestTemplateBuilder()
-						.rootUri("http://" + container.getContainerIpAddress() + ":"
-								+ container.getMappedPort(this.port) + "/spring-boot")
+						.rootUri("http://" + container.getHost() + ":" + container.getMappedPort(this.port)
+								+ "/spring-boot")
 						.requestFactory(() -> new HttpComponentsClientHttpRequestFactory(HttpClients.custom()
 								.setRetryHandler(new StandardHttpRequestRetryHandler(10, false)).build())));
 				try {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-r2dbc-flyway/src/test/java/smoketest/data/r2dbc/CityRepositoryTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-r2dbc-flyway/src/test/java/smoketest/data/r2dbc/CityRepositoryTests.java
@@ -61,7 +61,7 @@ class CityRepositoryTests {
 	}
 
 	private static String r2dbcUrl() {
-		return String.format("r2dbc:postgresql://%s:%s/%s", postgresql.getContainerIpAddress(),
+		return String.format("r2dbc:postgresql://%s:%s/%s", postgresql.getHost(),
 				postgresql.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT), postgresql.getDatabaseName());
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-r2dbc-liquibase/src/test/java/smoketest/data/r2dbc/CityRepositoryTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-r2dbc-liquibase/src/test/java/smoketest/data/r2dbc/CityRepositoryTests.java
@@ -61,7 +61,7 @@ class CityRepositoryTests {
 	}
 
 	private static String r2dbcUrl() {
-		return String.format("r2dbc:postgresql://%s:%s/%s", postgresql.getContainerIpAddress(),
+		return String.format("r2dbc:postgresql://%s:%s/%s", postgresql.getHost(),
 				postgresql.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT), postgresql.getDatabaseName());
 	}
 


### PR DESCRIPTION
Hi,

this PR upgrades Testcontainers to 1.14.2 and uses the new `getHost` method instead of using `getContainerIpAddress`.

Cheers,
Christoph