### PR TITLE
Temporary files not cleaned up after Maven plugin execution

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/SizeCalculatingEntryWriter.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/SizeCalculatingEntryWriter.java
@@ -98,8 +98,7 @@ final class SizeCalculatingEntryWriter implements EntryWriter {
 
 		private OutputStream outputStream;
 
-		SizeCalculatingOutputStream() throws IOException {
-			this.tempFile = File.createTempFile("springboot-", "-entrycontent");
+		SizeCalculatingOutputStream() {
 			this.outputStream = new ByteArrayOutputStream();
 		}
 
@@ -119,9 +118,17 @@ final class SizeCalculatingEntryWriter implements EntryWriter {
 		}
 
 		private OutputStream convertToFileOutputStream(ByteArrayOutputStream byteArrayOutputStream) throws IOException {
+			initializeTempFile();
 			FileOutputStream fileOutputStream = new FileOutputStream(this.tempFile);
 			StreamUtils.copy(byteArrayOutputStream.toByteArray(), fileOutputStream);
 			return fileOutputStream;
+		}
+
+		private void initializeTempFile() throws IOException {
+			if (this.tempFile == null) {
+				this.tempFile = File.createTempFile("springboot-", "-entrycontent");
+				this.tempFile.deleteOnExit();
+			}
 		}
 
 		@Override


### PR DESCRIPTION
Hi,

this PR fixes #22108 by calling `deleteOnExit` on the temporary file and additionally prevents creating the file all together if we don't exceed the thresholds for which it was introduced.

Since `deleteOnExit` is only executed on "normal" VM termination, there is still a slight chance that temporary files will not be cleaned up when the VM dies for unknown reasons. But with the additional lazy init they probably won't be created in the first place for most apps.

Let me know what you think.

Cheers,
Christoph