### PR TITLE
Add a command line option for image.cleanCache when building with Maven

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging-oci-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging-oci-image.adoc
@@ -153,7 +153,7 @@ Acceptable values are `ALWAYS`, `NEVER`, and `IF_NOT_PRESENT`.
 
 | `cleanCache`
 | Whether to clean the cache before building.
-|
+| `spring-boot.build-image.cleanCache`
 | `false`
 
 | `verboseLogging`

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildImageMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildImageMojo.java
@@ -131,6 +131,14 @@ public class BuildImageMojo extends AbstractPackagerMojo {
 	String runImage;
 
 	/**
+	 * Alias for {@link Image#cleanCache} to support configuration via command-line
+	 * property.
+	 * @since 2.4.0
+	 */
+	@Parameter(property = "spring-boot.build-image.cleanCache", readonly = true)
+	Boolean cleanCache;
+
+	/**
 	 * Alias for {@link Image#pullPolicy} to support configuration via command-line
 	 * property.
 	 */
@@ -188,6 +196,9 @@ public class BuildImageMojo extends AbstractPackagerMojo {
 		}
 		if (image.runImage == null && this.runImage != null) {
 			image.setRunImage(this.runImage);
+		}
+		if (image.cleanCache == null && this.cleanCache != null) {
+			image.setCleanCache(this.cleanCache);
 		}
 		if (image.pullPolicy == null && this.pullPolicy != null) {
 			image.setPullPolicy(this.pullPolicy);

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/Image.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/Image.java
@@ -46,7 +46,7 @@ public class Image {
 
 	Map<String, String> env;
 
-	boolean cleanCache;
+	Boolean cleanCache;
 
 	boolean verboseLogging;
 
@@ -102,8 +102,12 @@ public class Image {
 	 * If the cache should be cleaned before building.
 	 * @return {@code true} if the cache should be cleaned
 	 */
-	public boolean isCleanCache() {
+	public Boolean isCleanCache() {
 		return this.cleanCache;
+	}
+
+	void setCleanCache(Boolean cleanCache) {
+		this.cleanCache = cleanCache;
 	}
 
 	/**
@@ -160,7 +164,9 @@ public class Image {
 		if (this.env != null && !this.env.isEmpty()) {
 			request = request.withEnv(this.env);
 		}
-		request = request.withCleanCache(this.cleanCache);
+		if (this.cleanCache != null) {
+			request = request.withCleanCache(this.cleanCache);
+		}
 		request = request.withVerboseLogging(this.verboseLogging);
 		if (this.pullPolicy != null) {
 			request = request.withPullPolicy(this.pullPolicy);


### PR DESCRIPTION
Exposed `image.cleanCache` as command line option for cache cleanup when building with Maven.

Closes gh-23202.