### PR TITLE
Support sending metrics to InfluxDB v2

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxProperties.java
@@ -16,10 +16,12 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.influx;
 
+import io.micrometer.influx.InfluxApiVersion;
 import io.micrometer.influx.InfluxConsistency;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link ConfigurationProperties @ConfigurationProperties} for configuring Influx metrics
@@ -33,7 +35,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class InfluxProperties extends StepRegistryProperties {
 
 	/**
-	 * Tag that will be mapped to "host" when shipping metrics to Influx.
+	 * Destination to write metrics when using an InfluxDB 1.x database.
 	 */
 	private String db = "mydb";
 
@@ -92,6 +94,29 @@ public class InfluxProperties extends StepRegistryProperties {
 	 * publish metrics to it.
 	 */
 	private boolean autoCreateDb = true;
+
+	/**
+	 * API version of InfluxDB to use. Defaults to 'v1' unless an org is configured. If an
+	 * org is configured, defaults to 'v2'.
+	 */
+	private InfluxApiVersion apiVersion;
+
+	/**
+	 * InfluxDB v2 org to write metrics.
+	 */
+	private String org;
+
+	/**
+	 * InfluxDB v2 bucket for metrics. Use either the bucket name or ID. Defaults to the
+	 * value of the db property if not set.
+	 */
+	private String bucket;
+
+	/**
+	 * Authentication token to use with calls to the InfluxDB backend. For InfluxDB v1,
+	 * the Bearer scheme is used. For v2, the Token scheme is used.
+	 */
+	private String token;
 
 	public String getDb() {
 		return this.db;
@@ -179,6 +204,44 @@ public class InfluxProperties extends StepRegistryProperties {
 
 	public void setAutoCreateDb(boolean autoCreateDb) {
 		this.autoCreateDb = autoCreateDb;
+	}
+
+	public InfluxApiVersion getApiVersion() {
+		if (this.apiVersion != null) {
+			return this.apiVersion;
+		}
+		return StringUtils.hasText(this.org) ? InfluxApiVersion.V2 : InfluxApiVersion.V1;
+	}
+
+	public void setApiVersion(InfluxApiVersion apiVersion) {
+		this.apiVersion = apiVersion;
+	}
+
+	public String getOrg() {
+		return this.org;
+	}
+
+	public void setOrg(String org) {
+		this.org = org;
+	}
+
+	public String getBucket() {
+		if (this.bucket != null) {
+			return this.bucket;
+		}
+		return this.db;
+	}
+
+	public void setBucket(String bucket) {
+		this.bucket = bucket;
+	}
+
+	public String getToken() {
+		return this.token;
+	}
+
+	public void setToken(String token) {
+		this.token = token;
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxPropertiesConfigAdapter.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.influx;
 
+import io.micrometer.influx.InfluxApiVersion;
 import io.micrometer.influx.InfluxConfig;
 import io.micrometer.influx.InfluxConsistency;
 
@@ -92,6 +93,26 @@ class InfluxPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<
 	@Override
 	public boolean autoCreateDb() {
 		return get(InfluxProperties::isAutoCreateDb, InfluxConfig.super::autoCreateDb);
+	}
+
+	@Override
+	public InfluxApiVersion apiVersion() {
+		return get(InfluxProperties::getApiVersion, InfluxConfig.super::apiVersion);
+	}
+
+	@Override
+	public String org() {
+		return get(InfluxProperties::getOrg, InfluxConfig.super::org);
+	}
+
+	@Override
+	public String bucket() {
+		return get(InfluxProperties::getBucket, InfluxConfig.super::bucket);
+	}
+
+	@Override
+	public String token() {
+		return get(InfluxProperties::getToken, InfluxConfig.super::token);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/influx/InfluxPropertiesTests.java
@@ -46,6 +46,10 @@ class InfluxPropertiesTests extends StepRegistryPropertiesTests {
 		assertThat(properties.getUri()).isEqualTo(config.uri());
 		assertThat(properties.isCompressed()).isEqualTo(config.compressed());
 		assertThat(properties.isAutoCreateDb()).isEqualTo(config.autoCreateDb());
+		assertThat(properties.getApiVersion()).isEqualTo(config.apiVersion());
+		assertThat(properties.getOrg()).isEqualTo(config.org());
+		assertThat(properties.getBucket()).isEqualTo(config.bucket());
+		assertThat(properties.getToken()).isEqualTo(config.token());
 	}
 
 }

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
@@ -1833,7 +1833,8 @@ You should also configure one or more tags to identify the data source to which 
 
 [[production-ready-metrics-export-influx]]
 ==== Influx
-By default, metrics are exported to {micrometer-registry-docs}/influx[Influx] running on your local machine.
+By default, metrics are exported to an {micrometer-registry-docs}/influx[Influx] v1 instance running on your local machine with the default configuration.
+To export metrics to InfluxDB v2, configure the `org`, `bucket`, and authentication `token` for writing metrics.
 The location of the https://www.influxdata.com[Influx server] to use can be provided using:
 
 [source,yaml,indent=0,configprops,configblocks]


### PR DESCRIPTION
Micrometer 1.7.0-M1 adds support for InfluxDB v2 in addition to the existing support for InfluxDB v1. Some concepts have changed in v2. So we need additional properties for users to be able to configure where to write metrics and authenticate via token.

Maybe we want to consider also updating the description of existing properties to note which are specific to v1. What do you think?