### PR TITLE
Support DOCKER_AUTHENTICATION_TOKEN env to access private docker registries

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/RemoteHttpClientTransportTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/RemoteHttpClientTransportTests.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Scott Frederick
  * @author Phillip Webb
+ * @author wmz7year
  */
 class RemoteHttpClientTransportTests {
 
@@ -94,6 +95,14 @@ class RemoteHttpClientTransportTests {
 		RemoteHttpClientTransport transport = RemoteHttpClientTransport.createIfPossible(this.environment::get,
 				sslContextFactory);
 		assertThat(transport.getHost()).satisfies(hostOf("https", "192.168.1.2", 2376));
+	}
+
+	@Test
+	void createIfPossibleWhenUsesDockerAuthenticationToken() {
+		this.environment.put("DOCKER_HOST", "tcp://192.168.1.2:2376");
+		this.environment.put("DOCKER_AUTHENTICATION_TOKEN", "MOCK_DOCKER_AUTHENTICATION_TOKEN");
+		RemoteHttpClientTransport transport = RemoteHttpClientTransport.createIfPossible(this.environment::get);
+		assertThat(transport).isNotNull();
 	}
 
 	private Consumer<HttpHost> hostOf(String scheme, String hostName, int port) {


### PR DESCRIPTION
https://github.com/spring-projects/spring-boot/issues/22836

spring-boot-maven-plugin 2.3.x version support build layers docker image.

but use custom builder image or run image with private docker registry it can't works

like this:

```xml
			<plugin>
				<groupId>org.springframework.boot</groupId>
				<artifactId>spring-boot-maven-plugin</artifactId>
				<executions>
					<execution>
						<goals>
							<goal>build-info</goal>
						</goals>
					</execution>
				</executions>
				<configuration>
					<layers>
						<enabled>true</enabled>
					</layers>
					<image>
						<builder>xxxxx.dkr.ecr.cn-north-1.amazonaws.com.cn/paketo-buildpacks-builder:base-platform-api-0.3</builder>
					</image>
				</configuration>
			</plugin>
```

then run ./mvnw spring-boot:build-image will throw 

```
 Failed to execute goal org.springframework.boot:spring-boot-maven-plugin:2.3.2.RELEASE:build-image (default-cli) on project athena-marketing-server-start: Execution default-cli of goal org.springframework.boot:spring-boot-maven-plugin:2.3.2.RELEASE:build-image failed: Docker API call to 'localhost/v1.24/images/create?fromImage=882440569488.dkr.ecr.cn-north-1.amazonaws.com.cn%2Fpaketo-buildpacks-builder%3Abase-platform-api-0.3' failed with status code 500 "Internal Server Error" and message "Get https://xxxxx.dkr.ecr.cn-north-1.amazonaws.com.cn/v2/paketo-buildpacks-builder/manifests/base-platform-api-0.3: no basic auth credentials" -> [Help 1]
```

the docker registry xxxxx.dkr.ecr.cn-north-1.amazonaws.com.cn is private and authentication to pull docker images.


spring boot maven plugin call docker api does't have any auth params

https://github.com/spring-projects/spring-boot/blob/4933b2688fd2114c75f8f4835d9f27bbd08165c9/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/transport/HttpClientTransport.java#L126

docker engine api provide ```X-Registry-Auth``` Header to authentication https://docs.docker.com/engine/api/v1.39/#section/Authentication

```
Authentication
Authentication for registries is handled client side. The client has to send authentication details to various endpoints that need to communicate with registries, such as POST /images/(name)/push. These are sent as X-Registry-Auth header as a base64url encoded (JSON) string with the following structure:

{
  "username": "string",
  "password": "string",
  "email": "string",
  "serveraddress": "string"
}
```

looks like spring boot maven plugin need support config ```X-Registry-Auth``` header or docker registry auth params to configure it.