### PR TITLE
Adjust to main branch in docs

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/AsciidoctorConventions.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/AsciidoctorConventions.java
@@ -125,7 +125,7 @@ class AsciidoctorConventions {
 
 	private String determineGitHubTag(Project project) {
 		String version = "v" + project.getVersion();
-		return (version.endsWith("-SNAPSHOT")) ? "master" : version;
+		return (version.endsWith("-SNAPSHOT")) ? "main" : version;
 	}
 
 	private void configureOptions(AbstractAsciidoctorTask asciidoctorTask) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/index.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/index.adoc
@@ -10,7 +10,7 @@ Andy Wilkinson, Scott Frederick
 :docinfo: shared,private
 
 :dependency-management-plugin: https://github.com/spring-gradle-plugins/dependency-management-plugin
-:dependency-management-plugin-documentation: {dependency-management-plugin}/blob/master/README.md
+:dependency-management-plugin-documentation: {dependency-management-plugin}/blob/main/README.md
 :gradle-userguide: https://docs.gradle.org/current/userguide
 :gradle-dsl: https://docs.gradle.org/current/dsl
 :gradle-api: https://docs.gradle.org/current/javadoc


### PR DESCRIPTION
Hi,

this PR adjust two more places where the new `main` branch naming of Spring projects could be used. It doesn't break anything because GitHub redirects properly, but it shows a banner at the top which is slightly annoying (at least for me).

![image](https://user-images.githubusercontent.com/6304496/116249518-32c55880-a76d-11eb-8f1b-d1b5e3925a0c.png)

Cheers,
Christoph