### PR TITLE
Support addressShuffleMode to Spring Amqp Autoconfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -106,7 +106,7 @@ public class RabbitAutoConfiguration {
 							.getObject());
 			PropertyMapper map = PropertyMapper.get();
 			map.from(properties::determineAddresses).to(factory::setAddresses);
-			map.from(properties::determineAddressShuffleMode).to(factory::setAddressShuffleMode);
+			map.from(properties::getAddressShuffleMode).whenNonNull().to(factory::setAddressShuffleMode);
 			map.from(properties::isPublisherReturns).to(factory::setPublisherReturns);
 			map.from(properties::getPublisherConfirmType).whenNonNull().to(factory::setPublisherConfirmType);
 			RabbitProperties.Cache.Channel channel = properties.getCache().getChannel();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -83,6 +83,7 @@ import org.springframework.context.annotation.Import;
  * @author Gary Russell
  * @author Phillip Webb
  * @author Artsiom Yudovin
+ * @author Jonghan Kim
  * @since 1.0.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -105,6 +106,7 @@ public class RabbitAutoConfiguration {
 							.getObject());
 			PropertyMapper map = PropertyMapper.get();
 			map.from(properties::determineAddresses).to(factory::setAddresses);
+			map.from(properties::determineAddressShuffleMode).to(factory::setAddressShuffleMode);
 			map.from(properties::isPublisherReturns).to(factory::setPublisherReturns);
 			map.from(properties::getPublisherConfirmType).whenNonNull().to(factory::setPublisherConfirmType);
 			RabbitProperties.Cache.Channel channel = properties.getCache().getChannel();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.rabbit.connection.AbstractConnectionFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.CacheMode;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.ConfirmType;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -41,6 +42,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Artsiom Yudovin
  * @author Franjo Zilic
+ * @author Jonghan Kim
  * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "spring.rabbitmq")
@@ -86,6 +88,11 @@ public class RabbitProperties {
 	 * host and port are ignored.
 	 */
 	private String addresses;
+
+	/**
+	 * Shuffling mode for connecting host. Default mode is NONE.
+	 */
+	private String addressShuffleMode = "NONE";
 
 	/**
 	 * Requested heartbeat timeout; zero for none. If a duration suffix is not specified,
@@ -280,6 +287,28 @@ public class RabbitProperties {
 
 	public void setVirtualHost(String virtualHost) {
 		this.virtualHost = "".equals(virtualHost) ? "/" : virtualHost;
+	}
+
+	public String getAddressShuffleMode() {
+		return this.addressShuffleMode;
+	}
+
+	/**
+	 * If addresses have been set and address shuffle mode has been set it is returned.
+	 * Otherwise returns the result of calling {@code getAddressShuffleMode()}.
+	 * @return the address shuffle mode
+	 * @see #setAddressShuffleMode(String)
+	 * @see #getAddressShuffleMode()
+	 */
+	public AbstractConnectionFactory.AddressShuffleMode determineAddressShuffleMode() {
+		if (CollectionUtils.isEmpty(this.parsedAddresses)) {
+			return AbstractConnectionFactory.AddressShuffleMode.NONE;
+		}
+		return AbstractConnectionFactory.AddressShuffleMode.valueOf(this.addressShuffleMode.toUpperCase());
+	}
+
+	public void setAddressShuffleMode(String addressShuffleMode) {
+		this.addressShuffleMode = addressShuffleMode;
 	}
 
 	public Duration getRequestedHeartbeat() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.amqp.core.AcknowledgeMode;
-import org.springframework.amqp.rabbit.connection.AbstractConnectionFactory;
+import org.springframework.amqp.rabbit.connection.AbstractConnectionFactory.AddressShuffleMode;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.CacheMode;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.ConfirmType;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -90,9 +90,9 @@ public class RabbitProperties {
 	private String addresses;
 
 	/**
-	 * Shuffling mode for connecting host. Default mode is NONE.
+	 * Shuffling mode for connecting host.
 	 */
-	private String addressShuffleMode = "NONE";
+	private AddressShuffleMode addressShuffleMode;
 
 	/**
 	 * Requested heartbeat timeout; zero for none. If a duration suffix is not specified,
@@ -289,25 +289,11 @@ public class RabbitProperties {
 		this.virtualHost = "".equals(virtualHost) ? "/" : virtualHost;
 	}
 
-	public String getAddressShuffleMode() {
+	public AddressShuffleMode getAddressShuffleMode() {
 		return this.addressShuffleMode;
 	}
 
-	/**
-	 * If addresses have been set and address shuffle mode has been set it is returned.
-	 * Otherwise returns the result of calling {@code getAddressShuffleMode()}.
-	 * @return the address shuffle mode
-	 * @see #setAddressShuffleMode(String)
-	 * @see #getAddressShuffleMode()
-	 */
-	public AbstractConnectionFactory.AddressShuffleMode determineAddressShuffleMode() {
-		if (CollectionUtils.isEmpty(this.parsedAddresses)) {
-			return AbstractConnectionFactory.AddressShuffleMode.NONE;
-		}
-		return AbstractConnectionFactory.AddressShuffleMode.valueOf(this.addressShuffleMode.toUpperCase());
-	}
-
-	public void setAddressShuffleMode(String addressShuffleMode) {
+	public void setAddressShuffleMode(AddressShuffleMode addressShuffleMode) {
 		this.addressShuffleMode = addressShuffleMode;
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This support connecting to RabbitMQ clustered host addresses with shuffling.
https://docs.spring.io/spring-amqp/reference/html/#cluster

Because of `shuffle-addresses` mode is deprecated, i have added `addressShuffleMode` property which is `String`.
Please review and comment. Thanks.
