### PR TITLE
Upgrade to Java 16 GA builds in CI

### DIFF
--- a/ci/images/get-jdk-url.sh
+++ b/ci/images/get-jdk-url.sh
@@ -12,7 +12,7 @@ case "$1" in
 		 echo "https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_linux_hotspot_15.0.2_7.tar.gz"
 	;;
 	java16)
-		 echo "https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk16-2021-03-09-12-41/OpenJDK16-jdk_x64_linux_hotspot_2021-03-09-12-41.tar.gz"
+		 echo "https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz"
 	;;
   *)
 		echo $"Unknown java version"

--- a/ci/scripts/detect-jdk-updates.sh
+++ b/ci/scripts/detect-jdk-updates.sh
@@ -21,7 +21,7 @@ case "$JDK_VERSION" in
 		 ISSUE_TITLE="Upgrade Java 15 version in CI image"
 	;;
 	java16)
-		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/16/ea"
+		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/16/ga"
 		 ISSUE_TITLE="Upgrade Java 16 version in CI image"
 	;;
 	*)


### PR DESCRIPTION
Hi,

with JDK 16 going GA we can switch to GA builds in the CI environment.

Cheers,
Christoph