### PR TITLE
Avoid unnecessary allocations in ConditionMessage for NORMAL style

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionMessage.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionMessage.java
@@ -405,6 +405,11 @@ public final class ConditionMessage {
 			protected Object applyToItem(Object item) {
 				return item;
 			}
+
+			@Override
+			public Collection<?> applyTo(Collection<?> items) {
+				return items;
+			}
 		},
 
 		QUOTE {
@@ -415,7 +420,7 @@ public final class ConditionMessage {
 		};
 
 		public Collection<?> applyTo(Collection<?> items) {
-			List<Object> result = new ArrayList<>();
+			List<Object> result = new ArrayList<>(items.size());
 			for (Object item : items) {
 				result.add(applyToItem(item));
 			}


### PR DESCRIPTION
Hi,

I noticed a small possible improvement in `ConditionMessage`. When the `NORMAL` style is used, nothing really happens to the applied items, so it is not necessary to create a new `ArrayList` to copy things. Instead the initial collection can be used.

Cheers,
Christoph

P.S.: While working on this, I noticed that the several `items` methods specify the following:
```@param items the source of the items (may be {@code null})```
Yet, the default `applyTo` method in `Style` would throw an NPE in case null is passed. Do you want me to open another PR to fix this or should I do another commit in this one to fix things?