### PR TITLE
Remove reference to surefirebooter JAR

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/classpath/ModifiedClassPathClassLoader.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/classpath/ModifiedClassPathClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,11 +131,7 @@ final class ModifiedClassPathClassLoader extends URLClassLoader {
 	}
 
 	private static boolean isManifestOnlyJar(URL url) {
-		return isSurefireBooterJar(url) || isShortenedIntelliJJar(url);
-	}
-
-	private static boolean isSurefireBooterJar(URL url) {
-		return url.getPath().contains("surefirebooter");
+		return isShortenedIntelliJJar(url);
 	}
 
 	private static boolean isShortenedIntelliJJar(URL url) {


### PR DESCRIPTION
Hi,

I just noticed this remaining reference to the `surefirebooter` JAR that is effectively not needed since we're not using Maven Surefire anymore.

Cheers,
Christoph