### PR TITLE
Remove duplicate declaration of jackson-databind

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -15,7 +15,6 @@ targetCompatibility = 1.8
 
 dependencies {
 	checkstyle "io.spring.javaformat:spring-javaformat-checkstyle:${javaFormatVersion}"
-	implementation("com.fasterxml.jackson.core:jackson-databind:2.10.0")
 	implementation("commons-codec:commons-codec:1.13")
 	implementation("org.apache.maven:maven-embedder:3.6.2")
 	implementation("org.asciidoctor:asciidoctor-gradle-jvm:3.0.0")


### PR DESCRIPTION
Removes duplicate declaration of `com.fasterxml.jackson.core:jackson-databind` from `buildSrc/build.gradle` file.

Related to #25177
