### PR TITLE
Upgrade to Hibernate 7.0.1.Final

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -426,7 +426,7 @@ bom {
 			]
 		}
 	}
-	library("Hibernate Validator", "6.2.0.Final") {
+	library("Hibernate Validator", "7.0.1.Final") {
 		prohibit("[7.0.0.Alpha1,)") {
 			because "it uses the jakarta.* namespace"
 		}


### PR DESCRIPTION
Upgrade to latest Hibernate due to OWASP CVE-2020-10693 https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10693