### PR TITLE
Accept empty filter dispatcher types in auto-configurations

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/SecurityFilterAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/SecurityFilterAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ public class SecurityFilterAutoConfiguration {
 		}
 		return securityProperties.getFilter().getDispatcherTypes().stream()
 				.map((type) -> DispatcherType.valueOf(type.name()))
-				.collect(Collectors.collectingAndThen(Collectors.toSet(), EnumSet::copyOf));
+				.collect(Collectors.toCollection(() -> EnumSet.noneOf(DispatcherType.class)));
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionRepositoryFilterConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionRepositoryFilterConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ class SessionRepositoryFilterConfiguration {
 			return null;
 		}
 		return servletProperties.getFilterDispatcherTypes().stream().map((type) -> DispatcherType.valueOf(type.name()))
-				.collect(Collectors.collectingAndThen(Collectors.toSet(), EnumSet::copyOf));
+				.collect(Collectors.toCollection(() -> EnumSet.noneOf(DispatcherType.class)));
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/servlet/SecurityAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/servlet/SecurityAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,6 +161,19 @@ class SecurityAutoConfigurationTests {
 					EnumSet<DispatcherType> dispatcherTypes = (EnumSet<DispatcherType>) ReflectionTestUtils
 							.getField(bean, "dispatcherTypes");
 					assertThat(dispatcherTypes).containsOnly(DispatcherType.INCLUDE, DispatcherType.ERROR);
+				});
+	}
+
+	@Test
+	void emptyFilterDispatcherTypesDoNotThrowException() {
+		this.contextRunner.withPropertyValues("spring.security.filter.dispatcher-types:")
+				.withConfiguration(AutoConfigurations.of(SecurityFilterAutoConfiguration.class)).run((context) -> {
+					DelegatingFilterProxyRegistrationBean bean = context.getBean("securityFilterChainRegistration",
+							DelegatingFilterProxyRegistrationBean.class);
+					@SuppressWarnings("unchecked")
+					EnumSet<DispatcherType> dispatcherTypes = (EnumSet<DispatcherType>) ReflectionTestUtils
+							.getField(bean, "dispatcherTypes");
+					assertThat(dispatcherTypes).isEmpty();
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
@@ -142,6 +142,17 @@ class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurationTest
 				});
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	void emptyFilterDispatcherTypesDoNotThrowException() {
+		this.contextRunner.withUserConfiguration(SessionRepositoryConfiguration.class)
+				.withPropertyValues("spring.session.servlet.filter-dispatcher-types=").run((context) -> {
+					FilterRegistrationBean<?> registration = context.getBean(FilterRegistrationBean.class);
+					Object dispatcherTypes = ReflectionTestUtils.getField(registration, "dispatcherTypes");
+					assertThat((EnumSet<DispatcherType>) dispatcherTypes).isEmpty();
+				});
+	}
+
 	@Test
 	void sessionCookieConfigurationIsAppliedToAutoConfiguredCookieSerializer() {
 		this.contextRunner.withUserConfiguration(SessionRepositoryConfiguration.class)


### PR DESCRIPTION
Hi,

this PR fixes #22128 by using

- `Collectors.toCollection(() -> EnumSet.noneOf(DispatcherType.class))` rather than
- `Collectors.collectingAndThen(Collectors.toSet(), EnumSet::copyOf)`

to prevent exceptions when the underlying collection is empty.

Let me know what you think.
Cheers,
Christoph