### PR TITLE
Excludes old asm lib from json-path

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -905,7 +905,9 @@ bom {
 	library("Json Path", "2.4.0") {
 		group("com.jayway.jsonpath") {
 			modules = [
-				"json-path",
+				"json-path"  {
+					exclude group: "org.ow2.asm", module: "asm"
+				},
 				"json-path-assert"
 			]
 		}

--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-test/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-test/build.gradle
@@ -8,7 +8,9 @@ dependencies {
 	api(project(":spring-boot-project:spring-boot-starters:spring-boot-starter"))
 	api(project(":spring-boot-project:spring-boot-test"))
 	api(project(":spring-boot-project:spring-boot-test-autoconfigure"))
-	api("com.jayway.jsonpath:json-path")
+	api("com.jayway.jsonpath:json-path") {
+		exclude group: "org.ow2.asm", module: "asm"
+	}
 	api("jakarta.xml.bind:jakarta.xml.bind-api")
 	api("org.assertj:assertj-core")
 	api("org.hamcrest:hamcrest")


### PR DESCRIPTION
### Summary
Excludes old asm lib from json-path

Fixes gh-24218

### Details
Ideally this would be fixed in `json-path -> json-smart -> smart-asserter` but since those repos are inactive (AFAICT) I explored using a Gradle component metadata rule (see [example 2](https://docs.gradle.org/current/userguide/component_metadata_rules.html#fixing_wrong_dependency_details) to simulate this sort of systemic fix. I have no experience w/ that portion of Gradle and it did not seem to work for me. Being out of my comfort zone I went w/ the less risky approach of brute-force exclusion from the only modules that outwardly publish `json-path`: `spring-boot-starter-test` and `spring-boot-dependencies`. 

The other modules use `optional` or `testImplementation` for `json-path`. My initial fear was that by not excluding `asm` on these declarations as well that our tests would be running against the old asm (5.x) and thus hiding bugs that could possibly occur when pointing at the new asm (7.x). Due to Gradle version alignment this is not an issue - it picks the latest. For example, in `spring-boot-actuator` there is a `testImplementation` dependency on `json-path`. To see what it uses at runtime I executed the following:
```
IT-USA-B00159:spring-boot-actuator cbono$ ../../gradlew dependencyInsight --configuration testRuntimeClasspath --dependency asm
```
The results are the most recent `asm:7.1` is chosen (you can see the `5.0.4 -> 7.1` version alignment happening:
```
org.ow2.asm:asm:5.0.4 -> 7.1
\--- net.minidev:accessors-smart:1.2
     \--- net.minidev:json-smart:2.3
          +--- project :spring-boot-project:spring-boot-dependencies
          |    \--- project :spring-boot-project:spring-boot-parent
          |         +--- testRuntimeClasspath
          |         \--- project :spring-boot-project:spring-boot-tools:spring-boot-test-support
          |              \--- testRuntimeClasspath
          \--- com.jayway.jsonpath:json-path:2.4.0
               +--- testRuntimeClasspath (requested com.jayway.jsonpath:json-path)
               \--- project :spring-boot-project:spring-boot-dependencies (*)
```