### PR TITLE
Exclude starters from Javadoc aggregation

### DIFF
--- a/spring-boot-project/spring-boot-docs/build.gradle
+++ b/spring-boot-project/spring-boot-docs/build.gradle
@@ -119,6 +119,7 @@ task aggregatedJavadoc(type: Javadoc) {
 		Set<Project> publishedProjects = rootProject.subprojects.findAll { it != project}
 			.findAll { it.plugins.hasPlugin(JavaPlugin) && it.plugins.hasPlugin(MavenPublishPlugin) }
 			.findAll { !excludedProjects.contains(it.name) }
+			.findAll { !it.name.startsWith('spring-boot-starter') }
 		dependsOn publishedProjects.javadoc
 		source publishedProjects.javadoc.source
 		classpath = project.files(publishedProjects.javadoc.classpath)


### PR DESCRIPTION
Hi,

I was looking through some build scans the other day and noticed some deprecation warnings that seem to be generated by the `aggregateJavadoc` task: see https://ge.spring.io/s/z27xbdykxsjse/deprecations for an example.

This PR excludes the starters from the Javadoc aggregation which seems to help with the deprecations. As the starters have no source, they don't need to be checked anyways in my opinion. So we gain a little as well in terms of performance.

I couldn't find why the starters are special and throw those warnings while other modules don't. Maybe you have an idea, but I guess it's safe to exclude them in the first place.

Let me know what you think.
Cheers,
Christoph