### PR TITLE
Fix typo in NamedContributors Javadoc

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/NamedContributors.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/NamedContributors.java
@@ -33,7 +33,7 @@ public interface NamedContributors<C> extends Iterable<NamedContributor<C>> {
 	/**
 	 * Return the contributor with the given name.
 	 * @param name the name of the contributor
-	 * @return a contributor instance of {@code null}
+	 * @return a contributor instance or {@code null}
 	 */
 	C getContributor(String name);
 


### PR DESCRIPTION
Compared to the existing implementation [NamedContributorsMapAdapter](https://github.com/spring-projects/spring-boot/blob/4febe6485c226a8e5372bd66a68607150abec6cc/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/NamedContributorsMapAdapter.java) of the affected interface, only a typo needs to be corrected.