### PR TITLE
Use of spring.profiles.include in a profile-specific document is not detected when it's configured as a YAML list

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataEnvironment.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataEnvironment.java
@@ -297,6 +297,8 @@ class ConfigDataEnvironment {
 				binder.bind(Profiles.INCLUDE_PROFILES, STRING_LIST).ifBound((includes) -> {
 					if (!contributor.isActive(activationContext)) {
 						InactiveConfigDataAccessException.throwIfPropertyFound(contributor, Profiles.INCLUDE_PROFILES);
+						InactiveConfigDataAccessException.throwIfPropertyFound(contributor,
+								Profiles.INCLUDE_PROFILES.append("[0]"));
 					}
 					result.addAll(includes);
 				});

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentTests.java
@@ -270,7 +270,8 @@ class ConfigDataEnvironmentTests {
 
 	@ParameterizedTest
 	@CsvSource({ "spring.config.activate.on-profile", "spring.profiles.include", "spring.profiles.include[0]" })
-	void processAndApplyDoseNotThrowExceptionWhenActivateProfileWithoutProfileInclude(String property, TestInfo info) {
+	void processAndApplyDoseNotThrowExceptionWhenUsingEitherActivateProfileOrProfileInclude(String property,
+			TestInfo info) {
 		this.environment.setProperty("spring.config.location", getConfigLocation(info));
 		ConfigDataEnvironment configDataEnvironment = new ConfigDataEnvironment(this.logFactory, this.bootstrapContext,
 				this.environment, this.resourceLoader, this.additionalProfiles, null) {


### PR DESCRIPTION
bug fix #26204 .

The below case throw `InactiveConfigDataAccessException`
```
spring:
  config:
    activate:
      on-profile: local
  profiles:
    include:
      - kakaopay1
      - kakaopay2
```