### PR TITLE
Add missing space for asciidoc ordered list

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/properties-and-configuration.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/properties-and-configuration.adoc
@@ -135,9 +135,9 @@ Given the examples above, if we have the following configuration:
 The actual application will show the banner (as overridden by configuration) and uses three sources for the `ApplicationContext`.
 The application sources are:
 
-.`MyApplication` (from the code)
-.`MyDatabaseConfig` (from the external config)
-.`MyJmsConfig`(from the external config)
+. `MyApplication` (from the code)
+. `MyDatabaseConfig` (from the external config)
+. `MyJmsConfig`(from the external config)
 
 
 


### PR DESCRIPTION
The list is not rendering before this commit
![1](https://user-images.githubusercontent.com/143040/122492852-22b55100-d019-11eb-8d06-f829a7ec249e.jpg)
