### PR TITLE
Allow specifying unit type of configuration property when injected via constructor

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DataSizeUnit.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DataSizeUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,10 @@ import org.springframework.util.unit.DataUnit;
  * {@link DataSize}.
  *
  * @author Stephane Nicoll
+ * @author Vladislav Kisel
  * @since 2.1.0
  */
-@Target(ElementType.FIELD)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface DataSizeUnit {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DurationUnit.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DurationUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,10 @@ import java.time.temporal.ChronoUnit;
  * {@link Duration}.
  *
  * @author Phillip Webb
+ * @author Vladislav Kisel
  * @since 2.0.0
  */
-@Target(ElementType.FIELD)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface DurationUnit {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/PeriodUnit.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/PeriodUnit.java
@@ -30,9 +30,10 @@ import java.time.temporal.ChronoUnit;
  *
  * @author Eddú Meléndez
  * @author Edson Chávez
+ * @author Vladislav Kisel
  * @since 2.3.0
  */
-@Target(ElementType.FIELD)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface PeriodUnit {


### PR DESCRIPTION
Allow specifying unit type of configuration property when injected via constructor #20892
