### PR TITLE
Exclude hibernate-jpa-2.1-api from data-jpa

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-data-jpa/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-data-jpa/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 		exclude group: "javax.persistence", module: "javax.persistence-api"
 		exclude group: "javax.xml.bind", module: "jaxb-api"
 		exclude group: "org.jboss.spec.javax.transaction", module: "jboss-transaction-api_1.2_spec"
+		exclude group: "org.hibernate.javax.persistence", module: "hibernate-jpa-2.1-api"
 	}
 	api("org.springframework.data:spring-data-jpa") {
 		exclude group: "org.aspectj", module: "aspectjrt"


### PR DESCRIPTION
This dependency duplicates the classes from `jakarta.persistence:jakarta.persistence-api`

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
