### PR TITLE
Upgrade to Micrometer 1.7.0-M1

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 	optional("io.micrometer:micrometer-registry-signalfx")
 	optional("io.micrometer:micrometer-registry-statsd")
 	optional("io.micrometer:micrometer-registry-wavefront")
+	optional("org.hibernate:hibernate-micrometer")
 	optional("io.projectreactor.netty:reactor-netty-http")
 	optional("io.r2dbc:r2dbc-pool")
 	optional("io.r2dbc:r2dbc-spi")

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/orm/jpa/HibernateMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/orm/jpa/HibernateMetricsAutoConfiguration.java
@@ -23,8 +23,8 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceException;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.jpa.HibernateMetrics;
 import org.hibernate.SessionFactory;
+import org.hibernate.stat.HibernateMetrics;
 
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1178,7 +1178,7 @@ bom {
 			]
 		}
 	}
-	library("Micrometer", "1.6.5") {
+	library("Micrometer", "1.7.0-M1") {
 		group("io.micrometer") {
 			modules = [
 				"micrometer-registry-stackdriver" {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-jpa/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-jpa/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-actuator"))
 
 	runtimeOnly("com.h2database:h2")
+	runtimeOnly("org.hibernate:hibernate-micrometer")
 
 	testImplementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-test"))
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-flyway/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-flyway/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
 	runtimeOnly("com.h2database:h2")
 	runtimeOnly("org.flywaydb:flyway-core")
+	runtimeOnly("org.hibernate:hibernate-micrometer")
 
 	testImplementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-test"))
 }


### PR DESCRIPTION
Micrometer's new milestone release is out ([1.7.0-M1](https://github.com/micrometer-metrics/micrometer/releases/tag/v1.7.0-M1)), this PR upgrades Micrometer (preparing for Boot 2.5.0) and contains the necessary changes for the upgrade.
