### PR TITLE
FieldValues test class would cause infinite recursive loop

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/fieldvalues/FieldValues.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/fieldvalues/FieldValues.java
@@ -109,7 +109,7 @@ public class FieldValues {
 
 	private Integer[] integerArray = new Integer[] { 42, 24 };
 
-	private FieldValues[] unknownArray = new FieldValues[] { new FieldValues() };
+	private FieldValues[] unknownArray;
 
 	private Duration durationNone;
 


### PR DESCRIPTION
We expect the initial field value for filed "unknownArray" to be null. At least that's what the test says:

AbstractFieldValuesProcessorTests

An attempt to create a FieldValues object, ends up calling an endless loop.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
