### PR TITLE
Add Cassandra driver Actuator metrics

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/cassandra/CassandraMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/cassandra/CassandraMetricsAutoConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.cassandra;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
+import org.springframework.boot.actuate.metrics.cassandra.CassandraMetricsBinder;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.cassandra.CassandraAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for metrics on all available
+ * {@link CqlSession Cassandra sessions}.
+ *
+ * @author Erik Merkle
+ * @since 2.4.0
+ */
+@Configuration
+@AutoConfigureAfter({ MetricsAutoConfiguration.class, SimpleMetricsExportAutoConfiguration.class,
+		CassandraAutoConfiguration.class })
+@ConditionalOnClass({ MeterRegistry.class, CqlSession.class })
+@ConditionalOnBean({ MeterRegistry.class, CqlSession.class })
+public class CassandraMetricsAutoConfiguration {
+
+	@Autowired
+	public void bindCqlSessionMetricsToRegistry(CqlSession cqlSession, MeterRegistry registry) {
+
+		// Don't bind to the MeterRegistry if the session has no metrics configured
+		if (!cqlSession.getMetrics().isPresent()) {
+			return;
+		}
+		CassandraMetricsBinder cassandraMetrics = new CassandraMetricsBinder(cqlSession);
+		cassandraMetrics.bindTo(registry);
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/cassandra/package-info.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/cassandra/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Cassandra metrics.
+ */
+package org.springframework.boot.actuate.autoconfigure.metrics.cassandra;

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -47,6 +47,7 @@ org.springframework.boot.actuate.autoconfigure.metrics.MetricsEndpointAutoConfig
 org.springframework.boot.actuate.autoconfigure.metrics.SystemMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.amqp.RabbitMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.cache.CacheMetricsAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.metrics.cassandra.CassandraMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.export.appoptics.AppOpticsMetricsExportAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.export.atlas.AtlasMetricsExportAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.export.datadog.DatadogMetricsExportAutoConfiguration,\

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/cassandra/CassandraMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/cassandra/CassandraMetricsAutoConfigurationTests.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.cassandra;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metrics.Metrics;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.test.MetricsRun;
+import org.springframework.boot.actuate.metrics.cassandra.CassandraMetricsBinder;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link CassandraMetricsAutoConfiguration}.
+ *
+ * @author Erik Merkle
+ */
+public class CassandraMetricsAutoConfigurationTests {
+
+	private static final String CQL_SESSION_NAME = "mock-session";
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().with(MetricsRun.simple())
+			.withConfiguration(AutoConfigurations.of(CassandraMetricsAutoConfiguration.class));
+
+	/**
+	 * Cassandra driver metrics should be enabled by default as long as the desired
+	 * metrics are enabled in the Driver's configuration.
+	 */
+	@Test
+	void autoConfiguredCassandraIsInstrumented() {
+		this.contextRunner.withBean(CqlSession.class, () -> mockSession(true)).run((context) -> {
+			MeterRegistry registry = context.getBean(MeterRegistry.class);
+			// Assert a Driver Meter metric
+			assertMeterMetric(registry, "bytes-sent", 42);
+			// Assert a Driver Gauge metric
+			assertGaugeMetric(registry, "connected-nodes", 7);
+			// Assert a Driver Timer metric
+			assertTimerMetric(registry, "cql-requests", 4);
+			// Assert Driver Timer snapshot metrics (min, max, avg)
+			assertTimerSnapshotMetrics(registry, "cql-requests", Duration.ofMillis(10).toNanos(),
+					Duration.ofMillis(40).toNanos(), Duration.ofMillis(25).toNanos());
+		});
+	}
+
+	/**
+	 * Cassandra driver metrics should be disabled if set to false via Spring metrics
+	 * management.
+	 */
+	@Test
+	void cassandraInstrumentationCanBeDisabledThroughSpringMetricsManagement() {
+		this.contextRunner.withBean(CqlSession.class, () -> mockSession(true))
+				.withPropertyValues("management.metrics.enable.spring.data.cassandra.driver.session=false")
+				.run((context) -> {
+					MeterRegistry registry = context.getBean(MeterRegistry.class);
+					assertThat(registry.find(getMetricName("bytes-sent")).meter()).isNull();
+					assertThat(registry.find(getMetricName("connected-nodes")).meter()).isNull();
+					assertThat(registry.find(getMetricName("cql-requests")).meter()).isNull();
+				});
+	}
+
+	/**
+	 * Cassandra driver metrics should be disabled if no metrics are enabled in the
+	 * Driver's configuration.
+	 */
+	@Test
+	void cassandraInstrumentationIsDisabledIfNoMetricsEnabledInDriverConfig() {
+		this.contextRunner.withBean(CqlSession.class, () -> mockSession(false)).run((context) -> {
+			MeterRegistry registry = context.getBean(MeterRegistry.class);
+			assertThat(registry.find(getMetricName("bytes-sent")).meter()).isNull();
+			assertThat(registry.find(getMetricName("connected-nodes")).meter()).isNull();
+			assertThat(registry.find(getMetricName("cql-requests")).meter()).isNull();
+		});
+	}
+
+	/**
+	 * Cassandra driver metrics should be disabled if {@link CqlSession} and
+	 * {@link MetricRegistry} are not available on the classpath.
+	 */
+	@Test
+	void cassandraInstrumentationNotAvailableIfClassesNotOnClasspath() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader(CqlSession.class, MetricRegistry.class))
+				.run((context) -> {
+					MeterRegistry registry = context.getBean(MeterRegistry.class);
+					assertThat(registry.find(getMetricName(".bytes-sent")).meter()).isNull();
+					assertThat(registry.find(getMetricName("connected-nodes")).meter()).isNull();
+					assertThat(registry.find(getMetricName("cql-requests")).meter()).isNull();
+				});
+	}
+
+	private String getMetricName(String metric) {
+		return CassandraMetricsBinder.SESSION_PREFIX + "." + CQL_SESSION_NAME + "." + metric;
+	}
+
+	private void assertGaugeMetric(MeterRegistry registry, String metric, double expectedValue) {
+		final String metricName = getMetricName(metric);
+		assertThat(registry.find(metricName).meter()).isNotNull();
+		assertThat(registry.get(metricName).gauge().value()).isEqualTo(expectedValue);
+	}
+
+	private void assertMeterMetric(MeterRegistry registry, String metric, double expectedValue) {
+		final String metricName = getMetricName(metric);
+		assertThat(registry.find(metricName).meter()).isNotNull();
+		assertThat(registry.get(metricName).functionCounter().count()).isEqualTo(expectedValue);
+	}
+
+	private void assertTimerMetric(MeterRegistry registry, String metric, double expectedValue) {
+		final String metricName = getMetricName(metric);
+		assertThat(registry.find(metricName).meter()).isNotNull();
+		assertThat(registry.get(metricName).functionCounter().count()).isEqualTo(expectedValue);
+	}
+
+	private void assertTimerSnapshotMetrics(MeterRegistry registry, String metric, long expectedMinValue,
+			long expectedMaxValue, long expectedMeanValue) {
+		final String minMetricName = getMetricName(metric + ".min");
+		final String maxMetricName = getMetricName(metric + ".max");
+		final String meanMetricName = getMetricName(metric + ".mean");
+
+		assertThat(registry.find(minMetricName).meter()).isNotNull();
+		assertThat(registry.find(maxMetricName).meter()).isNotNull();
+		assertThat(registry.find(meanMetricName).meter()).isNotNull();
+
+		assertThat(registry.get(minMetricName).functionCounter().count()).isEqualTo(expectedMinValue);
+		assertThat(registry.get(maxMetricName).functionCounter().count()).isEqualTo(expectedMaxValue);
+		assertThat(registry.get(meanMetricName).functionCounter().count()).isEqualTo(expectedMeanValue);
+	}
+
+	private CqlSession mockSession(boolean metricsEnabled) {
+		CqlSession session = mock(CqlSession.class);
+		given(session.getName()).willReturn(CQL_SESSION_NAME);
+		if (metricsEnabled) {
+			MetricRegistry registry = new MetricRegistry();
+			// register a Driver Counter
+			registry.meter(CQL_SESSION_NAME + ".bytes-sent").mark(42);
+			// register a Driver Gauge
+			registry.gauge(CQL_SESSION_NAME + ".connected-nodes", () -> new Gauge() {
+				@Override
+				public Object getValue() {
+					return 7;
+				}
+			});
+			// register a Driver Timer
+			final Timer cqlRequestTimer = new Timer();
+			// simulate 4 timer pegs with durations of 10ms, 20ms, 30ms and 40ms
+			cqlRequestTimer.update(Duration.ofMillis(10));
+			cqlRequestTimer.update(Duration.ofMillis(20));
+			cqlRequestTimer.update(Duration.ofMillis(30));
+			cqlRequestTimer.update(Duration.ofMillis(40));
+			registry.timer(CQL_SESSION_NAME + ".cql-requests", new MetricRegistry.MetricSupplier<Timer>() {
+				@Override
+				public Timer newMetric() {
+					return cqlRequestTimer;
+				}
+			});
+			Metrics metrics = mock(Metrics.class);
+			given(metrics.getRegistry()).willReturn(registry);
+			given(session.getMetrics()).willReturn(Optional.of(metrics));
+		}
+		else {
+			given(session.getMetrics()).willReturn(Optional.empty());
+		}
+		return session;
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/cassandra/CassandraMetricsBinder.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/cassandra/CassandraMetricsBinder.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.metrics.cassandra;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import com.codahale.metrics.Counting;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import com.datastax.oss.driver.api.core.CqlSession;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import org.springframework.util.Assert;
+
+/**
+ * This is a {@link MeterBinder} that binds all available Cassandra DataStax driver
+ * metrics to Micrometer.
+ *
+ * @author Erik Merkle
+ * @since 2.4.0
+ */
+public class CassandraMetricsBinder implements MeterBinder {
+
+	/**
+	 * Prefix for all Driver configuration parameters.
+	 */
+	public static final String SESSION_PREFIX = "spring.data.cassandra.driver.session";
+
+	/**
+	 * Description for micrometer metrics.
+	 */
+	private static final String DESCRIPTION = "Please see reference.conf for more information.";
+
+	private static final Map<String, Function<Snapshot, Number>> TIMER_SNAPSHOT_METRICS;
+
+	private static final Map<String, Function<Timer, Number>> TIMER_METRICS;
+
+	static {
+		Map<String, Function<Snapshot, Number>> map = new HashMap<>(10);
+		map.put("p999", Snapshot::get999thPercentile);
+		map.put("p99", Snapshot::get99thPercentile);
+		map.put("p98", Snapshot::get98thPercentile);
+		map.put("p95", Snapshot::get95thPercentile);
+		map.put("p75", Snapshot::get75thPercentile);
+		map.put("min", Snapshot::getMin);
+		map.put("max", Snapshot::getMax);
+		map.put("mean", Snapshot::getMean);
+		map.put("median", Snapshot::getMedian);
+		map.put("stdDev", Snapshot::getStdDev);
+		TIMER_SNAPSHOT_METRICS = Collections.unmodifiableMap(map);
+	}
+
+	static {
+		Map<String, Function<Timer, Number>> map = new HashMap<>(4);
+		map.put("mean_rate", Timer::getMeanRate);
+		map.put("m1_rate", Timer::getOneMinuteRate);
+		map.put("m5_rate", Timer::getFiveMinuteRate);
+		map.put("m15_rate", Timer::getFifteenMinuteRate);
+		TIMER_METRICS = Collections.unmodifiableMap(map);
+	}
+
+	private final Iterable<Tag> tags;
+
+	private final CqlSession session;
+
+	public CassandraMetricsBinder(@NonNull CqlSession cqlSession) {
+		this.session = cqlSession;
+		this.tags = Tags.of("sessionName", cqlSession.getName());
+	}
+
+	@Override
+	public void bindTo(@NonNull MeterRegistry meterRegistry) {
+		Assert.isTrue(this.session.getMetrics().isPresent(), "Metrics on the CqlSession needs to be present");
+
+		this.session.getMetrics().get().getRegistry().getMetrics().forEach((name, m) -> {
+			if (m instanceof Timer) {
+				registerTimer(name, (Timer) m, meterRegistry);
+			}
+			else if (m instanceof Counting) {
+				registerMeter(name, (Counting) m, meterRegistry);
+			}
+			else if (m instanceof com.codahale.metrics.Gauge) {
+				registerGauge(name, (com.codahale.metrics.Gauge<?>) m, meterRegistry);
+			}
+		});
+	}
+
+	private void registerTimer(String metricName, Timer timer, MeterRegistry meterRegistry) {
+		String name = String.format("%s.%s", SESSION_PREFIX, metricName);
+
+		// count metric should be registered at the root level of the metric name
+		FunctionCounter.builder(name, timer, Timer::getCount).tags(this.tags).description(DESCRIPTION)
+				.register(meterRegistry);
+
+		TIMER_METRICS.forEach((n, supplier) -> {
+			String nameTimerMetric = String.format("%s.%s", name, n);
+			FunctionCounter.builder(nameTimerMetric, timer, (t) -> supplier.apply(timer).doubleValue()).tags(this.tags)
+					// all rates are calculated per second
+					.baseUnit(TimeUnit.SECONDS.name()).description(DESCRIPTION).register(meterRegistry);
+		});
+
+		final Snapshot snapshot = timer.getSnapshot();
+		TIMER_SNAPSHOT_METRICS.forEach((n, supplier) -> {
+			String nameTimerMetric = String.format("%s.%s", name, n);
+			FunctionCounter.builder(nameTimerMetric, timer, (t) -> supplier.apply(snapshot).longValue()).tags(this.tags)
+					.baseUnit(TimeUnit.NANOSECONDS.name()).description(DESCRIPTION).register(meterRegistry);
+		});
+	}
+
+	private void registerMeter(String metricName, Counting counter, MeterRegistry meterRegistry) {
+		String name = String.format("%s.%s", SESSION_PREFIX, metricName);
+		FunctionCounter.builder(name, counter, Counting::getCount).tags(this.tags).description(DESCRIPTION)
+				.register(meterRegistry);
+	}
+
+	private void registerGauge(String metricName, com.codahale.metrics.Gauge<?> gauge, MeterRegistry meterRegistry) {
+		String name = String.format("%s.%s", SESSION_PREFIX, metricName);
+		Gauge.builder(name, gauge, (m) -> ((Number) m.getValue()).doubleValue()).tags(this.tags)
+				.description(DESCRIPTION).register(meterRegistry);
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/cassandra/package-info.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/cassandra/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Actuator support for Cassandra Java Client metrics.
+ */
+package org.springframework.boot.actuate.metrics.cassandra;


### PR DESCRIPTION
Motivation:

The DataStax Java driver for Cassandra can be configured to expose driver session operational metrics. Currently these metrics are not available through Spring Boot Actuator.

Modifications:

This commit adds support for Cassandra driver metrics through Spring Boot Actuator by binding the native driver metrics to Micrometer metrics.

Result:

Users are now able to access Cassandra driver enabled metrics through Actuator .