### PR TITLE
Fix SpringApplicationShutdownHook throws ClassCastException

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -301,7 +301,14 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 
 	@Override
 	public Runnable getShutdownHandler() {
-		return () -> getLoggerContext().stop();
+		return () -> {
+			try {
+				getLoggerContext().stop();
+			}
+			catch (ClassCastException ex) {
+				// Ignore
+			}
+		};
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #26953

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
 I think the we can  programmatically disabling log4j shutdown hook when initialize, since SpringApplicationShutdownHook will handle shutdown. I noticed in the previous version(before 2.5.1), spring shutdown hook is executed before log4j2 shutdown hook,so no exception throws.  

Or we can try catch in shutdownhandler to ignore the exception, exception means log context has been removed, so created a one will throw excpetion .I perfer the try catch  method,  since the previous is not Configurable. 