### PR TITLE
Improve deployment integration tests

### DIFF
--- a/spring-boot-tests/spring-boot-deployment-tests/build.gradle
+++ b/spring-boot-tests/spring-boot-deployment-tests/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	intTestImplementation(project(":spring-boot-project:spring-boot-tools:spring-boot-test-support"))
 	intTestImplementation("org.apache.httpcomponents:httpasyncclient")
 	intTestImplementation("org.awaitility:awaitility")
+	intTestImplementation("org.testcontainers:junit-jupiter")
 	intTestImplementation("org.testcontainers:testcontainers")
 	intTestImplementation("org.springframework:spring-web")
 

--- a/spring-boot-tests/spring-boot-deployment-tests/src/intTest/java/sample/AbstractDeploymentIntegrationTests.java
+++ b/spring-boot-tests/spring-boot-deployment-tests/src/intTest/java/sample/AbstractDeploymentIntegrationTests.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Deployment integration tests.
  */
 @DisabledIfDockerUnavailable
-class DeploymentIntegrationTests {
+class AbstractDeploymentIntegrationTests {
 
 	@ParameterizedTest
 	@MethodSource("deployedApplications")

--- a/spring-boot-tests/spring-boot-deployment-tests/src/intTest/java/sample/OpenLibertyDeploymentIntegrationTests.java
+++ b/spring-boot-tests/spring-boot-deployment-tests/src/intTest/java/sample/OpenLibertyDeploymentIntegrationTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Deployment integration tests for Open Liberty.
+ *
+ * @author Christoph Dreis
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class OpenLibertyDeploymentIntegrationTests extends AbstractDeploymentIntegrationTests {
+
+	private static final int PORT = 9080;
+
+	@Container
+	static WarDeploymentContainer container = new WarDeploymentContainer(
+			"openliberty/open-liberty:20.0.0.9-kernel-java8-openj9-ubi", "/config/dropins", PORT);
+
+	@Override
+	WarDeploymentContainer getContainer() {
+		return container;
+	}
+
+	@Override
+	protected int getPort() {
+		return PORT;
+	}
+
+}

--- a/spring-boot-tests/spring-boot-deployment-tests/src/intTest/java/sample/TomEEDeploymentIntegrationTests.java
+++ b/spring-boot-tests/spring-boot-deployment-tests/src/intTest/java/sample/TomEEDeploymentIntegrationTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Deployment integration tests for TomEE.
+ *
+ * @author Christoph Dreis
+ */
+@Testcontainers(disabledWithoutDocker = true)
+public class TomEEDeploymentIntegrationTests extends AbstractDeploymentIntegrationTests {
+
+	@Container
+	static WarDeploymentContainer container = new WarDeploymentContainer("tomee:8-jre-8.0.2-webprofile",
+			"/usr/local/tomee/webapps", DEFAULT_PORT);
+
+	@Override
+	WarDeploymentContainer getContainer() {
+		return container;
+	}
+
+}

--- a/spring-boot-tests/spring-boot-deployment-tests/src/intTest/java/sample/TomcatDeploymentIntegrationTests.java
+++ b/spring-boot-tests/spring-boot-deployment-tests/src/intTest/java/sample/TomcatDeploymentIntegrationTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Deployment integration tests for Tomcat.
+ *
+ * @author Christoph Dreis
+ */
+@Testcontainers(disabledWithoutDocker = true)
+public class TomcatDeploymentIntegrationTests extends AbstractDeploymentIntegrationTests {
+
+	@Container
+	static WarDeploymentContainer container = new WarDeploymentContainer("tomcat:9.0.37-jdk8-openjdk",
+			"/usr/local/tomcat/webapps", DEFAULT_PORT);
+
+	@Override
+	WarDeploymentContainer getContainer() {
+		return container;
+	}
+
+}

--- a/spring-boot-tests/spring-boot-deployment-tests/src/intTest/java/sample/WildflyDeploymentIntegrationTests.java
+++ b/spring-boot-tests/spring-boot-deployment-tests/src/intTest/java/sample/WildflyDeploymentIntegrationTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample;
+
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Deployment integration tests for Wildfly.
+ *
+ * @author Christoph Dreis
+ */
+@Testcontainers(disabledWithoutDocker = true)
+public class WildflyDeploymentIntegrationTests extends AbstractDeploymentIntegrationTests {
+
+	@Container
+	static WarDeploymentContainer container = new WarDeploymentContainer("jboss/wildfly:20.0.1.Final",
+			"/opt/jboss/wildfly/standalone/deployments", DEFAULT_PORT);
+
+	@Override
+	WarDeploymentContainer getContainer() {
+		return container;
+	}
+
+}


### PR DESCRIPTION
Hi,

this PR improves the `spring-boot-deployment-tests` build step by splitting them apart based on their underlying container (e.g. Wildfly, TomEE etc.).

By doing so we can make use of static per-class testcontainers instead of starting a container for every test. This reduces the amount of started containers from 12 to 4 and therefore obviously the test time as well. (On my machine it only takes a third of what it took before). My hope is that this reduces the pressure on CI as well and helps to minimize flaky tests reported in #25410.

Let me know what you think.
Cheers,
Christoph

P.S.: The separate renaming commit was kind of intentional in order to preserve history for `DeploymentIntegrationTests`.
