### PR TITLE
Use Supplier assertion variants in AvailabilityStateHealthIndicator

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/availability/AvailabilityStateHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/availability/AvailabilityStateHealthIndicator.java
@@ -69,7 +69,8 @@ public class AvailabilityStateHealthIndicator extends AbstractHealthIndicator {
 		if (!this.statusMappings.containsKey(null) && Enum.class.isAssignableFrom(stateType)) {
 			EnumSet elements = EnumSet.allOf((Class) stateType);
 			for (Object element : elements) {
-				Assert.isTrue(this.statusMappings.containsKey(element), "StatusMappings does not include " + element);
+				Assert.isTrue(this.statusMappings.containsKey(element),
+						() -> "StatusMappings does not include " + element);
 			}
 		}
 	}
@@ -81,7 +82,7 @@ public class AvailabilityStateHealthIndicator extends AbstractHealthIndicator {
 		if (status == null) {
 			status = this.statusMappings.get(null);
 		}
-		Assert.state(status != null, "No mapping provided for " + state);
+		Assert.state(status != null, () -> "No mapping provided for " + state);
 		builder.status(status);
 	}
 


### PR DESCRIPTION
Hi,

I just noticed that `AvailabilityStateHealthIndicator` does assertions with string concats. Specifically, the one in `doHealthCheck` could be changed, because it's executed on every health check.

Cheers,
Christoph