### PR TITLE
Autoconfiguring mogo metrics listeners

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoCommandListenerClientSettingsBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoCommandListenerClientSettingsBuilderCustomizer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.mongo;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.event.CommandListener;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Adds {@link CommandListener} instances to {@link MongoClientSettings} through
+ * {@link MongoClientSettingsBuilderCustomizer}.
+ *
+ * @author Jonatan Ivanov
+ * @since 2.5.0
+ */
+public class MongoCommandListenerClientSettingsBuilderCustomizer implements MongoClientSettingsBuilderCustomizer {
+
+	private final Iterable<CommandListener> commandListeners;
+
+	public MongoCommandListenerClientSettingsBuilderCustomizer(@NonNull Iterable<CommandListener> commandListeners) {
+		this.commandListeners = commandListeners;
+	}
+
+	@Override
+	public void customize(MongoClientSettings.Builder clientSettingsBuilder) {
+		for (CommandListener commandListener : this.commandListeners) {
+			clientSettingsBuilder.addCommandListener(commandListener);
+		}
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoConnectionPoolListenerClientSettingsBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoConnectionPoolListenerClientSettingsBuilderCustomizer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.mongo;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.event.ConnectionPoolListener;
+
+import org.springframework.lang.NonNull;
+
+/**
+ * Adds {@link ConnectionPoolListener} instances to {@link MongoClientSettings} through
+ * {@link MongoClientSettingsBuilderCustomizer}.
+ *
+ * @author Jonatan Ivanov
+ * @since 2.5.0
+ */
+public class MongoConnectionPoolListenerClientSettingsBuilderCustomizer
+		implements MongoClientSettingsBuilderCustomizer {
+
+	private final Iterable<ConnectionPoolListener> connectionPoolListeners;
+
+	public MongoConnectionPoolListenerClientSettingsBuilderCustomizer(
+			@NonNull Iterable<ConnectionPoolListener> connectionPoolListeners) {
+		this.connectionPoolListeners = connectionPoolListeners;
+	}
+
+	@Override
+	public void customize(MongoClientSettings.Builder clientSettingsBuilder) {
+		for (ConnectionPoolListener connectionPoolListener : this.connectionPoolListeners) {
+			clientSettingsBuilder.applyToConnectionPoolSettings(
+					(builder) -> builder.addConnectionPoolListener(connectionPoolListener));
+		}
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoCommandListenerClientSettingsBuilderCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoCommandListenerClientSettingsBuilderCustomizerTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.mongo;
+
+import java.util.List;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.event.CommandListener;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MongoCommandListenerClientSettingsBuilderCustomizer}.
+ *
+ * @author Jonatan Ivanov
+ */
+class MongoCommandListenerClientSettingsBuilderCustomizerTests {
+
+	@Test
+	void shouldNotSetUpAnyCommandListeners() {
+		MongoClientSettings mongoClientSettings = buildAndCustomizeMongoClientSettings(Lists.list());
+		assertThat(mongoClientSettings.getCommandListeners()).isEmpty();
+	}
+
+	@Test
+	void shouldSetUpCommandListeners() {
+		List<CommandListener> commandListeners = Lists.list(createCommandListener(), createCommandListener(),
+				createCommandListener());
+		MongoClientSettings mongoClientSettings = buildAndCustomizeMongoClientSettings(commandListeners);
+		assertThat(mongoClientSettings.getCommandListeners()).isEqualTo(commandListeners);
+	}
+
+	private MongoClientSettings buildAndCustomizeMongoClientSettings(List<CommandListener> listeners) {
+		MongoClientSettings.Builder builder = MongoClientSettings.builder();
+		new MongoCommandListenerClientSettingsBuilderCustomizer(listeners).customize(builder);
+
+		return builder.build();
+	}
+
+	private CommandListener createCommandListener() {
+		return new CommandListener() {
+		};
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoConnectionPoolListenerClientSettingsBuilderCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoConnectionPoolListenerClientSettingsBuilderCustomizerTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.mongo;
+
+import java.util.List;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.connection.ConnectionPoolSettings;
+import com.mongodb.event.ConnectionPoolListener;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MongoConnectionPoolListenerClientSettingsBuilderCustomizer}.
+ *
+ * @author Jonatan Ivanov
+ */
+public class MongoConnectionPoolListenerClientSettingsBuilderCustomizerTests {
+
+	@Test
+	void shouldNotSetUpAnyConnectionPoolListeners() {
+		ConnectionPoolSettings connectionPoolSettings = buildAndCustomizeMongoClientSettings(Lists.list());
+		assertThat(connectionPoolSettings.getConnectionPoolListeners()).isEmpty();
+	}
+
+	@Test
+	void shouldSetUpConnectionPoolListeners() {
+		List<ConnectionPoolListener> connectionPoolListeners = Lists.list(createConnectionPoolListener(),
+				createConnectionPoolListener(), createConnectionPoolListener());
+		ConnectionPoolSettings connectionPoolSettings = buildAndCustomizeMongoClientSettings(connectionPoolListeners);
+		assertThat(connectionPoolSettings.getConnectionPoolListeners()).isEqualTo(connectionPoolListeners);
+	}
+
+	private ConnectionPoolSettings buildAndCustomizeMongoClientSettings(List<ConnectionPoolListener> listeners) {
+		MongoClientSettings.Builder builder = MongoClientSettings.builder();
+		new MongoConnectionPoolListenerClientSettingsBuilderCustomizer(listeners).customize(builder);
+
+		return builder.build().getConnectionPoolSettings();
+	}
+
+	private ConnectionPoolListener createConnectionPoolListener() {
+		return new ConnectionPoolListener() {
+		};
+	}
+
+}


### PR DESCRIPTION
Autoconfiguring Micrometer support for MongoDB, also autoconfiguring their tag provider support added in 1.7.0, see:
- https://github.com/micrometer-metrics/micrometer/pull/2360
- https://github.com/micrometer-metrics/micrometer/pull/2437