### PR TITLE
Fix invalid assert on MongoClientFactorySupport.validateConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoClientFactorySupport.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoClientFactorySupport.java
@@ -76,7 +76,7 @@ public abstract class MongoClientFactorySupport<T> {
 
 	private void validateConfiguration() {
 		if (hasCustomAddress() || hasCustomCredentials() || hasReplicaSet()) {
-			Assert.state(this.properties.getUri() == null,
+			Assert.state(this.properties.getUri() != null,
 					"Invalid mongo configuration, either uri or host/port/credentials/replicaSet must be specified");
 		}
 	}


### PR DESCRIPTION
Fix an issue where if this.properties.getUri() returns a non null value it will throw IllegalStateException complaining URI is null