### PR TITLE
Restructure "Building Container Images" section

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -8186,9 +8186,12 @@ If you need the `Mockk` equivalent of the Mockito specific <<boot-features-testi
 
 
 
+
+== Building Container Images
+Spring Boot applications can be containerized either by <<building-docker-images,packaging them into Docker images>>, or by <<using-buildpacks,using Buildpacks to create docker compatible container images that you can run anywhere>>.
+
 [[building-docker-images]]
-== Building Docker Images
-Spring Boot applications can be containerized by packaging them into Docker images.
+=== Building Docker images
 A typical Spring Boot fat jar can be converted into a Docker image by adding just a few lines to a Dockerfile that can be used to build the image.
 However, there are various downsides to copying and running the fat jar as is in the docker image.
 There’s always a certain amount of overhead when running a fat jar without unpacking it, and in a containerized environment this can be noticeable.
@@ -8196,7 +8199,7 @@ The other issue is that putting your application's code and all its dependencies
 Since you probably recompile your code more often than you upgrade the version of Spring Boot you use, it’s often better to separate things a bit more.
 If you put jar files in the layer before your application classes, Docker often only needs to change the very bottom layer and can pick others up from its cache.
 
-=== Layering Docker Images
+==== Layering Docker Images
 To make it easier to create optimized Docker images that can be built with a dockerfile, Spring Boot supports adding a layer index file to the jar.
 It provides a list of layers and the parts of the jar that should be contained within them.
 The list of layers in the index is ordered based on the order in which the layers should be added to the Docker/OCI image.
@@ -8233,7 +8236,7 @@ For Gradle, refer to the {spring-boot-gradle-plugin-docs}#packaging-layered-jars
 
 
 
-=== Writing the Dockerfile
+==== Writing the Dockerfile
 When you create a jar containing the layers index file, the `spring-boot-jarmode-layertools` jar will be added as a dependency to your jar.
 With this jar on the classpath, you can launch your application in a special mode which allows the bootstrap code to run something entirely different from your application, for example, something that extracts the layers.
 Here’s how you can launch your jar with a `layertools` jar mode:
@@ -8291,7 +8294,7 @@ Of course, a Dockerfile can be written without using the jarmode.
 You can use some combination of `unzip` and `mv` to move things to the right layer but jarmode simplifies that.
 
 
-
+[[using-buildpacks]]
 === Buildpacks
 Dockerfiles are just one way to build docker images.
 Another way to build docker images is directly from your Maven or Gradle plugin, using buildpacks.


### PR DESCRIPTION
This commit attempts to close #22279 by restructuring the sections about creating docker images, in order to add attention to Buildpacks in the introduction of the section.