### PR TITLE
Layertools may extract entries outside of the destination path

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/main/java/org/springframework/boot/jarmode/layertools/ExtractCommand.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/main/java/org/springframework/boot/jarmode/layertools/ExtractCommand.java
@@ -88,7 +88,7 @@ class ExtractCommand extends Command {
 	private void write(ZipInputStream zip, ZipEntry entry, File destination) throws IOException {
 		String path = StringUtils.cleanPath(entry.getName());
 		File file = new File(destination, path);
-		if (file.getAbsolutePath().startsWith(destination.getAbsolutePath())) {
+		if (file.getCanonicalPath().startsWith(destination.getCanonicalPath() + File.separator)) {
 			mkParentDirs(file);
 			try (OutputStream out = new FileOutputStream(file)) {
 				StreamUtils.copy(zip, out);


### PR DESCRIPTION
The check for subdirectory in ExtractCommand.java will always return true because `getAbsolutePath` does not resolve `..` and symlinks.
This PR uses `getCanonicalPath` and adds a file separator at the end of destination path to avoid treating directories with the same prefix as subdirectories (e.g /foo, /foobar).