### PR TITLE
Add possibility to disable event propagation

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -443,6 +443,10 @@ public class SpringApplication {
 	}
 
 	private <T> Collection<T> getSpringFactoriesInstances(Class<T> type, Class<?>[] parameterTypes, Object... args) {
+		if (Arrays.asList(args).contains("--spring.lister=suppress")) {
+			return Collections.emptyList();
+		}
+
 		ClassLoader classLoader = getClassLoader();
 		// Use names and ensure unique to protect against duplicates
 		Set<String> names = new LinkedHashSet<>(SpringFactoriesLoader.loadFactoryNames(type, classLoader));


### PR DESCRIPTION
Add possibility to disable event propagation,

this is required to fix the broken "readiness" event propagation of SpringCloudStream.
For further Information see:
https://github.com/spring-cloud/spring-cloud-stream/issues/2083