### PR TITLE
When running with a context hierarchy, PrimaryDefaultValidatorPostProcessor causes a NoSuchBeanDefinitionException when a Validator is in an ancestor context

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/PrimaryDefaultValidatorPostProcessor.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/PrimaryDefaultValidatorPostProcessor.java
@@ -20,6 +20,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -81,9 +82,13 @@ class PrimaryDefaultValidatorPostProcessor implements ImportBeanDefinitionRegist
 		String[] validatorBeans = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(this.beanFactory, Validator.class,
 				false, false);
 		for (String validatorBean : validatorBeans) {
-			BeanDefinition definition = registry.getBeanDefinition(validatorBean);
-			if (definition != null && definition.isPrimary()) {
-				return true;
+			try {
+				BeanDefinition definition = registry.getBeanDefinition(validatorBean);
+				if (definition.isPrimary()) {
+					return true;
+				}
+			}
+			catch (NoSuchBeanDefinitionException ignored) {
 			}
 		}
 		return false;


### PR DESCRIPTION
When `BeanDefinitionRegistry.getBeanDefinition()` is called it will throw `NoSuchBeanDefinitionException` which will cause failure. To fix this, try-catch was introduced and the null check was removed since the method will never return null.

Relevant to:
https://github.com/awspring/spring-cloud-aws/issues/101

