### PR TITLE
Bump Tomcat 9.0.40

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1698,7 +1698,7 @@ bom {
 			]
 		}
 	}
-	library("Tomcat", "9.0.39") {
+	library("Tomcat", "9.0.40") {
 		group("org.apache.tomcat") {
 			modules = [
 				"tomcat-annotations-api",


### PR DESCRIPTION
because of CVE-2020-17527
https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-17527

