### PR TITLE
Register Couchbase's JsonValueModule to ObjectMapper in CouchbaseAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseAutoConfiguration.java
@@ -31,6 +31,7 @@ import com.couchbase.client.java.ClusterOptions;
 import com.couchbase.client.java.codec.JacksonJsonSerializer;
 import com.couchbase.client.java.env.ClusterEnvironment;
 import com.couchbase.client.java.env.ClusterEnvironment.Builder;
+import com.couchbase.client.java.json.JsonValueModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -54,6 +55,7 @@ import org.springframework.util.ResourceUtils;
  * @author Eddú Meléndez
  * @author Stephane Nicoll
  * @author Yulin Qin
+ * @author Nguyen Bao Sach
  * @since 1.4.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -139,7 +141,7 @@ public class CouchbaseAutoConfiguration {
 		private final ObjectMapper objectMapper;
 
 		private JacksonClusterEnvironmentBuilderCustomizer(ObjectMapper objectMapper) {
-			this.objectMapper = objectMapper;
+			this.objectMapper = objectMapper.copy().registerModule(new JsonValueModule());
 		}
 
 		@Override

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/couchbase/CouchbaseAutoConfigurationTests.java
@@ -26,6 +26,7 @@ import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.codec.JacksonJsonSerializer;
 import com.couchbase.client.java.codec.JsonSerializer;
 import com.couchbase.client.java.env.ClusterEnvironment;
+import com.couchbase.client.java.json.JsonValueModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +44,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @author Nguyen Bao Sach
  */
 class CouchbaseAutoConfigurationTests {
 
@@ -72,8 +74,9 @@ class CouchbaseAutoConfigurationTests {
 				.withPropertyValues("spring.couchbase.connection-string=localhost").run((context) -> {
 					ClusterEnvironment env = context.getBean(ClusterEnvironment.class);
 					JsonSerializer serializer = env.jsonSerializer();
-					assertThat(serializer).isInstanceOf(JacksonJsonSerializer.class)
-							.hasFieldOrPropertyWithValue("mapper", context.getBean(ObjectMapper.class));
+					assertThat(serializer).isInstanceOf(JacksonJsonSerializer.class).extracting("mapper")
+							.hasFieldOrPropertyWithValue("_registeredModuleTypes", context.getBean(ObjectMapper.class)
+									.copy().registerModule(new JsonValueModule()).getRegisteredModuleIds());
 				});
 	}
 


### PR DESCRIPTION
Fixes #26363 

- Copy the ObjectMapper that gets configured by Spring Boot to create a new ObjectMapper
- Register Couchbase's JsonValueModule to the new ObjectMapper