### PR TITLE
Link all three document formats

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/index.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/index.adoc
@@ -6,6 +6,8 @@ include::attributes.adoc[]
 
 *{spring-boot-version}*
 
+NOTE: You can also view this documentation as {spring-boot-docs}/htmlsingle/index.html[a single HTML file] (give it some time to load) or as {spring-boot-docs}/pdf/spring-boot-reference.pdf[a PDF file].
+
 The reference documentation consists of the following sections:
 
 [horizontal]

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/index.singleadoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/index.singleadoc
@@ -6,6 +6,14 @@ include::attributes.adoc[]
 
 *{spring-boot-version}*
 
+ifdef::backend-html[]
+NOTE: You can also view this documentation as {spring-boot-docs}/html/index.html[multiple HTML pages] or as {spring-boot-docs}/pdf/spring-boot-reference.pdf[a PDF file].
+endif::backend-html[]
+
+ifdef::backend-pdf[]
+NOTE: You can also view this documentation as {spring-boot-docs}/html/index.html[multiple HTML pages] or as {spring-boot-docs}/htmlsingle/index.html[a single HTML page] (give it some time to load).
+endif::backend-pdf[]
+
 include::legal.adoc[leveloffset=+1]
 include::documentation.adoc[leveloffset=+1]
 include::getting-started.adoc[leveloffset=+1]


### PR DESCRIPTION
Per issue 26314, add links to each document format (multi-page HTML, single-page
HTML, and PDF)  such that each document format links to the other two.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
