### PR TITLE
Use only non-identifying parameters from last execution for batch with incrementer

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunner.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunner.java
@@ -211,13 +211,13 @@ public class JobLauncherApplicationRunner implements ApplicationRunner, Ordered,
 		}
 		JobParameters nextParameters = new JobParametersBuilder(jobParameters, this.jobExplorer)
 				.getNextJobParameters(job).toJobParameters();
-		return merge(nextParameters, jobParameters);
+		return merge(getIdentifying(nextParameters), jobParameters);
 	}
 
 	private JobParameters getNextJobParametersForExisting(Job job, JobParameters jobParameters) {
 		JobExecution lastExecution = this.jobRepository.getLastJobExecution(job.getName(), jobParameters);
 		if (isStoppedOrFailed(lastExecution) && job.isRestartable()) {
-			JobParameters previousIdentifyingParameters = getGetIdentifying(lastExecution.getJobParameters());
+			JobParameters previousIdentifyingParameters = getIdentifying(lastExecution.getJobParameters());
 			return merge(previousIdentifyingParameters, jobParameters);
 		}
 		return jobParameters;
@@ -228,14 +228,14 @@ public class JobLauncherApplicationRunner implements ApplicationRunner, Ordered,
 		return (status == BatchStatus.STOPPED || status == BatchStatus.FAILED);
 	}
 
-	private JobParameters getGetIdentifying(JobParameters parameters) {
-		HashMap<String, JobParameter> nonIdentifying = new LinkedHashMap<>(parameters.getParameters().size());
+	private JobParameters getIdentifying(JobParameters parameters) {
+		HashMap<String, JobParameter> identifying = new LinkedHashMap<>(parameters.getParameters().size());
 		parameters.getParameters().forEach((key, value) -> {
 			if (value.isIdentifying()) {
-				nonIdentifying.put(key, value);
+				identifying.put(key, value);
 			}
 		});
-		return new JobParameters(nonIdentifying);
+		return new JobParameters(identifying);
 	}
 
 	private JobParameters merge(JobParameters parameters, JobParameters additionals) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunnerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunnerTests.java
@@ -102,8 +102,8 @@ class JobLauncherApplicationRunnerTests {
 			JobLauncherApplicationRunnerContext jobLauncherContext = new JobLauncherApplicationRunnerContext(context);
 			Job job = jobLauncherContext.configureJob().incrementer(new RunIdIncrementer()).build();
 			// start job instance with non-identifying parameter
-			JobParameters nonIdentifyingParameter = new JobParametersBuilder()
-					.addString("foo", "bar", false).toJobParameters();
+			JobParameters nonIdentifyingParameter = new JobParametersBuilder().addString("foo", "bar", false)
+					.toJobParameters();
 			jobLauncherContext.runner.execute(job, nonIdentifyingParameter);
 			// start next job instance without the non-identifying parameter
 			jobLauncherContext.runner.execute(job, new JobParameters());
@@ -111,8 +111,8 @@ class JobLauncherApplicationRunnerTests {
 			List<JobExecution> jobExecutions = jobLauncherContext.jobExecutions();
 			assertThat(jobExecutions).hasSize(2);
 			assertThat(jobExecutions.get(0).getJobParameters().getParameters()).doesNotContainKey("foo");
-			assertThat(jobExecutions.get(1).getJobParameters().getParameters())
-					.containsEntry("foo", new JobParameter("bar", false));
+			assertThat(jobExecutions.get(1).getJobParameters().getParameters()).containsEntry("foo",
+					new JobParameter("bar", false));
 		});
 	}
 
@@ -221,8 +221,7 @@ class JobLauncherApplicationRunnerTests {
 		}
 
 		List<JobExecution> jobExecutions() {
-			return jobInstances().stream()
-					.flatMap(instance -> jobExplorer.getJobExecutions(instance).stream())
+			return jobInstances().stream().flatMap((instance) -> this.jobExplorer.getJobExecutions(instance).stream())
 					.collect(Collectors.toList());
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunnerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunnerTests.java
@@ -18,9 +18,11 @@ package org.springframework.boot.autoconfigure.batch;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
 import javax.sql.DataSource;
 
 import org.junit.jupiter.api.Test;
+
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionException;


### PR DESCRIPTION
### The issue

When the `JobLauncherApplicationRunner` is used to start a Spring Batch job with a `JobParametersIncrementer`, parameter keys that have once been assigned a value cannot be unset without manipulating the history of previous job executions. If a parameter is not explicitly set to something, its value will be recovered from the last job execution (of the job, not the job instance).

This may be desirable for identifying parameters of the job instances but in my opinion not for non-identifying parameters.

### A minimal example

I've written a [minimal example](https://github.com/hpoettker/spring-cloud-task-gh-770/tree/without-task). Originally, I've set up the repository for an analogous issue with Spring Cloud Task: https://github.com/spring-cloud/spring-cloud-task/issues/770 The branch `without-task` uses only Spring Batch and Spring Boot.

First, I start a MySQL container and build the code:
```
$ docker run -p 3306:3306 --name mysql -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=task -d mysql:5.7.25
$ ./gradlew build
```
Then, I start the application twice:
```
$ java -jar build/libs/task-0.0.1-SNAPSHOT.jar foo=bar -yada=yada
$ java -jar build/libs/task-0.0.1-SNAPSHOT.jar foo=bar
```
From the logs, one can see that the second job execution is still started with the non-identifying parameter:
```
o.s.b.a.b.JobLauncherApplicationRunner   : Running default command line with: [foo=bar, -yada=yada]
o.s.b.c.l.support.SimpleJobLauncher      : Job: [SimpleJob: [name=job]] launched with the following parameters: [{run.id=1, yada=yada, foo=bar}]
...
o.s.b.a.b.JobLauncherApplicationRunner   : Running default command line with: [foo=bar]
o.s.b.c.l.support.SimpleJobLauncher      : Job: [SimpleJob: [name=job]] launched with the following parameters: [{run.id=2, yada=yada, foo=bar}]
```
It seems to me that there is no way to ever unset the `yada` parameter without manually removing the corresponding row in the database table for the last job execution which effectively means rewriting history.