### PR TITLE
Disable Gradle's welcome message in gradle.properties

### DIFF
--- a/ci/scripts/build-pr-project.sh
+++ b/ci/scripts/build-pr-project.sh
@@ -4,5 +4,5 @@ set -e
 source $(dirname $0)/common.sh
 
 pushd git-repo > /dev/null
-./gradlew -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false --no-daemon --max-workers=4 --continue build
+./gradlew --no-daemon --max-workers=4 --continue build
 popd > /dev/null

--- a/ci/scripts/build-project-windows.bat
+++ b/ci/scripts/build-project-windows.bat
@@ -1,4 +1,4 @@
 SET "JAVA_HOME=C:\opt\jdk-8"
 SET PATH=%PATH%;C:\Program Files\Git\usr\bin
 cd git-repo
-.\gradlew -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false --no-daemon --max-workers=4 build
+.\gradlew --no-daemon --max-workers=4 build

--- a/ci/scripts/build-project.sh
+++ b/ci/scripts/build-project.sh
@@ -5,5 +5,5 @@ source $(dirname $0)/common.sh
 repository=$(pwd)/distribution-repository
 
 pushd git-repo > /dev/null
-./gradlew -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false --no-daemon --max-workers=4 -PdeploymentRepository=${repository} build publishAllPublicationsToDeploymentRepository
+./gradlew --no-daemon --max-workers=4 -PdeploymentRepository=${repository} build publishAllPublicationsToDeploymentRepository
 popd > /dev/null

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,7 @@ org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 
+systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false
+
 kotlinVersion=1.4.30
 kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
Hi,

I'm currently preparing the JDK 16 pipeline and noticed that the `org.gradle.internal.launcher.welcomeMessageEnabled` property could be disabled via `gradle.properties`. That makes things a little easier to read in the build scripts if you ask me. This will especially help because I'm likely complicating them a bit with the pipeline adjustments.

Obviously, this will also disable the welcome message for local builds, but I think that's acceptable given that we should be probably aware of the new features before upgrading.

Let me know what you think.
Cheers,
Christoph