### PR TITLE
Avoid illegal reflective access in CLI tests

### DIFF
--- a/spring-boot-project/spring-boot-cli/build.gradle
+++ b/spring-boot-project/spring-boot-cli/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
 	loader(project(":spring-boot-project:spring-boot-tools:spring-boot-loader"))
 
+	testCompileOnly("org.apache.tomcat.embed:tomcat-embed-core")
 	testImplementation(project(":spring-boot-project:spring-boot"))
 	testImplementation(project(":spring-boot-project:spring-boot-tools:spring-boot-test-support"))
 	testImplementation(project(":spring-boot-project:spring-boot-test"))

--- a/spring-boot-project/spring-boot-cli/src/test/java/org/springframework/boot/cli/CliTester.java
+++ b/spring-boot-project/spring-boot-cli/src/test/java/org/springframework/boot/cli/CliTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.reflect.Field;
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
@@ -127,7 +125,6 @@ public class CliTester implements BeforeEachCallback, AfterEachCallback {
 	}
 
 	private <T extends OptionParsingCommand> Future<T> submitCommand(T command, String... args) {
-		clearUrlHandler();
 		final String[] sources = getSources(args);
 		return Executors.newSingleThreadExecutor().submit(() -> {
 			ClassLoader loader = Thread.currentThread().getContextClassLoader();
@@ -150,21 +147,6 @@ public class CliTester implements BeforeEachCallback, AfterEachCallback {
 				Thread.currentThread().setContextClassLoader(loader);
 			}
 		});
-	}
-
-	/**
-	 * The TomcatURLStreamHandlerFactory fails if the factory is already set, use
-	 * reflection to reset it.
-	 */
-	private void clearUrlHandler() {
-		try {
-			Field field = URL.class.getDeclaredField("factory");
-			field.setAccessible(true);
-			field.set(null, null);
-		}
-		catch (Exception ex) {
-			throw new IllegalStateException(ex);
-		}
 	}
 
 	protected String[] getSources(String... args) {

--- a/spring-boot-project/spring-boot-cli/src/test/java/org/springframework/boot/cli/CliTesterSpringApplication.java
+++ b/spring-boot-project/spring-boot-cli/src/test/java/org/springframework/boot/cli/CliTesterSpringApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,12 @@
 
 package org.springframework.boot.cli;
 
+import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.web.context.WebServerPortFileWriter;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.util.ClassUtils;
 
 /**
  * Custom {@link SpringApplication} used by {@link CliTester}.
@@ -26,6 +29,13 @@ import org.springframework.context.ConfigurableApplicationContext;
  * @author Andy Wilkinson
  */
 public class CliTesterSpringApplication extends SpringApplication {
+
+	static {
+		if (ClassUtils.isPresent("org.apache.catalina.webresources.TomcatURLStreamHandlerFactory",
+				CliTesterSpringApplication.class.getClassLoader())) {
+			TomcatURLStreamHandlerFactory.disable();
+		}
+	}
 
 	public CliTesterSpringApplication(Class<?>... sources) {
 		super(sources);


### PR DESCRIPTION
Hi,

this is an attempt to get rid of illegal reflective access warnings in CLI tests. The idea is to use `TomcatURLStreamHandlerFactory.disable();` and thus not registering any `factory` in `URL` that we would otherwise need to reset via reflection.

As this is part of the overall JDK 17 story under #26767, it should probably go into 2.5.x.

Let me know what you think.
Cheers,
Christoph

P.S.: I have this flaky / failing test that seems unrelated, but for completeness reasons:
```
:spring-boot-project:spring-boot-cli:test
    org.springframework.boot.cli.ReproIntegrationTests > securityDependencies()

General error during conversion: java.lang.IllegalArgumentException: Malformed \uxxxx encoding.

org.springframework.boot.cli.compiler.grape.DependencyResolutionFailedException: java.lang.IllegalArgumentException: Malformed \uxxxx encoding.
	at org.springframework.boot.cli.compiler.grape.AetherGrapeEngine.resolve(AetherGrapeEngine.java:298)
	at org.springframework.boot.cli.compiler.grape.AetherGrapeEngine.grab(AetherGrapeEngine.java:116)
        ...
```