### PR TITLE
Allow the project to be built with Java 16

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/toolchain/ToolchainExtension.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/toolchain/ToolchainExtension.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.build.toolchain;
+
+import java.util.Optional;
+
+import org.gradle.api.Project;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+
+/**
+ * DSL extension for {@link ToolchainPlugin}.
+ *
+ * @author Christoph Dreis
+ */
+public class ToolchainExtension {
+
+	private final Project project;
+
+	private int maximumCompatibleJavaVersion;
+
+	public ToolchainExtension(Project project) {
+		this.project = project;
+	}
+
+	public void setMaximumCompatibleJavaVersion(int maximumVersion) {
+		this.maximumCompatibleJavaVersion = maximumVersion;
+	}
+
+	public Optional<JavaLanguageVersion> getToolchainVersion() {
+		String toolchainVersion = (String) this.project.findProperty("toolchainVersion");
+		if (toolchainVersion == null) {
+			return Optional.empty();
+		}
+		int version = Integer.parseInt(toolchainVersion);
+		return getJavaLanguageVersion(version);
+	}
+
+	public boolean isJavaVersionSupported() {
+		Optional<JavaLanguageVersion> maximumVersion = getJavaLanguageVersion(this.maximumCompatibleJavaVersion);
+		if (!maximumVersion.isPresent()) {
+			return true;
+		}
+		Optional<JavaLanguageVersion> toolchainVersion = getToolchainVersion();
+		return toolchainVersion.isPresent() && maximumVersion.get().canCompileOrRun(toolchainVersion.get());
+	}
+
+	private Optional<JavaLanguageVersion> getJavaLanguageVersion(int version) {
+		if (version >= 8) {
+			return Optional.of(JavaLanguageVersion.of(version));
+		}
+		return Optional.empty();
+	}
+
+}

--- a/buildSrc/src/main/java/org/springframework/boot/build/toolchain/ToolchainPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/toolchain/ToolchainPlugin.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.build.toolchain;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.gradle.api.Action;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.javadoc.Javadoc;
+import org.gradle.api.tasks.testing.Test;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
+
+/**
+ * {@link Plugin} for customizing Gradle's toolchain support.
+ *
+ * @author Christoph Dreis
+ */
+public class ToolchainPlugin implements Plugin<Project> {
+
+	@Override
+	public void apply(Project project) {
+		configureToolchain(project);
+	}
+
+	private void configureToolchain(Project project) {
+		ToolchainExtension toolchain = project.getExtensions().create("toolchain", ToolchainExtension.class, project);
+		project.afterEvaluate((evaluated) -> {
+			Optional<JavaLanguageVersion> toolchainVersion = toolchain.getToolchainVersion();
+			if (toolchainVersion.isPresent()) {
+				if (!toolchain.isJavaVersionSupported()) {
+					disableToolchainTasks(project);
+				}
+				else {
+					configureJavaCompileToolchain(project, toolchain);
+					configureJavadocToolchain(project, toolchain);
+					configureTestToolchain(project, toolchain);
+				}
+			}
+		});
+	}
+
+	private void disableToolchainTasks(Project project) {
+		project.getTasks().withType(JavaCompile.class, (task) -> task.setEnabled(false));
+		project.getTasks().withType(Javadoc.class, (task) -> task.setEnabled(false));
+		project.getTasks().withType(Test.class, (task) -> task.setEnabled(false));
+	}
+
+	private void configureJavaCompileToolchain(Project project, ToolchainExtension toolchain) {
+		project.getTasks().withType(JavaCompile.class, (compile) -> {
+			withOptionalJavaToolchain(toolchain).ifPresent((action) -> {
+				JavaToolchainService service = getJavaToolchainService(project);
+				compile.getJavaCompiler().set(service.compilerFor(action));
+				compile.getOptions().setFork(true);
+				// See https://github.com/gradle/gradle/issues/15538
+				List<String> forkArgs = Arrays.asList("--add-opens",
+						"jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED");
+				compile.getOptions().getForkOptions().getJvmArgs().addAll(forkArgs);
+			});
+		});
+	}
+
+	private void configureJavadocToolchain(Project project, ToolchainExtension toolchain) {
+		project.getTasks().withType(Javadoc.class, (javadoc) -> {
+			withOptionalJavaToolchain(toolchain).ifPresent((action) -> {
+				JavaToolchainService service = getJavaToolchainService(project);
+				javadoc.getJavadocTool().set(service.javadocToolFor(action));
+			});
+		});
+	}
+
+	private void configureTestToolchain(Project project, ToolchainExtension toolchain) {
+		project.getTasks().withType(Test.class, (test) -> {
+			withOptionalJavaToolchain(toolchain).ifPresent((action) -> {
+				JavaToolchainService service = getJavaToolchainService(project);
+				test.getJavaLauncher().set(service.launcherFor(action));
+				// See https://github.com/spring-projects/spring-ldap/issues/570
+				List<String> arguments = Arrays.asList("--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED",
+						"--illegal-access=warn");
+				test.jvmArgs(arguments);
+			});
+		});
+	}
+
+	private JavaToolchainService getJavaToolchainService(Project project) {
+		return project.getExtensions().getByType(JavaToolchainService.class);
+	}
+
+	private Optional<Action<JavaToolchainSpec>> withOptionalJavaToolchain(ToolchainExtension toolchain) {
+		return toolchain.getToolchainVersion().map((toolchainVersion) -> {
+			Action<JavaToolchainSpec> action = (javaToolchainSpec) -> javaToolchainSpec.getLanguageVersion()
+					.convention(toolchainVersion);
+			return Optional.of(action);
+		}).orElse(Optional.empty());
+	}
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,10 +31,6 @@ rootProject.name="spring-boot-build"
 settings.gradle.projectsLoaded {
 	gradleEnterprise {
 		buildScan {
-			if (settings.gradle.rootProject.hasProperty('buildJavaHome')) {
-				value('Build Java home', settings.gradle.rootProject.getProperty('buildJavaHome'))
-			}
-
 			settings.gradle.rootProject.getBuildDir().mkdirs()
 			new File(settings.gradle.rootProject.getBuildDir(), "build-scan-uri.txt").text = "build scan not generated"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,6 +31,10 @@ rootProject.name="spring-boot-build"
 settings.gradle.projectsLoaded {
 	gradleEnterprise {
 		buildScan {
+			if (settings.gradle.rootProject.hasProperty('toolchainVersion')) {
+				value('Toolchain Version', settings.gradle.rootProject.getProperty('toolchainVersion'))
+			}
+
 			settings.gradle.rootProject.getBuildDir().mkdirs()
 			new File(settings.gradle.rootProject.getBuildDir(), "build-scan-uri.txt").text = "build scan not generated"
 

--- a/spring-boot-project/spring-boot-cli/build.gradle
+++ b/spring-boot-project/spring-boot-cli/build.gradle
@@ -7,6 +7,10 @@ plugins {
 
 description = "Spring Boot CLI"
 
+toolchain {
+	maximumCompatibleJavaVersion = 15
+}
+
 configurations {
 	dependenciesBom
 	loader

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/json/JsonbTesterTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/json/JsonbTesterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/json/JsonbTesterTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/json/JsonbTesterTests.java
@@ -22,8 +22,6 @@ import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import org.springframework.core.ResolvableType;
 
@@ -60,12 +58,6 @@ class JsonbTesterTests extends AbstractJsonMarshalTesterTests {
 		assertThat(test.base).isNotNull();
 		assertThat(test.test.getType().resolve()).isEqualTo(List.class);
 		assertThat(test.test.getType().resolveGeneric()).isEqualTo(ExampleObject.class);
-	}
-
-	@DisabledForJreRange(min = JRE.JAVA_16)
-	@Test
-	void writeArrayShouldReturnJsonContent() throws Exception {
-		// Remove after https://issues.apache.org/jira/browse/JOHNZON-331 is released
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/json/JsonbTesterTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/json/JsonbTesterTests.java
@@ -22,6 +22,8 @@ import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import org.springframework.core.ResolvableType;
 
@@ -58,6 +60,12 @@ class JsonbTesterTests extends AbstractJsonMarshalTesterTests {
 		assertThat(test.base).isNotNull();
 		assertThat(test.test.getType().resolve()).isEqualTo(List.class);
 		assertThat(test.test.getType().resolveGeneric()).isEqualTo(ExampleObject.class);
+	}
+
+	@DisabledForJreRange(min = JRE.JAVA_16)
+	@Test
+	void writeArrayShouldReturnJsonContent() throws Exception {
+		// Remove after https://issues.apache.org/jira/browse/JOHNZON-331 is released
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
@@ -10,6 +10,10 @@ plugins {
 
 description = "Spring Boot Gradle Plugin"
 
+toolchain {
+	maximumCompatibleJavaVersion = 15
+}
+
 configurations {
 	asciidoctorExtensions {
 		extendsFrom dependencyManagement

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/build.gradle
@@ -69,7 +69,7 @@ processResources {
 }
 
 compileJava {
-	if ((!project.hasProperty("buildJavaHome")) && JavaVersion.current() == JavaVersion.VERSION_1_8) {
+	if ((!project.hasProperty("toolchainVersion")) && JavaVersion.current() == JavaVersion.VERSION_1_8) {
 		options.compilerArgs += ['-Xlint:-sunapi', '-XDenableSunApiLintControl']	
 	}	
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/JarIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/JarIntegrationTests.java
@@ -25,6 +25,8 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.boot.loader.tools.FileUtils;
@@ -247,6 +249,7 @@ class JarIntegrationTests extends AbstractArchiveIntegrationTests {
 		});
 	}
 
+	@DisabledForJreRange(min = JRE.JAVA_16) // Remove this once Kotlin supports Java 16
 	@TestTemplate
 	void whenAProjectUsesKotlinItsModuleMetadataIsRepackagedIntoBootInfClasses(MavenBuild mavenBuild) {
 		mavenBuild.project("jar-with-kotlin-module").execute((project) -> {


### PR DESCRIPTION
Hi,

this PR gets us one step further into supporting JDK 16 (see #24402).

I'm at a stage where I have random failures on my machine that seem related to network errors & timeouts, so I'm both confident and desperate enough to share my first draft.

Essentially, the PR replaces the functionality of `buildJavaHome` with a new property `toolchainVersion` that controls whether or not an optional toolchain should be configured for compilation, javadoc and test runs.

I should note that the `spring-boot-gradle-plugin` has multiple problems. None of the current versions support JDK 16 and thus a lot of tests fail. Unfortunately, you can't provide an empty stream in `GradleCompatibilityExtension.provideTestTemplateInvocationContexts`. I had some hacky code that would workaround that but I figured that a simple exclude would suffice for the time being. E.g. I used the following:

```
./gradlew build -x :spring-boot-project:spring-boot-tools:spring-boot-gradle-plugin:test -x :spring-boot-project:spring-boot-tools:spring-boot-gradle-plugin:validatePlugins -PtoolchainVersion=16
```

As you can see, I excluded the `validatePlugins` task as well, which is failing due to https://github.com/gradle/gradle/issues/15538.

The big issue is something else though. With JDK 16 and more specifically [JEP-396](https://openjdk.java.net/jeps/396) we have strong encapsulation enabled by default. That breaks a lot of tests and libraries. Just to name a few:

- Any `AbstractServletWebServerFactoryTests` due to the `URL.factory` field being reset.
- `CliTester` for a similar reason
- `JsonbTesterTests` due to a [bug](https://issues.apache.org/jira/browse/JOHNZON-331) in Johnzon 
- A couple of tests related to LDAP because of https://github.com/spring-projects/spring-ldap/issues/570
- ...

I decided to add `--illegal-access=warn` so we get warned, but at the same time have access allowed for the time being.

Feel free to test around with this PR. Again - I didn't have a single test run today that was green, but all test failures were random and successful when run in isolation.

### Next steps
If this PR is merged eventually, I would tackle the actual pipeline. I thought this might be a bit much for this PR, given that I need to add a secondary JDK to the CI images. (I can hopefully reuse some logic though that I build in the past for Boot already)

Let me know what you think.
Christoph

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
