### PR TITLE
fix for "BootJar.getConfigurations() should not be public API" #23527

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootJar.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootJar.java
@@ -124,6 +124,7 @@ public class BootJar extends Jar implements BootArchive {
 	}
 
 	@Internal
+	@Deprecated
 	protected Iterable<Configuration> getConfigurations() {
 		return getProject().getConfigurations();
 	}


### PR DESCRIPTION
Changes: 
This a fix for BootJar.getConfigurations() should not be public API #23527
deprecated the method. All tests have passed and the method is no longer in the public API.

