### PR TITLE
Add mime mapping for mjs files

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/MimeMappings.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/MimeMappings.java
@@ -101,6 +101,7 @@ public final class MimeMappings implements Iterable<MimeMappings.Mapping> {
 		mappings.add("mid", "audio/midi");
 		mappings.add("midi", "audio/midi");
 		mappings.add("mif", "application/x-mif");
+		mappings.add("mjs", "text/javascript");
 		mappings.add("mov", "video/quicktime");
 		mappings.add("movie", "video/x-sgi-movie");
 		mappings.add("mp1", "audio/mpeg");


### PR DESCRIPTION
Hello,

`.mjs` is a file extension used by javascript modules. More details here : https://v8.dev/features/modules#mjs

It would be nice if Spring Boot supports them out of the box.

Have a nice day ! 