### PR TITLE
Unexpected constructor-based initialization of nested @ConfigurationProperties leads to inconsistent behaviour #25368

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
@@ -113,7 +113,7 @@ class ConfigurationPropertiesBinder {
 	private <T> BindHandler getBindHandler(Bindable<T> target, ConfigurationProperties annotation) {
 		List<Validator> validators = getValidators(target);
 		BindHandler handler = getHandler();
-		handler = new ConfigurationPropertiesBindHander(handler);
+		handler = new ConfigurationPropertiesBindHandler(handler);
 		if (annotation.ignoreInvalidFields()) {
 			handler = new IgnoreErrorsBindHandler(handler);
 		}
@@ -240,9 +240,9 @@ class ConfigurationPropertiesBinder {
 	 * {@link BindHandler} to deal with
 	 * {@link ConfigurationProperties @ConfigurationProperties} concerns.
 	 */
-	private static class ConfigurationPropertiesBindHander extends AbstractBindHandler {
+	private static class ConfigurationPropertiesBindHandler extends AbstractBindHandler {
 
-		ConfigurationPropertiesBindHander(BindHandler handler) {
+		ConfigurationPropertiesBindHandler(BindHandler handler) {
 			super(handler);
 		}
 
@@ -252,8 +252,31 @@ class ConfigurationPropertiesBinder {
 					? target.withBindRestrictions(BindRestriction.NO_DIRECT_PROPERTY) : target;
 		}
 
-		private boolean isConfigurationProperties(Class<?> target) {
-			return target != null && MergedAnnotations.from(target).isPresent(ConfigurationProperties.class);
+		private boolean isConfigurationProperties(final Class<?> target) {
+			return target != null && (hasConfigurationProperty(target) || isNestedClassOfConfigurationProperty(target));
+		}
+
+		private boolean hasConfigurationProperty(final Class<?> target) {
+			return MergedAnnotations.from(target).isPresent(ConfigurationProperties.class);
+		}
+
+		/**
+		 * Iterates over the nested classes till top level class is found or a class with
+		 * {@link ConfigurationProperties} is found.
+		 * @param target the nested class
+		 * @return
+		 * {@link Boolean TRUE} When {@link ConfigurationProperties} annotation is found.
+		 * {@link Boolean FALSE} When {@link ConfigurationProperties} annotation is not found.
+		 */
+		private boolean isNestedClassOfConfigurationProperty(final Class<?> target) {
+			Class<?> enclosingClass = target.getEnclosingClass();
+			while (enclosingClass != null) {
+				if (hasConfigurationProperty(enclosingClass)) {
+					return Boolean.TRUE;
+				}
+				enclosingClass = enclosingClass.getEnclosingClass();
+			}
+			return Boolean.FALSE;
 		}
 
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
@@ -264,9 +264,9 @@ class ConfigurationPropertiesBinder {
 		 * Iterates over the nested classes till top level class is found or a class with
 		 * {@link ConfigurationProperties} is found.
 		 * @param target the nested class
-		 * @return
-		 * {@link Boolean TRUE} When {@link ConfigurationProperties} annotation is found.
-		 * {@link Boolean FALSE} When {@link ConfigurationProperties} annotation is not found.
+		 * @return {@link Boolean TRUE} When {@link ConfigurationProperties} annotation is
+		 * found. {@link Boolean FALSE} When {@link ConfigurationProperties} annotation is
+		 * not found.
 		 */
 		private boolean isNestedClassOfConfigurationProperty(final Class<?> target) {
 			Class<?> enclosingClass = target.getEnclosingClass();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
@@ -270,7 +270,7 @@ class ConfigurationPropertiesBinder {
 		 */
 		private boolean isNestedClassOfConfigurationProperty(final Class<?> target) {
 			Class<?> enclosingClass = target.getEnclosingClass();
-			while (enclosingClass != null) {
+			while (enclosingClass != null && enclosingClass.getDeclaredConstructors().length > 1) {
 				if (hasConfigurationProperty(enclosingClass)) {
 					return Boolean.TRUE;
 				}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
@@ -1055,10 +1055,16 @@ class ConfigurationPropertiesTests {
 		Map<String, Object> source = new HashMap<>();
 		source.put("test", "bar");
 		source.put("test.a", "baz");
+		source.put("test.bar", "xyz");
+		source.put("test.bar.baz", "bar");
+		source.put("test.bar.foo", "x");
+		source.put("test.bar.foo.a", "foo");
 		sources.addLast(new MapPropertySource("test", source));
 		load(WithPublicStringConstructorPropertiesConfiguration.class);
 		WithPublicStringConstructorProperties bean = this.context.getBean(WithPublicStringConstructorProperties.class);
 		assertThat(bean.getA()).isEqualTo("baz");
+		assertThat(bean.getBar().getBaz()).isEqualTo("bar");
+		assertThat(bean.getBar().getFoo().getA()).isEqualTo("foo");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/WithPublicStringConstructorProperties.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/WithPublicStringConstructorProperties.java
@@ -18,8 +18,8 @@ package org.springframework.boot.context.properties;
 
 /**
  * A {@link ConfigurationProperties @ConfigurationProperties} with an additional
- * single-arg public constructor, along with layered inner classes.
- *Used in {@link ConfigurationPropertiesTests}.
+ * single-arg public constructor, along with layered inner classes. Used in
+ * {@link ConfigurationPropertiesTests}.
  *
  * @author Madhura Bhave
  * @author prasoonanand
@@ -101,7 +101,9 @@ public class WithPublicStringConstructorProperties {
 			public void setA(String a) {
 				this.a = a;
 			}
+
 		}
 
 	}
+
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/WithPublicStringConstructorProperties.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/WithPublicStringConstructorProperties.java
@@ -18,14 +18,18 @@ package org.springframework.boot.context.properties;
 
 /**
  * A {@link ConfigurationProperties @ConfigurationProperties} with an additional
- * single-arg public constructor. Used in {@link ConfigurationPropertiesTests}.
+ * single-arg public constructor, along with layered inner classes.
+ *Used in {@link ConfigurationPropertiesTests}.
  *
  * @author Madhura Bhave
+ * @author prasoonanand
  */
 @ConfigurationProperties(prefix = "test")
 public class WithPublicStringConstructorProperties {
 
 	private String a;
+
+	private Bar bar;
 
 	public WithPublicStringConstructorProperties() {
 	}
@@ -42,4 +46,62 @@ public class WithPublicStringConstructorProperties {
 		this.a = a;
 	}
 
+	public Bar getBar() {
+		return this.bar;
+	}
+
+	public void setBar(Bar bar) {
+		this.bar = bar;
+	}
+
+	public static class Bar {
+
+		private String baz;
+
+		private Foo foo;
+
+		public Bar() {
+		}
+
+		public Bar(String baz) {
+			this.baz = baz;
+		}
+
+		public String getBaz() {
+			return this.baz;
+		}
+
+		public void setBaz(String baz) {
+			this.baz = baz;
+		}
+
+		public Foo getFoo() {
+			return this.foo;
+		}
+
+		public void setFoo(Foo foo) {
+			this.foo = foo;
+		}
+
+		public static class Foo {
+
+			private String a;
+
+			public Foo() {
+			}
+
+			public Foo(String a) {
+				this.a = a;
+			}
+
+			public String getA() {
+				return this.a;
+			}
+
+			public void setA(String a) {
+				this.a = a;
+			}
+		}
+
+	}
 }


### PR DESCRIPTION
ConfigurationProperties on a top level class having a nested class is having an inconsistent behaviour.
 Example file has been added as a test case file `WithPublicStringConstructorProperties`...

Resolution:
On ConfigurationPropertiesBindHandler, Using the check which adds the BindRestriction.NO_DIRECT_PROPERTY. 
Created a method to check whether the target class is a Nested class of top-level class or a class which has the annotation ConfigurationProperties.
Also corrected the typo of `ConfigurationPropertiesBindHandler`...
#25368