### PR TITLE
Make sure ReactiveOAuth2ClientConfigurations actually creates a ReactiveClientRegistrationRepositoryConfig

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/reactive/ReactiveOAuth2ClientConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/reactive/ReactiveOAuth2ClientConfigurations.java
@@ -51,7 +51,7 @@ class ReactiveOAuth2ClientConfigurations {
 	static class ReactiveClientRegistrationRepositoryConfiguration {
 
 		@Bean
-		InMemoryReactiveClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+		ReactiveClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
 			List<ClientRegistration> registrations = new ArrayList<>(
 					OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
 			return new InMemoryReactiveClientRegistrationRepository(registrations);


### PR DESCRIPTION
Trying out Spring Cloud Gateway 2.4.0-M4 with TokenRelayGatewayFilterFactory, which will not be autoconfigured correctly due to 

```
GatewayAutoConfiguration.TokenRelayConfiguration:
      Did not match:
         - @ConditionalOnBean (types: org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository; SearchStrategy: all) did not find any beans of type org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository (OnBeanCondition)

```

Traced this back to autoconfiguration, where the default config actually creates a bean of the specialized type `InMemoryReactiveClientRegistrationRepository`, rather than `ReactiveClientRegistrationRepository`.

Workaround for now is to configure the bean manually via 

```
@Component
public class ReactiveClientRegistrationRepositoryConfig {

    @Bean
    **ReactiveClientRegistrationRepository** clientRegistrationRepository(@Autowired OAuth2ClientProperties properties) {
        List<ClientRegistration> registrations = new ArrayList<>(
                OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
        return new InMemoryReactiveClientRegistrationRepository(registrations);
    }
}

```

This PR should hopefully fix this, although I have no way of testing this really.

