### PR TITLE
Redis health indicators report that Redis is up when the cluster's state is fail

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisHealth.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisHealth.java
@@ -38,11 +38,16 @@ final class RedisHealth {
 		return builder.up();
 	}
 
-	static Builder up(Health.Builder builder, ClusterInfo clusterInfo) {
+	static Builder info(Health.Builder builder, ClusterInfo clusterInfo) {
 		builder.withDetail("cluster_size", clusterInfo.getClusterSize());
 		builder.withDetail("slots_up", clusterInfo.getSlotsOk());
 		builder.withDetail("slots_fail", clusterInfo.getSlotsFail());
-		return builder.up();
+
+		if ("fail".equalsIgnoreCase(clusterInfo.getState())) {
+			return builder.down();
+		} else {
+			return builder.up();
+		}
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisHealthIndicator.java
@@ -57,7 +57,7 @@ public class RedisHealthIndicator extends AbstractHealthIndicator {
 
 	private void doHealthCheck(Health.Builder builder, RedisConnection connection) {
 		if (connection instanceof RedisClusterConnection) {
-			RedisHealth.up(builder, ((RedisClusterConnection) connection).clusterGetClusterInfo());
+			RedisHealth.info(builder, ((RedisClusterConnection) connection).clusterGetClusterInfo());
 		}
 		else {
 			RedisHealth.up(builder, connection.info("server"));

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicator.java
@@ -65,7 +65,7 @@ public class RedisReactiveHealthIndicator extends AbstractReactiveHealthIndicato
 	private Mono<Health> getHealth(Health.Builder builder, ReactiveRedisConnection connection) {
 		if (connection instanceof ReactiveRedisClusterConnection) {
 			return ((ReactiveRedisClusterConnection) connection).clusterGetClusterInfo()
-					.map((info) -> up(builder, info));
+					.map(info -> info(builder, info));
 		}
 		return connection.serverCommands().info("server").map((info) -> up(builder, info));
 	}
@@ -74,8 +74,8 @@ public class RedisReactiveHealthIndicator extends AbstractReactiveHealthIndicato
 		return RedisHealth.up(builder, info).build();
 	}
 
-	private Health up(Health.Builder builder, ClusterInfo clusterInfo) {
-		return RedisHealth.up(builder, clusterInfo).build();
+	private Health info(Health.Builder builder, ClusterInfo clusterInfo) {
+		return RedisHealth.info(builder, clusterInfo).build();
 	}
 
 }


### PR DESCRIPTION
## Given
a Redis cluster with 3 shards + 3 replicas as:
 - :7001 (master) ~> :7004 (slave)
 - :7002 (master) ~> :7005 (slave)
 - :7003 (master) ~> :7006 (slave)

Kill processes with ports 7003, 7004, 7005, 7006.

check `CLUSTER INFO` command:
```
cluster_state:fail
cluster_slots_assigned:16384
cluster_slots_ok:5462
cluster_slots_pfail:10922
cluster_slots_fail:0
cluster_known_nodes:6
cluster_size:3
...
```

## As is:
Although cluster's state is **fail** but RedisHealthIndicator still mark Health as **UP**

## To be:
If cluster's state is **fail**, then we will mark Redis Health as **DOWN**

## Solution:
Check `cluster_state` value, if it equals (ignore case) with `fail`, then Redis Health is DOWN.

## Reference
https://redis.io/commands/cluster-info