### PR TITLE
Fix broken assertions in tests

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/server/AbstractReactiveWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/server/AbstractReactiveWebServerFactoryTests.java
@@ -469,7 +469,7 @@ public abstract class AbstractReactiveWebServerFactoryTests {
 		try {
 			ContentResponse response = client.POST("http://localhost:" + this.webServer.getPort())
 					.content(new StringContentProvider("Hello World"), "text/plain").send();
-			assertThat(response.getStatus() == HttpStatus.OK.value());
+			assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
 			assertThat(response.getContentAsString()).isEqualTo("Hello World");
 		}
 		finally {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
@@ -1139,7 +1139,8 @@ public abstract class AbstractServletWebServerFactoryTests {
 		client.start();
 		try {
 			ContentResponse response = client.GET("http://localhost:" + this.webServer.getPort() + "/hello");
-			assertThat(response.getStatus() == HttpStatus.OK.value());
+			assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+			assertThat(response.getContentAsString()).isEqualTo("Hello World");
 		}
 		finally {
 			client.stop();


### PR DESCRIPTION
This PR fixes broken assertions in tests.

This PR also restores the HTTP response body assertion that seems to have been dropped in 5873dddc1c9ff41a27eae9ea48f6bf681b859e7e accidentally.