### PR TITLE
Fix Gradle Plugin custom image name example and documentation

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging-oci-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging-oci-image.adoc
@@ -19,13 +19,13 @@ The following table shows the environment variables and their values:
 |===
 | Environment variable | Description
 
-| DOCKER_HOST 
+| DOCKER_HOST
 | URL containing the host and port for the Docker daemon - e.g. `tcp://192.168.99.100:2376`
 
-| DOCKER_TLS_VERIFY 
+| DOCKER_TLS_VERIFY
 | Enable secure HTTPS protocol when set to `1` (optional)
 
-| DOCKER_CERT_PATH 
+| DOCKER_CERT_PATH
 | Path to certificate and key files for HTTPS (required if `DOCKER_TLS_VERIFY=1`, ignored otherwise)
 |===
 
@@ -59,7 +59,7 @@ The following table summarizes the available properties and their default values
 | `imageName`
 | `--imageName`
 | {spring-boot-api}/buildpack/platform/docker/type/ImageReference.html#of-java.lang.String-[Image name] for the generated image.
-| `docker.io/library/${project.artifactId}:${project.version}`
+| `docker.io/library/${project.name}:${project.version}`
 
 | `environment`
 |
@@ -148,7 +148,7 @@ include::../gradle/packaging/boot-build-image-env-proxy.gradle.kts[tags=env]
 
 [[build-image-example-custom-image-name]]
 ==== Custom Image Name
-By default, the image name is inferred from the `artifactId` and the `version` of the project, something like `docker.io/library/${project.artifactId}:${project.version}`.
+By default, the image name is inferred from the `name` and the `version` of the project, something like `docker.io/library/${project.name}:${project.version}`.
 You can take control over the name by setting task properties, as shown in the following example:
 
 [source,groovy,indent=0,subs="verbatim,attributes",role="primary"]

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-build-image-name.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-build-image-name.gradle
@@ -3,12 +3,14 @@ plugins {
 	id 'org.springframework.boot' version '{gradle-project-version}'
 }
 
-bootJar {
-	mainClassName 'com.example.ExampleApplication'
-}
-
 // tag::image-name[]
 bootBuildImage {
-	imageName = "example.com/library/${project.artifactId}"
+	imageName = "example.com/library/${project.name}"
 }
 // end::image-name[]
+
+task bootBuildImageName {
+    doFirst {
+        println(tasks.bootBuildImage.imageName)
+    }
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-build-image-name.gradle.kts
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-build-image-name.gradle.kts
@@ -1,16 +1,18 @@
-import org.springframework.boot.gradle.tasks.bundling.BootJar
+import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
 
 plugins {
 	java
 	id("org.springframework.boot") version "{gradle-project-version}"
 }
 
-tasks.getByName<BootJar>("bootJar") {
-	mainClassName = "com.example.ExampleApplication"
-}
-
 // tag::image-name[]
 tasks.getByName<BootBuildImage>("bootBuildImage") {
-	imageName = "example.com/library/${project.artifactId}"
+	imageName = "example.com/library/${project.name}"
 }
 // end::image-name[]
+
+tasks.register("bootBuildImageName") {
+    doFirst {
+        println(tasks.getByName<BootBuildImage>("bootBuildImage").imageName)
+    }
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/docs/PackagingDocumentationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/docs/PackagingDocumentationTests.java
@@ -235,6 +235,13 @@ class PackagingDocumentationTests {
 				.contains("HTTPS_PROXY=https://proxy.example.com");
 	}
 
+	@TestTemplate
+	void bootBuildImageWithCustomImageName() throws IOException {
+		BuildResult result = this.gradleBuild.script("src/docs/gradle/packaging/boot-build-image-name")
+				.build("bootBuildImageName");
+		assertThat(result.getOutput()).contains("example.com/library/" + this.gradleBuild.getProjectDir().getName());
+	}
+
 	protected void jarFile(File file) throws IOException {
 		try (JarOutputStream jar = new JarOutputStream(new FileOutputStream(file))) {
 			jar.putNextEntry(new ZipEntry("META-INF/MANIFEST.MF"));


### PR DESCRIPTION
There is no `artifactId` property in a gradle Project, and the default value uses the project name.
