### PR TITLE
Document how to use Devtools without an IDE

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/using-spring-boot.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/using-spring-boot.adoc
@@ -592,6 +592,7 @@ As DevTools monitors classpath resources, the only way to trigger a restart is t
 The way in which you cause the classpath to be updated depends on the IDE that you are using.
 In Eclipse, saving a modified file causes the classpath to be updated and triggers a restart.
 In IntelliJ IDEA, building the project (`Build +->+ Build Project`) has the same effect.
+If using a build plugin, running `mvn compile` for maven or `gradle build` for gradle will trigger a restart.
 ****
 
 NOTE: As long as forking is enabled, you can also start your application by using the supported build plugins (Maven and Gradle), since DevTools needs an isolated application classloader to operate properly.


### PR DESCRIPTION
Updates docs in order to avoid confusion for people who aren't using an IDE. The following NOTE paragraph alone made it seem like the build plugins should just work in the same way as devtools via an IDE.


This somewhat helps address the problem brought up in issue #5136

I discovered that this step was necessary only after hours of searching and testing when I noticed it here: https://github.com/spring-projects/spring-boot/issues/3315#issuecomment-114740127
