### PR TITLE
Fix dead link url and name of the STS download link

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -76,7 +76,7 @@ added after the original pull request but before a merge.
 
 == Working with the Code
 If you don't have an IDE preference we would recommend that you use
-https://spring.io/tools/sts[Spring Tools Suite] or
+https://spring.io/tools[Spring Tool Suite] or
 https://eclipse.org[Eclipse] when working with the code. We use the
 https://projects.eclipse.org/projects/tools.buildship[Buildship] Eclipse plugin for Gradle
 support. Other IDEs and tools should also work without issue.

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -76,7 +76,7 @@ added after the original pull request but before a merge.
 
 == Working with the Code
 If you don't have an IDE preference we would recommend that you use
-https://spring.io/tools[Spring Tool Suite] or
+https://spring.io/tools[Spring Tools] or
 https://eclipse.org[Eclipse] when working with the code. We use the
 https://projects.eclipse.org/projects/tools.buildship[Buildship] Eclipse plugin for Gradle
 support. Other IDEs and tools should also work without issue.


### PR DESCRIPTION
In the CONTRIBUTING documentation the link to the Spring Tool Suite url is a dead link. The url is replaced by the new url where STS can be downloaded.
The name of this link is contains a typo: Tools Suite (with an s after the Tool) instead of Tool Suite.