### PR TITLE
Remove redundant judgment conditions in DefaultErrorAttributes#getErr…

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ErrorProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ErrorProperties.java
@@ -46,7 +46,7 @@ public class ErrorProperties {
 	private IncludeAttribute includeStacktrace = IncludeAttribute.NEVER;
 
 	/**
-	 * When to include data in "message" attribute.
+	 * When to persist data in "message" attribute.
 	 */
 	private IncludeAttribute includeMessage = IncludeAttribute.NEVER;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ErrorProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ErrorProperties.java
@@ -46,7 +46,7 @@ public class ErrorProperties {
 	private IncludeAttribute includeStacktrace = IncludeAttribute.NEVER;
 
 	/**
-	 * When to include "message" attribute.
+	 * When to include data in "message" attribute.
 	 */
 	private IncludeAttribute includeMessage = IncludeAttribute.NEVER;
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributes.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributes.java
@@ -95,7 +95,7 @@ public class DefaultErrorAttributes implements ErrorAttributes {
 		if (!options.isIncluded(Include.STACK_TRACE)) {
 			errorAttributes.remove("trace");
 		}
-		if (!options.isIncluded(Include.MESSAGE) && errorAttributes.get("message") != null) {
+		if (!options.isIncluded(Include.MESSAGE)) {
 			errorAttributes.put("message", "");
 		}
 		if (!options.isIncluded(Include.BINDING_ERRORS)) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/error/DefaultErrorAttributes.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/error/DefaultErrorAttributes.java
@@ -118,7 +118,7 @@ public class DefaultErrorAttributes implements ErrorAttributes, HandlerException
 		if (!options.isIncluded(Include.STACK_TRACE)) {
 			errorAttributes.remove("trace");
 		}
-		if (!options.isIncluded(Include.MESSAGE) && errorAttributes.get("message") != null) {
+		if (!options.isIncluded(Include.MESSAGE)) {
 			errorAttributes.put("message", "");
 		}
 		if (!options.isIncluded(Include.BINDING_ERRORS)) {


### PR DESCRIPTION
https://github.com/spring-projects/spring-boot/blob/b3278f459e9f69bac948e691d07d79330da7ff20/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/error/DefaultErrorAttributes.java#L121

https://github.com/spring-projects/spring-boot/blob/b3278f459e9f69bac948e691d07d79330da7ff20/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributes.java#L98

I carefully checked the DefaultErrorAttributes.java code context, I think the judgment statement `errorAttributes.get("message") != null` will always be true, and even if it is not true, this judgment will not affect the `execution of errorAttributes.put("message", "");`

So I think it is not necessary to have a conditional judgment

I understand the source code is `errorAttributes.put("message", "");` instead of `errorAttributes.remove("message");` because no matter whether `server.error.include-message` is `always` or `never`, the response body should always be Contains the `message` field, right? If it is, it should be indicated in the configuration file to distinguish it from other server.error.*, because the current explanation says `When to include "message" attribute`. It is easy for users to misunderstand.
