### PR TITLE
Improve performance of DispatcherServletRegistrationCondition

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/DispatcherServletAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/DispatcherServletAutoConfiguration.java
@@ -168,10 +168,13 @@ public class DispatcherServletAutoConfiguration {
 		}
 
 		private ConditionOutcome checkDefaultDispatcherName(ConfigurableListableBeanFactory beanFactory) {
+			boolean containsDispatcherBean = beanFactory.containsBean(DEFAULT_DISPATCHER_SERVLET_BEAN_NAME);
+			if (!containsDispatcherBean) {
+				return ConditionOutcome.match();
+			}
 			List<String> servlets = Arrays
 					.asList(beanFactory.getBeanNamesForType(DispatcherServlet.class, false, false));
-			boolean containsDispatcherBean = beanFactory.containsBean(DEFAULT_DISPATCHER_SERVLET_BEAN_NAME);
-			if (containsDispatcherBean && !servlets.contains(DEFAULT_DISPATCHER_SERVLET_BEAN_NAME)) {
+			if (!servlets.contains(DEFAULT_DISPATCHER_SERVLET_BEAN_NAME)) {
 				return ConditionOutcome.noMatch(
 						startMessage().found("non dispatcher servlet").items(DEFAULT_DISPATCHER_SERVLET_BEAN_NAME));
 			}


### PR DESCRIPTION
Hi,

this PR slightly improves the performance of `DispatcherServletRegistrationCondition` inside `DispatcherServletAutoConfiguration` by avoiding a relatively costly call to `beanFactory.getBeanNamesForType` if the beanFactory doesn't contain a default dispatcher servlet - which seems to be the case most of the time.

I didn't do any benchmarks on this one - it won't save much obviously. It's just a tiny improvement.

Cheers,
Christoph