### PR TITLE
Avoid using reflection when configuring Tomcat's WebSocket support

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/websocket/reactive/TomcatWebSocketReactiveWebServerCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/websocket/reactive/TomcatWebSocketReactiveWebServerCustomizer.java
@@ -16,8 +16,9 @@
 
 package org.springframework.boot.autoconfigure.websocket.reactive;
 
-import org.apache.tomcat.websocket.server.WsContextListener;
+import java.util.Collections;
 
+import org.apache.tomcat.websocket.server.WsSci;
 import org.springframework.boot.web.embedded.tomcat.TomcatReactiveWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.core.Ordered;
@@ -33,7 +34,8 @@ public class TomcatWebSocketReactiveWebServerCustomizer
 
 	@Override
 	public void customize(TomcatReactiveWebServerFactory factory) {
-		factory.addContextCustomizers((context) -> context.addApplicationListener(WsContextListener.class.getName()));
+		factory.addContextCustomizers((context) ->
+				context.addServletContainerInitializer(new WsSci(), Collections.emptySet()));
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/websocket/servlet/TomcatWebSocketServletWebServerCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/websocket/servlet/TomcatWebSocketServletWebServerCustomizer.java
@@ -16,8 +16,9 @@
 
 package org.springframework.boot.autoconfigure.websocket.servlet;
 
-import org.apache.tomcat.websocket.server.WsContextListener;
+import java.util.Collections;
 
+import org.apache.tomcat.websocket.server.WsSci;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.core.Ordered;
@@ -35,7 +36,8 @@ public class TomcatWebSocketServletWebServerCustomizer
 
 	@Override
 	public void customize(TomcatServletWebServerFactory factory) {
-		factory.addContextCustomizers((context) -> context.addApplicationListener(WsContextListener.class.getName()));
+		factory.addContextCustomizers((context) ->
+				context.addServletContainerInitializer(new WsSci(), Collections.emptySet()));
 	}
 
 	@Override


### PR DESCRIPTION
This benefits native image building and AOT compilation,
as reflection requires manual configuration.

The Servlet specification doesn't allow context listeners to programatically add filters/servlets, so I'm changing the code to add a ServletContainerInitializer. This will add the context listener automatically

https://download.oracle.com/otn-pub/jcp/servlet-3.0-fr-eval-oth-JSpec/servlet-3_0-final-spec.pdf (Section 4.4 , Page 30)



