### PR TITLE
Test Maven plugin against latest Maven versions

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/build.gradle
@@ -115,7 +115,7 @@ task zip(type: Zip) {
 }
 
 prepareMavenBinaries {
-	versions "3.6.2", "3.5.4"
+	versions "3.8.1", "3.6.3", "3.5.4"
 }
 
 artifacts {


### PR DESCRIPTION
Maven version 3.8.1 is only bug fixes for 3.6.3 so can be used in it tests instead of 3.6.2

https://maven.apache.org/docs/3.8.1/release-notes.html
https://maven.apache.org/docs/3.6.3/release-notes.html