### PR TITLE
Use Class.getDeclaredConstructor().newInstance()

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.java
@@ -204,7 +204,7 @@ class HibernateJpaConfiguration extends JpaBaseConfiguration {
 	private Object getNoJtaPlatformManager() {
 		for (String candidate : NO_JTA_PLATFORM_CLASSES) {
 			try {
-				return Class.forName(candidate).newInstance();
+				return Class.forName(candidate).getDeclaredConstructor().newInstance();
 			}
 			catch (Exception ex) {
 				// Continue searching

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -538,7 +538,8 @@ class ServerPropertiesTests {
 	}
 
 	private AbstractProtocol<?> getDefaultProtocol() throws Exception {
-		return (AbstractProtocol<?>) Class.forName(TomcatServletWebServerFactory.DEFAULT_PROTOCOL).newInstance();
+		return (AbstractProtocol<?>) Class.forName(TomcatServletWebServerFactory.DEFAULT_PROTOCOL)
+				.getDeclaredConstructor().newInstance();
 	}
 
 	private void bind(String name, String value) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/Handler.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/Handler.java
@@ -132,7 +132,7 @@ public class Handler extends URLStreamHandler {
 		for (String handlerClassName : FALLBACK_HANDLERS) {
 			try {
 				Class<?> handlerClass = Class.forName(handlerClassName);
-				this.fallbackHandler = (URLStreamHandler) handlerClass.newInstance();
+				this.fallbackHandler = (URLStreamHandler) handlerClass.getDeclaredConstructor().newInstance();
 				return this.fallbackHandler;
 			}
 			catch (Exception ex) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/junit/platform/SummaryGeneratingListener.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/junit/platform/SummaryGeneratingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/junit/platform/SummaryGeneratingListener.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/junit/platform/SummaryGeneratingListener.java
@@ -28,7 +28,7 @@ public class SummaryGeneratingListener extends ReflectiveWrapper {
 
 	public SummaryGeneratingListener(ClassLoader classLoader) throws Throwable {
 		super(classLoader, "org.junit.platform.launcher.listeners.SummaryGeneratingListener");
-		this.instance = this.type.newInstance();
+		this.instance = this.type.getDeclaredConstructor().newInstance();
 	}
 
 	public TestExecutionSummary getSummary() throws Throwable {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/EnvironmentConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/EnvironmentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/EnvironmentConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/EnvironmentConverter.java
@@ -87,7 +87,7 @@ final class EnvironmentConverter {
 
 	private StandardEnvironment createEnvironment(Class<? extends StandardEnvironment> type) {
 		try {
-			return type.newInstance();
+			return type.getDeclaredConstructor().newInstance();
 		}
 		catch (Exception ex) {
 			return new StandardEnvironment();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JasperInitializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JasperInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JasperInitializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JasperInitializer.java
@@ -55,7 +55,7 @@ class JasperInitializer extends AbstractLifeCycle {
 		for (String className : INITIALIZER_CLASSES) {
 			try {
 				Class<?> initializerClass = ClassUtils.forName(className, null);
-				return (ServletContainerInitializer) initializerClass.newInstance();
+				return (ServletContainerInitializer) initializerClass.getDeclaredConstructor().newInstance();
 			}
 			catch (Exception ex) {
 				// Ignore

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
@@ -288,7 +288,8 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	private void addJasperInitializer(TomcatEmbeddedContext context) {
 		try {
 			ServletContainerInitializer initializer = (ServletContainerInitializer) ClassUtils
-					.forName("org.apache.jasper.servlet.JasperInitializer", null).newInstance();
+					.forName("org.apache.jasper.servlet.JasperInitializer", null).getDeclaredConstructor()
+					.newInstance();
 			context.addServletContainerInitializer(initializer, null);
 		}
 		catch (Exception ex) {


### PR DESCRIPTION
Hi,

this PR replaces the deprecated `Class.newInstance()` with `Class.getDeclaredConstructor().newInstance()`. While only deprecated since 9, it is already possible to change things on JDK 8.

Let me know what you think.
Cheers,
Christoph