### PR TITLE
Add HOCON Property Source

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1807,6 +1807,15 @@ bom {
 			]
 		}
 	}
+
+	library ("Typesafe Config", "1.4.1") {
+		group("com.typesafe"){
+			modules = [
+					"config"
+			]
+		}
+	}
+
 	library("UnboundID LDAPSDK", "4.0.14") {
 		group("com.unboundid") {
 			modules = [

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsHomePropertiesPostProcessor.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsHomePropertiesPostProcessor.java
@@ -28,10 +28,7 @@ import java.util.function.Function;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.devtools.system.DevToolsEnablementDeducer;
-import org.springframework.boot.env.EnvironmentPostProcessor;
-import org.springframework.boot.env.PropertiesPropertySourceLoader;
-import org.springframework.boot.env.PropertySourceLoader;
-import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.boot.env.*;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.FileSystemResource;
@@ -64,6 +61,9 @@ public class DevToolsHomePropertiesPostProcessor implements EnvironmentPostProce
 		propertySourceLoaders.add(new PropertiesPropertySourceLoader());
 		if (ClassUtils.isPresent("org.yaml.snakeyaml.Yaml", null)) {
 			propertySourceLoaders.add(new YamlPropertySourceLoader());
+		}
+		if(ClassUtils.isPresent("com.typesafe.config.ConfigFactory", null)) {
+			propertySourceLoaders.add(new HoconPropertySourceLoader());
 		}
 		PROPERTY_SOURCE_LOADERS = Collections.unmodifiableSet(propertySourceLoaders);
 	}

--- a/spring-boot-project/spring-boot/build.gradle
+++ b/spring-boot-project/spring-boot/build.gradle
@@ -81,6 +81,7 @@ dependencies {
 	optional("org.springframework.security:spring-security-web")
 	optional("org.springframework.ws:spring-ws-core")
 	optional("org.yaml:snakeyaml")
+	optional("com.typesafe:config")
 	optional("org.jetbrains.kotlin:kotlin-reflect")
 	optional("org.jetbrains.kotlin:kotlin-stdlib")
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/HoconPropertySourceFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/HoconPropertySourceFactory.java
@@ -1,0 +1,90 @@
+package org.springframework.boot.env;
+
+import com.typesafe.config.*;
+import org.springframework.boot.origin.Origin;
+import org.springframework.boot.origin.OriginTrackedValue;
+import org.springframework.boot.origin.TextResourceOrigin;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.core.io.support.PropertySourceFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A {@link PropertySourceFactory} factory that loads a HOCON file into an instance of {@link PropertySource}.
+ */
+public class HoconPropertySourceFactory implements PropertySourceFactory {
+	private static final ConfigParseOptions PARSE_OPTIONS =
+			ConfigParseOptions.defaults().setSyntax(ConfigSyntax.CONF);
+
+	@Override
+	public PropertySource<?> createPropertySource(String name, EncodedResource encoded) throws IOException {
+		Resource resource = encoded.getResource();
+		String actualName = Optional.ofNullable(name).orElseGet(resource::getFilename);
+		Map<String, Object> source = toFlatMap(resource, parseHoconFrom(resource));
+		return new OriginTrackedMapPropertySource(actualName, source);
+	}
+
+	private Config parseHoconFrom(Resource resource) throws IOException {
+		try (InputStream inputStream = resource.getInputStream(); InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+			return ConfigFactory.parseReader(reader, PARSE_OPTIONS).resolve();
+		}
+	}
+
+	private Map<String, Object> toFlatMap(Resource resource, Config config) {
+		Map<String, Object> properties = new LinkedHashMap<>();
+		toFlatMap(properties, "", resource, config);
+		return properties;
+	}
+
+	private void toFlatMap(Map<String, Object> properties, String parentKey, Resource resource, Config config) {
+		final String prefix = "".equals(parentKey) ? "" : parentKey + ".";
+
+		config.entrySet().stream().forEach(entry -> {
+			String propertyKey = prefix + entry.getKey();
+			addConfigValuePropertyTo(properties, propertyKey, resource, entry.getValue());
+		});
+	}
+
+	private void addConfigValuePropertyTo(Map<String, Object> properties, String key, Resource resource, ConfigValue value) {
+		if (value instanceof ConfigList) {
+			processListValue(properties, key, resource, (ConfigList) value);
+		} else if (value instanceof ConfigObject) {
+			processObjectValue(properties, key, resource, (ConfigObject) value);
+		} else {
+			processScalarValue(properties, key, resource, value);
+		}
+	}
+
+	private void processListValue(Map<String, Object> properties, String key, Resource resource, ConfigList value) {
+		if (value.isEmpty()) {
+			addConfigValuePropertyTo(properties, key, resource, ConfigValueFactory.fromAnyRef(""));
+			return;
+		}
+
+		for (int i = 0; i < value.size(); i++) {
+			// Used to properly populate lists in @ConfigurationProperties beans
+			String propertyName = String.format("%s[%d]", key, i);
+			ConfigValue propertyValue = value.get(i);
+			addConfigValuePropertyTo(properties, propertyName, resource, propertyValue);
+		}
+	}
+
+	private void processObjectValue(Map<String, Object> properties, String key, Resource resource, ConfigObject value) {
+		toFlatMap(properties, key, resource, value.toConfig());
+	}
+
+	private void processScalarValue(Map<String, Object> properties, String key, Resource resource, ConfigValue value) {
+		properties.put(key, value.unwrapped());
+		Origin origin = new TextResourceOrigin(resource, new TextResourceOrigin.Location(value.origin().lineNumber() - 1, 0));
+		properties.put(key, OriginTrackedValue.of(value.unwrapped(), origin));
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/HoconPropertySourceLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/HoconPropertySourceLoader.java
@@ -1,0 +1,33 @@
+package org.springframework.boot.env;
+
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.util.ClassUtils;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Strategy to load '.conf' files in
+ * <a href="https://github.com/typesafehub/config/blob/master/HOCON.md">HOCON</a>
+ * format into a {@link PropertySource}.
+ */
+public class HoconPropertySourceLoader implements PropertySourceLoader {
+
+	@Override
+	public String[] getFileExtensions() {
+		return new String[]{"conf", "hocon"};
+	}
+
+	@Override
+	public List<PropertySource<?>> load(String name, Resource resource) throws IOException {
+		if (!ClassUtils.isPresent("com.typesafe.config.ConfigFactory", null)) {
+			throw new IllegalStateException(
+					"Attempted to load " + name + " but lightbend's typesafe config was not found on the classpath");
+		}
+		return Collections.singletonList(new HoconPropertySourceFactory()
+				.createPropertySource(name, resource instanceof EncodedResource ? (EncodedResource) resource : new EncodedResource(resource)));
+	}
+}

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/spring.factories
@@ -7,7 +7,8 @@ org.springframework.boot.logging.java.JavaLoggingSystem.Factory
 # PropertySource Loaders
 org.springframework.boot.env.PropertySourceLoader=\
 org.springframework.boot.env.PropertiesPropertySourceLoader,\
-org.springframework.boot.env.YamlPropertySourceLoader
+org.springframework.boot.env.YamlPropertySourceLoader,\
+org.springframework.boot.env.HoconPropertySourceLoader
 
 # ConfigData Location Resolvers
 org.springframework.boot.context.config.ConfigDataLocationResolver=\

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/HoconPropertySourceLoaderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/HoconPropertySourceLoaderTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.env;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link YamlPropertySourceLoader}.
+ *
+ * @author Dave Syer
+ * @author Phillip Webb
+ * @author Andy Wilkinson
+ */
+class HoconPropertySourceLoaderTests {
+
+	private HoconPropertySourceLoader loader = new HoconPropertySourceLoader();
+
+	@Test
+	void load() throws Exception {
+		ByteArrayResource resource = new ByteArrayResource("foo {\n  bar = spam\n}".getBytes());
+		PropertySource<?> source = this.loader.load("resource", resource).get(0);
+		assertThat(source).isNotNull();
+		assertThat(source.getProperty("foo.bar")).isEqualTo("spam");
+	}
+
+	@Test
+	void orderedItems() throws Exception {
+		StringBuilder hocon = new StringBuilder();
+		List<String> expected = new ArrayList<>();
+		for (char c = 'a'; c <= 'z'; c++) {
+			hocon.append(c).append("= \"value").append(c).append("\"\n");
+			expected.add(String.valueOf(c));
+		}
+		ByteArrayResource resource = new ByteArrayResource(hocon.toString().getBytes());
+		EnumerablePropertySource<?> source = (EnumerablePropertySource<?>) this.loader.load("resource", resource)
+				.get(0);
+		assertThat(source).isNotNull();
+		assertThat(source.getPropertyNames()).isEqualTo(StringUtils.toStringArray(expected));
+	}
+
+	@Test
+	void loadOriginAware() throws Exception {
+		Resource resource = new ClassPathResource("test-hocon.hocon", getClass());
+		List<PropertySource<?>> loaded = this.loader.load("resource", resource);
+		for (PropertySource<?> source : loaded) {
+			EnumerablePropertySource<?> enumerableSource = (EnumerablePropertySource<?>) source;
+			for (String name : enumerableSource.getPropertyNames()) {
+				System.out.println(name + " = " + enumerableSource.getProperty(name));
+			}
+		}
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/NoTypesafeHoconPropertySourceLoaderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/NoTypesafeHoconPropertySourceLoaderTests.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * Tests for {@link HoconPropertySourceLoader} when lightbend's config is not available.
  *
  * @author Madhura Bhave
+ * @author Mario Daniel Ruiz Saavedra
  */
 @ClassPathExclusions("config-*.jar")
 class NoTypesafeHoconPropertySourceLoaderTests {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/NoTypesafeHoconPropertySourceLoaderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/NoTypesafeHoconPropertySourceLoaderTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.env;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
+import org.springframework.core.io.ByteArrayResource;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+/**
+ * Tests for {@link HoconPropertySourceLoader} when lightbend's config is not available.
+ *
+ * @author Madhura Bhave
+ */
+@ClassPathExclusions("config-*.jar")
+class NoTypesafeHoconPropertySourceLoaderTests {
+
+	private HoconPropertySourceLoader loader = new HoconPropertySourceLoader();
+
+	@Test
+	void load() throws Exception {
+		ByteArrayResource resource = new ByteArrayResource("foo {\n  bar= \"spam\"}".getBytes());
+		assertThatIllegalStateException().isThrownBy(() -> this.loader.load("resource", resource))
+				.withMessageContaining("Attempted to load resource but lightbend's typesafe config was not found on the classpath");
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/env/test-hocon.hocon
+++ b/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/env/test-hocon.hocon
@@ -1,0 +1,31 @@
+// This comment is here just to show you that HOCON supports comments
+# This is a comment too
+
+name = "Martin D'vloper"
+job = "Developer"
+skill = "Elite"
+employed = true
+// Quotes are optional for strings
+foods = ["Apple", Orange, "Strawberry", "Mango"]
+languages {
+  perl = Elite
+  python = Elite
+  pascal = Lame
+}
+education: "4 GCSEs\n3 A-Levels\nBSc in the Internet of Things"
+example {
+  foo {
+    name = "springboot"
+    url = "https://springboot.example.com/"
+
+    bar {
+      bar1 = "baz"
+      bar2 = "bling"
+    }
+  }
+}
+duration = 5s
+empty = ""
+null-value = null
+emptylist = []
+emptymap = {}


### PR DESCRIPTION
This is just for testing the idea from #3558 and to see if there's any interest in adopting HOCON as a property file format. HOCON is used a lot in the Scala ecosystem, it's really easy, and a bit more powerful than YAML. It also supports importing other HOCON files natively.

This implementation is taken from https://github.com/zeldigas/spring-hocon-property-source