### PR TITLE
Use JdbcTransactionManager in favor of DatasourceTransactionManager

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
@@ -30,12 +30,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.transaction.TransactionManager;
 
 /**
- * {@link EnableAutoConfiguration Auto-configuration} for
- * {@link DataSourceTransactionManager}.
+ * {@link EnableAutoConfiguration Auto-configuration} for {@link JdbcTransactionManager}.
  *
  * @author Dave Syer
  * @author Stephane Nicoll
@@ -55,9 +54,9 @@ public class DataSourceTransactionManagerAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(TransactionManager.class)
-		DataSourceTransactionManager transactionManager(DataSource dataSource,
+		JdbcTransactionManager transactionManager(DataSource dataSource,
 				ObjectProvider<TransactionManagerCustomizers> transactionManagerCustomizers) {
-			DataSourceTransactionManager transactionManager = new DataSourceTransactionManager(dataSource);
+			JdbcTransactionManager transactionManager = new JdbcTransactionManager(dataSource);
 			transactionManagerCustomizers.ifAvailable((customizers) -> customizers.customize(transactionManager));
 			return transactionManager;
 		}


### PR DESCRIPTION
Spring 5.3 introduced the JdbcTransactionManager with exception translation
on commit and rollback. With this commit, this transaction manager is going
to be used in favour of the DataSourceTransactionManager used previously.
