### PR TITLE
Fix Javadoc deprecated since

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/r2dbc/ConnectionFactoryBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/r2dbc/ConnectionFactoryBuilder.java
@@ -92,7 +92,7 @@ public final class ConnectionFactoryBuilder {
 	 * @param connectionFactory the connection factory whose options are to be used to
 	 * initialize the builder
 	 * @return a new builder initialized with the options from the connection factory
-	 * @deprecated since 2.5.0 for removal in 2.7.0 in favor of
+	 * @deprecated since 2.5.1 for removal in 2.7.0 in favor of
 	 * {@link #derivedFrom(ConnectionFactory)}
 	 */
 	@Deprecated


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR fixes Javadoc `@deprecated` since for `ConnectionFactoryBuilder.derivefrom()` that has been added in b7ac1e6cd7bf50a5e25fa38c88dc98c4f7db7755.