### PR TITLE
Fix snapshot deps resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 		if (!version.endsWith('RELEASE')) {
 			maven { url "https://repo.spring.io/milestone" }
 		}
-		if (version.endsWith('BUILD-SNAPSHOT')) {
+		if (version.endsWith('SNAPSHOT')) {
 			maven { url "https://repo.spring.io/snapshot" }
 		}
 	}

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ pluginManagement {
 		maven {
 			url 'https://repo.spring.io/plugins-release'
 		}
-		if (version.endsWith('BUILD-SNAPSHOT')) {
+		if (version.endsWith('SNAPSHOT')) {
 			maven { url "https://repo.spring.io/snapshot" }
 		}
 	}


### PR DESCRIPTION
As part of 8e8548756e, snapshot dependency resolution change from
`BUILD-SNAPSHOT` to `-SNAPSHOT`. Currently, if we add a version
dependency which is store in snapshots it is not resolved. This
commit allow to resolves plugins and dependencies.
