### PR TITLE
Add condition that checks for the presence of a configurable annotation

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/AbstractAnnotationCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/AbstractAnnotationCondition.java
@@ -16,13 +16,13 @@
 
 package org.springframework.boot.autoconfigure.condition;
 
-import org.springframework.context.annotation.Condition;
-import org.springframework.context.annotation.ConditionContext;
-import org.springframework.core.type.AnnotatedTypeMetadata;
-
 import java.lang.annotation.Annotation;
 import java.util.Map;
 import java.util.Objects;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
  * Abstract base class for annotation conditions.

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/AbstractAnnotationCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/AbstractAnnotationCondition.java
@@ -14,32 +14,34 @@ import java.util.Objects;
  */
 abstract class AbstractAnnotationCondition implements Condition {
 
-    protected static final String VALUE_ATTRIBUTE = "value";
+	protected static final String VALUE_ATTRIBUTE = "value";
 
-    private Map<String, Object> attributes;
+	private Map<String, Object> attributes;
 
-    protected abstract Class<? extends Annotation> annotationClass();
+	protected abstract Class<? extends Annotation> annotationClass();
 
-    protected Map<String, Object> getAnnotationAttributes(AnnotatedTypeMetadata metadata) {
-        if (attributes == null) {
-            final Map<String, Object> attributes = metadata.getAnnotationAttributes(annotationClass().getName());
-            assert attributes != null;
-            this.attributes = attributes;
-        }
-        return attributes;
-    }
+	protected Map<String, Object> getAnnotationAttributes(AnnotatedTypeMetadata metadata) {
+		if (attributes == null) {
+			final Map<String, Object> attributes = metadata.getAnnotationAttributes(annotationClass().getName());
+			assert attributes != null;
+			this.attributes = attributes;
+		}
+		return attributes;
+	}
 
-    @SuppressWarnings("unchecked")
-    protected <T> T getAttribute(AnnotatedTypeMetadata metadata, String attributeName) {
-        return (T) getAnnotationAttributes(metadata).get(attributeName);
-    }
+	@SuppressWarnings("unchecked")
+	protected <T> T getAttribute(AnnotatedTypeMetadata metadata, String attributeName) {
+		return (T) getAnnotationAttributes(metadata).get(attributeName);
+	}
 
-    @SuppressWarnings("unchecked")
-    protected <T> T getValue(AnnotatedTypeMetadata metadata) {
-        return (T) getAttribute(metadata, VALUE_ATTRIBUTE);
-    }
+	@SuppressWarnings("unchecked")
+	protected <T> T getValue(AnnotatedTypeMetadata metadata) {
+		return (T) getAttribute(metadata, VALUE_ATTRIBUTE);
+	}
 
-    protected Map<String, Object> getBeansWithAnnotation(ConditionContext context, Class<? extends Annotation> annotationClass) {
-        return Objects.requireNonNull(context.getBeanFactory()).getBeansWithAnnotation(annotationClass);
-    }
+	protected Map<String, Object> getBeansWithAnnotation(ConditionContext context,
+			Class<? extends Annotation> annotationClass) {
+		return Objects.requireNonNull(context.getBeanFactory()).getBeansWithAnnotation(annotationClass);
+	}
+
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/AbstractAnnotationCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/AbstractAnnotationCondition.java
@@ -1,0 +1,45 @@
+package org.springframework.boot.autoconfigure.condition;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author Vimalraj Chandra Sekaran (Github: rajvimalc)
+ * @since 2.3.2
+ */
+abstract class AbstractAnnotationCondition implements Condition {
+
+    protected static final String VALUE_ATTRIBUTE = "value";
+
+    private Map<String, Object> attributes;
+
+    protected abstract Class<? extends Annotation> annotationClass();
+
+    protected Map<String, Object> getAnnotationAttributes(AnnotatedTypeMetadata metadata) {
+        if (attributes == null) {
+            final Map<String, Object> attributes = metadata.getAnnotationAttributes(annotationClass().getName());
+            assert attributes != null;
+            this.attributes = attributes;
+        }
+        return attributes;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T> T getAttribute(AnnotatedTypeMetadata metadata, String attributeName) {
+        return (T) getAnnotationAttributes(metadata).get(attributeName);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T> T getValue(AnnotatedTypeMetadata metadata) {
+        return (T) getAttribute(metadata, VALUE_ATTRIBUTE);
+    }
+
+    protected Map<String, Object> getBeansWithAnnotation(ConditionContext context, Class<? extends Annotation> annotationClass) {
+        return Objects.requireNonNull(context.getBeanFactory()).getBeansWithAnnotation(annotationClass);
+    }
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/AbstractAnnotationCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/AbstractAnnotationCondition.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.autoconfigure.condition;
 
 import org.springframework.context.annotation.Condition;
@@ -9,10 +25,12 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
+ * Abstract base class for annotation conditions.
+ *
  * @author Vimalraj Chandra Sekaran (Github: rajvimalc)
- * @since 2.3.2
+ * @since 2.4.0
  */
-abstract class AbstractAnnotationCondition implements Condition {
+public abstract class AbstractAnnotationCondition implements Condition {
 
 	protected static final String VALUE_ATTRIBUTE = "value";
 
@@ -21,12 +39,12 @@ abstract class AbstractAnnotationCondition implements Condition {
 	protected abstract Class<? extends Annotation> annotationClass();
 
 	protected Map<String, Object> getAnnotationAttributes(AnnotatedTypeMetadata metadata) {
-		if (attributes == null) {
+		if (this.attributes == null) {
 			final Map<String, Object> attributes = metadata.getAnnotationAttributes(annotationClass().getName());
 			assert attributes != null;
 			this.attributes = attributes;
 		}
-		return attributes;
+		return this.attributes;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotation.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotation.java
@@ -16,13 +16,13 @@
 
 package org.springframework.boot.autoconfigure.condition;
 
-import org.springframework.context.annotation.Conditional;
-
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Conditional;
 
 /**
  * Indicates the Annotation class(es) which need to be checked on the main boot class

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotation.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotation.java
@@ -1,0 +1,74 @@
+package org.springframework.boot.autoconfigure.condition;
+
+import org.springframework.context.annotation.Conditional;
+
+import java.lang.annotation.*;
+
+/**
+ * Indicates the Annotation class(es) which need to be checked on the main boot class annotated with @SpringBootApplication.
+ * Usage Examples:
+ *  1.	@ConditionalOnAnnotation(EnableAsync.class)
+ *  2.	@ConditionalOnAnnotation({ EnableAsync.class, EnableCaching.class })
+ *  3.	@ConditionalOnAnnotation(
+ *  		value = { EnableAsync.class, EnableCaching.class },
+ *  		conditionType = ConditionalOnAnnotation.ConditionType.AND
+ *  	)
+ *
+ * This Annotation will be useful when making a AutoConfiguration class as conditional.
+ *
+ * <p>
+ * When placed on a {@code @Configuration} class, the configuration takes place only when the specified annotation
+ * is present on main spring boot class.
+ *
+ * <pre class="code">
+ * &#064;Configuration
+ * &#064;ConditionalOnAnnotation(EnableAsync.class)
+ * public class MyAutoConfiguration {
+ *
+ *     &#064;Bean
+ *     public MyService myService() {
+ *         ...
+ *     }
+ * }</pre>
+ * <p>
+ *
+ *
+ * <p>
+ * When placed on a {@code @Bean} method, the bean is created only when the specified annotation is present
+ * on main spring boot class.
+ *
+ * <pre class="code">
+ * &#064;Configuration
+ * public class MyAppConfiguration {
+ *
+ *     &#064;ConditionalOnAnnotation(EnableAsync.class)
+ *     &#064;Bean
+ *     public MyService myService() {
+ *         ...
+ *     }
+ * }</pre>
+ * <p>
+ *
+ * @author Vimalraj Chandra Sekaran (Github: rajvimalc)
+ * @since 2.3.2
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Conditional(OnAnnotationCondition.class)
+public @interface ConditionalOnAnnotation {
+
+    /**
+     * Minimum 1 Annotation type class should be provided.
+     */
+    Class<? extends Annotation>[] value();
+
+    /**
+     * When ConditionType is OR, the condition is true when any one of the annotations mentioned is present.
+     * When ConditionType is AND, the condition is true when all of the annotations mentioned are present.
+     */
+    ConditionType conditionType() default ConditionType.OR;
+
+    enum ConditionType {
+        OR, AND
+    }
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotation.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotation.java
@@ -1,8 +1,28 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.autoconfigure.condition;
 
 import org.springframework.context.annotation.Conditional;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Indicates the Annotation class(es) which need to be checked on the main boot class
@@ -48,7 +68,7 @@ import java.lang.annotation.*;
  * }</pre>
  *
  * @author Vimalraj Chandra Sekaran (Github: rajvimalc)
- * @since 2.3.2
+ * @since 2.4.0
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotation.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotation.java
@@ -5,7 +5,11 @@ import org.springframework.context.annotation.Conditional;
 import java.lang.annotation.*;
 
 /**
- * Indicates the Annotation class(es) which need to be checked on the main boot class annotated with @SpringBootApplication.
+ * Indicates the Annotation class(es) which need to be checked on the main boot class
+ * annotated with @SpringBootApplication. @ConditionalOnAnnotation annotation should work on
+ * any @Configuration class, but the order of loading is not guaranteed. So annotating at @SpringBootApplication
+ * main class makes sure this bean is loaded by the time the condition is evaluated.
+ *
  * Usage Examples:
  *  1.	@ConditionalOnAnnotation(EnableAsync.class)
  *  2.	@ConditionalOnAnnotation({ EnableAsync.class, EnableCaching.class })

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotation.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotation.java
@@ -18,7 +18,6 @@ import java.lang.annotation.*;
  *
  * This Annotation will be useful when making a AutoConfiguration class as conditional.
  *
- * <p>
  * When placed on a {@code @Configuration} class, the configuration takes place only when
  * the specified annotation is present on main spring boot class.
  *
@@ -32,10 +31,8 @@ import java.lang.annotation.*;
  *         ...
  *     }
  * }</pre>
- * <p>
  *
  *
- * <p>
  * When placed on a {@code @Bean} method, the bean is created only when the specified
  * annotation is present on main spring boot class.
  *
@@ -49,7 +46,6 @@ import java.lang.annotation.*;
  *         ...
  *     }
  * }</pre>
- * <p>
  *
  * @author Vimalraj Chandra Sekaran (Github: rajvimalc)
  * @since 2.3.2
@@ -61,6 +57,7 @@ public @interface ConditionalOnAnnotation {
 
 	/**
 	 * Minimum 1 Annotation type class should be provided.
+	 * @return the classes that must be present
 	 */
 	Class<? extends Annotation>[] value();
 
@@ -68,6 +65,7 @@ public @interface ConditionalOnAnnotation {
 	 * When ConditionType is OR, the condition is true when any one of the annotations
 	 * mentioned is present. When ConditionType is AND, the condition is true when all of
 	 * the annotations mentioned are present.
+	 * @return the ConditionType to be evaluated
 	 */
 	ConditionType conditionType() default ConditionType.OR;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotation.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotation.java
@@ -6,23 +6,21 @@ import java.lang.annotation.*;
 
 /**
  * Indicates the Annotation class(es) which need to be checked on the main boot class
- * annotated with @SpringBootApplication. @ConditionalOnAnnotation annotation should work on
- * any @Configuration class, but the order of loading is not guaranteed. So annotating at @SpringBootApplication
- * main class makes sure this bean is loaded by the time the condition is evaluated.
+ * annotated with @SpringBootApplication. @ConditionalOnAnnotation annotation should work
+ * on any @Configuration class, but the order of loading is not guaranteed. So annotating
+ * at @SpringBootApplication main class makes sure this bean is loaded by the time the
+ * condition is evaluated.
  *
- * Usage Examples:
- *  1.	@ConditionalOnAnnotation(EnableAsync.class)
- *  2.	@ConditionalOnAnnotation({ EnableAsync.class, EnableCaching.class })
- *  3.	@ConditionalOnAnnotation(
- *  		value = { EnableAsync.class, EnableCaching.class },
- *  		conditionType = ConditionalOnAnnotation.ConditionType.AND
- *  	)
+ * Usage Examples: 1. @ConditionalOnAnnotation(EnableAsync.class)
+ * 2. @ConditionalOnAnnotation({ EnableAsync.class, EnableCaching.class })
+ * 3. @ConditionalOnAnnotation( value = { EnableAsync.class, EnableCaching.class },
+ * conditionType = ConditionalOnAnnotation.ConditionType.AND )
  *
  * This Annotation will be useful when making a AutoConfiguration class as conditional.
  *
  * <p>
- * When placed on a {@code @Configuration} class, the configuration takes place only when the specified annotation
- * is present on main spring boot class.
+ * When placed on a {@code @Configuration} class, the configuration takes place only when
+ * the specified annotation is present on main spring boot class.
  *
  * <pre class="code">
  * &#064;Configuration
@@ -38,8 +36,8 @@ import java.lang.annotation.*;
  *
  *
  * <p>
- * When placed on a {@code @Bean} method, the bean is created only when the specified annotation is present
- * on main spring boot class.
+ * When placed on a {@code @Bean} method, the bean is created only when the specified
+ * annotation is present on main spring boot class.
  *
  * <pre class="code">
  * &#064;Configuration
@@ -61,18 +59,22 @@ import java.lang.annotation.*;
 @Conditional(OnAnnotationCondition.class)
 public @interface ConditionalOnAnnotation {
 
-    /**
-     * Minimum 1 Annotation type class should be provided.
-     */
-    Class<? extends Annotation>[] value();
+	/**
+	 * Minimum 1 Annotation type class should be provided.
+	 */
+	Class<? extends Annotation>[] value();
 
-    /**
-     * When ConditionType is OR, the condition is true when any one of the annotations mentioned is present.
-     * When ConditionType is AND, the condition is true when all of the annotations mentioned are present.
-     */
-    ConditionType conditionType() default ConditionType.OR;
+	/**
+	 * When ConditionType is OR, the condition is true when any one of the annotations
+	 * mentioned is present. When ConditionType is AND, the condition is true when all of
+	 * the annotations mentioned are present.
+	 */
+	ConditionType conditionType() default ConditionType.OR;
 
-    enum ConditionType {
-        OR, AND
-    }
+	enum ConditionType {
+
+		OR, AND
+
+	}
+
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnAnnotationCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnAnnotationCondition.java
@@ -1,0 +1,68 @@
+package org.springframework.boot.autoconfigure.condition;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+/**
+ * @author Vimalraj Chandra Sekaran (Github: rajvimalc)
+ * @since 2.3.2
+ */
+class OnAnnotationCondition extends AbstractAnnotationCondition {
+
+    private static final Logger log = LoggerFactory.getLogger(OnAnnotationCondition.class);
+
+    private static final String CONDITION_TYPE_ATTRIBUTE = "conditionType";
+
+    @Override
+    public Class<? extends Annotation> annotationClass() {
+        return ConditionalOnAnnotation.class;
+    }
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+
+        final Class<? extends Annotation>[] annotatedClasses = getValue(metadata);
+
+        if(ArrayUtils.isEmpty(annotatedClasses)) {
+			log.warn("@ConditionalOnAnnotation should be annotated with " +
+					"minimum 1 Annotation type classes. Making the condition as true.");
+			return true;
+        }
+
+		final ConditionalOnAnnotation.ConditionType conditionType = getAttribute(metadata, CONDITION_TYPE_ATTRIBUTE);
+
+        return conditionType == ConditionalOnAnnotation.ConditionType.OR
+				? onOrConditionType(context, annotatedClasses)
+				: onAndConditionType(context, annotatedClasses);
+    }
+
+    protected boolean onOrConditionType(ConditionContext context, Class<? extends Annotation>[] annotatedClasses) {
+        for (Class<? extends Annotation> annotatedClass : annotatedClasses) {
+            final Map<String, Object> candidates = getBeansWithAnnotation(context, annotatedClass);
+
+            // Return true if any one of the annotation classes is present
+            if(!candidates.isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+	protected boolean onAndConditionType(ConditionContext context, Class<? extends Annotation>[] annotatedClasses) {
+        for (Class<? extends Annotation> annotatedClass : annotatedClasses) {
+            final Map<String, Object> candidates = getBeansWithAnnotation(context, annotatedClass);
+
+            // Return false if any one of the annotation classes is not present
+            if(candidates.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnAnnotationCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnAnnotationCondition.java
@@ -16,15 +16,16 @@
 
 package org.springframework.boot.autoconfigure.condition;
 
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
-
-import java.lang.annotation.Annotation;
-import java.util.Map;
 
 /**
  * {@link Condition} that checks for the presence or absence of specific annotations.
@@ -34,9 +35,9 @@ import java.util.Map;
  */
 public class OnAnnotationCondition extends AbstractAnnotationCondition {
 
-	private final Log log = LogFactory.getLog(getClass());
-
 	private static final String CONDITION_TYPE_ATTRIBUTE = "conditionType";
+
+	private final Log log = LogFactory.getLog(getClass());
 
 	@Override
 	public Class<? extends Annotation> annotationClass() {
@@ -49,7 +50,7 @@ public class OnAnnotationCondition extends AbstractAnnotationCondition {
 		final Class<? extends Annotation>[] annotatedClasses = getValue(metadata);
 
 		if (ArrayUtils.isEmpty(annotatedClasses)) {
-			log.warn("@ConditionalOnAnnotation should be annotated with "
+			this.log.warn("@ConditionalOnAnnotation should be annotated with "
 					+ "minimum 1 Annotation type classes. Making the condition as true.");
 			return true;
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnAnnotationCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnAnnotationCondition.java
@@ -15,54 +15,54 @@ import java.util.Map;
  */
 class OnAnnotationCondition extends AbstractAnnotationCondition {
 
-    private static final Logger log = LoggerFactory.getLogger(OnAnnotationCondition.class);
+	private static final Logger log = LoggerFactory.getLogger(OnAnnotationCondition.class);
 
-    private static final String CONDITION_TYPE_ATTRIBUTE = "conditionType";
+	private static final String CONDITION_TYPE_ATTRIBUTE = "conditionType";
 
-    @Override
-    public Class<? extends Annotation> annotationClass() {
-        return ConditionalOnAnnotation.class;
-    }
+	@Override
+	public Class<? extends Annotation> annotationClass() {
+		return ConditionalOnAnnotation.class;
+	}
 
-    @Override
-    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+	@Override
+	public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
 
-        final Class<? extends Annotation>[] annotatedClasses = getValue(metadata);
+		final Class<? extends Annotation>[] annotatedClasses = getValue(metadata);
 
-        if(ArrayUtils.isEmpty(annotatedClasses)) {
-			log.warn("@ConditionalOnAnnotation should be annotated with " +
-					"minimum 1 Annotation type classes. Making the condition as true.");
+		if (ArrayUtils.isEmpty(annotatedClasses)) {
+			log.warn("@ConditionalOnAnnotation should be annotated with "
+					+ "minimum 1 Annotation type classes. Making the condition as true.");
 			return true;
-        }
+		}
 
 		final ConditionalOnAnnotation.ConditionType conditionType = getAttribute(metadata, CONDITION_TYPE_ATTRIBUTE);
 
-        return conditionType == ConditionalOnAnnotation.ConditionType.OR
-				? onOrConditionType(context, annotatedClasses)
+		return conditionType == ConditionalOnAnnotation.ConditionType.OR ? onOrConditionType(context, annotatedClasses)
 				: onAndConditionType(context, annotatedClasses);
-    }
+	}
 
-    protected boolean onOrConditionType(ConditionContext context, Class<? extends Annotation>[] annotatedClasses) {
-        for (Class<? extends Annotation> annotatedClass : annotatedClasses) {
-            final Map<String, Object> candidates = getBeansWithAnnotation(context, annotatedClass);
+	protected boolean onOrConditionType(ConditionContext context, Class<? extends Annotation>[] annotatedClasses) {
+		for (Class<? extends Annotation> annotatedClass : annotatedClasses) {
+			final Map<String, Object> candidates = getBeansWithAnnotation(context, annotatedClass);
 
-            // Return true if any one of the annotation classes is present
-            if(!candidates.isEmpty()) {
-                return true;
-            }
-        }
-        return false;
-    }
+			// Return true if any one of the annotation classes is present
+			if (!candidates.isEmpty()) {
+				return true;
+			}
+		}
+		return false;
+	}
 
 	protected boolean onAndConditionType(ConditionContext context, Class<? extends Annotation>[] annotatedClasses) {
-        for (Class<? extends Annotation> annotatedClass : annotatedClasses) {
-            final Map<String, Object> candidates = getBeansWithAnnotation(context, annotatedClass);
+		for (Class<? extends Annotation> annotatedClass : annotatedClasses) {
+			final Map<String, Object> candidates = getBeansWithAnnotation(context, annotatedClass);
 
-            // Return false if any one of the annotation classes is not present
-            if(candidates.isEmpty()) {
-                return false;
-            }
-        }
-        return true;
-    }
+			// Return false if any one of the annotation classes is not present
+			if (candidates.isEmpty()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnAnnotationCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnAnnotationCondition.java
@@ -1,8 +1,25 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.autoconfigure.condition;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
@@ -10,12 +27,14 @@ import java.lang.annotation.Annotation;
 import java.util.Map;
 
 /**
+ * {@link Condition} that checks for the presence or absence of specific annotations.
+ *
  * @author Vimalraj Chandra Sekaran (Github: rajvimalc)
- * @since 2.3.2
+ * @since 2.4.0
  */
-class OnAnnotationCondition extends AbstractAnnotationCondition {
+public class OnAnnotationCondition extends AbstractAnnotationCondition {
 
-	private static final Logger log = LoggerFactory.getLogger(OnAnnotationCondition.class);
+	private final Log log = LogFactory.getLog(getClass());
 
 	private static final String CONDITION_TYPE_ATTRIBUTE = "conditionType";
 
@@ -37,8 +56,8 @@ class OnAnnotationCondition extends AbstractAnnotationCondition {
 
 		final ConditionalOnAnnotation.ConditionType conditionType = getAttribute(metadata, CONDITION_TYPE_ATTRIBUTE);
 
-		return conditionType == ConditionalOnAnnotation.ConditionType.OR ? onOrConditionType(context, annotatedClasses)
-				: onAndConditionType(context, annotatedClasses);
+		return (conditionType == ConditionalOnAnnotation.ConditionType.OR)
+				? onOrConditionType(context, annotatedClasses) : onAndConditionType(context, annotatedClasses);
 	}
 
 	protected boolean onOrConditionType(ConditionContext context, Class<? extends Annotation>[] annotatedClasses) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotationTests.java
@@ -35,75 +35,60 @@ class ConditionalOnAnnotationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
 
-
 	// Tests
 
 	@Test
 	void testAnnotationAtConfigurationWhenPresent() {
-		this.contextRunner.withUserConfiguration(
-				DefaultSpringBootConfiguration.class,
-				MyAutoConfiguration.class,
-				MyAppConfiguration.class
-		).run(context -> this.hasBean(context, "exampleBean1"));
+		this.contextRunner.withUserConfiguration(DefaultSpringBootConfiguration.class, MyAutoConfiguration.class,
+				MyAppConfiguration.class).run(context -> this.hasBean(context, "exampleBean1"));
 	}
 
 	@Test
 	void testAnnotationAtBeanWhenPresent() {
-		this.contextRunner.withUserConfiguration(
-				DefaultSpringBootConfiguration.class,
-				MyAutoConfiguration.class,
-				MyAppConfiguration.class
-		).run(context -> this.hasBean(context, "exampleBean2"));
+		this.contextRunner.withUserConfiguration(DefaultSpringBootConfiguration.class, MyAutoConfiguration.class,
+				MyAppConfiguration.class).run(context -> this.hasBean(context, "exampleBean2"));
 	}
 
 	@Test
 	void testAnnotationAtConfigurationWhenNotPresent() {
-		this.contextRunner.withUserConfiguration(
-				DefaultSpringBootConfiguration.class,
-				MyAutoConfigurationNotPresent.class,
-				MyAppConfigurationNotPresent.class
-		).run(context -> assertThat(context).doesNotHaveBean("exampleBean3"));
+		this.contextRunner
+				.withUserConfiguration(DefaultSpringBootConfiguration.class, MyAutoConfigurationNotPresent.class,
+						MyAppConfigurationNotPresent.class)
+				.run(context -> assertThat(context).doesNotHaveBean("exampleBean3"));
 	}
 
 	@Test
 	void testAnnotationAtBeanWhenNotPresent() {
-		this.contextRunner.withUserConfiguration(
-				DefaultSpringBootConfiguration.class,
-				MyAutoConfigurationNotPresent.class,
-				MyAppConfigurationNotPresent.class
-		).run(context -> assertThat(context).doesNotHaveBean("exampleBean4"));
+		this.contextRunner
+				.withUserConfiguration(DefaultSpringBootConfiguration.class, MyAutoConfigurationNotPresent.class,
+						MyAppConfigurationNotPresent.class)
+				.run(context -> assertThat(context).doesNotHaveBean("exampleBean4"));
 	}
 
 	@Test
 	void testMultipleAnnotationsWhenPresentForAND() {
-		this.contextRunner.withUserConfiguration(
-				MultipleAnnotationsSpringBootConfiguration.class,
-				MultipleAnnotationsConfiguration.class
-		).run(context -> this.hasBean(context, "exampleBean5"));
+		this.contextRunner.withUserConfiguration(MultipleAnnotationsSpringBootConfiguration.class,
+				MultipleAnnotationsConfiguration.class).run(context -> this.hasBean(context, "exampleBean5"));
 	}
 
 	@Test
 	void testMultipleAnnotationsWhenPresentForOR() {
-		this.contextRunner.withUserConfiguration(
-				MultipleAnnotationsSpringBootConfiguration.class,
-				MultipleAnnotationsConfiguration.class
-		).run(context -> this.hasBean(context, "exampleBean6"));
+		this.contextRunner.withUserConfiguration(MultipleAnnotationsSpringBootConfiguration.class,
+				MultipleAnnotationsConfiguration.class).run(context -> this.hasBean(context, "exampleBean6"));
 	}
 
 	@Test
 	void testMultipleAnnotationsWhenNotPresentForAND() {
-		this.contextRunner.withUserConfiguration(
-				MultipleAnnotationsSpringBootConfiguration.class,
-				MultipleAnnotationsConfiguration.class
-		).run(context -> assertThat(context).doesNotHaveBean("exampleBean7"));
+		this.contextRunner
+				.withUserConfiguration(MultipleAnnotationsSpringBootConfiguration.class,
+						MultipleAnnotationsConfiguration.class)
+				.run(context -> assertThat(context).doesNotHaveBean("exampleBean7"));
 	}
 
 	@Test
 	void testMultipleAnnotationsWhenNotPresentForOR() {
-		this.contextRunner.withUserConfiguration(
-				MultipleAnnotationsSpringBootConfiguration.class,
-				MultipleAnnotationsConfiguration.class
-		).run(context -> this.hasBean(context, "exampleBean8"));
+		this.contextRunner.withUserConfiguration(MultipleAnnotationsSpringBootConfiguration.class,
+				MultipleAnnotationsConfiguration.class).run(context -> this.hasBean(context, "exampleBean8"));
 	}
 
 	private void hasBean(AssertableApplicationContext context, String beanName) {
@@ -111,97 +96,97 @@ class ConditionalOnAnnotationTests {
 		assertThat(context.getBean(beanName).toString().equals(beanName));
 	}
 
-
 	// Configurations
 
 	@Configuration
 	@TestAnnotation
 	static class DefaultSpringBootConfiguration {
+
 	}
 
 	@Configuration
 	@TestAnnotation
 	@SampleAnnotation
 	static class MultipleAnnotationsSpringBootConfiguration {
+
 	}
 
 	@Configuration
 	@ConditionalOnAnnotation(TestAnnotation.class)
 	static class MyAutoConfiguration {
+
 		@Bean
 		ExampleBean exampleBean1() {
 			return new ExampleBean("exampleBean1");
 		}
+
 	}
 
 	@Configuration
 	static class MyAppConfiguration {
+
 		@Bean
 		@ConditionalOnAnnotation(TestAnnotation.class)
 		ExampleBean exampleBean2() {
 			return new ExampleBean("exampleBean2");
 		}
+
 	}
 
 	@Configuration
 	@ConditionalOnAnnotation(SampleAnnotation.class)
 	static class MyAutoConfigurationNotPresent {
+
 		@Bean
 		ExampleBean exampleBean3() {
 			return new ExampleBean("exampleBean3");
 		}
+
 	}
 
 	@Configuration
 	static class MyAppConfigurationNotPresent {
+
 		@Bean
 		@ConditionalOnAnnotation(SampleAnnotation.class)
 		ExampleBean exampleBean4() {
 			return new ExampleBean("exampleBean4");
 		}
-	}
 
+	}
 
 	@Configuration
 	static class MultipleAnnotationsConfiguration {
 
 		@Bean
-		@ConditionalOnAnnotation(
-				value = { TestAnnotation.class, SampleAnnotation.class },
-				conditionType = ConditionalOnAnnotation.ConditionType.AND
-		)
+		@ConditionalOnAnnotation(value = { TestAnnotation.class, SampleAnnotation.class },
+				conditionType = ConditionalOnAnnotation.ConditionType.AND)
 		ExampleBean exampleBean5() {
 			return new ExampleBean("exampleBean5");
 		}
 
 		@Bean
-		@ConditionalOnAnnotation(
-				value = { TestAnnotation.class, SampleAnnotation.class },
-				conditionType = ConditionalOnAnnotation.ConditionType.OR
-		)
+		@ConditionalOnAnnotation(value = { TestAnnotation.class, SampleAnnotation.class },
+				conditionType = ConditionalOnAnnotation.ConditionType.OR)
 		ExampleBean exampleBean6() {
 			return new ExampleBean("exampleBean6");
 		}
 
 		@Bean
-		@ConditionalOnAnnotation(
-				value = { TestAnnotation.class, ExampleAnnotation.class },
-				conditionType = ConditionalOnAnnotation.ConditionType.AND
-		)
+		@ConditionalOnAnnotation(value = { TestAnnotation.class, ExampleAnnotation.class },
+				conditionType = ConditionalOnAnnotation.ConditionType.AND)
 		ExampleBean exampleBean7() {
 			return new ExampleBean("exampleBean7");
 		}
 
 		@Bean
-		@ConditionalOnAnnotation(
-				value = { TestAnnotation.class, ExampleAnnotation.class },
-				conditionType = ConditionalOnAnnotation.ConditionType.OR
-		)
+		@ConditionalOnAnnotation(value = { TestAnnotation.class, ExampleAnnotation.class },
+				conditionType = ConditionalOnAnnotation.ConditionType.OR)
 		ExampleBean exampleBean8() {
 			return new ExampleBean("exampleBean8");
 		}
-	}
 
+	}
 
 	static class ExampleBean {
 
@@ -215,8 +200,8 @@ class ConditionalOnAnnotationTests {
 		public String toString() {
 			return this.value;
 		}
-	}
 
+	}
 
 	// Annotations
 
@@ -224,17 +209,21 @@ class ConditionalOnAnnotationTests {
 	@Retention(RetentionPolicy.RUNTIME)
 	@Documented
 	@interface TestAnnotation {
+
 	}
 
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	@Documented
 	@interface SampleAnnotation {
+
 	}
 
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	@Documented
 	@interface ExampleAnnotation {
+
 	}
+
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotationTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.condition;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.lang.annotation.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConditionalOnAnnotation @ConditionalOnAnnotation}.
+ *
+ * @author Vimalraj Chandra Sekaran (Github: rajvimalc)
+ */
+class ConditionalOnAnnotationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+
+
+	// Tests
+
+	@Test
+	void testAnnotationAtConfigurationWhenPresent() {
+		this.contextRunner.withUserConfiguration(
+				DefaultSpringBootConfiguration.class,
+				MyAutoConfiguration.class,
+				MyAppConfiguration.class
+		).run(context -> this.hasBean(context, "exampleBean1"));
+	}
+
+	@Test
+	void testAnnotationAtBeanWhenPresent() {
+		this.contextRunner.withUserConfiguration(
+				DefaultSpringBootConfiguration.class,
+				MyAutoConfiguration.class,
+				MyAppConfiguration.class
+		).run(context -> this.hasBean(context, "exampleBean2"));
+	}
+
+	@Test
+	void testAnnotationAtConfigurationWhenNotPresent() {
+		this.contextRunner.withUserConfiguration(
+				DefaultSpringBootConfiguration.class,
+				MyAutoConfigurationNotPresent.class,
+				MyAppConfigurationNotPresent.class
+		).run(context -> assertThat(context).doesNotHaveBean("exampleBean3"));
+	}
+
+	@Test
+	void testAnnotationAtBeanWhenNotPresent() {
+		this.contextRunner.withUserConfiguration(
+				DefaultSpringBootConfiguration.class,
+				MyAutoConfigurationNotPresent.class,
+				MyAppConfigurationNotPresent.class
+		).run(context -> assertThat(context).doesNotHaveBean("exampleBean4"));
+	}
+
+	private void hasBean(AssertableApplicationContext context, String beanName) {
+		assertThat(context).hasBean(beanName);
+		assertThat(context.getBean(beanName).toString().equals(beanName));
+	}
+
+
+	// Configurations
+
+	@Configuration
+	@TestAnnotation
+	static class DefaultSpringBootConfiguration {
+	}
+
+	@Configuration
+	@ConditionalOnAnnotation(TestAnnotation.class)
+	static class MyAutoConfiguration {
+		@Bean
+		ExampleBean exampleBean1() {
+			return new ExampleBean("exampleBean1");
+		}
+	}
+
+	@Configuration
+	static class MyAppConfiguration {
+		@Bean
+		@ConditionalOnAnnotation(TestAnnotation.class)
+		ExampleBean exampleBean2() {
+			return new ExampleBean("exampleBean2");
+		}
+	}
+
+	@Configuration
+	@ConditionalOnAnnotation(SampleAnnotation.class)
+	static class MyAutoConfigurationNotPresent {
+		@Bean
+		ExampleBean exampleBean3() {
+			return new ExampleBean("exampleBean3");
+		}
+	}
+
+	@Configuration
+	static class MyAppConfigurationNotPresent {
+		@Bean
+		@ConditionalOnAnnotation(SampleAnnotation.class)
+		ExampleBean exampleBean4() {
+			return new ExampleBean("exampleBean4");
+		}
+	}
+
+	static class ExampleBean {
+
+		private final String value;
+
+		ExampleBean(String value) {
+			this.value = value;
+		}
+
+		@Override
+		public String toString() {
+			return this.value;
+		}
+	}
+
+
+	// Annotations
+
+	@Target(ElementType.TYPE)
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	@interface TestAnnotation {
+	}
+
+	@Target(ElementType.TYPE)
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	@interface SampleAnnotation {
+	}
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotationTests.java
@@ -16,13 +16,18 @@
 
 package org.springframework.boot.autoconfigure.condition;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 import org.junit.jupiter.api.Test;
+
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.lang.annotation.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,13 +45,13 @@ class ConditionalOnAnnotationTests {
 	@Test
 	void testAnnotationAtConfigurationWhenPresent() {
 		this.contextRunner.withUserConfiguration(DefaultSpringBootConfiguration.class, MyAutoConfiguration.class,
-				MyAppConfiguration.class).run(context -> this.hasBean(context, "exampleBean1"));
+				MyAppConfiguration.class).run((context) -> this.hasBean(context, "exampleBean1"));
 	}
 
 	@Test
 	void testAnnotationAtBeanWhenPresent() {
 		this.contextRunner.withUserConfiguration(DefaultSpringBootConfiguration.class, MyAutoConfiguration.class,
-				MyAppConfiguration.class).run(context -> this.hasBean(context, "exampleBean2"));
+				MyAppConfiguration.class).run((context) -> this.hasBean(context, "exampleBean2"));
 	}
 
 	@Test
@@ -54,7 +59,7 @@ class ConditionalOnAnnotationTests {
 		this.contextRunner
 				.withUserConfiguration(DefaultSpringBootConfiguration.class, MyAutoConfigurationNotPresent.class,
 						MyAppConfigurationNotPresent.class)
-				.run(context -> assertThat(context).doesNotHaveBean("exampleBean3"));
+				.run((context) -> assertThat(context).doesNotHaveBean("exampleBean3"));
 	}
 
 	@Test
@@ -62,19 +67,19 @@ class ConditionalOnAnnotationTests {
 		this.contextRunner
 				.withUserConfiguration(DefaultSpringBootConfiguration.class, MyAutoConfigurationNotPresent.class,
 						MyAppConfigurationNotPresent.class)
-				.run(context -> assertThat(context).doesNotHaveBean("exampleBean4"));
+				.run((context) -> assertThat(context).doesNotHaveBean("exampleBean4"));
 	}
 
 	@Test
 	void testMultipleAnnotationsWhenPresentForAND() {
 		this.contextRunner.withUserConfiguration(MultipleAnnotationsSpringBootConfiguration.class,
-				MultipleAnnotationsConfiguration.class).run(context -> this.hasBean(context, "exampleBean5"));
+				MultipleAnnotationsConfiguration.class).run((context) -> this.hasBean(context, "exampleBean5"));
 	}
 
 	@Test
 	void testMultipleAnnotationsWhenPresentForOR() {
 		this.contextRunner.withUserConfiguration(MultipleAnnotationsSpringBootConfiguration.class,
-				MultipleAnnotationsConfiguration.class).run(context -> this.hasBean(context, "exampleBean6"));
+				MultipleAnnotationsConfiguration.class).run((context) -> this.hasBean(context, "exampleBean6"));
 	}
 
 	@Test
@@ -82,13 +87,13 @@ class ConditionalOnAnnotationTests {
 		this.contextRunner
 				.withUserConfiguration(MultipleAnnotationsSpringBootConfiguration.class,
 						MultipleAnnotationsConfiguration.class)
-				.run(context -> assertThat(context).doesNotHaveBean("exampleBean7"));
+				.run((context) -> assertThat(context).doesNotHaveBean("exampleBean7"));
 	}
 
 	@Test
 	void testMultipleAnnotationsWhenNotPresentForOR() {
 		this.contextRunner.withUserConfiguration(MultipleAnnotationsSpringBootConfiguration.class,
-				MultipleAnnotationsConfiguration.class).run(context -> this.hasBean(context, "exampleBean8"));
+				MultipleAnnotationsConfiguration.class).run((context) -> this.hasBean(context, "exampleBean8"));
 	}
 
 	private void hasBean(AssertableApplicationContext context, String beanName) {
@@ -97,6 +102,27 @@ class ConditionalOnAnnotationTests {
 	}
 
 	// Configurations
+
+	@Target(ElementType.TYPE)
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	@interface TestAnnotation {
+
+	}
+
+	@Target(ElementType.TYPE)
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	@interface SampleAnnotation {
+
+	}
+
+	@Target(ElementType.TYPE)
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	@interface ExampleAnnotation {
+
+	}
 
 	@Configuration
 	@TestAnnotation
@@ -143,6 +169,8 @@ class ConditionalOnAnnotationTests {
 		}
 
 	}
+
+	// Annotations
 
 	@Configuration
 	static class MyAppConfigurationNotPresent {
@@ -200,29 +228,6 @@ class ConditionalOnAnnotationTests {
 		public String toString() {
 			return this.value;
 		}
-
-	}
-
-	// Annotations
-
-	@Target(ElementType.TYPE)
-	@Retention(RetentionPolicy.RUNTIME)
-	@Documented
-	@interface TestAnnotation {
-
-	}
-
-	@Target(ElementType.TYPE)
-	@Retention(RetentionPolicy.RUNTIME)
-	@Documented
-	@interface SampleAnnotation {
-
-	}
-
-	@Target(ElementType.TYPE)
-	@Retention(RetentionPolicy.RUNTIME)
-	@Documented
-	@interface ExampleAnnotation {
 
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotationTests.java
@@ -74,6 +74,38 @@ class ConditionalOnAnnotationTests {
 		).run(context -> assertThat(context).doesNotHaveBean("exampleBean4"));
 	}
 
+	@Test
+	void testMultipleAnnotationsWhenPresentForAND() {
+		this.contextRunner.withUserConfiguration(
+				MultipleAnnotationsSpringBootConfiguration.class,
+				MultipleAnnotationsConfiguration.class
+		).run(context -> this.hasBean(context, "exampleBean5"));
+	}
+
+	@Test
+	void testMultipleAnnotationsWhenPresentForOR() {
+		this.contextRunner.withUserConfiguration(
+				MultipleAnnotationsSpringBootConfiguration.class,
+				MultipleAnnotationsConfiguration.class
+		).run(context -> this.hasBean(context, "exampleBean6"));
+	}
+
+	@Test
+	void testMultipleAnnotationsWhenNotPresentForAND() {
+		this.contextRunner.withUserConfiguration(
+				MultipleAnnotationsSpringBootConfiguration.class,
+				MultipleAnnotationsConfiguration.class
+		).run(context -> assertThat(context).doesNotHaveBean("exampleBean7"));
+	}
+
+	@Test
+	void testMultipleAnnotationsWhenNotPresentForOR() {
+		this.contextRunner.withUserConfiguration(
+				MultipleAnnotationsSpringBootConfiguration.class,
+				MultipleAnnotationsConfiguration.class
+		).run(context -> this.hasBean(context, "exampleBean8"));
+	}
+
 	private void hasBean(AssertableApplicationContext context, String beanName) {
 		assertThat(context).hasBean(beanName);
 		assertThat(context.getBean(beanName).toString().equals(beanName));
@@ -85,6 +117,12 @@ class ConditionalOnAnnotationTests {
 	@Configuration
 	@TestAnnotation
 	static class DefaultSpringBootConfiguration {
+	}
+
+	@Configuration
+	@TestAnnotation
+	@SampleAnnotation
+	static class MultipleAnnotationsSpringBootConfiguration {
 	}
 
 	@Configuration
@@ -123,6 +161,48 @@ class ConditionalOnAnnotationTests {
 		}
 	}
 
+
+	@Configuration
+	static class MultipleAnnotationsConfiguration {
+
+		@Bean
+		@ConditionalOnAnnotation(
+				value = { TestAnnotation.class, SampleAnnotation.class },
+				conditionType = ConditionalOnAnnotation.ConditionType.AND
+		)
+		ExampleBean exampleBean5() {
+			return new ExampleBean("exampleBean5");
+		}
+
+		@Bean
+		@ConditionalOnAnnotation(
+				value = { TestAnnotation.class, SampleAnnotation.class },
+				conditionType = ConditionalOnAnnotation.ConditionType.OR
+		)
+		ExampleBean exampleBean6() {
+			return new ExampleBean("exampleBean6");
+		}
+
+		@Bean
+		@ConditionalOnAnnotation(
+				value = { TestAnnotation.class, ExampleAnnotation.class },
+				conditionType = ConditionalOnAnnotation.ConditionType.AND
+		)
+		ExampleBean exampleBean7() {
+			return new ExampleBean("exampleBean7");
+		}
+
+		@Bean
+		@ConditionalOnAnnotation(
+				value = { TestAnnotation.class, ExampleAnnotation.class },
+				conditionType = ConditionalOnAnnotation.ConditionType.OR
+		)
+		ExampleBean exampleBean8() {
+			return new ExampleBean("exampleBean8");
+		}
+	}
+
+
 	static class ExampleBean {
 
 		private final String value;
@@ -150,5 +230,11 @@ class ConditionalOnAnnotationTests {
 	@Retention(RetentionPolicy.RUNTIME)
 	@Documented
 	@interface SampleAnnotation {
+	}
+
+	@Target(ElementType.TYPE)
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	@interface ExampleAnnotation {
 	}
 }


### PR DESCRIPTION
**Enhancement for Conditional Annotations:**
When creating Auto Configurations we need to rely on @ConditionalOnProperty. This new annotation @ConditionalOnAnnotation serves as utility for conditional configuration with a custom enable annotation or an already existing annotation and acts similar to @ConditionalOnProperty but with annotation.