### PR TITLE
Add configuration to disable Redis Cluster dynamic sources refresh

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
@@ -138,6 +138,9 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 			if (refreshProperties.isAdaptive()) {
 				refreshBuilder.enableAllAdaptiveRefreshTriggers();
 			}
+			if (refreshProperties.isDynamicSources() != null) {
+				refreshBuilder.dynamicRefreshSources(refreshProperties.isDynamicSources());
+			}
 			return builder.topologyRefreshOptions(refreshBuilder.build());
 		}
 		return ClientOptions.builder();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -410,6 +410,13 @@ public class RedisProperties {
 				 */
 				private boolean adaptive;
 
+				/**
+				 * Whether discovered nodes should be used as the source for the cluster
+				 * topology. When set to {@literal false}, only the initial seed nodes
+				 * will be used as sources for topology discovery.
+				 */
+				private Boolean dynamicSources = null;
+
 				public Duration getPeriod() {
 					return this.period;
 				}
@@ -424,6 +431,14 @@ public class RedisProperties {
 
 				public void setAdaptive(boolean adaptive) {
 					this.adaptive = adaptive;
+				}
+
+				public Boolean isDynamicSources() {
+					return this.dynamicSources;
+				}
+
+				public void setDynamicSources(Boolean dynamicSources) {
+					this.dynamicSources = dynamicSources;
 				}
 
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -412,10 +412,10 @@ public class RedisProperties {
 
 				/**
 				 * Whether discovered nodes should be used as the source for the cluster
-				 * topology. When set to {@literal false}, only the initial seed nodes
+				 * topology. When set to false, only the initial seed nodes
 				 * will be used as sources for topology discovery.
 				 */
-				private Boolean dynamicSources = null;
+				private Boolean dynamicSources;
 
 				public Duration getPeriod() {
 					return this.period;


### PR DESCRIPTION
This commit adds an option to enable/disable the DynamicRefreshSources setting on the Lettuce cluster toplogy refresh options.

Closes gh-22398