### PR TITLE
Fix Gradle deprecation warnings for duplicates

### DIFF
--- a/spring-boot-project/spring-boot-cli/build.gradle
+++ b/spring-boot-project/spring-boot-cli/build.gradle
@@ -117,6 +117,7 @@ task fullJar(type: Jar) {
 			"Start-Class": "org.springframework.boot.cli.SpringCli"
 		)
 	}
+	duplicatesStrategy = DuplicatesStrategy.WARN
 }
 
 def configureArchive(archive) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/build.gradle
@@ -46,6 +46,7 @@ task reproducibleLoaderJar(type: Jar) {
 	}
 	reproducibleFileOrder = true
 	preserveFileTimestamps = false
+	duplicatesStrategy = DuplicatesStrategy.WARN
 	archiveFileName = "spring-boot-loader.jar"
 	destinationDirectory = file("${generatedResources}/META-INF/loader")
 }
@@ -57,6 +58,7 @@ task reproducibleJarModeLayerToolsJar(type: Jar) {
 	}
 	reproducibleFileOrder = true
 	preserveFileTimestamps = false
+	duplicatesStrategy = DuplicatesStrategy.WARN
 	archiveFileName = "spring-boot-jarmode-layertools.jar"
 	destinationDirectory = file("${generatedResources}/META-INF/jarmode")
 }


### PR DESCRIPTION
Hi,

I was trying to build Boot with the newest Gradle 7 milestone to see what we have to do. And while there are certain bigger things like the `MavenPluginAction` that need to be addressed, I found a couple of deprecation warnings around setting the `duplicatesStrategy` that could be fixed already without too much effort. They are already deprecation warnings now and with 7 it fails.

I went with the warning strategy as I found it quite useful to see what exactly is duplicated instead of just including (or excluding) things. Currently it's the legal files that are duplicated. But let me know if you have a favourite here.

Cheers,
Christoph