### PR TITLE
Use lazy lambdas instead of explicit argument

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/http/HttpExchangeTracerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/http/HttpExchangeTracerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/http/HttpExchangeTracerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/http/HttpExchangeTracerTests.java
@@ -318,7 +318,7 @@ class HttpExchangeTracerTests {
 		@Override
 		protected void postProcessRequestHeaders(Map<String, List<String>> headers) {
 			headers.remove("to-remove");
-			headers.putIfAbsent("to-add", Collections.singletonList("42"));
+			headers.computeIfAbsent("to-add", (key) -> Collections.singletonList("42"));
 		}
 
 	}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/client/WebServiceClientExcludeFilter.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/client/WebServiceClientExcludeFilter.java
@@ -36,7 +36,7 @@ public final class WebServiceClientExcludeFilter
 
 	protected WebServiceClientExcludeFilter(Class<?> testClass) {
 		super(testClass);
-		this.components = getAnnotation().getValue("components", Class[].class).orElse(new Class<?>[0]);
+		this.components = getAnnotation().getValue("components", Class[].class).orElseGet(() -> new Class<?>[0]);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/result/view/MustacheView.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/result/view/MustacheView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/result/view/MustacheView.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/result/view/MustacheView.java
@@ -84,7 +84,7 @@ public class MustacheView extends AbstractUrlBasedView {
 		DataBuffer dataBuffer = exchange.getResponse().bufferFactory().allocateBuffer();
 		try (Reader reader = getReader(resource)) {
 			Template template = this.compiler.compile(reader);
-			Charset charset = getCharset(contentType).orElse(getDefaultCharset());
+			Charset charset = getCharset(contentType).orElseGet(this::getDefaultCharset);
 			try (Writer writer = new OutputStreamWriter(dataBuffer.asOutputStream(), charset)) {
 				template.execute(model, writer);
 				writer.flush();


### PR DESCRIPTION
Hi,

this tiny PR avoids using explicit arguments that are always evaluated by using lambdas where possible.

Cheers,
Christoph 