### PR TITLE
Update default builder image for image builds with buildpacks

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildRequest.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildRequest.java
@@ -37,7 +37,7 @@ import org.springframework.util.Assert;
  */
 public class BuildRequest {
 
-	static final String DEFAULT_BUILDER_IMAGE_NAME = "gcr.io/paketo-buildpacks/builder:base-platform-api-0.3";
+	static final String DEFAULT_BUILDER_IMAGE_NAME = "paketobuildpacks/builder:base";
 
 	private static final ImageReference DEFAULT_BUILDER = ImageReference.of(DEFAULT_BUILDER_IMAGE_NAME);
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging-oci-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging-oci-image.adoc
@@ -105,7 +105,7 @@ The following table summarizes the available properties and their default values
 | `builder`
 | `--builder`
 | Name of the Builder image to use.
-| `gcr.io/paketo-buildpacks/builder:base-platform-api-0.3`
+| `paketobuildpacks/builder:base`
 
 | `runImage`
 | `--runImage`

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging-oci-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging-oci-image.adoc
@@ -128,7 +128,7 @@ The following table summarizes the available parameters and their default values
 | `builder`
 | Name of the Builder image to use.
 | `spring-boot.build-image.builder`
-| `gcr.io/paketo-buildpacks/builder:base-platform-api-0.3`
+| `paketobuildpacks/builder:base`
 
 | `runImage`
 | Name of the run image to use.

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/BuildImageTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/BuildImageTests.java
@@ -52,7 +52,7 @@ public class BuildImageTests extends AbstractArchiveIntegrationTests {
 			assertThat(jar).isFile();
 			File original = new File(project, "target/build-image-0.0.1.BUILD-SNAPSHOT.jar.original");
 			assertThat(original).doesNotExist();
-			assertThat(buildLog(project)).contains("Building image").contains("paketo-buildpacks/builder")
+			assertThat(buildLog(project)).contains("Building image").contains("paketobuildpacks/builder")
 					.contains("docker.io/library/build-image:0.0.1.BUILD-SNAPSHOT")
 					.contains("Successfully built image");
 			ImageReference imageReference = ImageReference.of(ImageName.of("build-image"), "0.0.1.BUILD-SNAPSHOT");
@@ -94,13 +94,13 @@ public class BuildImageTests extends AbstractArchiveIntegrationTests {
 		mavenBuild.project("build-image").goals("package")
 				.systemProperty("spring-boot.build-image.imageName", "example.com/test/cmd-property-name:v1")
 				.systemProperty("spring-boot.build-image.builder",
-						"gcr.io/paketo-buildpacks/builder:full-cf-platform-api-0.3")
-				.systemProperty("spring-boot.build-image.runImage", "gcr.io/paketo-buildpacks/run:full-cnb-cf")
+						"paketobuildpacks/builder:full")
+				.systemProperty("spring-boot.build-image.runImage", "paketobuildpacks/run:full-cnb")
 				.execute((project) -> {
 					assertThat(buildLog(project)).contains("Building image")
 							.contains("example.com/test/cmd-property-name:v1")
-							.contains("paketo-buildpacks/builder:full-cf-platform-api-0.3")
-							.contains("paketo-buildpacks/run:full-cnb-cf").contains("Successfully built image");
+							.contains("paketobuildpacks/builder:full")
+							.contains("paketobuildpacks/run:full-cnb").contains("Successfully built image");
 					ImageReference imageReference = ImageReference.of("example.com/test/cmd-property-name:v1");
 					try (GenericContainer<?> container = new GenericContainer<>(imageReference.toString())) {
 						container.waitingFor(Wait.forLogMessage("Launched\\n", 1)).start();
@@ -115,8 +115,8 @@ public class BuildImageTests extends AbstractArchiveIntegrationTests {
 	void whenBuildImageIsInvokedWithCustomBuilderImageAndRunImage(MavenBuild mavenBuild) {
 		mavenBuild.project("build-image-custom-builder").goals("package").execute((project) -> {
 			assertThat(buildLog(project)).contains("Building image")
-					.contains("paketo-buildpacks/builder:full-cf-platform-api-0.3")
-					.contains("paketo-buildpacks/run:full-cnb-cf")
+					.contains("paketobuildpacks/builder:full")
+					.contains("paketobuildpacks/run:full-cnb")
 					.contains("docker.io/library/build-image-v2-builder:0.0.1.BUILD-SNAPSHOT")
 					.contains("Successfully built image");
 			ImageReference imageReference = ImageReference
@@ -134,7 +134,7 @@ public class BuildImageTests extends AbstractArchiveIntegrationTests {
 	void whenBuildImageIsInvokedWithEmptyEnvEntry(MavenBuild mavenBuild) {
 		mavenBuild.project("build-image-empty-env-entry").goals("package").prepare(this::writeLongNameResource)
 				.execute((project) -> {
-					assertThat(buildLog(project)).contains("Building image").contains("paketo-buildpacks/builder")
+					assertThat(buildLog(project)).contains("Building image").contains("paketobuildpacks/builder")
 							.contains("docker.io/library/build-image-empty-env-entry:0.0.1.BUILD-SNAPSHOT")
 							.contains("Successfully built image");
 					ImageReference imageReference = ImageReference.of(ImageName.of("build-image-empty-env-entry"),

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-image-custom-builder/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-image-custom-builder/pom.xml
@@ -23,8 +23,8 @@
 						</goals>
 						<configuration>
 							<image>
-								<builder>gcr.io/paketo-buildpacks/builder:full-cf-platform-api-0.3</builder>
-								<runImage>gcr.io/paketo-buildpacks/run:full-cnb-cf</runImage>
+								<builder>paketobuildpacks/builder:full</builder>
+								<runImage>paketobuildpacks/run:full-cnb</runImage>
 							</image>
 						</configuration>
 					</execution>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ImageTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ImageTests.java
@@ -59,7 +59,7 @@ class ImageTests {
 	void getBuildRequestWhenNoCustomizationsUsesDefaults() {
 		BuildRequest request = new Image().getBuildRequest(createArtifact(), mockApplicationContent());
 		assertThat(request.getName().toString()).isEqualTo("docker.io/library/my-app:0.0.1-SNAPSHOT");
-		assertThat(request.getBuilder().toString()).contains("paketo-buildpacks/builder");
+		assertThat(request.getBuilder().toString()).contains("paketobuildpacks/builder");
 		assertThat(request.getRunImage()).isNull();
 		assertThat(request.getEnv()).isEmpty();
 		assertThat(request.isCleanCache()).isFalse();


### PR DESCRIPTION
Now that the Cloud Native Buildpacks lifecycle [supports multiple platform API versions](https://github.com/buildpacks/rfcs/blob/main/text/0049-multi-api-lifecycle-descriptor.md) Spring Boot can safely consume the latest Paketo builder image. This image will contain the latest lifecycle and will support API versions 0.3+. The platform API version can be configured by setting CNB_PLATFORM_API in the lifecycle container; it defaults to 0.3.

Also, the Paketo team is now recommending Dockerhub instead of GCR as the default location from which to pull images.

