### PR TITLE
Fix unwrapping of captured PrintStream in test support's OutputCapture

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/system/OutputCapture.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/system/OutputCapture.java
@@ -194,7 +194,7 @@ class OutputCapture implements CapturedOutput {
 
 		private static PrintStream getSystemStream(PrintStream printStream) {
 			while (printStream instanceof PrintStreamCapture) {
-				return ((PrintStreamCapture) printStream).getParent();
+				printStream = ((PrintStreamCapture) printStream).getParent();
 			}
 			return printStream;
 		}


### PR DESCRIPTION
this should not be like this. I guess you made a mistake here.
if you really get the original work flow, you should use `if` insteadof `while`.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Warning: this fix might be WRONG, so take good care about it.
If your original codes be a typo, and what I fix now is the function you want, that is OK.
But if the original codes works exactly what you want, then you should change `while` to `if`
either of the two fixes should happen.
