### PR TITLE
Default value of spring.netty.leak-detection does not match Netty's default

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/netty/NettyAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/netty/NettyAutoConfiguration.java
@@ -37,8 +37,7 @@ public class NettyAutoConfiguration {
 
 	public NettyAutoConfiguration(NettyProperties properties) {
 		if (properties.getLeakDetection() != null) {
-			NettyProperties.LeakDetection leakDetection = properties.getLeakDetection();
-			ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.valueOf(leakDetection.name()));
+			ResourceLeakDetector.setLevel(properties.getLeakDetection());
 		}
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/netty/NettyProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/netty/NettyProperties.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.autoconfigure.netty;
 
+import io.netty.util.ResourceLeakDetector;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -32,38 +33,13 @@ public class NettyProperties {
 	/**
 	 * Level of leak detection for reference-counted buffers.
 	 */
-	private LeakDetection leakDetection = LeakDetection.DISABLED;
+	private ResourceLeakDetector.Level leakDetection;
 
-	public LeakDetection getLeakDetection() {
+	public ResourceLeakDetector.Level getLeakDetection() {
 		return this.leakDetection;
 	}
 
-	public void setLeakDetection(LeakDetection leakDetection) {
+	public void setLeakDetection(ResourceLeakDetector.Level leakDetection) {
 		this.leakDetection = leakDetection;
 	}
-
-	public enum LeakDetection {
-
-		/**
-		 * Disable leak detection completely.
-		 */
-		DISABLED,
-
-		/**
-		 * Detect leaks for 1% of buffers.
-		 */
-		SIMPLE,
-
-		/**
-		 * Detect leaks for 1% of buffers and track where they were accessed.
-		 */
-		ADVANCED,
-
-		/**
-		 * Detect leaks for 100% of buffers and track where they were accessed.
-		 */
-		PARANOID
-
-	}
-
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1784,8 +1784,7 @@
       "description": "Comma-separated list of locations of WSDLs and accompanying XSDs to be exposed as beans."
     },
     {
-      "name": "spring.netty.leak-detection",
-      "defaultValue": "disabled"
+      "name": "spring.netty.leak-detection"
     }
   ],
   "hints": [

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/netty/NettyAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/netty/NettyAutoConfigurationTests.java
@@ -36,11 +36,18 @@ class NettyAutoConfigurationTests {
 
 	@Test
 	void leakDetectionShouldBeConfigured() {
+		ResourceLeakDetector.Level originLevel = ResourceLeakDetector.getLevel();
 		this.contextRunner.withPropertyValues("spring.netty.leak-detection=paranoid").run((context) -> {
 			assertThat(ResourceLeakDetector.getLevel()).isEqualTo(ResourceLeakDetector.Level.PARANOID);
 			// reset configuration for the following tests.
-			ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);
+			ResourceLeakDetector.setLevel(originLevel);
 		});
+	}
+
+	@Test
+	void leakDetectionNotBeConfigured() {
+		ResourceLeakDetector.Level originLevel = ResourceLeakDetector.getLevel();
+		this.contextRunner.run((context) -> assertThat(ResourceLeakDetector.getLevel()).isEqualTo(originLevel));
 	}
 
 }


### PR DESCRIPTION
I use netty to build a tcp server from springboot 2.4.x to 2.5.x and I found the project does not detect memory leak any more.
The NettyAutoConfiguration was added from 2.5.x, and the LeakDetection of NettyProperties  is disable.
I think it shoud keep same with netty default ResourceLeakDetector level, otherwise the netty debug log shows its ResourceLeakDetector level is simple, but it is disable actually.
In most situations, we need the default simple ResourceLeakDetector  and it works well
By the way, NettyAutoConfiguration seems useless for now, because it only set ResourceLeakDetector. Maybe it will provide more properties in the future？