### PR TITLE
Fix wrong property reference to keys-to-sanitize in Javadoc

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpoint.java
@@ -75,7 +75,7 @@ import org.springframework.util.StringUtils;
  * <p>
  * To protect sensitive information from being exposed, certain property values are masked
  * if their names end with a set of configurable values (default "password" and "secret").
- * Configure property names by using {@code endpoints.configprops.keys_to_sanitize} in
+ * Configure property names by using {@code management.endpoint.configprops.keys-to-sanitize} in
  * your Spring Boot application configuration.
  *
  * @author Christian Dupuis

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpoint.java
@@ -75,8 +75,9 @@ import org.springframework.util.StringUtils;
  * <p>
  * To protect sensitive information from being exposed, certain property values are masked
  * if their names end with a set of configurable values (default "password" and "secret").
- * Configure property names by using {@code management.endpoint.configprops.keys-to-sanitize} in
- * your Spring Boot application configuration.
+ * Configure property names by using
+ * {@code management.endpoint.configprops.keys-to-sanitize} in your Spring Boot
+ * application configuration.
  *
  * @author Christian Dupuis
  * @author Dave Syer


### PR DESCRIPTION

When I use the /actuator/configprops endpoint to get the @ConfigurationProperties bean details.

I want to show the sensitive configuration such as password. Since the official website documentation does not explain the detailed usage of configprops endpoint, reading the source code notes found that it is incorrect and cannot work

---

```
management:
  endpoint:
    configprops:
      keys-to-sanitize:
        - secret
```