### PR TITLE
Pass the appropriate classloader to load factory names

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLocationResolvers.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLocationResolvers.java
@@ -54,7 +54,7 @@ class ConfigDataLocationResolvers {
 	ConfigDataLocationResolvers(DeferredLogFactory logFactory, ConfigurableBootstrapContext bootstrapContext,
 			Binder binder, ResourceLoader resourceLoader) {
 		this(logFactory, bootstrapContext, binder, resourceLoader,
-				SpringFactoriesLoader.loadFactoryNames(ConfigDataLocationResolver.class, null));
+				SpringFactoriesLoader.loadFactoryNames(ConfigDataLocationResolver.class, ConfigDataLocationResolver.class.getClassLoader()));
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLocationResolvers.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLocationResolvers.java
@@ -54,7 +54,8 @@ class ConfigDataLocationResolvers {
 	ConfigDataLocationResolvers(DeferredLogFactory logFactory, ConfigurableBootstrapContext bootstrapContext,
 			Binder binder, ResourceLoader resourceLoader) {
 		this(logFactory, bootstrapContext, binder, resourceLoader,
-				SpringFactoriesLoader.loadFactoryNames(ConfigDataLocationResolver.class, ConfigDataLocationResolver.class.getClassLoader()));
+				SpringFactoriesLoader.loadFactoryNames(ConfigDataLocationResolver.class, 
+													   ConfigDataLocationResolver.class.getClassLoader()));
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLocationResolvers.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLocationResolvers.java
@@ -54,8 +54,8 @@ class ConfigDataLocationResolvers {
 	ConfigDataLocationResolvers(DeferredLogFactory logFactory, ConfigurableBootstrapContext bootstrapContext,
 			Binder binder, ResourceLoader resourceLoader) {
 		this(logFactory, bootstrapContext, binder, resourceLoader,
-				SpringFactoriesLoader.loadFactoryNames(ConfigDataLocationResolver.class, 
-													   ConfigDataLocationResolver.class.getClassLoader()));
+				SpringFactoriesLoader.loadFactoryNames(ConfigDataLocationResolver.class,
+					ConfigDataLocationResolver.class.getClassLoader()));
 	}
 
 	/**


### PR DESCRIPTION
To pass appropriate classloader as an argument to load factory names similar to spring boot versions < 2.4.0
This was modified as a part of the commit - https://github.com/spring-projects/spring-boot/commit/3352024b1ca641fa0beaaa4cd87788c190242eb0

Consider a scenario where Spring-core is loaded from ${catalina.home}/lib and Spring-boot is loaded from project-specific WEB-INF/lib.
Without passing the classloader, SpringFactoriesLoader present in the Spring-Core is unable to find the loaded config classes such as ConfigTreeConfigDataLocationResolver and StandardConfigDataLocationResolver.

Due to which migration from 2.2.x from 2.4.x is causing UnsupportedConfigDataLocationException.
Unsupported config data location 'optional:file:./config/*/'
For more reference of the issue - https://stackoverflow.com/questions/67134959/spring-boot-unsupported-config-data-location-optionalfile-config
