### PR TITLE
Clear cache in SpyBeanWithAopProxyTests.verifyShouldUseProxyTarget

### DIFF
--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanWithAopProxyTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanWithAopProxyTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
@@ -60,6 +61,7 @@ class SpyBeanWithAopProxyTests {
 		verify(this.dateService, times(1)).getDate(false);
 		verify(this.dateService, times(1)).getDate(eq(false));
 		verify(this.dateService, times(1)).getDate(anyBoolean());
+		this.dateService.clearCache();
 	}
 
 	@Configuration(proxyBeanMethods = false)
@@ -91,6 +93,8 @@ class SpyBeanWithAopProxyTests {
 			return System.nanoTime();
 		}
 
+		@CacheEvict(value = "test", allEntries = true)
+		public void clearCache() {}
 	}
 
 }


### PR DESCRIPTION
The test `org.springframework.boot.test.mock.mockito.SpyBeanWithAopProxyTests.verifyShouldUseProxyTarget` is not idempotent and fail if run twice in the same JVM, because it pollutes some states shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

### Detail
Running `SpyBeanWithAopProxyTests.verifyShouldUseProxyTarget`  twice would result in the second run failing for the following error:
```
Wanted but not invoked:
org.springframework.boot.test.mock.mockito.SpyBeanWithAopProxyTests$DateService.getDate(
    false
);
-> at org.springframework.boot.test.mock.mockito.SpyBeanWithAopProxyTests.verifyShouldUseProxyTarget
Actually, there were zero interactions with this mock.
```
The root cause is that `dateService.getDate()` is invoked and the result is cached during the first testrun, which is not cleared when the test exits. Therefore, when during the second test run, `dateService.getDate()` is not called since it's available in the cache, resulting in the above error.

The suggested fix is to clear the cache when the test exits.

With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).