### PR TITLE
Use Supplier variants of Assert methods

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationSorter.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationSorter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,14 +88,18 @@ class AutoConfigurationSorter {
 		}
 		processing.add(current);
 		for (String after : classes.getClassesRequestedAfter(current)) {
-			Assert.state(!processing.contains(after),
-					"AutoConfigure cycle detected between " + current + " and " + after);
+			checkForCycles(processing, current, after);
 			if (!sorted.contains(after) && toSort.contains(after)) {
 				doSortByAfterAnnotation(classes, toSort, sorted, processing, after);
 			}
 		}
 		processing.remove(current);
 		sorted.add(current);
+	}
+
+	private void checkForCycles(Set<String> processing, String current, String after) {
+		Assert.state(!processing.contains(after),
+				() -> "AutoConfigure cycle detected between " + current + " and " + after);
 	}
 
 	private static class AutoConfigurationClasses {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyRegistrationConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyRegistrationConfiguration.java
@@ -111,7 +111,7 @@ class Saml2RelyingPartyRegistrationConfiguration {
 
 	private RSAPrivateKey readPrivateKey(Resource location) {
 		Assert.state(location != null, "No private key location specified");
-		Assert.state(location.exists(), "Private key location '" + location + "' does not exist");
+		Assert.state(location.exists(), () -> "Private key location '" + location + "' does not exist");
 		try (InputStream inputStream = location.getInputStream()) {
 			return RsaKeyConverters.pkcs8().convert(inputStream);
 		}
@@ -122,7 +122,7 @@ class Saml2RelyingPartyRegistrationConfiguration {
 
 	private X509Certificate readCertificate(Resource location) {
 		Assert.state(location != null, "No certificate location specified");
-		Assert.state(location.exists(), "Certificate  location '" + location + "' does not exist");
+		Assert.state(location.exists(), () -> "Certificate  location '" + location + "' does not exist");
 		try (InputStream inputStream = location.getInputStream()) {
 			return (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(inputStream);
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/template/AbstractTemplateViewResolverProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/template/AbstractTemplateViewResolverProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,7 +152,7 @@ public abstract class AbstractTemplateViewResolverProperties extends AbstractVie
 	 */
 	public void applyToMvcViewResolver(Object viewResolver) {
 		Assert.isInstanceOf(AbstractTemplateViewResolver.class, viewResolver,
-				"ViewResolver is not an instance of AbstractTemplateViewResolver :" + viewResolver);
+				() -> "ViewResolver is not an instance of AbstractTemplateViewResolver :" + viewResolver);
 		AbstractTemplateViewResolver resolver = (AbstractTemplateViewResolver) viewResolver;
 		resolver.setPrefix(getPrefix());
 		resolver.setSuffix(getSuffix());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/UndertowWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/UndertowWebServerFactoryCustomizer.java
@@ -168,7 +168,7 @@ public class UndertowWebServerFactoryCustomizer
 			return (map) -> map.forEach((key, value) -> {
 				Option<T> option = (Option<T>) this.nameLookup.get(getCanonicalName(key));
 				Assert.state(option != null,
-						"Unable to find '" + key + "' in " + ClassUtils.getShortClassName(this.source));
+						() -> "Unable to find '" + key + "' in " + ClassUtils.getShortClassName(this.source));
 				T parsed = option.parseValue(value, getClass().getClassLoader());
 				function.apply(option).accept(parsed);
 			});

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/Builder.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/Builder.java
@@ -113,8 +113,8 @@ public class Builder {
 	private void assertStackIdsMatch(Image runImage, Image builderImage) {
 		StackId runImageStackId = StackId.fromImage(runImage);
 		StackId builderImageStackId = StackId.fromImage(builderImage);
-		Assert.state(runImageStackId.equals(builderImageStackId),
-				"Run image stack '" + runImageStackId + "' does not match builder stack '" + builderImageStackId + "'");
+		Assert.state(runImageStackId.equals(builderImageStackId), () -> "Run image stack '" + runImageStackId
+				+ "' does not match builder stack '" + builderImageStackId + "'");
 	}
 
 	private void executeLifecycle(BuildRequest request, EphemeralBuilder builder) throws IOException {

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/JarModeLibrary.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/JarModeLibrary.java
@@ -65,7 +65,7 @@ public class JarModeLibrary extends Library {
 	public InputStream openStream() throws IOException {
 		String path = "META-INF/jarmode/" + getCoordinates().getArtifactId() + ".jar";
 		URL resource = getClass().getClassLoader().getResource(path);
-		Assert.state(resource != null, "Unable to find resource " + path);
+		Assert.state(resource != null, () -> "Unable to find resource " + path);
 		return resource.openStream();
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Packager.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Packager.java
@@ -94,7 +94,7 @@ public abstract class Packager {
 	protected Packager(File source, LayoutFactory layoutFactory) {
 		Assert.notNull(source, "Source file must not be null");
 		Assert.isTrue(source.exists() && source.isFile(),
-				"Source must refer to an existing file, got " + source.getAbsolutePath());
+				() -> "Source must refer to an existing file, got " + source.getAbsolutePath());
 		this.source = source.getAbsoluteFile();
 		this.layoutFactory = layoutFactory;
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/layer/CustomLayers.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/layer/CustomLayers.java
@@ -64,7 +64,7 @@ public class CustomLayers implements Layers {
 		Layer layer = selector.getLayer();
 		Assert.state(layer != null, "Missing content selector layer");
 		Assert.state(layers.contains(layer),
-				"Content selector layer '" + selector.getLayer() + "' not found in " + layers);
+				() -> "Content selector layer '" + selector.getLayer() + "' not found in " + layers);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/LayersIndexTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/LayersIndexTests.java
@@ -130,7 +130,7 @@ class LayersIndexTests {
 				String actualContent = getContent();
 				String name = "LayersIndexTests-" + LayersIndexTests.this.testMethodName + ".txt";
 				InputStream in = LayersIndexTests.class.getResourceAsStream(name);
-				Assert.state(in != null, "Can't read " + name);
+				Assert.state(in != null, () -> "Can't read " + name);
 				String expectedContent = new String(FileCopyUtils.copyToByteArray(in), StandardCharsets.UTF_8);
 				expectedContent = expectedContent.replace("\r", "");
 				assertThat(actualContent).isEqualTo(expectedContent);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLoaders.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLoaders.java
@@ -105,7 +105,7 @@ class ConfigDataLoaders {
 				}
 			}
 		}
-		Assert.state(result != null, "No loader found for location '" + location + "'");
+		Assert.state(result != null, () -> "No loader found for location '" + location + "'");
 		return result;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/DelegatingApplicationContextInitializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/DelegatingApplicationContextInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ public class DelegatingApplicationContextInitializer
 		Class<?> requireContextClass = GenericTypeResolver.resolveTypeArgument(initializerClass,
 				ApplicationContextInitializer.class);
 		Assert.isAssignable(requireContextClass, contextClass,
-				String.format(
+				() -> String.format(
 						"Could not add context initializer [%s] as its generic parameter [%s] is not assignable "
 								+ "from the type of application context used by this context loader [%s]: ",
 						initializerClass.getName(), requireContextClass.getName(), contextClass.getName()));

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/DelegatingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/DelegatingApplicationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public class DelegatingApplicationListener implements ApplicationListener<Applic
 				try {
 					Class<?> clazz = ClassUtils.forName(className, ClassUtils.getDefaultClassLoader());
 					Assert.isAssignable(ApplicationListener.class, clazz,
-							"class [" + className + "] must implement ApplicationListener");
+							() -> "class [" + className + "] must implement ApplicationListener");
 					listeners.add((ApplicationListener<ApplicationEvent>) BeanUtils.instantiateClass(clazz));
 				}
 				catch (Exception ex) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -249,7 +249,7 @@ public final class ConfigurationPropertiesBean {
 	static ConfigurationPropertiesBean forValueObject(Class<?> beanClass, String beanName) {
 		ConfigurationPropertiesBean propertiesBean = create(beanName, null, beanClass, null);
 		Assert.state(propertiesBean != null && propertiesBean.getBindMethod() == BindMethod.VALUE_OBJECT,
-				"Bean '" + beanName + "' is not a @ConfigurationProperties value object");
+				() -> "Bean '" + beanName + "' is not a @ConfigurationProperties value object");
 		return propertiesBean;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBindConstructorProvider.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBindConstructorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,9 +67,9 @@ class ConfigurationPropertiesBindConstructorProvider implements BindConstructorP
 		for (Constructor<?> candidate : candidates) {
 			if (MergedAnnotations.from(candidate).isPresent(ConstructorBinding.class)) {
 				Assert.state(candidate.getParameterCount() > 0,
-						type.getName() + " declares @ConstructorBinding on a no-args constructor");
+						() -> type.getName() + " declares @ConstructorBinding on a no-args constructor");
 				Assert.state(constructor == null,
-						type.getName() + " has more than one @ConstructorBinding constructor");
+						() -> type.getName() + " has more than one @ConstructorBinding constructor");
 				constructor = candidate;
 			}
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/PeriodStyle.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/PeriodStyle.java
@@ -48,7 +48,7 @@ public enum PeriodStyle {
 				}
 				Matcher matcher = matcher(value);
 				Assert.state(matcher.matches(), "Does not match simple period pattern");
-				Assert.isTrue(hasAtLeastOneGroupValue(matcher), "'" + value + "' is not a valid simple period");
+				Assert.isTrue(hasAtLeastOneGroupValue(matcher), () -> "'" + value + "' is not a valid simple period");
 				int years = parseInt(matcher, 1);
 				int months = parseInt(matcher, 2);
 				int weeks = parseInt(matcher, 3);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/VolumeMountDirectoryPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/VolumeMountDirectoryPropertySource.java
@@ -100,8 +100,8 @@ public class VolumeMountDirectoryPropertySource extends EnumerablePropertySource
 
 	private VolumeMountDirectoryPropertySource(String name, Path sourceDirectory, Set<Option> options) {
 		super(name, sourceDirectory);
-		Assert.isTrue(Files.exists(sourceDirectory), "Directory '" + sourceDirectory + "' does not exist");
-		Assert.isTrue(Files.isDirectory(sourceDirectory), "File '" + sourceDirectory + "' is not a directory");
+		Assert.isTrue(Files.exists(sourceDirectory), () -> "Directory '" + sourceDirectory + "' does not exist");
+		Assert.isTrue(Files.isDirectory(sourceDirectory), () -> "File '" + sourceDirectory + "' is not a directory");
 		this.propertyFiles = PropertyFile.findAll(sourceDirectory, options);
 		this.options = options;
 		this.names = StringUtils.toStringArray(this.propertyFiles.keySet());

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -286,7 +286,7 @@ public class LogbackLoggingSystem extends Slf4JLoggingSystem {
 	private LoggerContext getLoggerContext() {
 		ILoggerFactory factory = StaticLoggerBinder.getSingleton().getLoggerFactory();
 		Assert.isInstanceOf(LoggerContext.class, factory,
-				String.format(
+				() -> String.format(
 						"LoggerFactory is not a Logback LoggerContext but Logback is on "
 								+ "the classpath. Either remove Logback or the competing "
 								+ "implementation (%s loaded from %s). If you are using "


### PR DESCRIPTION
Hi,

this PR uses the `Supplier` variants for `Assert.state()` and alike where possible to avoid unnecessary String allocations.

Cheers,
Christoph