### PR TITLE
Polish SpringApplicationAdminJmxAutoConfigurationTests

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/admin/SpringApplicationAdminJmxAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/admin/SpringApplicationAdminJmxAutoConfiguration.java
@@ -36,13 +36,13 @@ import org.springframework.jmx.export.MBeanExporter;
  *
  * @author Stephane Nicoll
  * @author Andy Wilkinson
+ * @author Nguyen Bao Sach
  * @since 1.3.0
  * @see SpringApplicationAdminMXBean
  */
 @Configuration(proxyBeanMethods = false)
 @AutoConfigureAfter(JmxAutoConfiguration.class)
-@ConditionalOnProperty(prefix = "spring.application.admin", value = "enabled", havingValue = "true",
-		matchIfMissing = false)
+@ConditionalOnProperty(prefix = "spring.application.admin", value = "enabled", havingValue = "true")
 public class SpringApplicationAdminJmxAutoConfiguration {
 
 	/**
@@ -61,11 +61,8 @@ public class SpringApplicationAdminJmxAutoConfiguration {
 	public SpringApplicationAdminMXBeanRegistrar springApplicationAdminRegistrar(
 			ObjectProvider<MBeanExporter> mbeanExporters, Environment environment) throws MalformedObjectNameException {
 		String jmxName = environment.getProperty(JMX_NAME_PROPERTY, DEFAULT_JMX_NAME);
-		if (mbeanExporters != null) { // Make sure to not register that MBean twice
-			for (MBeanExporter mbeanExporter : mbeanExporters) {
-				mbeanExporter.addExcludedBean(jmxName);
-			}
-		}
+		// Make sure to not register that MBean twice
+		mbeanExporters.forEach((mbeanExporter) -> mbeanExporter.addExcludedBean(jmxName));
 		return new SpringApplicationAdminMXBeanRegistrar(jmxName);
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/admin/SpringApplicationAdminJmxAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/admin/SpringApplicationAdminJmxAutoConfigurationTests.java
@@ -50,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  *
  * @author Stephane Nicoll
  * @author Andy Wilkinson
+ * @author Nguyen Bao Sach
  */
 class SpringApplicationAdminJmxAutoConfigurationTests {
 
@@ -60,17 +61,10 @@ class SpringApplicationAdminJmxAutoConfigurationTests {
 	private final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(MultipleMBeanExportersConfiguration.class,
-					SpringApplicationAdminJmxAutoConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(SpringApplicationAdminJmxAutoConfiguration.class));
 
 	@Test
-	void notRegisteredByDefault() {
-		this.contextRunner.run((context) -> assertThatExceptionOfType(InstanceNotFoundException.class)
-				.isThrownBy(() -> this.server.getObjectInstance(createDefaultObjectName())));
-	}
-
-	@Test
-	void registeredWithProperty() {
+	void WhenThereAreNotAnyMBeanExporters() {
 		this.contextRunner.withPropertyValues(ENABLE_ADMIN_PROP).run((context) -> {
 			ObjectName objectName = createDefaultObjectName();
 			ObjectInstance objectInstance = this.server.getObjectInstance(objectName);
@@ -79,9 +73,27 @@ class SpringApplicationAdminJmxAutoConfigurationTests {
 	}
 
 	@Test
-	void registerWithCustomJmxName() {
+	void notRegisteredByDefaultWhenThereAreMultipleMBeanExporters() {
+		this.contextRunner.withUserConfiguration(MultipleMBeanExportersConfiguration.class)
+				.run((context) -> assertThatExceptionOfType(InstanceNotFoundException.class)
+						.isThrownBy(() -> this.server.getObjectInstance(createDefaultObjectName())));
+	}
+
+	@Test
+	void registeredWithPropertyWhenThereAreMultipleMBeanExporters() {
+		this.contextRunner.withUserConfiguration(MultipleMBeanExportersConfiguration.class)
+				.withPropertyValues(ENABLE_ADMIN_PROP).run((context) -> {
+					ObjectName objectName = createDefaultObjectName();
+					ObjectInstance objectInstance = this.server.getObjectInstance(objectName);
+					assertThat(objectInstance).as("Lifecycle bean should have been registered").isNotNull();
+				});
+	}
+
+	@Test
+	void registerWithCustomJmxNameWhenThereAreMultipleMBeanExporters() {
 		String customJmxName = "org.acme:name=FooBar";
-		this.contextRunner.withSystemProperties("spring.application.admin.jmx-name=" + customJmxName)
+		this.contextRunner.withUserConfiguration(MultipleMBeanExportersConfiguration.class)
+				.withSystemProperties("spring.application.admin.jmx-name=" + customJmxName)
 				.withPropertyValues(ENABLE_ADMIN_PROP).run((context) -> {
 					try {
 						this.server.getObjectInstance(createObjectName(customJmxName));


### PR DESCRIPTION
Refactor SpringApplicationAdminJmxAutoConfiguration
- Because the default value of `matchIfMissing` is false in `ConditionalOnProperty`, delete unnecessary `matchIfMissing=false`.
- Add new `WhenThereAreNotAnyMBeanExporters` test case proving that `mbeanExporters` can not be null. So, there is no need to check if `mbeanExporters` is null.