### PR TITLE
Adjust to latest changes in Spring Integration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -118,7 +118,7 @@ public class IntegrationAutoConfiguration {
 	protected static class IntegrationManagementConfiguration {
 
 		@Configuration(proxyBeanMethods = false)
-		@EnableIntegrationManagement(defaultCountsEnabled = "true")
+		@EnableIntegrationManagement
 		protected static class EnableIntegrationManagementConfiguration {
 
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
@@ -195,14 +195,6 @@ class IntegrationAutoConfigurationTests {
 	}
 
 	@Test
-	void integrationEnablesDefaultCounts() {
-		this.contextRunner.withUserConfiguration(MessageSourceConfiguration.class).run((context) -> {
-			assertThat(context).hasBean("myMessageSource");
-			assertThat(((MessageProcessorMessageSource) context.getBean("myMessageSource")).isCountsEnabled()).isTrue();
-		});
-	}
-
-	@Test
 	void rsocketSupportEnabled() {
 		this.contextRunner.withUserConfiguration(RSocketServerConfiguration.class)
 				.withConfiguration(AutoConfigurations.of(RSocketServerAutoConfiguration.class,


### PR DESCRIPTION
Hi,

the latest changes in Spring Integration https://github.com/spring-projects/spring-integration/commit/1beb854fb4f498d2fb8ab037f1df84881eed7222 & https://github.com/spring-projects/spring-integration/commit/43950d16ae5c4e9353c5d43f805e749327c91591 have removed & deprecated some legacy metrics logic, which currently fails the build.

Cheers,
Christoph