### PR TITLE
Add Java 15 CI

### DIFF
--- a/ci/images/get-jdk-url.sh
+++ b/ci/images/get-jdk-url.sh
@@ -11,6 +11,9 @@ case "$1" in
 	java14)
 		 echo "https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7/OpenJDK14U-jdk_x64_linux_hotspot_14.0.1_7.tar.gz"
 	;;
+	java15)
+		 echo "https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-2020-05-26-19-22/OpenJDK-jdk_x64_linux_hotspot_2020-05-26-11-00.tar.gz"
+	;;
   *)
 		echo $"Unknown java version"
 		exit 1

--- a/ci/images/spring-boot-jdk15-ci-image/Dockerfile
+++ b/ci/images/spring-boot-jdk15-ci-image/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:bionic-20200403
+
+ADD setup.sh /setup.sh
+ADD get-jdk-url.sh /get-jdk-url.sh
+ADD get-docker-url.sh /get-docker-url.sh
+RUN ./setup.sh java15
+
+ENV JAVA_HOME /opt/openjdk
+ENV PATH $JAVA_HOME/bin:$PATH
+ADD docker-lib.sh /docker-lib.sh
+
+ENTRYPOINT [ "switch", "shell=/bin/bash", "--", "codep", "/bin/docker daemon" ]

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -94,6 +94,14 @@ resources:
     username: ((docker-hub-username))
     password: ((docker-hub-password))
     tag: 2.4.x
+- name: spring-boot-jdk15-ci-image
+  type: docker-image
+  icon: docker
+  source:
+    repository: ((docker-hub-organization))/spring-boot-jdk15-ci-image
+    username: ((docker-hub-username))
+    password: ((docker-hub-password))
+    tag: 2.4.x
 - name: artifactory-repo
   type: artifactory-resource
   icon: package-variant
@@ -126,6 +134,14 @@ resources:
     access_token: ((github-ci-status-token))
     branch: ((branch))
     context: jdk14-build
+- name: repo-status-jdk15-build
+  type: github-status-resource
+  icon: eye-check-outline
+  source:
+    repository: ((github-repo-name))
+    access_token: ((github-ci-status-token))
+    branch: ((branch))
+    context: jdk15-build
 - name: slack-alert
   type: slack-notification
   icon: slack
@@ -160,6 +176,10 @@ jobs:
       params:
         build: ci-images-git-repo/ci/images
         dockerfile: ci-images-git-repo/ci/images/spring-boot-jdk14-ci-image/Dockerfile
+    - put: spring-boot-jdk15-ci-image
+      params:
+        build: ci-images-git-repo/ci/images
+        dockerfile: ci-images-git-repo/ci/images/spring-boot-jdk15-ci-image/Dockerfile
 - name: detect-jdk-updates
   plan:
   - get: git-repo
@@ -195,6 +215,16 @@ jobs:
         GITHUB_PASSWORD: ((github-password))
         GITHUB_USERNAME: ((github-username))
         JDK_VERSION: java14
+        MILESTONE: ((milestone))
+      image: spring-boot-ci-image
+    - task: detect-jdk15-update
+      file: git-repo/ci/tasks/detect-jdk-updates.yml
+      params:
+        GITHUB_REPO: spring-boot
+        GITHUB_ORGANIZATION: spring-projects
+        GITHUB_PASSWORD: ((github-password))
+        GITHUB_USERNAME: ((github-username))
+        JDK_VERSION: java15
         MILESTONE: ((milestone))
       image: spring-boot-ci-image
 - name: detect-ubuntu-image-updates
@@ -410,6 +440,52 @@ jobs:
               icon_emoji: ":concourse:"
               username: concourse-ci
     - put: repo-status-jdk14-build
+      params: { state: "success", commit: "git-repo" }
+    - put: slack-alert
+      params:
+        text: >
+          :concourse-succeeded: ${BUILD_PIPELINE_NAME} ${BUILD_JOB_NAME} was successful!
+          [<https://ci.spring.io/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}|build log>]
+          [$TEXT_FILE_CONTENT]
+        text_file: git-repo/build/build-scan-uri.txt
+        silent: true
+        icon_emoji: ":concourse:"
+        username: concourse-ci
+- name: jdk15-build
+  serial: true
+  public: true
+  plan:
+    - get: spring-boot-jdk15-ci-image
+    - get: git-repo
+      trigger: true
+    - put: repo-status-jdk15-build
+      params: { state: "pending", commit: "git-repo" }
+    - do:
+        - task: build-project
+          privileged: true
+          timeout: ((task-timeout))
+          image: spring-boot-jdk15-ci-image
+          file: git-repo/ci/tasks/build-project.yml
+          params:
+            BRANCH: ((branch))
+            GRADLE_ENTERPRISE_ACCESS_KEY: ((gradle_enterprise_secret_access_key))
+            GRADLE_ENTERPRISE_CACHE_USERNAME: ((gradle_enterprise_cache_user.username))
+            GRADLE_ENTERPRISE_CACHE_PASSWORD: ((gradle_enterprise_cache_user.password))
+      on_failure:
+        do:
+          - put: repo-status-jdk15-build
+            params: { state: "failure", commit: "git-repo" }
+          - put: slack-alert
+            params:
+              text: >
+                :concourse-failed: ${BUILD_PIPELINE_NAME} ${BUILD_JOB_NAME} failed!
+                [<https://ci.spring.io/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}|build log>]
+                [$TEXT_FILE_CONTENT]
+              text_file: git-repo/build/build-scan-uri.txt
+              silent: true
+              icon_emoji: ":concourse:"
+              username: concourse-ci
+    - put: repo-status-jdk15-build
       params: { state: "success", commit: "git-repo" }
     - put: slack-alert
       params:
@@ -645,7 +721,7 @@ jobs:
       body: generated-release-notes/release-notes.md
 groups:
 - name: "Build"
-  jobs: ["build", "jdk11-build", "jdk14-build", "windows-build"]
+  jobs: ["build", "jdk11-build", "jdk14-build", "jdk15-build", "windows-build"]
 - name: "Release"
   jobs: ["stage-milestone", "stage-rc", "stage-release", "promote-milestone", "promote-rc", "promote-release", "sync-to-maven-central"]
 - name: "CI Images"

--- a/ci/scripts/detect-jdk-updates.sh
+++ b/ci/scripts/detect-jdk-updates.sh
@@ -2,15 +2,19 @@
 
 case "$JDK_VERSION" in
 	java8)
-		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/8"
+		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ga"
 		 ISSUE_TITLE="Upgrade Java 8 version in CI image"
 	;;
 	java11)
-		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/11"
+		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga"
 		 ISSUE_TITLE="Upgrade Java 11 version in CI image"
 	;;
 	java14)
-		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/14"
+		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga"
+		 ISSUE_TITLE="Upgrade Java 14 version in CI image"
+	;;
+	java15)
+		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/15/ea"
 		 ISSUE_TITLE="Upgrade Java 14 version in CI image"
 	;;
 	*)
@@ -18,7 +22,7 @@ case "$JDK_VERSION" in
 		exit 1;
 esac
 
-response=$( curl -s ${BASE_URL}\/ga\?architecture\=x64\&heap_size\=normal\&image_type\=jdk\&jvm_impl\=hotspot\&os\=linux\&sort_order\=DESC\&vendor\=adoptopenjdk )
+response=$( curl -s ${BASE_URL}\?architecture\=x64\&heap_size\=normal\&image_type\=jdk\&jvm_impl\=hotspot\&os\=linux\&sort_order\=DESC\&vendor\=adoptopenjdk )
 latest=$( jq -r '.[0].binaries[0].package.link' <<< "$response" )
 
 current=$( git-repo/ci/images/get-jdk-url.sh ${JDK_VERSION} )

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/mappings/reactive/HandlerFunctionDescription.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/mappings/reactive/HandlerFunctionDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,11 +29,17 @@ public class HandlerFunctionDescription {
 	private final String className;
 
 	HandlerFunctionDescription(HandlerFunction<?> handlerFunction) {
-		this.className = handlerFunction.getClass().getName();
+		this.className = getHandlerFunctionClassName(handlerFunction);
 	}
 
 	public String getClassName() {
 		return this.className;
+	}
+
+	private String getHandlerFunctionClassName(HandlerFunction<?> handlerFunction) {
+		Class<?> functionClass = handlerFunction.getClass();
+		String canonicalName = functionClass.getCanonicalName();
+		return canonicalName != null ? canonicalName : functionClass.getName();
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/mappings/reactive/HandlerFunctionDescription.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/mappings/reactive/HandlerFunctionDescription.java
@@ -39,7 +39,7 @@ public class HandlerFunctionDescription {
 	private String getHandlerFunctionClassName(HandlerFunction<?> handlerFunction) {
 		Class<?> functionClass = handlerFunction.getClass();
 		String canonicalName = functionClass.getCanonicalName();
-		return canonicalName != null ? canonicalName : functionClass.getName();
+		return (canonicalName != null) ? canonicalName : functionClass.getName();
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/mappings/reactive/HandlerFunctionDescription.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/mappings/reactive/HandlerFunctionDescription.java
@@ -29,7 +29,7 @@ public class HandlerFunctionDescription {
 	private final String className;
 
 	HandlerFunctionDescription(HandlerFunction<?> handlerFunction) {
-		this.className = handlerFunction.getClass().getCanonicalName();
+		this.className = handlerFunction.getClass().getName();
 	}
 
 	public String getClassName() {

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/StringSequence.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/StringSequence.java
@@ -72,7 +72,11 @@ final class StringSequence implements CharSequence {
 		return new StringSequence(this.source, subSequenceStart, subSequenceEnd);
 	}
 
-	boolean isEmpty() {
+	/**
+	 * Returns {@code true} if the sequence is empty. Public to be compatible with JDK 15.
+	 * @return {@code true} if {@link #length()} is {@code 0}, otherwise {@code false}
+	 */
+	public boolean isEmpty() {
 		return length() == 0;
 	}
 

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -46,4 +46,5 @@
 	<suppress files="[\\/]src[\\/]intTest[\\/]java[\\/]" checks="SpringJavadoc" message="\@since" />
 	<suppress files="LinuxDomainSocket" checks="FinalClass" message="SockaddrUn" />
 	<suppress files="BsdDomainSocket" checks="FinalClass" message="SockaddrUn" />
+	<suppress files="StringSequence" checks="SpringMethodVisibility" />
 </suppressions>


### PR DESCRIPTION
Hi,

this PR tackles #21604 as discussed. Fortunately, even the automatic JDK upgrade should already work.

Before merging this, #21605 needs to be merged. Apart from that I haven't seen any test failures when I run with the custom `buildJavaHome` property being set to my local JDK 15 installation.

Cheers,
Christoph