### PR TITLE
Allow types other than Date to be used in the "timestamp" MVC error model

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfiguration.java
@@ -207,7 +207,7 @@ public class ErrorMvcAutoConfiguration {
 			}
 			response.setContentType(TEXT_HTML_UTF8.toString());
 			StringBuilder builder = new StringBuilder();
-			Date timestamp = (Date) model.get("timestamp");
+			Object timestamp = model.get("timestamp");
 			Object message = model.get("message");
 			Object trace = model.get("trace");
 			if (response.getContentType() == null) {


### PR DESCRIPTION
Remove casting timestamp to java.util.Date as the cast is not necessary and it makes using other objects (e.g. java.time classes) for the timestamp more cumbersome (requires supplying a custom ErrorView instead of being able to use the default StaticView).

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
