### PR TITLE
Introduce support for automatic rollback of log level after a given delay

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/LoggersEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/LoggersEndpointDocumentationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.endpoint.web.documentation;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -114,6 +115,23 @@ class LoggersEndpointDocumentationTests extends MockMvcEndpointDocumentationTest
 				.andExpect(status().isNoContent())
 				.andDo(MockMvcRestDocumentation.document("loggers/set", requestFields(fieldWithPath("configuredLevel")
 						.description("Level for the logger. May be omitted to clear the level.").optional())));
+		verify(this.loggingSystem).setLogLevel("com.example", LogLevel.DEBUG);
+	}
+
+	@Test
+	void setLogLevelAndAutomaticallyRollback() throws Exception {
+		this.mockMvc
+				.perform(post("/actuator/loggers/com.example")
+						.content("{\"configuredLevel\":\"debug\", \"rollbackAfter\":\"20ms\"}")
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNoContent())
+				.andDo(MockMvcRestDocumentation.document("loggers/set", requestFields(
+						fieldWithPath("configuredLevel")
+								.description("Level for the logger. May be omitted to clear the level.").optional(),
+						fieldWithPath("rollbackAfter").description(
+								"\"Automatically rollback to the previous value after a given delay. May be omitted.\"")
+								.optional())));
+		verify(this.loggingSystem).setLogLevelDelayed("com.example", null, Duration.ofMillis(20));
 		verify(this.loggingSystem).setLogLevel("com.example", LogLevel.DEBUG);
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/logging/LoggersEndpointWebIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/logging/LoggersEndpointWebIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,11 @@
 
 package org.springframework.boot.actuate.logging;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +60,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
  * @author Andy Wilkinson
  * @author HaiTao Zhang
  * @author Madhura Bhave
+ * @author Vladislav Kisel
  */
 class LoggersEndpointWebIntegrationTests {
 
@@ -120,6 +123,17 @@ class LoggersEndpointWebIntegrationTests {
 		this.client.post().uri("/actuator/loggers/ROOT").contentType(MediaType.APPLICATION_JSON)
 				.bodyValue(Collections.singletonMap("configuredLevel", "debug")).exchange().expectStatus()
 				.isNoContent();
+		verify(this.loggingSystem).setLogLevel("ROOT", LogLevel.DEBUG);
+	}
+
+	@WebEndpointTest
+	void setLoggerWithRollbackUsingApplicationJsonShouldSetLogLevelThenRollback() {
+		Map<String, String> body = new HashMap<>();
+		body.put("configuredLevel", "debug");
+		body.put("rollbackAfter", "30m");
+		this.client.post().uri("/actuator/loggers/ROOT").contentType(MediaType.APPLICATION_JSON).bodyValue(body)
+				.exchange().expectStatus().isNoContent();
+		verify(this.loggingSystem).setLogLevelDelayed("ROOT", null, Duration.ofMinutes(30));
 		verify(this.loggingSystem).setLogLevel("ROOT", LogLevel.DEBUG);
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LoggingSystemTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,10 @@
 
 package org.springframework.boot.logging;
 
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * Tests for {@link LoggingSystem}.
  *
  * @author Andy Wilkinson
+ * @author Vladislav Kisel
  */
 class LoggingSystemTests {
 
@@ -55,7 +60,21 @@ class LoggingSystemTests {
 				.isThrownBy(() -> new StubLoggingSystem().getLoggerConfigurations());
 	}
 
+	@Test
+	void setLoggerLevelDelayed() throws InterruptedException {
+		StubLoggingSystem loggingSystem = new StubLoggingSystem();
+
+		loggingSystem.setLogLevel("ROOT", LogLevel.INFO);
+		loggingSystem.setLogLevelDelayed("ROOT", LogLevel.DEBUG, Duration.ofMillis(20));
+
+		assertThat(loggingSystem.loggerNameToLevel.get("ROOT")).isEqualTo(LogLevel.INFO);
+		Thread.sleep(30);
+		assertThat(loggingSystem.loggerNameToLevel.get("ROOT")).isEqualTo(LogLevel.DEBUG);
+	}
+
 	private static final class StubLoggingSystem extends LoggingSystem {
+
+		Map<String, LogLevel> loggerNameToLevel = new HashMap<>();
 
 		@Override
 		public void beforeInitialize() {
@@ -64,7 +83,7 @@ class LoggingSystemTests {
 
 		@Override
 		public void setLogLevel(String loggerName, LogLevel level) {
-			// Stub implementation
+			this.loggerNameToLevel.put(loggerName, level);
 		}
 
 	}


### PR DESCRIPTION
#21740

Introduce support for automatic rollback of log level after a given delay. Log level will be set to previous value. On REST API it is represented as optional `rollbackAfter` duration attribute.


