### PR TITLE
DurationStyle.SIMPLE.print does not work correctly with ChronoUnit.MICROS

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DurationStyle.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DurationStyle.java
@@ -183,7 +183,7 @@ public enum DurationStyle {
 		/**
 		 * Microseconds.
 		 */
-		MICROS(ChronoUnit.MICROS, "us", (duration) -> duration.toMillis() * 1000L),
+		MICROS(ChronoUnit.MICROS, "us", duration -> duration.toNanos() / 1000L),
 
 		/**
 		 * Milliseconds.

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/DurationStyleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/DurationStyleTests.java
@@ -234,6 +234,7 @@ class DurationStyleTests {
 	void printSimpleWithUnitShouldPrintInUnit() {
 		Duration duration = Duration.ofMillis(1000);
 		assertThat(DurationStyle.SIMPLE.print(duration, ChronoUnit.SECONDS)).isEqualTo("1s");
+		assertThat(DurationStyle.SIMPLE.print(Duration.ofNanos(2000), ChronoUnit.MICROS)).isEqualTo("2us");
 	}
 
 }


### PR DESCRIPTION
Fix for the wrong duration to microseconds convertion in `DurationStyle`.

See gh-27148

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
