### PR TITLE
Reinstate SampleRSocketApplicationTests.rSocketEndpoint()

### DIFF
--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-rsocket/src/test/java/smoketest/rsocket/SampleRSocketApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-rsocket/src/test/java/smoketest/rsocket/SampleRSocketApplicationTests.java
@@ -18,7 +18,6 @@ package smoketest.rsocket;
 
 import io.rsocket.metadata.WellKnownMimeType;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -48,7 +47,6 @@ public class SampleRSocketApplicationTests {
 	}
 
 	@Test
-	@Disabled("Fails with an unexpected error during frame handling")
 	void rSocketEndpoint() {
 		RSocketRequester requester = this.builder
 				.rsocketStrategies((builder) -> builder.encoder(new SimpleAuthenticationEncoder()))


### PR DESCRIPTION
Hi,

this PR fixes #22725 .

Cheers,
Christoph