### PR TITLE
Simplify logic in ErrorPage's equals method

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/ErrorPage.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/ErrorPage.java
@@ -114,8 +114,7 @@ public class ErrorPage {
 		}
 		if (obj instanceof ErrorPage) {
 			ErrorPage other = (ErrorPage) obj;
-			boolean rtn = true;
-			rtn = ObjectUtils.nullSafeEquals(getExceptionName(), other.getExceptionName());
+			boolean rtn = ObjectUtils.nullSafeEquals(getExceptionName(), other.getExceptionName());
 			rtn = rtn && ObjectUtils.nullSafeEquals(this.path, other.path);
 			rtn = rtn && this.status == other.status;
 			return rtn;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/ErrorPage.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/ErrorPage.java
@@ -115,7 +115,7 @@ public class ErrorPage {
 		if (obj instanceof ErrorPage) {
 			ErrorPage other = (ErrorPage) obj;
 			boolean rtn = true;
-			rtn = rtn && ObjectUtils.nullSafeEquals(getExceptionName(), other.getExceptionName());
+			rtn = ObjectUtils.nullSafeEquals(getExceptionName(), other.getExceptionName());
 			rtn = rtn && ObjectUtils.nullSafeEquals(this.path, other.path);
 			rtn = rtn && this.status == other.status;
 			return rtn;


### PR DESCRIPTION
`rtn` variables in class `ErrorPage` is always true:

`boolean rtn = true;	`
`rtn = rtn && ObjectUtils.nullSafeEquals(getExceptionName(), other.getExceptionName());`


so it is reduced the following code: 

`boolean rtn = true;	`
`rtn = ObjectUtils.nullSafeEquals(getExceptionName(), other.getExceptionName());`