### PR TITLE
Add configuration option to configure RabbitConnectionFactory's channelRpcTimeout

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -149,6 +149,8 @@ public class RabbitAutoConfiguration {
 			}
 			map.from(properties::getConnectionTimeout).whenNonNull().asInt(Duration::toMillis)
 					.to(factory::setConnectionTimeout);
+			map.from(properties::getChannelRpcTimeout).whenNonNull().asInt(Duration::toMillis)
+					.to(factory::setChannelRpcTimeout);
 			map.from(credentialsProvider::getIfUnique).whenNonNull().to(factory::setCredentialsProvider);
 			map.from(credentialsRefreshService::getIfUnique).whenNonNull().to(factory::setCredentialsRefreshService);
 			factory.afterPropertiesSet();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -119,6 +119,11 @@ public class RabbitProperties {
 	 * Connection timeout. Set it to zero to wait forever.
 	 */
 	private Duration connectionTimeout;
+	
+	/**
+	 * Channel RPC timeout.
+	 */
+	private Duration channelRpcTimeout;
 
 	/**
 	 * Cache configuration.
@@ -323,6 +328,10 @@ public class RabbitProperties {
 	public Duration getConnectionTimeout() {
 		return this.connectionTimeout;
 	}
+	
+	public Duration getChannelRpcTimeout() {
+		return this.channelRpcTimeout;
+	}
 
 	public void setPublisherConfirmType(ConfirmType publisherConfirmType) {
 		this.publisherConfirmType = publisherConfirmType;
@@ -334,6 +343,10 @@ public class RabbitProperties {
 
 	public void setConnectionTimeout(Duration connectionTimeout) {
 		this.connectionTimeout = connectionTimeout;
+	}
+	
+	public void setChannelRpcTimeout(Duration channelRpcTimeout) {
+		this.channelRpcTimeout = channelRpcTimeout;
 	}
 
 	public Cache getCache() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -140,7 +140,7 @@ class RabbitAutoConfigurationTests {
 				.withPropertyValues("spring.rabbitmq.host:remote-server", "spring.rabbitmq.port:9000",
 						"spring.rabbitmq.address-shuffle-mode=random", "spring.rabbitmq.username:alice",
 						"spring.rabbitmq.password:secret", "spring.rabbitmq.virtual_host:/vhost",
-						"spring.rabbitmq.connection-timeout:123")
+						"spring.rabbitmq.connection-timeout:123", "spring.rabbitmq.channel-rpc-timeout:140")
 				.run((context) -> {
 					CachingConnectionFactory connectionFactory = context.getBean(CachingConnectionFactory.class);
 					assertThat(connectionFactory.getHost()).isEqualTo("remote-server");
@@ -150,6 +150,7 @@ class RabbitAutoConfigurationTests {
 					assertThat(connectionFactory.getVirtualHost()).isEqualTo("/vhost");
 					com.rabbitmq.client.ConnectionFactory rcf = connectionFactory.getRabbitConnectionFactory();
 					assertThat(rcf.getConnectionTimeout()).isEqualTo(123);
+					assertThat(rcf.getChannelRpcTimeout()).isEqualTo(140);
 					assertThat((List<Address>) ReflectionTestUtils.getField(connectionFactory, "addresses")).hasSize(1);
 				});
 	}


### PR DESCRIPTION
Added the property channelRpcTimeout in RabbitProperties.java file to be
configurable in RabbitAutoConfiguration

Thank you for the OSD opportunity to learn! I hope you all made a lot of progress on this project today.