### PR TITLE
WebServer implementations should return -1 if not listening on a port

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
@@ -275,11 +275,13 @@ public class JettyWebServer implements WebServer {
 	@Override
 	public int getPort() {
 		Connector[] connectors = this.server.getConnectors();
+		Integer localPort = -1;
 		for (Connector connector : connectors) {
 			// Probably only one...
-			return getLocalPort(connector);
+			localPort = getLocalPort(connector);
+			break;
 		}
-		return 0;
+		return (localPort > 0) ? localPort : -1;
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/NettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/NettyWebServer.java
@@ -217,7 +217,7 @@ public class NettyWebServer implements WebServer {
 				return -1;
 			}
 		}
-		return 0;
+		return -1;
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
@@ -364,7 +364,7 @@ public class TomcatWebServer implements WebServer {
 		if (connector != null) {
 			return connector.getLocalPort();
 		}
-		return 0;
+		return -1;
 	}
 
 	private String getContextPath() {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowWebServer.java
@@ -295,7 +295,7 @@ public class UndertowWebServer implements WebServer {
 	public int getPort() {
 		List<Port> ports = getActualPorts();
 		if (ports.isEmpty()) {
-			return 0;
+			return -1;
 		}
 		return ports.get(0).getNumber();
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/server/AbstractReactiveWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/server/AbstractReactiveWebServerFactoryTests.java
@@ -116,6 +116,16 @@ public abstract class AbstractReactiveWebServerFactoryTests {
 	}
 
 	@Test
+	void portIsMinusOneWhenConnectionIsClosed() {
+		AbstractReactiveWebServerFactory factory = getFactory();
+		this.webServer = factory.getWebServer(new EchoHandler());
+		this.webServer.start();
+		assertThat(this.webServer.getPort()).isGreaterThan(0);
+		this.webServer.stop();
+		assertThat(this.webServer.getPort()).isEqualTo(-1);
+	}
+
+	@Test
 	void basicSslFromClassPath() {
 		testBasicSslWithKeyStore("classpath:test.jks", "password");
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
@@ -250,7 +250,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 		factory.setPort(-1);
 		this.webServer = factory.getWebServer(exampleServletRegistration());
 		this.webServer.start();
-		assertThat(this.webServer.getPort()).isLessThan(0); // Jetty is -2
+		assertThat(this.webServer.getPort()).isEqualTo(-1);
 	}
 
 	@Test
@@ -298,6 +298,16 @@ public abstract class AbstractServletWebServerFactoryTests {
 		assertThat(servlet.getInitCount()).isEqualTo(0);
 		this.webServer.start();
 		assertThat(servlet.getInitCount()).isEqualTo(1);
+	}
+
+	@Test
+	void portIsMinusOneWhenConnectionIsClosed() {
+		AbstractServletWebServerFactory factory = getFactory();
+		this.webServer = factory.getWebServer();
+		this.webServer.start();
+		assertThat(this.webServer.getPort()).isGreaterThan(0);
+		this.webServer.stop();
+		assertThat(this.webServer.getPort()).isEqualTo(-1);
 	}
 
 	@Test


### PR DESCRIPTION
The interface `org.springframework.boot.web.server.WebServer` defines that `getPort()` returns `-1` if the server isn't listening on a port. But the current implementations of the interface return 0 instead. This changes the implementations to return -1.

Please note: Jetty itself does return -2 as the local port after the connection has been closed. Therefore in its implementation getPort() maps all local ports <= 0 to -1 to match the method's contract.

See #24540
