### PR TITLE
The untranslated SQLException is wrapped to UncategorizedSQLException

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqExceptionTranslator.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqExceptionTranslator.java
@@ -25,6 +25,7 @@ import org.jooq.SQLDialect;
 import org.jooq.impl.DefaultExecuteListener;
 
 import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.UncategorizedSQLException;
 import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator;
 import org.springframework.jdbc.support.SQLExceptionTranslator;
 import org.springframework.jdbc.support.SQLStateSQLExceptionTranslator;
@@ -80,6 +81,9 @@ public class JooqExceptionTranslator extends DefaultExecuteListener {
 	private void handle(ExecuteContext context, SQLExceptionTranslator translator, SQLException exception) {
 		DataAccessException translated = translate(context, translator, exception);
 		if (exception.getNextException() == null) {
+			if (translated == null) {
+				translated = new UncategorizedSQLException("jOOQ", context.sql(), exception);
+			}
 			context.exception(translated);
 		}
 		else {


### PR DESCRIPTION
The patch solves situation when Spring Boot with jOOQ is used and database driver returns type of exception which is not translated by used `SQLExceptionTranslator`. In this case the last Spring Boot (2.4.3 and also 2.5.0-SNAPSHOT) throws `org.jooq.exception.DataAccessException` instead of expected `org.springframework.dao.DataAccessException`. The original `SQLException` is furthermore lost and `getCause()` returns `null`.

The behavior was introduced with change in `AbstractFallbackSQLExceptionTranslator` with Spring Framework in 5.3.x. The extending translators return no longer `UncategorizedSQLException` but `null`. `null` is correct return value of `SQLExceptionTranslator` and caller have to create `UncategorizedSQLException` alone like eg. `JdbcTemplate` does. This change fixes same in `JooqExceptionTranslator` for jOOQ.

Some more details are in stack overflow question https://stackoverflow.com/questions/66279277/unexpected-mapping-of-exception-from-trigger-spring-boot-2-4-x-jooq