### PR TITLE
Fix links to Spring Framework documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/attributes.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/attributes.adoc
@@ -83,7 +83,7 @@
 :spring-data-solr-docs: https://docs.spring.io/spring-data/solr/docs/{spring-data-solr-version}/reference/html/
 :spring-framework: https://spring.io/projects/spring-framework
 :spring-framework-api: https://docs.spring.io/spring/docs/{spring-framework-version}/javadoc-api/org/springframework
-:spring-framework-docs: https://docs.spring.io/spring/docs/{spring-framework-version}/spring-framework-reference
+:spring-framework-docs: https://docs.spring.io/spring/docs/{spring-framework-version}/reference/html
 :spring-initializr-docs: https://docs.spring.io/initializr/docs/current/reference/html
 :spring-integration: https://spring.io/projects/spring-integration
 :spring-integration-docs: https://docs.spring.io/spring-integration/docs/{spring-integration-version}/reference/html/


### PR DESCRIPTION
Hi,

recent changes to Spring-Framework (https://github.com/spring-projects/spring-framework/commit/0db3f2b4de4bdd723b65e718c67635fdce8d13fd) have changed the docs location, that this PR addresses. (It seems there is a redirect planned, but I guess it's better to directly adjust to the new location)

Cheers,
Christoph