### PR TITLE
initQueryTimeout and ildeTimeout defaults are not aligned with Cassandra defaults

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
@@ -270,7 +270,7 @@ public class CassandraProperties {
 		 * Timeout to use for internal queries that run as part of the initialization
 		 * process, just after a connection is opened.
 		 */
-		private Duration initQueryTimeout = Duration.ofMillis(500);
+		private Duration initQueryTimeout = Duration.ofSeconds(5);
 
 		public Duration getConnectTimeout() {
 			return this.connectTimeout;
@@ -360,7 +360,7 @@ public class CassandraProperties {
 		/**
 		 * Idle timeout before an idle connection is removed.
 		 */
-		private Duration idleTimeout = Duration.ofSeconds(120);
+		private Duration idleTimeout = Duration.ofSeconds(5);
 
 		/**
 		 * Heartbeat interval after which a message is sent on an idle connection to make

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cassandra/CassandraPropertiesTest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cassandra/CassandraPropertiesTest.java
@@ -1,0 +1,43 @@
+package org.springframework.boot.autoconfigure.cassandra;
+
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.datastax.oss.driver.api.core.config.TypedDriverOption;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CassandraProperties}.
+ *
+ * @author Chris Bono
+ */
+class CassandraPropertiesTest {
+
+	@Test
+	void defaultValuesAreConsistent() {
+		CassandraProperties properties = new CassandraProperties();
+		OptionsMap optionsMap = OptionsMap.driverDefaults();
+
+		assertThat(properties.getConnection().getConnectTimeout())
+				.isEqualTo(optionsMap.get(TypedDriverOption.CONNECTION_CONNECT_TIMEOUT));
+
+		assertThat(properties.getConnection().getInitQueryTimeout())
+				.isEqualTo(optionsMap.get(TypedDriverOption.CONNECTION_INIT_QUERY_TIMEOUT));
+
+		assertThat(properties.getRequest().getTimeout()).isEqualTo(optionsMap.get(TypedDriverOption.REQUEST_TIMEOUT));
+
+		assertThat(properties.getRequest().getPageSize())
+				.isEqualTo(optionsMap.get(TypedDriverOption.REQUEST_PAGE_SIZE));
+
+		assertThat(properties.getRequest().getThrottler().getType().type())
+				.isEqualTo(optionsMap.get(TypedDriverOption.REQUEST_THROTTLER_CLASS));
+
+		assertThat(properties.getPool().getHeartbeatInterval())
+				.isEqualTo(optionsMap.get(TypedDriverOption.HEARTBEAT_INTERVAL));
+
+		assertThat(properties.getPool().getIdleTimeout())
+				.isEqualTo(optionsMap.get(TypedDriverOption.HEARTBEAT_TIMEOUT));
+
+	}
+
+}


### PR DESCRIPTION
See #25130 for background.

@snicoll I went ahead and added the defaults test in this PR as I needed to update it to include the default and also use it to verify the changes. 

If however, you want the 2.3.x changes to merge into here (purist tracking standpoint) just lmk and I will remove the test from this PR.