### PR TITLE
DefaultErrorWebExceptionHandler does not remove MetaType.ALL when a quality values is present

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandler.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandler.java
@@ -252,7 +252,7 @@ public class DefaultErrorWebExceptionHandler extends AbstractErrorWebExceptionHa
 		return (serverRequest) -> {
 			try {
 				List<MediaType> acceptedMediaTypes = serverRequest.headers().accept();
-				acceptedMediaTypes.remove(MediaType.ALL);
+				acceptedMediaTypes.removeIf((mediaType) -> MediaType.ALL.equalsTypeAndSubtype(mediaType));
 				MediaType.sortBySpecificityAndQuality(acceptedMediaTypes);
 				return acceptedMediaTypes.stream().anyMatch(MediaType.TEXT_HTML::isCompatibleWith);
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandlerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandlerTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.web.reactive.error;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -28,9 +29,12 @@ import org.springframework.boot.web.reactive.context.AnnotationConfigReactiveWeb
 import org.springframework.boot.web.reactive.error.ErrorAttributes;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.result.view.View;
 import org.springframework.web.reactive.result.view.ViewResolver;
 import org.springframework.web.server.ServerWebExchange;
@@ -84,6 +88,23 @@ class DefaultErrorWebExceptionHandlerTests {
 		ViewResolver viewResolver = mock(ViewResolver.class);
 		given(viewResolver.resolveViewName(any(), any())).willReturn(Mono.just(view));
 		exceptionHandler.setViewResolvers(Collections.singletonList(viewResolver));
+	}
+
+	@Test
+	void acceptsTextHtmlShouldNotConsiderMediaAllEvenWithQuality() {
+		ErrorAttributes errorAttributes = mock(ErrorAttributes.class);
+		Resources resourceProperties = new Resources();
+		ErrorProperties errorProperties = new ErrorProperties();
+		ApplicationContext context = new AnnotationConfigReactiveWebApplicationContext();
+		DefaultErrorWebExceptionHandler exceptionHandler = new DefaultErrorWebExceptionHandler(errorAttributes,
+				resourceProperties, errorProperties, context);
+		MediaType allWithQuality = new MediaType(MediaType.ALL.getType(), MediaType.ALL.getSubtype(), 0.9);
+		MockServerWebExchange exchange = MockServerWebExchange
+				.from(MockServerHttpRequest.get("/test").accept(allWithQuality));
+		List<HttpMessageReader<?>> readers = ServerCodecConfigurer.create().getReaders();
+		ServerRequest request = ServerRequest.create(exchange, readers);
+		boolean accepts = exceptionHandler.acceptsTextHtml().test(request);
+		assertThat(accepts).isFalse();
 	}
 
 }


### PR DESCRIPTION
The "match-all" media type is not properly ignored if it has a quality value, showing HTML content if accept header is, for example, `application/json, */*;q=0.9`.

The broken behaviour is rendering different content depending on the presence of a quality value and the fix ignores quality property while comparing media types.

```bash
$ curl -H "Accept: application/json, */*" http://localhost:8080/api
{"timestamp":"2021-03-24T03:38:37.888+00:00","path":"/api","status":404,
"error":"Not Found","message":null,"requestId":"c621637c-1"}⌅

$ curl -H "Accept: application/json, */*;q=0.9" http://localhost:8080/api
<html><body><h1>Whitelabel Error Page</h1><p>This application has no configured error view,
so you are seeing this as a fallback.</p><div id='created'>Wed Mar 24 00:38:41 BRT 2021</div>
<div>[14552d94-1] There was an unexpected error (type=Not Found, status=404).</div></body></html>⌅
```
