### PR TITLE
Fix Undertow do not preserve path of forward request by default

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactory.java
@@ -75,6 +75,7 @@ import org.springframework.util.Assert;
  * @author Andy Wilkinson
  * @author Marcos Barbero
  * @author Eddú Meléndez
+ * @author 橙 子
  * @since 2.0.0
  * @see UndertowServletWebServer
  */
@@ -283,6 +284,7 @@ public class UndertowServletWebServerFactory extends AbstractServletWebServerFac
 		deployment.setResourceManager(getDocumentRootResourceManager());
 		deployment.setTempDir(createTempDir("undertow"));
 		deployment.setEagerFilterInit(this.eagerInitFilters);
+		deployment.setPreservePathOnForward(false);
 		configureMimeMappings(deployment);
 		for (UndertowDeploymentInfoCustomizer customizer : this.deploymentInfoCustomizers) {
 			customizer.customize(deployment);

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-undertow/src/main/java/smoketest/undertow/web/SampleController.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-undertow/src/main/java/smoketest/undertow/web/SampleController.java
@@ -18,20 +18,31 @@ package smoketest.undertow.web;
 
 import java.util.concurrent.Callable;
 
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ResponseBody;
 
-@RestController
+@Controller
 public class SampleController {
 
+	@ResponseBody
 	@GetMapping("/")
 	public String helloWorld() {
 		return "Hello World";
 	}
 
+	@ResponseBody
 	@GetMapping("/async")
 	public Callable<String> helloWorldAsync() {
-		return () -> "async: Hello World";
+		return () -> {
+			Thread.sleep(10);
+			return "async: Hello World";
+		};
+	}
+
+	@GetMapping("/forwardToAsync")
+	public String helloWorldForwardToAsync() {
+		return "forward:/async";
 	}
 
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-undertow/src/test/java/smoketest/undertow/SampleUndertowApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-undertow/src/test/java/smoketest/undertow/SampleUndertowApplicationTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Ivan Sopov
  * @author Andy Wilkinson
+ * @author 橙 子
  */
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class SampleUndertowApplicationTests {
@@ -55,6 +56,11 @@ class SampleUndertowApplicationTests {
 	@Test
 	void testAsync() {
 		assertOkResponse("/async", "async: Hello World");
+	}
+
+	@Test
+	void testForwardToAsync() {
+		assertOkResponse("/forwardToAsync", "async: Hello World");
 	}
 
 	@Test


### PR DESCRIPTION
Access requests forwarded to async results will cause thread race. By default, after the Undertow task thread preserve the path of forwarding requests, InvocableHandlerMethod of async requests will be forward methods, not async methods. I writed an example unit test.