### PR TITLE
Add a "force-restart" command to force restart.

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/resources/org/springframework/boot/loader/tools/launch.script
@@ -254,6 +254,10 @@ restart() {
   stop && start
 }
 
+force_restart() {
+  force_stop && start
+}
+
 force_reload() {
   working_dir=$(dirname "$jarfile")
   pushd "$working_dir" > /dev/null
@@ -293,6 +297,8 @@ force-stop)
   force_stop "$@"; exit $?;;
 restart)
   restart "$@"; exit $?;;
+force-restart)
+  force_restart "$@"; exit $?;;
 force-reload)
   force_reload "$@"; exit $?;;
 status)
@@ -300,7 +306,7 @@ status)
 run)
   run "$@"; exit $?;;
 *)
-  echo "Usage: $0 {start|stop|force-stop|restart|force-reload|status|run}"; exit 1;
+  echo "Usage: $0 {start|stop|force-stop|restart|force-restart|force-reload|status|run}"; exit 1;
 esac
 
 exit 0


### PR DESCRIPTION
When I use spring-boot-loader-tools to publish Spring Boot application as a Linux service, sometimes my jar failed to stop due to some personal code error and I have to force stop before starting,like this “service my-app force-stop && service my-app start”. How about adding a "force-restart" command to force restart?