### PR TITLE
Restore persistOfNullThrowsIllegalArgumentExceptionWithoutExceptionTranslation()

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/dao/PersistenceExceptionTranslationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/dao/PersistenceExceptionTranslationAutoConfigurationTests.java
@@ -36,6 +36,7 @@ import org.springframework.stereotype.Repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  * Tests for {@link PersistenceExceptionTranslationAutoConfiguration}
@@ -86,15 +87,12 @@ class PersistenceExceptionTranslationAutoConfigurationTests {
 		assertThat(beans).isEmpty();
 	}
 
-	// @Test
-	// public void
-	// persistOfNullThrowsIllegalArgumentExceptionWithoutExceptionTranslation() {
-	// this.context = new AnnotationConfigApplicationContext(
-	// EmbeddedDataSourceConfiguration.class,
-	// HibernateJpaAutoConfiguration.class, TestConfiguration.class);
-	// assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
-	// () -> this.context.getBean(TestRepository.class).doSomething());
-	// }
+	@Test
+	void persistOfNullThrowsIllegalArgumentExceptionWithoutExceptionTranslation() {
+		this.context = new AnnotationConfigApplicationContext(EmbeddedDataSourceConfiguration.class,
+				HibernateJpaAutoConfiguration.class, TestConfiguration.class);
+		assertThatIllegalArgumentException().isThrownBy(() -> this.context.getBean(TestRepository.class).doSomething());
+	}
 
 	@Test
 	void persistOfNullThrowsInvalidDataAccessApiUsageExceptionWithExceptionTranslation() {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
`PersistenceExceptionTranslationAutoConfigurationTests.persistOfNullThrowsIllegalArgumentExceptionWithoutExceptionTranslation()` has been ignored in 59d2b0a3fb2e9f83345c23b32e5bbac47c74dbd2 somehow. I'm not sure if it was intentional, but it seems to pass for now. This PR simply restores it.