### PR TITLE
Configure the bootBuildInfo task lazily

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/dsl/SpringBootExtension.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/dsl/SpringBootExtension.java
@@ -96,16 +96,16 @@ public class SpringBootExtension {
 		TaskProvider<BuildInfo> bootBuildInfo = tasks.register("bootBuildInfo", BuildInfo.class,
 				this::configureBuildInfoTask);
 		this.project.getPlugins().withType(JavaPlugin.class, (plugin) -> {
-			tasks.getByName(JavaPlugin.CLASSES_TASK_NAME).dependsOn(bootBuildInfo.get());
-			this.project.afterEvaluate((evaluated) -> {
-				BuildInfoProperties properties = bootBuildInfo.get().getProperties();
+			tasks.named(JavaPlugin.CLASSES_TASK_NAME).configure((task) -> task.dependsOn(bootBuildInfo));
+			this.project.afterEvaluate((evaluated) -> bootBuildInfo.configure((buildInfo) -> {
+				BuildInfoProperties properties = buildInfo.getProperties();
 				if (properties.getArtifact() == null) {
 					properties.setArtifact(determineArtifactBaseName());
 				}
-			});
+			}));
 		});
 		if (configurer != null) {
-			configurer.execute(bootBuildInfo.get());
+			bootBuildInfo.configure(configurer);
 		}
 	}
 


### PR DESCRIPTION
This is a follow up to https://github.com/spring-projects/spring-boot/issues/18881

Prior to this commit, the `bootBuildInfo` was configured eagerly.
Configuring it lazily prevent this task from being configured when not explicitly needed.
Also, the `classes` and `bootJar` tasks are now lazily configured, as the `bootBuildInfo` task
required them eagerly.

There are still some improvement possible for the `AutoConfigurationPlugin`, but it requires a bit more work.
