### PR TITLE
Fix typo in section title

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/batch.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/batch.adoc
@@ -29,7 +29,7 @@ See {spring-boot-autoconfigure-module-code}/batch/BatchAutoConfiguration.java[Ba
 
 
 
-[[howto.batch.?running-from-the-command-line]]
+[[howto.batch.running-from-the-command-line]]
 === Running from the Command Line
 Spring Boot converts any command line argument starting with `--` to a property to add to the `Environment`, see <<features#features.external-config.command-line-args,accessing command line properties>>.
 This should not be used to pass arguments to batch jobs.


### PR DESCRIPTION
This small typo was causing that the section title wasn't rendered as
expected. It happens since boot 2.5.0, as can be checked in 
https://docs.spring.io/spring-boot/docs/2.5.0/reference/htmlsingle/#howto.batch.running-jobs-on-startup
where instead of the next section title, the following text is shown:

[[howto.batch.?running-from-the-command-line]] === Running from the Command Line Spring Boot converts any command line 

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
