### PR TITLE
Remove add-opens workaround in ToolchainPlugin

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/toolchain/ToolchainPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/toolchain/ToolchainPlugin.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.build.toolchain;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -57,7 +56,6 @@ public class ToolchainPlugin implements Plugin<Project> {
 			JavaToolchainSpec toolchainSpec = project.getExtensions().getByType(JavaPluginExtension.class)
 					.getToolchain();
 			toolchainSpec.getLanguageVersion().set(toolchain.getJavaVersion());
-			configureJavaCompileToolchain(project);
 			configureTestToolchain(project);
 		}
 	}
@@ -71,15 +69,6 @@ public class ToolchainPlugin implements Plugin<Project> {
 		project.getTasks().withType(JavaCompile.class, (task) -> task.setEnabled(false));
 		project.getTasks().withType(Javadoc.class, (task) -> task.setEnabled(false));
 		project.getTasks().withType(Test.class, (task) -> task.setEnabled(false));
-	}
-
-	private void configureJavaCompileToolchain(Project project) {
-		project.getTasks().withType(JavaCompile.class, (compile) -> {
-			compile.getOptions().setFork(true);
-			// See https://github.com/gradle/gradle/issues/15538
-			List<String> forkArgs = Arrays.asList("--add-opens", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED");
-			compile.getOptions().getForkOptions().getJvmArgs().addAll(forkArgs);
-		});
 	}
 
 	private void configureTestToolchain(Project project) {


### PR DESCRIPTION
Hi,

this PR removes the `--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED` workaround when using toolchains as https://github.com/gradle/gradle/issues/16126 was backported to Gradle 6.9 which we fortunately use.

Cheers,
Christoph