### PR TITLE
Checks 'javax.persistence.schema-generation.database.action' when determining DDL auto default

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/DataSourceInitializedPublisher.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/DataSourceInitializedPublisher.java
@@ -128,7 +128,8 @@ class DataSourceInitializedPublisher implements BeanPostProcessor {
 				: "none");
 		Map<String, Object> hibernate = this.hibernateProperties.determineHibernateProperties(
 				this.jpaProperties.getProperties(), new HibernateSettings().ddlAuto(defaultDdlAuto));
-		return hibernate.containsKey("hibernate.hbm2ddl.auto");
+		return hibernate.containsKey("hibernate.hbm2ddl.auto") || !hibernate
+				.getOrDefault("javax.persistence.schema-generation.database.action", "none").equals("none");
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateProperties.java
@@ -136,7 +136,18 @@ public class HibernateProperties {
 		}
 		String ddlDatabaseAction = existing.get(AvailableSettings.HBM2DDL_DATABASE_ACTION);
 		if (ddlDatabaseAction != null) {
-			return ddlDatabaseAction;
+			if (ddlDatabaseAction.equals("none")) {
+				return "none";
+			}
+			if (ddlDatabaseAction.equals("create")) {
+				return "create-only";
+			}
+			if (ddlDatabaseAction.equals("drop")) {
+				return "drop";
+			}
+			if (ddlDatabaseAction.equals("drop-and-create")) {
+				return "create";
+			}
 		}
 		return (this.ddlAuto != null) ? this.ddlAuto : defaultDdlAuto.get();
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateProperties.java
@@ -35,6 +35,7 @@ import org.springframework.util.StringUtils;
  * Configuration properties for Hibernate.
  *
  * @author Stephane Nicoll
+ * @author Chris Bono
  * @since 2.1.0
  * @see JpaProperties
  */
@@ -132,6 +133,10 @@ public class HibernateProperties {
 		String ddlAuto = existing.get(AvailableSettings.HBM2DDL_AUTO);
 		if (ddlAuto != null) {
 			return ddlAuto;
+		}
+		String ddlDatabaseAction = existing.get(AvailableSettings.HBM2DDL_DATABASE_ACTION);
+		if (ddlDatabaseAction != null) {
+			return ddlDatabaseAction;
 		}
 		return (this.ddlAuto != null) ? this.ddlAuto : defaultDdlAuto.get();
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateProperties.java
@@ -130,24 +130,12 @@ public class HibernateProperties {
 	}
 
 	private String determineDdlAuto(Map<String, String> existing, Supplier<String> defaultDdlAuto) {
+		if (existing.get(AvailableSettings.HBM2DDL_DATABASE_ACTION) != null) {
+			return null;
+		}
 		String ddlAuto = existing.get(AvailableSettings.HBM2DDL_AUTO);
 		if (ddlAuto != null) {
 			return ddlAuto;
-		}
-		String ddlDatabaseAction = existing.get(AvailableSettings.HBM2DDL_DATABASE_ACTION);
-		if (ddlDatabaseAction != null) {
-			if (ddlDatabaseAction.equals("none")) {
-				return "none";
-			}
-			if (ddlDatabaseAction.equals("create")) {
-				return "create-only";
-			}
-			if (ddlDatabaseAction.equals("drop")) {
-				return "drop";
-			}
-			if (ddlDatabaseAction.equals("drop-and-create")) {
-				return "create";
-			}
 		}
 		return (this.ddlAuto != null) ? this.ddlAuto : defaultDdlAuto.get();
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernatePropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernatePropertiesTests.java
@@ -19,10 +19,15 @@ package org.springframework.boot.autoconfigure.orm.jpa;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -136,16 +141,37 @@ class HibernatePropertiesTests {
 				.run(assertDefaultDdlAutoNotInvoked("create"));
 	}
 
-	@Test
-	void defaultDdlAutoIsNotInvokedIfJpaDatabaseActionPropertyIsSet() {
+	@ParameterizedTest
+	@MethodSource("validJpaDatabaseActionsToExpectedHbmValues")
+	void defaultDdlAutoIsNotInvokedIfJpaDatabaseActionPropertyIsSetToValidJpaValue(String jpaDatabaseAction,
+			String expectedHbmDdlAuto) {
+		this.contextRunner.withPropertyValues(
+				"spring.jpa.properties.javax.persistence.schema-generation.database.action=" + jpaDatabaseAction)
+				.run(assertDefaultDdlAutoNotInvoked(expectedHbmDdlAuto));
+	}
+
+	private static Stream<Arguments> validJpaDatabaseActionsToExpectedHbmValues() {
+		return Stream.of(Arguments.of("none", null), Arguments.of("create", "create-only"),
+				Arguments.of("drop", "drop"), Arguments.of("drop-and-create", "create"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "create-only", "create-drop", "validate", "update" })
+	void defaultDdlAutoIsInvokedIfJpaDatabaseActionPropertyIsSetToNonJpaValue(String nonJpaDatabaseActionValue) {
 		this.contextRunner
-				.withPropertyValues("spring.jpa.properties.javax.persistence.schema-generation.database.action=create")
-				.run(assertDefaultDdlAutoNotInvoked("create"));
+				.withPropertyValues("spring.jpa.properties.javax.persistence.schema-generation.database.action="
+						+ nonJpaDatabaseActionValue)
+				.run(assertHibernateProperties((hibernateProperties) -> verify(this.ddlAutoSupplier).get()));
 	}
 
 	private ContextConsumer<AssertableApplicationContext> assertDefaultDdlAutoNotInvoked(String expectedDdlAuto) {
 		return assertHibernateProperties((hibernateProperties) -> {
-			assertThat(hibernateProperties).containsEntry(AvailableSettings.HBM2DDL_AUTO, expectedDdlAuto);
+			if (expectedDdlAuto == null) {
+				assertThat(hibernateProperties).doesNotContainKey(AvailableSettings.HBM2DDL_AUTO);
+			}
+			else {
+				assertThat(hibernateProperties).containsEntry(AvailableSettings.HBM2DDL_AUTO, expectedDdlAuto);
+			}
 			verify(this.ddlAutoSupplier, never()).get();
 		});
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernatePropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernatePropertiesTests.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.verify;
  *
  * @author Stephane Nicoll
  * @author Artsiom Yudovin
+ * @author Chris Bono
  */
 class HibernatePropertiesTests {
 
@@ -132,6 +133,13 @@ class HibernatePropertiesTests {
 	@Test
 	void defaultDdlAutoIsNotInvokedIfHibernateSpecificPropertyIsSet() {
 		this.contextRunner.withPropertyValues("spring.jpa.properties.hibernate.hbm2ddl.auto=create")
+				.run(assertDefaultDdlAutoNotInvoked("create"));
+	}
+
+	@Test
+	void defaultDdlAutoIsNotInvokedIfJpaDatabaseActionPropertyIsSet() {
+		this.contextRunner
+				.withPropertyValues("spring.jpa.properties.javax.persistence.schema-generation.database.action=create")
 				.run(assertDefaultDdlAutoNotInvoked("create"));
 	}
 


### PR DESCRIPTION
Checks 'javax.persistence.schema-generation.database.action' before returning default ddlAuto in HibernateProperties.

Fixes gh-25054