### PR TITLE
Allow EntityScanner to be configured to scan for interfaces and abstract classes

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/domain/scan/a/AbstractEntityA.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/domain/scan/a/AbstractEntityA.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.domain.scan.a;
+
+import javax.persistence.Entity;
+
+@Entity
+public abstract class AbstractEntityA {
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/domain/scan/a/InterfaceEntityA.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/domain/scan/a/InterfaceEntityA.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.domain.scan.a;
+
+import javax.persistence.Entity;
+
+@Entity
+public interface InterfaceEntityA {
+
+}


### PR DESCRIPTION
The EntityScanner, used by Spring Boot starter implementations to correct discover domain objects with specific annotations (such as `@Entity`, `@PlanningEntity`, etc), **only scans for concrete classes**, not for abstract classes nor interfaces.
Some starter implementations (such as the optaplanner one) need to scan for abstract classes and interfaces too.

This change allows them to do that, by enabling it with a constructor parameter (it's still excluding them by default), so they don't have to duplicate the EntityScanner logic (so they remain compatible with future Spring Boot releases).