### PR TITLE
Do not include cookie headers in HTTP traces by default

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -626,7 +626,6 @@
       "defaultValue": [
         "request-headers",
         "response-headers",
-        "cookies",
         "errors"
       ]
     },

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/http/Include.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/http/Include.java
@@ -24,6 +24,8 @@ import java.util.Set;
  * Include options for HTTP tracing.
  *
  * @author Wallace Wadge
+ * @author Emily Tsanova
+ * @author Joseph Beeton
  * @since 2.0.0
  */
 public enum Include {
@@ -55,6 +57,7 @@ public enum Include {
 	PRINCIPAL,
 
 	/**
+	 *
 	 * Include the remote address.
 	 */
 	REMOTE_ADDRESS,
@@ -75,7 +78,6 @@ public enum Include {
 		Set<Include> defaultIncludes = new LinkedHashSet<>();
 		defaultIncludes.add(Include.REQUEST_HEADERS);
 		defaultIncludes.add(Include.RESPONSE_HEADERS);
-		defaultIncludes.add(Include.COOKIE_HEADERS);
 		defaultIncludes.add(Include.TIME_TAKEN);
 		DEFAULT_INCLUDES = Collections.unmodifiableSet(defaultIncludes);
 	}


### PR DESCRIPTION
Remove the cookie header from the **http trace** endpoint by default. #22745 
