### PR TITLE
Re-use the already built JAR file if possible

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildImageMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildImageMojo.java
@@ -164,7 +164,11 @@ public class BuildImageMojo extends AbstractPackagerMojo {
 	}
 
 	private TarArchive getApplicationContent(Owner owner, Libraries libraries) {
-		ImagePackager packager = getConfiguredPackager(() -> new ImagePackager(getJarFile()));
+		File jarFile = getJarFile();
+		if (jarFile.exists()) {
+			return TarArchive.fromZip(jarFile, owner);
+		}
+		ImagePackager packager = getConfiguredPackager(() -> new ImagePackager(jarFile));
 		return new PackagedTarArchive(owner, libraries, packager);
 	}
 


### PR DESCRIPTION
The build-image Mojo doesn't attempt to re-use an existing
JAR file that it has already built. This is a small change
that just checks if it already exists and re-uses it.

A side effect is that other plugins can modify the JAR file
(e.g. to optimize the reflection usage for a native-image
build) and those changes are visible in the container
image.

Possibly something similar can be done in the Gradle
plugin?