### PR TITLE
Fix StandardConfigDataLocationResolver.resolvePatternEmptyDirectories()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/StandardConfigDataLocationResolver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/StandardConfigDataLocationResolver.java
@@ -268,7 +268,7 @@ public class StandardConfigDataLocationResolver
 	private Set<StandardConfigDataResource> resolvePatternEmptyDirectories(StandardConfigDataReference reference) {
 		Resource[] subdirectories = this.resourceLoader.getResources(reference.getDirectory(), ResourceType.DIRECTORY);
 		ConfigDataLocation location = reference.getConfigDataLocation();
-		if (location.isOptional() && ObjectUtils.isEmpty(subdirectories)) {
+		if (!location.isOptional() && ObjectUtils.isEmpty(subdirectories)) {
 			String message = String.format("Config data location '%s' contains no subdirectories", location);
 			throw new ConfigDataLocationNotFoundException(location, message, null);
 		}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
@@ -715,7 +715,8 @@ class ConfigDataEnvironmentPostProcessorIntegrationTests {
 	void runWhenMandatoryWildcardLocationHasNoSubdirectories() {
 		assertThatExceptionOfType(ConfigDataLocationNotFoundException.class).isThrownBy(
 				() -> this.application.run("--spring.config.location=file:src/test/resources/config/0-empty/*/"))
-				.withMessage("Config data location 'file:src/test/resources/config/0-empty/*/' cannot be found");
+				.withMessage(
+						"Config data location 'file:src/test/resources/config/0-empty/*/' contains no subdirectories");
 	}
 
 	@Test


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR fixes `StandardConfigDataLocationResolver.resolvePatternEmptyDirectories()` by adding a missing negation as it seems to have been missed accidentally.