### PR TITLE
Document how to configure Maven's Failsafe plugin when not using spring-boot-starter-parent

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/using.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/using.adoc
@@ -120,7 +120,7 @@ If you are running integration tests with the https://maven.apache.org/surefire/
     </plugin>
 ----
 
-NOTE: When using JDK 11, Failsafe puts the repackaged application JAR on the module-path: `<property name="jdk.module.path" value="/path/to/project/target/MyApplication.jar"/>`. This also can cause a test failure when  not using the Spring Boot Parent POM. To solve, you need to set `<useModulePath>false</useModulePath>` in the `useModulePath` to `false` in the  `<configuration>` section of the `maven-failsafe-plugin` as follows:
+WARNING: When using JDK 11, Failsafe puts the repackaged application JAR on the module-path: `<property name="jdk.module.path" value="/path/to/project/target/MyApplication.jar"/>`. This also can cause a test failure when  not using the Spring Boot Parent POM. To solve, set the `useModulePath` to `false` in the  `<configuration>` section of the `maven-failsafe-plugin` as follows:
 
 [source,xml,indent=0]
 ----

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/using.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/using.adoc
@@ -107,7 +107,7 @@ For instance, to use a different version of the SLF4J library and the Spring Dat
 
 [[failsafe-plugin]]
 === Using Maven Failsafe Plugin without the Spring Boot Parent POM
-When using the Failsafe plugin, the Spring Boot Parent POM by default configures the <classesDirectory> to be ${project.build.outputDirectory}.
+When using the Failsafe plugin, the Spring Boot Parent POM by default configures the `<classesDirectory>` to be `${project.build.outputDirectory}`.
 This configures Failsafe to use the compiled classes rather than the repackaged jar as such:
 
 [source,xml,indent=0]

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/using.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/using.adoc
@@ -107,26 +107,19 @@ For instance, to use a different version of the SLF4J library and the Spring Dat
 
 [[failsafe-plugin]]
 === Using Maven Failsafe Plugin without the Spring Boot Parent POM
-If you are running integration tests with the https://maven.apache.org/surefire/maven-failsafe-plugin/[Maven Failsafe Plugin] while not using the Spring Boot Parent POM, you must be aware that as a default, the Spring Boot Parent POM configures https://maven.apache.org/surefire/maven-failsafe-plugin/integration-test-mojo.html#classesDirectory[<classesDirectory>] to be `${project.build.outputDirectory}`. Without this default setting, Failsafe will put the repackaged application JAR on the classpath, which can cause the integration tests to throw an `java.lang.IllegalStateException`.  To solve, you must configure a classifier for the repackaged jar. This allows Failsafe to use the original jar as follows:
+When using the Failsafe plugin, the Spring Boot Parent POM by default configures the <classesDirectory> to be ${project.build.outputDirectory}.
+This configures Failsafe to use the compiled classes rather than the repackaged jar as such:
 
 [source,xml,indent=0]
 ----
-    <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <classifier>exec</classifier>
-        </configuration>
-    </plugin>
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-failsafe-plugin</artifactId>
+    <configuration>
+        <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+    </configuration>
+</plugin>
 ----
-
-WARNING: When using JDK 11, Failsafe puts the repackaged application JAR on the module-path: `<property name="jdk.module.path" value="/path/to/project/target/MyApplication.jar"/>`. This also can cause a test failure when  not using the Spring Boot Parent POM. To solve, set the `useModulePath` property to `false` in the  `<configuration>` section of the `maven-failsafe-plugin` as follows:
-
-[source,xml,indent=0]
-----
-    <useModulePath>false</useModulePath>
-----
-
 
 
 [[using-overriding-command-line]]

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/using.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/using.adoc
@@ -105,6 +105,28 @@ For instance, to use a different version of the SLF4J library and the Spring Dat
 	</dependencyManagement>
 ----
 
+[[failsafe-plugin]]
+=== Using Maven Failsafe Plugin without the Spring Boot Parent POM
+If you are running integration tests with the https://maven.apache.org/surefire/maven-failsafe-plugin/[Maven Failsafe Plugin] while not using the Spring Boot Parent POM, you must be aware that as a default, the Spring Boot Parent POM configures https://maven.apache.org/surefire/maven-failsafe-plugin/integration-test-mojo.html#classesDirectory[<classesDirectory>] to be `${project.build.outputDirectory}`. Without this default setting, Failsafe will put the repackaged application JAR on the classpath.  To solve, configure a classifier for the repackaged jar. This allows Failsafe to use the original jar as follows:
+
+[source,xml,indent=0]
+----
+    <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+            <classifier>exec</classifier>
+        </configuration>
+    </plugin>
+----
+
+NOTE: When using JDK 11, Failsafe puts the repackaged application JAR on the module-path: `<property name="jdk.module.path" value="/path/to/project/target/MyApplication.jar"/>`. This also can cause a test failure when  not using the Spring Boot Parent POM. To solve, you need to set `<useModulePath>false</useModulePath>` in the `useModulePath` to `false` in the  `<configuration>` section of the `maven-failsafe-plugin` as follows:
+
+[source,xml,indent=0]
+----
+    <useModulePath>false</useModulePath>
+----
+
 
 
 [[using-overriding-command-line]]

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/using.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/using.adoc
@@ -107,7 +107,7 @@ For instance, to use a different version of the SLF4J library and the Spring Dat
 
 [[failsafe-plugin]]
 === Using Maven Failsafe Plugin without the Spring Boot Parent POM
-If you are running integration tests with the https://maven.apache.org/surefire/maven-failsafe-plugin/[Maven Failsafe Plugin] while not using the Spring Boot Parent POM, you must be aware that as a default, the Spring Boot Parent POM configures https://maven.apache.org/surefire/maven-failsafe-plugin/integration-test-mojo.html#classesDirectory[<classesDirectory>] to be `${project.build.outputDirectory}`. Without this default setting, Failsafe will put the repackaged application JAR on the classpath.  To solve, configure a classifier for the repackaged jar. This allows Failsafe to use the original jar as follows:
+If you are running integration tests with the https://maven.apache.org/surefire/maven-failsafe-plugin/[Maven Failsafe Plugin] while not using the Spring Boot Parent POM, you must be aware that as a default, the Spring Boot Parent POM configures https://maven.apache.org/surefire/maven-failsafe-plugin/integration-test-mojo.html#classesDirectory[<classesDirectory>] to be `${project.build.outputDirectory}`. Without this default setting, Failsafe will put the repackaged application JAR on the classpath, which can cause the integration tests to throw an `java.lang.IllegalStateException`.  To solve, you must configure a classifier for the repackaged jar. This allows Failsafe to use the original jar as follows:
 
 [source,xml,indent=0]
 ----
@@ -120,7 +120,7 @@ If you are running integration tests with the https://maven.apache.org/surefire/
     </plugin>
 ----
 
-WARNING: When using JDK 11, Failsafe puts the repackaged application JAR on the module-path: `<property name="jdk.module.path" value="/path/to/project/target/MyApplication.jar"/>`. This also can cause a test failure when  not using the Spring Boot Parent POM. To solve, set the `useModulePath` to `false` in the  `<configuration>` section of the `maven-failsafe-plugin` as follows:
+WARNING: When using JDK 11, Failsafe puts the repackaged application JAR on the module-path: `<property name="jdk.module.path" value="/path/to/project/target/MyApplication.jar"/>`. This also can cause a test failure when  not using the Spring Boot Parent POM. To solve, set the `useModulePath` property to `false` in the  `<configuration>` section of the `maven-failsafe-plugin` as follows:
 
 [source,xml,indent=0]
 ----


### PR DESCRIPTION
A documentation fix for #25473 to document how to configure maven's failsafe plugin when not using spring boot starter parent pom. 