### PR TITLE
Add extra documentation to clarify the draining of startup steps on retrieval

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -474,6 +474,9 @@ Once configured, you can record data by running the application with the Flight 
 	$ java -XX:StartFlightRecording:filename=recording.jfr,duration=10s -jar demo.jar
 ----
 
+WARNING: The buffer of startup steps is drained before the events are sent.
+This means that startup steps are not cached between calls to retrieve; each new call will only return newly buffered steps.
+
 Spring Boot ships with the `BufferingApplicationStartup` variant; this implementation is meant for buffering the startup steps and draining them into an external metrics system.
 Applications can ask for the bean of type `BufferingApplicationStartup` in any component.
 Additionally, Spring Boot Actuator will <<production-ready-features.adoc#production-ready-endpoints, expose a `startup` endpoint to expose this information as a JSON document>>.


### PR DESCRIPTION
Documentation fix to clarify the draining of startup steps on retrieval when using [BufferingApplicationStartup](https://docs.spring.io/spring-boot/docs/2.4.0/api/org/springframework/boot/context/metrics/buffering/BufferingApplicationStartup.html)

Clarifies Issue #24605 