### PR TITLE
Add preliminary support for JDK 16

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/TestJarCreator.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/TestJarCreator.java
@@ -98,6 +98,7 @@ public abstract class TestJarCreator {
 			writeEntry(jarOutputStream, "META-INF/versions/13/multi-release.dat", 13);
 			writeEntry(jarOutputStream, "META-INF/versions/14/multi-release.dat", 14);
 			writeEntry(jarOutputStream, "META-INF/versions/15/multi-release.dat", 15);
+			writeEntry(jarOutputStream, "META-INF/versions/16/multi-release.dat", 16);
 		}
 		else {
 			writeEntry(jarOutputStream, "3.dat", 3);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/JavaVersion.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/JavaVersion.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.springframework.util.ClassUtils;
 
@@ -71,7 +72,12 @@ public enum JavaVersion {
 	/**
 	 * Java 15.
 	 */
-	FIFTEEN("15", CharSequence.class, "isEmpty");
+	FIFTEEN("15", CharSequence.class, "isEmpty"),
+
+	/**
+	 * Java 16.
+	 */
+	SIXTEEN("16", Stream.class, "toList");
 
 	private final String name;
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/system/JavaVersionTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/system/JavaVersionTests.java
@@ -127,4 +127,10 @@ class JavaVersionTests {
 		assertThat(JavaVersion.getJavaVersion()).isEqualTo(JavaVersion.FIFTEEN);
 	}
 
+	@Test
+	@EnabledOnJre(JRE.JAVA_16)
+	void currentJavaVersionSixteen() {
+		assertThat(JavaVersion.getJavaVersion()).isEqualTo(JavaVersion.SIXTEEN);
+	}
+
 }


### PR DESCRIPTION
Hi,

this PR is a first step into supporting JDK 16 (see #24402 ), which can be tested when setting the custom `buildJavaHome` property (at least build `16.ea.27` is needed to have `Stream.toList()` available). For everything else in #24402 we need Gradle with JDK 16 support.

Cheers,
Christoph