### PR TITLE
Fix ClassCastException when using ImportAsConfigurationPropertiesBean

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessor.java
@@ -365,7 +365,7 @@ public class ConfigurationMetadataAnnotationProcessor extends AbstractProcessor 
 			return (String) prefix;
 		}
 		Object value = elementValues.get("value");
-		if (value != null && !"".equals(value)) {
+		if ((value instanceof String) && !"".equals(value)) {
 			return (String) value;
 		}
 		return null;

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ImportBeanTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ImportBeanTests.java
@@ -24,6 +24,7 @@ import org.springframework.boot.configurationsample.ImportAsConfigurationPropert
 import org.springframework.boot.configurationsample.ImportAsConfigurationPropertiesBeans;
 import org.springframework.boot.configurationsample.importbean.ImportAnnotatedJavaBean;
 import org.springframework.boot.configurationsample.importbean.ImportJavaBeanConfigurationPropertiesBean;
+import org.springframework.boot.configurationsample.importbean.ImportJavaBeanWithoutPrefixUsingValueConfigurationPropertiesBean;
 import org.springframework.boot.configurationsample.importbean.ImportMultipleTypeConfigurationPropertiesBean;
 import org.springframework.boot.configurationsample.importbean.ImportRepeatedConfigurationPropertiesBean;
 import org.springframework.boot.configurationsample.importbean.ImportValueObjectConfigurationPropertiesBean;
@@ -76,6 +77,13 @@ public class ImportBeanTests extends AbstractMetadataGenerationTests {
 		ConfigurationMetadata metadata = compile(ImportAnnotatedJavaBean.class);
 		assertThat(metadata)
 				.has(Metadata.withProperty("test.name", String.class).fromSource(ImportedAnnotatedJavaBean.class));
+	}
+
+	@Test
+	void importJavaBeanConfigurationWithoutPrefixUsingValuePropertiesBean() {
+		ConfigurationMetadata metadata = compile(
+				ImportJavaBeanWithoutPrefixUsingValueConfigurationPropertiesBean.class);
+		assertThat(metadata).has(Metadata.withProperty("name", String.class).fromSource(ImportedJavaBean.class));
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/ImportAsConfigurationPropertiesBean.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/ImportAsConfigurationPropertiesBean.java
@@ -38,7 +38,11 @@ import org.springframework.core.annotation.AliasFor;
 @Repeatable(ImportAsConfigurationPropertiesBeans.class)
 public @interface ImportAsConfigurationPropertiesBean {
 
-	Class<?>[] type();
+	@AliasFor("type")
+	Class<?>[] value() default {};
+
+	@AliasFor("value")
+	Class<?>[] type() default {};
 
 	@AliasFor(annotation = ConfigurationProperties.class)
 	String prefix() default "";

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/importbean/ImportJavaBeanWithoutPrefixUsingValueConfigurationPropertiesBean.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/importbean/ImportJavaBeanWithoutPrefixUsingValueConfigurationPropertiesBean.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.configurationsample.importbean;
+
+import org.springframework.boot.configurationsample.ImportAsConfigurationPropertiesBean;
+
+/**
+ * An import of a java bean without an explicit prefix using the {@code value} property of
+ * the {@link ImportAsConfigurationPropertiesBean} annotation. Related to gh-23552.
+ *
+ * @author Daniel Meier
+ */
+@ImportAsConfigurationPropertiesBean(ImportedJavaBean.class)
+public class ImportJavaBeanWithoutPrefixUsingValueConfigurationPropertiesBean {
+
+}


### PR DESCRIPTION
Fix a `ClassCastException` in `ConfigurationMetadataAnnotationProcessor` that occurred when using the value property of the `ImportAsConfigurationPropertiesBean` without specifying a prefix.

* add missing value property to `ImportAsConfigurationPropertiesBean` test annotation
* add new test case in `ImportBeanTests`

* Fixes #23552 


