### PR TITLE
Upgrade to Maven Shade Plugin 3.2.4

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1127,10 +1127,7 @@ bom {
 			]
 		}
 	}
-	library("Maven Shade Plugin", "3.2.2") {
-		prohibit("3.2.3") {
-			because "https://github.com/spring-projects/spring-boot/issues/21128"
-		}
+	library("Maven Shade Plugin", "3.2.4") {
 		group("org.apache.maven.plugins") {
 			plugins = [
 				"maven-shade-plugin"


### PR DESCRIPTION
This PR updates `maven-shade-plugin` to 3.2.4.


The resource transformer was updated here https://github.com/spring-projects/spring-boot/commit/5e7917e33a142ea41e7e787478182122466d13f1, but the plugin version in `spring-boot-dependencies` was not updated.