### PR TITLE
Fix Docker update detection on CI

### DIFF
--- a/ci/scripts/detect-docker-updates.sh
+++ b/ci/scripts/detect-docker-updates.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-latest_version=$(curl -I -s https://github.com/docker/docker-ce/releases/latest | grep -i "location:" | awk '{n=split($0, parts, "/"); print substr(parts[n],2);}' | awk '{$1=$1;print}' | tr -d '\r' | tr -d '\n' )
+latest_version=$(curl -I -s https://github.com/moby/moby/releases/latest | grep -i "location:" | awk '{n=split($0, parts, "/"); print substr(parts[n],2);}' | awk '{$1=$1;print}' | tr -d '\r' | tr -d '\n' )
 
 if [[ $latest_version =~ (beta|rc) ]]; then
 	echo "Skip pre-release versions"


### PR DESCRIPTION
Hi,

I just noticed that the Docker update detection job apparently didn't notice any new updates, while there are newer versions available. I traced this back to https://github.com/docker/docker-ce being deprecated in favor of moby or docker-cli. I chose moby here as the new url as this is basically the engine of Docker.

I decided against including the upgrade to 20.10.6 here as I want to see that the job actually creates tickets.

Cheers,
Christoph