### PR TITLE
Reduce the overhead of char[] creation

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/SimpleHttpCodeStatusMapper.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/SimpleHttpCodeStatusMapper.java
@@ -81,7 +81,8 @@ public class SimpleHttpCodeStatusMapper implements HttpCodeStatusMapper {
 			return null;
 		}
 		StringBuilder builder = new StringBuilder();
-		for (char ch : code.toCharArray()) {
+		for (int i = 0; i < code.length(); i++) {
+			char ch = code.charAt(i);
 			if (Character.isAlphabetic(ch) || Character.isDigit(ch)) {
 				builder.append(Character.toLowerCase(ch));
 			}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/SimpleStatusAggregator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/SimpleStatusAggregator.java
@@ -89,7 +89,8 @@ public class SimpleStatusAggregator implements StatusAggregator {
 			return null;
 		}
 		StringBuilder builder = new StringBuilder();
-		for (char ch : code.toCharArray()) {
+		for (int i = 0; i < code.length(); i++) {
+			char ch = code.charAt(i);
 			if (Character.isAlphabetic(ch) || Character.isDigit(ch)) {
 				builder.append(Character.toLowerCase(ch));
 			}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/ConfigurationMetadata.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/ConfigurationMetadata.java
@@ -189,7 +189,8 @@ public class ConfigurationMetadata {
 	static String toDashedCase(String name) {
 		StringBuilder dashed = new StringBuilder();
 		Character previous = null;
-		for (char current : name.toCharArray()) {
+		for (int i = 0; i < name.length(); i++) {
+			char current = name.charAt(i);
 			if (SEPARATORS.contains(current)) {
 				dashed.append("-");
 			}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/ConfigTreePropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/ConfigTreePropertySource.java
@@ -308,7 +308,8 @@ public class ConfigTreePropertySource extends EnumerablePropertySource<Path> imp
 				return string;
 			}
 			int numberOfLines = 0;
-			for (char ch : string.toCharArray()) {
+			for (int i = 0; i < string.length(); i++) {
+				char ch = string.charAt(i);
 				if (ch == '\n') {
 					numberOfLines++;
 				}


### PR DESCRIPTION
There some locations which could benefit from not using a
toCharArray on a String, but rather use the charAt method from
the String itself. This to prevent an additional copy of the
char[] being created.