### PR TITLE
Do not start Jetty if auto-start is set to false

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
@@ -132,9 +132,10 @@ public class JettyWebServer implements WebServer {
 					}
 
 				});
-				// Start the server so that the ServletContext is available
-				this.server.start();
 				this.server.setStopAtShutdown(false);
+				if (this.autoStart) {
+					start();
+				}
 			}
 			catch (Throwable ex) {
 				// Ensure process isn't left running
@@ -160,9 +161,6 @@ public class JettyWebServer implements WebServer {
 				return;
 			}
 			this.server.setConnectors(this.connectors);
-			if (!this.autoStart) {
-				return;
-			}
 			try {
 				this.server.start();
 				for (Handler handler : this.server.getHandlers()) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/jetty/JettyWebServerTest.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/jetty/JettyWebServerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.embedded.jetty;
+
+import org.eclipse.jetty.server.Server;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.SocketUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link JettyWebServer}.
+ *
+ * @author Michael Schneider
+ */
+class JettyWebServerTest {
+
+	private JettyWebServer webServer;
+
+	@AfterEach
+	void tearDown() {
+		if (this.webServer != null) {
+			try {
+				this.webServer.stop();
+			}
+			catch (Exception exception) {
+				// ignore
+			}
+		}
+	}
+
+	private Server createServer() {
+		return new Server(SocketUtils.findAvailableTcpPort());
+	}
+
+	@Test
+	void startManually() {
+		final Server server = createServer();
+		this.webServer = new JettyWebServer(server, false);
+		assertThat(this.webServer.getServer().isStarted()).isFalse();
+		this.webServer.start();
+		assertThat(this.webServer.getServer().isStarted()).isTrue();
+	}
+
+	@Test
+	void startAutomatically() {
+		final Server server = createServer();
+		this.webServer = new JettyWebServer(server, true);
+		assertThat(this.webServer.getServer().isStarted()).isTrue();
+	}
+
+}


### PR DESCRIPTION
Currently, JettyWebServer's constructor argument autoStart did not
prevent the server from being started automatically during
initialization.
If the server is started with autoStart=false, it can not be started
manually.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
