### PR TITLE
Add StatsD transport protocol configuration option

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdProperties.java
@@ -19,6 +19,7 @@ package org.springframework.boot.actuate.autoconfigure.metrics.export.statsd;
 import java.time.Duration;
 
 import io.micrometer.statsd.StatsdFlavor;
+import io.micrometer.statsd.StatsdProtocol;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -52,6 +53,11 @@ public class StatsdProperties {
 	 * Port of the StatsD server to receive exported metrics.
 	 */
 	private Integer port = 8125;
+
+	/**
+	 * Protocol of the StatsD server to receive exported metrics.
+	 */
+	private StatsdProtocol protocol = StatsdProtocol.UDP;
 
 	/**
 	 * Total length of a single payload should be kept within your network's MTU.
@@ -100,6 +106,14 @@ public class StatsdProperties {
 
 	public void setPort(Integer port) {
 		this.port = port;
+	}
+
+	public StatsdProtocol getProtocol() {
+		return this.protocol;
+	}
+
+	public void setProtocol(StatsdProtocol protocol) {
+		this.protocol = protocol;
 	}
 
 	public Integer getMaxPacketLength() {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapter.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 
 import io.micrometer.statsd.StatsdConfig;
 import io.micrometer.statsd.StatsdFlavor;
+import io.micrometer.statsd.StatsdProtocol;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.PropertiesConfigAdapter;
 
@@ -63,6 +64,11 @@ public class StatsdPropertiesConfigAdapter extends PropertiesConfigAdapter<Stats
 	@Override
 	public int port() {
 		return get(StatsdProperties::getPort, StatsdConfig.super::port);
+	}
+
+	@Override
+	public StatsdProtocol protocol() {
+		return get(StatsdProperties::getProtocol, StatsdConfig.super::protocol);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -464,6 +464,10 @@
       "defaultValue": "datadog"
     },
     {
+      "name": "management.metrics.export.statsd.protocol",
+      "defaultValue": "udp"
+    },
+    {
       "name": "management.metrics.export.statsd.queue-size",
       "defaultValue": 2147483647,
       "deprecation": {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesTests.java
@@ -36,6 +36,7 @@ class StatsdPropertiesTests {
 		assertThat(properties.getFlavor()).isEqualTo(config.flavor());
 		assertThat(properties.getHost()).isEqualTo(config.host());
 		assertThat(properties.getPort()).isEqualTo(config.port());
+		assertThat(properties.getProtocol()).isEqualTo(config.protocol());
 		assertThat(properties.getMaxPacketLength()).isEqualTo(config.maxPacketLength());
 		assertThat(properties.getPollingFrequency()).isEqualTo(config.pollingFrequency());
 		assertThat(properties.isPublishUnchangedMeters()).isEqualTo(config.publishUnchangedMeters());

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
@@ -1764,12 +1764,13 @@ You can also change the interval at which metrics are sent to Stackdriver:
 ==== StatsD
 The StatsD registry pushes metrics over UDP to a StatsD agent eagerly.
 By default, metrics are exported to a {micrometer-registry-docs}/statsd[StatsD] agent running on your local machine.
-The StatsD agent host and port to use can be provided using:
+The StatsD agent host,port, and protocol to use can be provided using:
 
 [source,properties,indent=0,configprops]
 ----
 	management.metrics.export.statsd.host=statsd.example.com
 	management.metrics.export.statsd.port=9125
+	management.metrics.export.statsd.protocol=udp
 ----
 
 You can also change the StatsD line protocol to use (default to Datadog):


### PR DESCRIPTION
This will expose the StatsD transport protocol configuration option as a configuration option for actuator. I have a need to use TCP for exporting StatsD to telegraf, the underlying micrometer library supports using TCP, but it is not yet exposed as a configuration property for Spring Boot.