### PR TITLE
TomcatMetricsBinder may log a warning for an NPE if the context is closed before the ApplicationStartedEvent is published

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/tomcat/TomcatMetricsBinder.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/tomcat/TomcatMetricsBinder.java
@@ -86,7 +86,9 @@ public class TomcatMetricsBinder implements ApplicationListener<ApplicationStart
 
 	@Override
 	public void destroy() {
-		this.tomcatMetrics.close();
+		if (null != this.tomcatMetrics) {
+			this.tomcatMetrics.close();
+		}
 	}
 
 }


### PR DESCRIPTION
fix for NPE in my unit test.

````
2020-06-28 10:40:25.832 - org.springframework.beans.factory.support.DisposableBeanAdapter -467378 [SpringContextShutdownHook] WARN  [] - Invocation of destroy method failed on bean with name 'tomcatMetricsBinder': java.lang.NullPointerException
````

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
