### PR TITLE
Add more session cookie config property for WebFlux

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxProperties.java
@@ -16,7 +16,11 @@
 
 package org.springframework.boot.autoconfigure.web.reactive;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
 import org.springframework.util.StringUtils;
 
 /**
@@ -134,10 +138,96 @@ public class WebFluxProperties {
 
 	public static class Cookie {
 
+		private String name;
+
+		private String domain;
+
+		private String path;
+
+		@DurationUnit(ChronoUnit.SECONDS)
+		private Duration maxAge;
+
+		private Boolean httpOnly;
+
+		private Boolean secure;
+
 		/**
 		 * SameSite attribute value for session Cookies.
 		 */
 		private SameSite sameSite = SameSite.LAX;
+
+		/**
+		 * Return the session cookie name.
+		 * @return the session cookie name
+		 */
+		public String getName() {
+			return this.name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		/**
+		 * Return the domain for the session cookie.
+		 * @return the session cookie domain
+		 */
+		public String getDomain() {
+			return this.domain;
+		}
+
+		public void setDomain(String domain) {
+			this.domain = domain;
+		}
+
+		/**
+		 * Return the path of the session cookie.
+		 * @return the session cookie path
+		 */
+		public String getPath() {
+			return path;
+		}
+
+		public void setPath(String path) {
+			this.path = path;
+		}
+
+		/**
+		 * Return the maximum age of the session cookie.
+		 * @return the maximum age of the session cookie
+		 */
+		public Duration getMaxAge() {
+			return maxAge;
+		}
+
+		public void setMaxAge(Duration maxAge) {
+			this.maxAge = maxAge;
+		}
+
+		/**
+		 * Return whether to use "HttpOnly" cookies for session cookies.
+		 * @return {@code true} to use "HttpOnly" cookies for session cookies.
+		 */
+		public Boolean getHttpOnly() {
+			return httpOnly;
+		}
+
+		public void setHttpOnly(Boolean httpOnly) {
+			this.httpOnly = httpOnly;
+		}
+
+		/**
+		 * Return whether to always mark the session cookie as secure.
+		 * @return {@code true} to mark the session cookie as secure even if the request
+		 * that initiated the corresponding session is using plain HTTP
+		 */
+		public Boolean getSecure() {
+			return secure;
+		}
+
+		public void setSecure(Boolean secure) {
+			this.secure = secure;
+		}
 
 		public SameSite getSameSite() {
 			return this.sameSite;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxProperties.java
@@ -138,7 +138,9 @@ public class WebFluxProperties {
 
 	public static class Cookie {
 
-		private String name;
+		private static final String COOKIE_NAME = "SESSION";
+
+		private String name = COOKIE_NAME;
 
 		private String domain;
 
@@ -147,7 +149,7 @@ public class WebFluxProperties {
 		@DurationUnit(ChronoUnit.SECONDS)
 		private Duration maxAge;
 
-		private Boolean httpOnly;
+		private Boolean httpOnly = true;
 
 		private Boolean secure;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxProperties.java
@@ -128,10 +128,21 @@ public class WebFluxProperties {
 
 	public static class Session {
 
+		@DurationUnit(ChronoUnit.SECONDS)
+		private Duration timeout = Duration.ofMinutes(30);
+
 		private final Cookie cookie = new Cookie();
 
 		public Cookie getCookie() {
 			return this.cookie;
+		}
+
+		public Duration getTimeout() {
+			return this.timeout;
+		}
+
+		public void setTimeout(Duration timeout) {
+			this.timeout = timeout;
 		}
 
 	}
@@ -147,7 +158,7 @@ public class WebFluxProperties {
 		private String path;
 
 		@DurationUnit(ChronoUnit.SECONDS)
-		private Duration maxAge;
+		private Duration maxAge = Duration.ofSeconds(-1);
 
 		private Boolean httpOnly = true;
 
@@ -187,7 +198,7 @@ public class WebFluxProperties {
 		 * @return the session cookie path
 		 */
 		public String getPath() {
-			return path;
+			return this.path;
 		}
 
 		public void setPath(String path) {
@@ -199,7 +210,7 @@ public class WebFluxProperties {
 		 * @return the maximum age of the session cookie
 		 */
 		public Duration getMaxAge() {
-			return maxAge;
+			return this.maxAge;
 		}
 
 		public void setMaxAge(Duration maxAge) {
@@ -211,7 +222,7 @@ public class WebFluxProperties {
 		 * @return {@code true} to use "HttpOnly" cookies for session cookies.
 		 */
 		public Boolean getHttpOnly() {
-			return httpOnly;
+			return this.httpOnly;
 		}
 
 		public void setHttpOnly(Boolean httpOnly) {
@@ -224,7 +235,7 @@ public class WebFluxProperties {
 		 * that initiated the corresponding session is using plain HTTP
 		 */
 		public Boolean getSecure() {
-			return secure;
+			return this.secure;
 		}
 
 		public void setSecure(Boolean secure) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1768,24 +1768,30 @@
     },
     {
       "name": "spring.webflux.session.cookie.name",
-      "type": "java.lang.String",
+      "description": "Session cookie name.",
       "defaultValue": "SESSION"
     },
     {
       "name": "spring.webflux.session.cookie.domain",
-      "defaultValue": "lax"
+      "description": "Domain for the session cookie."
     },
     {
-      "name": "spring.webflux.session.cookie.same-site",
-      "defaultValue": "lax"
+      "name": "spring.webflux.session.cookie.path",
+      "description": "Path of the session cookie.",
+      "defaultValue": "server.servlet.context-path"
     },
     {
-      "name": "spring.webflux.session.cookie.same-site",
-      "defaultValue": "lax"
+      "name": "spring.webflux.session.cookie.max-age",
+      "description": "Maximum age of the session cookie. If a duration suffix is not specified, seconds will be used."
     },
     {
-      "name": "spring.webflux.session.cookie.same-site",
-      "defaultValue": "lax"
+      "name": "spring.webflux.session.cookie.http-only",
+      "description": "Whether to use \"HttpOnly\" cookies for session cookies.",
+      "defaultValue": true
+    },
+    {
+      "name": "spring.webflux.session.cookie.secure",
+      "description": "Whether to always mark the session cookie as secure."
     },
     {
       "name": "spring.webflux.session.cookie.same-site",

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1767,6 +1767,27 @@
       "defaultValue": false
     },
     {
+      "name": "spring.webflux.session.cookie.name",
+      "type": "java.lang.String",
+      "defaultValue": "SESSION"
+    },
+    {
+      "name": "spring.webflux.session.cookie.domain",
+      "defaultValue": "lax"
+    },
+    {
+      "name": "spring.webflux.session.cookie.same-site",
+      "defaultValue": "lax"
+    },
+    {
+      "name": "spring.webflux.session.cookie.same-site",
+      "defaultValue": "lax"
+    },
+    {
+      "name": "spring.webflux.session.cookie.same-site",
+      "defaultValue": "lax"
+    },
+    {
       "name": "spring.webflux.session.cookie.same-site",
       "defaultValue": "lax"
     },

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1767,6 +1767,11 @@
       "defaultValue": false
     },
     {
+      "name": "spring.webflux.session.timeout",
+      "description": "Session timeout. If a duration suffix is not specified, seconds will be used.",
+      "defaultValue": "30m"
+    },
+    {
       "name": "spring.webflux.session.cookie.name",
       "description": "Session cookie name.",
       "defaultValue": "SESSION"
@@ -1782,7 +1787,8 @@
     },
     {
       "name": "spring.webflux.session.cookie.max-age",
-      "description": "Maximum age of the session cookie. If a duration suffix is not specified, seconds will be used."
+      "description": "Maximum age of the session cookie. If a duration suffix is not specified, seconds will be used.\nA positive value indicates when the cookie expires relative to the current time. A value of 0 means the cookie should expire immediately. A negative value means no \"Max-Age\" attribute in which case the cookie is removed when the browser is closed.",
+      "defaultValue": "-1s"
     },
     {
       "name": "spring.webflux.session.cookie.http-only",

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfigurationTests.java
@@ -566,11 +566,11 @@ class WebFluxAutoConfigurationTests {
 
 	@Test
 	void customSameSteConfigurationShouldBeApplied() {
-		this.contextRunner.withPropertyValues("spring.webflux.session.timeout:123", "spring.webflux.session.cookie.name:JSESSIONID",
-				"spring.webflux.session.cookie.domain:.example.com", "spring.webflux.session.cookie.path:/example",
-				"spring.webflux.session.cookie.max-age:60", "spring.webflux.session.cookie.http-only:false",
-				"spring.webflux.session.cookie.secure:false", "spring.webflux.session.cookie.same-site:strict")
-				.run((context) -> {
+		this.contextRunner.withPropertyValues("spring.webflux.session.timeout:123",
+				"spring.webflux.session.cookie.name:JSESSIONID", "spring.webflux.session.cookie.domain:.example.com",
+				"spring.webflux.session.cookie.path:/example", "spring.webflux.session.cookie.max-age:60",
+				"spring.webflux.session.cookie.http-only:false", "spring.webflux.session.cookie.secure:false",
+				"spring.webflux.session.cookie.same-site:strict").run((context) -> {
 					MockServerHttpRequest request = MockServerHttpRequest.get("/").build();
 					MockServerWebExchange exchange = MockServerWebExchange.from(request);
 					WebSessionManager webSessionManager = context.getBean(WebSessionManager.class);
@@ -583,8 +583,8 @@ class WebFluxAutoConfigurationTests {
 					assertThat(cookies).allMatch((cookie) -> cookie.getDomain().equals(".example.com"));
 					assertThat(cookies).allMatch((cookie) -> cookie.getPath().equals("/example"));
 					assertThat(cookies).allMatch((cookie) -> cookie.getMaxAge().equals(Duration.ofSeconds(60)));
-					assertThat(cookies).allMatch((cookie) -> cookie.isHttpOnly() == false);
-					assertThat(cookies).allMatch((cookie) -> cookie.isSecure() == false);
+					assertThat(cookies).allMatch((cookie) -> !cookie.isHttpOnly());
+					assertThat(cookies).allMatch((cookie) -> !cookie.isSecure());
 					assertThat(cookies).allMatch((cookie) -> cookie.getSameSite().equals("Strict"));
 
 				});

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryCustomizerTests.java
@@ -114,7 +114,7 @@ class ServletWebServerFactoryCustomizerTests {
 		this.customizer.customize(factory);
 		ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
 		verify(factory).setSession(sessionCaptor.capture());
-		assertThat(sessionCaptor.getValue().getTimeout()).hasSeconds(123);
+		assertThat(sessionCaptor.getValue().getTimeout()).hasSeconds(124);
 		Cookie cookie = sessionCaptor.getValue().getCookie();
 		assertThat(cookie.getName()).isEqualTo("testname");
 		assertThat(cookie.getDomain()).isEqualTo("testdomain");

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryCustomizerTests.java
@@ -114,7 +114,7 @@ class ServletWebServerFactoryCustomizerTests {
 		this.customizer.customize(factory);
 		ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
 		verify(factory).setSession(sessionCaptor.capture());
-		assertThat(sessionCaptor.getValue().getTimeout()).hasSeconds(124);
+		assertThat(sessionCaptor.getValue().getTimeout()).hasSeconds(123);
 		Cookie cookie = sessionCaptor.getValue().getCookie();
 		assertThat(cookie.getName()).isEqualTo("testname");
 		assertThat(cookie.getDomain()).isEqualTo("testdomain");


### PR DESCRIPTION
## Add rich session cookie config property for WebFlux

**when spring-session is not integrated**

- [x] Provide `spring.webflux.session.cookie.*` properties.
- [x] Provide `spring.webflux.session.timeout` properties.

**when spring-session is on classpath(On the way)**

- [ ] `spring.webflux.session.cookie.*` properties adaptation spring-session
- [ ] `spring.webflux.session.timeout` and `spring.session.timeout` are equivalent

  > However, spring.session.timeout has a higher priority.

If the core members of springboot feel that this pr is worth continuing, I will set it to draft status and complete the rest of the work, otherwise it will be a bankrupt pr.
