### PR TITLE
Auto-configure Mongo metrics

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MongoMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MongoMetricsAutoConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics;
+
+import com.mongodb.MongoClientSettings;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.mongodb.MongoMetricsCommandListener;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoClientSettingsBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Mongo metrics.
+ *
+ * @author Chris Bono
+ * @since 2.4.0
+ */
+@Configuration(proxyBeanMethods = false)
+@AutoConfigureBefore(MongoAutoConfiguration.class)
+@AutoConfigureAfter({ MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class })
+@ConditionalOnClass(MongoClientSettings.class)
+@ConditionalOnBean(MeterRegistry.class)
+public class MongoMetricsAutoConfiguration {
+
+	@ConditionalOnClass(MongoMetricsCommandListener.class)
+	@ConditionalOnProperty(name = "management.metrics.mongo.command-listener.enabled", havingValue = "true",
+			matchIfMissing = true)
+	static class MongoMetricsCommandListenerConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean
+		MongoMetricsCommandListener mongoMetricsCommandListener(MeterRegistry meterRegistry) {
+			return new MongoMetricsCommandListener(meterRegistry);
+		}
+
+		@Bean
+		MongoClientSettingsBuilderCustomizer mongoMetricsCommandListenerClientSettingsBuilderCustomizer(
+				MongoMetricsCommandListener mongoMetricsCommandListener) {
+			return (builder) -> builder.addCommandListener(mongoMetricsCommandListener);
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MongoMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MongoMetricsAutoConfiguration.java
@@ -46,7 +46,7 @@ import org.springframework.context.annotation.Configuration;
 public class MongoMetricsAutoConfiguration {
 
 	@ConditionalOnClass(MongoMetricsCommandListener.class)
-	@ConditionalOnProperty(name = "management.metrics.mongo.command-listener.enabled", havingValue = "true",
+	@ConditionalOnProperty(name = "management.metrics.mongo.commandlistener.enabled", havingValue = "true",
 			matchIfMissing = true)
 	static class MongoMetricsCommandListenerConfiguration {
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MongoMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MongoMetricsAutoConfiguration.java
@@ -52,9 +52,9 @@ import org.springframework.context.annotation.Configuration;
 public class MongoMetricsAutoConfiguration {
 
 	@ConditionalOnClass(MongoMetricsCommandListener.class)
-	@ConditionalOnProperty(name = "management.metrics.mongo.commandlistener.enabled", havingValue = "true",
+	@ConditionalOnProperty(name = "management.metrics.mongo.command.enabled", havingValue = "true",
 			matchIfMissing = true)
-	static class MongoMetricsCommandListenerConfiguration {
+	static class MongoCommandMetricsConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
@@ -78,9 +78,9 @@ public class MongoMetricsAutoConfiguration {
 	}
 
 	@ConditionalOnClass(MongoMetricsConnectionPoolListener.class)
-	@ConditionalOnProperty(name = "management.metrics.mongo.connectionpoollistener.enabled", havingValue = "true",
+	@ConditionalOnProperty(name = "management.metrics.mongo.connectionpool.enabled", havingValue = "true",
 			matchIfMissing = true)
-	static class MongoMetricsConnectionPoolListenerConfiguration {
+	static class MongoConnectionPoolMetricsConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -522,6 +522,16 @@
       }
     },
     {
+      "name": "management.metrics.mongo.commandlistener.enabled",
+      "description": "Whether to enable Mongo client command metrics.",
+      "defaultValue": true
+    },
+    {
+      "name": "management.metrics.mongo.connectionpoollistener.enabled",
+      "description": "Whether to enable Mongo connection pool metrics.",
+      "defaultValue": true
+    },
+    {
       "name": "management.metrics.web.client.request.autotime.enabled",
       "description": "Whether to automatically time web client requests.",
       "defaultValue": true

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -522,12 +522,12 @@
       }
     },
     {
-      "name": "management.metrics.mongo.commandlistener.enabled",
+      "name": "management.metrics.mongo.command.enabled",
       "description": "Whether to enable Mongo client command metrics.",
       "defaultValue": true
     },
     {
-      "name": "management.metrics.mongo.connectionpoollistener.enabled",
+      "name": "management.metrics.mongo.connectionpool.enabled",
       "description": "Whether to enable Mongo connection pool metrics.",
       "defaultValue": true
     },

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -46,6 +46,7 @@ org.springframework.boot.actuate.autoconfigure.metrics.Log4J2MetricsAutoConfigur
 org.springframework.boot.actuate.autoconfigure.metrics.LogbackMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.MetricsEndpointAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.metrics.MongoMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.SystemMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.amqp.RabbitMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.cache.CacheMetricsAutoConfiguration,\

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MongoMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MongoMetricsAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MongoMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MongoMetricsAutoConfigurationTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import io.micrometer.core.instrument.binder.mongodb.MongoMetricsCommandListener;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.test.MetricsRun;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MongoMetricsAutoConfiguration}.
+ *
+ * @author Chris Bono
+ */
+class MongoMetricsAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(MongoMetricsAutoConfiguration.class));
+
+	@Test
+	void whenThereIsAMeterRegistryThenMetricsListenersAreAdded() {
+		this.contextRunner.with(MetricsRun.simple())
+				.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class)).run((context) -> {
+					assertThat(context).hasSingleBean(MongoMetricsCommandListener.class);
+					assertThat(getActualMongoClientSettingsUsedToConstructClient(context)).isNotNull()
+							.extracting(MongoClientSettings::getCommandListeners).asList()
+							.containsExactly(context.getBean(MongoMetricsCommandListener.class));
+				});
+	}
+
+	@Test
+	void whenThereIsNoMeterRegistryThenNoMetricsListenersAreAdded() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
+				.run(this::assertThatMetricsListenerNotAdded);
+	}
+
+	@Test
+	void whenThereIsNoMongoClientSettingsOnClasspathThenNoMetricsListenersAreAdded() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
+				.withClassLoader(new FilteredClassLoader(MongoClientSettings.class))
+				.run(this::assertThatMetricsListenerNotAdded);
+	}
+
+	@Test
+	void whenThereIsNoMongoMetricsCommandListenerOnClasspathThenNoMetricsListenersAreAdded() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
+				.withClassLoader(new FilteredClassLoader(MongoMetricsCommandListener.class))
+				.run(this::assertThatMetricsListenerNotAdded);
+
+	}
+
+	@Test
+	void whenMetricsCommandListenerEnabledPropertyFalseThenNoMetricsListenersAreAdded() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
+				.withPropertyValues("management.metrics.mongo.command-listener.enabled:false")
+				.run(this::assertThatMetricsListenerNotAdded);
+	}
+
+	private void assertThatMetricsListenerNotAdded(final AssertableApplicationContext context) {
+		assertThat(context).doesNotHaveBean(MongoMetricsCommandListener.class);
+		assertThat(getActualMongoClientSettingsUsedToConstructClient(context)).isNotNull()
+				.extracting(MongoClientSettings::getCommandListeners).asList().isEmpty();
+	}
+
+	private MongoClientSettings getActualMongoClientSettingsUsedToConstructClient(
+			final AssertableApplicationContext context) {
+		final MongoClient mongoClient = context.getBean(MongoClient.class);
+		return (MongoClientSettings) ReflectionTestUtils.getField(mongoClient, "settings");
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MongoMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MongoMetricsAutoConfigurationTests.java
@@ -143,14 +143,14 @@ class MongoMetricsAutoConfigurationTests {
 	@Test
 	void whenMetricsCommandListenerEnabledPropertyFalseThenNoMetricsCommandListenerIsAdded() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
-				.withPropertyValues("management.metrics.mongo.command-listener.enabled:false")
+				.withPropertyValues("management.metrics.mongo.command.enabled:false")
 				.run((context) -> assertThatMetricsCommandListenerNotAdded());
 	}
 
 	@Test
 	void whenMetricsConnectionPoolListenerEnabledPropertyFalseThenNoMetricsConnectionPoolListenerIsAdded() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
-				.withPropertyValues("management.metrics.mongo.connection-pool-listener.enabled:false")
+				.withPropertyValues("management.metrics.mongo.connectionpool.enabled:false")
 				.run((context) -> assertThatMetricsConnectionPoolListenerNotAdded());
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
@@ -2129,7 +2129,7 @@ Spring Boot registers the following core metrics when applicable:
 * Kafka consumer, producer, and streams metrics
 * Log4j2 metrics: record the number of events logged to Log4j2 at each level
 * Logback metrics: record the number of events logged to Logback at each level
-* MongoDB metrics for all commands issued from the client
+* MongoDB metrics for all commands issued from the client and for client connection pool information
 * Uptime metrics: report a gauge for uptime and a fixed gauge representing the application's absolute start time
 * Tomcat metrics (`server.tomcat.mbeanregistry.enabled` must be set to `true` for all Tomcat metrics to be registered)
 * {spring-integration-docs}system-management.html#micrometer-integration[Spring Integration] metrics
@@ -2390,10 +2390,12 @@ For more details refer to {spring-kafka-docs}#micrometer-native[Micrometer Nativ
 
 [[production-ready-metrics-mongodb]]
 ==== MongoDB Metrics
+
+===== Command Metrics
 Auto-configuration will register a `MongoMetricsCommandListener` for the auto-configured MongoClient.
 
 A timer metric with the name `mongodb.driver.commands` is created for each command issued to the underlying MongoDB driver.
-Each metric is tagged with the following information:
+Each metric is tagged with the following information by default:
 |===
 | Tag | Description
 
@@ -2410,7 +2412,17 @@ Each metric is tagged with the following information:
 | Outcome of the command - one of (`SUCCESS`, `FAILED`)
 |===
 
-If you want to disable the auto-configured metrics, you can set the following property:
+You can replace the default metric tags by providing a `MongoMetricsCommandTagsProvider` bean, as shown in the following example:
+
+[source,java,pending-extract=true,indent=0]
+----
+	@Bean
+	MongoMetricsCommandTagsProvider mongoMetricsCommandTagsProvider() {
+		return new MyCustomMongoMetricsCommandTagsProvider();
+	}
+----
+
+If you want to disable the auto-configured command metrics, you can set the following property:
 
 [source,yaml,indent=0,configprops,configblocks]
 ----
@@ -2421,6 +2433,50 @@ If you want to disable the auto-configured metrics, you can set the following pr
 	        enabled: false
 ----
 
+===== Connection Pool Metrics
+Auto-configuration will register a `MongoMetricsConnectionPoolListener` for the auto-configured MongoClient.
+
+The following gauge metrics are created for the connection pool:
+
+* `mongodb.driver.pool.size` that reports the current size of the connection pool, including idle and and in-use members
+* `mongodb.driver.pool.checkedout` that reports the count of connections that are currently in use
+* `mongodb.driver.pool.waitqueuesize` that reports the current size of the wait queue for a connection from the pool
+
+NOTE: The `waitqueuesize` metric was https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#why-are-waitqueuesize-and-waitqueuemultiple-deprecated[removed] in MongoDB 4.x
+and is being approximated by the connection pool listener and will most likely be removed in a future release.
+
+Each metric is tagged with the following information by default:
+|===
+| Tag | Description
+
+| `cluster.id`
+| Identifier of the cluster the connection pool corresponds to
+
+| `server.address`
+| Address of the server the connection pool corresponds to
+|===
+
+You can replace the default metric tags by providing a `MongoMetricsConnectionPoolTagsProvider` bean, as shown in the following example:
+
+[source,java,pending-extract=true,indent=0]
+----
+    @Bean
+    @ConditionalOnMissingBean
+    MongoMetricsConnectionPoolTagsProvider mongoMetricsConnectionPoolTagsProvider() {
+        return new DefaultMongoMetricsConnectionPoolTagsProvider();
+    }
+----
+
+If you want to disable the auto-configured connection pool metrics, you can set the following property:
+
+[source,yaml,indent=0,configprops,configblocks]
+----
+	management:
+	  metrics:
+	    mongo:
+	      connectionpoollistener:
+	        enabled: false
+----
 
 
 [[production-ready-metrics-custom]]

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
@@ -2129,6 +2129,7 @@ Spring Boot registers the following core metrics when applicable:
 * Kafka consumer, producer, and streams metrics
 * Log4j2 metrics: record the number of events logged to Log4j2 at each level
 * Logback metrics: record the number of events logged to Logback at each level
+* MongoDB metrics for all commands issued to the client
 * Uptime metrics: report a gauge for uptime and a fixed gauge representing the application's absolute start time
 * Tomcat metrics (`server.tomcat.mbeanregistry.enabled` must be set to `true` for all Tomcat metrics to be registered)
 * {spring-integration-docs}system-management.html#micrometer-integration[Spring Integration] metrics
@@ -2384,6 +2385,41 @@ Auto-configuration will enable the instrumentation of all available RabbitMQ con
 Auto-configuration will register a `MicrometerConsumerListener` and `MicrometerProducerListener` for the auto-configured consumer factory and producer factory respectively.
 It will also register a `KafkaStreamsMicrometerListener` for `StreamsBuilderFactoryBean`.
 For more details refer to {spring-kafka-docs}#micrometer-native[Micrometer Native Metrics] section of the Spring Kafka documentation.
+
+
+
+[[production-ready-metrics-mongodb]]
+==== MongoDB Metrics
+Auto-configuration will register a `MongoMetricsCommandListener` for the auto-configured MongoClient.
+
+A timer metric with the name `mongodb.driver.commands` is created for each command issued to the underlying MongoDB driver.
+Each metric is tagged with the following information:
+|===
+| Tag | Description
+
+| `command`
+| Name of the command issued
+
+| `cluster.id`
+| Identifier of the cluster the command was sent to
+
+| `server.address`
+| Address of the server the command was sent to
+
+| `status`
+| Outcome of the command - one of (`SUCCESS`, `FAILED`)
+|===
+
+If you want to disable the auto-configured metrics, you can set the following property:
+
+[source,yaml,indent=0,configprops,configblocks]
+----
+	management:
+	  metrics:
+	    mongo:
+	      command-listener:
+	        enabled: false
+----
 
 
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
@@ -2429,7 +2429,7 @@ If you want to disable the auto-configured command metrics, you can set the foll
 	management:
 	  metrics:
 	    mongo:
-	      commandlistener:
+	      command:
 	        enabled: false
 ----
 
@@ -2441,9 +2441,6 @@ The following gauge metrics are created for the connection pool:
 * `mongodb.driver.pool.size` that reports the current size of the connection pool, including idle and and in-use members
 * `mongodb.driver.pool.checkedout` that reports the count of connections that are currently in use
 * `mongodb.driver.pool.waitqueuesize` that reports the current size of the wait queue for a connection from the pool
-
-NOTE: The `waitqueuesize` metric was https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#why-are-waitqueuesize-and-waitqueuemultiple-deprecated[removed] in MongoDB 4.x
-and is being approximated by the connection pool listener and will most likely be removed in a future release.
 
 Each metric is tagged with the following information by default:
 |===
@@ -2474,7 +2471,7 @@ If you want to disable the auto-configured connection pool metrics, you can set 
 	management:
 	  metrics:
 	    mongo:
-	      connectionpoollistener:
+	      connectionpool:
 	        enabled: false
 ----
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
@@ -2129,7 +2129,7 @@ Spring Boot registers the following core metrics when applicable:
 * Kafka consumer, producer, and streams metrics
 * Log4j2 metrics: record the number of events logged to Log4j2 at each level
 * Logback metrics: record the number of events logged to Logback at each level
-* MongoDB metrics for all commands issued to the client
+* MongoDB metrics for all commands issued from the client
 * Uptime metrics: report a gauge for uptime and a fixed gauge representing the application's absolute start time
 * Tomcat metrics (`server.tomcat.mbeanregistry.enabled` must be set to `true` for all Tomcat metrics to be registered)
 * {spring-integration-docs}system-management.html#micrometer-integration[Spring Integration] metrics
@@ -2417,7 +2417,7 @@ If you want to disable the auto-configured metrics, you can set the following pr
 	management:
 	  metrics:
 	    mongo:
-	      command-listener:
+	      commandlistener:
 	        enabled: false
 ----
 


### PR DESCRIPTION
The current mechanism to enable Micrometer metrics for Mongo is to add the [MongoMetricsCommandListener](https://github.com/micrometer-metrics/micrometer/blob/master/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsCommandListener.java) to the [MongoClientSettings.Builder](https://github.com/mongodb/mongo-java-driver/blob/master/driver-core/src/main/com/mongodb/MongoClientSettings.java#L152). This code proposal simply auto-configures in this command listener when appropriate. 

:information_source: There is also a [MongoMetricsConnectionPoolListener](https://github.com/micrometer-metrics/micrometer/blob/master/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListener.java#L18) that would add more Mongo (connection pool) metrics. However, I left it out because it has a dependency on legacy `com.mongodb.MongoClient` as well as some Mongo event classes that were removed in Mongo 4 Java driver. I am planning on submitting a fix to Micrometer to bring it up to speed w/ Mongo 4 driver. Once that is available, I will circle back here and auto-configure it in. 