### PR TITLE
Avoid explicit initialization of Atomics with their default values

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/OnlyOnceLoggingDenyMeterFilter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/OnlyOnceLoggingDenyMeterFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/OnlyOnceLoggingDenyMeterFilter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/OnlyOnceLoggingDenyMeterFilter.java
@@ -38,7 +38,7 @@ public final class OnlyOnceLoggingDenyMeterFilter implements MeterFilter {
 
 	private static final Log logger = LogFactory.getLog(OnlyOnceLoggingDenyMeterFilter.class);
 
-	private final AtomicBoolean alreadyWarned = new AtomicBoolean(false);
+	private final AtomicBoolean alreadyWarned = new AtomicBoolean();
 
 	private final Supplier<String> message;
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicatorTests.java
@@ -87,7 +87,7 @@ class Neo4jHealthIndicatorTests {
 		ResultSummary resultSummary = ResultSummaryMock.createResultSummary("4711", "My Home", "");
 		Session session = mock(Session.class);
 		Result statementResult = mockStatementResult(resultSummary, "some edition");
-		AtomicInteger count = new AtomicInteger(0);
+		AtomicInteger count = new AtomicInteger();
 		given(session.run(anyString())).will((invocation) -> {
 			if (count.compareAndSet(0, 1)) {
 				throw new SessionExpiredException("Session expired");

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jReactiveHealthIndicatorTest.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jReactiveHealthIndicatorTest.java
@@ -66,7 +66,7 @@ class Neo4jReactiveHealthIndicatorTest {
 		ResultSummary resultSummary = ResultSummaryMock.createResultSummary("4711", "My Home", "");
 		RxSession session = mock(RxSession.class);
 		RxResult statementResult = mockStatementResult(resultSummary, "some edition");
-		AtomicInteger count = new AtomicInteger(0);
+		AtomicInteger count = new AtomicInteger();
 		given(session.run(anyString())).will((invocation) -> {
 			if (count.compareAndSet(0, 1)) {
 				throw new SessionExpiredException("Session expired");

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/BackgroundPreinitializer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/BackgroundPreinitializer.java
@@ -60,7 +60,7 @@ public class BackgroundPreinitializer implements ApplicationListener<SpringAppli
 	 */
 	public static final String IGNORE_BACKGROUNDPREINITIALIZER_PROPERTY_NAME = "spring.backgroundpreinitializer.ignore";
 
-	private static final AtomicBoolean preinitializationStarted = new AtomicBoolean(false);
+	private static final AtomicBoolean preinitializationStarted = new AtomicBoolean();
 
 	private static final CountDownLatch preinitializationComplete = new CountDownLatch(1);
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/builder/SpringApplicationBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/builder/SpringApplicationBuilder.java
@@ -79,7 +79,7 @@ public class SpringApplicationBuilder {
 
 	private SpringApplicationBuilder parent;
 
-	private final AtomicBoolean running = new AtomicBoolean(false);
+	private final AtomicBoolean running = new AtomicBoolean();
 
 	private final Set<Class<?>> sources = new LinkedHashSet<>();
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/ApplicationPidFileWriter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/ApplicationPidFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/ApplicationPidFileWriter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/ApplicationPidFileWriter.java
@@ -86,7 +86,7 @@ public class ApplicationPidFileWriter implements ApplicationListener<SpringAppli
 		FAIL_ON_WRITE_ERROR_PROPERTIES = Collections.unmodifiableList(properties);
 	}
 
-	private static final AtomicBoolean created = new AtomicBoolean(false);
+	private static final AtomicBoolean created = new AtomicBoolean();
 
 	private int order = Ordered.HIGHEST_PRECEDENCE + 13;
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/ContextIdApplicationContextInitializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/ContextIdApplicationContextInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/ContextIdApplicationContextInitializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/ContextIdApplicationContextInitializer.java
@@ -74,7 +74,7 @@ public class ContextIdApplicationContextInitializer
 	 */
 	static class ContextId {
 
-		private final AtomicLong children = new AtomicLong(0);
+		private final AtomicLong children = new AtomicLong();
 
 		private final String id;
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
@@ -170,7 +170,7 @@ public class LoggingApplicationListener implements GenericApplicationListener {
 
 	private static final Class<?>[] SOURCE_TYPES = { SpringApplication.class, ApplicationContext.class };
 
-	private static final AtomicBoolean shutdownHookRegistered = new AtomicBoolean(false);
+	private static final AtomicBoolean shutdownHookRegistered = new AtomicBoolean();
 
 	private final Log logger = LogFactory.getLog(getClass());
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
@@ -1506,7 +1506,7 @@ class SpringApplicationTests {
 
 		@Bean
 		AtomicInteger counter() {
-			return new AtomicInteger(0);
+			return new AtomicInteger();
 		}
 
 		@Bean
@@ -1529,7 +1529,7 @@ class SpringApplicationTests {
 
 		@Bean
 		AtomicInteger counter() {
-			return new AtomicInteger(0);
+			return new AtomicInteger();
 		}
 
 		@Bean
@@ -1553,7 +1553,7 @@ class SpringApplicationTests {
 
 		@Bean
 		AtomicInteger counter() {
-			return new AtomicInteger(0);
+			return new AtomicInteger();
 		}
 
 		@Bean

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
@@ -1355,7 +1355,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 
 	private class TestGzipInputStreamFactory implements InputStreamFactory {
 
-		private final AtomicBoolean requested = new AtomicBoolean(false);
+		private final AtomicBoolean requested = new AtomicBoolean();
 
 		@Override
 		public InputStream create(InputStream in) throws IOException {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/main/java/smoketest/websocket/jetty/snake/SnakeWebSocketHandler.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/main/java/smoketest/websocket/jetty/snake/SnakeWebSocketHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/main/java/smoketest/websocket/jetty/snake/SnakeWebSocketHandler.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/main/java/smoketest/websocket/jetty/snake/SnakeWebSocketHandler.java
@@ -28,7 +28,7 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 public class SnakeWebSocketHandler extends TextWebSocketHandler {
 
-	private static final AtomicInteger snakeIds = new AtomicInteger(0);
+	private static final AtomicInteger snakeIds = new AtomicInteger();
 
 	private static final Random random = new Random();
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/main/java/smoketest/websocket/tomcat/snake/SnakeWebSocketHandler.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/main/java/smoketest/websocket/tomcat/snake/SnakeWebSocketHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/main/java/smoketest/websocket/tomcat/snake/SnakeWebSocketHandler.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/main/java/smoketest/websocket/tomcat/snake/SnakeWebSocketHandler.java
@@ -28,7 +28,7 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 public class SnakeWebSocketHandler extends TextWebSocketHandler {
 
-	private static final AtomicInteger snakeIds = new AtomicInteger(0);
+	private static final AtomicInteger snakeIds = new AtomicInteger();
 
 	private static final Random random = new Random();
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/main/java/smoketest/websocket/undertow/snake/SnakeWebSocketHandler.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/main/java/smoketest/websocket/undertow/snake/SnakeWebSocketHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/main/java/smoketest/websocket/undertow/snake/SnakeWebSocketHandler.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/main/java/smoketest/websocket/undertow/snake/SnakeWebSocketHandler.java
@@ -28,7 +28,7 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 public class SnakeWebSocketHandler extends TextWebSocketHandler {
 
-	private static final AtomicInteger snakeIds = new AtomicInteger(0);
+	private static final AtomicInteger snakeIds = new AtomicInteger();
 
 	private static final Random random = new Random();
 


### PR DESCRIPTION
Hi,

this PR changes some constructor calls like `new AtomicInteger(0)` that cause a volatile write which can be saved in cases where the constructor parameter is the default value.

Cheers,
Christoph