### PR TITLE
Run spring-boot-cli tasks on Java 16

### DIFF
--- a/spring-boot-project/spring-boot-cli/build.gradle
+++ b/spring-boot-project/spring-boot-cli/build.gradle
@@ -7,10 +7,6 @@ plugins {
 
 description = "Spring Boot CLI"
 
-toolchain {
-	maximumCompatibleJavaVersion = JavaLanguageVersion.of(15)
-}
-
 configurations {
 	dependenciesBom
 	loader


### PR DESCRIPTION
Hi,

this PR removes the `maximumCompatibleJavaVersion` setting from `spring-boot-cli` that was introduced in 2.4.x, because it only supports Groovy 2.x which is not supporting Java 16. On 2.5.x and Groovy 3.x things should be running just fine, though.

Cheers,
Christoph