### PR TITLE
Add ElasticsearchReactiveHealthIndicator to docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
@@ -850,6 +850,9 @@ The following `ReactiveHealthIndicators` are auto-configured by Spring Boot when
 | {spring-boot-actuator-module-code}/couchbase/CouchbaseReactiveHealthIndicator.java[`CouchbaseReactiveHealthIndicator`]
 | Checks that a Couchbase cluster is up.
 
+| {spring-boot-actuator-module-code}/elasticsearch/ElasticsearchReactiveHealthIndicator.java[`ElasticsearchReactiveHealthIndicator`]
+| Checks that an Elasticsearch cluster is up.
+
 | {spring-boot-actuator-module-code}/mongo/MongoReactiveHealthIndicator.java[`MongoReactiveHealthIndicator`]
 | Checks that a Mongo database is up.
 


### PR DESCRIPTION
Hi,

as discussed in #22598 this PR adds the new `ElasticsearchReactiveHealthIndicator` separately to the docs for simpler merging.

Cheers,
Christoph