### PR TITLE
Increase test coverage on Java 16

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/toolchain/ToolchainPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/toolchain/ToolchainPlugin.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.tasks.GradleBuild;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
@@ -57,8 +56,8 @@ public class ToolchainPlugin implements Plugin<Project> {
 			JavaToolchainSpec toolchainSpec = project.getExtensions().getByType(JavaPluginExtension.class)
 					.getToolchain();
 			toolchainSpec.getLanguageVersion().set(toolchain.getJavaVersion());
-			configureJavaCompileToolchain(project, toolchain);
-			configureTestToolchain(project, toolchain);
+			configureJavaCompileToolchain(project);
+			configureTestToolchain(project);
 		}
 	}
 
@@ -71,10 +70,9 @@ public class ToolchainPlugin implements Plugin<Project> {
 		project.getTasks().withType(JavaCompile.class, (task) -> task.setEnabled(false));
 		project.getTasks().withType(Javadoc.class, (task) -> task.setEnabled(false));
 		project.getTasks().withType(Test.class, (task) -> task.setEnabled(false));
-		project.getTasks().withType(GradleBuild.class, (task) -> task.setEnabled(false));
 	}
 
-	private void configureJavaCompileToolchain(Project project, ToolchainExtension toolchain) {
+	private void configureJavaCompileToolchain(Project project) {
 		project.getTasks().withType(JavaCompile.class, (compile) -> {
 			compile.getOptions().setFork(true);
 			// See https://github.com/gradle/gradle/issues/15538
@@ -83,7 +81,7 @@ public class ToolchainPlugin implements Plugin<Project> {
 		});
 	}
 
-	private void configureTestToolchain(Project project, ToolchainExtension toolchain) {
+	private void configureTestToolchain(Project project) {
 		project.getTasks().withType(Test.class, (test) -> {
 			// See https://github.com/spring-projects/spring-ldap/issues/570
 			List<String> arguments = Arrays.asList("--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED",

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
@@ -10,10 +10,6 @@ plugins {
 
 description = "Spring Boot Gradle Plugin"
 
-toolchain {
-	maximumCompatibleJavaVersion = JavaLanguageVersion.of(15)
-}
-
 configurations {
 	documentation
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/docs/PublishingDocumentationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/docs/PublishingDocumentationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.springframework.boot.gradle.docs;
 import java.io.IOException;
 
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.boot.gradle.junit.GradleMultiDslExtension;
@@ -37,6 +39,7 @@ class PublishingDocumentationTests {
 
 	GradleBuild gradleBuild;
 
+	@DisabledForJreRange(min = JRE.JAVA_16)
 	@TestTemplate
 	void mavenUpload() throws IOException {
 		assertThat(this.gradleBuild.expectDeprecationWarningsWithAtLeastVersion("5.6")

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleCompatibilityExtension.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleCompatibilityExtension.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.gradle.api.JavaVersion;
 import org.gradle.util.GradleVersion;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.Extension;
@@ -42,8 +43,17 @@ import org.springframework.util.StringUtils;
  */
 final class GradleCompatibilityExtension implements TestTemplateInvocationContextProvider {
 
-	private static final List<String> GRADLE_VERSIONS = Arrays.asList("6.3", "6.4.1", "6.5.1", "6.6.1", "6.7.1",
-			"current", "7.0-rc-1");
+	private static final List<String> GRADLE_VERSIONS;
+
+	static {
+		JavaVersion javaVersion = JavaVersion.current();
+		if (javaVersion.isCompatibleWith(JavaVersion.VERSION_16)) {
+			GRADLE_VERSIONS = Arrays.asList("7.0-rc-1");
+		}
+		else {
+			GRADLE_VERSIONS = Arrays.asList("6.3", "6.4.1", "6.5.1", "6.6.1", "6.7.1", "current", "7.0-rc-1");
+		}
+	}
 
 	@Override
 	public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleMultiDslExtension.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleMultiDslExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.gradle.api.JavaVersion;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -59,7 +60,12 @@ public class GradleMultiDslExtension implements TestTemplateInvocationContextPro
 
 		@Override
 		public List<Extension> getAdditionalExtensions() {
-			return Arrays.asList(new GradleBuildFieldSetter(new GradleBuild(this.dsl)), new GradleBuildExtension());
+			GradleBuild gradleBuild = new GradleBuild(this.dsl);
+			JavaVersion javaVersion = JavaVersion.current();
+			if (javaVersion.isCompatibleWith(JavaVersion.VERSION_16)) {
+				gradleBuild.gradleVersion("7.0-rc-1");
+			}
+			return Arrays.asList(new GradleBuildFieldSetter(gradleBuild), new GradleBuildExtension());
 		}
 
 		@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/MavenPluginActionIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/MavenPluginActionIntegrationTests.java
@@ -17,6 +17,8 @@
 package org.springframework.boot.gradle.plugin;
 
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import org.springframework.boot.gradle.junit.GradleCompatibility;
 import org.springframework.boot.gradle.testkit.GradleBuild;
@@ -28,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Andy Wilkinson
  */
+@DisabledForJreRange(min = JRE.JAVA_16)
 @GradleCompatibility(versionsLessThan = "7.0-milestone-1")
 class MavenPluginActionIntegrationTests {
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/SpringBootPluginIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/SpringBootPluginIntegrationTests.java
@@ -45,6 +45,7 @@ class SpringBootPluginIntegrationTests {
 				.contains("Spring Boot plugin requires Gradle 6 (6.3 or later). The current version is Gradle 6.2.2");
 	}
 
+	@DisabledForJreRange(min = JRE.JAVA_16)
 	@Test
 	void succeedWithVersionOfGradle6MatchingWithIsRequired() {
 		this.gradleBuild.gradleVersion("6.3").build();

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/MavenIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/MavenIntegrationTests.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import org.springframework.boot.gradle.junit.GradleCompatibility;
 import org.springframework.boot.gradle.testkit.GradleBuild;
@@ -34,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Andy Wilkinson
  */
+@DisabledForJreRange(min = JRE.JAVA_16)
 @GradleCompatibility(versionsLessThan = "7.0-milestone-1")
 class MavenIntegrationTests {
 

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/build.gradle
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/build.gradle
@@ -6,10 +6,6 @@ plugins {
 
 description = "Spring Boot Launch Script Integration Tests"
 
-toolchain {
-	maximumCompatibleJavaVersion = JavaLanguageVersion.of(15)
-}
-
 configurations {
 	app
 }

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-loader-tests/build.gradle
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-loader-tests/build.gradle
@@ -6,10 +6,6 @@ plugins {
 
 description = "Spring Boot Loader Integration Tests"
 
-toolchain {
-	maximumCompatibleJavaVersion = JavaLanguageVersion.of(15)
-}
-
 configurations {
 	app
 }


### PR DESCRIPTION
Hi,

after a chat with @wilkinsona about Gradle 7 in 2.5.x it became apparent that it might be a little late to do this once it's out. As only Gradle 7 is supporting Java 16 at the moment, I went ahead and removed the remaining `maximumCompatibleJavaVersion` configurations from the build in favor of this PR, which mainly includes more `DisabledForJreRange` usages.

Let me know what you think.
Cheers,
Christoph