### PR TITLE
Use server version from database in Neo4j health details

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/neo4j/Neo4jHealthDetailsHandler.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/neo4j/Neo4jHealthDetailsHandler.java
@@ -33,14 +33,13 @@ class Neo4jHealthDetailsHandler {
 	/**
 	 * Add health details for the specified {@link ResultSummary} and {@code edition}.
 	 * @param builder the {@link Builder} to use
+	 * @param version the version of the server
 	 * @param edition the edition of the server
 	 * @param resultSummary server information
 	 */
-	@SuppressWarnings("deprecation")
-	void addHealthDetails(Builder builder, String edition, ResultSummary resultSummary) {
+	void addHealthDetails(Builder builder, String version, String edition, ResultSummary resultSummary) {
 		ServerInfo serverInfo = resultSummary.server();
-		builder.up().withDetail("server", serverInfo.version() + "@" + serverInfo.address()).withDetail("edition",
-				edition);
+		builder.up().withDetail("server", version + "@" + serverInfo.address()).withDetail("edition", edition);
 		DatabaseInfo databaseInfo = resultSummary.database();
 		if (StringUtils.hasText(databaseInfo.name())) {
 			builder.withDetail("database", databaseInfo.name());

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicator.java
@@ -20,6 +20,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
+import org.neo4j.driver.Record;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.SessionConfig;
@@ -91,8 +92,9 @@ public class Neo4jHealthIndicator extends AbstractHealthIndicator {
 		// all possible workloads
 		try (Session session = this.driver.session(DEFAULT_SESSION_CONFIG)) {
 			Result result = session.run(CYPHER);
-			String edition = result.single().get("edition").asString();
-			String version = result.single().get("version").asString();
+			Record record = result.single();
+			String edition = record.get("edition").asString();
+			String version = record.get("version").asString();
 			ResultSummary resultSummary = result.consume();
 			this.healthDetailsHandler.addHealthDetails(builder, version, edition, resultSummary);
 		}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicator.java
@@ -46,7 +46,7 @@ public class Neo4jHealthIndicator extends AbstractHealthIndicator {
 	/**
 	 * The Cypher statement used to verify Neo4j is up.
 	 */
-	static final String CYPHER = "CALL dbms.components() YIELD name, edition WHERE name = 'Neo4j Kernel' RETURN edition";
+	static final String CYPHER = "CALL dbms.components() YIELD versions, name, edition WHERE name = 'Neo4j Kernel' RETURN edition, versions[0] as version";
 
 	/**
 	 * Message logged before retrying a health check.
@@ -92,8 +92,9 @@ public class Neo4jHealthIndicator extends AbstractHealthIndicator {
 		try (Session session = this.driver.session(DEFAULT_SESSION_CONFIG)) {
 			Result result = session.run(CYPHER);
 			String edition = result.single().get("edition").asString();
+			String version = result.single().get("version").asString();
 			ResultSummary resultSummary = result.consume();
-			this.healthDetailsHandler.addHealthDetails(builder, edition, resultSummary);
+			this.healthDetailsHandler.addHealthDetails(builder, version, edition, resultSummary);
 		}
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jHealthIndicatorTests.java
@@ -51,8 +51,8 @@ class Neo4jHealthIndicatorTests {
 
 	@Test
 	void neo4jIsUp() {
-		ResultSummary resultSummary = ResultSummaryMock.createResultSummary("4711", "My Home", "test");
-		Driver driver = mockDriver(resultSummary, "ultimate collectors edition");
+		ResultSummary resultSummary = ResultSummaryMock.createResultSummary("My Home", "test");
+		Driver driver = mockDriver(resultSummary, "4711", "ultimate collectors edition");
 		Health health = new Neo4jHealthIndicator(driver).health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
 		assertThat(health.getDetails()).containsEntry("server", "4711@My Home");
@@ -62,8 +62,8 @@ class Neo4jHealthIndicatorTests {
 
 	@Test
 	void neo4jIsUpWithoutDatabaseName() {
-		ResultSummary resultSummary = ResultSummaryMock.createResultSummary("4711", "My Home", null);
-		Driver driver = mockDriver(resultSummary, "some edition");
+		ResultSummary resultSummary = ResultSummaryMock.createResultSummary("My Home", null);
+		Driver driver = mockDriver(resultSummary, "4711", "some edition");
 		Health health = new Neo4jHealthIndicator(driver).health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
 		assertThat(health.getDetails()).containsEntry("server", "4711@My Home");
@@ -73,8 +73,8 @@ class Neo4jHealthIndicatorTests {
 
 	@Test
 	void neo4jIsUpWithEmptyDatabaseName() {
-		ResultSummary resultSummary = ResultSummaryMock.createResultSummary("4711", "My Home", "");
-		Driver driver = mockDriver(resultSummary, "some edition");
+		ResultSummary resultSummary = ResultSummaryMock.createResultSummary("My Home", "");
+		Driver driver = mockDriver(resultSummary, "4711", "some edition");
 		Health health = new Neo4jHealthIndicator(driver).health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
 		assertThat(health.getDetails()).containsEntry("server", "4711@My Home");
@@ -84,9 +84,9 @@ class Neo4jHealthIndicatorTests {
 
 	@Test
 	void neo4jIsUpWithOneSessionExpiredException() {
-		ResultSummary resultSummary = ResultSummaryMock.createResultSummary("4711", "My Home", "");
+		ResultSummary resultSummary = ResultSummaryMock.createResultSummary("My Home", "");
 		Session session = mock(Session.class);
-		Result statementResult = mockStatementResult(resultSummary, "some edition");
+		Result statementResult = mockStatementResult(resultSummary, "4711", "some edition");
 		AtomicInteger count = new AtomicInteger();
 		given(session.run(anyString())).will((invocation) -> {
 			if (count.compareAndSet(0, 1)) {
@@ -112,17 +112,18 @@ class Neo4jHealthIndicatorTests {
 		assertThat(health.getDetails()).containsKeys("error");
 	}
 
-	private Result mockStatementResult(ResultSummary resultSummary, String edition) {
+	private Result mockStatementResult(ResultSummary resultSummary, String version, String edition) {
 		Record record = mock(Record.class);
 		given(record.get("edition")).willReturn(Values.value(edition));
+		given(record.get("version")).willReturn(Values.value(version));
 		Result statementResult = mock(Result.class);
 		given(statementResult.single()).willReturn(record);
 		given(statementResult.consume()).willReturn(resultSummary);
 		return statementResult;
 	}
 
-	private Driver mockDriver(ResultSummary resultSummary, String edition) {
-		Result statementResult = mockStatementResult(resultSummary, edition);
+	private Driver mockDriver(ResultSummary resultSummary, String version, String edition) {
+		Result statementResult = mockStatementResult(resultSummary, version, edition);
 		Session session = mock(Session.class);
 		given(session.run(anyString())).willReturn(statementResult);
 		Driver driver = mock(Driver.class);

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jReactiveHealthIndicatorTest.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jReactiveHealthIndicatorTest.java
@@ -51,8 +51,8 @@ class Neo4jReactiveHealthIndicatorTest {
 
 	@Test
 	void neo4jIsUp() {
-		ResultSummary resultSummary = ResultSummaryMock.createResultSummary("4711", "My Home", "test");
-		Driver driver = mockDriver(resultSummary, "ultimate collectors edition");
+		ResultSummary resultSummary = ResultSummaryMock.createResultSummary("My Home", "test");
+		Driver driver = mockDriver(resultSummary, "4711", "ultimate collectors edition");
 		Neo4jReactiveHealthIndicator healthIndicator = new Neo4jReactiveHealthIndicator(driver);
 		healthIndicator.health().as(StepVerifier::create).consumeNextWith((health) -> {
 			assertThat(health.getStatus()).isEqualTo(Status.UP);
@@ -63,9 +63,9 @@ class Neo4jReactiveHealthIndicatorTest {
 
 	@Test
 	void neo4jIsUpWithOneSessionExpiredException() {
-		ResultSummary resultSummary = ResultSummaryMock.createResultSummary("4711", "My Home", "");
+		ResultSummary resultSummary = ResultSummaryMock.createResultSummary("My Home", "");
 		RxSession session = mock(RxSession.class);
-		RxResult statementResult = mockStatementResult(resultSummary, "some edition");
+		RxResult statementResult = mockStatementResult(resultSummary, "4711", "some edition");
 		AtomicInteger count = new AtomicInteger();
 		given(session.run(anyString())).will((invocation) -> {
 			if (count.compareAndSet(0, 1)) {
@@ -95,17 +95,18 @@ class Neo4jReactiveHealthIndicatorTest {
 		}).verifyComplete();
 	}
 
-	private RxResult mockStatementResult(ResultSummary resultSummary, String edition) {
+	private RxResult mockStatementResult(ResultSummary resultSummary, String version, String edition) {
 		Record record = mock(Record.class);
 		given(record.get("edition")).willReturn(Values.value(edition));
+		given(record.get("version")).willReturn(Values.value(version));
 		RxResult statementResult = mock(RxResult.class);
 		given(statementResult.records()).willReturn(Mono.just(record));
 		given(statementResult.consume()).willReturn(Mono.just(resultSummary));
 		return statementResult;
 	}
 
-	private Driver mockDriver(ResultSummary resultSummary, String edition) {
-		RxResult statementResult = mockStatementResult(resultSummary, edition);
+	private Driver mockDriver(ResultSummary resultSummary, String version, String edition) {
+		RxResult statementResult = mockStatementResult(resultSummary, version, edition);
 		RxSession session = mock(RxSession.class);
 		given(session.run(anyString())).willReturn(statementResult);
 		Driver driver = mock(Driver.class);

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/ResultSummaryMock.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/ResultSummaryMock.java
@@ -33,10 +33,8 @@ final class ResultSummaryMock {
 	private ResultSummaryMock() {
 	}
 
-	@SuppressWarnings("deprecation")
-	static ResultSummary createResultSummary(String serverVersion, String serverAddress, String databaseName) {
+	static ResultSummary createResultSummary(String serverAddress, String databaseName) {
 		ServerInfo serverInfo = mock(ServerInfo.class);
-		given(serverInfo.version()).willReturn(serverVersion);
 		given(serverInfo.address()).willReturn(serverAddress);
 		DatabaseInfo databaseInfo = mock(DatabaseInfo.class);
 		given(databaseInfo.name()).willReturn(databaseName);


### PR DESCRIPTION
The version are now fetched via the build in meta-information from the database itself. They were previously retrieved via the Neo4j driver's `ServerInfo#version` method.
Is the reactive return type nice? No, but pragmatic.