### PR TITLE
Customize RestTemplateBuilder

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/client/RestTemplateAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/client/RestTemplateAutoConfiguration.java
@@ -33,12 +33,14 @@ import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
 import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration.NotReactiveWebApplicationCondition;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.web.client.RestTemplateBuilderCustomizer;
 import org.springframework.boot.web.client.RestTemplateCustomizer;
 import org.springframework.boot.web.client.RestTemplateRequestCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.util.Assert;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -59,6 +61,7 @@ public class RestTemplateAutoConfiguration {
 	@ConditionalOnMissingBean
 	public RestTemplateBuilder restTemplateBuilder(ObjectProvider<HttpMessageConverters> messageConverters,
 			ObjectProvider<RestTemplateCustomizer> restTemplateCustomizers,
+			ObjectProvider<RestTemplateBuilderCustomizer> restTemplateBuilderCustomizer,
 			ObjectProvider<RestTemplateRequestCustomizer<?>> restTemplateRequestCustomizers) {
 		RestTemplateBuilder builder = new RestTemplateBuilder();
 		HttpMessageConverters converters = messageConverters.getIfUnique();
@@ -67,6 +70,10 @@ public class RestTemplateAutoConfiguration {
 		}
 		builder = addCustomizers(builder, restTemplateCustomizers, RestTemplateBuilder::customizers);
 		builder = addCustomizers(builder, restTemplateRequestCustomizers, RestTemplateBuilder::requestCustomizers);
+		for (RestTemplateBuilderCustomizer customizer : restTemplateBuilderCustomizer) {
+			builder = customizer.customize(builder);
+			Assert.notNull(builder, "RestTemplateBuilderCustomizer returned null builder");
+		}
 		return builder;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RestTemplateBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RestTemplateBuilderCustomizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.client;
+
+/**
+ * Callback interface that can be used to customize a {@link RestTemplateBuilder}.
+ *
+ * @author Ivo Smid
+ * @see RestTemplateBuilder
+ * @since 5.3.0
+ */
+@FunctionalInterface
+public interface RestTemplateBuilderCustomizer {
+
+	/**
+	 * Callback to customize a {@link RestTemplateBuilder} instance.
+	 * @param restTemplateBuilder the original builder to customize
+	 * @return customized builder instance
+	 */
+	RestTemplateBuilder customize(RestTemplateBuilder restTemplateBuilder);
+
+}


### PR DESCRIPTION
Hi,
I found that it would be handy to customize `RestTemplateBuilder` created by auto-configuration. It has some useful method that sometimes I want to call. Currently I have to use bean post processor to customize it - I think that it is ugly and error prone.
What do you think about this proposal?
Thx
Ivos