### PR TITLE
Enable Spring Integration RSocket test again

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
@@ -20,7 +20,6 @@ import javax.management.MBeanServer;
 
 import io.rsocket.transport.ClientTransport;
 import io.rsocket.transport.netty.client.TcpClientTransport;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
@@ -196,7 +195,6 @@ class IntegrationAutoConfigurationTests {
 	}
 
 	@Test
-	@Disabled("SI is incompatible with the latest RSocket snapshots")
 	void rsocketSupportEnabled() {
 		this.contextRunner.withUserConfiguration(RSocketServerConfiguration.class)
 				.withConfiguration(AutoConfigurations.of(RSocketServerAutoConfiguration.class,


### PR DESCRIPTION
Hi,

SI just upgraded RSocket to the latest snapshot, so #23218 can be closed with this.

Cheers,
Christoph