### PR TITLE
When a single bean causes a dependency cycle the failure analysis does not clearly illustrate the cycle

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/BeanCurrentlyInCreationFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/BeanCurrentlyInCreationFailureAnalyzer.java
@@ -74,7 +74,7 @@ class BeanCurrentlyInCreationFailureAnalyzer extends AbstractFailureAnalyzer<Bea
 		for (int i = 0; i < beansInCycle.size(); i++) {
 			BeanInCycle beanInCycle = beansInCycle.get(i);
 			if (i == cycleStart) {
-				message.append(String.format("┌─────┐%n"));
+				message.append(String.format(beansInCycle.size() == 1 ? "┌──->──┐%n" : "┌─────┐%n"));
 			}
 			else if (i > 0) {
 				String leftSide = (i < cycleStart) ? " " : "↑";
@@ -83,7 +83,7 @@ class BeanCurrentlyInCreationFailureAnalyzer extends AbstractFailureAnalyzer<Bea
 			String leftSide = (i < cycleStart) ? " " : "|";
 			message.append(String.format("%s  %s%n", leftSide, beanInCycle));
 		}
-		message.append(String.format("└─────┘%n"));
+		message.append(String.format(beansInCycle.size() == 1 ? "└──<-──┘%n" : "└─────┘%n"));
 		return message.toString();
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/BeanCurrentlyInCreationFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/BeanCurrentlyInCreationFailureAnalyzer.java
@@ -74,7 +74,7 @@ class BeanCurrentlyInCreationFailureAnalyzer extends AbstractFailureAnalyzer<Bea
 		for (int i = 0; i < beansInCycle.size(); i++) {
 			BeanInCycle beanInCycle = beansInCycle.get(i);
 			if (i == cycleStart) {
-				message.append(String.format(beansInCycle.size() == 1 ? "┌──->──┐%n" : "┌─────┐%n"));
+				message.append(String.format((beansInCycle.size() == 1) ? "┌──->──┐%n" : "┌─────┐%n"));
 			}
 			else if (i > 0) {
 				String leftSide = (i < cycleStart) ? " " : "↑";
@@ -83,7 +83,7 @@ class BeanCurrentlyInCreationFailureAnalyzer extends AbstractFailureAnalyzer<Bea
 			String leftSide = (i < cycleStart) ? " " : "|";
 			message.append(String.format("%s  %s%n", leftSide, beanInCycle));
 		}
-		message.append(String.format(beansInCycle.size() == 1 ? "└──<-──┘%n" : "└─────┘%n"));
+		message.append(String.format((beansInCycle.size() == 1) ? "└──<-──┘%n" : "└─────┘%n"));
 		return message.toString();
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BeanCurrentlyInCreationFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BeanCurrentlyInCreationFailureAnalyzerTests.java
@@ -16,7 +16,14 @@
 
 package org.springframework.boot.diagnostics.analyzer;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Test;
+
 import org.springframework.beans.factory.BeanCurrentlyInCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.diagnostics.FailureAnalysis;
@@ -29,12 +36,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BeanCurrentlyInCreationFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BeanCurrentlyInCreationFailureAnalyzerTests.java
@@ -16,14 +16,7 @@
 
 package org.springframework.boot.diagnostics.analyzer;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.BeanCurrentlyInCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.diagnostics.FailureAnalysis;
@@ -36,6 +29,12 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -110,6 +109,19 @@ class BeanCurrentlyInCreationFailureAnalyzerTests {
 	}
 
 	@Test
+	void testSelfReferenceCycle() throws IOException {
+		FailureAnalysis analysis = performAnalysis(SelfReferenceBeanConfiguration.class);
+		List<String> lines = readDescriptionLines(analysis);
+		assertThat(lines).hasSize(5);
+		assertThat(lines.get(0))
+				.isEqualTo("The dependencies of some of the beans in the application context form a cycle:");
+		assertThat(lines.get(1)).isEqualTo("");
+		assertThat(lines.get(2)).isEqualTo("┌──->──┐");
+		assertThat(lines.get(3)).startsWith("|  bean defined in " + SelfReferenceBeanConfiguration.class.getName());
+		assertThat(lines.get(4)).isEqualTo("└──<-──┘");
+	}
+
+	@Test
 	void cycleWithAnUnknownStartIsNotAnalyzed() {
 		assertThat(this.analyzer.analyze(new BeanCurrentlyInCreationException("test"))).isNull();
 	}
@@ -137,6 +149,7 @@ class BeanCurrentlyInCreationFailureAnalyzerTests {
 	}
 
 	@org.springframework.context.annotation.Configuration(proxyBeanMethods = false)
+	@SuppressWarnings("unused")
 	static class CyclicBeanMethodsConfiguration {
 
 		@Bean
@@ -167,6 +180,7 @@ class BeanCurrentlyInCreationFailureAnalyzerTests {
 	}
 
 	@Configuration(proxyBeanMethods = false)
+	@SuppressWarnings("unused")
 	static class CycleReferencedViaOtherBeansConfiguration {
 
 		@Bean
@@ -231,11 +245,23 @@ class BeanCurrentlyInCreationFailureAnalyzerTests {
 		@org.springframework.context.annotation.Configuration(proxyBeanMethods = false)
 		static class BeanThreeConfiguration {
 
+			@SuppressWarnings("unused")
 			@Bean
 			BeanThree three(BeanOne one) {
 				return new BeanThree();
 			}
 
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class SelfReferenceBeanConfiguration {
+
+		@SuppressWarnings("unused")
+		@Bean
+		SelfReferenceBean bean(SelfReferenceBean bean) {
+			return new SelfReferenceBean();
 		}
 
 	}
@@ -263,6 +289,13 @@ class BeanCurrentlyInCreationFailureAnalyzerTests {
 	}
 
 	static class BeanThree {
+
+	}
+
+	static class SelfReferenceBean {
+
+		@Autowired
+		SelfReferenceBean bean;
 
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

From now on, if a bean depends on itself we'll get such a message:
```
The dependencies of some of the beans in the application context form a cycle:

┌──->──┐
|  bean defined in org.springframework.boot.diagnostics.analyzer.BeanCurrentlyInCreationFailureAnalyzerTests$SelfReferenceBeanConfiguration
└──<-──┘
```


Closes #26269.
