### PR TITLE
Upgrade to Flyway 6.5 and support new create schemas property

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
@@ -178,6 +178,7 @@ public class FlywayAutoConfiguration {
 			// No method reference for compatibility with Flyway 5.x
 			map.from(properties.getDefaultSchema()).to((schema) -> configuration.defaultSchema(schema));
 			map.from(properties.getSchemas()).as(StringUtils::toStringArray).to(configuration::schemas);
+			configureCreateSchemas(configuration, properties.isCreateSchemas());
 			map.from(properties.getTable()).to(configuration::table);
 			// No method reference for compatibility with Flyway 5.x
 			map.from(properties.getTablespace()).whenNonNull().to((tablespace) -> configuration.tablespace(tablespace));
@@ -219,6 +220,16 @@ public class FlywayAutoConfiguration {
 					.to((oracleSqlplusWarn) -> configuration.oracleSqlplusWarn(oracleSqlplusWarn));
 			map.from(properties.getStream()).whenNonNull().to(configuration::stream);
 			map.from(properties.getUndoSqlMigrationPrefix()).whenNonNull().to(configuration::undoSqlMigrationPrefix);
+		}
+
+		private void configureCreateSchemas(FluentConfiguration configuration,
+				boolean createSchemas) {
+			try {
+				configuration.createSchemas(createSchemas);
+			}
+			catch (NoSuchMethodError ex) {
+				// Flyway < 6.5
+			}
 		}
 
 		private void configureValidateMigrationNaming(FluentConfiguration configuration,

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
@@ -222,8 +222,7 @@ public class FlywayAutoConfiguration {
 			map.from(properties.getUndoSqlMigrationPrefix()).whenNonNull().to(configuration::undoSqlMigrationPrefix);
 		}
 
-		private void configureCreateSchemas(FluentConfiguration configuration,
-				boolean createSchemas) {
+		private void configureCreateSchemas(FluentConfiguration configuration, boolean createSchemas) {
 			try {
 				configuration.createSchemas(createSchemas);
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java
@@ -75,6 +75,12 @@ public class FlywayProperties {
 	private List<String> schemas = new ArrayList<>();
 
 	/**
+	 * Whether Flyway should attempt to create the schemas
+	 * specified in the schemas property.
+	 */
+	private boolean createSchemas = true;
+
+	/**
 	 * Name of the schema history table that will be used by Flyway.
 	 */
 	private String table = "flyway_schema_history";
@@ -341,6 +347,14 @@ public class FlywayProperties {
 
 	public void setSchemas(List<String> schemas) {
 		this.schemas = schemas;
+	}
+
+	public boolean isCreateSchemas() {
+		return this.createSchemas;
+	}
+
+	public void setCreateSchemas(boolean createSchemas) {
+		this.createSchemas = createSchemas;
 	}
 
 	public String getTable() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java
@@ -75,8 +75,8 @@ public class FlywayProperties {
 	private List<String> schemas = new ArrayList<>();
 
 	/**
-	 * Whether Flyway should attempt to create the schemas
-	 * specified in the schemas property.
+	 * Whether Flyway should attempt to create the schemas specified in the schemas
+	 * property.
 	 */
 	private boolean createSchemas = true;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayPropertiesTests.java
@@ -53,6 +53,7 @@ class FlywayPropertiesTests {
 		assertThat(properties.getConnectRetries()).isEqualTo(configuration.getConnectRetries());
 		assertThat(properties.getDefaultSchema()).isEqualTo(configuration.getDefaultSchema());
 		assertThat(properties.getSchemas()).isEqualTo(Arrays.asList(configuration.getSchemas()));
+		assertThat(properties.isCreateSchemas()).isEqualTo(configuration.getCreateSchemas());
 		assertThat(properties.getTable()).isEqualTo(configuration.getTable());
 		assertThat(properties.getBaselineDescription()).isEqualTo(configuration.getBaselineDescription());
 		assertThat(MigrationVersion.fromVersion(properties.getBaselineVersion()))

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayPropertiesTests.java
@@ -99,7 +99,8 @@ class FlywayPropertiesTests {
 		ignoreProperties(properties, "url", "user", "password", "enabled", "checkLocation", "createDataSource");
 
 		// High level object we can't set with properties
-		ignoreProperties(configuration, "callbacks", "classLoader", "dataSource", "javaMigrations", "resolvers");
+		ignoreProperties(configuration, "callbacks", "classLoader", "dataSource", "javaMigrations",
+				"javaMigrationClassProvider", "resourceProvider", "resolvers");
 		// Properties we don't want to expose
 		ignoreProperties(configuration, "resolversAsClassNames", "callbacksAsClassNames");
 		// Handled by the conversion service
@@ -110,6 +111,8 @@ class FlywayPropertiesTests {
 		ignoreProperties(properties, "initSqls");
 		// Handled as dryRunOutput
 		ignoreProperties(configuration, "dryRunOutputAsFile", "dryRunOutputAsFileName");
+		// Handled as createSchemas
+		ignoreProperties(configuration, "shouldCreateSchemas");
 		List<String> configurationKeys = new ArrayList<>(configuration.keySet());
 		Collections.sort(configurationKeys);
 		List<String> propertiesKeys = new ArrayList<>(properties.keySet());

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -310,7 +310,7 @@ bom {
 			]
 		}
 	}
-	library("Flyway", "6.4.4") {
+	library("Flyway", "6.5.0") {
 		group("org.flywaydb") {
 			modules = [
 				"flyway-core"


### PR DESCRIPTION
This PR upgrades to Flyway 6.5 and adds support for property `flyway.createSchemas`.

See https://flywaydb.org/documentation/releaseNotes#6.5.0.
See https://flywaydb.org/documentation/migrations#toggle-schema-creation.