### PR TITLE
Allow additional JVM args when running tests via toolchain

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/toolchain/ToolchainExtension.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/toolchain/ToolchainExtension.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.build.toolchain;
 
 import org.gradle.api.Project;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 
@@ -29,16 +30,23 @@ public class ToolchainExtension {
 
 	private final Property<JavaLanguageVersion> maximumCompatibleJavaVersion;
 
+	private final ListProperty<String> testJvmArgs;
+
 	private final JavaLanguageVersion javaVersion;
 
 	public ToolchainExtension(Project project) {
 		this.maximumCompatibleJavaVersion = project.getObjects().property(JavaLanguageVersion.class);
+		this.testJvmArgs = project.getObjects().listProperty(String.class);
 		String toolchainVersion = (String) project.findProperty("toolchainVersion");
 		this.javaVersion = (toolchainVersion != null) ? JavaLanguageVersion.of(toolchainVersion) : null;
 	}
 
 	public Property<JavaLanguageVersion> getMaximumCompatibleJavaVersion() {
 		return this.maximumCompatibleJavaVersion;
+	}
+
+	public ListProperty<String> getTestJvmArgs() {
+		return this.testJvmArgs;
 	}
 
 	JavaLanguageVersion getJavaVersion() {

--- a/buildSrc/src/main/java/org/springframework/boot/build/toolchain/ToolchainPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/toolchain/ToolchainPlugin.java
@@ -16,9 +16,6 @@
 
 package org.springframework.boot.build.toolchain;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -56,7 +53,7 @@ public class ToolchainPlugin implements Plugin<Project> {
 			JavaToolchainSpec toolchainSpec = project.getExtensions().getByType(JavaPluginExtension.class)
 					.getToolchain();
 			toolchainSpec.getLanguageVersion().set(toolchain.getJavaVersion());
-			configureTestToolchain(project);
+			configureTestToolchain(project, toolchain);
 		}
 	}
 
@@ -71,11 +68,11 @@ public class ToolchainPlugin implements Plugin<Project> {
 		project.getTasks().withType(Test.class, (task) -> task.setEnabled(false));
 	}
 
-	private void configureTestToolchain(Project project) {
-		project.getTasks().withType(Test.class, (test) -> {
-			List<String> arguments = Collections.singletonList("--illegal-access=warn");
-			test.jvmArgs(arguments);
-		});
+	private void configureTestToolchain(Project project, ToolchainExtension toolchain) {
+		if (!toolchain.getTestJvmArgs().isPresent()) {
+			return;
+		}
+		project.getTasks().withType(Test.class, (test) -> test.jvmArgs(toolchain.getTestJvmArgs().get()));
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/build.gradle
@@ -6,10 +6,6 @@ plugins {
 
 description = "Spring Boot Loader"
 
-toolchain {
-	testJvmArgs.add("--add-opens=java.base/java.util.zip=ALL-UNNAMED")
-}
-
 dependencies {
 	compileOnly("org.springframework:spring-core")
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/build.gradle
@@ -6,6 +6,10 @@ plugins {
 
 description = "Spring Boot Loader"
 
+toolchain {
+	testJvmArgs.add("--add-opens=java.base/java.util.zip=ALL-UNNAMED")
+}
+
 dependencies {
 	compileOnly("org.springframework:spring-core")
 

--- a/spring-boot-project/spring-boot/build.gradle
+++ b/spring-boot-project/spring-boot/build.gradle
@@ -9,6 +9,10 @@ plugins {
 
 description = "Spring Boot"
 
+toolchain {
+	testJvmArgs.add("--add-opens=java.base/java.net=ALL-UNNAMED")
+}
+
 def tomcatConfigProperties = "$buildDir/tomcat-config-properties"
 
 configurations {


### PR DESCRIPTION
Hi,

this is part of the overall Java 17 story #26767 and is a solution for points 6 & 7, where we access internals to either reset state (clearing `URL.factory` in Servlet tests) or create a test scenario (setting `xdostime` on `ZipEntry`) and were no alternative exists to fix those (apart from disabling them for JDK 17)

> 6. Similar problem as 5. but in AbstractServletWebServerFactoryTests.tearDown() - Possibly similar solution with opening modules
> 7. JarFileTests.jarFileEntryWithEpochTimeOfZeroShouldNotFail() fails because it tries to set xdostime on ZipEntry, which is internal. We could disable that test for JDK 17 and higher or again fiddle around with opening up modules.

The idea is to extend the `ToolchainExtension` with a new property that sets the JVM args of `Test` tasks - if given. I designed this to be flexible, so any kind of JVM args could be passed instead of just providing a way to open up modules.

While being on that, I also removed `--illegal-access=warn` already which has no effect on Java 17. I can keep it though on lower versions if you'd like me to keep it, but effectively it would only be set on the Java 16 pipeline, because that's the only toolchain based build at the moment. And likely the pipeline for 16 is going away once we have one for 17.

Let me know what you think.
Cheers,
Christoph