### PR TITLE
Add generated-snippets as output to test goal

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/pom.xml
@@ -734,4 +734,56 @@
 			</build>
 		</profile>
 	</profiles>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.gradle</groupId>
+				<artifactId>gradle-enterprise-maven-extension</artifactId>
+				<configuration>
+					<gradleEnterprise>
+						<plugins>
+							<plugin>
+								<artifactId>maven-surefire-plugin</artifactId>
+								<executions>
+									<execution>
+										<id>default-test</id>
+										<outputs>
+											<directories>
+												<directory>
+													<name>generated-snippets</name>
+													<path>${project.basedir}/target/generated-snippets</path>
+												</directory>
+											</directories>
+										</outputs>
+									</execution>
+								</executions>
+							</plugin>
+							<plugin>
+								<artifactId>asciidoctor-maven-plugin</artifactId>
+								<executions>
+									<execution>
+										<id>generate-html-documentation</id>
+										<inputs>
+											<fileSets>
+												<fileSet>
+													<name>generated-snippets</name>
+													<paths>
+														<path>${project.basedir}/target/generated-snippets</path>
+													</paths>
+													<includes>
+														<include>**/*</include>
+													</includes>
+													<normalization>RELATIVE_PATH</normalization>
+												</fileSet>
+											</fileSets>
+										</inputs>
+									</execution>
+								</executions>
+							</plugin>
+						</plugins>
+					</gradleEnterprise>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
The generated snippets were not declared as an output to the `spring-boot-actuator-autoconfigure` test goal so when the test was pulled from the cache, it did not contain the `generated-snippets` directory. This directory is required as an input to the asciidoctor plugin. This also declares that directory as an input to the asciidoctor plugin.

Note: This adds the `generated-snippets` directory as an output to _all_ the `default-test` goals.