### PR TITLE
Add detection of Azure App Service to CloudPlatform

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
@@ -48,7 +48,7 @@ public enum CloudPlatform {
 	/**
 	 * Azure App Service platform.
 	 */
-	AZURE {
+	AZURE_APP_SERVICE {
 
 		@Override
 		public boolean isDetected(Environment environment) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
@@ -46,6 +46,18 @@ public enum CloudPlatform {
 	},
 
 	/**
+	 * Azure App Service platform.
+	 */
+	AZURE {
+
+		@Override
+		public boolean isDetected(Environment environment) {
+			return environment.containsProperty("WEBSITE_SITE_NAME");
+		}
+
+	},
+
+	/**
 	 * Cloud Foundry platform.
 	 */
 	CLOUD_FOUNDRY {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
@@ -17,7 +17,11 @@
 package org.springframework.boot.cloud;
 
 import org.springframework.boot.context.properties.bind.Binder;
-import org.springframework.core.env.*;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
 
 /**
  * Simple detection for well known cloud platforms. Detection can be forced using the

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
@@ -17,11 +17,7 @@
 package org.springframework.boot.cloud;
 
 import org.springframework.boot.context.properties.bind.Binder;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.EnumerablePropertySource;
-import org.springframework.core.env.Environment;
-import org.springframework.core.env.PropertySource;
-import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.*;
 
 /**
  * Simple detection for well known cloud platforms. Detection can be forced using the
@@ -50,9 +46,14 @@ public enum CloudPlatform {
 	 */
 	AZURE_APP_SERVICE {
 
+		private static final String WEBSITE_SITE_NAME = "WEBSITE_SITE_NAME";
+
+		private static final String WEBSITES_ENABLE_APP_SERVICE_STORAGE = "WEBSITES_ENABLE_APP_SERVICE_STORAGE";
+
 		@Override
 		public boolean isDetected(Environment environment) {
-			return environment.containsProperty("WEBSITE_SITE_NAME");
+			return environment.containsProperty(WEBSITE_SITE_NAME) &&
+					environment.containsProperty(WEBSITES_ENABLE_APP_SERVICE_STORAGE);
 		}
 
 	},

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
@@ -52,8 +52,8 @@ public enum CloudPlatform {
 
 		@Override
 		public boolean isDetected(Environment environment) {
-			return environment.containsProperty(WEBSITE_SITE_NAME) &&
-					environment.containsProperty(WEBSITES_ENABLE_APP_SERVICE_STORAGE);
+			return environment.containsProperty(WEBSITE_SITE_NAME)
+					&& environment.containsProperty(WEBSITES_ENABLE_APP_SERVICE_STORAGE);
 		}
 
 	},

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
@@ -53,7 +53,7 @@ class CloudPlatformTests {
 	}
 
 	@Test
-	void getActiveWhenHasWebsiteSiteNameShouldReturnAzureAppService() {
+	void getActiveWhenHasWebsiteSiteNameAndWebsitesEnableAppServiceStorageShouldReturnAzureAppService() {
 		Map<String, Object> envVars = new HashMap<>();
 		envVars.put("WEBSITE_SITE_NAME", "---");
 		envVars.put("WEBSITES_ENABLE_APP_SERVICE_STORAGE", "false");
@@ -61,6 +61,22 @@ class CloudPlatformTests {
 		CloudPlatform platform = CloudPlatform.getActive(environment);
 		assertThat(platform).isEqualTo(CloudPlatform.AZURE_APP_SERVICE);
 		assertThat(platform.isActive(environment)).isTrue();
+	}
+
+	@Test
+	void getActiveWhenHasWebsiteSiteNameShouldReturnNull() {
+		Environment environment = getEnvironmentWithEnvVariables(
+				Collections.singletonMap("WEBSITE_SITE_NAME", "---"));
+		CloudPlatform platform = CloudPlatform.getActive(environment);
+		assertThat(platform).isNull();
+	}
+
+	@Test
+	void getActiveWhenHasWebsitesEnableAppServiceStorageShouldReturnNull() {
+		Environment environment = getEnvironmentWithEnvVariables(
+				Collections.singletonMap("WEBSITES_ENABLE_APP_SERVICE_STORAGE", "---"));
+		CloudPlatform platform = CloudPlatform.getActive(environment);
+		assertThat(platform).isNull();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
@@ -53,7 +53,7 @@ class CloudPlatformTests {
 	}
 
 	@Test
-	void getActiveWhenHasDynoShouldReturnAzure() {
+	void getActiveWhenHasWebsiteSiteNameShouldReturnAzureAppService() {
 		Environment environment = new MockEnvironment().withProperty("WEBSITE_SITE_NAME", "---");
 		CloudPlatform platform = CloudPlatform.getActive(environment);
 		assertThat(platform).isEqualTo(CloudPlatform.AZURE);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
@@ -56,7 +56,7 @@ class CloudPlatformTests {
 	void getActiveWhenHasWebsiteSiteNameShouldReturnAzureAppService() {
 		Environment environment = new MockEnvironment().withProperty("WEBSITE_SITE_NAME", "---");
 		CloudPlatform platform = CloudPlatform.getActive(environment);
-		assertThat(platform).isEqualTo(CloudPlatform.AZURE);
+		assertThat(platform).isEqualTo(CloudPlatform.AZURE_APP_SERVICE);
 		assertThat(platform.isActive(environment)).isTrue();
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
@@ -54,7 +54,10 @@ class CloudPlatformTests {
 
 	@Test
 	void getActiveWhenHasWebsiteSiteNameShouldReturnAzureAppService() {
-		Environment environment = new MockEnvironment().withProperty("WEBSITE_SITE_NAME", "---");
+		Map<String, Object> envVars = new HashMap<>();
+		envVars.put("WEBSITE_SITE_NAME", "---");
+		envVars.put("WEBSITES_ENABLE_APP_SERVICE_STORAGE", "false");
+		Environment environment = getEnvironmentWithEnvVariables(envVars);
 		CloudPlatform platform = CloudPlatform.getActive(environment);
 		assertThat(platform).isEqualTo(CloudPlatform.AZURE_APP_SERVICE);
 		assertThat(platform.isActive(environment)).isTrue();

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
@@ -50,7 +50,14 @@ class CloudPlatformTests {
 		Environment environment = new MockEnvironment();
 		CloudPlatform platform = CloudPlatform.getActive(environment);
 		assertThat(platform).isNull();
+	}
 
+	@Test
+	void getActiveWhenHasDynoShouldReturnAzure() {
+		Environment environment = new MockEnvironment().withProperty("WEBSITE_SITE_NAME", "---");
+		CloudPlatform platform = CloudPlatform.getActive(environment);
+		assertThat(platform).isEqualTo(CloudPlatform.AZURE);
+		assertThat(platform.isActive(environment)).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
__Add Azure platform support to Spring Boot.__

More specifically, this adds "Azure App Service" support to Spring Boot - as this is the Azure standard PaaS service, it makes sense to give it the "AZURE" enum name. If it provides any additional value, we can add later Azure Functions and Azure Spring Cloud, but those shouldn't be the default and would have their own enumeration name, as they work very differently.

This discovers Azure using [the "WEBSITE_SITE_NAME" environment properties](https://stackoverflow.com/questions/25678419/how-to-check-if-code-is-running-on-azure-websites), which is similar to what is done with Heroku (using the "DYNO" environment property).

I put Azure near the top of the file, trying to have some alphabetical sorting after "NONE", as I believe this is how people will read that class.

As a consequence, setting this value should put `server.forward-headers-strategy=native` by default, which will allow applications to receive sensitive security headers from the reverse proxy. More specifically, this will solve this error, when using Active Directory to secure App Service, which looks pretty common: https://stackoverflow.com/questions/60365017/redirect-url-for-spring-oauth2-app-on-azure-with-active-directory-invalid-redir


