### PR TITLE
MainClassConvention: use JavaApplication.getMainClass() instead of deprecated JavaApplication.getMainClassName()

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/MainClassConvention.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/MainClassConvention.java
@@ -55,8 +55,8 @@ final class MainClassConvention implements Callable<Object> {
 			return springBootExtension.getMainClassName();
 		}
 		JavaApplication javaApplication = this.project.getConvention().findByType(JavaApplication.class);
-		if (javaApplication != null && javaApplication.getMainClassName() != null) {
-			return javaApplication.getMainClassName();
+		if (javaApplication != null && javaApplication.getMainClass().isPresent()) {
+			return javaApplication.getMainClass().get();
 		}
 		return resolveMainClass();
 	}


### PR DESCRIPTION
Hello folks,

While working on Gradle 6.7-rc-1 upgrades I found this Gradle warning:

```
The JavaApplication.getMainClassName() method has been deprecated. This is scheduled to be removed in Gradle 8.0. Use #getMainClass() instead. See https://docs.gradle.org/6.7-rc-1/dsl/org.gradle.api.plugins.JavaApplication.html#org.gradle.api.plugins.JavaApplication:mainClass for more details.
	at org.gradle.api.plugins.internal.DefaultJavaApplication.getMainClassName(DefaultJavaApplication.java:64)
	at org.gradle.api.plugins.internal.DefaultJavaApplication_Decorated.getMainClassName(Unknown Source)
	at org.springframework.boot.gradle.plugin.MainClassConvention.call(MainClassConvention.java:58)
	at org.gradle.util.GUtil.uncheckedCall(GUtil.java:442)

```

I went ahead an modify the `MainClassConvention` to use the `MainClass` lazy property instead
