### PR TITLE
Persistent and RelationshipProperties-annotated types are not scanned with Spring Data Neo4j

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.annotation.Persistent;
 import org.springframework.data.neo4j.config.Neo4jDefaultCallbacksRegistrar;
 import org.springframework.data.neo4j.core.DatabaseSelectionProvider;
 import org.springframework.data.neo4j.core.Neo4jClient;
@@ -44,6 +45,7 @@ import org.springframework.data.neo4j.core.Neo4jTemplate;
 import org.springframework.data.neo4j.core.convert.Neo4jConversions;
 import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
 import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.RelationshipProperties;
 import org.springframework.data.neo4j.core.transaction.Neo4jTransactionManager;
 import org.springframework.data.neo4j.repository.config.Neo4jRepositoryConfigurationExtension;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -79,7 +81,8 @@ public class Neo4jDataAutoConfiguration {
 	@ConditionalOnMissingBean
 	public Neo4jMappingContext neo4jMappingContext(ApplicationContext applicationContext,
 			Neo4jConversions neo4jConversions) throws ClassNotFoundException {
-		Set<Class<?>> initialEntityClasses = new EntityScanner(applicationContext).scan(Node.class);
+		Set<Class<?>> initialEntityClasses = new EntityScanner(applicationContext).scan(Node.class, Persistent.class,
+				RelationshipProperties.class);
 		Neo4jMappingContext context = new Neo4jMappingContext(neo4jConversions);
 		context.setInitialEntitySet(initialEntityClasses);
 		return context;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfigurationTests.java
@@ -19,6 +19,11 @@ package org.springframework.boot.autoconfigure.data.neo4j;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.TestAutoConfigurationPackage;
+import org.springframework.boot.autoconfigure.data.neo4j.scan.AnnotatedWithNode;
+import org.springframework.boot.autoconfigure.data.neo4j.scan.AnnotatedWithPersistent;
+import org.springframework.boot.autoconfigure.data.neo4j.scan.AnnotatedWithRelationshipProperties;
+import org.springframework.boot.autoconfigure.data.neo4j.scan.NotAnnotatedEntity;
 import org.springframework.boot.autoconfigure.neo4j.Neo4jAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -29,6 +34,7 @@ import org.springframework.data.neo4j.core.Neo4jClient;
 import org.springframework.data.neo4j.core.Neo4jOperations;
 import org.springframework.data.neo4j.core.Neo4jTemplate;
 import org.springframework.data.neo4j.core.convert.Neo4jConversions;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
 import org.springframework.data.neo4j.core.transaction.Neo4jTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.ReactiveTransactionManager;
@@ -137,6 +143,17 @@ class Neo4jDataAutoConfigurationTests {
 						.hasBean("myCustomTransactionManager"));
 	}
 
+	@Test
+	void shouldFilterInitialEntityScanWithKnownAnnotations() {
+		this.contextRunner.withUserConfiguration(PackageConfig.class).run((context) -> {
+			Neo4jMappingContext mappingContext = context.getBean(Neo4jMappingContext.class);
+			assertThat(mappingContext.hasPersistentEntityFor(AnnotatedWithNode.class)).isTrue();
+			assertThat(mappingContext.hasPersistentEntityFor(AnnotatedWithPersistent.class)).isTrue();
+			assertThat(mappingContext.hasPersistentEntityFor(AnnotatedWithRelationshipProperties.class)).isTrue();
+			assertThat(mappingContext.hasPersistentEntityFor(NotAnnotatedEntity.class)).isFalse();
+		});
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class CustomDatabaseSelectionProviderConfiguration {
 
@@ -144,6 +161,12 @@ class Neo4jDataAutoConfigurationTests {
 		DatabaseSelectionProvider databaseSelectionProvider() {
 			return () -> DatabaseSelection.byName("custom");
 		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@TestAutoConfigurationPackage(AnnotatedWithPersistent.class)
+	static class PackageConfig {
 
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jReactiveRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jReactiveRepositoriesAutoConfigurationTests.java
@@ -26,9 +26,14 @@ import org.springframework.boot.autoconfigure.data.neo4j.city.CityRepository;
 import org.springframework.boot.autoconfigure.data.neo4j.city.ReactiveCityRepository;
 import org.springframework.boot.autoconfigure.data.neo4j.country.CountryRepository;
 import org.springframework.boot.autoconfigure.data.neo4j.country.ReactiveCountryRepository;
+import org.springframework.boot.autoconfigure.data.neo4j.scan.AnnotatedWithNode;
+import org.springframework.boot.autoconfigure.data.neo4j.scan.AnnotatedWithPersistent;
+import org.springframework.boot.autoconfigure.data.neo4j.scan.AnnotatedWithRelationshipProperties;
+import org.springframework.boot.autoconfigure.data.neo4j.scan.NotAnnotatedEntity;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.neo4j.core.ReactiveNeo4jTemplate;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
 import org.springframework.data.neo4j.repository.ReactiveNeo4jRepository;
 import org.springframework.data.neo4j.repository.config.EnableReactiveNeo4jRepositories;
 
@@ -84,6 +89,17 @@ public class Neo4jReactiveRepositoriesAutoConfigurationTests {
 						.hasSingleBean(ReactiveCountryRepository.class));
 	}
 
+	@Test
+	void shouldFilterInitialEntityScanWithKnownAnnotations() {
+		this.contextRunner.withUserConfiguration(PackageConfig.class).run((context) -> {
+			Neo4jMappingContext mappingContext = context.getBean(Neo4jMappingContext.class);
+			assertThat(mappingContext.hasPersistentEntityFor(AnnotatedWithNode.class)).isTrue();
+			assertThat(mappingContext.hasPersistentEntityFor(AnnotatedWithPersistent.class)).isTrue();
+			assertThat(mappingContext.hasPersistentEntityFor(AnnotatedWithRelationshipProperties.class)).isTrue();
+			assertThat(mappingContext.hasPersistentEntityFor(NotAnnotatedEntity.class)).isFalse();
+		});
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	@TestAutoConfigurationPackage(City.class)
 	static class TestConfiguration {
@@ -106,6 +122,12 @@ public class Neo4jReactiveRepositoriesAutoConfigurationTests {
 	@Configuration(proxyBeanMethods = false)
 	@EnableReactiveNeo4jRepositories(basePackageClasses = ReactiveCountryRepository.class)
 	static class WithCustomReactiveRepositoryScan {
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@TestAutoConfigurationPackage(AnnotatedWithPersistent.class)
+	static class PackageConfig {
 
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/scan/AnnotatedWithNode.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/scan/AnnotatedWithNode.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.neo4j.scan;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+
+/**
+ * @author Gerrit Meier
+ */
+@Node
+public class AnnotatedWithNode {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/scan/AnnotatedWithPersistent.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/scan/AnnotatedWithPersistent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.neo4j.scan;
+
+import org.springframework.data.annotation.Persistent;
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+
+/**
+ * @author Gerrit Meier
+ */
+@Persistent
+public class AnnotatedWithPersistent {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/scan/AnnotatedWithRelationshipProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/scan/AnnotatedWithRelationshipProperties.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.neo4j.scan;
+
+import org.springframework.data.neo4j.core.schema.RelationshipProperties;
+
+/**
+ * @author Gerrit Meier
+ */
+@RelationshipProperties
+public class AnnotatedWithRelationshipProperties {
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/scan/NotAnnotatedEntity.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/scan/NotAnnotatedEntity.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.neo4j.scan;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+
+/**
+ * @author Gerrit Meier
+ */
+public class NotAnnotatedEntity {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+}


### PR DESCRIPTION
To align with the other store modules, I added the `Persistent` type to the initial scan list. We already added this in SDN itself as a supported type.
Also the `RelationshipProperties` type got added to this list, because the loading of those entities would fail if we are running in Spring Data's strict mode (e.g. multi store modules) and they would get requested during runtime. In contrast to the startup phase when this method gets called.