### PR TITLE
Verifies that the CassandraProperties default values are the same as driver built-in defaults

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.List;
 
 import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
-import com.datastax.oss.driver.api.core.config.OptionsMap;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
@@ -34,7 +34,6 @@ import org.springframework.boot.context.properties.DeprecatedConfigurationProper
  * @author Phillip Webb
  * @author Mark Paluch
  * @author Stephane Nicoll
- * @author Chris Bono
  * @since 1.3.0
  */
 @ConfigurationProperties(prefix = "spring.data.cassandra")

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
+import com.datastax.oss.driver.api.core.config.OptionsMap;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
@@ -29,14 +30,23 @@ import org.springframework.boot.context.properties.DeprecatedConfigurationProper
 /**
  * Configuration properties for Cassandra.
  *
+ * <p>
+ * <strong>NOTE:</strong> default property values generally align with the Cassandra
+ * driver's {@link OptionsMap built-in defaults}.
+ *
  * @author Julien Dubois
  * @author Phillip Webb
  * @author Mark Paluch
  * @author Stephane Nicoll
+ * @author Chris Bono
  * @since 1.3.0
  */
 @ConfigurationProperties(prefix = "spring.data.cassandra")
 public class CassandraProperties {
+
+	// NOTE: If you specify a default value for one of the driver properties be sure to
+	// add a test to CassandraPropertiesTest that verifies it is the same as the built-in
+	// driver's default value - unless the variance in value is intentional.
 
 	/**
 	 * Keyspace name to use.

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
@@ -30,10 +30,6 @@ import org.springframework.boot.context.properties.DeprecatedConfigurationProper
 /**
  * Configuration properties for Cassandra.
  *
- * <p>
- * <strong>NOTE:</strong> default property values generally align with the Cassandra
- * driver's {@link OptionsMap built-in defaults}.
- *
  * @author Julien Dubois
  * @author Phillip Webb
  * @author Mark Paluch
@@ -43,10 +39,6 @@ import org.springframework.boot.context.properties.DeprecatedConfigurationProper
  */
 @ConfigurationProperties(prefix = "spring.data.cassandra")
 public class CassandraProperties {
-
-	// NOTE: If you specify a default value for one of the driver properties be sure to
-	// add a test to CassandraPropertiesTest that verifies it is the same as the built-in
-	// driver's default value - unless the variance in value is intentional.
 
 	/**
 	 * Keyspace name to use.

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cassandra/CassandraPropertiesTest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cassandra/CassandraPropertiesTest.java
@@ -1,0 +1,42 @@
+package org.springframework.boot.autoconfigure.cassandra;
+
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.datastax.oss.driver.api.core.config.TypedDriverOption;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CassandraProperties}.
+ *
+ * @author Chris Bono
+ */
+class CassandraPropertiesTest {
+
+	@Test
+	void defaultValuesAreConsistent() {
+		String failMsg = "the default value has diverged from the driver's built-in default";
+
+		CassandraProperties properties = new CassandraProperties();
+		OptionsMap optionsMap = OptionsMap.driverDefaults();
+
+		assertThat(properties.getConnection().getConnectTimeout()).describedAs(failMsg)
+				.isEqualTo(optionsMap.get(TypedDriverOption.CONNECTION_CONNECT_TIMEOUT));
+
+		assertThat(properties.getConnection().getInitQueryTimeout()).describedAs(failMsg)
+				.isEqualTo(optionsMap.get(TypedDriverOption.CONNECTION_INIT_QUERY_TIMEOUT));
+
+		assertThat(properties.getRequest().getTimeout()).describedAs(failMsg)
+				.isEqualTo(optionsMap.get(TypedDriverOption.REQUEST_TIMEOUT));
+
+		assertThat(properties.getRequest().getPageSize()).describedAs(failMsg)
+				.isEqualTo(optionsMap.get(TypedDriverOption.REQUEST_PAGE_SIZE));
+
+		assertThat(properties.getRequest().getThrottler().getType().type()).describedAs(failMsg)
+				.isEqualTo(optionsMap.get(TypedDriverOption.REQUEST_THROTTLER_CLASS));
+
+		assertThat(properties.getPool().getHeartbeatInterval()).describedAs(failMsg)
+				.isEqualTo(optionsMap.get(TypedDriverOption.HEARTBEAT_INTERVAL));
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cassandra/CassandraPropertiesTest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cassandra/CassandraPropertiesTest.java
@@ -15,27 +15,24 @@ class CassandraPropertiesTest {
 
 	@Test
 	void defaultValuesAreConsistent() {
-		String failMsg = "the default value has diverged from the driver's built-in default";
-
 		CassandraProperties properties = new CassandraProperties();
 		OptionsMap optionsMap = OptionsMap.driverDefaults();
 
-		assertThat(properties.getConnection().getConnectTimeout()).describedAs(failMsg)
+		assertThat(properties.getConnection().getConnectTimeout())
 				.isEqualTo(optionsMap.get(TypedDriverOption.CONNECTION_CONNECT_TIMEOUT));
 
-		assertThat(properties.getConnection().getInitQueryTimeout()).describedAs(failMsg)
+		assertThat(properties.getConnection().getInitQueryTimeout())
 				.isEqualTo(optionsMap.get(TypedDriverOption.CONNECTION_INIT_QUERY_TIMEOUT));
 
-		assertThat(properties.getRequest().getTimeout()).describedAs(failMsg)
-				.isEqualTo(optionsMap.get(TypedDriverOption.REQUEST_TIMEOUT));
+		assertThat(properties.getRequest().getTimeout()).isEqualTo(optionsMap.get(TypedDriverOption.REQUEST_TIMEOUT));
 
-		assertThat(properties.getRequest().getPageSize()).describedAs(failMsg)
+		assertThat(properties.getRequest().getPageSize())
 				.isEqualTo(optionsMap.get(TypedDriverOption.REQUEST_PAGE_SIZE));
 
-		assertThat(properties.getRequest().getThrottler().getType().type()).describedAs(failMsg)
+		assertThat(properties.getRequest().getThrottler().getType().type())
 				.isEqualTo(optionsMap.get(TypedDriverOption.REQUEST_THROTTLER_CLASS));
 
-		assertThat(properties.getPool().getHeartbeatInterval()).describedAs(failMsg)
+		assertThat(properties.getPool().getHeartbeatInterval())
 				.isEqualTo(optionsMap.get(TypedDriverOption.HEARTBEAT_INTERVAL));
 	}
 


### PR DESCRIPTION
Fixes gh-24965

# Points Of Interest

## Developer documentation
I was not sure the best way to document "Hey if you set a default value and it aligns w/ the driver default add a test for it in  assandraPropertiesTest".  For now I put an inline comment in the [CasssandraProperties](https://github.com/spring-projects/spring-boot/pull/25130/files#diff-42a2c92c73a1927e7f3e778a1d950dbe581ea203060b90a293f9a2642e7dab39R46).

## Generally align w/ defaults
I am assuming that we want to generally align w/ the driver defaults. 

We have a few properties we set defaults for that have no default in the driver. The following tests would fail as the default value in the driver is null. I omitted these tests:

```java
assertThat(properties.getRequest().getThrottler().getMaxQueueSize()).isEqualTo(
        optionsMap.get(TypedDriverOption.REQUEST_THROTTLER_MAX_QUEUE_SIZE));

assertThat(properties.getRequest().getThrottler().getMaxConcurrentRequests()).isEqualTo(
        optionsMap.get(TypedDriverOption.REQUEST_THROTTLER_MAX_CONCURRENT_REQUESTS));

assertThat(properties.getRequest().getThrottler().getMaxRequestsPerSecond()).isEqualTo(
        optionsMap.get(TypedDriverOption.REQUEST_THROTTLER_MAX_REQUESTS_PER_SECOND));

assertThat(properties.getRequest().getThrottler().getDrainInterval()).isEqualTo(
        optionsMap.get(TypedDriverOption.REQUEST_THROTTLER_DRAIN_INTERVAL));
```

Also, we have a property that is divergent from the driver (test omitted as well): 
```java
// This breaks as we have 120s and the driver has 500ms
assertThat(properties.getPool().getIdleTimeout()).isEqualTo(
                optionsMap.get(TypedDriverOption.HEARTBEAT_TIMEOUT));
```

