### PR TITLE
Reproducible build for spring-boot-maven-plugin:build-info

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/BuildInfoIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/BuildInfoIntegrationTests.java
@@ -64,6 +64,15 @@ public class BuildInfoIntegrationTests {
 	}
 
 	@TestTemplate
+	void generatedBuildInfoReproducible(MavenBuild mavenBuild) {
+		mavenBuild.project("build-info-reproducible")
+				.execute(buildInfo((buildInfo) -> assertThat(buildInfo)
+						.hasBuildGroup("org.springframework.boot.maven.it").hasBuildArtifact("build-reproducible")
+						.hasBuildName("Generate build info with build time from project.build.outputTimestamp")
+						.hasBuildVersion("0.0.1.BUILD-SNAPSHOT").hasBuildTime("2021-04-21T11:22:33Z")));
+	}
+
+	@TestTemplate
 	void buildInfoPropertiesAreGeneratedToCustomOutputLocation(MavenBuild mavenBuild) {
 		mavenBuild.project("build-info-custom-file")
 				.execute(buildInfo("target/build.info",

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-info-reproducible/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-info-reproducible/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.boot.maven.it</groupId>
+	<artifactId>build-reproducible</artifactId>
+	<version>0.0.1.BUILD-SNAPSHOT</version>
+	<name>Generate build info with build time from project.build.outputTimestamp</name>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>@java.version@</maven.compiler.source>
+		<maven.compiler.target>@java.version@</maven.compiler.target>
+		<project.build.outputTimestamp>2021-04-21T11:22:33Z</project.build.outputTimestamp>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>build-info</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-info-reproducible/src/main/java/org/test/SampleApplication.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-info-reproducible/src/main/java/org/test/SampleApplication.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.test;
+
+public class SampleApplication {
+
+	public static void main(String[] args) {
+	}
+
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildInfoMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildInfoMojo.java
@@ -69,11 +69,13 @@ public class BuildInfoMojo extends AbstractMojo {
 
 	/**
 	 * The value used for the {@code build.time} property in a form suitable for
-	 * {@link Instant#parse(CharSequence)}. Defaults to {@code session.request.startTime}.
-	 * To disable the {@code build.time} property entirely, use {@code 'off'}.
+	 * {@link Instant#parse(CharSequence)}. Defaults to
+	 * {@code project.build.outputTimestamp} otherwise {@code session.request.startTime}
+	 * if property is not set. To disable the {@code build.time} property entirely, use
+	 * {@code 'off'}.
 	 * @since 2.2.0
 	 */
-	@Parameter
+	@Parameter(defaultValue = "${project.build.outputTimestamp}")
 	private String time;
 
 	/**


### PR DESCRIPTION
In order to make maven build will be reproducible we use property `project.build.outputTimestamp` in maven project.

So `spring-boot-maven-plugin:build-info` should take this value as default to not break reproducible build.

Most of maven plugins takes into account this property.

https://maven.apache.org/guides/mini/guide-reproducible-builds.html