### PR TITLE
Ignore empty prefixes in new PrefixedConfigurationPropertySource

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/PrefixedConfigurationPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/PrefixedConfigurationPropertySource.java
@@ -47,7 +47,10 @@ class PrefixedConfigurationPropertySource implements ConfigurationPropertySource
 	}
 
 	private ConfigurationPropertyName getPrefixedName(ConfigurationPropertyName name) {
-		String prefix = (StringUtils.hasText(this.prefix)) ? this.prefix + "." : "";
+		if (!StringUtils.hasText(this.prefix)) {
+			return name;
+		}
+		String prefix = this.prefix + ".";
 		return ConfigurationPropertyName.of(prefix + name);
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/PrefixedIterableConfigurationPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/PrefixedIterableConfigurationPropertySource.java
@@ -18,6 +18,8 @@ package org.springframework.boot.context.properties.source;
 
 import java.util.stream.Stream;
 
+import org.springframework.util.StringUtils;
+
 /**
  * An iterable {@link PrefixedConfigurationPropertySource}.
  *
@@ -32,6 +34,9 @@ class PrefixedIterableConfigurationPropertySource extends PrefixedConfigurationP
 
 	@Override
 	public Stream<ConfigurationPropertyName> stream() {
+		if (!StringUtils.hasText(getPrefix())) {
+			return getSource().stream();
+		}
 		ConfigurationPropertyName prefix = ConfigurationPropertyName.of(getPrefix());
 		return getSource().stream().map((propertyName) -> {
 			if (prefix.isAncestorOf(propertyName)) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/PrefixedIterableConfigurationPropertySourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/PrefixedIterableConfigurationPropertySourceTests.java
@@ -38,4 +38,15 @@ class PrefixedIterableConfigurationPropertySourceTests {
 				ConfigurationPropertyName.of("foo.baz"), ConfigurationPropertyName.of("hello.bing"));
 	}
 
+	@Test
+	void emptyPrefixShouldReturnOriginalStream() {
+		MockConfigurationPropertySource source = new MockConfigurationPropertySource();
+		source.put("my.foo.bar", "bing");
+		source.put("my.foo.baz", "biff");
+		source.put("hello.bing", "blah");
+		IterableConfigurationPropertySource prefixed = source.withPrefix("");
+		assertThat(prefixed.stream()).containsExactly(ConfigurationPropertyName.of("my.foo.bar"),
+				ConfigurationPropertyName.of("my.foo.baz"), ConfigurationPropertyName.of("hello.bing"));
+	}
+
 }


### PR DESCRIPTION
Hi,

the new support for prefixes in property sources added by a8592f36d425fa6b9faff59a45e1936e87b2ec9d has broken the tests, I think.

In case no prefix is specified, the `PrefixedIterableConfigurationPropertySource` actually filtered a bit too much, because `isAncestorOf` should be true in all those cases.

The alternative would be to check for the empty prefix when the property source is created in the first place, but the check inside the actual source felt a little safer for eventual callers outside the Spring-Boot source code itself. But I can change that if you'd like me to.

Cheers,
Christoph