### PR TITLE
Note the Kt class name suffix when describing how to configure a Kotlin application's main class name

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging.adoc
@@ -147,6 +147,11 @@ include::../gradle/packaging/boot-jar-manifest-main-class.gradle[tags=main-class
 include::../gradle/packaging/boot-jar-manifest-main-class.gradle.kts[tags=main-class]
 ----
 
+NOTE: Although the use of Kotlin is demonstrated in some examples above, a main class written in Java is assumed.
+If however the main class is written in Kotlin, the name of the generated Java class should be used.
+By default, this is the name of the Kotlin class with the `Kt` suffix added.
+For example: `ExampleApplication` becomes `ExampleApplicationKt`.
+(If another name is defined using the `@JvmName` annotation, then that name should be used.)
 
 
 [[packaging-executable-configuring-including-development-only-dependencies]]


### PR DESCRIPTION
The purpose of this PR is to make it clearer that when Kotlin is used, the name of the main class is not equal to the name of the Kotlin class. This is unrelated with what language the Gradle build script is written in.

In issue gh-22664 this confusion was brought up.