### PR TITLE
Simplify InputStream assertions

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/ZipFileTarArchiveTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/ZipFileTarArchiveTests.java
@@ -29,8 +29,6 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import org.springframework.util.StreamUtils;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
@@ -77,8 +75,7 @@ class ZipFileTarArchiveTests {
 			assertThat(fileEntry.getLongUserId()).isEqualTo(123);
 			assertThat(fileEntry.getLongGroupId()).isEqualTo(456);
 			assertThat(fileEntry.getSize()).isEqualTo(4);
-			String fileContent = StreamUtils.copyToString(tarStream, StandardCharsets.UTF_8);
-			assertThat(fileContent).isEqualTo("test");
+			assertThat(tarStream).hasContent("test");
 		}
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
@@ -564,8 +564,7 @@ class JarFileTests {
 			for (int i = 0; i < entries.size(); i++) {
 				JarEntry entry = entries.get(i);
 				InputStream entryInput = zip64JarFile.getInputStream(entry);
-				String contents = StreamUtils.copyToString(entryInput, StandardCharsets.UTF_8);
-				assertThat(contents).isEqualTo("Entry " + (i + 1));
+				assertThat(entryInput).hasContent("Entry " + (i + 1));
 			}
 		}
 	}
@@ -594,8 +593,7 @@ class JarFileTests {
 				for (int i = 0; i < entries.size(); i++) {
 					JarEntry entry = entries.get(i);
 					InputStream entryInput = nestedZip64JarFile.getInputStream(entry);
-					String contents = StreamUtils.copyToString(entryInput, StandardCharsets.UTF_8);
-					assertThat(contents).isEqualTo("Entry " + (i + 1));
+					assertThat(entryInput).hasContent("Entry " + (i + 1));
 				}
 			}
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarURLConnectionTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarURLConnectionTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.loader.jar;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
@@ -76,7 +75,7 @@ class JarURLConnectionTests {
 	void connectionToEntryUsingAbsoluteUrl() throws Exception {
 		URL url = new URL("jar:" + this.rootJarFile.toURI().toURL() + "!/1.dat");
 		try (InputStream input = JarURLConnection.get(url, this.jarFile).getInputStream()) {
-			assertThat(input).hasSameContentAs(new ByteArrayInputStream(new byte[] { 1 }));
+			assertThat(input).hasBinaryContent(new byte[] { 1 });
 		}
 	}
 
@@ -84,7 +83,7 @@ class JarURLConnectionTests {
 	void connectionToEntryUsingRelativeUrl() throws Exception {
 		URL url = new URL("jar:file:" + getRelativePath() + "!/1.dat");
 		try (InputStream input = JarURLConnection.get(url, this.jarFile).getInputStream()) {
-			assertThat(input).hasSameContentAs(new ByteArrayInputStream(new byte[] { 1 }));
+			assertThat(input).hasBinaryContent(new byte[] { 1 });
 		}
 	}
 
@@ -92,7 +91,7 @@ class JarURLConnectionTests {
 	void connectionToEntryUsingAbsoluteUrlWithFileColonSlashSlashPrefix() throws Exception {
 		URL url = new URL("jar:" + this.rootJarFile.toURI().toURL() + "!/1.dat");
 		try (InputStream input = JarURLConnection.get(url, this.jarFile).getInputStream()) {
-			assertThat(input).hasSameContentAs(new ByteArrayInputStream(new byte[] { 1 }));
+			assertThat(input).hasBinaryContent(new byte[] { 1 });
 		}
 	}
 
@@ -101,7 +100,7 @@ class JarURLConnectionTests {
 		URL url = new URL("jar:" + this.rootJarFile.toURI().toURL() + "!/nested.jar!/3.dat");
 		JarURLConnection connection = JarURLConnection.get(url, this.jarFile);
 		try (InputStream input = connection.getInputStream()) {
-			assertThat(input).hasSameContentAs(new ByteArrayInputStream(new byte[] { 3 }));
+			assertThat(input).hasBinaryContent(new byte[] { 3 });
 		}
 		connection.getJarFile().close();
 	}
@@ -111,7 +110,7 @@ class JarURLConnectionTests {
 		URL url = new URL("jar:file:" + getRelativePath() + "!/nested.jar!/3.dat");
 		JarURLConnection connection = JarURLConnection.get(url, this.jarFile);
 		try (InputStream input = connection.getInputStream()) {
-			assertThat(input).hasSameContentAs(new ByteArrayInputStream(new byte[] { 3 }));
+			assertThat(input).hasBinaryContent(new byte[] { 3 });
 		}
 		connection.getJarFile().close();
 	}
@@ -121,7 +120,7 @@ class JarURLConnectionTests {
 		URL url = new URL("jar:" + this.rootJarFile.toURI().toURL() + "!/nested.jar!/3.dat");
 		try (JarFile nested = this.jarFile.getNestedJarFile(this.jarFile.getEntry("nested.jar"))) {
 			try (InputStream input = JarURLConnection.get(url, nested).getInputStream()) {
-				assertThat(input).hasSameContentAs(new ByteArrayInputStream(new byte[] { 3 }));
+				assertThat(input).hasBinaryContent(new byte[] { 3 });
 			}
 		}
 	}
@@ -131,7 +130,7 @@ class JarURLConnectionTests {
 		URL url = new URL("jar:file:" + getRelativePath() + "!/nested.jar!/3.dat");
 		try (JarFile nested = this.jarFile.getNestedJarFile(this.jarFile.getEntry("nested.jar"))) {
 			try (InputStream input = JarURLConnection.get(url, nested).getInputStream()) {
-				assertThat(input).hasSameContentAs(new ByteArrayInputStream(new byte[] { 3 }));
+				assertThat(input).hasBinaryContent(new byte[] { 3 });
 			}
 		}
 	}
@@ -142,7 +141,7 @@ class JarURLConnectionTests {
 				"/3.dat");
 		try (JarFile nested = this.jarFile.getNestedJarFile(this.jarFile.getEntry("nested.jar"))) {
 			try (InputStream input = JarURLConnection.get(url, nested).getInputStream()) {
-				assertThat(input).hasSameContentAs(new ByteArrayInputStream(new byte[] { 3 }));
+				assertThat(input).hasBinaryContent(new byte[] { 3 });
 			}
 		}
 	}
@@ -152,7 +151,7 @@ class JarURLConnectionTests {
 		URL url = new URL("jar:file:" + getRelativePath() + "!/space nested.jar!/3.dat");
 		JarURLConnection connection = JarURLConnection.get(url, this.jarFile);
 		try (InputStream input = connection.getInputStream()) {
-			assertThat(input).hasSameContentAs(new ByteArrayInputStream(new byte[] { 3 }));
+			assertThat(input).hasBinaryContent(new byte[] { 3 });
 		}
 		connection.getJarFile().close();
 	}
@@ -162,7 +161,7 @@ class JarURLConnectionTests {
 		URL url = new URL("jar:file:" + getRelativePath() + "!/space%20nested.jar!/3.dat");
 		JarURLConnection connection = JarURLConnection.get(url, this.jarFile);
 		try (InputStream input = connection.getInputStream()) {
-			assertThat(input).hasSameContentAs(new ByteArrayInputStream(new byte[] { 3 }));
+			assertThat(input).hasBinaryContent(new byte[] { 3 });
 		}
 		connection.getJarFile().close();
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/context/ServletWebServerMvcIntegrationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/context/ServletWebServerMvcIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.boot.web.servlet.context;
 
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +37,6 @@ import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Controller;
-import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.DispatcherServlet;
@@ -97,8 +95,7 @@ class ServletWebServerMvcIntegrationTests {
 		ClientHttpRequest request = clientHttpRequestFactory.createRequest(
 				new URI("http://localhost:" + context.getWebServer().getPort() + resourcePath), HttpMethod.GET);
 		try (ClientHttpResponse response = request.execute()) {
-			String actual = StreamUtils.copyToString(response.getBody(), StandardCharsets.UTF_8);
-			assertThat(actual).isEqualTo("Hello World");
+			assertThat(response.getBody()).hasContent("Hello World");
 		}
 	}
 


### PR DESCRIPTION
Hi,

this PR simplifies some `InputStream` assertions. E.g. by using the newest `hasBinaryContent` assertion from AssertJ.

Cheers,
Christoph