### PR TITLE
Clear entries from the repository in DataJdbcTestIntegrationTests.testRepository

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/jdbc/DataJdbcTestIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/jdbc/DataJdbcTestIntegrationTests.java
@@ -59,6 +59,7 @@ class DataJdbcTestIntegrationTests {
 		this.jdbcTemplate.update("INSERT INTO EXAMPLE_ENTITY (id, name, reference) VALUES (1, 'a', 'alpha')");
 		this.jdbcTemplate.update("INSERT INTO EXAMPLE_ENTITY (id, name, reference) VALUES (2, 'b', 'bravo')");
 		assertThat(this.repository.findAll()).hasSize(2);
+		this.repository.deleteAll();
 	}
 
 	@Test


### PR DESCRIPTION
The test `org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTestIntegrationTests.testRepository` is not idempotent and fail if run twice in the same JVM, because it pollutes some states shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

### Detail
Running `DataJdbcTestIntegrationTests.testRepository` twice would result in the second run failing for the following assertion:
```
assertThat(this.repository.findAll()).hasSize(2);
```
The root cause is that two insertions are made during each of the test runs, which are not cleared when the test exits. Therefore, when the assertion is hit during the second test run, the repository contains 4 entries instead of 2.

The suggested fix is to clear the repository when the test exits.

With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).