### PR TITLE
Deprecate FlywayMigrationScriptMissingFailureAnalyzer

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayMigrationScriptMissingFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayMigrationScriptMissingFailureAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,9 @@ import org.springframework.boot.diagnostics.FailureAnalysis;
  *
  * @author Anand Shastri
  * @author Stephane Nicoll
+ * @deprecated since 2.5.0 as location checking is deprecated
  */
+@Deprecated
 class FlywayMigrationScriptMissingFailureAnalyzer
 		extends AbstractFailureAnalyzer<FlywayMigrationScriptMissingException> {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayMigrationScriptMissingFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayMigrationScriptMissingFailureAnalyzerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link FlywayMigrationScriptMissingFailureAnalyzer}.
  *
  * @author Anand Shastri
+ * @deprecated since 2.5.0 as location checking is deprecated
  */
+@Deprecated
 class FlywayMigrationScriptMissingFailureAnalyzerTests {
 
 	@Test


### PR DESCRIPTION
Hi,

the current builds on JDK 8 seem to [fail](https://ci.spring.io/builds/147913)

This PR deprecates `FlywayMigrationScriptMissingFailureAnalyzer` as part of the now deprecated location checking for Flyway.

Cheers,
Christoph