### PR TITLE
Exclude GradleBuild tasks on JDK 16 for now

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/toolchain/ToolchainPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/toolchain/ToolchainPlugin.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.GradleBuild;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
@@ -70,6 +71,7 @@ public class ToolchainPlugin implements Plugin<Project> {
 		project.getTasks().withType(JavaCompile.class, (task) -> task.setEnabled(false));
 		project.getTasks().withType(Javadoc.class, (task) -> task.setEnabled(false));
 		project.getTasks().withType(Test.class, (task) -> task.setEnabled(false));
+		project.getTasks().withType(GradleBuild.class, (task) -> task.setEnabled(false));
 	}
 
 	private void configureJavaCompileToolchain(Project project, ToolchainExtension toolchain) {

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/build.gradle
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/build.gradle
@@ -6,6 +6,10 @@ plugins {
 
 description = "Spring Boot Launch Script Integration Tests"
 
+toolchain {
+	maximumCompatibleJavaVersion = JavaLanguageVersion.of(15)
+}
+
 configurations {
 	app
 }

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-loader-tests/build.gradle
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-loader-tests/build.gradle
@@ -6,6 +6,10 @@ plugins {
 
 description = "Spring Boot Loader Integration Tests"
 
+toolchain {
+	maximumCompatibleJavaVersion = JavaLanguageVersion.of(15)
+}
+
 configurations {
 	app
 }


### PR DESCRIPTION
Hi,

unfortunately, the first [pipeline run](https://ci.spring.io/teams/spring-boot/pipelines/spring-boot-2.4.x/jobs/jdk16-build/builds/1) on JDK 16 failed due to the gradle-plugin not being built which the `spring-boot-launch-script-tests` and `spring-boot-loader-tests` depend upon. I've missed this on local tests, because previous runs populated my Gradle caches. I'm sorry for that.

As this is only a temporary solution until Gradle 7 is out, I chose to pragmatically disable things for now. There are other ways to fix this. E.g. by extending the toolchain DSL to enforce the compilation step, which would cause the `spring-boot-gradle-plugin` JAR to be built. Just let me know if you prefer that and I will play around with that idea.

Cheers,
Christoph
