### PR TITLE
Sanitize entire value if property is not of URI type; Fixes gh-23037

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
  * @author Stephane Nicoll
  * @author HaiTao Zhang
  * @author Chris Bono
+ * @author David Good
  * @since 2.0.0
  */
 public class Sanitizer {
@@ -134,7 +135,7 @@ public class Sanitizer {
 		if (password != null) {
 			return StringUtils.replace(value, ":" + password + "@", ":******@");
 		}
-		return value;
+		return "******";
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/SanitizerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/SanitizerTests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Phillip Webb
  * @author Stephane Nicoll
  * @author Chris Bono
+ * @author David Good
  */
 class SanitizerTests {
 
@@ -103,6 +104,14 @@ class SanitizerTests {
 		Sanitizer sanitizer = new Sanitizer();
 		assertThat(sanitizer.sanitize(key, "http://user1://@localhost:8080,http://user2://@localhost:8082"))
 				.isEqualTo("http://user1:******@localhost:8080,http://user2:******@localhost:8082");
+	}
+
+	@ParameterizedTest(name = "key = {0}")
+	@MethodSource("matchingUriUserInfoKeys")
+	void uriKeyWithUnmatchedValueShouldBeSanitized(String key) {
+		Sanitizer sanitizer = new Sanitizer();
+		assertThat(sanitizer.sanitize(key, "[amqp://username:password@host/]")).isEqualTo("******");
+		assertThat(sanitizer.sanitize(key, "any-other-unmatched-value")).isEqualTo("******");
 	}
 
 	private static Stream<String> matchingUriUserInfoKeys() {


### PR DESCRIPTION
Handles case where a property has a uri/address key but the value is not matched against the value regex. In this case, we now sanitize the value.