### PR TITLE
Add @WebServiceServerTest annotation that can be used when testing SOAP server

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/server/AutoConfigureMockWebServiceClient.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/server/AutoConfigureMockWebServiceClient.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.webservices.server;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.ws.test.server.MockWebServiceClient;
+
+/**
+ * Annotation that can be applied to a test class to enable and configure
+ * auto-configuration of {@link MockWebServiceClient}.
+ *
+ * @author Daniil Razorenov
+ * @since 2.6.0
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ImportAutoConfiguration
+public @interface AutoConfigureMockWebServiceClient {
+
+}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/server/AutoConfigureWebServiceServer.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/server/AutoConfigureWebServiceServer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.webservices.server;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+
+/**
+ * Annotation that can be applied to a test class to enable and configure
+ * auto-configuration of web service servers endpoints.
+ *
+ * @author Daniil Razorenov
+ * @since 2.6.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ImportAutoConfiguration
+public @interface AutoConfigureWebServiceServer {
+
+}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/server/MockWebServiceClientAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/server/MockWebServiceClientAutoConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.webservices.server;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.webservices.WebServicesAutoConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.ws.test.server.MockWebServiceClient;
+
+/**
+ * Auto-configuration for {@link MockWebServiceClient} support.
+ *
+ * @author Daniil Razorenov
+ * @see AutoConfigureMockWebServiceClient
+ * @since 2.6.0
+ */
+@Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(WebServicesAutoConfiguration.class)
+@ConditionalOnClass({ MockWebServiceClient.class })
+public class MockWebServiceClientAutoConfiguration {
+
+	@Bean
+	MockWebServiceClient mockWebServiceClient(ApplicationContext applicationContext) {
+		return MockWebServiceClient.createClient(applicationContext);
+	}
+
+}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/server/WebServiceServerTest.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/server/WebServiceServerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.webservices.server;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Annotation that can be used for typical Spring web service server test. Can be used
+ * when a test focused <strong>only</strong> on Spring WS endpoints.
+ * <p>
+ * Using this annotation will disable full auto-configuration and instead apply only
+ * configuration relevant to Web Service Server tests (i.e. {@code Endpoint},
+ * {@code EndpointInterceptor} beans but not {@code @Component}, {@code @Service} or
+ * {@code @Repository} beans).
+ * <p>
+ * Typically {@code WebMvcTest} is used in combination with
+ * {@link org.springframework.boot.test.mock.mockito.MockBean @MockBean} or
+ * {@link org.springframework.context.annotation.Import @Import} to create any
+ * collaborators required by your {@code Endpoint} beans.
+ * <p>
+ * If you are looking to load your full application configuration and use
+ * MockWebServiceClient, you should consider
+ * {@link org.springframework.boot.test.context.SpringBootTest @SpringBootTest} combined
+ * with {@link AutoConfigureMockWebServiceClient @AutoConfigureMockWebServiceClient}
+ * rather than this annotation.
+ *
+ * @author Daniil Razorenov
+ * @since 2.6.0
+ * @see AutoConfigureMockWebServiceClient
+ * @see AutoConfigureWebServiceServer
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@BootstrapWith(WebServiceServerTestContextBootstrapper.class)
+@ExtendWith(SpringExtension.class)
+@OverrideAutoConfiguration(enabled = false)
+@TypeExcludeFilters(WebServiceServerTypeExcludeFilter.class)
+@AutoConfigureWebServiceServer
+@AutoConfigureMockWebServiceClient
+@ImportAutoConfiguration
+public @interface WebServiceServerTest {
+
+	/**
+	 * Properties in form {@literal key=value} that should be added to the Spring
+	 * {@link Environment} before the test runs.
+	 * @return the properties to add
+	 * @since 2.1.0
+	 */
+	String[] properties() default {};
+
+	/**
+	 * Specifies the endpoints to test. This is an alias of {@link #endpoints()} which can
+	 * be used for brevity if no other attributes are defined. See {@link #endpoints()}
+	 * for details.
+	 * @return the endpoints to test
+	 * @see #endpoints()
+	 */
+	@AliasFor("endpoints")
+	Class<?>[] value() default {};
+
+	/**
+	 * Specifies the endpoints to test. May be left blank if all {@code @Endpoint} beans
+	 * should be added to the application context.
+	 * @return the endpoints to test
+	 * @see #value()
+	 */
+	@AliasFor("value")
+	Class<?>[] endpoints() default {};
+
+	/**
+	 * Determines if default filtering should be used with
+	 * {@link SpringBootApplication @SpringBootApplication}. By default only
+	 * {@code @Endpoint} (when no explicit {@link #endpoints() controllers} are defined),
+	 * {@code @ControllerAdvice} and {@code WebMvcConfigurer} beans are included.
+	 * @see #includeFilters()
+	 * @see #excludeFilters()
+	 * @return if default filters should be used
+	 */
+	boolean useDefaultFilters() default true;
+
+	/**
+	 * A set of include filters which can be used to add otherwise filtered beans to the
+	 * application context.
+	 * @return include filters to apply
+	 */
+	ComponentScan.Filter[] includeFilters() default {};
+
+	/**
+	 * A set of exclude filters which can be used to filter beans that would otherwise be
+	 * added to the application context.
+	 * @return exclude filters to apply
+	 */
+	ComponentScan.Filter[] excludeFilters() default {};
+
+	/**
+	 * Auto-configuration exclusions that should be applied for this test.
+	 * @return auto-configuration exclusions to apply
+	 */
+	@AliasFor(annotation = ImportAutoConfiguration.class, attribute = "exclude")
+	Class<?>[] excludeAutoConfiguration() default {};
+
+}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/server/WebServiceServerTestContextBootstrapper.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/server/WebServiceServerTestContextBootstrapper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.webservices.server;
+
+import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.annotation.MergedAnnotations.SearchStrategy;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.test.context.TestContextBootstrapper;
+import org.springframework.test.context.web.WebMergedContextConfiguration;
+
+/**
+ * {@link TestContextBootstrapper} for {@link WebServiceServerTest @WebServiceServerTest}
+ * support.
+ *
+ * @author Daniil Razorenov
+ */
+class WebServiceServerTestContextBootstrapper extends SpringBootTestContextBootstrapper {
+
+	@Override
+	protected MergedContextConfiguration processMergedContextConfiguration(MergedContextConfiguration mergedConfig) {
+		MergedContextConfiguration processedMergedConfiguration = super.processMergedContextConfiguration(mergedConfig);
+		return new WebMergedContextConfiguration(processedMergedConfiguration, determineResourceBasePath(mergedConfig));
+	}
+
+	@Override
+	protected String[] getProperties(Class<?> testClass) {
+		return MergedAnnotations.from(testClass, SearchStrategy.INHERITED_ANNOTATIONS).get(WebServiceServerTest.class)
+				.getValue("properties", String[].class).orElse(null);
+	}
+
+}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/server/WebServiceServerTypeExcludeFilter.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/server/WebServiceServerTypeExcludeFilter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.webservices.server;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.springframework.boot.context.TypeExcludeFilter;
+import org.springframework.boot.test.autoconfigure.filter.StandardAnnotationCustomizableTypeExcludeFilter;
+import org.springframework.util.ObjectUtils;
+import org.springframework.ws.server.EndpointInterceptor;
+import org.springframework.ws.server.endpoint.annotation.Endpoint;
+
+/**
+ * {@link TypeExcludeFilter} for {@link WebServiceServerTest @WebServiceServerTest}.
+ *
+ * @author Daniil Razorenov
+ * @since 2.6.0
+ */
+public class WebServiceServerTypeExcludeFilter
+		extends StandardAnnotationCustomizableTypeExcludeFilter<WebServiceServerTest> {
+
+	private static final Class<?>[] NO_ENDPOINTS = {};
+
+	private static final Set<Class<?>> DEFAULT_INCLUDES;
+
+	private static final Set<Class<?>> DEFAULT_INCLUDES_AND_ENDPOINT;
+
+	static {
+		Set<Class<?>> includes = new LinkedHashSet<>();
+		includes.add(EndpointInterceptor.class);
+		DEFAULT_INCLUDES = Collections.unmodifiableSet(includes);
+	}
+
+	static {
+		Set<Class<?>> includes = new LinkedHashSet<>(DEFAULT_INCLUDES);
+		includes.add(Endpoint.class);
+		DEFAULT_INCLUDES_AND_ENDPOINT = Collections.unmodifiableSet(includes);
+	}
+
+	private final Class<?>[] endpoints;
+
+	WebServiceServerTypeExcludeFilter(Class<?> testClass) {
+		super(testClass);
+		this.endpoints = getAnnotation().getValue("endpoints", Class[].class).orElse(NO_ENDPOINTS);
+	}
+
+	@Override
+	protected Set<Class<?>> getDefaultIncludes() {
+		if (ObjectUtils.isEmpty(this.endpoints)) {
+			return DEFAULT_INCLUDES_AND_ENDPOINT;
+		}
+		return DEFAULT_INCLUDES;
+	}
+
+	@Override
+	protected Set<Class<?>> getComponentIncludes() {
+		return new LinkedHashSet<>(Arrays.asList(this.endpoints));
+	}
+
+}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/server/package-info.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/webservices/server/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for web service server tests.
+ */
+package org.springframework.boot.test.autoconfigure.webservices.server;

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -196,6 +196,14 @@ org.springframework.boot.autoconfigure.webservices.client.WebServiceTemplateAuto
 org.springframework.boot.test.autoconfigure.webservices.client.AutoConfigureMockWebServiceServer=\
 org.springframework.boot.test.autoconfigure.webservices.client.MockWebServiceServerAutoConfiguration
 
+# AutoConfigureWebServiceServer auto-configuration imports
+org.springframework.boot.test.autoconfigure.webservices.server.AutoConfigureWebServiceServer=\
+org.springframework.boot.autoconfigure.webservices.WebServicesAutoConfiguration
+
+# AutoConfigureMockWebServiceClient auto-configuration imports
+org.springframework.boot.test.autoconfigure.webservices.server.AutoConfigureMockWebServiceClient=\
+org.springframework.boot.test.autoconfigure.webservices.server.MockWebServiceClientAutoConfiguration
+
 # DefaultTestExecutionListenersPostProcessors
 org.springframework.boot.test.context.DefaultTestExecutionListenersPostProcessor=\
 org.springframework.boot.test.autoconfigure.SpringBootDependencyInjectionTestExecutionListener$PostProcessor

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/ExampleWebServiceEndpoint.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/ExampleWebServiceEndpoint.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.webservices.server;
+
+import org.springframework.ws.server.endpoint.annotation.Endpoint;
+import org.springframework.ws.server.endpoint.annotation.PayloadRoot;
+import org.springframework.ws.server.endpoint.annotation.RequestPayload;
+import org.springframework.ws.server.endpoint.annotation.ResponsePayload;
+
+/**
+ * Example web service {@code @Endpoint} used with
+ * {@link WebServiceServerTest @WebServiceServerTest} tests.
+ *
+ * @author Daniil Razorenov
+ */
+@Endpoint
+public class ExampleWebServiceEndpoint {
+
+	@PayloadRoot(localPart = "request")
+	@ResponsePayload
+	Response payloadMethod(@RequestPayload Request request) {
+		return new Response(42);
+	}
+
+}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/ExampleWebServiceServerApplication.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/ExampleWebServiceServerApplication.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.webservices.server;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Example {@link SpringBootApplication @SpringBootApplication} used with
+ * {@link WebServiceServerTest @WebServiceServerTest} tests.
+ *
+ * @author Daniil Razorenov
+ */
+@SpringBootApplication
+public class ExampleWebServiceServerApplication {
+
+}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/MockWebServiceClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/MockWebServiceClientAutoConfigurationTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.webservices.server;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.ws.test.server.MockWebServiceClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MockWebServiceClientAutoConfiguration}.
+ *
+ * @author Daniil Razorenov
+ */
+class MockWebServiceClientAutoConfigurationTests {
+
+	private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(MockWebServiceClientAutoConfiguration.class));
+
+	@Test
+	void shouldRegisterMockWebServiceClient() {
+		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(MockWebServiceClient.class));
+	}
+
+	@Test
+	void shouldNotRegisterMockWebServiceClientWhenItNotOnClassPath() {
+		FilteredClassLoader classLoader = new FilteredClassLoader(MockWebServiceClient.class);
+
+		this.contextRunner.withClassLoader(classLoader)
+				.run((context) -> assertThat(context).doesNotHaveBean(MockWebServiceClient.class));
+	}
+
+}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/Request.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/Request.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.webservices.server;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Test request.
+ *
+ * @author Daniil Razorenov
+ */
+@XmlRootElement(name = "request")
+class Request {
+
+	@XmlElement(required = true)
+	private String message;
+
+}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/Response.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/Response.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.webservices.server;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Test response.
+ *
+ * @author Daniil Razorenov
+ */
+@XmlRootElement(name = "response")
+class Response {
+
+	@XmlElement(required = true)
+	private int code;
+
+	Response(int code) {
+		this.code = code;
+	}
+
+	Response() {
+	}
+
+}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/WebServiceServerIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/WebServiceServerIntegrationTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.webservices.server;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.ws.test.server.MockWebServiceClient;
+import org.springframework.ws.test.server.RequestCreators;
+import org.springframework.ws.test.server.ResponseMatchers;
+import org.springframework.xml.transform.StringSource;
+
+/**
+ * Tests for {@link WebServiceServerTest @WebServiceServerTest}.
+ *
+ * @author Daniil Razorenov
+ */
+@WebServiceServerTest(endpoints = ExampleWebServiceEndpoint.class)
+public class WebServiceServerIntegrationTests {
+
+	@Autowired
+	private MockWebServiceClient mock;
+
+	@Test
+	void payloadRootMethod() {
+		this.mock
+				.sendRequest(
+						RequestCreators.withPayload(new StringSource("<request><message>Hello</message></request>")))
+				.andExpect(ResponseMatchers.payload(new StringSource("<response><code>42</code></response>")));
+	}
+
+}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/WebServiceServerPropertiesIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/WebServiceServerPropertiesIntegrationTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.webservices.server;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the {@link WebServiceServerTest#properties properties} attribute of
+ * {@link WebServiceServerTest @WebServiceServerTest}.
+ *
+ * @author Daniil Razorenov
+ */
+@WebServiceServerTest(properties = "spring.profiles.active=test")
+public class WebServiceServerPropertiesIntegrationTests {
+
+	@Autowired
+	private Environment environment;
+
+	@Test
+	void environmentWithNewProfile() {
+		assertThat(this.environment.getActiveProfiles()).containsExactly("test");
+	}
+
+}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/WebServiceServerTypeExcludeFilterTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/webservices/server/WebServiceServerTypeExcludeFilterTests.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.webservices.server;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.core.type.classreading.MetadataReader;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.core.type.classreading.SimpleMetadataReaderFactory;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+import org.springframework.ws.server.endpoint.annotation.Endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link WebServiceServerTypeExcludeFilter}.
+ *
+ * @author Daniil Razorenov
+ */
+public class WebServiceServerTypeExcludeFilterTests {
+
+	private final MetadataReaderFactory metadataReaderFactory = new SimpleMetadataReaderFactory();
+
+	@Test
+	void matchWhenHasNoEndpoints() throws IOException {
+		WebServiceServerTypeExcludeFilter filter = new WebServiceServerTypeExcludeFilter(WithNoEndpoints.class);
+
+		assertThat(exclude(filter, WebService1.class)).isFalse();
+		assertThat(exclude(filter, WebService2.class)).isFalse();
+		assertThat(exclude(filter, ExampleService.class)).isTrue();
+		assertThat(exclude(filter, ExampleRepository.class)).isTrue();
+	}
+
+	@Test
+	void matchWhenHasEndpoint() throws IOException {
+		WebServiceServerTypeExcludeFilter filter = new WebServiceServerTypeExcludeFilter(WithEndpoint.class);
+
+		assertThat(exclude(filter, WebService1.class)).isFalse();
+		assertThat(exclude(filter, WebService2.class)).isTrue();
+		assertThat(exclude(filter, ExampleService.class)).isTrue();
+		assertThat(exclude(filter, ExampleRepository.class)).isTrue();
+	}
+
+	@Test
+	void matchNotUsingDefaultFilters() throws IOException {
+		WebServiceServerTypeExcludeFilter filter = new WebServiceServerTypeExcludeFilter(NotUsingDefaultFilters.class);
+
+		assertThat(exclude(filter, WebService1.class)).isTrue();
+		assertThat(exclude(filter, WebService2.class)).isTrue();
+		assertThat(exclude(filter, ExampleService.class)).isTrue();
+		assertThat(exclude(filter, ExampleRepository.class)).isTrue();
+	}
+
+	@Test
+	void matchWithIncludeFilter() throws IOException {
+		WebServiceServerTypeExcludeFilter filter = new WebServiceServerTypeExcludeFilter(WithIncludeFilter.class);
+
+		assertThat(exclude(filter, WebService1.class)).isFalse();
+		assertThat(exclude(filter, WebService2.class)).isFalse();
+		assertThat(exclude(filter, ExampleService.class)).isTrue();
+		assertThat(exclude(filter, ExampleRepository.class)).isFalse();
+	}
+
+	@Test
+	void matchWithExcludeFilter() throws IOException {
+		WebServiceServerTypeExcludeFilter filter = new WebServiceServerTypeExcludeFilter(WithExcludeFilter.class);
+
+		assertThat(exclude(filter, WebService1.class)).isTrue();
+		assertThat(exclude(filter, WebService2.class)).isFalse();
+		assertThat(exclude(filter, ExampleService.class)).isTrue();
+		assertThat(exclude(filter, ExampleRepository.class)).isTrue();
+	}
+
+	private boolean exclude(WebServiceServerTypeExcludeFilter filter, Class<?> type) throws IOException {
+		MetadataReader metadataReader = this.metadataReaderFactory.getMetadataReader(type.getName());
+		return filter.match(metadataReader, this.metadataReaderFactory);
+	}
+
+	@WebServiceServerTest
+	static class WithNoEndpoints {
+
+	}
+
+	@WebServiceServerTest(WebService1.class)
+	static class WithEndpoint {
+
+	}
+
+	@WebServiceServerTest(useDefaultFilters = false)
+	static class NotUsingDefaultFilters {
+
+	}
+
+	@WebServiceServerTest(includeFilters = @Filter(Repository.class))
+	static class WithIncludeFilter {
+
+	}
+
+	@WebServiceServerTest(excludeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebService1.class))
+	static class WithExcludeFilter {
+
+	}
+
+	@Endpoint
+	static class WebService1 {
+
+	}
+
+	@Endpoint
+	static class WebService2 {
+
+	}
+
+	@Service
+	static class ExampleService {
+
+	}
+
+	@Repository
+	static class ExampleRepository {
+
+	}
+
+}


### PR DESCRIPTION
Add `@WebServiceServerTest` and related test auto-configuration to allow slice testing of Spring Web Service server applications.

This enhancement adds autoconfiguration for the `MockWebServiceClient` so that testing web services becomes similar to testing `REST` services with `@WebMvcTest`.

Here is a usage example:

```java
@WebServiceServerTest(endpoints = ExampleWebServiceEndpoint.class)
public class WebServiceServerIntegrationTests {

	@Autowired
	private MockWebServiceClient mock;

	@Test
	void payloadRootMethod() {
		mock.sendRequest(withPayload(new StringSource("<request><message>Hello</message></request>")))
				.andExpect(payload(new StringSource("<response><code>42</code></response>")));
	}

}
```

I hope you find this useful. Thanks.