### PR TITLE
Make Scheduler consistent for Spring Integration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,9 @@ import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.rsocket.RSocketMessagingAutoConfiguration;
+import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.task.TaskSchedulerBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -56,6 +58,8 @@ import org.springframework.integration.rsocket.outbound.RSocketOutboundGateway;
 import org.springframework.messaging.rsocket.RSocketRequester;
 import org.springframework.messaging.rsocket.RSocketStrategies;
 import org.springframework.messaging.rsocket.annotation.support.RSocketMessageHandler;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.StringUtils;
 
 /**
@@ -72,8 +76,25 @@ import org.springframework.util.StringUtils;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(EnableIntegration.class)
 @EnableConfigurationProperties(IntegrationProperties.class)
-@AutoConfigureAfter({ DataSourceAutoConfiguration.class, JmxAutoConfiguration.class })
+@AutoConfigureAfter({
+		DataSourceAutoConfiguration.class,
+		JmxAutoConfiguration.class,
+		TaskSchedulingAutoConfiguration.class })
 public class IntegrationAutoConfiguration {
+
+	/**
+	 * The {@link TaskScheduler} configuration.
+	 */
+	@Configuration(proxyBeanMethods = false)
+	protected static class IntegrationTaskSchedulerConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean
+		public ThreadPoolTaskScheduler taskScheduler(TaskSchedulerBuilder builder) {
+			return builder.build();
+		}
+
+	}
 
 	/**
 	 * Basic Spring Integration configuration.

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -86,6 +86,7 @@ public class IntegrationAutoConfiguration {
 	 * The {@link TaskScheduler} configuration.
 	 */
 	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnBean(TaskSchedulerBuilder.class)
 	protected static class IntegrationTaskSchedulerConfiguration {
 
 		@Bean

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -76,9 +76,7 @@ import org.springframework.util.StringUtils;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(EnableIntegration.class)
 @EnableConfigurationProperties(IntegrationProperties.class)
-@AutoConfigureAfter({
-		DataSourceAutoConfiguration.class,
-		JmxAutoConfiguration.class,
+@AutoConfigureAfter({ DataSourceAutoConfiguration.class, JmxAutoConfiguration.class,
 		TaskSchedulingAutoConfiguration.class })
 public class IntegrationAutoConfiguration {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
@@ -74,9 +74,7 @@ import static org.mockito.Mockito.mock;
 class IntegrationAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(
-					JmxAutoConfiguration.class,
-					IntegrationAutoConfiguration.class,
+			.withConfiguration(AutoConfigurations.of(JmxAutoConfiguration.class, IntegrationAutoConfiguration.class,
 					TaskSchedulingAutoConfiguration.class));
 
 	@Test
@@ -232,12 +230,10 @@ class IntegrationAutoConfigurationTests {
 		this.contextRunner
 				.withPropertyValues("spring.task.scheduling.thread-name-prefix=integration-scheduling-",
 						"spring.task.scheduling.pool.size=3")
-				.run((context) ->
-			assertThat(context)
-					.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class)
-					.hasFieldOrPropertyWithValue("threadNamePrefix", "integration-scheduling-")
-					.hasFieldOrPropertyWithValue("scheduledExecutor.corePoolSize", 3)
-		);
+				.run((context) -> assertThat(context)
+						.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class)
+						.hasFieldOrPropertyWithValue("threadNamePrefix", "integration-scheduling-")
+						.hasFieldOrPropertyWithValue("scheduledExecutor.corePoolSize", 3));
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.boot.autoconfigure.rsocket.RSocketMessagingAutoConfig
 import org.springframework.boot.autoconfigure.rsocket.RSocketRequesterAutoConfiguration;
 import org.springframework.boot.autoconfigure.rsocket.RSocketServerAutoConfiguration;
 import org.springframework.boot.autoconfigure.rsocket.RSocketStrategiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration;
 import org.springframework.boot.jdbc.DataSourceInitializationMode;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -42,6 +43,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.config.IntegrationManagementConfigurer;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.endpoint.MessageProcessorMessageSource;
 import org.springframework.integration.gateway.RequestReplyExchanger;
@@ -56,6 +58,7 @@ import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jmx.export.MBeanExporter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.rsocket.annotation.support.RSocketMessageHandler;
+import org.springframework.scheduling.TaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -71,7 +74,10 @@ import static org.mockito.Mockito.mock;
 class IntegrationAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(JmxAutoConfiguration.class, IntegrationAutoConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(
+					JmxAutoConfiguration.class,
+					IntegrationAutoConfiguration.class,
+					TaskSchedulingAutoConfiguration.class));
 
 	@Test
 	void integrationIsAvailable() {
@@ -219,6 +225,19 @@ class IntegrationAutoConfigurationTests {
 
 					assertThat(clientTransport).isInstanceOf(TcpClientTransport.class);
 				});
+	}
+
+	@Test
+	void taskSchedulerAutoConfigured() {
+		this.contextRunner
+				.withPropertyValues("spring.task.scheduling.thread-name-prefix=integration-scheduling-",
+						"spring.task.scheduling.pool.size=3")
+				.run((context) ->
+			assertThat(context)
+					.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class)
+					.hasFieldOrPropertyWithValue("threadNamePrefix", "integration-scheduling-")
+					.hasFieldOrPropertyWithValue("scheduledExecutor.corePoolSize", 3)
+		);
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/spring-boot-features.adoc
@@ -6540,6 +6540,10 @@ Spring Boot offers several conveniences for working with {spring-integration}[Sp
 Spring Integration provides abstractions over messaging and also other transports such as HTTP, TCP, and others.
 If Spring Integration is available on your classpath, it is initialized through the `@EnableIntegration` annotation.
 
+Spring Integration polling logic is based on the `TaskScheduler`.
+So, it relies on the auto-configured one (see the previous section), or exposes a `taskScheduler` bean according provided `spring.task.scheduling` configuration properties.
+If only Spring Integration is used, the `@EnableScheduling` annotation is optional and can be omitted on the target configuration classes.
+
 Spring Boot also configures some features that are triggered by the presence of additional Spring Integration modules.
 If `spring-integration-jmx` is also on the classpath, message processing statistics are published over JMX.
 If `spring-integration-jdbc` is available, the default database schema can be created on startup, as shown in the following line:


### PR DESCRIPTION
Related to https://stackoverflow.com/questions/65883496/mix-spring-integration-and-spring-scheduler

Currently Spring Integration creates its own `TaskScheduler` bean
if one doesn't exist in the ctx yet.
When we add `@EnableScheduling`, Spring Boot auto-configures one
for us, but this one comes with slightly different options
then one in Spring Integration

* Make Spring Integration auto-configuration to rely on the
auto-configured `TaskScheduler`, so we will have a consistency
when we use just Spring Integration or with `@Scheduled` methods
and would rely on a single set of configuration properties for `TaskScheduler`.
It does not make it consistent with what we have in Spring Integration
by default, but Spring Boot may have its own opinion how to auto-configure
target features

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
