### PR TITLE
Remove unused methods

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/WelcomePageRouterFunctionFactoryTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/WelcomePageRouterFunctionFactoryTests.java
@@ -121,15 +121,6 @@ class WelcomePageRouterFunctionFactoryTests {
 				.isEqualTo("welcome-page-static");
 	}
 
-	private WebTestClient createClient(WelcomePageRouterFunctionFactory factory) {
-		return WebTestClient.bindToRouterFunction(factory.createRouterFunction()).build();
-	}
-
-	private WebTestClient createClient(WelcomePageRouterFunctionFactory factory, ViewResolver viewResolver) {
-		return WebTestClient.bindToRouterFunction(factory.createRouterFunction())
-				.handlerStrategies(HandlerStrategies.builder().viewResolver(viewResolver).build()).build();
-	}
-
 	private WebTestClient withStaticIndex() {
 		WelcomePageRouterFunctionFactory factory = factoryWithoutTemplateSupport(this.indexLocations, "/**");
 		return WebTestClient.bindToRouterFunction(factory.createRouterFunction()).build();


### PR DESCRIPTION
Hi,

this PR removes two unused methods in `WelcomePageRouterFunctionFactoryTests`.

Cheers,
Christoph