### PR TITLE
NPE in BeanDefinitionLoader when loading non-Class sources and XML support is disabled

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/BeanDefinitionLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/BeanDefinitionLoader.java
@@ -189,7 +189,7 @@ class BeanDefinitionLoader {
 	}
 
 	private void load(CharSequence source) {
-		String resolvedSource = this.xmlReader.getEnvironment().resolvePlaceholders(source.toString());
+		String resolvedSource = this.scanner.getEnvironment().resolvePlaceholders(source.toString());
 		// Attempt as a Class
 		try {
 			load(ClassUtils.forName(resolvedSource, null));


### PR DESCRIPTION
Hi,

I was playing with `spring.xml.ignore` and found an NPE when loading CharSequence sources.

The following application snippet should reproduce the error
```
@SpringBootApplication
public class Application {

	public static void main(String[] args) {
		SpringApplication app = new SpringApplication(Application.class);
		app.setSources(Set.of("test", "source"));
		app.run(args);
	}

}
```

When running `java -Dspring.xml.ignore=true -jar app.jar` the following NPE occurs:

```
java.lang.NullPointerException: null
        at org.springframework.boot.BeanDefinitionLoader.load(BeanDefinitionLoader.java:192)
        at org.springframework.boot.BeanDefinitionLoader.load(BeanDefinitionLoader.java:155)
        at org.springframework.boot.BeanDefinitionLoader.load(BeanDefinitionLoader.java:136)
        at org.springframework.boot.SpringApplication.load(SpringApplication.java:691)
        at org.springframework.boot.SpringApplication.prepareContext(SpringApplication.java:392)
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:314)
```

This is due to the fact that `xmlReader` is null when XML support is disabled. As the reader is only used to get the `Environment`, I think we can workaround this by just using the `scanner` field. They should have the same `Environment` here.

Unfortunately, it's a bit cumbersome to write a test for this. I would need to set the final `xmlReader` field to null via reflection, which is what I try to avoid usually. Nonetheless, let me know If I should add a test like described that mimics XML support being disabled.

Cheers,
Christoph

P.S.: I tried setting `spring.xml.ignore` in my `application.properties` first, which didn't work. I think we would need to use `Binder` facilities to make this work. Maybe that's worth evaluating.