### PR TITLE
ConditionMessage#items throws an NPE with a null list of items although the Javadoc states it is tolerated

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionMessage.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionMessage.java
@@ -381,7 +381,8 @@ public final class ConditionMessage {
 			Assert.notNull(style, "Style must not be null");
 			StringBuilder message = new StringBuilder(this.reason);
 			items = style.applyTo(items);
-			if ((this.condition == null || items.size() <= 1) && StringUtils.hasLength(this.singular)) {
+			if ((this.condition == null || items == null || items.size() <= 1)
+					&& StringUtils.hasLength(this.singular)) {
 				message.append(" ").append(this.singular);
 			}
 			else if (StringUtils.hasLength(this.plural)) {
@@ -420,6 +421,9 @@ public final class ConditionMessage {
 		};
 
 		public Collection<?> applyTo(Collection<?> items) {
+			if (items == null) {
+				return null;
+			}
 			List<Object> result = new ArrayList<>(items.size());
 			for (Object item : items) {
 				result.add(applyToItem(item));

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionMessageTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionMessageTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionMessageTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionMessageTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.condition;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -186,6 +187,21 @@ class ConditionMessageTests {
 	void availableShouldConstructMessage() {
 		ConditionMessage message = ConditionMessage.forCondition(Test.class).available("JMX");
 		assertThat(message.toString()).isEqualTo("@Test JMX is available");
+	}
+
+	@Test
+	void itemsTolerateNullInput() {
+		Collection<?> items = null;
+		ConditionMessage message = ConditionMessage.forCondition(Test.class).didNotFind("item").items(items);
+		assertThat(message.toString()).isEqualTo("@Test did not find item");
+	}
+
+	@Test
+	void quotedItemsTolerateNullInput() {
+		Collection<?> items = null;
+		ConditionMessage message = ConditionMessage.forCondition(Test.class).didNotFind("item").items(Style.QUOTE,
+				items);
+		assertThat(message.toString()).isEqualTo("@Test did not find item");
 	}
 
 }


### PR DESCRIPTION
Hi,

as noted in #22330 the several `items` methods in `ConditionMessage` state that the passed items might be null.
```
* @param items the source of the items (may be {@code null})
```
Yet, currently they would thrown a NPE if `null` would be passed. This PR fixes that.

Cheers,
Christoph