### PR TITLE
Upgrade Groovy 3.0.8

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -357,7 +357,7 @@ bom {
 			]
 		}
 	}
-	library("Groovy", "3.0.7") {
+	library("Groovy", "3.0.8") {
 		group("org.codehaus.groovy") {
 			imports = [
 				"groovy-bom"


### PR DESCRIPTION
Upgrading to Groovy 3.0.8.
I've read the warning about dependency upgrades. Let me know how can I help.
Thanks!