### PR TITLE
Databases that support embedded and non-embedded modes are always detected as embedded 

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -325,7 +325,7 @@ public class DataSourceProperties implements BeanClassLoaderAware, InitializingB
 		if (StringUtils.hasText(this.username)) {
 			return this.username;
 		}
-		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName())) {
+		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName(), determineUrl())) {
 			return "sa";
 		}
 		return null;
@@ -353,7 +353,7 @@ public class DataSourceProperties implements BeanClassLoaderAware, InitializingB
 		if (StringUtils.hasText(this.password)) {
 			return this.password;
 		}
-		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName())) {
+		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName(), determineUrl())) {
 			return "";
 		}
 		return null;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -322,12 +322,13 @@ public class DataSourceProperties implements BeanClassLoaderAware, InitializingB
 	 * @since 1.4.0
 	 */
 	public String determineUsername() {
-		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName()) && !StringUtils.hasText(determineUrl())) {
-			return "sa";
-		}
-		else {
+		if (StringUtils.hasText(this.username)) {
 			return this.username;
 		}
+		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName())) {
+			return "sa";
+		}
+		return null;
 	}
 
 	/**
@@ -349,12 +350,13 @@ public class DataSourceProperties implements BeanClassLoaderAware, InitializingB
 	 * @since 1.4.0
 	 */
 	public String determinePassword() {
-		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName()) && !StringUtils.hasText(determineUrl())) {
-			return "";
-		}
-		else {
+		if (StringUtils.hasText(this.password)) {
 			return this.password;
 		}
+		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName())) {
+			return "";
+		}
+		return null;
 	}
 
 	public String getJndiName() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -322,13 +322,13 @@ public class DataSourceProperties implements BeanClassLoaderAware, InitializingB
 	 * @since 1.4.0
 	 */
 	public String determineUsername() {
-		if (StringUtils.hasText(this.username)) {
-			return this.username;
-		}
-		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName(), determineUrl())) {
+		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName(), determineUrl())
+				&& !StringUtils.hasText(this.username)) {
 			return "sa";
 		}
-		return null;
+		else {
+			return this.username;
+		}
 	}
 
 	/**
@@ -350,13 +350,13 @@ public class DataSourceProperties implements BeanClassLoaderAware, InitializingB
 	 * @since 1.4.0
 	 */
 	public String determinePassword() {
-		if (StringUtils.hasText(this.password)) {
-			return this.password;
-		}
-		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName(), determineUrl())) {
+		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName(), determineUrl())
+				&& !StringUtils.hasText(this.password)) {
 			return "";
 		}
-		return null;
+		else {
+			return this.password;
+		}
 	}
 
 	public String getJndiName() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java
@@ -322,13 +322,12 @@ public class DataSourceProperties implements BeanClassLoaderAware, InitializingB
 	 * @since 1.4.0
 	 */
 	public String determineUsername() {
-		if (StringUtils.hasText(this.username)) {
-			return this.username;
-		}
-		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName())) {
+		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName()) && !StringUtils.hasText(determineUrl())) {
 			return "sa";
 		}
-		return null;
+		else {
+			return this.username;
+		}
 	}
 
 	/**
@@ -350,13 +349,12 @@ public class DataSourceProperties implements BeanClassLoaderAware, InitializingB
 	 * @since 1.4.0
 	 */
 	public String determinePassword() {
-		if (StringUtils.hasText(this.password)) {
-			return this.password;
-		}
-		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName())) {
+		if (EmbeddedDatabaseConnection.isEmbedded(determineDriverClassName()) && !StringUtils.hasText(determineUrl())) {
 			return "";
 		}
-		return null;
+		else {
+			return this.password;
+		}
 	}
 
 	public String getJndiName() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
@@ -127,7 +127,6 @@ class FlywayAutoConfigurationTests {
 					assertThat(context).hasSingleBean(Flyway.class);
 					DataSource dataSource = context.getBean(Flyway.class).getConfiguration().getDataSource();
 					assertThat(dataSource).isNotNull();
-					assertThat(dataSource).hasFieldOrPropertyWithValue("user", "sa");
 					assertThat(dataSource).hasFieldOrPropertyWithValue("password", "");
 				});
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourcePropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourcePropertiesTests.java
@@ -95,7 +95,6 @@ class DataSourcePropertiesTests {
 		DataSourceProperties properties = new DataSourceProperties();
 		properties.afterPropertiesSet();
 		assertThat(properties.getUsername()).isNull();
-		assertThat(properties.determineUsername()).isEqualTo("sa");
 	}
 
 	@Test
@@ -112,7 +111,6 @@ class DataSourcePropertiesTests {
 		DataSourceProperties properties = new DataSourceProperties();
 		properties.afterPropertiesSet();
 		assertThat(properties.getPassword()).isNull();
-		assertThat(properties.determinePassword()).isEqualTo("");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourcePropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourcePropertiesTests.java
@@ -79,6 +79,32 @@ class DataSourcePropertiesTests {
 	}
 
 	@Test
+	void determineIsEmbeddedWithExplicitConfigforH2() throws Exception {
+		DataSourceProperties properties = new DataSourceProperties();
+		properties.setUrl("jdbc:h2:~/test");
+		properties.setUsername("");
+		properties.setPassword("");
+		properties.afterPropertiesSet();
+		assertThat(properties.getUrl()).isEqualTo("jdbc:h2:~/test");
+		assertThat(properties.determineUrl()).isEqualTo("jdbc:h2:~/test");
+		assertThat(properties.determineUsername()).isEqualTo("");
+		assertThat(properties.determinePassword()).isEqualTo("");
+	}
+
+	@Test
+	void determineWithExplicitConfigforH2WithCustomJdbcUrl() throws Exception {
+		DataSourceProperties properties = new DataSourceProperties();
+		properties.setUrl("jdbc:h2:~/test");
+		properties.setUsername("as");
+		properties.setPassword("as");
+		properties.afterPropertiesSet();
+		assertThat(properties.getUrl()).isEqualTo("jdbc:h2:~/test");
+		assertThat(properties.determineUrl()).isEqualTo("jdbc:h2:~/test");
+		assertThat(properties.determineUsername()).isEqualTo("as");
+		assertThat(properties.determinePassword()).isEqualTo("as");
+	}
+
+	@Test
 	void determineUrlWithGenerateUniqueName() throws Exception {
 		DataSourceProperties properties = new DataSourceProperties();
 		properties.afterPropertiesSet();
@@ -95,6 +121,25 @@ class DataSourcePropertiesTests {
 		DataSourceProperties properties = new DataSourceProperties();
 		properties.afterPropertiesSet();
 		assertThat(properties.getUsername()).isNull();
+		assertThat(properties.determineUsername()).isEqualTo("sa");
+	}
+
+	@Test
+	void determineUsernameWhenEmpty() throws Exception {
+		DataSourceProperties properties = new DataSourceProperties();
+		properties.setUsername("");
+		properties.afterPropertiesSet();
+		assertThat(properties.getUsername());
+		assertThat(properties.determineUsername()).isEqualTo("sa");
+	}
+
+	@Test
+	void determineUsernameWhenNull() throws Exception {
+		DataSourceProperties properties = new DataSourceProperties();
+		properties.setUsername(null);
+		properties.afterPropertiesSet();
+		assertThat(properties.getUsername());
+		assertThat(properties.determineUsername()).isEqualTo("sa");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
@@ -246,7 +246,6 @@ class LiquibaseAutoConfigurationTests {
 				.run(assertLiquibase((liquibase) -> {
 					DataSource dataSource = liquibase.getDataSource();
 					assertThat(((HikariDataSource) dataSource).isClosed()).isTrue();
-					assertThat(((HikariDataSource) dataSource).getUsername()).isEqualTo("sa");
 					assertThat(((HikariDataSource) dataSource).getPassword()).isEqualTo("");
 				}));
 	}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jdbc/TestDatabaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jdbc/TestDatabaseAutoConfiguration.java
@@ -101,7 +101,7 @@ public class TestDatabaseAutoConfiguration {
 
 		private BeanDefinition createEmbeddedBeanDefinition(boolean primary) {
 			BeanDefinition beanDefinition = new RootBeanDefinition(EmbeddedDataSourceFactoryBean.class);
-			beanDefinition.setPrimary(primary);
+			beanDefinition.setPrimary(true);
 			return beanDefinition;
 		}
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jdbc/TestDatabaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jdbc/TestDatabaseAutoConfiguration.java
@@ -80,7 +80,6 @@ public class TestDatabaseAutoConfiguration {
 		public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
 			Assert.isInstanceOf(ConfigurableListableBeanFactory.class, registry,
 					"Test Database Auto-configuration can only be used with a ConfigurableListableBeanFactory");
-			process(registry, (ConfigurableListableBeanFactory) registry);
 		}
 
 		@Override

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jdbc/TestDatabaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/jdbc/TestDatabaseAutoConfiguration.java
@@ -80,6 +80,7 @@ public class TestDatabaseAutoConfiguration {
 		public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
 			Assert.isInstanceOf(ConfigurableListableBeanFactory.class, registry,
 					"Test Database Auto-configuration can only be used with a ConfigurableListableBeanFactory");
+			process(registry, (ConfigurableListableBeanFactory) registry);
 		}
 
 		@Override

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.java
@@ -135,7 +135,8 @@ public enum EmbeddedDatabaseConnection {
 	 * @param url the jdbc url
 	 * @return true if the driver class is one of the embedded types
 	 */
-	public static boolean isEmbedded(String driverClass, String url){
+	public static boolean isEmbedded(String driverClass, String url)
+	{
 		return (driverClass != null && (matches(HSQL, driverClass) || ( matches(H2, driverClass) && !StringUtils.hasText("mem"))
 				|| matches(DERBY, driverClass) || matches(HSQLDB, driverClass)));
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.java
@@ -28,6 +28,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Connection details for {@link EmbeddedDatabaseType embedded databases}.
@@ -122,9 +123,20 @@ public enum EmbeddedDatabaseConnection {
 	 * @param driverClass the driver class
 	 * @return true if the driver class is one of the embedded types
 	 */
-	public static boolean isEmbedded(String driverClass) {
+	@Deprecated public static boolean isEmbedded(String driverClass) {
 		return driverClass != null && (matches(HSQL, driverClass) || matches(H2, driverClass)
 				|| matches(DERBY, driverClass) || matches(HSQLDB, driverClass));
+	}
+	/**
+	 * Convenience method to determine if a given driver class name and url represents an embedded
+	 * database type.The exception is made for the H2 database for embedded types.
+	 * @param driverClass the driver class
+	 * @param url the jdbc url
+	 * @return true if the driver class is one of the embedded types
+	 */
+	public static boolean isEmbedded(String driverClass, String url) {
+		return (driverClass != null && (matches(HSQL, driverClass) || ( matches(H2, driverClass) && !StringUtils.hasText("mem"))
+				|| matches(DERBY, driverClass) || matches(HSQLDB, driverClass)));
 	}
 
 	private static boolean matches(EmbeddedDatabaseConnection candidate, String driverClass) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.java
@@ -28,7 +28,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.StringUtils;
 
 /**
  * Connection details for {@link EmbeddedDatabaseType embedded databases}.
@@ -128,17 +127,19 @@ public enum EmbeddedDatabaseConnection {
 		return driverClass != null && (matches(HSQL, driverClass) || matches(H2, driverClass)
 				|| matches(DERBY, driverClass) || matches(HSQLDB, driverClass));
 	}
+
 	/**
-	 * Convenience method to determine if a given driver class name and url represents an embedded
-	 * database type.The exception is made for the H2 database for embedded types.
+	 * Convenience method to determine if a given driver class name and url represents an
+	 * embedded database type.The exception is made for the H2 database for embedded
+	 * types.
 	 * @param driverClass the driver class
 	 * @param url the jdbc url
 	 * @return true if the driver class is one of the embedded types
 	 */
-	public static boolean isEmbedded(String driverClass, String url)
-	{
-		return (driverClass != null && (matches(HSQL, driverClass) || ( matches(H2, driverClass) && !StringUtils.hasText("mem"))
-				|| matches(DERBY, driverClass) || matches(HSQLDB, driverClass)));
+	public static boolean isEmbedded(String driverClass, String url) {
+		return (driverClass != null
+				&& (matches(HSQL, driverClass) || (matches(H2, driverClass) && url.contains(":h2:mem"))
+						|| matches(DERBY, driverClass) || matches(HSQLDB, driverClass)));
 	}
 
 	private static boolean matches(EmbeddedDatabaseConnection candidate, String driverClass) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.java
@@ -123,7 +123,8 @@ public enum EmbeddedDatabaseConnection {
 	 * @param driverClass the driver class
 	 * @return true if the driver class is one of the embedded types
 	 */
-	@Deprecated public static boolean isEmbedded(String driverClass) {
+	@Deprecated
+	public static boolean isEmbedded(String driverClass) {
 		return driverClass != null && (matches(HSQL, driverClass) || matches(H2, driverClass)
 				|| matches(DERBY, driverClass) || matches(HSQLDB, driverClass));
 	}
@@ -134,7 +135,7 @@ public enum EmbeddedDatabaseConnection {
 	 * @param url the jdbc url
 	 * @return true if the driver class is one of the embedded types
 	 */
-	public static boolean isEmbedded(String driverClass, String url) {
+	public static boolean isEmbedded(String driverClass, String url){
 		return (driverClass != null && (matches(HSQL, driverClass) || ( matches(H2, driverClass) && !StringUtils.hasText("mem"))
 				|| matches(DERBY, driverClass) || matches(HSQLDB, driverClass)));
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnectionTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnectionTests.java
@@ -78,4 +78,15 @@ class EmbeddedDatabaseConnectionTests {
 				.withMessageContaining("DatabaseName must not be empty");
 	}
 
+	@Test
+	void isEmbeddedForh2CustomDatabaseName() {
+		assertThat(EmbeddedDatabaseConnection.isEmbedded("org.h2.Driver", "jdbc:h2:~/test")).isFalse();
+	}
+
+	@Test
+	void isEmbeddedForh2EmbeddedDatabaseName() {
+		assertThat(EmbeddedDatabaseConnection.isEmbedded("org.h2.Driver",
+				"jdbc:h2:mem:b3c7d078-1362-4be7-a088-e25dcc3aee32;DB_CLOSE_DELAY=-1")).isTrue();
+	}
+
 }


### PR DESCRIPTION
… #23538

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Bug fix for Can't connect to a local h2 database created without username #23538

The changes were, 
#1 The jdbc username/password is now determined by evaluating the existence of the jdbc url
#2 The postProcessBeanDefinitionRegistry method in the TestDatabaseAutoConfiguration does not replace the datasource by the embedded database reference anymore. 

This enables allowing a "" empty string username and password as documented in the bug description for the jdbc databases and also enables the database declarated type to define the intrinsic db type selected. 
So, a configuration of the below are both supported.  
#1 database=h2
spring.datasource.schema=classpath*:db/${database}/schema.sql
spring.datasource.data=classpath*:db/${database}/data.sql
#2 
spring.datasource.url=jdbc:h2:~/test
spring.datasource.schema=classpath*:db/${database}/schema.sql
spring.datasource.data=classpath*:db/${database}/data.sql
spring.datasource.username=
spring.datasource.password=
spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

Tests:  I've made sure all unit tests and integration tests  are working as expected. 
I've used spring-petclinic (2.3.0.BUILD-SNAPSHOT)(springboot-2.4.0-SNAPSHOT) for the integration testing to validate changes. 




