### PR TITLE
Add resource labels to Stackdriver metrics configuration properties

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverProperties.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.stackdriver;
 
+import java.util.Map;
+
 import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -40,6 +42,11 @@ public class StackdriverProperties extends StepRegistryProperties {
 	 */
 	private String resourceType = "global";
 
+	/**
+	 * Monitored resource's labels.
+	 */
+	private Map<String, String> resourceLabels;
+
 	public String getProjectId() {
 		return this.projectId;
 	}
@@ -54,6 +61,14 @@ public class StackdriverProperties extends StepRegistryProperties {
 
 	public void setResourceType(String resourceType) {
 		this.resourceType = resourceType;
+	}
+
+	public Map<String, String> getResourceLabels() {
+		return this.resourceLabels;
+	}
+
+	public void setResourceLabels(Map<String, String> resourceLabels) {
+		this.resourceLabels = resourceLabels;
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverPropertiesConfigAdapter.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.stackdriver;
 
+import java.util.Map;
+
 import io.micrometer.stackdriver.StackdriverConfig;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.StepRegistryPropertiesConfigAdapter;
@@ -46,6 +48,11 @@ public class StackdriverPropertiesConfigAdapter extends StepRegistryPropertiesCo
 	@Override
 	public String resourceType() {
 		return get(StackdriverProperties::getResourceType, StackdriverConfig.super::resourceType);
+	}
+
+	@Override
+	public Map<String, String> resourceLabels() {
+		return get(StackdriverProperties::getResourceLabels, StackdriverConfig.super::resourceLabels);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverPropertiesConfigAdapterTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.stackdriver;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,6 +42,17 @@ class StackdriverPropertiesConfigAdapterTests {
 		StackdriverProperties properties = new StackdriverProperties();
 		properties.setResourceType("my-resource-type");
 		assertThat(new StackdriverPropertiesConfigAdapter(properties).resourceType()).isEqualTo("my-resource-type");
+	}
+
+	@Test
+	void whenPropertiesResourceLabelsAreSetAdapterResourceTypeReturnsThem() {
+		final Map<String, String> labels = new HashMap<>();
+		labels.put("labelOne", "valueOne");
+		labels.put("labelTwo", "valueTwo");
+		StackdriverProperties properties = new StackdriverProperties();
+		properties.setResourceLabels(labels);
+		assertThat(new StackdriverPropertiesConfigAdapter(properties).resourceLabels())
+				.containsExactlyInAnyOrderEntriesOf(labels);
 	}
 
 }


### PR DESCRIPTION
Using resource labels is mandatory for most Stackdriver resources other then `Global`, i.e. `k8s_pod`.
While setting resource type is supported in `StackdriverProperties`, it is not possible to set labels in the same, configurable way.
Configuring resource type only lead to issues as described in micrometer-metrics/micrometer#1907.

Using valid resource type along with required labels makes it possible to use given metric in a wider set of
GCP solutions, i.e. custom metric based GKE horizontal pod autoscaler.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
