### PR TITLE
log4j2(xml) configuration enhancement, support <SpringProfile> tag

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import ch.qos.logback.classic.joran.JoranConfigurator;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Marker;
@@ -64,6 +63,7 @@ import org.springframework.util.StringUtils;
  * @author Andy Wilkinson
  * @author Alexander Heusingfeld
  * @author Ben Hale
+ * @author xin jiang
  * @since 1.2.0
  */
 public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
@@ -168,10 +168,10 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 	@Override
 	protected void loadDefaults(LoggingInitializationContext initializationContext, LogFile logFile) {
 		if (logFile != null) {
-			loadConfigurationInternal(initializationContext,getPackagedConfigFile("log4j2-file.xml"), logFile);
+			loadConfigurationInternal(initializationContext, getPackagedConfigFile("log4j2-file.xml"), logFile);
 		}
 		else {
-			loadConfiguration(initializationContext,getPackagedConfigFile("log4j2.xml"), logFile);
+			loadConfiguration(initializationContext, getPackagedConfigFile("log4j2.xml"), logFile);
 		}
 	}
 
@@ -179,10 +179,11 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 	protected void loadConfiguration(LoggingInitializationContext initializationContext, String location,
 			LogFile logFile) {
 		super.loadConfiguration(initializationContext, location, logFile);
-		loadConfiguration(initializationContext,location, logFile);
+		loadConfiguration(initializationContext, location, logFile);
 	}
 
-	protected void loadConfigurationInternal(LoggingInitializationContext initializationContext,String location, LogFile logFile) {
+	protected void loadConfigurationInternal(LoggingInitializationContext initializationContext, String location,
+			LogFile logFile) {
 		Assert.notNull(location, "Location must not be null");
 		try {
 			LoggerContext ctx = getLoggerContext();
@@ -190,8 +191,9 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 			ConfigurationSource source = getConfigurationSource(url);
 			Configuration configuration;
 			if (url.toString().endsWith("xml")) {
-				configuration = new SpringBootXmlConfiguration(initializationContext,ctx, source);
-			}else{
+				configuration = new SpringBootXmlConfiguration(initializationContext, ctx, source);
+			}
+			else {
 				configuration = ConfigurationFactory.getInstance().getConfiguration(ctx, source);
 			}
 			ctx.start(configuration);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -63,7 +63,7 @@ import org.springframework.util.StringUtils;
  * @author Andy Wilkinson
  * @author Alexander Heusingfeld
  * @author Ben Hale
- * @author xin jiang
+ * @author Kong Wu
  * @since 1.2.0
  */
 public class Log4J2LoggingSystem extends Slf4JLoggingSystem {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/SpringBootXmlConfiguration.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/SpringBootXmlConfiguration.java
@@ -1,0 +1,398 @@
+package org.springframework.boot.logging.log4j2;
+
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.*;
+import org.apache.logging.log4j.core.config.plugins.util.PluginType;
+import org.apache.logging.log4j.core.config.plugins.util.ResolverUtil;
+import org.apache.logging.log4j.core.config.status.StatusConfiguration;
+import org.apache.logging.log4j.core.util.Closer;
+import org.apache.logging.log4j.core.util.Loader;
+import org.apache.logging.log4j.core.util.Patterns;
+import org.apache.logging.log4j.core.util.Throwables;
+import org.springframework.boot.logging.LoggingInitializationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.*;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class SpringBootXmlConfiguration extends AbstractConfiguration implements Reconfigurable {
+	private LoggingInitializationContext initializationContext;
+	private Environment environment;
+	/**
+	 * Constructor.
+	 *
+	 * @param loggerContext
+	 * @param configurationSource
+	 */
+	private static final String XINCLUDE_FIXUP_LANGUAGE =
+			"http://apache.org/xml/features/xinclude/fixup-language";
+	private static final String XINCLUDE_FIXUP_BASE_URIS =
+			"http://apache.org/xml/features/xinclude/fixup-base-uris";
+	private static final String[] VERBOSE_CLASSES = new String[] {ResolverUtil.class.getName()};
+	private static final String LOG4J_XSD = "Log4j-config.xsd";
+
+	private static final String SPRING_PROFILE_TAG_NAME = "SpringProfile";
+
+	private final List<Status> status = new ArrayList<>();
+	private Element rootElement;
+	private boolean strict;
+	private String schemaResource;
+
+	/**
+	 * Add a initializationContext construct parameter
+	 */
+	public SpringBootXmlConfiguration(final LoggingInitializationContext initializationContext, final LoggerContext loggerContext, final ConfigurationSource configSource) {
+		super(loggerContext, configSource);
+		this.initializationContext = initializationContext;
+		this.environment = initializationContext.getEnvironment();
+		final File configFile = configSource.getFile();
+		byte[] buffer = null;
+
+		try {
+			final InputStream configStream = configSource.getInputStream();
+			try {
+				buffer = toByteArray(configStream);
+			} finally {
+				Closer.closeSilently(configStream);
+			}
+			final InputSource source = new InputSource(new ByteArrayInputStream(buffer));
+			source.setSystemId(configSource.getLocation());
+			final DocumentBuilder documentBuilder = newDocumentBuilder(true);
+			Document document;
+			try {
+				document = documentBuilder.parse(source);
+			} catch (final Exception e) {
+				// LOG4J2-1127
+				final Throwable throwable = Throwables.getRootCause(e);
+				if (throwable instanceof UnsupportedOperationException) {
+					LOGGER.warn(
+							"The DocumentBuilder {} does not support an operation: {}."
+									+ "Trying again without XInclude...",
+							documentBuilder, e);
+					document = newDocumentBuilder(false).parse(source);
+				} else {
+					throw e;
+				}
+			}
+			rootElement = document.getDocumentElement();
+			final Map<String, String> attrs = processAttributes(rootNode, rootElement);
+			final StatusConfiguration statusConfig = new StatusConfiguration().withVerboseClasses(VERBOSE_CLASSES)
+					.withStatus(getDefaultStatus());
+			int monitorIntervalSeconds = 0;
+			for (final Map.Entry<String, String> entry : attrs.entrySet()) {
+				final String key = entry.getKey();
+				final String value = getStrSubstitutor().replace(entry.getValue());
+				if ("status".equalsIgnoreCase(key)) {
+					statusConfig.withStatus(value);
+				} else if ("dest".equalsIgnoreCase(key)) {
+					statusConfig.withDestination(value);
+				} else if ("shutdownHook".equalsIgnoreCase(key)) {
+					isShutdownHookEnabled = !"disable".equalsIgnoreCase(value);
+				} else if ("shutdownTimeout".equalsIgnoreCase(key)) {
+					shutdownTimeoutMillis = Long.parseLong(value);
+				} else if ("verbose".equalsIgnoreCase(key)) {
+					statusConfig.withVerbosity(value);
+				} else if ("packages".equalsIgnoreCase(key)) {
+					pluginPackages.addAll(Arrays.asList(value.split(Patterns.COMMA_SEPARATOR)));
+				} else if ("name".equalsIgnoreCase(key)) {
+					setName(value);
+				} else if ("strict".equalsIgnoreCase(key)) {
+					strict = Boolean.parseBoolean(value);
+				} else if ("schema".equalsIgnoreCase(key)) {
+					schemaResource = value;
+				} else if ("monitorInterval".equalsIgnoreCase(key)) {
+					monitorIntervalSeconds = Integer.parseInt(value);
+				} else if ("advertiser".equalsIgnoreCase(key)) {
+					createAdvertiser(value, configSource, buffer, "text/xml");
+				}
+			}
+			initializeWatchers(this, configSource, monitorIntervalSeconds);
+			statusConfig.initialize();
+		} catch (final SAXException | IOException | ParserConfigurationException e) {
+			LOGGER.error("Error parsing " + configSource.getLocation(), e);
+		}
+		if (strict && schemaResource != null && buffer != null) {
+			try (InputStream is = Loader.getResourceAsStream(schemaResource, SpringBootXmlConfiguration.class.getClassLoader())) {
+				if (is != null) {
+					final javax.xml.transform.Source src = new StreamSource(is, LOG4J_XSD);
+					final SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+					Schema schema = null;
+					try {
+						schema = factory.newSchema(src);
+					} catch (final SAXException ex) {
+						LOGGER.error("Error parsing Log4j schema", ex);
+					}
+					if (schema != null) {
+						final Validator validator = schema.newValidator();
+						try {
+							validator.validate(new StreamSource(new ByteArrayInputStream(buffer)));
+						} catch (final IOException ioe) {
+							LOGGER.error("Error reading configuration for validation", ioe);
+						} catch (final SAXException ex) {
+							LOGGER.error("Error validating configuration", ex);
+						}
+					}
+				}
+			} catch (final Exception ex) {
+				LOGGER.error("Unable to access schema {}", this.schemaResource, ex);
+			}
+		}
+
+		if (getName() == null) {
+			setName(configSource.getLocation());
+		}
+	}
+
+	/**
+	 * Creates a new DocumentBuilder suitable for parsing a configuration file.
+	 *
+	 * @param xIncludeAware enabled XInclude
+	 * @return a new DocumentBuilder
+	 * @throws ParserConfigurationException
+	 */
+	static DocumentBuilder newDocumentBuilder(final boolean xIncludeAware) throws ParserConfigurationException {
+		final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		factory.setNamespaceAware(true);
+
+		disableDtdProcessing(factory);
+
+		if (xIncludeAware) {
+			enableXInclude(factory);
+		}
+		return factory.newDocumentBuilder();
+	}
+
+	private static void disableDtdProcessing(final DocumentBuilderFactory factory) {
+		factory.setValidating(false);
+		factory.setExpandEntityReferences(false);
+		setFeature(factory, "http://xml.org/sax/features/external-general-entities", false);
+		setFeature(factory, "http://xml.org/sax/features/external-parameter-entities", false);
+		setFeature(factory, "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+	}
+
+	private static void setFeature(final DocumentBuilderFactory factory, final String featureName, final boolean value) {
+		try {
+			factory.setFeature(featureName, value);
+		} catch (Exception | LinkageError e) {
+			getStatusLogger().error("Caught {} setting feature {} to {} on DocumentBuilderFactory {}: {}",
+					e.getClass().getCanonicalName(), featureName, value, factory, e, e);
+		}
+	}
+
+	/**
+	 * Enables XInclude for the given DocumentBuilderFactory
+	 *
+	 * @param factory a DocumentBuilderFactory
+	 */
+	private static void enableXInclude(final DocumentBuilderFactory factory) {
+		try {
+			// Alternative: We set if a system property on the command line is set, for example:
+			// -DLog4j.XInclude=true
+			factory.setXIncludeAware(true);
+		} catch (final UnsupportedOperationException e) {
+			LOGGER.warn("The DocumentBuilderFactory [{}] does not support XInclude: {}", factory, e);
+		} catch (@SuppressWarnings("ErrorNotRethrown") final AbstractMethodError | NoSuchMethodError err) {
+			LOGGER.warn("The DocumentBuilderFactory [{}] is out of date and does not support XInclude: {}", factory,
+					err);
+		}
+		try {
+			// Alternative: We could specify all features and values with system properties like:
+			// -DLog4j.DocumentBuilderFactory.Feature="http://apache.org/xml/features/xinclude/fixup-base-uris true"
+			factory.setFeature(XINCLUDE_FIXUP_BASE_URIS, true);
+		} catch (final ParserConfigurationException e) {
+			LOGGER.warn("The DocumentBuilderFactory [{}] does not support the feature [{}]: {}", factory,
+					XINCLUDE_FIXUP_BASE_URIS, e);
+		} catch (@SuppressWarnings("ErrorNotRethrown") final AbstractMethodError err) {
+			LOGGER.warn("The DocumentBuilderFactory [{}] is out of date and does not support setFeature: {}", factory,
+					err);
+		}
+		try {
+			factory.setFeature(XINCLUDE_FIXUP_LANGUAGE, true);
+		} catch (final ParserConfigurationException e) {
+			LOGGER.warn("The DocumentBuilderFactory [{}] does not support the feature [{}]: {}", factory,
+					XINCLUDE_FIXUP_LANGUAGE, e);
+		} catch (@SuppressWarnings("ErrorNotRethrown") final AbstractMethodError err) {
+			LOGGER.warn("The DocumentBuilderFactory [{}] is out of date and does not support setFeature: {}", factory,
+					err);
+		}
+	}
+
+	@Override
+	public void setup() {
+		if (rootElement == null) {
+			LOGGER.error("No logging configuration");
+			return;
+		}
+		constructHierarchy(rootNode, rootElement,false);
+		if (status.size() > 0) {
+			for (final Status s : status) {
+				LOGGER.error("Error processing element {} ({}): {}", s.name, s.element, s.errorType);
+			}
+			return;
+		}
+		rootElement = null;
+	}
+
+	@Override
+	public Configuration reconfigure() {
+		try {
+			final ConfigurationSource source = getConfigurationSource().resetInputStream();
+			if (source == null) {
+				return null;
+			}
+			final SpringBootXmlConfiguration config = new SpringBootXmlConfiguration(initializationContext,getLoggerContext(), source);
+			return config.rootElement == null ? null : config;
+		} catch (final IOException ex) {
+			LOGGER.error("Cannot locate file {}", getConfigurationSource(), ex);
+		}
+		return null;
+	}
+
+	private void constructHierarchy(final Node node, final Element element, boolean profileNode) {
+		if(!profileNode){
+			processAttributes(node,element);
+		}
+		final StringBuilder buffer = new StringBuilder();
+		final NodeList list = element.getChildNodes();
+		final List<Node> children = node.getChildren();
+		for (int i = 0; i < list.getLength(); i++) {
+			final org.w3c.dom.Node w3cNode = list.item(i);
+			if (w3cNode instanceof Element) {
+				final Element child = (Element) w3cNode;
+
+				final String name = getType(child);
+
+				// Enhance log4j2.xml configuration
+				if(SPRING_PROFILE_TAG_NAME.equalsIgnoreCase(name)){
+					if(acceptsProfiles(child.getAttribute("name"))){
+						constructHierarchy(node, child, true);
+					}
+					// Break <SpringProfile> node
+					continue;
+				}
+				final PluginType<?> type = pluginManager.getPluginType(name);
+				final Node childNode = new Node(node, name, type);
+				constructHierarchy(childNode, child, false);
+				if (type == null) {
+					final String value = childNode.getValue();
+					if (!childNode.hasChildren() && value != null) {
+						node.getAttributes().put(name, value);
+					} else {
+						status.add(new Status(name, element, ErrorType.CLASS_NOT_FOUND));
+					}
+				} else {
+					children.add(childNode);
+				}
+			} else if (w3cNode instanceof Text) {
+				final Text data = (Text) w3cNode;
+				buffer.append(data.getData());
+			}
+		}
+
+		final String text = buffer.toString().trim();
+		if (text.length() > 0 || (!node.hasChildren() && !node.isRoot())) {
+			node.setValue(text);
+		}
+	}
+
+	private boolean acceptsProfiles(String profile) {
+		if (this.environment == null) {
+			return false;
+		}
+		String[] profileNames = StringUtils
+				.trimArrayElements(StringUtils.commaDelimitedListToStringArray(profile));
+		if (profileNames.length == 0) {
+			return false;
+		}
+		return this.environment.acceptsProfiles(Profiles.of(profileNames));
+	}
+
+	private String getType(final Element element) {
+		if (strict) {
+			final NamedNodeMap attrs = element.getAttributes();
+			for (int i = 0; i < attrs.getLength(); ++i) {
+				final org.w3c.dom.Node w3cNode = attrs.item(i);
+				if (w3cNode instanceof Attr) {
+					final Attr attr = (Attr) w3cNode;
+					if (attr.getName().equalsIgnoreCase("type")) {
+						final String type = attr.getValue();
+						attrs.removeNamedItem(attr.getName());
+						return type;
+					}
+				}
+			}
+		}
+		return element.getTagName();
+	}
+
+	private Map<String, String> processAttributes(final Node node, final Element element) {
+		final NamedNodeMap attrs = element.getAttributes();
+		final Map<String, String> attributes = node.getAttributes();
+
+		for (int i = 0; i < attrs.getLength(); ++i) {
+			final org.w3c.dom.Node w3cNode = attrs.item(i);
+			if (w3cNode instanceof Attr) {
+				final Attr attr = (Attr) w3cNode;
+				if (attr.getName().equals("xml:base")) {
+					continue;
+				}
+				attributes.put(attr.getName(), attr.getValue());
+			}
+		}
+		return attributes;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + "[location=" + getConfigurationSource() + "]";
+	}
+
+	/**
+	 * The error that occurred.
+	 */
+	private enum ErrorType {
+		CLASS_NOT_FOUND
+	}
+
+	/**
+	 * Status for recording errors.
+	 */
+	private static class Status {
+		private final Element element;
+		private final String name;
+		private final ErrorType errorType;
+
+		public Status(final String name, final Element element, final ErrorType errorType) {
+			this.name = name;
+			this.element = element;
+			this.errorType = errorType;
+		}
+
+		@Override
+		public String toString() {
+			return "Status [name=" + name + ", element=" + element + ", errorType=" + errorType + "]";
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/SpringBootXmlConfiguration.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/SpringBootXmlConfiguration.java
@@ -1,22 +1,28 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.logging.log4j2;
 
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Node;
-import org.apache.logging.log4j.core.config.*;
-import org.apache.logging.log4j.core.config.plugins.util.PluginType;
-import org.apache.logging.log4j.core.config.plugins.util.ResolverUtil;
-import org.apache.logging.log4j.core.config.status.StatusConfiguration;
-import org.apache.logging.log4j.core.util.Closer;
-import org.apache.logging.log4j.core.util.Loader;
-import org.apache.logging.log4j.core.util.Patterns;
-import org.apache.logging.log4j.core.util.Throwables;
-import org.springframework.boot.logging.LoggingInitializationContext;
-import org.springframework.core.env.Environment;
-import org.springframework.core.env.Profiles;
-import org.springframework.util.StringUtils;
-import org.w3c.dom.*;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
@@ -26,53 +32,77 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.AbstractConfiguration;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.Reconfigurable;
+import org.apache.logging.log4j.core.config.plugins.util.PluginType;
+import org.apache.logging.log4j.core.config.plugins.util.ResolverUtil;
+import org.apache.logging.log4j.core.config.status.StatusConfiguration;
+import org.apache.logging.log4j.core.util.Closer;
+import org.apache.logging.log4j.core.util.Loader;
+import org.apache.logging.log4j.core.util.Patterns;
+import org.apache.logging.log4j.core.util.Throwables;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import org.springframework.boot.logging.LoggingInitializationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.util.StringUtils;
+
+/**
+ * Extended version of the Log4j2 XmlConfiguration that adds additional Spring Boot rules.
+ *
+ * @author Kong Wu
+ * @since 2.4.4
+ */
 public class SpringBootXmlConfiguration extends AbstractConfiguration implements Reconfigurable {
-	private LoggingInitializationContext initializationContext;
-	private Environment environment;
-	/**
-	 * Constructor.
-	 *
-	 * @param loggerContext
-	 * @param configurationSource
-	 */
-	private static final String XINCLUDE_FIXUP_LANGUAGE =
-			"http://apache.org/xml/features/xinclude/fixup-language";
-	private static final String XINCLUDE_FIXUP_BASE_URIS =
-			"http://apache.org/xml/features/xinclude/fixup-base-uris";
-	private static final String[] VERBOSE_CLASSES = new String[] {ResolverUtil.class.getName()};
+
+	private static final String XINCLUDE_FIXUP_LANGUAGE = "http://apache.org/xml/features/xinclude/fixup-language";
+
+	private static final String XINCLUDE_FIXUP_BASE_URIS = "http://apache.org/xml/features/xinclude/fixup-base-uris";
+
+	private static final String[] VERBOSE_CLASSES = new String[] { ResolverUtil.class.getName() };
+
 	private static final String LOG4J_XSD = "Log4j-config.xsd";
 
 	private static final String SPRING_PROFILE_TAG_NAME = "SpringProfile";
 
+	private final LoggingInitializationContext initializationContext;
+
+	private final Environment environment;
+
 	private final List<Status> status = new ArrayList<>();
+
 	private Element rootElement;
+
 	private boolean strict;
+
 	private String schemaResource;
 
-	/**
-	 * Add a initializationContext construct parameter
-	 */
-	public SpringBootXmlConfiguration(final LoggingInitializationContext initializationContext, final LoggerContext loggerContext, final ConfigurationSource configSource) {
+	public SpringBootXmlConfiguration(final LoggingInitializationContext initializationContext,
+			final LoggerContext loggerContext, final ConfigurationSource configSource) {
 		super(loggerContext, configSource);
 		this.initializationContext = initializationContext;
 		this.environment = initializationContext.getEnvironment();
-		final File configFile = configSource.getFile();
 		byte[] buffer = null;
 
 		try {
 			final InputStream configStream = configSource.getInputStream();
 			try {
 				buffer = toByteArray(configStream);
-			} finally {
+			}
+			finally {
 				Closer.closeSilently(configStream);
 			}
 			final InputSource source = new InputSource(new ByteArrayInputStream(buffer));
@@ -81,21 +111,21 @@ public class SpringBootXmlConfiguration extends AbstractConfiguration implements
 			Document document;
 			try {
 				document = documentBuilder.parse(source);
-			} catch (final Exception e) {
+			}
+			catch (final Exception ex) {
 				// LOG4J2-1127
-				final Throwable throwable = Throwables.getRootCause(e);
-				if (throwable instanceof UnsupportedOperationException) {
-					LOGGER.warn(
-							"The DocumentBuilder {} does not support an operation: {}."
-									+ "Trying again without XInclude...",
-							documentBuilder, e);
+				final Throwable e = Throwables.getRootCause(ex);
+				if (e instanceof UnsupportedOperationException) {
+					LOGGER.warn("The DocumentBuilder {} does not support an operation: {}."
+							+ "Trying again without XInclude...", documentBuilder, ex);
 					document = newDocumentBuilder(false).parse(source);
-				} else {
-					throw e;
+				}
+				else {
+					throw ex;
 				}
 			}
-			rootElement = document.getDocumentElement();
-			final Map<String, String> attrs = processAttributes(rootNode, rootElement);
+			this.rootElement = document.getDocumentElement();
+			final Map<String, String> attrs = processAttributes(this.rootNode, this.rootElement);
 			final StatusConfiguration statusConfig = new StatusConfiguration().withVerboseClasses(VERBOSE_CLASSES)
 					.withStatus(getDefaultStatus());
 			int monitorIntervalSeconds = 0;
@@ -104,56 +134,72 @@ public class SpringBootXmlConfiguration extends AbstractConfiguration implements
 				final String value = getStrSubstitutor().replace(entry.getValue());
 				if ("status".equalsIgnoreCase(key)) {
 					statusConfig.withStatus(value);
-				} else if ("dest".equalsIgnoreCase(key)) {
+				}
+				else if ("dest".equalsIgnoreCase(key)) {
 					statusConfig.withDestination(value);
-				} else if ("shutdownHook".equalsIgnoreCase(key)) {
-					isShutdownHookEnabled = !"disable".equalsIgnoreCase(value);
-				} else if ("shutdownTimeout".equalsIgnoreCase(key)) {
-					shutdownTimeoutMillis = Long.parseLong(value);
-				} else if ("verbose".equalsIgnoreCase(key)) {
+				}
+				else if ("shutdownHook".equalsIgnoreCase(key)) {
+					this.isShutdownHookEnabled = !"disable".equalsIgnoreCase(value);
+				}
+				else if ("shutdownTimeout".equalsIgnoreCase(key)) {
+					this.shutdownTimeoutMillis = Long.parseLong(value);
+				}
+				else if ("verbose".equalsIgnoreCase(key)) {
 					statusConfig.withVerbosity(value);
-				} else if ("packages".equalsIgnoreCase(key)) {
-					pluginPackages.addAll(Arrays.asList(value.split(Patterns.COMMA_SEPARATOR)));
-				} else if ("name".equalsIgnoreCase(key)) {
+				}
+				else if ("packages".equalsIgnoreCase(key)) {
+					this.pluginPackages.addAll(Arrays.asList(value.split(Patterns.COMMA_SEPARATOR)));
+				}
+				else if ("name".equalsIgnoreCase(key)) {
 					setName(value);
-				} else if ("strict".equalsIgnoreCase(key)) {
-					strict = Boolean.parseBoolean(value);
-				} else if ("schema".equalsIgnoreCase(key)) {
-					schemaResource = value;
-				} else if ("monitorInterval".equalsIgnoreCase(key)) {
+				}
+				else if ("strict".equalsIgnoreCase(key)) {
+					this.strict = Boolean.parseBoolean(value);
+				}
+				else if ("schema".equalsIgnoreCase(key)) {
+					this.schemaResource = value;
+				}
+				else if ("monitorInterval".equalsIgnoreCase(key)) {
 					monitorIntervalSeconds = Integer.parseInt(value);
-				} else if ("advertiser".equalsIgnoreCase(key)) {
+				}
+				else if ("advertiser".equalsIgnoreCase(key)) {
 					createAdvertiser(value, configSource, buffer, "text/xml");
 				}
 			}
 			initializeWatchers(this, configSource, monitorIntervalSeconds);
 			statusConfig.initialize();
-		} catch (final SAXException | IOException | ParserConfigurationException e) {
-			LOGGER.error("Error parsing " + configSource.getLocation(), e);
 		}
-		if (strict && schemaResource != null && buffer != null) {
-			try (InputStream is = Loader.getResourceAsStream(schemaResource, SpringBootXmlConfiguration.class.getClassLoader())) {
+		catch (final SAXException | IOException | ParserConfigurationException ex) {
+			LOGGER.error("Error parsing " + configSource.getLocation(), ex);
+		}
+		if (this.strict && this.schemaResource != null && buffer != null) {
+			try (InputStream is = Loader.getResourceAsStream(this.schemaResource,
+					SpringBootXmlConfiguration.class.getClassLoader())) {
 				if (is != null) {
 					final javax.xml.transform.Source src = new StreamSource(is, LOG4J_XSD);
 					final SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
 					Schema schema = null;
 					try {
 						schema = factory.newSchema(src);
-					} catch (final SAXException ex) {
+					}
+					catch (final SAXException ex) {
 						LOGGER.error("Error parsing Log4j schema", ex);
 					}
 					if (schema != null) {
 						final Validator validator = schema.newValidator();
 						try {
 							validator.validate(new StreamSource(new ByteArrayInputStream(buffer)));
-						} catch (final IOException ioe) {
+						}
+						catch (final IOException ioe) {
 							LOGGER.error("Error reading configuration for validation", ioe);
-						} catch (final SAXException ex) {
+						}
+						catch (final SAXException ex) {
 							LOGGER.error("Error validating configuration", ex);
 						}
 					}
 				}
-			} catch (final Exception ex) {
+			}
+			catch (final Exception ex) {
 				LOGGER.error("Unable to access schema {}", this.schemaResource, ex);
 			}
 		}
@@ -165,10 +211,8 @@ public class SpringBootXmlConfiguration extends AbstractConfiguration implements
 
 	/**
 	 * Creates a new DocumentBuilder suitable for parsing a configuration file.
-	 *
 	 * @param xIncludeAware enabled XInclude
 	 * @return a new DocumentBuilder
-	 * @throws ParserConfigurationException
 	 */
 	static DocumentBuilder newDocumentBuilder(final boolean xIncludeAware) throws ParserConfigurationException {
 		final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -190,48 +234,58 @@ public class SpringBootXmlConfiguration extends AbstractConfiguration implements
 		setFeature(factory, "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 	}
 
-	private static void setFeature(final DocumentBuilderFactory factory, final String featureName, final boolean value) {
+	private static void setFeature(final DocumentBuilderFactory factory, final String featureName,
+			final boolean value) {
 		try {
 			factory.setFeature(featureName, value);
-		} catch (Exception | LinkageError e) {
+		}
+		catch (Exception | LinkageError ex) {
 			getStatusLogger().error("Caught {} setting feature {} to {} on DocumentBuilderFactory {}: {}",
-					e.getClass().getCanonicalName(), featureName, value, factory, e, e);
+					ex.getClass().getCanonicalName(), featureName, value, factory, ex, ex);
 		}
 	}
 
 	/**
-	 * Enables XInclude for the given DocumentBuilderFactory
-	 *
+	 * Enables XInclude for the given DocumentBuilderFactory.
 	 * @param factory a DocumentBuilderFactory
 	 */
 	private static void enableXInclude(final DocumentBuilderFactory factory) {
 		try {
-			// Alternative: We set if a system property on the command line is set, for example:
+			// Alternative: We set if a system property on the command line is set, for
+			// example:
 			// -DLog4j.XInclude=true
 			factory.setXIncludeAware(true);
-		} catch (final UnsupportedOperationException e) {
-			LOGGER.warn("The DocumentBuilderFactory [{}] does not support XInclude: {}", factory, e);
-		} catch (@SuppressWarnings("ErrorNotRethrown") final AbstractMethodError | NoSuchMethodError err) {
+		}
+		catch (final UnsupportedOperationException ex) {
+			LOGGER.warn("The DocumentBuilderFactory [{}] does not support XInclude: {}", factory, ex);
+		}
+		catch (@SuppressWarnings("ErrorNotRethrown") final AbstractMethodError | NoSuchMethodError err) {
 			LOGGER.warn("The DocumentBuilderFactory [{}] is out of date and does not support XInclude: {}", factory,
 					err);
 		}
 		try {
-			// Alternative: We could specify all features and values with system properties like:
-			// -DLog4j.DocumentBuilderFactory.Feature="http://apache.org/xml/features/xinclude/fixup-base-uris true"
+			// Alternative: We could specify all features and values with system
+			// properties like:
+			// -DLog4j.DocumentBuilderFactory.Feature="http://apache.org/xml/features/xinclude/fixup-base-uris
+			// true"
 			factory.setFeature(XINCLUDE_FIXUP_BASE_URIS, true);
-		} catch (final ParserConfigurationException e) {
+		}
+		catch (final ParserConfigurationException ex) {
 			LOGGER.warn("The DocumentBuilderFactory [{}] does not support the feature [{}]: {}", factory,
-					XINCLUDE_FIXUP_BASE_URIS, e);
-		} catch (@SuppressWarnings("ErrorNotRethrown") final AbstractMethodError err) {
+					XINCLUDE_FIXUP_BASE_URIS, ex);
+		}
+		catch (@SuppressWarnings("ErrorNotRethrown") final AbstractMethodError err) {
 			LOGGER.warn("The DocumentBuilderFactory [{}] is out of date and does not support setFeature: {}", factory,
 					err);
 		}
 		try {
 			factory.setFeature(XINCLUDE_FIXUP_LANGUAGE, true);
-		} catch (final ParserConfigurationException e) {
+		}
+		catch (final ParserConfigurationException ex) {
 			LOGGER.warn("The DocumentBuilderFactory [{}] does not support the feature [{}]: {}", factory,
-					XINCLUDE_FIXUP_LANGUAGE, e);
-		} catch (@SuppressWarnings("ErrorNotRethrown") final AbstractMethodError err) {
+					XINCLUDE_FIXUP_LANGUAGE, ex);
+		}
+		catch (@SuppressWarnings("ErrorNotRethrown") final AbstractMethodError err) {
 			LOGGER.warn("The DocumentBuilderFactory [{}] is out of date and does not support setFeature: {}", factory,
 					err);
 		}
@@ -239,18 +293,18 @@ public class SpringBootXmlConfiguration extends AbstractConfiguration implements
 
 	@Override
 	public void setup() {
-		if (rootElement == null) {
+		if (this.rootElement == null) {
 			LOGGER.error("No logging configuration");
 			return;
 		}
-		constructHierarchy(rootNode, rootElement,false);
-		if (status.size() > 0) {
-			for (final Status s : status) {
+		constructHierarchy(this.rootNode, this.rootElement, false);
+		if (this.status.size() > 0) {
+			for (final Status s : this.status) {
 				LOGGER.error("Error processing element {} ({}): {}", s.name, s.element, s.errorType);
 			}
 			return;
 		}
-		rootElement = null;
+		this.rootElement = null;
 	}
 
 	@Override
@@ -260,17 +314,19 @@ public class SpringBootXmlConfiguration extends AbstractConfiguration implements
 			if (source == null) {
 				return null;
 			}
-			final SpringBootXmlConfiguration config = new SpringBootXmlConfiguration(initializationContext,getLoggerContext(), source);
-			return config.rootElement == null ? null : config;
-		} catch (final IOException ex) {
+			final SpringBootXmlConfiguration config = new SpringBootXmlConfiguration(this.initializationContext,
+					getLoggerContext(), source);
+			return (config.rootElement == null) ? null : config;
+		}
+		catch (final IOException ex) {
 			LOGGER.error("Cannot locate file {}", getConfigurationSource(), ex);
 		}
 		return null;
 	}
 
 	private void constructHierarchy(final Node node, final Element element, boolean profileNode) {
-		if(!profileNode){
-			processAttributes(node,element);
+		if (!profileNode) {
+			processAttributes(node, element);
 		}
 		final StringBuilder buffer = new StringBuilder();
 		final NodeList list = element.getChildNodes();
@@ -283,8 +339,8 @@ public class SpringBootXmlConfiguration extends AbstractConfiguration implements
 				final String name = getType(child);
 
 				// Enhance log4j2.xml configuration
-				if(SPRING_PROFILE_TAG_NAME.equalsIgnoreCase(name)){
-					if(acceptsProfiles(child.getAttribute("name"))){
+				if (SPRING_PROFILE_TAG_NAME.equalsIgnoreCase(name)) {
+					if (acceptsProfiles(child.getAttribute("name"))) {
 						constructHierarchy(node, child, true);
 					}
 					// Break <SpringProfile> node
@@ -297,13 +353,16 @@ public class SpringBootXmlConfiguration extends AbstractConfiguration implements
 					final String value = childNode.getValue();
 					if (!childNode.hasChildren() && value != null) {
 						node.getAttributes().put(name, value);
-					} else {
-						status.add(new Status(name, element, ErrorType.CLASS_NOT_FOUND));
 					}
-				} else {
+					else {
+						this.status.add(new Status(name, element, ErrorType.CLASS_NOT_FOUND));
+					}
+				}
+				else {
 					children.add(childNode);
 				}
-			} else if (w3cNode instanceof Text) {
+			}
+			else if (w3cNode instanceof Text) {
 				final Text data = (Text) w3cNode;
 				buffer.append(data.getData());
 			}
@@ -319,8 +378,7 @@ public class SpringBootXmlConfiguration extends AbstractConfiguration implements
 		if (this.environment == null) {
 			return false;
 		}
-		String[] profileNames = StringUtils
-				.trimArrayElements(StringUtils.commaDelimitedListToStringArray(profile));
+		String[] profileNames = StringUtils.trimArrayElements(StringUtils.commaDelimitedListToStringArray(profile));
 		if (profileNames.length == 0) {
 			return false;
 		}
@@ -328,7 +386,7 @@ public class SpringBootXmlConfiguration extends AbstractConfiguration implements
 	}
 
 	private String getType(final Element element) {
-		if (strict) {
+		if (this.strict) {
 			final NamedNodeMap attrs = element.getAttributes();
 			for (int i = 0; i < attrs.getLength(); ++i) {
 				final org.w3c.dom.Node w3cNode = attrs.item(i);
@@ -371,18 +429,23 @@ public class SpringBootXmlConfiguration extends AbstractConfiguration implements
 	 * The error that occurred.
 	 */
 	private enum ErrorType {
+
 		CLASS_NOT_FOUND
+
 	}
 
 	/**
 	 * Status for recording errors.
 	 */
 	private static class Status {
+
 		private final Element element;
+
 		private final String name;
+
 		private final ErrorType errorType;
 
-		public Status(final String name, final Element element, final ErrorType errorType) {
+		Status(final String name, final Element element, final ErrorType errorType) {
 			this.name = name;
 			this.element = element;
 			this.errorType = errorType;
@@ -390,7 +453,7 @@ public class SpringBootXmlConfiguration extends AbstractConfiguration implements
 
 		@Override
 		public String toString() {
-			return "Status [name=" + name + ", element=" + element + ", errorType=" + errorType + "]";
+			return "Status [name=" + this.name + ", element=" + this.element + ", errorType=" + this.errorType + "]";
 		}
 
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/SpringBootXmlConfigurationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/SpringBootXmlConfigurationTests.java
@@ -1,0 +1,147 @@
+package org.springframework.boot.logging.log4j2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.logging.LoggingInitializationContext;
+import org.springframework.boot.testsupport.system.CapturedOutput;
+import org.springframework.boot.testsupport.system.OutputCaptureExtension;
+import org.springframework.mock.env.MockEnvironment;
+
+@ExtendWith(OutputCaptureExtension.class)
+public class SpringBootXmlConfigurationTests {
+	private MockEnvironment environment;
+
+	private LoggingInitializationContext initializationContext;
+
+	private Logger logger;
+
+	private CapturedOutput output;
+
+	private Configuration configuration;
+
+	@BeforeEach
+	void setup(CapturedOutput output) {
+		this.output = output;
+		this.environment = new MockEnvironment();
+		this.initializationContext = new LoggingInitializationContext(this.environment);
+	}
+
+	@AfterEach
+	void reset() {
+		this.configuration.stop();
+	}
+
+	@Test
+	void profileActive() {
+		this.environment.setActiveProfiles("production");
+		initialize("production-profile.xml");
+		this.logger.error("Hello");
+		assertThat(this.output).contains("Hello");
+	}
+
+	@Test
+	void multipleNamesFirstProfileActive() {
+		this.environment.setActiveProfiles("production");
+		initialize("multi-profile-names.xml");
+		this.logger.trace("Hello");
+		assertThat(this.output).contains("Hello");
+	}
+
+	@Test
+	void multipleNamesSecondProfileActive() {
+		this.environment.setActiveProfiles("test");
+		initialize("multi-profile-names.xml");
+		this.logger.trace("Hello");
+		assertThat(this.output).contains("Hello");
+	}
+
+	@Test
+	void profileNotActive() {
+		initialize("production-profile.xml");
+		this.logger.trace("Hello");
+		assertThat(this.output).doesNotContain("Hello");
+	}
+
+	@Test
+	void profileExpressionMatchFirst() {
+		this.environment.setActiveProfiles("production");
+		initialize("profile-expression.xml");
+		this.logger.trace("Hello");
+		assertThat(this.output).contains("Hello");
+	}
+
+	@Test
+	void profileExpressionMatchSecond() {
+		this.environment.setActiveProfiles("test");
+		initialize("profile-expression.xml");
+		this.logger.trace("Hello");
+		assertThat(this.output).contains("Hello");
+	}
+
+	@Test
+	void profileExpressionNoMatch() {
+		this.environment.setActiveProfiles("development");
+		initialize("profile-expression.xml");
+		this.logger.trace("Hello");
+		assertThat(this.output).doesNotContain("Hello");
+	}
+
+	@Test
+	void profileNestedActiveActive() {
+		doTestNestedProfile(true, "outer", "inner");
+	}
+
+	@Test
+	void profileNestedActiveNotActive() {
+		doTestNestedProfile(false, "outer");
+	}
+
+	@Test
+	void profileNestedNotActiveActive() {
+		doTestNestedProfile(false, "inner");
+	}
+
+	@Test
+	void profileNestedNotActiveNotActive() {
+		doTestNestedProfile(false);
+	}
+
+	private void doTestNestedProfile(boolean expected, String... profiles) {
+		this.environment.setActiveProfiles(profiles);
+		initialize("nested.xml");
+		this.logger.trace("Hello");
+		if (expected) {
+			assertThat(this.output).contains("Hello");
+		} else {
+			assertThat(this.output).doesNotContain("Hello");
+		}
+	}
+
+	private void initialize(String config) {
+		LoggerContext context = new LoggerContext("SpringBoot");
+		this.configuration = new SpringBootXmlConfiguration(this.initializationContext, context,
+				configurationSource(config));
+		this.configuration.initialize();
+		context.start(configuration);
+		this.logger = context.getLogger(this.getClass());
+	}
+
+	private ConfigurationSource configurationSource(String config) {
+		try (InputStream in = getClass().getResourceAsStream(config)) {
+			return new ConfigurationSource(in);
+		} catch (IOException ex) {
+			throw new RuntimeException(ex);
+		}
+	}
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/SpringBootXmlConfigurationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/SpringBootXmlConfigurationTests.java
@@ -1,6 +1,20 @@
-package org.springframework.boot.logging.log4j2;
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import static org.assertj.core.api.Assertions.assertThat;
+package org.springframework.boot.logging.log4j2;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,13 +27,22 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.springframework.boot.logging.LoggingInitializationContext;
 import org.springframework.boot.testsupport.system.CapturedOutput;
 import org.springframework.boot.testsupport.system.OutputCaptureExtension;
 import org.springframework.mock.env.MockEnvironment;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SpringBootXmlConfiguration}.
+ *
+ * @author : Kong Wu
+ */
 @ExtendWith(OutputCaptureExtension.class)
 public class SpringBootXmlConfigurationTests {
+
 	private MockEnvironment environment;
 
 	private LoggingInitializationContext initializationContext;
@@ -123,7 +146,8 @@ public class SpringBootXmlConfigurationTests {
 		this.logger.trace("Hello");
 		if (expected) {
 			assertThat(this.output).contains("Hello");
-		} else {
+		}
+		else {
 			assertThat(this.output).doesNotContain("Hello");
 		}
 	}
@@ -133,15 +157,17 @@ public class SpringBootXmlConfigurationTests {
 		this.configuration = new SpringBootXmlConfiguration(this.initializationContext, context,
 				configurationSource(config));
 		this.configuration.initialize();
-		context.start(configuration);
+		context.start(this.configuration);
 		this.logger = context.getLogger(this.getClass());
 	}
 
 	private ConfigurationSource configurationSource(String config) {
 		try (InputStream in = getClass().getResourceAsStream(config)) {
 			return new ConfigurationSource(in);
-		} catch (IOException ex) {
+		}
+		catch (IOException ex) {
 			throw new RuntimeException(ex);
 		}
 	}
+
 }

--- a/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/logging/log4j2/log4j2-spring.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/logging/log4j2/log4j2-spring.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+	<Properties>
+
+		<Property name="LOG_EXCEPTION_CONVERSION_WORD">%xwEx</Property>
+		<Property name="LOG_LEVEL_PATTERN">%5p</Property>
+		<Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd HH:mm:ss.SSS</Property>
+		<SpringProfile name="dev">
+			<Property name="CONSOLE_LOG_PATTERN">[DEV] %clr{%d{${sys:LOG_DATEFORMAT_PATTERN}}}{faint} %clr{${sys:LOG_LEVEL_PATTERN}} %clr{%pid}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+		</SpringProfile>
+		<SpringProfile name="!dev">
+			<Property name="CONSOLE_LOG_PATTERN">[!DEV] %clr{%d{${sys:LOG_DATEFORMAT_PATTERN}}}{faint} %clr{${sys:LOG_LEVEL_PATTERN}} %clr{%pid}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+		</SpringProfile>
+	</Properties>
+	<Appenders>
+		<SpringProfile name="dev">
+			<Console name="ConsoleDEV" target="SYSTEM_OUT">
+				<PatternLayout pattern="${CONSOLE_LOG_PATTERN}"/>
+			</Console>
+		</SpringProfile>
+		<Console name="Console" target="SYSTEM_OUT">
+			<PatternLayout pattern="${CONSOLE_LOG_PATTERN}"/>
+		</Console>
+	</Appenders>
+	<Loggers>
+		<springProfile name="dev">
+			<Logger name="org.springframework.boot.logging.log4j2.SpringBootXmlConfigurationTests" level="trace" additivity="false">
+				<AppenderRef ref="ConsoleDEV" />
+			</Logger>
+		</springProfile>
+		<Root level="info">
+			<AppenderRef ref="Console" />
+		</Root>
+	</Loggers>
+</Configuration>

--- a/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/logging/log4j2/multi-profile-names.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/logging/log4j2/multi-profile-names.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+	<Properties>
+		<Property name="CONSOLE_LOG_CHARSET">UTF-8</Property>
+		<Property name="LOG_EXCEPTION_CONVERSION_WORD">%xwEx</Property>
+		<Property name="LOG_LEVEL_PATTERN">%5p</Property>
+		<Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd HH:mm:ss.SSS</Property>
+		<Property name="CONSOLE_LOG_PATTERN">%clr{%d{${sys:LOG_DATEFORMAT_PATTERN}}}{faint} %clr{${sys:LOG_LEVEL_PATTERN}} %clr{%pid}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+		<Property name="FILE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} ${LOG_LEVEL_PATTERN} %pid --- [%t] %-40.40c{1.} : %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+	</Properties>
+	<Appenders>
+		<Console name="Console" target="SYSTEM_OUT" follow="true">
+			<PatternLayout pattern="${sys:CONSOLE_LOG_PATTERN}" charset="${sys:CONSOLE_LOG_CHARSET}"/>
+		</Console>
+	</Appenders>
+	<Loggers>
+		<springProfile name="production, test">
+			<logger name="org.springframework.boot.logging.log4j2" level="TRACE" />
+		</springProfile>
+		<Root level="info">
+			<AppenderRef ref="Console" />
+		</Root>
+	</Loggers>
+</Configuration>

--- a/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/logging/log4j2/nested.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/logging/log4j2/nested.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+	<Properties>
+		<Property name="CONSOLE_LOG_CHARSET">UTF-8</Property>
+		<Property name="LOG_EXCEPTION_CONVERSION_WORD">%xwEx</Property>
+		<Property name="LOG_LEVEL_PATTERN">%5p</Property>
+		<Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd HH:mm:ss.SSS</Property>
+		<Property name="CONSOLE_LOG_PATTERN">%clr{%d{${sys:LOG_DATEFORMAT_PATTERN}}}{faint} %clr{${sys:LOG_LEVEL_PATTERN}} %clr{%pid}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+		<Property name="FILE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} ${LOG_LEVEL_PATTERN} %pid --- [%t] %-40.40c{1.} : %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+	</Properties>
+	<Appenders>
+		<Console name="Console" target="SYSTEM_OUT" follow="true">
+			<PatternLayout pattern="${sys:CONSOLE_LOG_PATTERN}" charset="${sys:CONSOLE_LOG_CHARSET}"/>
+		</Console>
+	</Appenders>
+	<Loggers>
+		<springProfile name="outer">
+			<springProfile name="inner">
+				<logger name="org.springframework.boot.logging.log4j2" level="TRACE" />
+			</springProfile>
+		</springProfile>
+		<Root level="info">
+			<AppenderRef ref="Console" />
+		</Root>
+	</Loggers>
+</Configuration>

--- a/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/logging/log4j2/production-profile.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/logging/log4j2/production-profile.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+	<Properties>
+		<Property name="CONSOLE_LOG_CHARSET">UTF-8</Property>
+		<Property name="LOG_EXCEPTION_CONVERSION_WORD">%xwEx</Property>
+		<Property name="LOG_LEVEL_PATTERN">%5p</Property>
+		<Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd HH:mm:ss.SSS</Property>
+		<Property name="CONSOLE_LOG_PATTERN">%clr{%d{${sys:LOG_DATEFORMAT_PATTERN}}}{faint} %clr{${sys:LOG_LEVEL_PATTERN}} %clr{%pid}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+		<Property name="FILE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} ${LOG_LEVEL_PATTERN} %pid --- [%t] %-40.40c{1.} : %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+	</Properties>
+	<Appenders>
+		<Console name="Console" target="SYSTEM_OUT" follow="true">
+			<PatternLayout pattern="${sys:CONSOLE_LOG_PATTERN}" charset="${sys:CONSOLE_LOG_CHARSET}"/>
+		</Console>
+	</Appenders>
+	<Loggers>
+		<springProfile name="production">
+			<logger name="org.springframework.boot.logging.log4j2" level="TRACE" />
+		</springProfile>
+		<Root level="info">
+			<AppenderRef ref="Console" />
+		</Root>
+	</Loggers>
+</Configuration>

--- a/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/logging/log4j2/profile-expression.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/logging/log4j2/profile-expression.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+	<Properties>
+		<Property name="CONSOLE_LOG_CHARSET">UTF-8</Property>
+		<Property name="LOG_EXCEPTION_CONVERSION_WORD">%xwEx</Property>
+		<Property name="LOG_LEVEL_PATTERN">%5p</Property>
+		<Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd HH:mm:ss.SSS</Property>
+		<Property name="CONSOLE_LOG_PATTERN">%clr{%d{${sys:LOG_DATEFORMAT_PATTERN}}}{faint} %clr{${sys:LOG_LEVEL_PATTERN}} %clr{%pid}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+		<Property name="FILE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} ${LOG_LEVEL_PATTERN} %pid --- [%t] %-40.40c{1.} : %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+	</Properties>
+	<Appenders>
+		<Console name="Console" target="SYSTEM_OUT" follow="true">
+			<PatternLayout pattern="${sys:CONSOLE_LOG_PATTERN}" charset="${sys:CONSOLE_LOG_CHARSET}"/>
+		</Console>
+	</Appenders>
+	<Loggers>
+		<springProfile name="production | test">
+			<logger name="org.springframework.boot.logging.log4j2" level="TRACE" />
+		</springProfile>
+		<Root level="info">
+			<AppenderRef ref="Console" />
+		</Root>
+	</Loggers>
+</Configuration>


### PR DESCRIPTION
Enhance the configuration of log4j2 (xml), support Profile-specific Configuration (`<SpringProfile>`), consistent with logback extension.

Spring Boot currently only enhances the Logback (XML) configuration to support the <springProfile> tag. This feature is very useful, but is not supported by Log4j2.

I copied the code in Log4j2 XML to parse the XML configuration and created a new SpringBootXmlConfiguration to support the <SpringProfile> tag, which is as simple and easy to use as Logback Extension.

**Compatibility issues with rewriting the Log4j2 parsing code:**

1. I just copied the `XmlConfiguration` code directly from Log4j2, adding very little code and making no big changes like formatting. If there is an update to Log4j2, it is easy to rewrite the parsing class and update it accordingly.
2. The `XmlConfiguration` class in Log4j2 was last updated in June 2019, with no updates between [2.12.0,2.14.1] and the default dependent version of Log4j2 in Springboot (master) is 2.14.1

**To sum up, there is no risk in this kind of enhancement**