### PR TITLE
Update yaml shortcomings wrong example

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -971,7 +971,8 @@ The `SpringApplication` class automatically supports YAML as an alternative to p
 
 NOTE: If you use "`Starters`", SnakeYAML is automatically provided by `spring-boot-starter`.
 
-
+WARNING: YAML files cannot be loaded by using the `@PropertySource` or `@TestPropertySource` annotations.
+So, in the case that you need to load values that way, you need to use a properties file.
 
 ==== Mapping YAML to Properties
 YAML documents need to be converted from their hierarchical format to a flat structure that can be used with the Spring `Environment`.
@@ -1030,34 +1031,6 @@ Spring Framework provides two convenient classes that can be used to load YAML d
 The `YamlPropertiesFactoryBean` loads YAML as `Properties` and the `YamlMapFactoryBean` loads YAML as a `Map`.
 
 You can also use the `YamlPropertySourceLoader` class if you want to load YAML as a Spring `PropertySource`.
-
-
-
-[[boot-features-external-config-yaml-shortcomings]]
-==== YAML Shortcomings
-YAML files cannot be loaded by using the `@PropertySource` annotation.
-So, in the case that you need to load values that way, you need to use a properties file.
-
-Using the multi-document YAML syntax in profile-specific YAML files can lead to unexpected behavior.
-For example, consider the following config in a file:
-
-.application-dev.yml
-[source,yaml,indent=0]
-----
-	server.port: 8000
-	---
-	spring.config.activate.on-profile: "!test"
-	mypassword: "secret"
-----
-
-If you run the application with the argument `--spring.profiles.active=prod` you might expect `mypassword` to be set to "`secret`", but this is not the case.
-
-The nested document will be filtered because the main file is named `application-dev.yml`.
-It is already considered to be profile-specific, and nested documents will be ignored.
-
-TIP: We recommend that you don't mix profile-specific YAML files and multiple YAML documents.
-Stick to using only one of them.
-
 
 
 [[boot-features-external-config-random-values]]

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -1050,7 +1050,7 @@ For example, consider the following config in a file:
 	mypassword: "secret"
 ----
 
-If you run the application with the argument `--spring.profiles.active=dev` you might expect `mypassword` to be set to "`secret`", but this is not the case.
+If you run the application with the argument `--spring.profiles.active=prod` you might expect `mypassword` to be set to "`secret`", but this is not the case.
 
 The nested document will be filtered because the main file is named `application-dev.yml`.
 It is already considered to be profile-specific, and nested documents will be ignored.


### PR DESCRIPTION
This is a small documentation fix, I was working today with multi-document profile-specific YAML files and after reading the example I thought that directly that setup does not work, but that's not the case it is just the example is not correct.

The current example does work as expected as the active profile is the same as the one in the profile-specific file so the nested document is not filtered out, the file name or the active profile should be changed to make the filter out the nested document.

Anyway, that whole part and example probably should be moved to section 2.3.8 as it is no longer exclusive of Yaml files, it is related to multi-document files.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
