### PR TITLE
Avoid duplicate classes in MergedContextConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestContextBootstrapper.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestContextBootstrapper.java
@@ -135,7 +135,7 @@ public class SpringBootTestContextBootstrapper extends DefaultTestContextBootstr
 	}
 
 	private void addConfigAttributesClasses(ContextConfigurationAttributes configAttributes, Class<?>[] classes) {
-		List<Class<?>> combined = new ArrayList<>(Arrays.asList(classes));
+		Set<Class<?>> combined = new HashSet<>(Arrays.asList(classes));
 		if (configAttributes.getClasses() != null) {
 			combined.addAll(Arrays.asList(configAttributes.getClasses()));
 		}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestContextBootstrapper.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestContextBootstrapper.java
@@ -135,7 +135,7 @@ public class SpringBootTestContextBootstrapper extends DefaultTestContextBootstr
 	}
 
 	private void addConfigAttributesClasses(ContextConfigurationAttributes configAttributes, Class<?>[] classes) {
-		Set<Class<?>> combined = new HashSet<>(Arrays.asList(classes));
+		Set<Class<?>> combined = new LinkedHashSet<>(Arrays.asList(classes));
 		if (configAttributes.getClasses() != null) {
 			combined.addAll(Arrays.asList(configAttributes.getClasses()));
 		}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/bootstrap/SpringBootTestContextBootstrapperTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/bootstrap/SpringBootTestContextBootstrapperTests.java
@@ -23,6 +23,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
 import org.springframework.test.context.BootstrapContext;
 import org.springframework.test.context.CacheAwareContextLoaderDelegate;
+import org.springframework.test.context.MergedContextConfiguration;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -56,37 +57,45 @@ class SpringBootTestContextBootstrapperTests {
 	@Test
 	void mergedContextConfigurationWhenArgsDifferentShouldNotBeConsideredEqual() {
 		TestContext context = buildTestContext(SpringBootTestArgsConfiguration.class);
-		Object contextConfiguration = ReflectionTestUtils.getField(context, "mergedContextConfiguration");
+		MergedContextConfiguration contextConfiguration = getMergedContextConfiguration(context);
 		TestContext otherContext2 = buildTestContext(SpringBootTestOtherArgsConfiguration.class);
-		Object otherContextConfiguration = ReflectionTestUtils.getField(otherContext2, "mergedContextConfiguration");
+		MergedContextConfiguration otherContextConfiguration = getMergedContextConfiguration(otherContext2);
 		assertThat(contextConfiguration).isNotEqualTo(otherContextConfiguration);
 	}
 
 	@Test
 	void mergedContextConfigurationWhenArgsSameShouldBeConsideredEqual() {
 		TestContext context = buildTestContext(SpringBootTestArgsConfiguration.class);
-		Object contextConfiguration = ReflectionTestUtils.getField(context, "mergedContextConfiguration");
+		MergedContextConfiguration contextConfiguration = getMergedContextConfiguration(context);
 		TestContext otherContext2 = buildTestContext(SpringBootTestSameArgsConfiguration.class);
-		Object otherContextConfiguration = ReflectionTestUtils.getField(otherContext2, "mergedContextConfiguration");
+		MergedContextConfiguration otherContextConfiguration = getMergedContextConfiguration(otherContext2);
 		assertThat(contextConfiguration).isEqualTo(otherContextConfiguration);
 	}
 
 	@Test
 	void mergedContextConfigurationWhenWebEnvironmentsDifferentShouldNotBeConsideredEqual() {
 		TestContext context = buildTestContext(SpringBootTestMockWebEnvironmentConfiguration.class);
-		Object contextConfiguration = ReflectionTestUtils.getField(context, "mergedContextConfiguration");
+		MergedContextConfiguration contextConfiguration = getMergedContextConfiguration(context);
 		TestContext otherContext = buildTestContext(SpringBootTestDefinedPortWebEnvironmentConfiguration.class);
-		Object otherContextConfiguration = ReflectionTestUtils.getField(otherContext, "mergedContextConfiguration");
+		MergedContextConfiguration otherContextConfiguration = getMergedContextConfiguration(otherContext);
 		assertThat(contextConfiguration).isNotEqualTo(otherContextConfiguration);
 	}
 
 	@Test
-	void mergedContextConfigurationWhenWebEnvironmentsSameShouldtBeConsideredEqual() {
+	void mergedContextConfigurationWhenWebEnvironmentsSameShouldBeConsideredEqual() {
 		TestContext context = buildTestContext(SpringBootTestMockWebEnvironmentConfiguration.class);
-		Object contextConfiguration = ReflectionTestUtils.getField(context, "mergedContextConfiguration");
+		MergedContextConfiguration contextConfiguration = getMergedContextConfiguration(context);
 		TestContext otherContext = buildTestContext(SpringBootTestAnotherMockWebEnvironmentConfiguration.class);
-		Object otherContextConfiguration = ReflectionTestUtils.getField(otherContext, "mergedContextConfiguration");
+		MergedContextConfiguration otherContextConfiguration = getMergedContextConfiguration(otherContext);
 		assertThat(contextConfiguration).isEqualTo(otherContextConfiguration);
+	}
+
+	@Test
+	void mergedContextConfigurationClassesShouldNotContainDuplicates() {
+		TestContext context = buildTestContext(SpringBootTestClassesConfiguration.class);
+		MergedContextConfiguration contextConfiguration = getMergedContextConfiguration(context);
+		Class<?>[] classes = contextConfiguration.getClasses();
+		assertThat(classes).containsExactly(SpringBootTestContextBootstrapperExampleConfig.class);
 	}
 
 	@SuppressWarnings("rawtypes")
@@ -98,6 +107,10 @@ class SpringBootTestContextBootstrapperTests {
 		CacheAwareContextLoaderDelegate contextLoaderDelegate = mock(CacheAwareContextLoaderDelegate.class);
 		given(bootstrapContext.getCacheAwareContextLoaderDelegate()).willReturn(contextLoaderDelegate);
 		return bootstrapper.buildTestContext();
+	}
+
+	private MergedContextConfiguration getMergedContextConfiguration(TestContext context) {
+		return (MergedContextConfiguration) ReflectionTestUtils.getField(context, "mergedContextConfiguration");
 	}
 
 	@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -139,6 +152,11 @@ class SpringBootTestContextBootstrapperTests {
 
 	@SpringBootTest(args = "--app.test=different")
 	static class SpringBootTestOtherArgsConfiguration {
+
+	}
+
+	@SpringBootTest(classes = SpringBootTestContextBootstrapperExampleConfig.class)
+	static class SpringBootTestClassesConfiguration {
 
 	}
 


### PR DESCRIPTION
Hi,

I just noticed the following log while debugging some test context cache optimizations in one of my projects:

```
19:44:41.758 [Test worker] DEBUG o.s.t.c.s... - Before test class: context [DefaultTestContext@209b736 ... classes = '{class com.example.Application, class com.example.Application}' ...], class annotated with @DirtiesContext [false] with mode [null].
```
It's trimmed down, but as you can see `classes` contains the same class twice. This seems to be happen when I explicitly declare the `classes` on `@SpringBootTest` as follows:
```
@SpringBootTest(classes = {Application.class})
```

While not critical at all, I guess we can make an effort to avoid the duplicates. That should fix the logs and maybe saves a few cycles on the road (although that impact should be veeery small as the duplicates are filtered in `SpringApplication` the latest).

Let me know what you think.
Cheers,
Christoph