### PR TITLE
Fix link to Webservices reference docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/attributes.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/attributes.adoc
@@ -87,7 +87,7 @@
 :spring-security-oauth2: https://spring.io/projects/spring-security-oauth
 :spring-security-oauth2-docs: https://projects.spring.io/spring-security-oauth/docs/oauth2.html
 :spring-session: https://spring.io/projects/spring-session
-:spring-webservices-docs: https://docs.spring.io/spring-ws/docs/{spring-webservices-version}/reference/
+:spring-webservices-docs: https://docs.spring.io/spring-ws/docs/{spring-webservices-version}/reference/html/
 :ant-docs: https://ant.apache.org/manual
 :dependency-management-plugin-code: https://github.com/spring-gradle-plugins/dependency-management-plugin
 :gradle-docs: https://docs.gradle.org/current/userguide


### PR DESCRIPTION
Hi,

this PR fixes a link to the [Spring Web Services Reference Documentation](https://docs.spring.io/spring-ws/docs/3.1.0-RC1/reference/html/) that now seems to reside under `reference/html` since 3.1.0-RC1 and not under `reference`.

Cheers,
Christoph