### PR TITLE
Missing Spring Integration metrics due to the MeterRegistry bean being looked for before it has been defined

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/CompositeMeterRegistryAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/CompositeMeterRegistryAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@ package org.springframework.boot.actuate.autoconfigure.metrics;
 
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -28,11 +30,13 @@ import org.springframework.context.annotation.Import;
  * {@link CompositeMeterRegistry}.
  *
  * @author Andy Wilkinson
+ * @author Artem Bilan
  * @since 2.0.0
  */
 @Configuration(proxyBeanMethods = false)
 @Import({ NoOpMeterRegistryConfiguration.class, CompositeMeterRegistryConfiguration.class })
 @ConditionalOnClass(CompositeMeterRegistry.class)
+@AutoConfigureBefore(IntegrationAutoConfiguration.class)
 public class CompositeMeterRegistryAutoConfiguration {
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/CompositeMeterRegistryAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/CompositeMeterRegistryAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,8 @@ package org.springframework.boot.actuate.autoconfigure.metrics;
 
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -30,13 +28,11 @@ import org.springframework.context.annotation.Import;
  * {@link CompositeMeterRegistry}.
  *
  * @author Andy Wilkinson
- * @author Artem Bilan
  * @since 2.0.0
  */
 @Configuration(proxyBeanMethods = false)
 @Import({ NoOpMeterRegistryConfiguration.class, CompositeMeterRegistryConfiguration.class })
 @ConditionalOnClass(CompositeMeterRegistry.class)
-@AutoConfigureBefore(IntegrationAutoConfiguration.class)
 public class CompositeMeterRegistryAutoConfiguration {
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/integration/IntegrationMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/integration/IntegrationMetricsAutoConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.integration;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Spring Integration's metrics.
+ * Orders auto-configuration classes to ensure that the {@link MeterRegistry} bean has
+ * been defined before Spring Integration's Micrometer support queries the bean factory
+ * for it.
+ *
+ * @author Andy Wilkinson
+ * @since 2.3.6
+ */
+@AutoConfigureAfter({ MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class })
+@AutoConfigureBefore(IntegrationAutoConfiguration.class)
+@Configuration(proxyBeanMethods = false)
+public class IntegrationMetricsAutoConfiguration {
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/integration/package-info.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/integration/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Spring Integration metrics.
+ */
+package org.springframework.boot.actuate.autoconfigure.metrics.integration;

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -68,6 +68,7 @@ org.springframework.boot.actuate.autoconfigure.metrics.export.stackdriver.Stackd
 org.springframework.boot.actuate.autoconfigure.metrics.export.statsd.StatsdMetricsExportAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.export.wavefront.WavefrontMetricsExportAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.jdbc.DataSourcePoolMetricsAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.metrics.integration.IntegrationMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.jersey.JerseyServerMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.orm.jpa.HibernateMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.r2dbc.ConnectionPoolMetricsAutoConfiguration,\

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/integration/IntegrationMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/integration/IntegrationMetricsAutoConfigurationTests.java
@@ -35,7 +35,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link RabbitMetricsAutoConfiguration}.
  *
  * @author Artem Bilan
- *
  * @since 2.3.6
  */
 class IntegrationMetricsAutoConfigurationTests {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/integration/IntegrationMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/integration/IntegrationMetricsAutoConfigurationTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.integration;
+
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.integration.IntegrationGraphEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.amqp.RabbitMetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.test.MetricsRun;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link RabbitMetricsAutoConfiguration}.
+ *
+ * @author Artem Bilan
+ *
+ * @since 2.3.6
+ */
+class IntegrationMetricsAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner =
+			new ApplicationContextRunner()
+					.withConfiguration(AutoConfigurations.of(
+							IntegrationAutoConfiguration.class,
+							IntegrationGraphEndpointAutoConfiguration.class))
+					.with(MetricsRun.simple())
+					.withPropertyValues("management.metrics.tags.someTag=someValue");
+
+	@Test
+	void integrationMetersAreInstrumented() {
+		this.contextRunner.run((context) -> {
+			MeterRegistry registry = context.getBean(MeterRegistry.class);
+			Gauge gauge =
+					registry.get("spring.integration.channels")
+							.tag("someTag", "someValue")
+							.gauge();
+			assertThat(gauge).isNotNull().extracting(Gauge::value).isEqualTo(2.0);
+		});
+	}
+
+}

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1683,7 +1683,7 @@ bom {
 			]
 		}
 	}
-	library("Spring Integration", "5.3.3.RELEASE") {
+	library("Spring Integration", "5.3.4.BUILD-SNAPSHOT") {
 		group("org.springframework.integration") {
 			imports = [
 				"spring-integration-bom"


### PR DESCRIPTION
Related to https://github.com/spring-projects/spring-integration/issues/3420

After fixing https://github.com/spring-projects/spring-integration/issues/3376
to make sure that Spring Integration has a dependency on the `MeterRegistry`
for the proper lifecycle on shutdown, it turns out that Spring Integration
metrics features must be configured *after* the `MeterRegistry` is
provided properly by Spring Boot

Note: we start observing the wrong order problem when we also have an
`IntegrationGraphEndpointAutoConfiguration` which is ordered alphabetically
(therefore before `MetricsAutoConfiguration`) and pushes an
`IntegrationAutoConfiguration` up - before `MetricsAutoConfiguration`

* Add `@AutoConfigureBefore(IntegrationAutoConfiguration.class)`
to the `CompositeMeterRegistryAutoConfiguration` to ensure that `MeterRegistry`
bean is provided before `@EnableIntegrationManagement` logic

**Back-port to `master` moving `@AutoConfigureBefore(IntegrationAutoConfiguration.class)`
onto the `MeterRegistryAutoConfiguration` already**

