### PR TITLE
Remove RabbitMQ AutoConfig Boolean Coercion

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/SimpleRabbitListenerContainerFactoryConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/SimpleRabbitListenerContainerFactoryConfigurer.java
@@ -40,9 +40,6 @@ public final class SimpleRabbitListenerContainerFactoryConfigurer
 		map.from(config::getMaxConcurrency).whenNonNull().to(factory::setMaxConcurrentConsumers);
 		map.from(config::getBatchSize).whenNonNull().to(factory::setBatchSize);
 		map.from(config::isConsumerBatchEnabled).to(factory::setConsumerBatchEnabled);
-		if (config.isConsumerBatchEnabled()) {
-			factory.setDeBatchingEnabled(true);
-		}
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -33,7 +33,6 @@ import com.rabbitmq.client.impl.CredentialsRefreshService;
 import com.rabbitmq.client.impl.DefaultCredentialsProvider;
 import org.aopalliance.aop.Advice;
 import org.junit.jupiter.api.Test;
-import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import org.springframework.amqp.core.AcknowledgeMode;
@@ -556,17 +555,13 @@ class RabbitAutoConfigurationTests {
 	void testSimpleRabbitListenerContainerFactoryConfigurerEnableDeBatchingWithConsumerBatchEnabled() {
 		this.contextRunner.withUserConfiguration(TestConfiguration.class)
 				.withPropertyValues("spring.rabbitmq.listener.type:direct",
-						"spring.rabbitmq.listener.simple.consumer-batch-enabled:true",
-						"spring.rabbitmq.listener.simple.de-batching-enabled:false")
+						"spring.rabbitmq.listener.simple.consumer-batch-enabled:true")
 				.run((context) -> {
 					SimpleRabbitListenerContainerFactoryConfigurer configurer = context
 							.getBean(SimpleRabbitListenerContainerFactoryConfigurer.class);
 					SimpleRabbitListenerContainerFactory factory = mock(SimpleRabbitListenerContainerFactory.class);
 					configurer.configure(factory, mock(ConnectionFactory.class));
-					InOrder inOrder = Mockito.inOrder(factory);
 					verify(factory).setConsumerBatchEnabled(true);
-					inOrder.verify(factory).setDeBatchingEnabled(false);
-					inOrder.verify(factory).setDeBatchingEnabled(true);
 				});
 	}
 


### PR DESCRIPTION
It has been moved to spring-amqp instead.
