### PR TITLE
Auto-configured DataSourceTransactionManager uses spring.dao.exceptiontranslation.enable rather than spring.dao.exceptiontranslation.enabled to control exception translation

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
@@ -64,7 +64,7 @@ public class DataSourceTransactionManagerAutoConfiguration {
 		}
 
 		private DataSourceTransactionManager createTransactionManager(Environment environment, DataSource dataSource) {
-			return environment.getProperty("spring.dao.exceptiontranslation.enable", Boolean.class, Boolean.TRUE)
+			return environment.getProperty("spring.dao.exceptiontranslation.enabled", Boolean.class, Boolean.TRUE)
 					? new JdbcTransactionManager(dataSource) : new DataSourceTransactionManager(dataSource);
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfigurationTests.java
@@ -87,7 +87,7 @@ class DataSourceTransactionManagerAutoConfigurationTests {
 	@Test // gh-24321
 	void transactionManagerWithDaoExceptionTranslationDisabled() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
-				.withPropertyValues("spring.dao.exceptiontranslation.enable=false")
+				.withPropertyValues("spring.dao.exceptiontranslation.enabled=false")
 				.run((context) -> assertThat(context.getBean(TransactionManager.class))
 						.isExactlyInstanceOf(DataSourceTransactionManager.class));
 	}
@@ -95,7 +95,7 @@ class DataSourceTransactionManagerAutoConfigurationTests {
 	@Test // gh-24321
 	void transactionManagerWithDaoExceptionTranslationEnabled() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
-				.withPropertyValues("spring.dao.exceptiontranslation.enable=true")
+				.withPropertyValues("spring.dao.exceptiontranslation.enabled=true")
 				.run((context) -> assertThat(context.getBean(TransactionManager.class))
 						.isExactlyInstanceOf(JdbcTransactionManager.class));
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR fixes property name for `spring.dao.exceptiontranslation.enabled`.