### PR TITLE
Fix MongoMetricsAutoConfigurationTests

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/mongo/MongoMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/mongo/MongoMetricsAutoConfigurationTests.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link MongoMetricsAutoConfiguration}.
  *
  * @author Chris Bono
+ * @author Johnny Lim
  */
 class MongoMetricsAutoConfigurationTests {
 
@@ -80,13 +81,13 @@ class MongoMetricsAutoConfigurationTests {
 	@Test
 	void whenThereIsNoMeterRegistryThenNoMetricsCommandListenerIsAdded() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
-				.run((context) -> assertThatMetricsCommandListenerNotAdded());
+				.run(assertThatMetricsCommandListenerNotAdded());
 	}
 
 	@Test
 	void whenThereIsNoMeterRegistryThenNoMetricsConnectionPoolListenerIsAdded() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
-				.run((context) -> assertThatMetricsConnectionPoolListenerNotAdded());
+				.run(assertThatMetricsConnectionPoolListenerNotAdded());
 	}
 
 	@Test
@@ -114,44 +115,50 @@ class MongoMetricsAutoConfigurationTests {
 
 	@Test
 	void whenThereIsNoMongoClientSettingsOnClasspathThenNoMetricsCommandListenerIsAdded() {
-		this.contextRunner.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
+		this.contextRunner.with(MetricsRun.simple())
+				.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
 				.withClassLoader(new FilteredClassLoader(MongoClientSettings.class))
-				.run((context) -> assertThatMetricsCommandListenerNotAdded());
+				.run(assertThatMetricsCommandListenerNotAdded());
 	}
 
 	@Test
 	void whenThereIsNoMongoClientSettingsOnClasspathThenNoMetricsConnectionPoolListenerIsAdded() {
-		this.contextRunner.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
+		this.contextRunner.with(MetricsRun.simple())
+				.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
 				.withClassLoader(new FilteredClassLoader(MongoClientSettings.class))
-				.run((context) -> assertThatMetricsConnectionPoolListenerNotAdded());
+				.run(assertThatMetricsConnectionPoolListenerNotAdded());
 	}
 
 	@Test
 	void whenThereIsNoMongoMetricsCommandListenerOnClasspathThenNoMetricsCommandListenerIsAdded() {
-		this.contextRunner.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
+		this.contextRunner.with(MetricsRun.simple())
+				.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
 				.withClassLoader(new FilteredClassLoader(MongoMetricsCommandListener.class))
-				.run((context) -> assertThatMetricsCommandListenerNotAdded());
+				.run(assertThatMetricsCommandListenerNotAdded());
 	}
 
 	@Test
 	void whenThereIsNoMongoMetricsConnectionPoolListenerOnClasspathThenNoMetricsConnectionPoolListenerIsAdded() {
-		this.contextRunner.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
+		this.contextRunner.with(MetricsRun.simple())
+				.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
 				.withClassLoader(new FilteredClassLoader(MongoMetricsConnectionPoolListener.class))
-				.run((context) -> assertThatMetricsConnectionPoolListenerNotAdded());
+				.run(assertThatMetricsConnectionPoolListenerNotAdded());
 	}
 
 	@Test
 	void whenMetricsCommandListenerEnabledPropertyFalseThenNoMetricsCommandListenerIsAdded() {
-		this.contextRunner.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
+		this.contextRunner.with(MetricsRun.simple())
+				.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
 				.withPropertyValues("management.metrics.mongo.command.enabled:false")
-				.run((context) -> assertThatMetricsCommandListenerNotAdded());
+				.run(assertThatMetricsCommandListenerNotAdded());
 	}
 
 	@Test
 	void whenMetricsConnectionPoolListenerEnabledPropertyFalseThenNoMetricsConnectionPoolListenerIsAdded() {
-		this.contextRunner.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
+		this.contextRunner.with(MetricsRun.simple())
+				.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class))
 				.withPropertyValues("management.metrics.mongo.connectionpool.enabled:false")
-				.run((context) -> assertThatMetricsConnectionPoolListenerNotAdded());
+				.run(assertThatMetricsConnectionPoolListenerNotAdded());
 	}
 
 	private ContextConsumer<AssertableApplicationContext> assertThatMetricsCommandListenerNotAdded() {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR fixes the following:

- nested `ContextConsumer`
- missing `.with(MetricsRun.simple())`

They could make the tests pass unintentionally.