### PR TITLE
Ensure the WebClient to be present before enabling the WebTestClientContextCustomizer

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/reactive/server/WebTestClientContextCustomizerFactory.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/reactive/server/WebTestClientContextCustomizerFactory.java
@@ -39,7 +39,7 @@ class WebTestClientContextCustomizerFactory implements ContextCustomizerFactory 
 			List<ContextConfigurationAttributes> configAttributes) {
 		SpringBootTest springBootTest = TestContextAnnotationUtils.findMergedAnnotation(testClass,
 				SpringBootTest.class);
-		return (springBootTest != null) ? new WebTestClientContextCustomizer() : null;
+		return (springBootTest != null && isWebClientPresent()) ? new WebTestClientContextCustomizer() : null;
 	}
 
 	private boolean isWebClientPresent() {

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/reactive/server/WebTestClientContextCustomizerFactoryWithWebfluxTest.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/reactive/server/WebTestClientContextCustomizerFactoryWithWebfluxTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.test.web.reactive.server;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextCustomizer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link WebTestClientContextCustomizerFactory} when spring webflux is on the
+ * classpath.
+ *
+ * @author Tobias Gesellchen
+ */
+class WebTestClientContextCustomizerFactoryWithWebfluxTest {
+
+	WebTestClientContextCustomizerFactory contextCustomizerFactory;
+
+	@BeforeEach
+	void setup() {
+		this.contextCustomizerFactory = new WebTestClientContextCustomizerFactory();
+	}
+
+	@Test
+	void createContextCustomizer() {
+		ContextCustomizer contextCustomizer = this.contextCustomizerFactory.createContextCustomizer(TestClass.class,
+				Collections.emptyList());
+		assertThat(contextCustomizer).isNotNull();
+	}
+
+	@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+	static class TestClass {
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/reactive/server/WebTestClientContextCustomizerFactoryWithoutWebfluxTest.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/reactive/server/WebTestClientContextCustomizerFactoryWithoutWebfluxTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.test.web.reactive.server;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
+import org.springframework.test.context.ContextCustomizer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link WebTestClientContextCustomizerFactory} when spring webflux is not on
+ * the classpath.
+ *
+ * @author Tobias Gesellchen
+ */
+@ClassPathExclusions("spring-webflux*.jar")
+public class WebTestClientContextCustomizerFactoryWithoutWebfluxTest {
+
+	WebTestClientContextCustomizerFactory contextCustomizerFactory;
+
+	@BeforeEach
+	void setup() {
+		this.contextCustomizerFactory = new WebTestClientContextCustomizerFactory();
+	}
+
+	@Test
+	void doNotCreateContextCustomizer() {
+		ContextCustomizer contextCustomizer = this.contextCustomizerFactory.createContextCustomizer(TestClass.class,
+				Collections.emptyList());
+		assertThat(contextCustomizer).isNull();
+	}
+
+	@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+	static class TestClass {
+
+	}
+
+}


### PR DESCRIPTION
Our `@SpringBootTest` in a `SERVLET` SpringApplication fails with the stacktrace below after an upgrade from Spring-Boot 2.3.6 to 2.4.0.

It seems like a check on the presence of `WebClient` had been removed with the refactoring at https://github.com/spring-projects/spring-boot/commit/6b437ece548802f0803f761f6b10acc9b560f571#diff-0468685a60929025a2cf3fe3ed6a01021f7b6865d562536897e5915c3a483c40L42.

This pull request adds the check for `isWebClientPresent()`.

<details><summary>stacktrace</summary>

```
Error creating bean with name 'org.springframework.test.web.reactive.server.WebTestClient': FactoryBean threw exception on object creation; nested exception is java.lang.IllegalStateException: No suitable default ClientHttpConnector found
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.test.web.reactive.server.WebTestClient': FactoryBean threw exception on object creation; nested exception is java.lang.IllegalStateException: No suitable default ClientHttpConnector found
	at org.springframework.beans.factory.support.FactoryBeanRegistrySupport.doGetObjectFromFactoryBean(FactoryBeanRegistrySupport.java:176)
	at org.springframework.beans.factory.support.FactoryBeanRegistrySupport.getObjectFromFactoryBean(FactoryBeanRegistrySupport.java:101)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getObjectForBeanInstance(AbstractBeanFactory.java:1879)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.getObjectForBeanInstance(AbstractAutowireCapableBeanFactory.java:1268)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:267)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208)
	at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1161)
	at org.spockframework.spring.SpringMockTestExecutionListener.beforeTestMethod(SpringMockTestExecutionListener.java:79)
	at org.spockframework.spring.AbstractSpringTestExecutionListener.beforeTestMethod(AbstractSpringTestExecutionListener.java:39)
	at org.springframework.test.context.TestContextManager.beforeTestMethod(TestContextManager.java:289)
	at org.spockframework.spring.SpringTestContextManager.beforeTestMethod(SpringTestContextManager.java:60)
	at org.spockframework.spring.SpringInterceptor.interceptSetupMethod(SpringInterceptor.java:50)
	at org.spockframework.runtime.extension.AbstractMethodInterceptor.intercept(AbstractMethodInterceptor.java:30)
	at org.spockframework.runtime.extension.MethodInvocation.proceed(MethodInvocation.java:97)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:119)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:414)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: java.lang.IllegalStateException: No suitable default ClientHttpConnector found
	at org.springframework.test.web.reactive.server.DefaultWebTestClientBuilder.initConnector(DefaultWebTestClientBuilder.java:295)
	at org.springframework.test.web.reactive.server.DefaultWebTestClientBuilder.build(DefaultWebTestClientBuilder.java:266)
	at org.springframework.boot.test.web.reactive.server.WebTestClientContextCustomizer$WebTestClientFactory.createWebTestClient(WebTestClientContextCustomizer.java:162)
	at org.springframework.boot.test.web.reactive.server.WebTestClientContextCustomizer$WebTestClientFactory.getObject(WebTestClientContextCustomizer.java:150)
	at org.springframework.boot.test.web.reactive.server.WebTestClientContextCustomizer$WebTestClientFactory.getObject(WebTestClientContextCustomizer.java:126)
	at org.springframework.beans.factory.support.FactoryBeanRegistrySupport.doGetObjectFromFactoryBean(FactoryBeanRegistrySupport.java:169)
	... 34 more
```
</details>
