### PR TITLE
Add additional profiles into environment when legacy processing is used

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -154,6 +154,7 @@ import org.springframework.web.context.support.StandardServletEnvironment;
  * @author Madhura Bhave
  * @author Brian Clozel
  * @author Ethan Rubinson
+ * @author Nguyen Bao Sach
  * @since 1.0.0
  * @see #run(Class, String[])
  * @see #run(Class[], String[])
@@ -373,7 +374,6 @@ public class SpringApplication {
 		ConfigurationPropertySources.attach(environment);
 		listeners.environmentPrepared(bootstrapContext, environment);
 		DefaultPropertiesPropertySource.moveToEnd(environment);
-		configureAdditionalProfiles(environment);
 		Assert.state(!environment.containsProperty("spring.main.environment-prefix"),
 				"Environment prefix cannot be set via properties.");
 		bindToSpringApplication(environment);
@@ -556,16 +556,6 @@ public class SpringApplication {
 	 * @see org.springframework.boot.context.config.ConfigFileApplicationListener
 	 */
 	protected void configureProfiles(ConfigurableEnvironment environment, String[] args) {
-	}
-
-	private void configureAdditionalProfiles(ConfigurableEnvironment environment) {
-		if (!CollectionUtils.isEmpty(this.additionalProfiles)) {
-			Set<String> profiles = new LinkedHashSet<>(Arrays.asList(environment.getActiveProfiles()));
-			if (!profiles.containsAll(this.additionalProfiles)) {
-				profiles.addAll(this.additionalProfiles);
-				environment.setActiveProfiles(StringUtils.toStringArray(profiles));
-			}
-		}
 	}
 
 	private void configureIgnoreBeanInfo(ConfigurableEnvironment environment) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessor.java
@@ -19,6 +19,8 @@ package org.springframework.boot.context.config;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.apache.commons.logging.Log;
@@ -34,6 +36,8 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.log.LogMessage;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link EnvironmentPostProcessor} that loads and applies {@link ConfigData} to Spring's
@@ -41,6 +45,7 @@ import org.springframework.core.log.LogMessage;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Nguyen Bao Sach
  * @since 2.4.0
  */
 public class ConfigDataEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
@@ -99,6 +104,7 @@ public class ConfigDataEnvironmentPostProcessor implements EnvironmentPostProces
 		catch (UseLegacyConfigProcessingException ex) {
 			this.logger.debug(LogMessage.format("Switching to legacy config file processing [%s]",
 					ex.getConfigurationProperty()));
+			configureAdditionalProfiles(environment, additionalProfiles);
 			postProcessUsingLegacyApplicationListener(environment, resourceLoader);
 		}
 	}
@@ -107,6 +113,15 @@ public class ConfigDataEnvironmentPostProcessor implements EnvironmentPostProces
 			Collection<String> additionalProfiles) {
 		return new ConfigDataEnvironment(this.logFactory, this.bootstrapContext, environment, resourceLoader,
 				additionalProfiles, this.environmentUpdateListener);
+	}
+
+	private void configureAdditionalProfiles(ConfigurableEnvironment environment,
+			Collection<String> additionalProfiles) {
+		if (!CollectionUtils.isEmpty(additionalProfiles)) {
+			Set<String> profiles = new LinkedHashSet<>(additionalProfiles);
+			profiles.addAll(Arrays.asList(environment.getActiveProfiles()));
+			environment.setActiveProfiles(StringUtils.toStringArray(profiles));
+		}
 	}
 
 	private void postProcessUsingLegacyApplicationListener(ConfigurableEnvironment environment,

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
@@ -147,6 +147,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  * @author Brian Clozel
  * @author Artsiom Yudovin
  * @author Marten Deinum
+ * @author Nguyen Bao Sach
  */
 @ExtendWith(OutputCaptureExtension.class)
 class SpringApplicationTests {
@@ -601,6 +602,17 @@ class SpringApplicationTests {
 		application.setEnvironment(environment);
 		this.context = application.run("--spring.profiles.active=bar,spam");
 		// Since Boot 2.4 additional should always be last
+		assertThat(environment.getActiveProfiles()).containsExactly("bar", "spam", "foo");
+	}
+
+	@Test
+	void includeProfilesOrder() {
+		SpringApplication application = new SpringApplication(ExampleConfig.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+		ConfigurableEnvironment environment = new StandardEnvironment();
+		application.setEnvironment(environment);
+		this.context = application.run("--spring.profiles.active=bar,spam", "--spring.profiles.include=foo");
+		// Since Boot 2.4 included profiles should always be last
 		assertThat(environment.getActiveProfiles()).containsExactly("bar", "spam", "foo");
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileApplicationListenerLegacyReproTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigFileApplicationListenerLegacyReproTests.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Phillip Webb
  * @author Dave Syer
+ * @author Nguyen Bao Sach
  */
 @ExtendWith(UseLegacyProcessing.class)
 class ConfigFileApplicationListenerLegacyReproTests {
@@ -165,6 +166,17 @@ class ConfigFileApplicationListenerLegacyReproTests {
 		String configName = "--spring.config.name=activeprofilerepro-without-override";
 		this.context = application.run(configName, "--spring.profiles.active=C,A");
 		assertVersionProperty(this.context, "A", "C", "A");
+	}
+
+	@Test
+	void additionalProfilesViaProgrammaticallySetting() {
+		// gh-25704
+		SpringApplication application = new SpringApplication(Config.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+		application.setAdditionalProfiles("dev");
+		this.context = application.run();
+		assertThat(this.context.getEnvironment().acceptsProfiles(Profiles.of("dev"))).isTrue();
+		assertThat(this.context.getEnvironment().getProperty("my.property")).isEqualTo("fromdevpropertiesfile");
 	}
 
 	private void assertVersionProperty(ConfigurableApplicationContext context, String expectedVersion,


### PR DESCRIPTION
In post-processing the given environment of ConfigDataEnvironmentPostProcessor, add SpringApplication's additional profiles that are set programmatically into the given environment when legacy processing is used.

This commit updates the following areas:

- Add configureAdditionalProfiles method into ConfigDataEnvironmentPostProcessor, that add the additional profiles into the given environment.

- When legacy processing is used, call configureAdditionalProfiles method to add the additional profiles into the given environment.

- Remove unnecessary configureAdditionalProfiles method in SpringApplication.

- Supplement unit test for SpringApplicationTests.

Fixes https://github.com/spring-projects/spring-boot/issues/25704
Fixes https://github.com/spring-projects/spring-boot/issues/26189