### PR TITLE
Remove Javadoc throw for ConfigurationPropertyName.ofIfValid()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -515,7 +515,6 @@ public final class ConfigurationPropertyName implements Comparable<Configuration
 	 * if the name is not valid.
 	 * @param name the source name
 	 * @return a {@link ConfigurationPropertyName} instance
-	 * @throws InvalidConfigurationPropertyNameException if the name is not valid
 	 * @since 2.3.1
 	 */
 	public static ConfigurationPropertyName ofIfValid(CharSequence name) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR removes Javadoc `@throw` for `ConfigurationPropertyName.ofIfValid()` as it doesn't seem to throw it.