### PR TITLE
Fix multi-release JAR test on JDK 15

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/TestJarCreator.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/TestJarCreator.java
@@ -99,6 +99,7 @@ public abstract class TestJarCreator {
 			writeEntry(jarOutputStream, "META-INF/versions/12/multi-release.dat", 12);
 			writeEntry(jarOutputStream, "META-INF/versions/13/multi-release.dat", 13);
 			writeEntry(jarOutputStream, "META-INF/versions/14/multi-release.dat", 14);
+			writeEntry(jarOutputStream, "META-INF/versions/15/multi-release.dat", 15);
 		}
 		else {
 			writeEntry(jarOutputStream, "3.dat", 3);


### PR DESCRIPTION
Hi,

I just did a quick for #21604 to see if everything works on JDK 15 with the custom `buildJavaHome` property I introduced for JDK 14.

This PR fixes a test failure in `JarFileTests.multiReleaseEntry`.

I'm wondering if we should add some entries in advance already for JDK 16 & 17 ;-)

Cheers,
Christoph