### PR TITLE
Remove default spring.mongodb.embedded.version

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,7 @@ import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
 import org.springframework.data.mongodb.core.MongoClientFactoryBean;
 import org.springframework.data.mongodb.core.ReactiveMongoClientFactoryBean;
+import org.springframework.util.Assert;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Embedded Mongo.
@@ -81,6 +82,7 @@ import org.springframework.data.mongodb.core.ReactiveMongoClientFactoryBean;
  * @author Mark Paluch
  * @author Issam El-atif
  * @author Paulius Dambrauskas
+ * @author Chris Bono
  * @since 1.3.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -143,6 +145,7 @@ public class EmbeddedMongoAutoConfiguration {
 	}
 
 	private IFeatureAwareVersion determineVersion(EmbeddedMongoProperties embeddedProperties) {
+		Assert.state(embeddedProperties.getVersion() != null, "Version must be set to use Embedded MongoDB.");
 		if (embeddedProperties.getFeatures() == null) {
 			for (Version version : Version.values()) {
 				if (version.asInDownloadPath().equals(embeddedProperties.getVersion())) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.util.unit.DataUnit;
  *
  * @author Andy Wilkinson
  * @author Yogesh Lonkar
+ * @author Chris Bono
  * @since 1.3.0
  */
 @ConfigurationProperties(prefix = "spring.mongodb.embedded")
@@ -38,7 +39,7 @@ public class EmbeddedMongoProperties {
 	/**
 	 * Version of Mongo to use.
 	 */
-	private String version = "3.5.5";
+	private String version;
 
 	private final Storage storage = new Storage();
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoAutoConfigurationTests.java
@@ -52,6 +52,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.util.FileSystemUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link EmbeddedMongoAutoConfiguration}.
@@ -60,6 +61,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  * @author Issam El-atif
+ * @author Chris Bono
  */
 class EmbeddedMongoAutoConfigurationTests {
 
@@ -73,8 +75,13 @@ class EmbeddedMongoAutoConfigurationTests {
 	}
 
 	@Test
-	void defaultVersion() {
-		assertVersionConfiguration(null, "3.5.5");
+	void noVersion() {
+		this.context = new AnnotationConfigApplicationContext();
+		TestPropertyValues.of("spring.data.mongodb.port=0").applyTo(this.context);
+		this.context.register(MongoAutoConfiguration.class, MongoDataAutoConfiguration.class,
+				EmbeddedMongoAutoConfiguration.class);
+		assertThatThrownBy(() -> this.context.refresh()).hasRootCauseExactlyInstanceOf(IllegalStateException.class)
+				.hasRootCauseMessage("Version must be set to use Embedded MongoDB.");
 	}
 
 	@Test
@@ -95,7 +102,7 @@ class EmbeddedMongoAutoConfigurationTests {
 		if (isWindows()) {
 			features.add(Feature.ONLY_WINDOWS_2008_SERVER);
 		}
-		load("spring.mongodb.embedded.features="
+		loadWithValidVersion("spring.mongodb.embedded.features="
 				+ features.stream().map(Feature::name).collect(Collectors.joining(", ")));
 		assertThat(this.context.getBean(EmbeddedMongoProperties.class).getFeatures())
 				.containsExactlyElementsOf(features);
@@ -103,7 +110,7 @@ class EmbeddedMongoAutoConfigurationTests {
 
 	@Test
 	void useRandomPortByDefault() {
-		load();
+		loadWithValidVersion();
 		assertThat(this.context.getBeansOfType(MongoClient.class)).hasSize(1);
 		MongoClient client = this.context.getBean(MongoClient.class);
 		Integer mongoPort = Integer.valueOf(this.context.getEnvironment().getProperty("local.mongo.port"));
@@ -112,7 +119,7 @@ class EmbeddedMongoAutoConfigurationTests {
 
 	@Test
 	void specifyPortToZeroAllocateRandomPort() {
-		load("spring.data.mongodb.port=0");
+		loadWithValidVersion("spring.data.mongodb.port=0");
 		assertThat(this.context.getBeansOfType(MongoClient.class)).hasSize(1);
 		MongoClient client = this.context.getBean(MongoClient.class);
 		Integer mongoPort = Integer.valueOf(this.context.getEnvironment().getProperty("local.mongo.port"));
@@ -121,7 +128,7 @@ class EmbeddedMongoAutoConfigurationTests {
 
 	@Test
 	void randomlyAllocatedPortIsAvailableWhenCreatingMongoClient() {
-		load(MongoClientConfiguration.class);
+		loadWithValidVersion(MongoClientConfiguration.class);
 		MongoClient client = this.context.getBean(MongoClient.class);
 		Integer mongoPort = Integer.valueOf(this.context.getEnvironment().getProperty("local.mongo.port"));
 		assertThat(getPort(client)).isEqualTo(mongoPort);
@@ -130,6 +137,7 @@ class EmbeddedMongoAutoConfigurationTests {
 	@Test
 	void portIsAvailableInParentContext() {
 		try (ConfigurableApplicationContext parent = new AnnotationConfigApplicationContext()) {
+			TestPropertyValues.of("spring.mongodb.embedded.version=3.5.5").applyTo(parent);
 			parent.refresh();
 			this.context = new AnnotationConfigApplicationContext();
 			this.context.setParent(parent);
@@ -141,7 +149,7 @@ class EmbeddedMongoAutoConfigurationTests {
 
 	@Test
 	void defaultStorageConfiguration() {
-		load(MongoClientConfiguration.class);
+		loadWithValidVersion(MongoClientConfiguration.class);
 		Storage replication = this.context.getBean(MongodConfig.class).replication();
 		assertThat(replication.getOplogSize()).isEqualTo(0);
 		assertThat(replication.getDatabaseDir()).isNull();
@@ -152,32 +160,32 @@ class EmbeddedMongoAutoConfigurationTests {
 	void mongoWritesToCustomDatabaseDir(@TempDir Path temp) {
 		File customDatabaseDir = new File(temp.toFile(), "custom-database-dir");
 		FileSystemUtils.deleteRecursively(customDatabaseDir);
-		load("spring.mongodb.embedded.storage.databaseDir=" + customDatabaseDir.getPath());
+		loadWithValidVersion("spring.mongodb.embedded.storage.databaseDir=" + customDatabaseDir.getPath());
 		assertThat(customDatabaseDir).isDirectory();
 		assertThat(customDatabaseDir.listFiles()).isNotEmpty();
 	}
 
 	@Test
 	void customOpLogSizeIsAppliedToConfiguration() {
-		load("spring.mongodb.embedded.storage.oplogSize=1024KB");
+		loadWithValidVersion("spring.mongodb.embedded.storage.oplogSize=1024KB");
 		assertThat(this.context.getBean(MongodConfig.class).replication().getOplogSize()).isEqualTo(1);
 	}
 
 	@Test
 	void customOpLogSizeUsesMegabytesPerDefault() {
-		load("spring.mongodb.embedded.storage.oplogSize=10");
+		loadWithValidVersion("spring.mongodb.embedded.storage.oplogSize=10");
 		assertThat(this.context.getBean(MongodConfig.class).replication().getOplogSize()).isEqualTo(10);
 	}
 
 	@Test
 	void customReplicaSetNameIsAppliedToConfiguration() {
-		load("spring.mongodb.embedded.storage.replSetName=testing");
+		loadWithValidVersion("spring.mongodb.embedded.storage.replSetName=testing");
 		assertThat(this.context.getBean(MongodConfig.class).replication().getReplSetName()).isEqualTo("testing");
 	}
 
 	@Test
 	void customizeDownloadConfiguration() {
-		load(DownloadConfigBuilderCustomizerConfiguration.class);
+		loadWithValidVersion(DownloadConfigBuilderCustomizerConfiguration.class);
 		RuntimeConfig runtimeConfig = this.context.getBean(RuntimeConfig.class);
 		DownloadConfig downloadConfig = (DownloadConfig) new DirectFieldAccessor(runtimeConfig.artifactStore())
 				.getPropertyValue("downloadConfig");
@@ -186,13 +194,13 @@ class EmbeddedMongoAutoConfigurationTests {
 
 	@Test
 	void shutdownHookIsNotRegistered() {
-		load();
+		loadWithValidVersion();
 		assertThat(this.context.getBean(MongodExecutable.class).isRegisteredJobKiller()).isFalse();
 	}
 
 	@Test
 	void customMongoServerConfiguration() {
-		load(CustomMongoConfiguration.class);
+		loadWithValidVersion(CustomMongoConfiguration.class);
 		Map<String, MongoClient> mongoClients = this.context.getBeansOfType(MongoClient.class);
 		assertThat(mongoClients).isNotEmpty();
 		for (String mongoClientBeanName : mongoClients.keySet()) {
@@ -216,15 +224,16 @@ class EmbeddedMongoAutoConfigurationTests {
 		assertThat(buildInfo.getString("version")).isEqualTo(expectedVersion);
 	}
 
-	private void load(String... environment) {
-		load(null, environment);
+	private void loadWithValidVersion(String... environment) {
+		loadWithValidVersion(null, environment);
 	}
 
-	private void load(Class<?> config, String... environment) {
+	private void loadWithValidVersion(Class<?> config, String... environment) {
 		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
 		if (config != null) {
 			ctx.register(config);
 		}
+		TestPropertyValues.of("spring.mongodb.embedded.version=3.5.5").applyTo(ctx);
 		TestPropertyValues.of(environment).applyTo(ctx);
 		ctx.register(EmbeddedMongoAutoConfiguration.class, MongoAutoConfiguration.class,
 				PropertyPlaceholderAutoConfiguration.class);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/ReactiveSessionAutoConfigurationMongoTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/ReactiveSessionAutoConfigurationMongoTests.java
@@ -41,7 +41,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ReactiveSessionAutoConfigurationMongoTests extends AbstractSessionAutoConfigurationTests {
 
 	private final ReactiveWebApplicationContextRunner contextRunner = new ReactiveWebApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(SessionAutoConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(SessionAutoConfiguration.class))
+			.withPropertyValues("spring.mongodb.embedded.version=3.5.5");
 
 	@Test
 	void defaultConfig() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationMongoTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationMongoTests.java
@@ -54,7 +54,8 @@ class SessionAutoConfigurationMongoTests extends AbstractSessionAutoConfiguratio
 	private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class, MongoDataAutoConfiguration.class,
 					SessionAutoConfiguration.class))
-			.withPropertyValues("spring.data.mongodb.uri=" + mongoDB.getReplicaSetUrl());
+			.withPropertyValues("spring.data.mongodb.uri=" + mongoDB.getReplicaSetUrl(),
+					"spring.mongodb.embedded.version=3.5.5");
 
 	@Test
 	void defaultConfig() {

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/nosql.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/nosql.adoc
@@ -151,6 +151,13 @@ TIP: For complete details of Spring Data MongoDB, including its rich object mapp
 Spring Boot offers auto-configuration for https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo[Embedded Mongo].
 To use it in your Spring Boot application, add a dependency on `de.flapdoodle.embed:de.flapdoodle.embed.mongo`.
 
+The version of the MongoDB server **must** be configured by setting the configprop:spring.data.mongodb.embedded.version property.
+
+NOTE: The default download configuration allows access to most of the versions listed in https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/blob/de.flapdoodle.embed.mongo-3.0.0/src/main/java/de/flapdoodle/embed/mongo/distribution/Version.java[Version.java]
+as well as some others. Inaccessible versions result in error when attempting to download the server. The download configuration may be adjusted to handle the desired version.
+
+The download configuration can be customized by declaring a `DownloadConfigBuilderCustomizer` bean.
+
 The port that Mongo listens on can be configured by setting the configprop:spring.data.mongodb.port[] property.
 To use a randomly allocated free port, use a value of 0.
 The `MongoClient` created by `MongoAutoConfiguration` is automatically configured to use the randomly allocated port.
@@ -160,8 +167,6 @@ NOTE: If you do not configure a custom port, the embedded support uses a random 
 If you have SLF4J on the classpath, the output produced by Mongo is automatically routed to a logger named `org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongo`.
 
 You can declare your own `IMongodConfig` and `IRuntimeConfig` beans to take control of the Mongo instance's configuration and logging routing.
-The download configuration can be customized by declaring a `DownloadConfigBuilderCustomizer` bean.
-
 
 
 [[features.nosql.neo4j]]

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-mongodb/src/test/java/smoketest/data/mongo/SampleMongoApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-mongodb/src/test/java/smoketest/data/mongo/SampleMongoApplicationTests.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andy Wilkinson
  */
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest
+@SpringBootTest(properties = "spring.mongodb.embedded.version=3.5.5")
 class SampleMongoApplicationTests {
 
 	@Test

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-session-webflux/src/main/resources/application.properties
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-session-webflux/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.security.user.name=user
 spring.security.user.password=password
+spring.mongodb.embedded.version=3.5.5


### PR DESCRIPTION
Removes the previous default setting for `spring.mongodb.embedded.version` of `3.5.5`. 

Fixes gh-26220
