### PR TITLE
Remove duplicated icon from git-repo-windows resource definition

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -100,7 +100,6 @@ resources:
     git_config:
     - name: core.autocrlf
       value: true
-  icon: github-circle
 - name: git-pull-request
   type: pull-request
   icon: source-pull


### PR DESCRIPTION
as title.
