### PR TITLE
hsqldb connection rename

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.java
@@ -59,7 +59,14 @@ public enum EmbeddedDatabaseConnection {
 	/**
 	 * HSQL Database Connection.
 	 */
+	@Deprecated
 	HSQL(EmbeddedDatabaseType.HSQL, DatabaseDriver.HSQLDB.getDriverClassName(), "org.hsqldb.jdbcDriver",
+			"jdbc:hsqldb:mem:%s"),
+
+	/**
+	 * HSQL Database Connection.
+	 */
+	HSQLDB(EmbeddedDatabaseType.HSQL, DatabaseDriver.HSQLDB.getDriverClassName(), "org.hsqldb.jdbcDriver",
 			"jdbc:hsqldb:mem:%s");
 
 	private final EmbeddedDatabaseType type;
@@ -115,7 +122,7 @@ public enum EmbeddedDatabaseConnection {
 	 */
 	public static boolean isEmbedded(String driverClass) {
 		return driverClass != null
-				&& (matches(HSQL, driverClass) || matches(H2, driverClass) || matches(DERBY, driverClass));
+				&& (matches(HSQL, driverClass) || matches(H2, driverClass) || matches(DERBY, driverClass) || matches(HSQLDB, driverClass));
 	}
 
 	private static boolean matches(EmbeddedDatabaseConnection candidate, String driverClass) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnectionTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnectionTests.java
@@ -40,20 +40,41 @@ class EmbeddedDatabaseConnectionTests {
 				.isEqualTo("jdbc:derby:memory:myderbydb;create=true");
 	}
 
+	@Deprecated
 	@Test
 	void hsqlCustomDatabaseName() {
 		assertThat(EmbeddedDatabaseConnection.HSQL.getUrl("myhsql")).isEqualTo("jdbc:hsqldb:mem:myhsql");
 	}
 
+	@Deprecated
 	@Test
 	void getUrlWithNullDatabaseName() {
 		assertThatIllegalArgumentException().isThrownBy(() -> EmbeddedDatabaseConnection.HSQL.getUrl(null))
 				.withMessageContaining("DatabaseName must not be empty");
 	}
 
+	@Deprecated
 	@Test
 	void getUrlWithEmptyDatabaseName() {
 		assertThatIllegalArgumentException().isThrownBy(() -> EmbeddedDatabaseConnection.HSQL.getUrl("  "))
+				.withMessageContaining("DatabaseName must not be empty");
+	}
+
+// HSQLDB connection tests added
+	@Test
+	void hsqldbCustomDatabaseName() {
+		assertThat(EmbeddedDatabaseConnection.HSQLDB.getUrl("myhsqldb")).isEqualTo("jdbc:hsqldb:mem:myhsqldb");
+	}
+
+	@Test
+	void getUrlWithNullDatabaseNameForHsqldb() {
+		assertThatIllegalArgumentException().isThrownBy(() -> EmbeddedDatabaseConnection.HSQLDB.getUrl(null))
+				.withMessageContaining("DatabaseName must not be empty");
+	}
+
+	@Test
+	void getUrlWithEmptyDatabaseNameForHsqldb() {
+		assertThatIllegalArgumentException().isThrownBy(() -> EmbeddedDatabaseConnection.HSQLDB.getUrl("  "))
 				.withMessageContaining("DatabaseName must not be empty");
 	}
 


### PR DESCRIPTION
-> Issue #23092 (Deprecate HSQL in EmbeddedDatabaseConnection and add HSQLDB as its preferred replacement).
-> PR is able to fix the issue by adding the enum hsqldb in the EmbeddedDatabaseConnection file and therey helping for consistency of connection name across different files.
-> Added deprecating annotation for old hsql connection name
-> Tests are added to verify the changes and ran locally with "pass" status.


