### PR TITLE
Add auto-configuration for micrometer-zabbix

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 	optional("io.micrometer:micrometer-registry-signalfx")
 	optional("io.micrometer:micrometer-registry-statsd")
 	optional("io.micrometer:micrometer-registry-wavefront")
+	optional("io.micrometer:micrometer-registry-zabbix")
 	optional("io.projectreactor.netty:reactor-netty-http")
 	optional("io.r2dbc:r2dbc-pool")
 	optional("io.r2dbc:r2dbc-spi")

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/zabbix/ZabbixMetricsExportAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/zabbix/ZabbixMetricsExportAutoConfiguration.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.export.zabbix;
+
+import io.micrometer.zabbix.NoopZabbixDiscoveryProvider;
+import io.micrometer.zabbix.ZabbixConfig;
+import io.micrometer.zabbix.ZabbixDiscoveryProvider;
+import io.micrometer.zabbix.ZabbixMeterRegistry;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.ConditionalOnEnabledMetricsExport;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.micrometer.core.instrument.Clock;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for exporting metrics to Zabbix.
+ */
+@Configuration(proxyBeanMethods = false)
+@AutoConfigureBefore({ CompositeMeterRegistryAutoConfiguration.class, SimpleMetricsExportAutoConfiguration.class })
+@AutoConfigureAfter(MetricsAutoConfiguration.class)
+@ConditionalOnBean(Clock.class)
+@ConditionalOnClass(ZabbixMeterRegistry.class)
+@ConditionalOnEnabledMetricsExport("zabbix")
+@EnableConfigurationProperties(ZabbixProperties.class)
+public class ZabbixMetricsExportAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ZabbixDiscoveryProvider zabbixDiscoveryProvider() {
+		return new NoopZabbixDiscoveryProvider();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ZabbixConfig zabbixConfig(ZabbixProperties zabbixProperties) {
+		return new ZabbixPropertiesConfigAdapter(zabbixProperties);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ZabbixMeterRegistry zabbixMeterRegistry(ZabbixConfig zabbixConfig, Clock clock,
+			ZabbixDiscoveryProvider zabbixDiscoveryProvider) {
+		return new ZabbixMeterRegistry(zabbixConfig, clock, zabbixDiscoveryProvider);
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/zabbix/ZabbixProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/zabbix/ZabbixProperties.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.export.zabbix;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.StepRegistryProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * {@link ConfigurationProperties @ConfigurationProperties} for configuring Zabbix metrics
+ * export.
+ */
+@ConfigurationProperties(prefix = "management.metrics.export.zabbix")
+public class ZabbixProperties extends StepRegistryProperties {
+
+	/**
+	 * The name of the host for the instance that is monitored.
+	 */
+	private String host = "instance";
+
+	/**
+	 * The hostname of the Zabbix installation where the metrics will be shipped.
+	 */
+	private String instanceHost = "localhost";
+
+	/**
+	 * The port of the Zabbix installation where the metrics will be shipped.
+	 */
+	private Integer instancePort = 8649;
+
+	/**
+	 * Prefix to be prepended to all metric keys sent to Zabbix.
+	 */
+	private String namePrefix = "";
+
+	/**
+	 * Postfix to be appended to all metric keys sent to Zabbix.
+	 */
+	private String nameSuffix = "";
+
+	public String getHost() {
+		return host;
+	}
+
+	public void setHost(final String host) {
+		this.host = host;
+	}
+
+	public String getInstanceHost() {
+		return instanceHost;
+	}
+
+	public void setInstanceHost(final String instanceHost) {
+		this.instanceHost = instanceHost;
+	}
+
+	public Integer getInstancePort() {
+		return instancePort;
+	}
+
+	public void setInstancePort(final Integer instancePort) {
+		this.instancePort = instancePort;
+	}
+
+	public String getNamePrefix() {
+		return namePrefix;
+	}
+
+	public void setNamePrefix(final String namePrefix) {
+		this.namePrefix = namePrefix;
+	}
+
+	public String getNameSuffix() {
+		return nameSuffix;
+	}
+
+	public void setNameSuffix(final String nameSuffix) {
+		this.nameSuffix = nameSuffix;
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/zabbix/ZabbixPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/zabbix/ZabbixPropertiesConfigAdapter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.export.zabbix;
+
+import io.micrometer.zabbix.ZabbixConfig;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.StepRegistryPropertiesConfigAdapter;
+
+/**
+ * Adapter to convert {@link ZabbixProperties} to a {@link ZabbixConfig}.
+ */
+class ZabbixPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<ZabbixProperties>
+		implements ZabbixConfig {
+
+	ZabbixPropertiesConfigAdapter(ZabbixProperties properties) {
+		super(properties);
+	}
+
+	@Override
+	public String instanceHost() {
+		return get(ZabbixProperties::getInstanceHost, ZabbixConfig.super::instanceHost);
+	}
+
+	@Override
+	public int instancePort() {
+		return get(ZabbixProperties::getInstancePort, ZabbixConfig.super::instancePort);
+	}
+
+	@Override
+	public String host() {
+		return get(ZabbixProperties::getHost, ZabbixConfig.super::host);
+	}
+
+	@Override
+	public String namePrefix() {
+		return get(ZabbixProperties::getNamePrefix, ZabbixConfig.super::namePrefix);
+	}
+
+	@Override
+	public String nameSuffix() {
+		return get(ZabbixProperties::getNameSuffix, ZabbixConfig.super::nameSuffix);
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/zabbix/package-info.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/zabbix/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Support for exporting actuator metrics to Zabbix.
+ */
+package org.springframework.boot.actuate.autoconfigure.metrics.export.zabbix;

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -67,6 +67,7 @@ org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetri
 org.springframework.boot.actuate.autoconfigure.metrics.export.stackdriver.StackdriverMetricsExportAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.export.statsd.StatsdMetricsExportAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.export.wavefront.WavefrontMetricsExportAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.metrics.export.zabbix.ZabbixMetricsExportAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.integration.IntegrationMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.jdbc.DataSourcePoolMetricsAutoConfiguration,\
 org.springframework.boot.actuate.autoconfigure.metrics.jersey.JerseyServerMetricsAutoConfiguration,\


### PR DESCRIPTION
Add support for the configuration of micrometer-zabbix.

This can be merged after https://github.com/micrometer-metrics/micrometer/pull/1773 is accepted and a new built version of Micrometer is referenced in https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-dependencies/build.gradle.