### PR TITLE
CloudPlatform.isActive can return true when spring.main.cloud-platform is set to NONE

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.core.env.StandardEnvironment;
  *
  * @author Phillip Webb
  * @author Brian Clozel
+ * @author Nguyen Sach
  * @since 1.3.0
  */
 public enum CloudPlatform {
@@ -140,7 +141,7 @@ public enum CloudPlatform {
 	 * @return if the platform is active.
 	 */
 	public boolean isActive(Environment environment) {
-		return isEnforced(environment) || isDetected(environment);
+		return isEnforced(environment) || (isAutoDetectionEnabled(environment) && isDetected(environment));
 	}
 
 	/**
@@ -177,6 +178,16 @@ public enum CloudPlatform {
 	 * @since 2.3.0
 	 */
 	public abstract boolean isDetected(Environment environment);
+
+	/**
+	 * Determines if it is enabled that the platform is detected by looking for
+	 * platform-specific environment variables.
+	 * @param environment the environment
+	 * @return if the platform auto-detection is enabled.
+	 */
+	private boolean isAutoDetectionEnabled(Environment environment) {
+		return environment.getProperty(PROPERTY_NAME) == null;
+	}
 
 	/**
 	 * Returns if the platform is behind a load balancer and uses

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,10 @@ package org.springframework.boot.cloud;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link CloudPlatform}.
  *
  * @author Phillip Webb
+ * @author Nguyen Sach
  */
 class CloudPlatformTests {
 
@@ -175,6 +179,18 @@ class CloudPlatformTests {
 	void isEnforcedWhenBinderPropertyIsMissingReturnsFalse() {
 		Binder binder = new Binder(new MockConfigurationPropertySource());
 		assertThat(CloudPlatform.KUBERNETES.isEnforced(binder)).isFalse();
+	}
+
+	@Test
+	void isActiveWhenNoCloudPlatformIsEnforcedAndHasKubernetesServiceHostAndKubernetesServicePort() {
+		Map<String, Object> envVars = new HashMap<>();
+		envVars.put("EXAMPLE_SERVICE_HOST", "---");
+		envVars.put("EXAMPLE_SERVICE_PORT", "8080");
+		Environment environment = getEnvironmentWithEnvVariables(envVars);
+		((MockEnvironment) environment).setProperty("spring.main.cloud-platform", "none");
+		List<CloudPlatform> activeCloudPlatforms = Stream.of(CloudPlatform.values())
+				.filter((cloudPlatform) -> cloudPlatform.isActive(environment)).collect(Collectors.toList());
+		assertThat(activeCloudPlatforms).containsExactly(CloudPlatform.NONE);
 	}
 
 	private Environment getEnvironmentWithEnvVariables(Map<String, Object> environmentVariables) {


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-boot/issues/25433

add isAutoDetectionEnabled method to determine that whether it is enabled that the platform is detected by looking for platform-specific environment variables.
