### PR TITLE
Fix ConfigDataProperties blank config import NPE

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataProperties.java
@@ -18,7 +18,9 @@ package org.springframework.boot.context.config;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.springframework.boot.cloud.CloudPlatform;
 import org.springframework.boot.context.properties.bind.BindContext;
@@ -35,6 +37,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Myeonghyeon Lee
  */
 class ConfigDataProperties {
 
@@ -62,7 +65,8 @@ class ConfigDataProperties {
 
 	private ConfigDataProperties(List<ConfigDataLocation> imports, Activate activate,
 			List<ConfigurationProperty> boundProperties) {
-		this.imports = (imports != null) ? imports : Collections.emptyList();
+		this.imports = (imports != null) ? imports.stream().filter(Objects::nonNull).collect(Collectors.toList())
+				: Collections.emptyList();
 		this.activate = activate;
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
@@ -72,6 +72,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
  *
  * @author Madhura Bhave
  * @author Phillip Webb
+ * @author Myeonghyeon Lee
  */
 class ConfigDataEnvironmentPostProcessorIntegrationTests {
 
@@ -678,6 +679,14 @@ class ConfigDataEnvironmentPostProcessorIntegrationTests {
 		ConfigurableEnvironment environment = context.getEnvironment();
 		assertThat(environment.getProperty("first.property")).isEqualTo("apple");
 		assertThat(environment.getProperty("second.property")).isEqualTo("ball");
+	}
+
+	@Test
+	void runWhenImportNullExcludeShouldNotFail() {
+		ConfigurableApplicationContext context = this.application
+				.run("--spring.config.location=classpath:configdata/yaml/");
+		String property = context.getEnvironment().getProperty("foo");
+		assertThat(property).isEqualTo("foo");
 	}
 
 	private Condition<ConfigurableEnvironment> matchingPropertySource(final String sourceName) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataPropertiesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataPropertiesTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Myeonghyeon Lee
  */
 class ConfigDataPropertiesTests {
 
@@ -201,6 +202,15 @@ class ConfigDataPropertiesTests {
 		ConfigDataProperties properties = ConfigDataProperties.get(binder);
 		assertThat(properties.getImports().get(1).getOrigin())
 				.hasToString("\"spring.config.import\" from property source \"source\"");
+	}
+
+	@Test
+	void getImportFilterBlankConfigImport() {
+		MapConfigurationPropertySource source = new MapConfigurationPropertySource();
+		source.put("spring.config.import", "one,two,three,");
+		Binder binder = new Binder(source);
+		ConfigDataProperties properties = ConfigDataProperties.get(binder);
+		assertThat(properties.getImports().size()).isEqualTo(3);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/resources/configdata/yaml/application.yml
+++ b/spring-boot-project/spring-boot/src/test/resources/configdata/yaml/application.yml
@@ -1,3 +1,5 @@
 foo: bar
 ---
 hello: world
+---
+spring.config.import: testimport.yml,

--- a/spring-boot-project/spring-boot/src/test/resources/configdata/yaml/testimport.yml
+++ b/spring-boot-project/spring-boot/src/test/resources/configdata/yaml/testimport.yml
@@ -1,0 +1,2 @@
+foo: foo
+bar: bar


### PR DESCRIPTION
Filter ConfigDataLocation imports null elements.

It could be NPE at [ConfigDataEnvironment#getMandatoryImports](https://github.com/spring-projects/spring-boot/blob/48e00fc7f4283f4a2b0277f1304386621d8bc5f0/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataEnvironment.java#L377)