### PR TITLE
Document that Java 15 is a supported version

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/getting-started.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/getting-started.adoc
@@ -29,7 +29,7 @@ Our primary goals are:
 
 [[getting-started-system-requirements]]
 == System Requirements
-Spring Boot {spring-boot-version} requires https://www.java.com[Java 8] and is compatible up to Java 14 (included).
+Spring Boot {spring-boot-version} requires https://www.java.com[Java 8] and is compatible up to Java 15 (included).
 {spring-framework-docs}/[Spring Framework {spring-framework-version}] or above is also required.
 
 Explicit build support is provided for the following build tools:


### PR DESCRIPTION
Hi,

when working on JDK 15 support, I apparently forgot to adjust the system requirements section in the "Getting started" docs.
This PR adjusts that.

Cheers,
Christoph