### PR TITLE
Move DatabaseSelection to Neo4jClient

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfiguration.java
@@ -94,15 +94,14 @@ public class Neo4jDataAutoConfiguration {
 
 	@Bean(Neo4jRepositoryConfigurationExtension.DEFAULT_NEO4J_CLIENT_BEAN_NAME)
 	@ConditionalOnMissingBean
-	public Neo4jClient neo4jClient(Driver driver) {
-		return Neo4jClient.create(driver);
+	public Neo4jClient neo4jClient(Driver driver, DatabaseSelectionProvider databaseNameProvider) {
+		return Neo4jClient.create(driver, databaseNameProvider);
 	}
 
 	@Bean(Neo4jRepositoryConfigurationExtension.DEFAULT_NEO4J_TEMPLATE_BEAN_NAME)
 	@ConditionalOnMissingBean(Neo4jOperations.class)
-	public Neo4jTemplate neo4jTemplate(Neo4jClient neo4jClient, Neo4jMappingContext neo4jMappingContext,
-			DatabaseSelectionProvider databaseNameProvider) {
-		return new Neo4jTemplate(neo4jClient, neo4jMappingContext, databaseNameProvider);
+	public Neo4jTemplate neo4jTemplate(Neo4jClient neo4jClient, Neo4jMappingContext neo4jMappingContext) {
+		return new Neo4jTemplate(neo4jClient, neo4jMappingContext);
 	}
 
 	@Bean(Neo4jRepositoryConfigurationExtension.DEFAULT_TRANSACTION_MANAGER_BEAN_NAME)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jReactiveDataAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jReactiveDataAutoConfiguration.java
@@ -58,15 +58,16 @@ public class Neo4jReactiveDataAutoConfiguration {
 
 	@Bean(ReactiveNeo4jRepositoryConfigurationExtension.DEFAULT_NEO4J_CLIENT_BEAN_NAME)
 	@ConditionalOnMissingBean
-	public ReactiveNeo4jClient reactiveNeo4jClient(Driver driver) {
+	public ReactiveNeo4jClient reactiveNeo4jClient(Driver driver,
+			ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
 		return ReactiveNeo4jClient.create(driver);
 	}
 
 	@Bean(ReactiveNeo4jRepositoryConfigurationExtension.DEFAULT_NEO4J_TEMPLATE_BEAN_NAME)
 	@ConditionalOnMissingBean(ReactiveNeo4jOperations.class)
 	public ReactiveNeo4jTemplate reactiveNeo4jTemplate(ReactiveNeo4jClient neo4jClient,
-			Neo4jMappingContext neo4jMappingContext, ReactiveDatabaseSelectionProvider databaseNameProvider) {
-		return new ReactiveNeo4jTemplate(neo4jClient, neo4jMappingContext, databaseNameProvider);
+			Neo4jMappingContext neo4jMappingContext) {
+		return new ReactiveNeo4jTemplate(neo4jClient, neo4jMappingContext);
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jReactiveDataAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jReactiveDataAutoConfiguration.java
@@ -59,8 +59,8 @@ public class Neo4jReactiveDataAutoConfiguration {
 	@Bean(ReactiveNeo4jRepositoryConfigurationExtension.DEFAULT_NEO4J_CLIENT_BEAN_NAME)
 	@ConditionalOnMissingBean
 	public ReactiveNeo4jClient reactiveNeo4jClient(Driver driver,
-			ReactiveDatabaseSelectionProvider databaseSelectionProvider) {
-		return ReactiveNeo4jClient.create(driver);
+			ReactiveDatabaseSelectionProvider databaseNameProvider) {
+		return ReactiveNeo4jClient.create(driver, databaseNameProvider);
 	}
 
 	@Bean(ReactiveNeo4jRepositoryConfigurationExtension.DEFAULT_NEO4J_TEMPLATE_BEAN_NAME)


### PR DESCRIPTION
There is an upcoming change in the main branch of Spring Data Neo4j that requires changes in the `Neo4j(Reactive)DataAutoConfiguration`.
Previously the database selection was only supported on the template level and upwards. With the change (https://github.com/spring-projects/spring-data-neo4j/pull/2161) the selection will be already on the `Neo4jClient` level and as a consequence cannot be defined on a higher level (template) anymore.