### PR TITLE
Polish HealthIndicators table in docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
@@ -685,7 +685,6 @@ with the `key` listed in the table below.
 |===
 | Key | Name | Description
 
-=======
 | `cassandra`
 | {spring-boot-actuator-module-code}/cassandra/CassandraDriverHealthIndicator.java[`CassandraDriverHealthIndicator`]
 | Checks that a Cassandra database is up.


### PR DESCRIPTION
`=======` was showing up in the header of the table, which should not be there.

Note: I did not see it in 2.3.x.