### PR TITLE
OnClassCondition tries to determine the outcome for single auto-configuration classes in parallel

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnClassCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnClassCondition.java
@@ -49,7 +49,7 @@ class OnClassCondition extends FilteringSpringBootCondition {
 		// Split the work and perform half in a background thread if more than one
 		// processor is available. Using a single additional thread seems to offer the
 		// best performance. More threads make things worse.
-		if (Runtime.getRuntime().availableProcessors() > 1) {
+		if (autoConfigurationClasses.length > 1 && Runtime.getRuntime().availableProcessors() > 1) {
 			return resolveOutcomesThreaded(autoConfigurationClasses, autoConfigurationMetadata);
 		}
 		else {


### PR DESCRIPTION
Hi,

I just noticed that a vanilla Spring-Boot app (with `web`, `security` and `actuator` starters) creates 200+ threads on startup. After a small investigation those threads turned out to be created by `OnClassCondition`. I noticed that threads are created even though the passed `autoConfigurationClasses` array has a length of 1. (Only one invocation in the lifetime of the app has multiple classes passed). In those cases it seems to be wasteful to create threads because the work cannot be split in half, really.

A small benchmark shows the following results:
|       | Baseline |  New  |
| ----- | -------: | ----: |
|       |    2.783 | 2.570 |
|       |    2.811 | 2.562 |
|       |    2.760 | 2.690 |
|       |    2.707 | 2.704 |
|       |    2.732 | 2.576 |
|       |    2.646 | 2.659 |
|       |    2.816 | 2.803 |
|       |    2.847 | 2.578 |
|       |    2.765 | 2.670 |
|       |    2.722 | 2.731 |
|  Mean |    2.759 | 2.654 |
| Range |    0.201 | 0.241 |

Let me know what you think.
Cheers,
Christoph