### PR TITLE
Change info endpoint in doc reference to be secure and unexposed by default

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/endpoints.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/endpoints.adoc
@@ -198,7 +198,7 @@ The following table shows the default exposure for the built-in endpoints:
 
 | `info`
 | Yes
-| Yes
+| No
 
 | `integrationgraph`
 | Yes
@@ -273,7 +273,7 @@ To change which endpoints are exposed, use the following technology-specific `in
 |
 
 | configprop:management.endpoints.web.exposure.include[]
-| `info, health`
+| `health`
 |===
 
 The `include` property lists the IDs of the endpoints that are exposed.


### PR DESCRIPTION
This pr continue to #24715 about document reference.