### PR TITLE
bootRun project property command line example is incomplete

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/running.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/running.adoc
@@ -112,7 +112,7 @@ Gradle allows project properties to be set in a variety of ways, including on th
 
 [source,bash,indent=0,subs="verbatim,attributes"]
 ----
-$ ./gradlew -Pexample=custom
+$ ./gradlew bootRun -Pexample=custom
 ----
 
 The preceding example sets the value of the `example` project property to `custom`.


### PR DESCRIPTION
I found the missing code while executing the example code of the document.
From the context, it seems that the `bootRun` task should be executed.
