### PR TITLE
Add reference to Bitcoin starter

### DIFF
--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -55,6 +55,9 @@ do as they were designed before this was clarified.
 | https://docs.microsoft.com/en-us/azure/application-insights/app-insights-overview[Azure Application Insights]
 | https://github.com/Microsoft/ApplicationInsights-Java/tree/master/azure-application-insights-spring-boot-starter
 
+| https://github.com/bitcoin/bitcoin[Bitcoin] (jsonrpc/zeromq clients, https://github.com/spesmilo/electrum[Electrum], https://github.com/lightningnetwork/lnd[lnd], https://www.torproject.org/[Tor], https://github.com/knowm/XChange[XChange])
+| https://github.com/theborakompanioni/bitcoin-spring-boot-starter
+
 | https://github.com/vladimir-bukhtoyarov/bucket4j/[Bucket4j]
 | https://github.com/MarcGiffing/bucket4j-spring-boot-starter
 


### PR DESCRIPTION
I would like to include Bitcoin related starter modules in the list of Spring Boot Starters.

The project contains Spring Boot Starters for several Bitcoin related modules
(Also included are modules especially useful for setting up integration/e2e test environments).

It complies with custom starter guidelines given in [Creating Your Own Starter](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-custom-starter).
