### PR TITLE
fix FreeMarkerConfigurer(xml) check template path error in fatjar

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/freemarker/FreeMarkerReactiveWebConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/freemarker/FreeMarkerReactiveWebConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.web.reactive.result.view.freemarker.FreeMarkerViewRes
 /**
  * Configuration for FreeMarker when used in a reactive web context.
  *
+ * @author Zhengsheng Xia
  * @author Brian Clozel
  * @author Andy Wilkinson
  */
@@ -44,15 +45,21 @@ class FreeMarkerReactiveWebConfiguration extends AbstractFreeMarkerConfiguration
 
 	@Bean
 	@ConditionalOnMissingBean(FreeMarkerConfig.class)
-	FreeMarkerConfigurer freeMarkerConfigurer() {
+	FreeMarkerConfigurer freeMarkerConfigurer(freemarker.template.Configuration configuration) {
 		FreeMarkerConfigurer configurer = new FreeMarkerConfigurer();
+		configurer.setConfiguration(configuration);
 		applyProperties(configurer);
 		return configurer;
 	}
 
 	@Bean
-	freemarker.template.Configuration freeMarkerConfiguration(FreeMarkerConfig configurer) {
-		return configurer.getConfiguration();
+	@ConditionalOnMissingBean(freemarker.template.Configuration.class)
+	freemarker.template.Configuration freeMarkerConfiguration() {
+		// Avoid the configurer(created by xml) itself call the createConfiguration,there
+		// is an error of checking template path by afterPropertiesSet in fatjar
+		freemarker.template.Configuration fmConfiguration = new freemarker.template.Configuration(
+				freemarker.template.Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
+		return fmConfiguration;
 	}
 
 	@Bean

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/freemarker/FreeMarkerServletWebConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/freemarker/FreeMarkerServletWebConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.web.servlet.view.freemarker.FreeMarkerViewResolver;
 /**
  * Configuration for FreeMarker when used in a servlet web context.
  *
+ * @author Zhengsheng Xia
  * @author Brian Clozel
  * @author Andy Wilkinson
  */
@@ -53,15 +54,21 @@ class FreeMarkerServletWebConfiguration extends AbstractFreeMarkerConfiguration 
 
 	@Bean
 	@ConditionalOnMissingBean(FreeMarkerConfig.class)
-	FreeMarkerConfigurer freeMarkerConfigurer() {
+	FreeMarkerConfigurer freeMarkerConfigurer(freemarker.template.Configuration configuration) {
 		FreeMarkerConfigurer configurer = new FreeMarkerConfigurer();
+		configurer.setConfiguration(configuration);
 		applyProperties(configurer);
 		return configurer;
 	}
 
 	@Bean
-	freemarker.template.Configuration freeMarkerConfiguration(FreeMarkerConfig configurer) {
-		return configurer.getConfiguration();
+	@ConditionalOnMissingBean(freemarker.template.Configuration.class)
+	freemarker.template.Configuration freeMarkerConfiguration() {
+		// Avoid the configurer(created by xml) itself call the createConfiguration,there
+		// is an error of checking template path by afterPropertiesSet in fatjar
+		freemarker.template.Configuration fmConfiguration = new freemarker.template.Configuration(
+				freemarker.template.Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
+		return fmConfiguration;
 	}
 
 	@Bean


### PR DESCRIPTION
If bean freeMarkerConfigurer  created by xml, afterProperitesSet will throw an error ,the spring debug the exception by try...catch this update avoid the error.
```
java.io.FileNotFoundException: ServletContext resource [/] cannot be resolved to absolute file path - web application archive not expanded?
	at org.springframework.web.util.WebUtils.getRealPath(WebUtils.java:344)
	at org.springframework.web.context.support.ServletContextResource.getFile(ServletContextResource.java:194)
	at org.springframework.ui.freemarker.FreeMarkerConfigurationFactory.getTemplateLoaderForPath(FreeMarkerConfigurationFactory.java:345)
	at org.springframework.ui.freemarker.FreeMarkerConfigurationFactory.createConfiguration(FreeMarkerConfigurationFactory.java:297)
	at org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer.afterPropertiesSet(FreeMarkerConfigurer.java:120)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1855)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1792)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:595)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:517)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:323)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:226)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:321)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:893)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:879)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:551)
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:143)
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:758)
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:750)
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:397)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:315)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1237)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1226)
	at com.mycompany.biz.TradeAppApplication.main(TradeAppApplication.java:46)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:49)
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:109)
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:58)
	at org.springframework.boot.loader.WarLauncher.main(WarLauncher.java:59)
```