### PR TITLE
Fix tests for multi-release JARs on JDK 17

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/TestJarCreator.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/TestJarCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,22 @@ import java.util.zip.ZipEntry;
  * @author Phillip Webb
  */
 public abstract class TestJarCreator {
+
+	private static final int BASE_VERSION = 8;
+
+	private static final int RUNTIME_VERSION;
+
+	static {
+		int version;
+		try {
+			Object runtimeVersion = Runtime.class.getMethod("version").invoke(null);
+			version = (int) runtimeVersion.getClass().getMethod("major").invoke(runtimeVersion);
+		}
+		catch (Throwable ex) {
+			version = BASE_VERSION;
+		}
+		RUNTIME_VERSION = version;
+	}
 
 	public static void createTestJar(File file) throws Exception {
 		createTestJar(file, false);
@@ -90,15 +106,9 @@ public abstract class TestJarCreator {
 		jarOutputStream.setComment("nested");
 		writeManifest(jarOutputStream, "j2", multiRelease);
 		if (multiRelease) {
-			writeEntry(jarOutputStream, "multi-release.dat", 8);
-			writeEntry(jarOutputStream, "META-INF/versions/9/multi-release.dat", 9);
-			writeEntry(jarOutputStream, "META-INF/versions/10/multi-release.dat", 10);
-			writeEntry(jarOutputStream, "META-INF/versions/11/multi-release.dat", 11);
-			writeEntry(jarOutputStream, "META-INF/versions/12/multi-release.dat", 12);
-			writeEntry(jarOutputStream, "META-INF/versions/13/multi-release.dat", 13);
-			writeEntry(jarOutputStream, "META-INF/versions/14/multi-release.dat", 14);
-			writeEntry(jarOutputStream, "META-INF/versions/15/multi-release.dat", 15);
-			writeEntry(jarOutputStream, "META-INF/versions/16/multi-release.dat", 16);
+			writeEntry(jarOutputStream, "multi-release.dat", BASE_VERSION);
+			writeEntry(jarOutputStream, String.format("META-INF/versions/%d/multi-release.dat", RUNTIME_VERSION),
+					RUNTIME_VERSION);
 		}
 		else {
 			writeEntry(jarOutputStream, "3.dat", 3);


### PR DESCRIPTION
Hi,

this is part of the overall JDK story #26767 and fixes the multi-release JAR tests. Instead of just adding another entry for JDK 17 this PR provides an alternative approach that is a little more dynamic and forgiving when a new JDK arrives.

Let me know what you think.
Cheers,
Christoph