### PR TITLE
Add auto-configuration for Micrometer DiskSpaceMetrics

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.java
@@ -16,8 +16,11 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics;
 
+import java.io.File;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.DiskSpaceMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
@@ -64,6 +67,12 @@ public class JvmMetricsAutoConfiguration {
 	@ConditionalOnMissingBean
 	public ClassLoaderMetrics classLoaderMetrics() {
 		return new ClassLoaderMetrics();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public DiskSpaceMetrics diskSpaceMetrics() {
+		return new DiskSpaceMetrics(new File(System.getProperty("user.dir")));
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.java
@@ -72,7 +72,7 @@ public class JvmMetricsAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public DiskSpaceMetrics diskSpaceMetrics() {
-		return new DiskSpaceMetrics(new File(System.getProperty("user.dir")));
+		return new DiskSpaceMetrics(new File("."));
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfigurationTests.java
@@ -54,43 +54,44 @@ class JvmMetricsAutoConfigurationTests {
 
 	@Test
 	void allowsCustomJvmGcMetricsToBeUsed() {
-		this.contextRunner.withUserConfiguration(CustomJvmGcMetricsConfiguration.class).run(
-		        validateBaseJvmMetricsBeansArePresentWithCustomBean("customJvmGcMetrics"));
+		this.contextRunner.withUserConfiguration(CustomJvmGcMetricsConfiguration.class)
+				.run(validateBaseJvmMetricsBeansArePresentWithCustomBean("customJvmGcMetrics"));
 	}
 
 	@Test
 	void allowsCustomJvmMemoryMetricsToBeUsed() {
-		this.contextRunner.withUserConfiguration(CustomJvmMemoryMetricsConfiguration.class).run(
-                validateBaseJvmMetricsBeansArePresentWithCustomBean("customJvmMemoryMetrics"));
+		this.contextRunner.withUserConfiguration(CustomJvmMemoryMetricsConfiguration.class)
+				.run(validateBaseJvmMetricsBeansArePresentWithCustomBean("customJvmMemoryMetrics"));
 	}
 
 	@Test
 	void allowsCustomJvmThreadMetricsToBeUsed() {
-		this.contextRunner.withUserConfiguration(CustomJvmThreadMetricsConfiguration.class).run(
-                validateBaseJvmMetricsBeansArePresentWithCustomBean("customJvmThreadMetrics"));
+		this.contextRunner.withUserConfiguration(CustomJvmThreadMetricsConfiguration.class)
+				.run(validateBaseJvmMetricsBeansArePresentWithCustomBean("customJvmThreadMetrics"));
 	}
 
 	@Test
 	void allowsCustomClassLoaderMetricsToBeUsed() {
-		this.contextRunner.withUserConfiguration(CustomClassLoaderMetricsConfiguration.class).run(
-                validateBaseJvmMetricsBeansArePresentWithCustomBean("customClassLoaderMetrics"));
+		this.contextRunner.withUserConfiguration(CustomClassLoaderMetricsConfiguration.class)
+				.run(validateBaseJvmMetricsBeansArePresentWithCustomBean("customClassLoaderMetrics"));
 	}
 
 	@Test
 	void allowsCustomDiskSpaceMetricsToBeUsed() {
-		this.contextRunner.withUserConfiguration(CustomDiskSpaceMetricsConfiguration.class).run(
-                validateBaseJvmMetricsBeansArePresentWithCustomBean("customDiskSpaceMetrics"));
+		this.contextRunner.withUserConfiguration(CustomDiskSpaceMetricsConfiguration.class)
+				.run(validateBaseJvmMetricsBeansArePresentWithCustomBean("customDiskSpaceMetrics"));
 	}
 
-	private ContextConsumer<AssertableApplicationContext> validateBaseJvmMetricsBeansArePresentWithCustomBean(String customBean) {
+	private ContextConsumer<AssertableApplicationContext> validateBaseJvmMetricsBeansArePresentWithCustomBean(
+			String customBean) {
 		return (context) -> {
-		    assertThat(context).hasSingleBean(JvmGcMetrics.class).hasSingleBean(JvmMemoryMetrics.class)
-                    .hasSingleBean(JvmThreadMetrics.class).hasSingleBean(ClassLoaderMetrics.class)
-                    .hasSingleBean(DiskSpaceMetrics.class);
-		    if (customBean != null) {
-		        assertThat(context).hasBean(customBean);
-            }
-        };
+			assertThat(context).hasSingleBean(JvmGcMetrics.class).hasSingleBean(JvmMemoryMetrics.class)
+					.hasSingleBean(JvmThreadMetrics.class).hasSingleBean(ClassLoaderMetrics.class)
+					.hasSingleBean(DiskSpaceMetrics.class);
+			if (customBean != null) {
+				assertThat(context).hasBean(customBean);
+			}
+		};
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfigurationTests.java
@@ -27,9 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.test.MetricsRun;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.boot.test.context.runner.ContextConsumer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -49,49 +47,53 @@ class JvmMetricsAutoConfigurationTests {
 
 	@Test
 	void autoConfiguresJvmMetrics() {
-		this.contextRunner.run(validateBaseJvmMetricsBeansArePresentWithCustomBean(null));
+		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(JvmGcMetrics.class)
+				.hasSingleBean(JvmMemoryMetrics.class).hasSingleBean(JvmThreadMetrics.class)
+				.hasSingleBean(ClassLoaderMetrics.class).hasSingleBean(DiskSpaceMetrics.class));
 	}
 
 	@Test
 	void allowsCustomJvmGcMetricsToBeUsed() {
 		this.contextRunner.withUserConfiguration(CustomJvmGcMetricsConfiguration.class)
-				.run(validateBaseJvmMetricsBeansArePresentWithCustomBean("customJvmGcMetrics"));
+				.run((context) -> assertThat(context).hasSingleBean(JvmGcMetrics.class).hasBean("customJvmGcMetrics")
+						.hasSingleBean(JvmMemoryMetrics.class).hasSingleBean(JvmThreadMetrics.class)
+						.hasSingleBean(ClassLoaderMetrics.class).hasSingleBean(DiskSpaceMetrics.class));
 	}
 
 	@Test
 	void allowsCustomJvmMemoryMetricsToBeUsed() {
 		this.contextRunner.withUserConfiguration(CustomJvmMemoryMetricsConfiguration.class)
-				.run(validateBaseJvmMetricsBeansArePresentWithCustomBean("customJvmMemoryMetrics"));
+				.run((context) -> assertThat(context).hasSingleBean(JvmGcMetrics.class)
+						.hasSingleBean(JvmMemoryMetrics.class).hasBean("customJvmMemoryMetrics")
+						.hasSingleBean(JvmThreadMetrics.class).hasSingleBean(ClassLoaderMetrics.class)
+						.hasSingleBean(DiskSpaceMetrics.class));
 	}
 
 	@Test
 	void allowsCustomJvmThreadMetricsToBeUsed() {
 		this.contextRunner.withUserConfiguration(CustomJvmThreadMetricsConfiguration.class)
-				.run(validateBaseJvmMetricsBeansArePresentWithCustomBean("customJvmThreadMetrics"));
+				.run((context) -> assertThat(context).hasSingleBean(JvmGcMetrics.class)
+						.hasSingleBean(JvmMemoryMetrics.class).hasSingleBean(JvmThreadMetrics.class)
+						.hasBean("customJvmThreadMetrics").hasSingleBean(ClassLoaderMetrics.class)
+						.hasSingleBean(DiskSpaceMetrics.class));
 	}
 
 	@Test
 	void allowsCustomClassLoaderMetricsToBeUsed() {
 		this.contextRunner.withUserConfiguration(CustomClassLoaderMetricsConfiguration.class)
-				.run(validateBaseJvmMetricsBeansArePresentWithCustomBean("customClassLoaderMetrics"));
+				.run((context) -> assertThat(context).hasSingleBean(JvmGcMetrics.class)
+						.hasSingleBean(JvmMemoryMetrics.class).hasSingleBean(JvmThreadMetrics.class)
+						.hasSingleBean(ClassLoaderMetrics.class).hasBean("customClassLoaderMetrics")
+						.hasSingleBean(DiskSpaceMetrics.class));
 	}
 
 	@Test
 	void allowsCustomDiskSpaceMetricsToBeUsed() {
 		this.contextRunner.withUserConfiguration(CustomDiskSpaceMetricsConfiguration.class)
-				.run(validateBaseJvmMetricsBeansArePresentWithCustomBean("customDiskSpaceMetrics"));
-	}
-
-	private ContextConsumer<AssertableApplicationContext> validateBaseJvmMetricsBeansArePresentWithCustomBean(
-			String customBean) {
-		return (context) -> {
-			assertThat(context).hasSingleBean(JvmGcMetrics.class).hasSingleBean(JvmMemoryMetrics.class)
-					.hasSingleBean(JvmThreadMetrics.class).hasSingleBean(ClassLoaderMetrics.class)
-					.hasSingleBean(DiskSpaceMetrics.class);
-			if (customBean != null) {
-				assertThat(context).hasBean(customBean);
-			}
-		};
+				.run((context) -> assertThat(context).hasSingleBean(JvmGcMetrics.class)
+						.hasSingleBean(JvmMemoryMetrics.class).hasSingleBean(JvmThreadMetrics.class)
+						.hasSingleBean(ClassLoaderMetrics.class).hasSingleBean(DiskSpaceMetrics.class)
+						.hasBean("customDiskSpaceMetrics"));
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfigurationTests.java
@@ -49,53 +49,48 @@ class JvmMetricsAutoConfigurationTests {
 
 	@Test
 	void autoConfiguresJvmMetrics() {
-		this.contextRunner.run((context) -> validateBaseJvmMetricsBeansArePresent());
+		this.contextRunner.run(validateBaseJvmMetricsBeansArePresentWithCustomBean(null));
 	}
 
 	@Test
 	void allowsCustomJvmGcMetricsToBeUsed() {
-		this.contextRunner.withUserConfiguration(CustomJvmGcMetricsConfiguration.class).run((context) -> {
-			validateBaseJvmMetricsBeansArePresent();
-			assertThat(context).hasBean("customJvmGcMetrics");
-		});
+		this.contextRunner.withUserConfiguration(CustomJvmGcMetricsConfiguration.class).run(
+		        validateBaseJvmMetricsBeansArePresentWithCustomBean("customJvmGcMetrics"));
 	}
 
 	@Test
 	void allowsCustomJvmMemoryMetricsToBeUsed() {
-		this.contextRunner.withUserConfiguration(CustomJvmMemoryMetricsConfiguration.class).run((context) -> {
-			validateBaseJvmMetricsBeansArePresent();
-			assertThat(context).hasBean("customJvmMemoryMetrics");
-		});
+		this.contextRunner.withUserConfiguration(CustomJvmMemoryMetricsConfiguration.class).run(
+                validateBaseJvmMetricsBeansArePresentWithCustomBean("customJvmMemoryMetrics"));
 	}
 
 	@Test
 	void allowsCustomJvmThreadMetricsToBeUsed() {
-		this.contextRunner.withUserConfiguration(CustomJvmThreadMetricsConfiguration.class).run((context) -> {
-			validateBaseJvmMetricsBeansArePresent();
-			assertThat(context).hasBean("customJvmThreadMetrics");
-		});
+		this.contextRunner.withUserConfiguration(CustomJvmThreadMetricsConfiguration.class).run(
+                validateBaseJvmMetricsBeansArePresentWithCustomBean("customJvmThreadMetrics"));
 	}
 
 	@Test
 	void allowsCustomClassLoaderMetricsToBeUsed() {
-		this.contextRunner.withUserConfiguration(CustomClassLoaderMetricsConfiguration.class).run((context) -> {
-			validateBaseJvmMetricsBeansArePresent();
-			assertThat(context).hasBean("customClassLoaderMetrics");
-		});
+		this.contextRunner.withUserConfiguration(CustomClassLoaderMetricsConfiguration.class).run(
+                validateBaseJvmMetricsBeansArePresentWithCustomBean("customClassLoaderMetrics"));
 	}
 
 	@Test
 	void allowsCustomDiskSpaceMetricsToBeUsed() {
-		this.contextRunner.withUserConfiguration(CustomDiskSpaceMetricsConfiguration.class).run((context) -> {
-			validateBaseJvmMetricsBeansArePresent();
-			assertThat(context).hasBean("customDiskSpaceMetrics");
-		});
+		this.contextRunner.withUserConfiguration(CustomDiskSpaceMetricsConfiguration.class).run(
+                validateBaseJvmMetricsBeansArePresentWithCustomBean("customDiskSpaceMetrics"));
 	}
 
-	private ContextConsumer<AssertableApplicationContext> validateBaseJvmMetricsBeansArePresent() {
-		return (context) -> assertThat(context).hasSingleBean(JvmGcMetrics.class).hasSingleBean(JvmMemoryMetrics.class)
-                .hasSingleBean(JvmThreadMetrics.class).hasSingleBean(ClassLoaderMetrics.class)
-                .hasSingleBean(DiskSpaceMetrics.class);
+	private ContextConsumer<AssertableApplicationContext> validateBaseJvmMetricsBeansArePresentWithCustomBean(String customBean) {
+		return (context) -> {
+		    assertThat(context).hasSingleBean(JvmGcMetrics.class).hasSingleBean(JvmMemoryMetrics.class)
+                    .hasSingleBean(JvmThreadMetrics.class).hasSingleBean(ClassLoaderMetrics.class)
+                    .hasSingleBean(DiskSpaceMetrics.class);
+		    if (customBean != null) {
+		        assertThat(context).hasBean(customBean);
+            }
+        };
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/production-ready-features.adoc
@@ -2140,7 +2140,7 @@ In most situations, the out-of-the-box defaults will provide sensible metrics th
 [[production-ready-metrics-jvm]]
 ==== JVM Metrics
 Auto-configuration will enable JVM Metrics using core Micrometer classes.
-JVM metrics are published under the `jvm.` meter name.
+JVM metrics are published under the `jvm.` and `disk.` meter names.
 
 The following JVM metrics are provided:
 
@@ -2148,6 +2148,7 @@ The following JVM metrics are provided:
 * Statistics related to garbage collection
 * Threads utilization
 * The Number of classes loaded/unloaded
+* Disk space available
 
 
 


### PR DESCRIPTION
@philwebb this one is a bit interesting as to where the "home" for the auto-configuration should go for "DiskSpaceMetrics". It is in the Micrometer JVM package but feels a bit more like "System" metrics. 

2 reasons I landed it in the JvmMetricsAutoConfiguration:
- I rooted it to `user.dir` which is the current working directory the JVM was launched from
- the metrics implementation uses methods on File that are from the viewpoint of the VM. For example, from [File.getUsableSpace](https://docs.oracle.com/javase/8/docs/api/java/io/File.html#getUsableSpace--) : 
    > Returns the number of bytes available to this virtual machine on the partition named by this abstract pathname

Fixes gh-25996
