### PR TITLE
Use plugin id instead of plugin class

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ApplicationPluginAction.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ApplicationPluginAction.java
@@ -24,7 +24,6 @@ import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
 
 import org.gradle.api.GradleException;
-import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.distribution.Distribution;
 import org.gradle.api.distribution.DistributionContainer;
@@ -121,8 +120,8 @@ final class ApplicationPluginAction implements PluginApplicationAction {
 	}
 
 	@Override
-	public Class<? extends Plugin<Project>> getPluginClass() {
-		return ApplicationPlugin.class;
+	public String getPluginId() {
+		return "application";
 	}
 
 	private String loadResource(String name) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/DependencyManagementPluginAction.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/DependencyManagementPluginAction.java
@@ -19,7 +19,6 @@ package org.springframework.boot.gradle.plugin;
 import io.spring.gradle.dependencymanagement.DependencyManagementPlugin;
 import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension;
 import org.gradle.api.Action;
-import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
 /**
@@ -37,8 +36,8 @@ final class DependencyManagementPluginAction implements PluginApplicationAction 
 	}
 
 	@Override
-	public Class<? extends Plugin<Project>> getPluginClass() {
-		return DependencyManagementPlugin.class;
+	public String getPluginId() {
+		return "io.spring.dependency-management";
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/JavaPluginAction.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/JavaPluginAction.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.gradle.api.Action;
-import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
@@ -65,8 +64,8 @@ final class JavaPluginAction implements PluginApplicationAction {
 	}
 
 	@Override
-	public Class<? extends Plugin<? extends Project>> getPluginClass() {
-		return JavaPlugin.class;
+	public String getPluginId() {
+		return "java";
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/KotlinPluginAction.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/KotlinPluginAction.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.gradle.plugin;
 
-import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper;
@@ -47,15 +46,8 @@ class KotlinPluginAction implements PluginApplicationAction {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public Class<? extends Plugin<? extends Project>> getPluginClass() {
-		try {
-			return (Class<? extends Plugin<? extends Project>>) Class
-					.forName("org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper");
-		}
-		catch (Throwable ex) {
-			return null;
-		}
+	public String getPluginId() {
+		return "org.jetbrains.kotlin.jvm";
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/MavenPluginAction.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/MavenPluginAction.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.gradle.plugin;
 
 import org.gradle.api.Action;
-import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.Upload;
 
@@ -36,9 +35,8 @@ final class MavenPluginAction implements PluginApplicationAction {
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
-	public Class<? extends Plugin<? extends Project>> getPluginClass() {
-		return org.gradle.api.plugins.MavenPlugin.class;
+	public String getPluginId() {
+		return "maven";
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/PluginApplicationAction.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/PluginApplicationAction.java
@@ -29,10 +29,10 @@ import org.gradle.api.Project;
 interface PluginApplicationAction extends Action<Project> {
 
 	/**
-	 * The class of the {@code Plugin} that, when applied, will trigger the execution of
-	 * this action. May return {@code null} if the plugin class is not on the classpath.
-	 * @return the plugin class or {@code null}
+	 * The id of the {@code Plugin} that, when applied, will trigger the execution of this
+	 * action.
+	 * @return the plugin id
 	 */
-	Class<? extends Plugin<? extends Project>> getPluginClass();
+	String getPluginId();
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/SpringBootPlugin.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/SpringBootPlugin.java
@@ -119,10 +119,8 @@ public class SpringBootPlugin implements Plugin<Project> {
 				new WarPluginAction(singlePublishedArtifact), new MavenPluginAction(bootArchives.getUploadTaskName()),
 				new DependencyManagementPluginAction(), new ApplicationPluginAction(), new KotlinPluginAction());
 		for (PluginApplicationAction action : actions) {
-			Class<? extends Plugin<? extends Project>> pluginClass = action.getPluginClass();
-			if (pluginClass != null) {
-				project.getPlugins().withType(pluginClass, (plugin) -> action.execute(project));
-			}
+			String pluginId = action.getPluginId();
+			project.getPluginManager().withPlugin(pluginId, (plugin) -> action.execute(project));
 		}
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/WarPluginAction.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/WarPluginAction.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.gradle.plugin;
 
 import org.gradle.api.Action;
-import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
@@ -47,8 +46,8 @@ class WarPluginAction implements PluginApplicationAction {
 	}
 
 	@Override
-	public Class<? extends Plugin<? extends Project>> getPluginClass() {
-		return WarPlugin.class;
+	public String getPluginId() {
+		return "war";
 	}
 
 	@Override


### PR DESCRIPTION
This commit changes how the Spring Boot Gradle plugin identifies
other plugins to react to. Before, it was using the `withType`
method, which requires to know the plugin class. There are a few
drawbacks to this approach:

- one has to figure out what the "main plugin class" is
- the plugin class might not even be on classpath, if the plugin
isn't bundled by Gradle
- the plugin class might not be available anymore, for example
Gradle 7 removes the `MavenPlugin` class

Therefore, the code has been updated to use the `withPlugin`
method which instead reacts on a plugin _id_. By using the id
we avoid eagerly loading classes and failing if they are not
available.

This should fix the compatibility with Gradle 7 even if this
plugin is still built with an older version of Gradle.
