### PR TITLE
Introduce SPI for automatic bean definition config registration

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/AdditionalConfigLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/AdditionalConfigLoader.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.context.config;
+
+/**
+ * Load additional configs using
+ * {@link org.springframework.core.io.support.SpringFactoriesLoader}
+ * <p>
+ * Example: In this special scenario, where you want to have a spring-boot-starter with
+ * its own configname-profile.properties with configured properties for multiple profiles,
+ * you can implement this interface, so spring will include the defined configName in its
+ * configs.
+ *
+ * If you want to order your configs you can annotate your class with
+ * {@link org.springframework.core.annotation.Order}. Implementations without annotation
+ * will get implicitly the lowest precedence by
+ * {@link org.springframework.core.io.support.SpringFactoriesLoader}.
+ *
+ * Example implementation: <pre class="code">
+ * class AdditionalCommonConfigLoader implements AdditionalConfigLoader {
+ *
+ *     &#064;Override
+ *     public String useAdditionalConfig() {
+ *         return "commons";
+ *     }
+ * }
+ * </pre>
+ * <p>
+ * Add the following line to the spring-boot-starters {@code spring.factories}:
+ * `org.springframework.boot.context.config.AdditionalConfigLoader=example.AdditionalCommonConfigLoader`
+ *
+ * Spring would now load an additional files like `commons.yaml` or `commons-local.yaml`.
+ *
+ * @author Kevin Raddatz
+ * @since 28.01.2021
+ * @see org.springframework.core.annotation.Order
+ * @see org.springframework.core.io.support.SpringFactoriesLoader
+ */
+public interface AdditionalConfigLoader {
+
+	String useAdditionalConfig();
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/StandardConfigDataLocationResolver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/StandardConfigDataLocationResolver.java
@@ -18,6 +18,7 @@ package org.springframework.boot.context.config;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 
@@ -88,11 +90,20 @@ public class StandardConfigDataLocationResolver
 	}
 
 	private String[] getConfigNames(Binder binder) {
-		String[] configNames = binder.bind(CONFIG_NAME_PROPERTY, String[].class).orElse(DEFAULT_CONFIG_NAMES);
+		String[] configNames = binder.bind(CONFIG_NAME_PROPERTY, String[].class).orElse(getConfigNames());
 		for (String configName : configNames) {
 			validateConfigName(configName);
 		}
 		return configNames;
+	}
+
+	private String[] getConfigNames() {
+		List<AdditionalConfigLoader> additionalConfigs = SpringFactoriesLoader
+				.loadFactories(AdditionalConfigLoader.class, null);
+		List<String> configNames = additionalConfigs.stream().map((c) -> c.useAdditionalConfig())
+				.collect(Collectors.toList());
+		configNames.addAll(0, Arrays.asList(DEFAULT_CONFIG_NAMES));
+		return configNames.toArray(new String[0]);
 	}
 
 	private void validateConfigName(String name) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLocationResolverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLocationResolverTests.java
@@ -69,6 +69,13 @@ public class StandardConfigDataLocationResolverTests {
 	}
 
 	@Test
+	void resolveWhenConfigNameIsSpecifiedByAdditionalConfigLoader() {
+		ConfigDataLocation location = ConfigDataLocation.of("classpath:/config/additional-configs/");
+		List<StandardConfigDataResource> locations = this.resolver.resolve(this.context, location);
+		assertThat(locations.size()).isEqualTo(1);
+	}
+
+	@Test
 	void resolveWhenLocationIsDirectoryResolvesAllMatchingFilesInDirectory() {
 		ConfigDataLocation location = ConfigDataLocation.of("classpath:/configdata/properties/");
 		List<StandardConfigDataResource> locations = this.resolver.resolve(this.context, location);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/TestAdditionalConfigLoader.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/TestAdditionalConfigLoader.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.context.config;
+
+public class TestAdditionalConfigLoader implements AdditionalConfigLoader {
+
+	@Override
+	public String useAdditionalConfig() {
+		return "testadditional";
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot/src/test/resources/META-INF/spring.factories
@@ -7,3 +7,6 @@ org.springframework.boot.context.config.TestConfigDataBootstrap.LocationResolver
 
 org.springframework.boot.context.config.ConfigDataLoader=\
 org.springframework.boot.context.config.TestConfigDataBootstrap.Loader
+
+org.springframework.boot.context.config.AdditionalConfigLoader=\
+org.springframework.boot.context.config.TestAdditionalConfigLoader


### PR DESCRIPTION
In our project we created a starter which contains most general stuff, like database, feign clients and so on.
Now we want to configure this starter with different properties per stage.
Currently we created a file `application-commons.yaml` in our starter and include this "profile" at spring.profiles.active, but this does not really scale well if we create more starters, or more applications. We would have to keep in mind to add all the profiles to all the services.

With this PR we are able to implement an `AdditionalConfigLoader`, which returns the name of the starters "name", and then add the class to the `spring.factories`: `org.springframework.boot.context.config.AdditionalConfigLoader=example.AdditionalCommonConfigLoader`

We could now create multiple files like `commons.yaml`, `commons-local.yaml` and so.

This PR relates to https://github.com/spring-projects/spring-framework/pull/26458 which adds the ability to load an additional file like `application-commons.yaml`.