### PR TITLE
Keystore.load calls do not close InputStream

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.autoconfigure.couchbase;
 
+import java.io.InputStream;
 import java.net.URL;
 import java.security.KeyStore;
 
@@ -114,7 +115,9 @@ public class CouchbaseAutoConfiguration {
 	private KeyStore loadKeyStore(String resource, String keyStorePassword) throws Exception {
 		KeyStore store = KeyStore.getInstance(KeyStore.getDefaultType());
 		URL url = ResourceUtils.getURL(resource);
-		store.load(url.openStream(), (keyStorePassword != null) ? keyStorePassword.toCharArray() : null);
+		try (InputStream inputStream = url.openStream()) {
+			store.load(inputStream, (keyStorePassword != null) ? keyStorePassword.toCharArray() : null);
+		}
 		return store;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/SslServerCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/SslServerCustomizer.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.web.embedded.netty;
 
+import java.io.InputStream;
 import java.net.Socket;
 import java.net.URL;
 import java.security.InvalidAlgorithmParameterException;
@@ -170,7 +171,9 @@ public class SslServerCustomizer implements NettyServerCustomizer {
 		KeyStore store = (provider != null) ? KeyStore.getInstance(type, provider) : KeyStore.getInstance(type);
 		try {
 			URL url = ResourceUtils.getURL(resource);
-			store.load(url.openStream(), (password != null) ? password.toCharArray() : null);
+			try (InputStream inputStream = url.openStream()) {
+				store.load(inputStream, (password != null) ? password.toCharArray() : null);
+			}
 			return store;
 		}
 		catch (Exception ex) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/SslBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/SslBuilderCustomizer.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.web.embedded.undertow;
 
+import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.URL;
@@ -181,7 +182,9 @@ class SslBuilderCustomizer implements UndertowBuilderCustomizer {
 		KeyStore store = (provider != null) ? KeyStore.getInstance(type, provider) : KeyStore.getInstance(type);
 		try {
 			URL url = ResourceUtils.getURL(resource);
-			store.load(url.openStream(), (password != null) ? password.toCharArray() : null);
+			try (InputStream inputStream = url.openStream()) {
+				store.load(inputStream, (password != null) ? password.toCharArray() : null);
+			}
 			return store;
 		}
 		catch (Exception ex) {


### PR DESCRIPTION
I noticed that Java process keeps lock on the keystore file when Netty+SSL is used on Windows.
Detailed investigation shown that it happens because InputStream is not closed after keystore is loaded from it.

This PR fixes the issue described above. I also found similar code in other places and fixed it as well.
