### PR TITLE
Minor enhancements to KotlinConstructorParametersBinderTests

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/MockConfigurationPropertySource.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/MockConfigurationPropertySource.java
@@ -46,6 +46,10 @@ public class MockConfigurationPropertySource implements IterableConfigurationPro
 				OriginTrackedValue.of(value, MockOrigin.of(origin)));
 	}
 
+	public MockConfigurationPropertySource(Map<String, String> configs) {
+		configs.forEach(this::put);
+	}
+
 	public void put(String name, String value) {
 		put(ConfigurationPropertyName.of(name), value);
 	}

--- a/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/context/properties/bind/KotlinConstructorParametersBinderTests.kt
+++ b/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/context/properties/bind/KotlinConstructorParametersBinderTests.kt
@@ -16,107 +16,101 @@ class KotlinConstructorParametersBinderTests {
 
 	@Test
 	fun `Bind to class should create bound bean`() {
-		val source = MockConfigurationPropertySource()
-		source.put("foo.int-value", "12")
-		source.put("foo.long-value", "34")
-		source.put("foo.boolean-value", "true")
-		source.put("foo.string-value", "foo")
-		source.put("foo.enum-value", "foo-bar")
+		val source = MockConfigurationPropertySource(mapOf("foo.int-value" to "12",
+															"foo.int-value" to "12",
+															"foo.long-value" to "34",
+															"foo.boolean-value" to "true",
+															"foo.string-value" to "foo",
+															"foo.enum-value" to "foo-bar"))
 		val binder = Binder(source)
 		val bean = binder.bind("foo", Bindable.of(ExampleValueBean::class.java)).get()
 		assertThat(bean.intValue).isEqualTo(12)
 		assertThat(bean.longValue).isEqualTo(34)
-		assertThat(bean.booleanValue).isTrue()
+		assertThat(bean.booleanValue).isTrue
 		assertThat(bean.stringValue).isEqualTo("foo")
 		assertThat(bean.enumValue).isEqualTo(ExampleEnum.FOO_BAR)
 	}
 
 	@Test
 	fun `Bind to class when has no prefix should create bound bean`() {
-		val source = MockConfigurationPropertySource()
-		source.put("int-value", "12")
-		source.put("long-value", "34")
-		source.put("boolean-value", "true")
-		source.put("string-value", "foo")
-		source.put("enum-value", "foo-bar")
+		val source = MockConfigurationPropertySource(mapOf("int-value" to "12",
+															"long-value" to "34",
+															"boolean-value" to "true",
+															"string-value" to "foo",
+															"enum-value" to "foo-bar"))
 		val binder = Binder(source)
 		val bean = binder.bind(ConfigurationPropertyName.of(""),
 				Bindable.of(ExampleValueBean::class.java)).get()
 		assertThat(bean.intValue).isEqualTo(12)
 		assertThat(bean.longValue).isEqualTo(34)
-		assertThat(bean.booleanValue).isTrue()
+		assertThat(bean.booleanValue).isTrue
 		assertThat(bean.stringValue).isEqualTo("foo")
 		assertThat(bean.enumValue).isEqualTo(ExampleEnum.FOO_BAR)
 	}
 
 	@Test
 	fun `Bind to data class should create bound bean`() {
-		val source = MockConfigurationPropertySource()
-		source.put("foo.int-value", "12")
-		source.put("foo.long-value", "34")
-		source.put("foo.boolean-value", "true")
-		source.put("foo.string-value", "foo")
-		source.put("foo.enum-value", "foo-bar")
+		val source = MockConfigurationPropertySource(mapOf("foo.int-value" to "12",
+															"foo.long-value" to "34",
+															"foo.boolean-value" to "true",
+															"foo.string-value" to "foo",
+															"foo.enum-value" to "foo-bar"))
 		val binder = Binder(source)
 		val bean = binder.bind("foo", Bindable.of(ExampleDataClassBean::class.java)).get()
-		assertThat(bean.intValue).isEqualTo(12)
-		assertThat(bean.longValue).isEqualTo(34)
-		assertThat(bean.booleanValue).isTrue()
-		assertThat(bean.stringValue).isEqualTo("foo")
-		assertThat(bean.enumValue).isEqualTo(ExampleEnum.FOO_BAR)
+		val expectedBean = ExampleDataClassBean(intValue = 12,
+												longValue = 34,
+												booleanValue = true,
+												stringValue = "foo",
+												enumValue = ExampleEnum.FOO_BAR)
+		assertThat(bean).isEqualTo(expectedBean)
 	}
 
 	@Test
 	fun `Bind to class with multiple constructors and primary constructor should bind`() {
-		val source = MockConfigurationPropertySource()
-		source.put("foo.int-value", "12")
+		val source = MockConfigurationPropertySource("foo.int-value", "12")
 		val binder = Binder(source)
 		val bindable = binder.bind("foo", Bindable.of(
 				MultipleConstructorsWithPrimaryConstructorBean::class.java))
-		assertThat(bindable.isBound).isTrue()
+		assertThat(bindable.isBound).isTrue
 		assertThat(bindable.get().intValue).isEqualTo(12)
 	}
 
 	@Test
 	fun `Bind to class with multiple constructors should not bind`() {
-		val source = MockConfigurationPropertySource()
-		source.put("foo.int-value", "12")
+		val source = MockConfigurationPropertySource("foo.int-value", "12")
 		val binder = Binder(source)
 		val bindable = binder.bind("foo", Bindable.of(
 				MultipleConstructorsBean::class.java))
-		assertThat(bindable.isBound).isFalse()
+		assertThat(bindable.isBound).isFalse
 	}
 
 	@Test
 	fun `Bind to class with only default constructor should not bind`() {
-		val source = MockConfigurationPropertySource()
-		source.put("foo.int-value", "12")
+		val source = MockConfigurationPropertySource("foo.int-value", "12")
 		val binder = Binder(source)
 		val bindable = binder.bind("foo", Bindable.of(
 				DefaultConstructorBean::class.java))
-		assertThat(bindable.isBound).isFalse()
+		assertThat(bindable.isBound).isFalse
 	}
 
 	@Test
 	fun `Bind to class should bind nested`() {
-		val source = MockConfigurationPropertySource()
-		source.put("foo.value-bean.int-value", "123")
-		source.put("foo.value-bean.long-value", "34")
-		source.put("foo.value-bean.boolean-value", "true")
-		source.put("foo.value-bean.string-value", "foo")
+		val source = MockConfigurationPropertySource(mapOf("foo.value-bean.int-value" to "123",
+															"foo.value-bean.long-value" to "34",
+															"foo.value-bean.boolean-value" to "true",
+															"foo.value-bean.string-value" to "foo"))
 		val binder = Binder(source)
 		val bean = binder.bind("foo", Bindable.of(ExampleNestedBean::class.java)).get()
 		assertThat(bean.valueBean.intValue).isEqualTo(123)
 		assertThat(bean.valueBean.longValue).isEqualTo(34)
-		assertThat(bean.valueBean.booleanValue).isTrue()
+		assertThat(bean.valueBean.booleanValue).isTrue
 		assertThat(bean.valueBean.stringValue).isEqualTo("foo")
 		assertThat(bean.valueBean.enumValue).isNull()
 	}
 
 	@Test
 	fun `Bind to class with no value for optional should use null`() {
-		val source = MockConfigurationPropertySource()
-		source.put("foo.string-value", "foo")
+		val source = MockConfigurationPropertySource("foo.string-value", "foo")
 		val binder = Binder(source)
 		val bean = binder.bind("foo", Bindable.of(
 				ExampleValueBean::class.java)).get()
@@ -129,31 +123,28 @@ class KotlinConstructorParametersBinderTests {
 
 	@Test
 	fun `Bind to class with no value for primitive should use default value`() {
-		val source = MockConfigurationPropertySource()
-		source.put("foo.string-value", "foo")
+		val source = MockConfigurationPropertySource("foo.string-value", "foo")
 		val binder = Binder(source)
 		val bean = binder.bind("foo", Bindable.of(
 				ExamplePrimitiveDefaultBean::class.java)).get()
 		assertThat(bean.intValue).isEqualTo(0)
 		assertThat(bean.longValue).isEqualTo(0)
-		assertThat(bean.booleanValue).isFalse()
+		assertThat(bean.booleanValue).isFalse
 		assertThat(bean.stringValue).isEqualTo("foo")
 		assertThat(bean.enumValue).isNull()
 	}
 
 	@Test
 	fun `Bind to class with no value and default value should return unbound`() {
-		val source = MockConfigurationPropertySource()
-		source.put("foo.string-value", "foo")
+		val source = MockConfigurationPropertySource("foo.string-value", "foo")
 		val binder = Binder(source)
 		assertThat(binder.bind("foo", Bindable.of(
-				ExampleDefaultValueBean::class.java)).isBound()).isFalse();
+				ExampleDefaultValueBean::class.java)).isBound).isFalse
 	}
 
 	@Test
 	fun `Bind or create to class with no value and default value should return default value`() {
-		val source = MockConfigurationPropertySource()
-		source.put("foo.string-value", "foo")
+		val source = MockConfigurationPropertySource("foo.string-value", "foo")
 		val binder = Binder(source)
 		val bean = binder.bindOrCreate("foo", Bindable.of(
 				ExampleDefaultValueBean::class.java))
@@ -164,37 +155,43 @@ class KotlinConstructorParametersBinderTests {
 
 	@Test
 	fun `Bind to data class with no value should use default value`() {
-		val source = MockConfigurationPropertySource()
-		source.put("foo.enum-value", "foo-bar")
+		val source = MockConfigurationPropertySource("foo.enum-value", "foo-bar")
 		val binder = Binder(source)
 		val bean = binder.bind("foo", Bindable.of(ExampleDataClassBean::class.java)).get()
-		assertThat(bean.intValue).isEqualTo(5)
-		assertThat(bean.longValue).isEqualTo(42)
-		assertThat(bean.booleanValue).isFalse()
-		assertThat(bean.stringValue).isEqualTo("my data")
-		assertThat(bean.enumValue).isEqualTo(ExampleEnum.FOO_BAR)
+		val expectedBean = ExampleDataClassBean(intValue = 5,
+												longValue = 42,
+												booleanValue = false,
+												stringValue = "my data",
+												enumValue = ExampleEnum.FOO_BAR)
+		assertThat(bean).isEqualTo(expectedBean)
 	}
 
 	@Test
 	fun `Bind to data class with generics`() {
-		val source = MockConfigurationPropertySource()
-		source.put("foo.value.bar", "baz")
+		val source = MockConfigurationPropertySource("foo.value.bar", "baz")
 		val binder = Binder(source)
 		val type = ResolvableType.forClassWithGenerics(Map::class.java, String::class.java,
 				String::class.java)
 		val bean = binder.bind("foo", Bindable
 				.of<GenericValue<Map<String, String>>>(ResolvableType.forClassWithGenerics(GenericValue::class.java, type)))
 				.get()
-		assertThat(bean.value.get("bar")).isEqualTo("baz");
+		assertThat(bean.value["bar"]).isEqualTo("baz")
 	}
 
 	@Test
 	fun `Bind to named constructor parameter`() {
-		val source = MockConfigurationPropertySource()
-		source.put("foo.string-value", "test")
+		val source = MockConfigurationPropertySource("foo.string-value", "test")
 		val binder = Binder(source)
 		val bean = binder.bind("foo", Bindable.of(ExampleNamedParameterBean::class.java)).get()
 		assertThat(bean.stringDataValue).isEqualTo("test")
+	}
+
+	@Test
+	fun `Bind to singleton object`() {
+		val source = MockConfigurationPropertySource("foo.string-value", "test")
+		val binder = Binder(source)
+		val bean = binder.bind("foo", Bindable.of(ExampleSingletonBean::class.java)).get()
+		assertThat(bean.stringValue).isEqualTo("test")
 	}
 
 	class ExampleValueBean(val intValue: Int?, val longValue: Long?,
@@ -244,4 +241,7 @@ class KotlinConstructorParametersBinderTests {
 		val value: T
 	)
 
+	object ExampleSingletonBean {
+		var stringValue: String? = null
+	}
 }


### PR DESCRIPTION
KotlinConstructorParametersBinderTests: 
- Minor enhancements to unit tests
   - Add new constructor for `MockConfigurationPropertySource` with map of configs
   - Inside of `KotlinConstructorParametersBinderTests`, create instances of `MockConfigurationPropertySource` with a map of configs
   - Use Kotlin property access on objects when possible
   - Assert against a whole expected object when validating a data class rather than individual properties of the object (`isEquals()` function is built into the data class)
- Added test case to Kotlin singleton object


Testing:
- Ran `./gradlew :spring-boot-project:spring-boot:test` on project with all tests succeeding

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
