### PR TITLE
Fix some illegal reflective access warnings

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.wavefront;
 
+import java.util.concurrent.LinkedBlockingQueue;
+
 import com.wavefront.sdk.common.WavefrontSender;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.wavefront.WavefrontConfig;
 import io.micrometer.wavefront.WavefrontMeterRegistry;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -28,6 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -85,8 +89,10 @@ class WavefrontMetricsExportAutoConfigurationTests {
 				.withPropertyValues("management.metrics.export.wavefront.api-token=abcde").run((context) -> {
 					WavefrontProperties properties = new WavefrontProperties();
 					WavefrontSender sender = context.getBean(WavefrontSender.class);
-					assertThat(sender).extracting("metricsBuffer").hasFieldOrPropertyWithValue("capacity",
-							properties.getSender().getMaxQueueSize());
+					assertThat(sender)
+							.extracting("metricsBuffer", as(InstanceOfAssertFactories.type(LinkedBlockingQueue.class)))
+							.satisfies((queue) -> assertThat(queue.remainingCapacity() + queue.size())
+									.isEqualTo(properties.getSender().getMaxQueueSize()));
 					assertThat(sender).hasFieldOrPropertyWithValue("batchSize", properties.getBatchSize());
 					assertThat(sender).hasFieldOrPropertyWithValue("messageSizeBytes",
 							(int) properties.getSender().getMessageSize().toBytes());
@@ -103,7 +109,9 @@ class WavefrontMetricsExportAutoConfigurationTests {
 				.run((context) -> {
 					WavefrontSender sender = context.getBean(WavefrontSender.class);
 					assertThat(sender).hasFieldOrPropertyWithValue("batchSize", 50);
-					assertThat(sender).extracting("metricsBuffer").hasFieldOrPropertyWithValue("capacity", 100);
+					assertThat(sender)
+							.extracting("metricsBuffer", as(InstanceOfAssertFactories.type(LinkedBlockingQueue.class)))
+							.satisfies((queue) -> assertThat(queue.remainingCapacity() + queue.size()).isEqualTo(100));
 					assertThat(sender).hasFieldOrPropertyWithValue("messageSizeBytes", 1024);
 				});
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaPropertiesKafka24Tests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaPropertiesKafka24Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,11 +32,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ClassPathOverrides("org.apache.kafka:kafka-clients:2.4.1")
 class KafkaPropertiesKafka24Tests {
 
+	@SuppressWarnings("rawtypes")
 	@Test
 	void isolationLevelEnumConsistentWithKafkaVersion() throws ClassNotFoundException {
 		Class<?> isolationLevelClass = Class.forName("org.apache.kafka.common.requests.IsolationLevel");
-		Object[] original = ReflectionTestUtils.invokeMethod(isolationLevelClass, "values");
-		assertThat(original).extracting("name").containsExactly(IsolationLevel.READ_UNCOMMITTED.name(),
+		Enum[] original = ReflectionTestUtils.invokeMethod(isolationLevelClass, "values");
+		assertThat(original).extracting(Enum::name).containsExactly(IsolationLevel.READ_UNCOMMITTED.name(),
 				IsolationLevel.READ_COMMITTED.name());
 		assertThat(original).extracting("id").containsExactly(IsolationLevel.READ_UNCOMMITTED.id(),
 				IsolationLevel.READ_COMMITTED.id());

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaPropertiesTests.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class KafkaPropertiesTests {
 
+	@SuppressWarnings("rawtypes")
 	@Test
 	void isolationLevelEnumConsistentWithKafkaVersion() {
 		org.apache.kafka.common.IsolationLevel[] original = org.apache.kafka.common.IsolationLevel.values();

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ class KafkaPropertiesTests {
 	@Test
 	void isolationLevelEnumConsistentWithKafkaVersion() {
 		org.apache.kafka.common.IsolationLevel[] original = org.apache.kafka.common.IsolationLevel.values();
-		assertThat(original).extracting("name").containsExactly(IsolationLevel.READ_UNCOMMITTED.name(),
+		assertThat(original).extracting(Enum::name).containsExactly(IsolationLevel.READ_UNCOMMITTED.name(),
 				IsolationLevel.READ_COMMITTED.name());
 		assertThat(original).extracting("id").containsExactly(IsolationLevel.READ_UNCOMMITTED.id(),
 				IsolationLevel.READ_COMMITTED.id());


### PR DESCRIPTION
Hi,

this PR fixes a couple of illegal reflective access warnings in tests.

Cheers,
Christoph