### PR TITLE
Fix typo in 'Reacting to the Maven plugin' title

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/reacting.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/reacting.adoc
@@ -65,7 +65,7 @@ When Gradle's {application-plugin}[`application` plugin] is applied to a project
 
 
 [[reacting-to-other-plugins-maven]]
-=Í= Reacting to the Maven plugin
+== Reacting to the Maven plugin
 WARNING: Support for reacting to Gradle's `maven` plugin is deprecated and will be removed in a future release.
 Please use the `maven-publish` plugin instead.
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Fixes a type in the section markup of `Reacting to the Maven plugin`.
This broke the AsciiDoc syntax with the following result in the HTML published version.
Instead of a title and admonitions we get a paragraf with all together.

![image](https://user-images.githubusercontent.com/5781153/120679112-19fd4080-c499-11eb-9615-7faa4fe16be9.png)

