### PR TITLE
Add possibility to disable the Elasticsearch Sniffer functionality

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java
@@ -36,6 +36,7 @@ import org.elasticsearch.client.sniff.SnifferBuilder;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.context.annotation.Bean;
@@ -113,6 +114,8 @@ class ElasticsearchRestClientConfigurations {
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(Sniffer.class)
 	@ConditionalOnSingleCandidate(RestHighLevelClient.class)
+	@ConditionalOnProperty(prefix = "spring.elasticsearch.rest.sniffer", name = "enabled", havingValue = "true",
+			matchIfMissing = true)
 	static class RestClientSnifferConfiguration {
 
 		@Bean

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientProperties.java
@@ -115,6 +115,11 @@ public class ElasticsearchRestClientProperties {
 		 */
 		private Duration delayAfterFailure = Duration.ofMinutes(1);
 
+		/**
+		 * Whether to enable Sniffer support.
+		 */
+		private boolean enabled = true;
+
 		public Duration getInterval() {
 			return this.interval;
 		}
@@ -129,6 +134,14 @@ public class ElasticsearchRestClientProperties {
 
 		public void setDelayAfterFailure(Duration delayAfterFailure) {
 			this.delayAfterFailure = delayAfterFailure;
+		}
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfigurationTests.java
@@ -221,6 +221,13 @@ class ElasticsearchRestClientAutoConfigurationTests {
 	}
 
 	@Test
+	void configureWithDisabledSnifferShouldNotCreateSniffer() {
+		this.contextRunner.withPropertyValues("spring.elasticsearch.rest.sniffer.enabled=false")
+				.run((context) -> assertThat(context).hasSingleBean(RestHighLevelClient.class)
+						.doesNotHaveBean(Sniffer.class));
+	}
+
+	@Test
 	void configureShouldCreateSnifferUsingRestHighLevelClient() {
 		this.contextRunner.run((context) -> {
 			assertThat(context).hasSingleBean(Sniffer.class);


### PR DESCRIPTION
With #24174 out-of-the-box support was added for Elasticsearch Sniffer.

After our upgrade to the latest Spring Boot 2.5.1, we noticed that using Elasticsearch Sniffer with Elasticsearch in Docker was not working correctly (at least not on Mac). The resolved nodes had some IP that could not be accessed from my host. I know that the functionality is there only if the Sniffer is on the classpath (it was for us by mistake). 

In my opinion it could be beneficial to enable / disable the functionality using a property as well. This can be interested for application build on top of Spring Boot that would like to offer an opt in to the Sniffer by enabling the flag.