### PR TITLE
log health status (and description) if status != UP

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthEndpointWebExtension.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthEndpointWebExtension.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.endpoint.SecurityContext;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
@@ -43,6 +45,8 @@ import org.springframework.boot.actuate.endpoint.web.annotation.EndpointWebExten
  */
 @EndpointWebExtension(endpoint = HealthEndpoint.class)
 public class HealthEndpointWebExtension extends HealthEndpointSupport<HealthContributor, HealthComponent> {
+
+	private static final Logger logger = LoggerFactory.getLogger(HealthEndpointWebExtension.class);
 
 	private static final String[] NO_PATH = {};
 
@@ -76,6 +80,10 @@ public class HealthEndpointWebExtension extends HealthEndpointSupport<HealthCont
 		}
 		HealthComponent health = result.getHealth();
 		HealthEndpointGroup group = result.getGroup();
+		if (!Status.UP.equals(health.getStatus())) {
+			logger.debug("health status={} with description={}", health.getStatus().getCode(),
+					health.getStatus().getDescription());
+		}
 		int statusCode = group.getHttpCodeStatusMapper().getStatusCode(health.getStatus());
 		return new WebEndpointResponse<>(health, statusCode);
 	}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthEndpointWebExtension.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthEndpointWebExtension.java
@@ -20,8 +20,9 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.boot.actuate.endpoint.SecurityContext;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
@@ -46,7 +47,7 @@ import org.springframework.boot.actuate.endpoint.web.annotation.EndpointWebExten
 @EndpointWebExtension(endpoint = HealthEndpoint.class)
 public class HealthEndpointWebExtension extends HealthEndpointSupport<HealthContributor, HealthComponent> {
 
-	private static final Logger logger = LoggerFactory.getLogger(HealthEndpointWebExtension.class);
+	private static final Log logger = LogFactory.getLog(HealthEndpointWebExtension.class);
 
 	private static final String[] NO_PATH = {};
 
@@ -81,8 +82,8 @@ public class HealthEndpointWebExtension extends HealthEndpointSupport<HealthCont
 		HealthComponent health = result.getHealth();
 		HealthEndpointGroup group = result.getGroup();
 		if (!Status.UP.equals(health.getStatus())) {
-			logger.debug("health status={} with description={}", health.getStatus().getCode(),
-					health.getStatus().getDescription());
+			logger.debug("health status=" + health.getStatus().getCode() + " with description="
+					+ health.getStatus().getDescription());
 		}
 		int statusCode = group.getHttpCodeStatusMapper().getStatusCode(health.getStatus());
 		return new WebEndpointResponse<>(health, statusCode);

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/ReactiveHealthEndpointWebExtension.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/ReactiveHealthEndpointWebExtension.java
@@ -20,11 +20,11 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.endpoint.SecurityContext;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
@@ -46,7 +46,7 @@ import org.springframework.boot.actuate.endpoint.web.annotation.EndpointWebExten
 public class ReactiveHealthEndpointWebExtension
 		extends HealthEndpointSupport<ReactiveHealthContributor, Mono<? extends HealthComponent>> {
 
-	private static final Logger logger = LoggerFactory.getLogger(ReactiveHealthEndpointWebExtension.class);
+	private static final Log logger = LogFactory.getLog(ReactiveHealthEndpointWebExtension.class);
 
 	private static final String[] NO_PATH = {};
 
@@ -82,8 +82,8 @@ public class ReactiveHealthEndpointWebExtension
 		HealthEndpointGroup group = result.getGroup();
 		return result.getHealth().map((health) -> {
 			if (!Status.UP.equals(health.getStatus())) {
-				logger.debug("health status={} with description={}", health.getStatus().getCode(),
-						health.getStatus().getDescription());
+				logger.debug("health status=" + health.getStatus().getCode() + " with description="
+						+ health.getStatus().getDescription());
 			}
 			int statusCode = group.getHttpCodeStatusMapper().getStatusCode(health.getStatus());
 			return new WebEndpointResponse<>(health, statusCode);

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/ReactiveHealthEndpointWebExtension.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/ReactiveHealthEndpointWebExtension.java
@@ -23,6 +23,8 @@ import java.util.Set;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.endpoint.SecurityContext;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
@@ -43,6 +45,8 @@ import org.springframework.boot.actuate.endpoint.web.annotation.EndpointWebExten
 @EndpointWebExtension(endpoint = HealthEndpoint.class)
 public class ReactiveHealthEndpointWebExtension
 		extends HealthEndpointSupport<ReactiveHealthContributor, Mono<? extends HealthComponent>> {
+
+	private static final Logger logger = LoggerFactory.getLogger(ReactiveHealthEndpointWebExtension.class);
 
 	private static final String[] NO_PATH = {};
 
@@ -77,6 +81,10 @@ public class ReactiveHealthEndpointWebExtension
 		}
 		HealthEndpointGroup group = result.getGroup();
 		return result.getHealth().map((health) -> {
+			if (!Status.UP.equals(health.getStatus())) {
+				logger.debug("health status={} with description={}", health.getStatus().getCode(),
+						health.getStatus().getDescription());
+			}
 			int statusCode = group.getHttpCodeStatusMapper().getStatusCode(health.getStatus());
 			return new WebEndpointResponse<>(health, statusCode);
 		});


### PR DESCRIPTION
It is important to not only know **that** a service is unhealthy, but also **why** it is (which health check, description). Unfortunately
some external monitoring systems do not provide the output/body of the HTTP request or do not create a history of that. A simple log message solves the issue completely in these cases.
For this reason I implemented a log statement in case the health check is not `UP`. To not change the default behavior and annoy people I choosed the `DEBUG` level.

I think that can be a useful feature for some people and does not harm anyone else.

btw: Its a bit unclear for me how you manage your branches. If this is merged into master, how will it be integrated best into `2.2.x` and `2.3.x`?