### PR TITLE
 Incorrect ConfigurationMetadataRepository when loaded from json files containing properties of the same group 

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata/src/main/java/org/springframework/boot/configurationmetadata/SimpleConfigurationMetadataRepository.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata/src/main/java/org/springframework/boot/configurationmetadata/SimpleConfigurationMetadataRepository.java
@@ -117,4 +117,17 @@ public class SimpleConfigurationMetadataRepository implements ConfigurationMetad
 		}
 	}
 
+/*
+Uncomment this code to fix issue revealed by ConfigurationMetadataRepositoryJsonBuilderTests#severalRepositoriesIdenticalGroups3()
+
+	private void putIfAbsent(Map<String, ConfigurationMetadataSource> sources, String name,
+			ConfigurationMetadataSource source) {
+		ConfigurationMetadataSource existing = sources.get(name);
+		if (existing == null) {
+			sources.put(name, source);
+		} else {
+			source.getProperties().forEach((k, v) -> putIfAbsent(existing.getProperties(), k, v));
+		}
+	}
+*/
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata/src/test/resources/metadata/configuration-metadata-foo3.json
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata/src/test/resources/metadata/configuration-metadata-foo3.json
@@ -1,0 +1,23 @@
+{
+  "groups": [
+    {
+      "name": "spring.foo",
+      "type": "org.acme.Foo",
+      "sourceType": "org.acme.config.FooApp",
+      "sourceMethod": "foo2()",
+      "description": "This is Foo."
+    }
+  ],
+  "properties": [
+    {
+      "name": "spring.foo.enabled",
+      "type": "java.lang.Boolean",
+      "sourceType": "org.acme.Foo"
+    },
+    {
+      "name": "spring.foo.type",
+      "type": "java.lang.String",
+      "sourceType": "org.acme.Foo"
+    }
+  ]
+}


### PR DESCRIPTION
This PR contains a simple test case to illustrate issue described in #25501.
It is based on the existing `severalRepositoriesIdenticalGroups` test. It loads “foo” and “foo3”.
“foo3” is a copy of “foo2”: it has the same properties except they refer to a group that already exists in “foo” with the same name and *TYPE*.

Please note that the test will obviously FAIL ;-)