### PR TITLE
Improve error handling in JDK upgrade checks

### DIFF
--- a/ci/scripts/detect-jdk-updates.sh
+++ b/ci/scripts/detect-jdk-updates.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-set -e
+
+report_error() {
+	echo "Script exited with error $1 on line $2"
+	exit 1;
+}
+
+trap 'report_error $? $LINENO' ERR
 
 case "$JDK_VERSION" in
 	java8)

--- a/ci/scripts/detect-jdk-updates.sh
+++ b/ci/scripts/detect-jdk-updates.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 case "$JDK_VERSION" in
 	java8)
@@ -16,6 +17,10 @@ esac
 
 response=$( curl -s ${BASE_URL}\/ga\?architecture\=x64\&heap_size\=normal\&image_type\=jdk\&jvm_impl\=hotspot\&os\=linux\&sort_order\=DESC\&vendor\=adoptopenjdk )
 latest=$( jq -r '.[0].binaries[0].package.link' <<< "$response" )
+if [[ ${latest} = "null" || ${latest} = "" ]]; then
+	echo "Could not parse JDK response: $response"
+	exit 1;
+fi
 
 current=$( git-repo/ci/images/get-jdk-url.sh ${JDK_VERSION} )
 
@@ -24,9 +29,16 @@ if [[ $current = $latest ]]; then
 	exit 0;
 fi
 
-milestone_number=$( curl -s https://api.github.com/repos/${GITHUB_ORGANIZATION}/${GITHUB_REPO}/milestones\?state\=open | jq -c --arg MILESTONE "$MILESTONE" '.[] | select(.title==$MILESTONE)' | jq -r '.number')
+milestone_response=$( curl -s https://api.github.com/repos/${GITHUB_ORGANIZATION}/${GITHUB_REPO}/milestones\?state\=open )
+milestone_result=$( jq -r -c --arg MILESTONE "$MILESTONE" '.[] | select(has("title")) | select(.title==$MILESTONE)' <<< "$milestone_response" )
+if [[ ${milestone_result} = "null" || ${milestone_result} = "" ]]; then
+	echo "Could not parse milestone: $milestone_response"
+	exit 1;
+fi
+
+milestone_number=$( jq -r '.number' <<< "$milestone_result" )
 existing_tasks=$( curl -s https://api.github.com/repos/${GITHUB_ORGANIZATION}/${GITHUB_REPO}/issues\?labels\=type:%20task\&state\=open\&creator\=spring-buildmaster\&milestone\=${milestone_number} )
-existing_jdk_issues=$( echo "$existing_tasks" | jq -c --arg TITLE "$ISSUE_TITLE" '.[] | select(.title==$TITLE)' )
+existing_jdk_issues=$( jq -r -c --arg TITLE "$ISSUE_TITLE" '.[] | select(has("title")) | select(.title==$TITLE)' <<< "$existing_tasks" )
 
 if [[ ${existing_jdk_issues} = "" ]]; then
 	curl \


### PR DESCRIPTION
Hi,

this is an attempt to fix #22098 for the time being with some more incremental steps (where possible) and `set -e` in order to step out as soon as we see an error to prevent unnecessary issues being opened.

In case we want to catch more errors in a more convenient way it might be a solution to craft a small java application that detects updates. Similar to the releasescript app. This could be also used for all the other detect jobs (docker, ubuntu...). Let me know if I should investigate this.

Cheers,
Christoph