### PR TITLE
Add Gradle Enterprise Maven Extension to 2.1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ transaction-logs
 secrets.yml
 .gradletasknamecache
 .sts4-cache
+.mvn/.gradle-enterprise/gradle-enterprise-workspace-id

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,12 +2,11 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>1.5.2</version>
+        <version>1.5.3</version>
     </extension>
     <extension>
-        <groupId>com.gradle</groupId>
-        <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <!-- TODO Use Spring Boot custom user data maven extension with custom values for CI and obfuscating IP address. -->
-        <version>1.1</version>
+        <groupId>io.spring.ge.conventions</groupId>
+        <artifactId>gradle-enterprise-conventions-maven-extension</artifactId>
+        <version>0.0.5</version>
     </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,13 @@
+<extensions>
+    <extension>
+        <groupId>com.gradle</groupId>
+        <artifactId>gradle-enterprise-maven-extension</artifactId>
+        <version>1.5.2</version>
+    </extension>
+    <extension>
+        <groupId>com.gradle</groupId>
+        <artifactId>common-custom-user-data-maven-extension</artifactId>
+        <!-- TODO Use Spring Boot custom user data maven extension with custom values for CI and obfuscating IP address. -->
+        <version>1.1</version>
+    </extension>
+</extensions>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -5,8 +5,6 @@
         <url>https://ge.spring.io</url>
     </server>
     <buildScan>
-        <publish>ALWAYS</publish>
-        <captureGoalInputFiles>true</captureGoalInputFiles>
         <publishIfAuthenticated>true</publishIfAuthenticated>
     </buildScan>
     <buildCache>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -1,0 +1,15 @@
+<gradleEnterprise
+        xmlns="https://www.gradle.com/gradle-enterprise-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">
+    <server>
+        <url>https://ge.spring.io</url>
+    </server>
+    <buildScan>
+        <publish>ALWAYS</publish>
+        <captureGoalInputFiles>true</captureGoalInputFiles>
+        <publishIfAuthenticated>true</publishIfAuthenticated>
+    </buildScan>
+    <buildCache>
+        <local><enabled>true</enabled></local>
+    </buildCache>
+</gradleEnterprise>

--- a/pom.xml
+++ b/pom.xml
@@ -250,5 +250,38 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>com.gradle</groupId>
+				<artifactId>gradle-enterprise-maven-extension</artifactId>
+				<!-- There is a build warning because we don't specify the version here. We do this instead of specifying the verison number twice -->
+				<configuration>
+					<gradleEnterprise>
+						<plugins>
+							<plugin>
+								<artifactId>maven-checkstyle-plugin</artifactId>
+								<inputs>
+									<fileSets>
+										<fileSet>
+											<name>allowlist</name>
+											<paths>
+												<path>${main.basedir}/src/checkstyle</path>
+											</paths>
+											<normalization>RELATIVE_PATH</normalization>
+										</fileSet>
+									</fileSets>
+									<properties>
+										<property>
+											<name>propertyExpansion</name>
+											<value>ignoredValue</value>
+										</property>
+									</properties>
+								</inputs>
+							</plugin>
+						</plugins>
+					</gradleEnterprise>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 </project>

--- a/spring-boot-project/spring-boot-starters/.mvn/empty-file-for-mvn
+++ b/spring-boot-project/spring-boot-starters/.mvn/empty-file-for-mvn
@@ -1,0 +1,1 @@
+This file is empty so that the starters project does not generate multiple build scans.

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/pom.xml
@@ -88,6 +88,9 @@
 									<addTestClassPath>true</addTestClassPath>
 									<skipInvocation>${skipTests}</skipInvocation>
 									<streamLogs>true</streamLogs>
+									<properties>
+										<scan>false</scan>
+									</properties>
 								</configuration>
 							</execution>
 						</executions>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/pom.xml
@@ -153,6 +153,9 @@
 									<addTestClassPath>true</addTestClassPath>
 									<skipInvocation>${skipTests}</skipInvocation>
 									<streamLogs>true</streamLogs>
+									<properties>
+										<scan>false</scan>
+									</properties>
 								</configuration>
 							</execution>
 						</executions>

--- a/spring-boot-samples-invoker/pom.xml
+++ b/spring-boot-samples-invoker/pom.xml
@@ -29,6 +29,9 @@
 					<pomIncludes>
 						<pomInclude>pom.xml</pomInclude>
 					</pomIncludes>
+					<properties>
+						<scan>false</scan>
+					</properties>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
This adds build caching and build scans.

The changes required disabling scans when using the maven invoker plugin in order to not cause duplicate build scans when invoking other maven builds.
There is also an empty `.mvn` folder in the spring-boot-starters project to prevent duplicate build scans as well since there is no way to pass properties to the maven-javadoc-plugin.

The checkstyle plugin was causing a cache miss with the `propertyExpansion` because it contains an absolute path. The absolute path is now ignored and instead the files are added as inputs to the checkstyle plugin.
This only enables the local build cache. The remote cache is not yet enabled.

On my local machine:
`./mvnw clean install` build times go from about 30 minutes to about 10 minutes.
`./mvnw clean install -Pfull` build times go from about 60 minutes to about 13 minutes.