### PR TITLE
Configurable SSL Logback extensions can't be supported due to URL checks

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
@@ -53,7 +53,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.log.LogMessage;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -307,7 +306,6 @@ public class LoggingApplicationListener implements GenericApplicationListener {
 		}
 		else {
 			try {
-				ResourceUtils.getURL(logConfig).openStream().close();
 				system.initialize(initializationContext, logConfig, logFile);
 			}
 			catch (Exception ex) {


### PR DESCRIPTION
Log4j 2 provides enhanced Spring Boot and Spring Cloud Config support with its [log4j-spring-boot](https://github.com/apache/logging-log4j2/tree/release-2.x/log4j-spring-boot) and [log4j-spring-cloud-config-client](https://github.com/apache/logging-log4j2/tree/release-2.x/log4j-spring-cloud-config/log4j-spring-cloud-config-client) modules.  The Spring Cloud Config Client allows Log4j configuration files to be managed in Spring Cloud Config allowing for dynamic updating of the configuration, configurable SSL support, and support for credentials to access Spring Cloud Config server.

Unfortunately, Spring Boot's LoggingApplicationListener makes it impossible to provide the configurable SSL and credentials support since it needlessly tries to access the configured URL ostensibly to determine if the URL is valid. This check really provides no value since the underlying LoggingSystem will throw an exception if the url cannot be accessed, and because it does not include credentials it results in a 401 response that prevents the Spring Boot application from starting if credentials are required to access the Spring Cloud Configuration server.