### PR TITLE
Configuration metadata for logging.charset.* has invalid reference for java.nio.charset.Charset

### DIFF
--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -21,12 +21,12 @@
     },
     {
       "name": "logging.charset.console",
-      "type": "java.nio.Charset",
+      "type": "java.nio.charset.Charset",
       "description": "Charset to use for console output."
     },
     {
       "name": "logging.charset.file",
-      "type": "java.nio.Charset",
+      "type": "java.nio.charset.Charset",
       "description": "Charset to use for file output."
     },
     {


### PR DESCRIPTION
Hi,

this PR fixes the configuration metadata for `logging.charset.console` and `logging.charset.file` by adjusting the wrong type information. 

I only noticed in IDEA that no warning was shown when I entered a wrong charset encoding.
![image](https://user-images.githubusercontent.com/6304496/104736562-73134480-5743-11eb-9e59-76eeb7125cd9.png)
I guess other places consuming the metadata could be affected as well.

Cheers,
Christoph