### PR TITLE
Document uuid support in RandomValuePropertySource

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/RandomValuePropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/RandomValuePropertySource.java
@@ -44,6 +44,7 @@ import org.springframework.util.StringUtils;
  * specified range.</li>
  * <li>When {@literal "long"}, a random {@link Long} value, restricted by an optionally
  * specified range.</li>
+ * <li>When {@literal "uuid"}, a random {@link UUID} value.</li>
  * <li>Otherwise, a {@code byte[]}.</li>
  * </ul>
  * The {@literal "random.int"} and {@literal "random.long"} properties supports a range


### PR DESCRIPTION
Class `org.springframework.boot.env.RandomValuePropertySource` contains incorrect Java Doc. When the suffix is not `int` or `long` the value not be always `byte[]`. When the suffix is `uuid` then result will be UUID value.