### PR TITLE
Measure with nanoseconds in HttpExchangeTracer

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/http/HttpExchangeTracer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/http/HttpExchangeTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -68,8 +69,7 @@ public class HttpExchangeTracer {
 	 */
 	public final void sendingResponse(HttpTrace trace, TraceableResponse response, Supplier<Principal> principal,
 			Supplier<String> sessionId) {
-		setIfIncluded(Include.TIME_TAKEN, () -> System.currentTimeMillis() - trace.getTimestamp().toEpochMilli(),
-				trace::setTimeTaken);
+		setIfIncluded(Include.TIME_TAKEN, () -> calculateTimeTaken(trace), trace::setTimeTaken);
 		setIfIncluded(Include.SESSION_ID, sessionId, trace::setSessionId);
 		setIfIncluded(Include.PRINCIPAL, principal, trace::setPrincipal);
 		trace.setResponse(new HttpTrace.Response(new FilteredTraceableResponse(response)));
@@ -100,6 +100,10 @@ public class HttpExchangeTracer {
 		}
 		return headersSupplier.get().entrySet().stream().filter((entry) -> headerPredicate.test(entry.getKey()))
 				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+	}
+
+	private long calculateTimeTaken(HttpTrace trace) {
+		return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - trace.getNanoTime());
 	}
 
 	private final class FilteredTraceableRequest implements TraceableRequest {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/http/HttpTrace.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/http/HttpTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,8 @@ public final class HttpTrace {
 
 	private volatile Long timeTaken;
 
+	private final transient long nanoTime;
+
 	/**
 	 * Creates a fully-configured {@code HttpTrace} instance. Primarily for use by
 	 * {@link HttpTraceRepository} implementations when recreating a trace from a
@@ -67,11 +69,13 @@ public final class HttpTrace {
 		this.principal = principal;
 		this.session = session;
 		this.timeTaken = timeTaken;
+		this.nanoTime = 0;
 	}
 
 	HttpTrace(TraceableRequest request) {
 		this.request = new Request(request);
 		this.timestamp = Instant.now();
+		this.nanoTime = System.nanoTime();
 	}
 
 	public Instant getTimestamp() {
@@ -116,6 +120,10 @@ public final class HttpTrace {
 
 	void setTimeTaken(long timeTaken) {
 		this.timeTaken = timeTaken;
+	}
+
+	long getNanoTime() {
+		return this.nanoTime;
 	}
 
 	/**


### PR DESCRIPTION
Hi,

this PR closes #21742 as discussed by providing a new transient field `nanoTime` in `HttpTrace` and a corresponding package-private accessor, that eventual persistent implementations of `HttpTraceRepository` don't need to care about.

Let me know what you think.

Cheers,
Christoph