### PR TITLE
Fix build deprecation warnings about duplicate jar entries

### DIFF
--- a/spring-boot-project/spring-boot-cli/build.gradle
+++ b/spring-boot-project/spring-boot-cli/build.gradle
@@ -108,7 +108,10 @@ task fullJar(type: Jar) {
 		into "BOOT-INF/classes"
 	}
 	into("") {
-		from zipTree(configurations.loader.singleFile)
+		from(zipTree(configurations.loader.singleFile)) {
+			exclude "META-INF/LICENSE.txt"
+			exclude "META-INF/NOTICE.txt"
+		}
 	}
 	manifest {
 		attributes(

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/build.gradle
@@ -41,8 +41,9 @@ sourceSets {
 
 task reproducibleLoaderJar(type: Jar) {
 	dependsOn configurations.loader
-	from {
-		zipTree(configurations.loader.incoming.files.filter {it.name.startsWith "spring-boot-loader" }.singleFile)
+	from(zipTree(configurations.loader.incoming.files.filter {it.name.startsWith "spring-boot-loader" }.singleFile)) {
+		exclude "META-INF/LICENSE.txt"
+		exclude "META-INF/NOTICE.txt"
 	}
 	reproducibleFileOrder = true
 	preserveFileTimestamps = false
@@ -52,8 +53,9 @@ task reproducibleLoaderJar(type: Jar) {
 
 task reproducibleJarModeLayerToolsJar(type: Jar) {
 	dependsOn configurations.jarmode
-	from {
-		zipTree(configurations.jarmode.incoming.files.filter {it.name.startsWith "spring-boot-jarmode-layertools" }.singleFile)
+	from(zipTree(configurations.jarmode.incoming.files.filter {it.name.startsWith "spring-boot-jarmode-layertools" }.singleFile)) {
+		exclude "META-INF/LICENSE.txt"
+		exclude "META-INF/NOTICE.txt"
 	}
 	reproducibleFileOrder = true
 	preserveFileTimestamps = false


### PR DESCRIPTION
Hi,

this is an attempt at fixing #23955. I say attempt because I chose to manually exclude the duplicate legal files in the few problematic places instead of doing things via the JavaConventions plugin (like in https://github.com/spring-projects/spring-boot/commit/1e100677c722db4f9839d39d4b104307d4917cc9).

That seems acceptable given the very few places we have, but let me know what you think.
Cheers,
Christoph
