### PR TITLE
Remove deprecated code in EndpointDiscoverer

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/EndpointDiscoverer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/EndpointDiscoverer.java
@@ -243,17 +243,6 @@ public abstract class EndpointDiscoverer<E extends ExposableEndpoint<O>, O exten
 	/**
 	 * Determine if an extension bean should be exposed. Subclasses can override this
 	 * method to provide additional logic.
-	 * @param extensionBean the extension bean
-	 * @return {@code true} if the extension is exposed
-	 */
-	@Deprecated
-	protected boolean isExtensionExposed(Object extensionBean) {
-		return true;
-	}
-
-	/**
-	 * Determine if an extension bean should be exposed. Subclasses can override this
-	 * method to provide additional logic.
 	 * @param extensionBeanType the extension bean type
 	 * @return {@code true} if the extension is exposed
 	 */
@@ -263,18 +252,7 @@ public abstract class EndpointDiscoverer<E extends ExposableEndpoint<O>, O exten
 
 	private boolean isEndpointExposed(EndpointBean endpointBean) {
 		return isFilterMatch(endpointBean.getFilter(), endpointBean) && !isEndpointFiltered(endpointBean)
-				&& isEndpointExposed(endpointBean.getBean());
-	}
-
-	/**
-	 * Determine if an endpoint bean should be exposed. Subclasses can override this
-	 * method to provide additional logic.
-	 * @param endpointBean the endpoint bean
-	 * @return {@code true} if the endpoint is exposed
-	 */
-	@Deprecated
-	protected boolean isEndpointExposed(Object endpointBean) {
-		return true;
+				&& isEndpointTypeExposed(endpointBean.getBeanType());
 	}
 
 	/**


### PR DESCRIPTION
Hi,

I just noticed two deprecated methods in `EndpointDiscoverer` that seem to be deprecated since 2.2.x already. I guess it's fine to remove them by now.

Cheers,
Christoph