### PR TITLE
Batch JobParameters can now be configured via properties

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
@@ -77,6 +77,10 @@ public class BatchAutoConfiguration {
 		if (StringUtils.hasText(jobNames)) {
 			runner.setJobNames(jobNames);
 		}
+		String jobParameters = properties.getJobParameters();
+		if (StringUtils.hasText(jobParameters)) {
+			runner.setBatchJobParameters(jobParameters);
+		}
 		return runner;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
@@ -25,6 +25,7 @@ import org.springframework.boot.jdbc.DataSourceInitializationMode;
  * @author Stephane Nicoll
  * @author Eddú Meléndez
  * @author Vedran Pavic
+ * @author Glenn Renfro
  * @since 1.2.0
  */
 @ConfigurationProperties(prefix = "spring.batch")
@@ -47,6 +48,11 @@ public class BatchProperties {
 	 * Database schema initialization mode.
 	 */
 	private DataSourceInitializationMode initializeSchema = DataSourceInitializationMode.EMBEDDED;
+
+	/**
+	 * Contains Job Parameters in a JSON format.
+	 */
+	private String jobParameters;
 
 	private final Job job = new Job();
 
@@ -76,6 +82,14 @@ public class BatchProperties {
 
 	public Job getJob() {
 		return this.job;
+	}
+
+	public String getJobParameters() {
+		return this.jobParameters;
+	}
+
+	public void setJobParameters(String jobParameters) {
+		this.jobParameters = jobParameters;
 	}
 
 	public static class Job {


### PR DESCRIPTION
A user can now configure batch JobParameters using the `spring.batch.job-parameters` property.
The expected format is json, for example: 
```
export spring_batch_jobParameters="{\"run.id(long)\":\"5\",\"foo.bat\":\"test\"}"
```

resolves #23411

