### PR TITLE
Invalid ErrorAttributesOptions#getInclude Javadoc

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/error/ErrorAttributeOptions.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/error/ErrorAttributeOptions.java
@@ -49,8 +49,7 @@ public final class ErrorAttributeOptions {
 
 	/**
 	 * Get all options for including attributes in the error response.
-	 * @return {@code true} if the {@code Include} attribute is included in the error
-	 * response, {@code false} otherwise
+	 * @return the options
 	 */
 	public Set<Include> getIncludes() {
 		return this.includes;


### PR DESCRIPTION
The JavaDoc return description of ErrorAttributeOptions.getIncludes reads the same as isIncluded's return description.
This pull request corrects the description.