### PR TITLE
Upgrade to Embedded Mongo 3.0.0

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/DownloadConfigBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/DownloadConfigBuilderCustomizer.java
@@ -16,13 +16,13 @@
 
 package org.springframework.boot.autoconfigure.mongo.embedded;
 
-import de.flapdoodle.embed.mongo.config.DownloadConfigBuilder;
-import de.flapdoodle.embed.process.config.store.IDownloadConfig;
+import de.flapdoodle.embed.process.config.store.DownloadConfig;
+import de.flapdoodle.embed.process.config.store.ImmutableDownloadConfig;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link IDownloadConfig} via a {@link DownloadConfigBuilder} whilst retaining default
- * auto-configuration.
+ * {@link DownloadConfig} via a {@link ImmutableDownloadConfig.Builder} whilst retaining
+ * default auto-configuration.
  *
  * @author Michael Gmeiner
  * @since 2.2.0
@@ -31,9 +31,10 @@ import de.flapdoodle.embed.process.config.store.IDownloadConfig;
 public interface DownloadConfigBuilderCustomizer {
 
 	/**
-	 * Customize the {@link DownloadConfigBuilder}.
-	 * @param downloadConfigBuilder the {@link DownloadConfigBuilder} to customize
+	 * Customize the {@link ImmutableDownloadConfig.Builder}.
+	 * @param downloadConfigBuilder the {@link ImmutableDownloadConfig.Builder} to
+	 * customize
 	 */
-	void customize(DownloadConfigBuilder downloadConfigBuilder);
+	void customize(ImmutableDownloadConfig.Builder downloadConfigBuilder);
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
@@ -27,26 +27,24 @@ import com.mongodb.MongoClientSettings;
 import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.DownloadConfigBuilder;
-import de.flapdoodle.embed.mongo.config.ExtractedArtifactStoreBuilder;
-import de.flapdoodle.embed.mongo.config.IMongodConfig;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.Defaults;
+import de.flapdoodle.embed.mongo.config.ImmutableMongodConfig;
+import de.flapdoodle.embed.mongo.config.MongodConfig;
 import de.flapdoodle.embed.mongo.config.Net;
-import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.mongo.config.Storage;
 import de.flapdoodle.embed.mongo.distribution.Feature;
 import de.flapdoodle.embed.mongo.distribution.IFeatureAwareVersion;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.mongo.distribution.Versions;
-import de.flapdoodle.embed.process.config.IRuntimeConfig;
+import de.flapdoodle.embed.process.config.RuntimeConfig;
 import de.flapdoodle.embed.process.config.io.ProcessOutput;
-import de.flapdoodle.embed.process.config.store.IDownloadConfig;
-import de.flapdoodle.embed.process.distribution.GenericVersion;
+import de.flapdoodle.embed.process.config.store.DownloadConfig;
+import de.flapdoodle.embed.process.config.store.ImmutableDownloadConfig;
 import de.flapdoodle.embed.process.io.Processors;
 import de.flapdoodle.embed.process.io.Slf4jLevel;
 import de.flapdoodle.embed.process.io.progress.Slf4jProgressListener;
 import de.flapdoodle.embed.process.runtime.Network;
-import de.flapdoodle.embed.process.store.ArtifactStoreBuilder;
+import de.flapdoodle.embed.process.store.ExtractedArtifactStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,6 +79,7 @@ import org.springframework.data.mongodb.core.ReactiveMongoClientFactoryBean;
  * @author Yogesh Lonkar
  * @author Mark Paluch
  * @author Issam El-atif
+ * @author Paulius Dambrauskas
  * @since 1.3.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -97,14 +96,14 @@ public class EmbeddedMongoAutoConfiguration {
 
 	private final MongoProperties properties;
 
-	public EmbeddedMongoAutoConfiguration(MongoProperties properties, EmbeddedMongoProperties embeddedProperties) {
+	public EmbeddedMongoAutoConfiguration(MongoProperties properties) {
 		this.properties = properties;
 	}
 
 	@Bean(initMethod = "start", destroyMethod = "stop")
 	@ConditionalOnMissingBean
-	public MongodExecutable embeddedMongoServer(IMongodConfig mongodConfig, IRuntimeConfig runtimeConfig,
-			ApplicationContext context) throws IOException {
+	public MongodExecutable embeddedMongoServer(MongodConfig mongodConfig, RuntimeConfig runtimeConfig,
+			ApplicationContext context) {
 		Integer configuredPort = this.properties.getPort();
 		if (configuredPort == null || configuredPort == 0) {
 			setEmbeddedPort(context, mongodConfig.net().getPort());
@@ -113,7 +112,7 @@ public class EmbeddedMongoAutoConfiguration {
 		return mongodStarter.prepare(mongodConfig);
 	}
 
-	private MongodStarter getMongodStarter(IRuntimeConfig runtimeConfig) {
+	private MongodStarter getMongodStarter(RuntimeConfig runtimeConfig) {
 		if (runtimeConfig == null) {
 			return MongodStarter.getDefaultInstance();
 		}
@@ -122,8 +121,8 @@ public class EmbeddedMongoAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public IMongodConfig embeddedMongoConfiguration(EmbeddedMongoProperties embeddedProperties) throws IOException {
-		MongodConfigBuilder builder = new MongodConfigBuilder().version(determineVersion(embeddedProperties));
+	public MongodConfig embeddedMongoConfiguration(EmbeddedMongoProperties embeddedProperties) throws IOException {
+		ImmutableMongodConfig.Builder builder = MongodConfig.builder().version(determineVersion(embeddedProperties));
 		EmbeddedMongoProperties.Storage storage = embeddedProperties.getStorage();
 		if (storage != null) {
 			String databaseDir = storage.getDatabaseDir();
@@ -149,9 +148,11 @@ public class EmbeddedMongoAutoConfiguration {
 					return version;
 				}
 			}
-			return Versions.withFeatures(new GenericVersion(embeddedProperties.getVersion()));
+			return Versions
+					.withFeatures(de.flapdoodle.embed.process.distribution.Version.of(embeddedProperties.getVersion()));
 		}
-		return Versions.withFeatures(new GenericVersion(embeddedProperties.getVersion()),
+		return Versions.withFeatures(
+				de.flapdoodle.embed.process.distribution.Version.of(embeddedProperties.getVersion()),
 				embeddedProperties.getFeatures().toArray(new Feature[0]));
 	}
 
@@ -189,29 +190,29 @@ public class EmbeddedMongoAutoConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(Logger.class)
-	@ConditionalOnMissingBean(IRuntimeConfig.class)
+	@ConditionalOnMissingBean(RuntimeConfig.class)
 	static class RuntimeConfigConfiguration {
 
 		@Bean
-		IRuntimeConfig embeddedMongoRuntimeConfig(
+		RuntimeConfig embeddedMongoRuntimeConfig(
 				ObjectProvider<DownloadConfigBuilderCustomizer> downloadConfigBuilderCustomizers) {
 			Logger logger = LoggerFactory.getLogger(getClass().getPackage().getName() + ".EmbeddedMongo");
 			ProcessOutput processOutput = new ProcessOutput(Processors.logTo(logger, Slf4jLevel.INFO),
 					Processors.logTo(logger, Slf4jLevel.ERROR),
 					Processors.named("[console>]", Processors.logTo(logger, Slf4jLevel.DEBUG)));
-			return new RuntimeConfigBuilder().defaultsWithLogger(Command.MongoD, logger).processOutput(processOutput)
+
+			return Defaults.runtimeConfigFor(Command.MongoD, logger).processOutput(processOutput)
 					.artifactStore(getArtifactStore(logger, downloadConfigBuilderCustomizers.orderedStream()))
-					.daemonProcess(false).build();
+					.isDaemonProcess(false).build();
 		}
 
-		private ArtifactStoreBuilder getArtifactStore(Logger logger,
+		private ExtractedArtifactStore getArtifactStore(Logger logger,
 				Stream<DownloadConfigBuilderCustomizer> downloadConfigBuilderCustomizers) {
-			DownloadConfigBuilder downloadConfigBuilder = new DownloadConfigBuilder()
-					.defaultsForCommand(Command.MongoD);
+			ImmutableDownloadConfig.Builder downloadConfigBuilder = Defaults.downloadConfigFor(Command.MongoD);
 			downloadConfigBuilder.progressListener(new Slf4jProgressListener(logger));
 			downloadConfigBuilderCustomizers.forEach((customizer) -> customizer.customize(downloadConfigBuilder));
-			IDownloadConfig downloadConfig = downloadConfigBuilder.build();
-			return new ExtractedArtifactStoreBuilder().defaults(Command.MongoD).download(downloadConfig);
+			DownloadConfig downloadConfig = downloadConfigBuilder.build();
+			return Defaults.extractedArtifactStoreFor(Command.MongoD).withDownloadConfig(downloadConfig);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfigurationTests.java
@@ -27,12 +27,12 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.IMongodConfig;
+import de.flapdoodle.embed.mongo.config.MongodConfig;
 import de.flapdoodle.embed.mongo.config.Storage;
 import de.flapdoodle.embed.mongo.distribution.Feature;
 import de.flapdoodle.embed.mongo.distribution.Version;
-import de.flapdoodle.embed.process.config.IRuntimeConfig;
-import de.flapdoodle.embed.process.config.store.IDownloadConfig;
+import de.flapdoodle.embed.process.config.RuntimeConfig;
+import de.flapdoodle.embed.process.config.store.DownloadConfig;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -143,7 +143,7 @@ class EmbeddedMongoAutoConfigurationTests {
 	@Test
 	void defaultStorageConfiguration() {
 		load(MongoClientConfiguration.class);
-		Storage replication = this.context.getBean(IMongodConfig.class).replication();
+		Storage replication = this.context.getBean(MongodConfig.class).replication();
 		assertThat(replication.getOplogSize()).isEqualTo(0);
 		assertThat(replication.getDatabaseDir()).isNull();
 		assertThat(replication.getReplSetName()).isNull();
@@ -161,26 +161,26 @@ class EmbeddedMongoAutoConfigurationTests {
 	@Test
 	void customOpLogSizeIsAppliedToConfiguration() {
 		load("spring.mongodb.embedded.storage.oplogSize=1024KB");
-		assertThat(this.context.getBean(IMongodConfig.class).replication().getOplogSize()).isEqualTo(1);
+		assertThat(this.context.getBean(MongodConfig.class).replication().getOplogSize()).isEqualTo(1);
 	}
 
 	@Test
 	void customOpLogSizeUsesMegabytesPerDefault() {
 		load("spring.mongodb.embedded.storage.oplogSize=10");
-		assertThat(this.context.getBean(IMongodConfig.class).replication().getOplogSize()).isEqualTo(10);
+		assertThat(this.context.getBean(MongodConfig.class).replication().getOplogSize()).isEqualTo(10);
 	}
 
 	@Test
 	void customReplicaSetNameIsAppliedToConfiguration() {
 		load("spring.mongodb.embedded.storage.replSetName=testing");
-		assertThat(this.context.getBean(IMongodConfig.class).replication().getReplSetName()).isEqualTo("testing");
+		assertThat(this.context.getBean(MongodConfig.class).replication().getReplSetName()).isEqualTo("testing");
 	}
 
 	@Test
 	void customizeDownloadConfiguration() {
 		load(DownloadConfigBuilderCustomizerConfiguration.class);
-		IRuntimeConfig runtimeConfig = this.context.getBean(IRuntimeConfig.class);
-		IDownloadConfig downloadConfig = (IDownloadConfig) new DirectFieldAccessor(runtimeConfig.getArtifactStore())
+		RuntimeConfig runtimeConfig = this.context.getBean(RuntimeConfig.class);
+		DownloadConfig downloadConfig = (DownloadConfig) new DirectFieldAccessor(runtimeConfig.artifactStore())
 				.getPropertyValue("downloadConfig");
 		assertThat(downloadConfig.getUserAgent()).isEqualTo("Test User Agent");
 	}
@@ -265,7 +265,7 @@ class EmbeddedMongoAutoConfigurationTests {
 	static class CustomMongoConfiguration {
 
 		@Bean(initMethod = "start", destroyMethod = "stop")
-		MongodExecutable customMongoServer(IRuntimeConfig runtimeConfig, IMongodConfig mongodConfig) {
+		MongodExecutable customMongoServer(RuntimeConfig runtimeConfig, MongodConfig mongodConfig) {
 			MongodStarter mongodStarter = MongodStarter.getInstance(runtimeConfig);
 			return mongodStarter.prepare(mongodConfig);
 		}

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -300,7 +300,7 @@ bom {
 			]
 		}
 	}
-	library("Embedded Mongo", "2.2.0") {
+	library("Embedded Mongo", "3.0.0") {
 		group("de.flapdoodle.embed") {
 			modules = [
 				"de.flapdoodle.embed.mongo"


### PR DESCRIPTION
New version of `de.flapdoodle.embed.mongo` was released about a month ago.
This PR updates Embeded Mongo dependency and updates EmbededMongoAutoconfiguration with new API.

Related: https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/325