### PR TITLE
Fix issues with PrometheusPushGateway during shutdown

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusPushGatewayManager.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusPushGatewayManager.java
@@ -136,7 +136,7 @@ public class PrometheusPushGatewayManager {
 	 * is set to "PUSH", the push gateway may trigger calls to meters that are present in
 	 * other beans. The push operation must happen BEFORE those beans are destroyed to
 	 * prevent errors during shutdown.
-	 * @param event The context closed event
+	 * @param event the context closed event
 	 */
 	@EventListener
 	public void shutdown(ContextClosedEvent event) {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusPushGatewayManager.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusPushGatewayManager.java
@@ -28,6 +28,8 @@ import io.prometheus.client.exporter.PushGateway;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.Assert;
@@ -130,9 +132,14 @@ public class PrometheusPushGatewayManager {
 	}
 
 	/**
-	 * Shutdown the manager, running any {@link ShutdownOperation}.
+	 * Shutdown the manager, running any {@link ShutdownOperation}. If shutdown operation
+	 * is set to "PUSH", the push gateway may trigger calls to meters that are present in
+	 * other beans. The push operation must happen BEFORE those beans are destroyed to
+	 * prevent errors during shutdown.
+	 * @param event The context closed event
 	 */
-	public void shutdown() {
+	@EventListener
+	public void shutdown(ContextClosedEvent event) {
 		shutdown(this.shutdownOperation);
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusPushGatewayManagerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusPushGatewayManagerTests.java
@@ -33,6 +33,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.boot.actuate.metrics.export.prometheus.PrometheusPushGatewayManager.PushGatewayTaskScheduler;
 import org.springframework.boot.actuate.metrics.export.prometheus.PrometheusPushGatewayManager.ShutdownOperation;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
@@ -53,6 +55,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
  */
 @ExtendWith(MockitoExtension.class)
 class PrometheusPushGatewayManagerTests {
+
+	@Mock
+	private ApplicationContext applicationContext;
 
 	@Mock
 	private PushGateway pushGateway;
@@ -122,7 +127,7 @@ class PrometheusPushGatewayManagerTests {
 				mock(PushGatewayTaskScheduler.class));
 		PrometheusPushGatewayManager manager = new PrometheusPushGatewayManager(this.pushGateway, this.registry,
 				ownedScheduler, this.pushRate, "job", this.groupingKey, null);
-		manager.shutdown();
+		manager.shutdown(new ContextClosedEvent(this.applicationContext));
 		verify(ownedScheduler).shutdown();
 	}
 
@@ -132,7 +137,7 @@ class PrometheusPushGatewayManagerTests {
 				mock(ThreadPoolTaskScheduler.class));
 		PrometheusPushGatewayManager manager = new PrometheusPushGatewayManager(this.pushGateway, this.registry,
 				otherScheduler, this.pushRate, "job", this.groupingKey, null);
-		manager.shutdown();
+		manager.shutdown(new ContextClosedEvent(this.applicationContext));
 		verify(otherScheduler, never()).shutdown();
 	}
 
@@ -141,7 +146,7 @@ class PrometheusPushGatewayManagerTests {
 		givenScheduleAtFixedRateWithReturnFuture();
 		PrometheusPushGatewayManager manager = new PrometheusPushGatewayManager(this.pushGateway, this.registry,
 				this.scheduler, this.pushRate, "job", this.groupingKey, ShutdownOperation.PUSH);
-		manager.shutdown();
+		manager.shutdown(new ContextClosedEvent(this.applicationContext));
 		verify(this.future).cancel(false);
 		verify(this.pushGateway).pushAdd(this.registry, "job", this.groupingKey);
 	}
@@ -151,7 +156,7 @@ class PrometheusPushGatewayManagerTests {
 		givenScheduleAtFixedRateWithReturnFuture();
 		PrometheusPushGatewayManager manager = new PrometheusPushGatewayManager(this.pushGateway, this.registry,
 				this.scheduler, this.pushRate, "job", this.groupingKey, ShutdownOperation.DELETE);
-		manager.shutdown();
+		manager.shutdown(new ContextClosedEvent(this.applicationContext));
 		verify(this.future).cancel(false);
 		verify(this.pushGateway).delete("job", this.groupingKey);
 	}
@@ -161,7 +166,7 @@ class PrometheusPushGatewayManagerTests {
 		givenScheduleAtFixedRateWithReturnFuture();
 		PrometheusPushGatewayManager manager = new PrometheusPushGatewayManager(this.pushGateway, this.registry,
 				this.scheduler, this.pushRate, "job", this.groupingKey, ShutdownOperation.NONE);
-		manager.shutdown();
+		manager.shutdown(new ContextClosedEvent(this.applicationContext));
 		verify(this.future).cancel(false);
 		verifyNoInteractions(this.pushGateway);
 	}


### PR DESCRIPTION
We ran into an issue with the PrometheusPushGateway during shutdown of our our Spring Cloud Task applications. Specifically, any task that leveraged Spring Integration would result in an error on shutdown when the shutdown operation was set to "PUSH": 

```

org.springframework.beans.factory.BeanCreationNotAllowedException: Error creating bean with name 'nullChannel': Singleton bean creation not allowed while singletons of this factory are in destruction (Do not request a bean from a BeanFactory in a destroy method implementation!)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:212) ~[spring-beans-5.2.6.RELEASE.jar:5.2.6.RELEASE]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:321) ~[spring-beans-5.2.6.RELEASE.jar:5.2.6.RELEASE]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202) ~[spring-beans-5.2.6.RELEASE.jar:5.2.6.RELEASE]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBeansOfType(DefaultListableBeanFactory.java:623) ~[spring-beans-5.2.6.RELEASE.jar:5.2.6.RELEASE]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBeansOfType(DefaultListableBeanFactory.java:611) ~[spring-beans-5.2.6.RELEASE.jar:5.2.6.RELEASE]
	at org.springframework.context.support.AbstractApplicationContext.getBeansOfType(AbstractApplicationContext.java:1242) ~[spring-context-5.2.6.RELEASE.jar:5.2.6.RELEASE]
	at org.springframework.integration.config.IntegrationManagementConfigurer.lambda$registerComponentGauges$1(IntegrationManagementConfigurer.java:444) ~[spring-integration-core-5.2.6.RELEASE.jar:5.2.6.RELEASE]
	at io.micrometer.core.instrument.internal.DefaultGauge.value(DefaultGauge.java:54) ~[micrometer-core-1.3.8.jar:1.3.8]
	at io.micrometer.prometheus.PrometheusMeterRegistry.lambda$newGauge$3(PrometheusMeterRegistry.java:245) [micrometer-registry-prometheus-1.3.8.jar:1.3.8]
	at io.micrometer.prometheus.MicrometerCollector.collect(MicrometerCollector.java:69) ~[micrometer-registry-prometheus-1.3.8.jar:1.3.8]
	at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.findNextElement(CollectorRegistry.java:190) ~[simpleclient-0.7.0.jar:na]
	at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.nextElement(CollectorRegistry.java:223) ~[simpleclient-0.7.0.jar:na]
	at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.nextElement(CollectorRegistry.java:144) ~[simpleclient-0.7.0.jar:na]
	at io.prometheus.client.exporter.common.TextFormat.write004(TextFormat.java:22) ~[simpleclient_common-0.7.0.jar:na]
	at io.prometheus.client.exporter.PushGateway.doRequest(PushGateway.java:310) ~[simpleclient_pushgateway-0.7.0.jar:na]
	at io.prometheus.client.exporter.PushGateway.pushAdd(PushGateway.java:182) ~[simpleclient_pushgateway-0.7.0.jar:na]
	at org.springframework.boot.actuate.metrics.export.prometheus.PrometheusPushGatewayManager.push(PrometheusPushGatewayManager.java:108) ~[spring-boot-actuator-2.2.7.RELEASE.jar:2.2.7.RELEASE]
	at org.springframework.boot.actuate.metrics.export.prometheus.PrometheusPushGatewayManager.shutdown(PrometheusPushGatewayManager.java:146) ~[spring-boot-actuator-2.2.7.RELEASE.jar:2.2.7.RELEASE]
	at org.springframework.boot.actuate.metrics.export.prometheus.PrometheusPushGatewayManager.shutdown(PrometheusPushGatewayManager.java:136) ~[spring-boot-actuator-2.2.7.RELEASE.jar:2.2.7.RELEASE]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_252]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_252]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_252]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_252]
	at org.springframework.beans.factory.support.DisposableBeanAdapter.invokeCustomDestroyMethod(DisposableBeanAdapter.java:339) ~[spring-beans-5.2.6.RELEASE.jar:5.2.6.RELEASE]

```

After investigating, you can see that the "push" event is being triggered by a "pre-destroy" event on the PrometheusGatewayManager and that, in turn, is attempting to get meter values from singleton beans that have already been destroyed. To fix this, the shutdown can instead be triggered from a ContextClosedEvent (prior to any beans being destroyed)

This is similar to what was discussed in this stack overflow thread: 

https://stackoverflow.com/questions/52785517/beancreationnotallowedexception-from-predestroy-annotation-from-prometheuspushg