### PR TITLE
If at least one couchbase node is connected to the cluster, couchbase is in up the health indicator

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/couchbase/CouchbaseHealth.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/couchbase/CouchbaseHealth.java
@@ -48,7 +48,7 @@ class CouchbaseHealth {
 	}
 
 	private boolean isCouchbaseUp(DiagnosticsResult diagnostics) {
-		return diagnostics.state() == ClusterState.ONLINE;
+		return diagnostics.state() != ClusterState.OFFLINE;
 	}
 
 	private Map<String, Object> describe(EndpointDiagnostics endpointHealth) {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/couchbase/CouchbaseHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/couchbase/CouchbaseHealthIndicatorTests.java
@@ -66,7 +66,7 @@ class CouchbaseHealthIndicatorTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	void couchbaseClusterWithDegradedStateIsUp() {
+	void couchbaseClusterIsUpWhenLeastOneServiceIsConnected() {
 		Cluster cluster = mock(Cluster.class);
 		CouchbaseHealthIndicator healthIndicator = new CouchbaseHealthIndicator(cluster);
 		Map<ServiceType, List<EndpointDiagnostics>> endpoints = Collections.singletonMap(ServiceType.KV,

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/couchbase/CouchbaseReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/couchbase/CouchbaseReactiveHealthIndicatorTests.java
@@ -63,7 +63,7 @@ class CouchbaseReactiveHealthIndicatorTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	void couchbaseClusterWithDegradedStateIsUp() {
+	void couchbaseClusterIsUpWhenLeastOneServiceIsConnected() {
 		Cluster cluster = mock(Cluster.class);
 		CouchbaseReactiveHealthIndicator healthIndicator = new CouchbaseReactiveHealthIndicator(cluster);
 		Map<ServiceType, List<EndpointDiagnostics>> endpoints = Collections.singletonMap(ServiceType.KV,

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/couchbase/CouchbaseReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/couchbase/CouchbaseReactiveHealthIndicatorTests.java
@@ -63,12 +63,33 @@ class CouchbaseReactiveHealthIndicatorTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
+	void couchbaseClusterWithDegradedStateIsUp() {
+		Cluster cluster = mock(Cluster.class);
+		CouchbaseReactiveHealthIndicator healthIndicator = new CouchbaseReactiveHealthIndicator(cluster);
+		Map<ServiceType, List<EndpointDiagnostics>> endpoints = Collections.singletonMap(ServiceType.KV,
+				Arrays.asList(
+						new EndpointDiagnostics(ServiceType.KV, EndpointState.DISCONNECTED, "127.0.0.1", "127.0.0.1",
+								Optional.empty(), Optional.of(1234L), Optional.of("endpoint-1")),
+						new EndpointDiagnostics(ServiceType.KV, EndpointState.CONNECTED, "127.0.0.1", "127.0.0.1",
+								Optional.empty(), Optional.of(1234L), Optional.of("endpoint-2"))));
+		DiagnosticsResult diagnostics = new DiagnosticsResult(endpoints, "test-sdk", "test-id");
+		given(cluster.diagnostics()).willReturn(diagnostics);
+		Health health = healthIndicator.health().block(Duration.ofSeconds(30));
+		assertThat(health.getStatus()).isEqualTo(Status.UP);
+		assertThat(health.getDetails()).containsEntry("sdk", "test-sdk");
+		assertThat(health.getDetails()).containsKey("endpoints");
+		assertThat((List<Map<String, Object>>) health.getDetails().get("endpoints")).hasSize(2);
+		verify(cluster).diagnostics();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
 	void couchbaseClusterIsDown() {
 		Cluster cluster = mock(Cluster.class);
 		CouchbaseReactiveHealthIndicator healthIndicator = new CouchbaseReactiveHealthIndicator(cluster);
 		Map<ServiceType, List<EndpointDiagnostics>> endpoints = Collections.singletonMap(ServiceType.KV,
 				Arrays.asList(
-						new EndpointDiagnostics(ServiceType.KV, EndpointState.CONNECTED, "127.0.0.1", "127.0.0.1",
+						new EndpointDiagnostics(ServiceType.KV, EndpointState.DISCONNECTING, "127.0.0.1", "127.0.0.1",
 								Optional.empty(), Optional.of(1234L), Optional.of("endpoint-1")),
 						new EndpointDiagnostics(ServiceType.KV, EndpointState.CONNECTING, "127.0.0.1", "127.0.0.1",
 								Optional.empty(), Optional.of(1234L), Optional.of("endpoint-2"))));


### PR DESCRIPTION
In the couchbase java sdk [documentation](https://docs.couchbase.com/java-sdk/current/howtos/health-check.html), the cluster state diagnostic is specified as degraded when at least one node is connected.
However, cluster state is expected online for couchbase health indicator in method isCouchbaseUp in class CouchbaseHealth and this makes the application look unhealthy while couchbase is at least operational.
