### PR TITLE
Remove last mention of Gradle 5.6.x support from docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/getting-started.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/getting-started.adoc
@@ -41,7 +41,7 @@ Explicit build support is provided for the following build tools:
 | 3.3+
 
 | Gradle
-| 6 (6.3 or later). 5.6.x is also supported but in a deprecated form
+| 6 (6.3 or later)
 |===
 
 


### PR DESCRIPTION
Hi,

the getting started section still mentions Gradle 5.6 support, but that was dropped a short while ago.

Cheers,
Christoph