### PR TITLE
Add new providers to jOOQ auto-configuration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfiguration.java
@@ -18,8 +18,11 @@ package org.springframework.boot.autoconfigure.jooq;
 
 import javax.sql.DataSource;
 
+import org.jooq.CharsetProvider;
 import org.jooq.ConnectionProvider;
+import org.jooq.ConverterProvider;
 import org.jooq.DSLContext;
+import org.jooq.DiagnosticsListenerProvider;
 import org.jooq.ExecuteListenerProvider;
 import org.jooq.ExecutorProvider;
 import org.jooq.RecordListenerProvider;
@@ -27,6 +30,7 @@ import org.jooq.RecordMapperProvider;
 import org.jooq.RecordUnmapperProvider;
 import org.jooq.TransactionListenerProvider;
 import org.jooq.TransactionProvider;
+import org.jooq.UnwrapperProvider;
 import org.jooq.VisitListenerProvider;
 import org.jooq.conf.Settings;
 import org.jooq.impl.DataSourceConnectionProvider;
@@ -101,7 +105,10 @@ public class JooqAutoConfiguration {
 				ObjectProvider<ExecuteListenerProvider> executeListenerProviders,
 				ObjectProvider<VisitListenerProvider> visitListenerProviders,
 				ObjectProvider<TransactionListenerProvider> transactionListenerProviders,
-				ObjectProvider<ExecutorProvider> executorProvider) {
+				ObjectProvider<ExecutorProvider> executorProvider,
+				ObjectProvider<DiagnosticsListenerProvider> diagnosticsListenerProviders,
+				ObjectProvider<UnwrapperProvider> unwrapperProvider, ObjectProvider<CharsetProvider> charsetProvider,
+				ObjectProvider<ConverterProvider> converterProvider) {
 			DefaultConfiguration configuration = new DefaultConfiguration();
 			configuration.set(properties.determineSqlDialect(dataSource));
 			configuration.set(connectionProvider);
@@ -115,6 +122,10 @@ public class JooqAutoConfiguration {
 			configuration.set(visitListenerProviders.orderedStream().toArray(VisitListenerProvider[]::new));
 			configuration.setTransactionListenerProvider(
 					transactionListenerProviders.orderedStream().toArray(TransactionListenerProvider[]::new));
+			configuration.set(diagnosticsListenerProviders.orderedStream().toArray(DiagnosticsListenerProvider[]::new));
+			unwrapperProvider.ifAvailable(configuration::set);
+			charsetProvider.ifAvailable(configuration::set);
+			converterProvider.ifAvailable(configuration::set);
 			return configuration;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfigurationTests.java
@@ -16,11 +16,17 @@
 
 package org.springframework.boot.autoconfigure.jooq;
 
+import java.nio.charset.Charset;
 import java.util.concurrent.Executor;
 
 import javax.sql.DataSource;
 
+import org.jooq.CharsetProvider;
+import org.jooq.Converter;
+import org.jooq.ConverterProvider;
 import org.jooq.DSLContext;
+import org.jooq.DiagnosticsListener;
+import org.jooq.DiagnosticsListenerProvider;
 import org.jooq.ExecuteListener;
 import org.jooq.ExecuteListenerProvider;
 import org.jooq.ExecutorProvider;
@@ -36,6 +42,8 @@ import org.jooq.SQLDialect;
 import org.jooq.TransactionListener;
 import org.jooq.TransactionListenerProvider;
 import org.jooq.TransactionalRunnable;
+import org.jooq.Unwrapper;
+import org.jooq.UnwrapperProvider;
 import org.jooq.VisitListener;
 import org.jooq.VisitListenerProvider;
 import org.jooq.impl.DefaultExecuteListenerProvider;
@@ -115,7 +123,9 @@ class JooqAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(JooqDataSourceConfiguration.class, TxManagerConfiguration.class,
 				TestRecordMapperProvider.class, TestRecordUnmapperProvider.class, TestRecordListenerProvider.class,
 				TestExecuteListenerProvider.class, TestVisitListenerProvider.class,
-				TestTransactionListenerProvider.class, TestExecutorProvider.class).run((context) -> {
+				TestTransactionListenerProvider.class, TestExecutorProvider.class,
+				TestDiagnosticsListenerProvider.class, TestUnwrapperProvider.class, TestCharsetProvider.class,
+				TestConverterProvider.class).run((context) -> {
 					DSLContext dsl = context.getBean(DSLContext.class);
 					assertThat(dsl.configuration().recordMapperProvider().getClass())
 							.isEqualTo(TestRecordMapperProvider.class);
@@ -129,6 +139,12 @@ class JooqAutoConfigurationTests {
 					assertThat(executeListenerProviders[1]).isInstanceOf(TestExecuteListenerProvider.class);
 					assertThat(dsl.configuration().visitListenerProviders()).hasSize(1);
 					assertThat(dsl.configuration().transactionListenerProviders()).hasSize(1);
+					assertThat(dsl.configuration().diagnosticsListenerProviders()).hasSize(1);
+					assertThat(dsl.configuration().unwrapperProvider().getClass())
+							.isEqualTo(TestUnwrapperProvider.class);
+					assertThat(dsl.configuration().charsetProvider().getClass()).isEqualTo(TestCharsetProvider.class);
+					assertThat(dsl.configuration().converterProvider().getClass())
+							.isEqualTo(TestConverterProvider.class);
 				});
 	}
 
@@ -260,6 +276,42 @@ class JooqAutoConfigurationTests {
 
 		@Override
 		public Executor provide() {
+			return null;
+		}
+
+	}
+
+	static class TestDiagnosticsListenerProvider implements DiagnosticsListenerProvider {
+
+		@Override
+		public DiagnosticsListener provide() {
+			return null;
+		}
+
+	}
+
+	static class TestUnwrapperProvider implements UnwrapperProvider {
+
+		@Override
+		public Unwrapper provide() {
+			return null;
+		}
+
+	}
+
+	static class TestCharsetProvider implements CharsetProvider {
+
+		@Override
+		public Charset provide() {
+			return null;
+		}
+
+	}
+
+	static class TestConverterProvider implements ConverterProvider {
+
+		@Override
+		public <T, U> Converter<T, U> provide(Class<T> tType, Class<U> uType) {
 			return null;
 		}
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -4443,6 +4443,11 @@ You can define beans for the following jOOQ Types:
 * `ExecuteListenerProvider`
 * `VisitListenerProvider`
 * `TransactionListenerProvider`
+* `ExecutorProvider`
+* `DiagnosticsListenerProvider`
+* `UnwrapperProvider`
+* `CharsetProvider`
+* `ConverterProvider`
 
 You can also create your own `org.jooq.Configuration` `@Bean` if you want to take complete control of the jOOQ configuration.
 


### PR DESCRIPTION
jOOQ introduced following new providers. Auto-configuration should be able to pick them up a and put into jOOQ configuration. This pull request makes it happen.

New providers added to `JooqAutoConfiguration`:

* `DiagnosticsListenerProvider`
* `UnwrapperProvider`
* `CharsetProvider`
* `ConverterProvider`

**Thank you for reviewing this PR.**