### PR TITLE
Document the need to use the launcher to be able to use application.* properties in a custom banner

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -152,6 +152,9 @@ You can also use the configprop:spring.main.banner-mode[] property to determine 
 
 The printed banner is registered as a singleton bean under the following name: `springBootBanner`.
 
+NOTE: If you are running with an unpacked jar (and not using the Spring Boot launcher), `application.*` properties are not available.
+As a workaround, you can use JarLauncher to start the app (for example, `java -cp . org.springframework.boot.loader.JarLauncher`).
+
 
 
 [[boot-features-customizing-spring-application]]


### PR DESCRIPTION
This is a documentation update to describe the need to use JarLauncher to use application.* properties in custom banner. This is in response to issue [22519](https://github.com/spring-projects/spring-boot/issues/22519)