### PR TITLE
Remove redundant compiler arguments in Gradle build files

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -147,14 +147,6 @@ dependencies {
 	testRuntimeOnly("org.springframework.security:spring-security-saml2-service-provider")
 }
 
-compileJava {
-	options.compilerArgs << "-parameters"
-}
-
-compileTestJava {
-	options.compilerArgs << "-parameters"
-}
-
 test {
 	outputs.dir("${buildDir}/generated-snippets")
 }

--- a/spring-boot-project/spring-boot-actuator/build.gradle
+++ b/spring-boot-project/spring-boot-actuator/build.gradle
@@ -90,11 +90,3 @@ dependencies {
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	testRuntimeOnly("org.hsqldb:hsqldb")
 }
-
-compileJava {
-	options.compilerArgs << "-parameters"
-}
-
-compileTestJava {
-	options.compilerArgs << "-parameters"
-}

--- a/spring-boot-project/spring-boot-test-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-test-autoconfigure/build.gradle
@@ -82,14 +82,6 @@ dependencies {
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
-compileJava {
-	options.compilerArgs << "-parameters"
-}
-
-compileTestJava {
-	options.compilerArgs << "-parameters"
-}
-
 test {
 	include "**/*Tests.class"
 }


### PR DESCRIPTION
Hi,

this PR removes redundant compiler arguments in `build.gradle` files. The `-parameters` option is already applied via the `JavaConventions` plugin, so there is no need for it to be configured twice.

Cheers,
Christoph