### PR TITLE
Handle missing manifest files in JarTypeFilter

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/JarTypeFilter.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/JarTypeFilter.java
@@ -20,8 +20,10 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 
 import org.apache.maven.artifact.Artifact;
 
@@ -43,8 +45,9 @@ class JarTypeFilter extends DependencyFilter {
 	@Override
 	protected boolean filter(Artifact artifact) {
 		try (JarFile jarFile = new JarFile(artifact.getFile())) {
-			String jarType = jarFile.getManifest().getMainAttributes().getValue("Spring-Boot-Jar-Type");
-			return jarType != null && EXCLUDED_JAR_TYPES.contains(jarType);
+			return Optional.ofNullable(jarFile.getManifest()).map(Manifest::getMainAttributes)
+					.map((attributes) -> attributes.getValue("Spring-Boot-Jar-Type")).map(EXCLUDED_JAR_TYPES::contains)
+					.orElse(Boolean.FALSE);
 		}
 		catch (IOException ex) {
 			return false;

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/JarTypeFilterTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/JarTypeFilterTests.java
@@ -60,6 +60,11 @@ class JarTypeFilterTests {
 		assertThat(new JarTypeFilter().filter(createArtifact("annotation-processor"))).isTrue();
 	}
 
+	@Test
+	void whenArtifactHasNoManifestFileThenItIsIncluded() {
+		assertThat(new JarTypeFilter().filter(createArtifactWithNoManifest())).isFalse();
+	}
+
 	private Artifact createArtifact(String jarType) {
 		Path jarPath = this.temp.resolve("test.jar");
 		Manifest manifest = new Manifest();
@@ -69,6 +74,19 @@ class JarTypeFilterTests {
 		}
 		try {
 			new JarOutputStream(new FileOutputStream(jarPath.toFile()), manifest).close();
+		}
+		catch (IOException ex) {
+			throw new RuntimeException(ex);
+		}
+		Artifact artifact = mock(Artifact.class);
+		given(artifact.getFile()).willReturn(jarPath.toFile());
+		return artifact;
+	}
+
+	private Artifact createArtifactWithNoManifest() {
+		Path jarPath = this.temp.resolve("test.jar");
+		try {
+			new JarOutputStream(new FileOutputStream(jarPath.toFile())).close();
 		}
 		catch (IOException ex) {
 			throw new RuntimeException(ex);


### PR DESCRIPTION
JarTypeFilter was not handling dependency jars with missing manifest files, resulting in all starter jars being included in repackaged jars.

Fixes gh-24594