### PR TITLE
Upgrade to spring-asciidoctor-extensions 0.5.0

### DIFF
--- a/spring-boot-project/spring-boot-parent/build.gradle
+++ b/spring-boot-project/spring-boot-parent/build.gradle
@@ -148,7 +148,7 @@ bom {
 			]
 		}
 	}
-	library("Spring Asciidoctor Extensions", "0.5.0-SNAPSHOT") {
+	library("Spring Asciidoctor Extensions", "0.5.0") {
 		group("io.spring.asciidoctor") {
 			modules = [
 				"spring-asciidoctor-extensions-block-switch",


### PR DESCRIPTION
https://github.com/spring-projects/spring-boot/issues/23605 seems to be meant to upgrade to `spring-asciidoctor-extensions` 0.5.0, but it has upgraded to `spring-asciidoctor-extensions` 0.5.0-SNAPSHOT somehow.

This PR upgrades to `spring-asciidoctor-extensions` 0.5.0.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
