### PR TITLE
Correct external application properties load order

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -591,8 +591,8 @@ Spring Boot will automatically find and load `application.properties` and `appli
 . The classpath root
 . The classpath `/config` package
 . The current directory
+. Immediate child directories of the `/config` subdirectory in the current directory
 . The `/config` subdirectory in the current directory
-. Immediate child directories of the `/config` subdirectory
 
 The list is ordered by precedence (with values from lower items overriding earlier ones).
 Documents from the loaded files are added as `PropertySources` to the Spring `Environment`.


### PR DESCRIPTION
It seems the documentation is showing the wrong order for configuration properties.

The correct order judging from `ConfigDataEnvironment` and the remainder of the documentation is:

```
		locations.add(ConfigDataLocation.of("optional:classpath:/"));
		locations.add(ConfigDataLocation.of("optional:classpath:/config/"));
		locations.add(ConfigDataLocation.of("optional:file:./"));
		locations.add(ConfigDataLocation.of("optional:file:./config/*/"));
		locations.add(ConfigDataLocation.of("optional:file:./config/"));
```

But the documentation states the subdirectories of `./config` are loaded last. I have corrected this and added 'in the current directory' to make sure everyone understands which subdirectories are meant.

I have not verified this is actually the correct loading order, but the code seems clear enough to me.