### PR TITLE
Dependency management for Netty tcNative does not include its netty-tcnative module

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1186,6 +1186,7 @@ bom {
 	library("Netty tcNative", "2.0.34.Final") {
 		group("io.netty") {
 			modules = [
+				"netty-tcnative",
 				"netty-tcnative-boringssl-static"
 			]
 		}


### PR DESCRIPTION
Add netty-tcnative in spring-boot-dependencies.