### PR TITLE
Speed up spring-boot-server-tests

### DIFF
--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/test/java/org/springframework/boot/context/embedded/AbstractApplicationLauncher.java
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/test/java/org/springframework/boot/context/embedded/AbstractApplicationLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -40,7 +39,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Andy Wilkinson
  */
-abstract class AbstractApplicationLauncher implements BeforeEachCallback, AfterEachCallback {
+abstract class AbstractApplicationLauncher implements BeforeEachCallback {
 
 	private final ApplicationBuilder applicationBuilder;
 
@@ -56,15 +55,16 @@ abstract class AbstractApplicationLauncher implements BeforeEachCallback, AfterE
 	}
 
 	@Override
-	public void afterEach(ExtensionContext context) throws Exception {
-		if (this.process != null) {
-			this.process.destroy();
+	public void beforeEach(ExtensionContext context) throws Exception {
+		if (this.process == null) {
+			this.process = startApplication();
 		}
 	}
 
-	@Override
-	public void beforeEach(ExtensionContext context) throws Exception {
-		this.process = startApplication();
+	void destroyProcess() {
+		if (this.process != null) {
+			this.process.destroy();
+		}
 	}
 
 	final int getHttpPort() {

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/test/java/org/springframework/boot/context/embedded/EmbeddedServerContainerInvocationContextProvider.java
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/test/java/org/springframework/boot/context/embedded/EmbeddedServerContainerInvocationContextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -62,6 +63,10 @@ class EmbeddedServerContainerInvocationContextProvider
 	private static final BuildOutput buildOutput = new BuildOutput(
 			EmbeddedServerContainerInvocationContextProvider.class);
 
+	private final Map<String, ApplicationBuilder> builderCache = new HashMap<>();
+
+	private final Map<String, AbstractApplicationLauncher> launcherCache = new HashMap<>();
+
 	private final Path tempDir;
 
 	EmbeddedServerContainerInvocationContextProvider() throws IOException {
@@ -77,14 +82,13 @@ class EmbeddedServerContainerInvocationContextProvider
 	public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
 		EmbeddedServletContainerTest annotation = context.getRequiredTestClass()
 				.getAnnotation(EmbeddedServletContainerTest.class);
-		return CONTAINERS.stream()
-				.map((container) -> new ApplicationBuilder(this.tempDir, annotation.packaging(),
-						container))
+		return CONTAINERS
+				.stream().map(
+						(container) -> getApplicationBuilder(annotation, container))
 				.flatMap(
 						(builder) -> Stream
 								.of(annotation.launchers()).map(
-										(launcherClass) -> ReflectionUtils.newInstance(launcherClass, builder,
-												buildOutput))
+										(launcherClass) -> getAbstractApplicationLauncher(builder, launcherClass))
 								.map((launcher) -> new EmbeddedServletContainerInvocationContext(
 										StringUtils.capitalize(builder.getContainer()) + ": "
 												+ launcher.getDescription(builder.getPackaging()),
@@ -94,6 +98,34 @@ class EmbeddedServerContainerInvocationContextProvider
 	@Override
 	public void afterAll(ExtensionContext context) throws Exception {
 		FileSystemUtils.deleteRecursively(this.tempDir);
+		cleanupCaches();
+	}
+
+	private void cleanupCaches() {
+		this.launcherCache.values().forEach(AbstractApplicationLauncher::destroyProcess);
+		this.launcherCache.clear();
+		this.builderCache.clear();
+	}
+
+	private AbstractApplicationLauncher getAbstractApplicationLauncher(ApplicationBuilder builder,
+			Class<? extends AbstractApplicationLauncher> launcherClass) {
+		String cacheKey = builder.getContainer() + ":" + builder.getPackaging() + ":" + launcherClass.getName();
+		if (this.launcherCache.containsKey(cacheKey)) {
+			return this.launcherCache.get(cacheKey);
+		}
+		AbstractApplicationLauncher launcher = ReflectionUtils.newInstance(launcherClass, builder, buildOutput);
+		this.launcherCache.put(cacheKey, launcher);
+		return launcher;
+	}
+
+	private ApplicationBuilder getApplicationBuilder(EmbeddedServletContainerTest annotation, String container) {
+		String cacheKey = container + ":" + annotation.packaging();
+		if (this.builderCache.containsKey(cacheKey)) {
+			return this.builderCache.get(cacheKey);
+		}
+		ApplicationBuilder builder = new ApplicationBuilder(this.tempDir, annotation.packaging(), container);
+		this.builderCache.put(cacheKey, builder);
+		return builder;
 	}
 
 	static class EmbeddedServletContainerInvocationContext implements TestTemplateInvocationContext, ParameterResolver {


### PR DESCRIPTION
Hi,

this PR improves the build time of `spring-boot-server-tests` by applying some caching in certain places. Specifically:

- A cache for the `ApplicationBuilder`s, which avoids packaging the JAR (or WAR) for each test invocation. With the cache the packaging now only run once per container and packaging method (e.g. Tomcat & JAR or Undertow & WAR)
- A cache for the AbstractApplicationLauncher, which pretty much follows the same idea as the tests don't need to start the application for each test invocation, but rather only once per container, packaging & launcher combination.

The second cache is a bit more aggressive and has the implication that the started processes can only be killed after all tests are run. Unfortunately, I found no way to make this a little cleaner in JUnit 5 as the `TestTemplateInvocationContext(Provider)` mechanism only works on the single test invocation level. The same applies to the exposed additional extensions in those contexts, which the `AbstractApplicationLauncher` is.

On my local machine the new approach reduces the time for testing from almost 8 minutes to roughly 1:30-2 minutes. The bigger part of this comes from the launcher cache, because we don't have to pay the 3-4 second application startup time hit on every test invocation.

Let me know what you think.
Cheers,
Christoph