### PR TITLE
Allow recursive profile group references

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/Profiles.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/Profiles.java
@@ -118,7 +118,7 @@ public class Profiles implements Iterable<String> {
 			String current = stack.pop();
 			expandedProfiles.add(current);
 			List<String> groupProfiles = asReversedList(this.groups.get(current));
-			groupProfiles.remove(current);
+			groupProfiles.removeAll(expandedProfiles);
 			groupProfiles.forEach(stack::push);
 		}
 		return asUniqueItemList(StringUtils.toStringArray(expandedProfiles));

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/Profiles.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/Profiles.java
@@ -117,7 +117,9 @@ public class Profiles implements Iterable<String> {
 		while (!stack.isEmpty()) {
 			String current = stack.pop();
 			expandedProfiles.add(current);
-			asReversedList(this.groups.get(current)).forEach(stack::push);
+			List<String> groupProfiles = asReversedList(this.groups.get(current));
+			groupProfiles.remove(current);
+			groupProfiles.forEach(stack::push);
 		}
 		return asUniqueItemList(StringUtils.toStringArray(expandedProfiles));
 	}
@@ -128,7 +130,7 @@ public class Profiles implements Iterable<String> {
 		}
 		List<String> reversed = new ArrayList<>(list);
 		Collections.reverse(reversed);
-		return Collections.unmodifiableList(reversed);
+		return reversed;
 	}
 
 	private List<String> asUniqueItemList(String[] array) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/Profiles.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/Profiles.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
@@ -118,10 +119,20 @@ public class Profiles implements Iterable<String> {
 			String current = stack.pop();
 			expandedProfiles.add(current);
 			List<String> groupProfiles = asReversedList(this.groups.get(current));
-			groupProfiles.removeAll(expandedProfiles);
+			Set<String> profileConflicts = getProfileConflicts(groupProfiles, expandedProfiles);
+			if (!profileConflicts.isEmpty()) {
+				String message = String.format("Profiles could not be resolved. Remove profiles %s from group: %s",
+						profileConflicts, current);
+				throw new IllegalStateException(message);
+
+			}
 			groupProfiles.forEach(stack::push);
 		}
 		return asUniqueItemList(StringUtils.toStringArray(expandedProfiles));
+	}
+
+	private Set<String> getProfileConflicts(List<String> groupProfiles, Set<String> expandedProfiles) {
+		return groupProfiles.stream().filter(expandedProfiles::contains).collect(Collectors.toSet());
 	}
 
 	private List<String> asReversedList(List<String> list) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ProfilesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ProfilesTests.java
@@ -360,11 +360,11 @@ class ProfilesTests {
 	}
 
 	@Test
-	void recursiveReferenceInProfileGroupIsIgnored() {
+	void recursiveReferencesInProfileGroupAreIgnored() {
 		MockEnvironment environment = new MockEnvironment();
 		environment.setProperty("spring.profiles.active", "a,b,c");
 		environment.setProperty("spring.profiles.group.a", "a,e,f");
-		environment.setProperty("spring.profiles.group.e", "x,y");
+		environment.setProperty("spring.profiles.group.e", "a,x,y");
 		Binder binder = Binder.get(environment);
 		Profiles profiles = new Profiles(environment, binder, null);
 		assertThat(profiles).containsExactly("a", "e", "x", "y", "f", "b", "c");

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ProfilesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ProfilesTests.java
@@ -359,4 +359,15 @@ class ProfilesTests {
 		assertThat(profiles.isAccepted("x")).isTrue();
 	}
 
+	@Test
+	void recursiveReferenceInProfileGroupIsIgnored() {
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("spring.profiles.active", "a,b,c");
+		environment.setProperty("spring.profiles.group.a", "a,e,f");
+		environment.setProperty("spring.profiles.group.e", "x,y");
+		Binder binder = Binder.get(environment);
+		Profiles profiles = new Profiles(environment, binder, null);
+		assertThat(profiles).containsExactly("a", "e", "x", "y", "f", "b", "c");
+	}
+
 }


### PR DESCRIPTION
Hi,

this PR fixes #24319 by removing the current profile from group profiles in order to avoid an endless loop when expanding/flattening the profile list.

Cheers,
Christoph