### PR TITLE
Enable stricter plugin validation for the Gradle plugin

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
@@ -65,6 +65,7 @@ task preparePluginValidationClasses(type: Copy) {
 
 validatePlugins {
 	classes.setFrom preparePluginValidationClasses
+	enableStricterValidation = true
 }
 
 task dependencyVersions(type: org.springframework.boot.build.constraints.ExtractVersionConstraints) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
@@ -56,15 +56,10 @@ gradlePlugin {
 	}
 }
 
-task preparePluginValidationClasses(type: Copy) {
-	destinationDir = file("$buildDir/classes/java/pluginValidation")
-	from(sourceSets.main.output.classesDirs) {
-		exclude "**/CreateBootStartScripts.class"
-	}
-}
-
 validatePlugins {
-	classes.setFrom preparePluginValidationClasses
+	classes.setFrom(files(sourceSets.main.output.classesDirs).asFileTree.matching {
+		exclude "**/CreateBootStartScripts.class"
+	})
 	enableStricterValidation = true
 }
 


### PR DESCRIPTION
The validate plugin task can be configured to do even stricter validation. The Spring boot plugin currently doesn't have any problems which make the stricter validation fail, and it makes sense to enable this validation so no problems are introduced.

This PR also simplifies the build script a little bit to avoid copying around classes only to exclude one class from plugin validation.