### PR TITLE
Provide a configuration property for Kafka listener container's idleBetweenPolls

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/ConcurrentKafkaListenerContainerFactoryConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/ConcurrentKafkaListenerContainerFactoryConfigurer.java
@@ -187,6 +187,7 @@ public class ConcurrentKafkaListenerContainerFactoryConfigurer {
 		map.from(properties::getIdleEventInterval).as(Duration::toMillis).to(container::setIdleEventInterval);
 		map.from(properties::getMonitorInterval).as(Duration::getSeconds).as(Number::intValue)
 				.to(container::setMonitorInterval);
+		map.from(properties.getIdleBetweenPolls()).as(Duration::toMillis).to(container::setIdleBetweenPolls);
 		map.from(properties::getLogContainerConfig).to(container::setLogContainerConfig);
 		map.from(properties::isMissingTopicsFatal).to(container::setMissingTopicsFatal);
 		map.from(this.transactionManager).to(container::setTransactionManager);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
@@ -891,6 +891,12 @@ public class KafkaProperties {
 		private Duration idleEventInterval;
 
 		/**
+		 * The sleep interval in milliseconds between
+		 * {@link org.apache.kafka.clients.consumer.Consumer#poll(Duration)} calls.
+		 */
+		private Duration idleBetweenPolls;
+
+		/**
 		 * Time between checks for non-responsive consumers. If a duration suffix is not
 		 * specified, seconds will be used.
 		 */
@@ -980,6 +986,14 @@ public class KafkaProperties {
 			this.idleEventInterval = idleEventInterval;
 		}
 
+		public Duration getIdleBetweenPolls() {
+			return idleBetweenPolls;
+		}
+
+		public void setIdleBetweenPolls(Duration idleBetweenPolls) {
+			this.idleBetweenPolls = idleBetweenPolls;
+		}
+
 		public Duration getMonitorInterval() {
 			return this.monitorInterval;
 		}
@@ -1003,7 +1017,6 @@ public class KafkaProperties {
 		public void setMissingTopicsFatal(boolean missingTopicsFatal) {
 			this.missingTopicsFatal = missingTopicsFatal;
 		}
-
 	}
 
 	public static class Ssl {


### PR DESCRIPTION
In my experience people sometimes need to control their consumption rate.
Spring kafka support this: https://github.com/spring-projects/spring-kafka/blob/master/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java

This simply add the property so it can be configure easily.