### PR TITLE
Align MustacheViewResolver with other similar resolvers

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/view/MustacheViewResolver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/view/MustacheViewResolver.java
@@ -75,4 +75,9 @@ public class MustacheViewResolver extends AbstractTemplateViewResolver {
 		return view;
 	}
 
+	@Override
+	protected AbstractUrlBasedView instantiateView() {
+		return (getViewClass() == MustacheView.class ? new MustacheView() : super.instantiateView());
+	}
+
 }


### PR DESCRIPTION
The `FreeMarkerViewResolver` (and other template-based resolvers) in Spring Framework avoid using reflection if they know how to instantiate the view class. This change aligns with them.