### PR TITLE
Support Maven's reproducible build feature for war repackaging

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Repackager.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Repackager.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.nio.file.attribute.FileTime;
 import java.util.jar.JarFile;
 
-import org.springframework.boot.loader.tools.Layouts.War;
 import org.springframework.util.Assert;
 
 /**
@@ -102,9 +101,6 @@ public class Repackager extends Packager {
 			throws IOException {
 		Assert.isTrue(destination != null && !destination.isDirectory(), "Invalid destination");
 		Layout layout = getLayout(); // get layout early
-		if (lastModifiedTime != null && layout instanceof War) {
-			throw new IllegalStateException("Reproducible repackaging is not supported with war packaging");
-		}
 		destination = destination.getAbsoluteFile();
 		File source = getSource();
 		if (isAlreadyPackaged() && source.equals(destination)) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
@@ -148,7 +148,7 @@ public class RepackageMojo extends AbstractPackagerMojo {
 	/**
 	 * Timestamp for reproducible output archive entries, either formatted as ISO 8601
 	 * (<code>yyyy-MM-dd'T'HH:mm:ssXXX</code>) or an {@code int} representing seconds
-	 * since the epoch. Not supported with war packaging.
+	 * since the epoch.
 	 * @since 2.3.0
 	 */
 	@Parameter(defaultValue = "${project.build.outputTimestamp}")


### PR DESCRIPTION
Support reproducable builds for WAR repackaging.

The Maven WAR plugin was fixed by [MWAR-432](https://issues.apache.org/jira/browse/MWAR-432) and [MWAR-436](https://issues.apache.org/jira/browse/MWAR-436). This has landed in version 3.3.1. Spring Boot already uses this version as of a35073def58fef050136de452051f59b5504e6f0. So, this pull request is just a revert of c4a55a5fb421dadf074fb39eddd542cf29a43deb.