### PR TITLE
Review support and documentation for preventing compile-only dependencies from being packaged in fat jars #21935

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -7925,7 +7925,7 @@ If you do it that way, the library is not provided and, by default, Spring Boot 
 
 Spring Boot uses an annotation processor to collect the conditions on auto-configurations in a metadata file (`META-INF/spring-autoconfigure-metadata.properties`).
 If that file is present, it is used to eagerly filter auto-configurations that do not match, which will improve startup time.
-It is recommended to add the following dependency in a module that contains auto-configurations and exclude it in the `spring-boot-maven-plugin` to prevent the repacking task from adding the dependency to the build:
+It is recommended to add the following dependency in a module that contains auto-configurations and exclude it in the `spring-boot-maven-plugin` to prevent the repacking task from adding the dependency into the fat jar:
 
 [source,xml,indent=0,subs="verbatim,quotes,attributes"]
 ----

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -7925,7 +7925,7 @@ If you do it that way, the library is not provided and, by default, Spring Boot 
 
 Spring Boot uses an annotation processor to collect the conditions on auto-configurations in a metadata file (`META-INF/spring-autoconfigure-metadata.properties`).
 If that file is present, it is used to eagerly filter auto-configurations that do not match, which will improve startup time.
-It is recommended to add the following dependency in a module containing automatic configurations and exclude it in the `spring-boot-maven-plugin` to prevent the repack task from adding the dependency to the build:
+It is recommended to add the following dependency in a module that contains auto-configurations and exclude it in the `spring-boot-maven-plugin` to prevent the repacking task from adding the dependency to the build:
 
 [source,xml,indent=0,subs="verbatim,quotes,attributes"]
 ----

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -7925,15 +7925,42 @@ If you do it that way, the library is not provided and, by default, Spring Boot 
 
 Spring Boot uses an annotation processor to collect the conditions on auto-configurations in a metadata file (`META-INF/spring-autoconfigure-metadata.properties`).
 If that file is present, it is used to eagerly filter auto-configurations that do not match, which will improve startup time.
-It is recommended to add the following dependency in a module that contains auto-configurations:
+It is recommended to add the following dependency in a module containing automatic configurations and exclude it in the `spring-boot-maven-plugin` to prevent the repack task from adding the dependency to the build:
 
 [source,xml,indent=0,subs="verbatim,quotes,attributes"]
 ----
-	<dependency>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-autoconfigure-processor</artifactId>
-		<optional>true</optional>
-	</dependency>
+	<project>
+    ...
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-autoconfigure-processor</artifactId>
+      </dependency>
+    </dependencies>
+    <build>
+      ...
+      <plugins>
+        ...
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <configuration>
+            <excludes>
+              ...
+              <exclude>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-autoconfigure-processor</artifactId>
+              </exclude>
+            </excludes>
+          </configuration>
+          ...
+        </plugin>
+        ...
+      </plugins>
+      ...
+    </build>
+    ...
+  </project>
 ----
 
 With Gradle 4.5 and earlier, the dependency should be declared in the `compileOnly` configuration, as shown in the following example:


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This pull request update the spring-boot-autoconfigure-processor documentation, and resolve the issue number #21109, in order to exclude the lib from the spring-boot compile versión repackage.