### PR TITLE
Avoid illegal reflective access in RabbitAutoConfigurationTests

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -20,20 +20,17 @@ import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
 
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.JDKSaslConfig;
-import com.rabbitmq.client.SslContextFactory;
-import com.rabbitmq.client.TrustEverythingTrustManager;
 import com.rabbitmq.client.impl.CredentialsProvider;
 import com.rabbitmq.client.impl.CredentialsRefreshService;
 import com.rabbitmq.client.impl.DefaultCredentialsProvider;
 import org.aopalliance.aop.Advice;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 
 import org.springframework.amqp.core.AcknowledgeMode;
@@ -59,6 +56,8 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -92,6 +91,7 @@ import static org.mockito.Mockito.verify;
  * @author HaiTao Zhang
  * @author Franjo Zilic
  */
+@ExtendWith(OutputCaptureExtension.class)
 class RabbitAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
@@ -722,24 +722,24 @@ class RabbitAutoConfigurationTests {
 	}
 
 	@Test
-	void enableSslWithValidateServerCertificateFalse() {
+	void enableSslWithValidateServerCertificateFalse(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestConfiguration.class)
 				.withPropertyValues("spring.rabbitmq.ssl.enabled:true",
 						"spring.rabbitmq.ssl.validateServerCertificate=false")
 				.run((context) -> {
 					com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory = getTargetConnectionFactory(context);
-					TrustManager trustManager = getTrustManager(rabbitConnectionFactory);
-					assertThat(trustManager).isInstanceOf(TrustEverythingTrustManager.class);
+					assertThat(rabbitConnectionFactory.isSSL()).isTrue();
+					assertThat(output).contains("TrustEverythingTrustManager", "SECURITY ALERT");
 				});
 	}
 
 	@Test
-	void enableSslWithValidateServerCertificateDefault() {
+	void enableSslWithValidateServerCertificateDefault(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestConfiguration.class)
 				.withPropertyValues("spring.rabbitmq.ssl.enabled:true").run((context) -> {
 					com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory = getTargetConnectionFactory(context);
-					TrustManager trustManager = getTrustManager(rabbitConnectionFactory);
-					assertThat(trustManager).isNotInstanceOf(TrustEverythingTrustManager.class);
+					assertThat(rabbitConnectionFactory.isSSL()).isTrue();
+					assertThat(output).doesNotContain("TrustEverythingTrustManager", "SECURITY ALERT");
 				});
 	}
 
@@ -847,18 +847,6 @@ class RabbitAutoConfigurationTests {
 					inOrder.verify(secondCustomizer).customize(targetConnectionFactory);
 					inOrder.verifyNoMoreInteractions();
 				});
-	}
-
-	private TrustManager getTrustManager(com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory) {
-		SslContextFactory sslContextFactory = (SslContextFactory) ReflectionTestUtils.getField(rabbitConnectionFactory,
-				"sslContextFactory");
-		SSLContext sslContext = sslContextFactory.create("connection");
-		Object spi = ReflectionTestUtils.getField(sslContext, "contextSpi");
-		Object trustManager = ReflectionTestUtils.getField(spi, "trustManager");
-		while (trustManager.getClass().getName().endsWith("Wrapper")) {
-			trustManager = ReflectionTestUtils.getField(trustManager, "tm");
-		}
-		return (TrustManager) trustManager;
 	}
 
 	private com.rabbitmq.client.ConnectionFactory getTargetConnectionFactory(AssertableApplicationContext context) {


### PR DESCRIPTION
Hi,

this is an attempt to avoid some illegal reflective access in `RabbitAutoConfigurationTests`. The idea is that rather than using reflection in order to get down to the used `TrustManager` we look for output that `TrustEverythingTrustManager` is producing when in use. It's not pretty, but it works and is reflection free. It's also the least invasive option without opening modules and/or changing the production code that I could find.

As this is part of the overall JDK 17 story under #26767, it should probably go into 2.5.x.

Let me know what you think.
Cheers,
Christoph