### PR TITLE
Incorrect Configuration Validation for mongo AutoConfigurationFactory() 

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoClientFactorySupport.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoClientFactorySupport.java
@@ -76,8 +76,7 @@ public abstract class MongoClientFactorySupport<T> {
 
 	private void validateConfiguration() {
 		if (hasCustomAddress() || hasCustomCredentials() || hasReplicaSet()) {
-			Assert.state(this.properties.getUri() == null,
-					"Invalid mongo configuration, either uri or host/port/credentials/replicaSet must be specified");
+			Assert.isTrue(!hasCustomAddress() && this.properties.getUri() == null, "Invalid mongo uri configuration");
 		}
 	}
 


### PR DESCRIPTION
### The following assertion is incorrect, the behavior of Assert.state is to throw an exception when the expression is false
```
private void validateConfiguration() {
	if (hasCustomAddress() || hasCustomCredentials() || hasReplicaSet()) {
		Assert.state(this.properties.getUri() == null,
		   "Invalid mongo configuration, either uri or host/port/credentials/replicaSet must be specified");
	}
}
```
The code above **throws an exception when the configuration includes a valid mongo-URI**


TLDR;
Assert.state() // tests for the expression to be false. when Assert.state(getURI() == null) is false then Assert.state throws an Exception. 
Also if the configuration hasCustomAddress() then the test for URI should not be considered as a validator option. 

