### PR TITLE
Allow to configure StartMojo's wait and maxAttempts attributes from the command-line

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StartMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StartMojo.java
@@ -61,13 +61,13 @@ public class StartMojo extends AbstractRunMojo {
 	 * The JMX name of the automatically deployed MBean managing the lifecycle of the
 	 * spring application.
 	 */
-	@Parameter(property = "spring-boot.start.jmxName", defaultValue = SpringApplicationAdminClient.DEFAULT_OBJECT_NAME)
+	@Parameter(defaultValue = SpringApplicationAdminClient.DEFAULT_OBJECT_NAME)
 	private String jmxName;
 
 	/**
 	 * The port to use to expose the platform MBeanServer if the application is forked.
 	 */
-	@Parameter(property = "spring-boot.start.jmxPort", defaultValue = "9001")
+	@Parameter(defaultValue = "9001")
 	private int jmxPort;
 
 	/**

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StartMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StartMojo.java
@@ -61,29 +61,29 @@ public class StartMojo extends AbstractRunMojo {
 	 * The JMX name of the automatically deployed MBean managing the lifecycle of the
 	 * spring application.
 	 */
-	@Parameter
-	private String jmxName = SpringApplicationAdminClient.DEFAULT_OBJECT_NAME;
+	@Parameter(property = "spring-boot.start.jmxName", defaultValue = SpringApplicationAdminClient.DEFAULT_OBJECT_NAME)
+	private String jmxName;
 
 	/**
 	 * The port to use to expose the platform MBeanServer if the application is forked.
 	 */
-	@Parameter
-	private int jmxPort = 9001;
+	@Parameter(property = "spring-boot.start.jmxPort", defaultValue = "9001")
+	private int jmxPort;
 
 	/**
 	 * The number of milli-seconds to wait between each attempt to check if the spring
 	 * application is ready.
 	 */
-	@Parameter
-	private long wait = 500;
+	@Parameter(property = "spring-boot.start.wait", defaultValue = "500")
+	private long wait;
 
 	/**
 	 * The maximum number of attempts to check if the spring application is ready.
 	 * Combined with the "wait" argument, this gives a global timeout value (30 sec by
 	 * default)
 	 */
-	@Parameter
-	private int maxAttempts = 60;
+	@Parameter(property = "spring-boot.start.maxAttempts", defaultValue = "60")
+	private int maxAttempts;
 
 	private final Object lock = new Object();
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StopMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StopMojo.java
@@ -62,14 +62,14 @@ public class StopMojo extends AbstractMojo {
 	 * The JMX name of the automatically deployed MBean managing the lifecycle of the
 	 * application.
 	 */
-	@Parameter(property = "spring-boot.start.jmxName", defaultValue = SpringApplicationAdminClient.DEFAULT_OBJECT_NAME)
+	@Parameter(defaultValue = SpringApplicationAdminClient.DEFAULT_OBJECT_NAME)
 	private String jmxName;
 
 	/**
 	 * The port to use to lookup the platform MBeanServer if the application has been
 	 * forked.
 	 */
-	@Parameter(property = "spring-boot.stop.jmxPort", defaultValue = "9001")
+	@Parameter(defaultValue = "9001")
 	private int jmxPort;
 
 	/**

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StopMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StopMojo.java
@@ -62,15 +62,15 @@ public class StopMojo extends AbstractMojo {
 	 * The JMX name of the automatically deployed MBean managing the lifecycle of the
 	 * application.
 	 */
-	@Parameter
-	private String jmxName = SpringApplicationAdminClient.DEFAULT_OBJECT_NAME;
+	@Parameter(property = "spring-boot.start.jmxName", defaultValue = SpringApplicationAdminClient.DEFAULT_OBJECT_NAME)
+	private String jmxName;
 
 	/**
 	 * The port to use to lookup the platform MBeanServer if the application has been
 	 * forked.
 	 */
-	@Parameter
-	private int jmxPort = 9001;
+	@Parameter(property = "spring-boot.stop.jmxPort", defaultValue = "9001")
+	private int jmxPort;
 
 	/**
 	 * Skip the execution.


### PR DESCRIPTION
This allows overriding the settings for the Maven StartMojo (`spring-boot:start`) from the command line, most notably `wait` and `maxAttempts`, but also the other missing ones and for StopMojo as well. It is useful to increase the timeout on an CI environment, where it can take a longer time to start than usual. I've also moved the default values to the `@Parameter` annotation, so that these show up in the documentation.