### PR TITLE
Alternate approach to addressing the url validation check

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
@@ -53,7 +53,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.log.LogMessage;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -314,7 +313,7 @@ public class LoggingApplicationListener implements GenericApplicationListener {
 		}
 		else {
 			try {
-				ResourceUtils.getURL(logConfig).openStream().close();
+				system.validateLoggingConfig(initializationContext, logConfig);
 				system.initialize(initializationContext, logConfig, logFile);
 			}
 			catch (Exception ex) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystem.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.logging;
 
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -25,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.springframework.util.ClassUtils;
+import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -83,6 +85,17 @@ public abstract class LoggingSystem {
 	 * console only output
 	 */
 	public void initialize(LoggingInitializationContext initializationContext, String configLocation, LogFile logFile) {
+	}
+
+	/**
+	 * Validate the logging configuration.
+	 * @param initializationContext the logging initialization context.
+	 * @param logConfig the logging configuration location.
+	 * @throws IOException if an error occurs accessing the configuration.
+	 */
+	public void validateLoggingConfig(LoggingInitializationContext initializationContext, String logConfig)
+			throws IOException {
+		ResourceUtils.getURL(logConfig).openStream().close();
 	}
 
 	/**

--- a/src/checkstyle/nohttp-checkstyle-suppressions.xml
+++ b/src/checkstyle/nohttp-checkstyle-suppressions.xml
@@ -3,6 +3,7 @@
 	"-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
 	"https://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
+	<suppress files="[\\/].idea[\\/]" checks="NoHttp" />
 	<suppress files="[\\/]transaction-logs[\\/]" checks="NoHttp" />
 	<suppress files="[\\/]target[\\/]" checks="NoHttp" />
 	<suppress files="[\\/]build.log" checks="NoHttp" />


### PR DESCRIPTION
This is an alternate approach to address the issue noted in #22946. Instead of just removing the validation it moves the code to the LoggingSystem where it can be overridden if, in fact, authentication is supported. The benefit of this approach is that the stack traces the users sees will only change by the addition of an addition StackTraceElement for the LoggingSystem.  Thus this change shouldn't be noticeable by most users.

I also added a checkstyle suppression for the .idea directory since the urls within it were causing the build to fail. Spring shouldn't care about IntelliJ's configuration anyway.
