### PR TITLE
Fix minor typo in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 Thanks for contributing to Spring Boot. Please review the following notes before
-submitting you pull request.
+submitting a pull request.
 
 Please submit only genuine pull-requests. Do not use this repository as a GitHub
 playground.


### PR DESCRIPTION
Minor typo fix `you` -> `a`, this could also be `your` instead.

I love this idea of using a comment to warn about submitting a vulnerability through GitHub.