### PR TITLE
Support configuration of localEntityIdTemplate for a SAML Relying Party

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyProperties.java
@@ -50,12 +50,31 @@ public class Saml2RelyingPartyProperties {
 	 */
 	public static class Registration {
 
+		/**
+		 * Relying party's EntityID.
+		 *
+		 * This value may contain a number of placeholders. They are: baseUrl,
+		 * registrationId, baseScheme, baseHost, and basePort.
+		 *
+		 * The default value is
+		 * {baseUrl}/saml2/service-provider-metadata/{registrationId}.
+		 */
+		private String relyingPartyEntityId = "{baseUrl}/saml2/service-provider-metadata/{registrationId}";
+
 		private final Signing signing = new Signing();
 
 		/**
 		 * Remote SAML Identity Provider.
 		 */
 		private Identityprovider identityprovider = new Identityprovider();
+
+		public String getRelyingPartyEntityId() {
+			return this.relyingPartyEntityId;
+		}
+
+		public void setRelyingPartyEntityId(String entityId) {
+			this.relyingPartyEntityId = entityId;
+		}
 
 		public Signing getSigning() {
 			return this.signing;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyRegistrationConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyRegistrationConfiguration.java
@@ -78,6 +78,7 @@ class Saml2RelyingPartyRegistrationConfiguration {
 				(details) -> details.binding(properties.getIdentityprovider().getSinglesignon().getBinding()));
 		builder.providerDetails((details) -> details.signAuthNRequest(signRequest));
 		builder.credentials((credentials) -> credentials.addAll(asCredentials(properties)));
+		builder.entityId(properties.getRelyingPartyEntityId());
 		return builder.build();
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyAutoConfigurationTests.java
@@ -90,6 +90,7 @@ public class Saml2RelyingPartyAutoConfigurationTests {
 			assertThat(registration.getProviderDetails().isSignAuthNRequest()).isEqualTo(false);
 			assertThat(registration.getSigningCredentials()).isNotNull();
 			assertThat(registration.getVerificationCredentials()).isNotNull();
+			assertThat(registration.getEntityId()).isEqualTo("{baseUrl}/saml2/foo-entity-id");
 		});
 	}
 
@@ -147,7 +148,8 @@ public class Saml2RelyingPartyAutoConfigurationTests {
 				PREFIX + ".foo.identityprovider.singlesignon.binding=post",
 				PREFIX + ".foo.identityprovider.singlesignon.sign-request=false",
 				PREFIX + ".foo.identityprovider.entity-id=https://simplesaml-for-spring-saml.cfapps.io/saml2/idp/metadata.php",
-				PREFIX + ".foo.identityprovider.verification.credentials[0].certificate-location=classpath:saml/certificate-location" };
+				PREFIX + ".foo.identityprovider.verification.credentials[0].certificate-location=classpath:saml/certificate-location",
+				PREFIX + ".foo.relying-party-entity-id={baseUrl}/saml2/foo-entity-id" };
 	}
 
 	private boolean hasFilter(AssertableWebApplicationContext context, Class<? extends Filter> filter) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyPropertiesTests.java
@@ -25,6 +25,7 @@ import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.Saml2MessageBinding;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -85,6 +86,20 @@ class Saml2RelyingPartyPropertiesTests {
 		this.properties.getRegistration().put("simplesamlphp", new Saml2RelyingPartyProperties.Registration());
 		assertThat(this.properties.getRegistration().get("simplesamlphp").getIdentityprovider().getSinglesignon()
 				.isSignRequest()).isEqualTo(true);
+	}
+
+	@Test
+	void customizeRelyingPartyEntityId() {
+		bind("spring.security.saml2.relyingparty.registration.simplesamlphp.relying-party-entity-id",
+				"{baseUrl}/saml2/custom-entity-id");
+		assertThat(this.properties.getRegistration().get("simplesamlphp").getRelyingPartyEntityId())
+				.isEqualTo("{baseUrl}/saml2/custom-entity-id");
+	}
+
+	@Test
+	void customizeRelyingPartyEntityIdDefaultsToServiceProviderMetadata() {
+		assertThat(RelyingPartyRegistration.withRegistrationId("id")).extracting("entityId")
+				.isEqualTo(new Saml2RelyingPartyProperties.Registration().getRelyingPartyEntityId());
 	}
 
 	private void bind(String name, String value) {

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1622,7 +1622,7 @@ bom {
 			]
 		}
 	}
-	library("Spring Security", "5.4.0-M1") {
+	library("Spring Security", "5.4.0-SNAPSHOT") {
 		group("org.springframework.security") {
 			imports = [
 				"spring-security-bom"

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-saml2-service-provider/src/main/resources/application.yml
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-saml2-service-provider/src/main/resources/application.yml
@@ -15,6 +15,7 @@ spring:
               entity-id: simplesaml
               singlesignon:
                 url: https://simplesaml-for-spring-saml/SSOService.php
+            relying-party-entity-id: "{baseUrl}/saml2/simple-relying-party"
           okta:
             signing:
               credentials:


### PR DESCRIPTION
Hi, this PR fixes #20352 by adding support for auto-configuring `RelyingPartyRegistration.localEntityIdTemplate`.

Support for the new property has been added to the top-level `Registration` class, as suggested by @mbhave in https://github.com/spring-projects/spring-boot/issues/20352#issuecomment-593659165.