### PR TITLE
Disable failing Gradle plugin tests on JDK 17

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/DisabledTemplateInvocationContext.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/DisabledTemplateInvocationContext.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.gradle.junit;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+/**
+ * {@link TestTemplateInvocationContext} that disables tests.
+ *
+ * @author Christoph Dreis
+ */
+final class DisabledTemplateInvocationContext implements TestTemplateInvocationContext {
+
+	@Override
+	public List<Extension> getAdditionalExtensions() {
+		return Collections.singletonList(new DisabledCondition());
+	}
+
+	private static class DisabledCondition implements ExecutionCondition {
+
+		@Override
+		public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+			return ConditionEvaluationResult.disabled("");
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleCompatibilityExtension.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleCompatibilityExtension.java
@@ -57,6 +57,9 @@ final class GradleCompatibilityExtension implements TestTemplateInvocationContex
 
 	@Override
 	public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+		if (JavaVersion.current() == JavaVersion.VERSION_17) {
+			return Stream.of(new DisabledTemplateInvocationContext());
+		}
 		Stream<String> gradleVersions = GRADLE_VERSIONS.stream().map((version) -> {
 			if (version.equals("current")) {
 				return GradleVersion.current().getVersion();

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleMultiDslExtension.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleMultiDslExtension.java
@@ -42,6 +42,9 @@ public class GradleMultiDslExtension implements TestTemplateInvocationContextPro
 
 	@Override
 	public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+		if (JavaVersion.current() == JavaVersion.VERSION_17) {
+			return Stream.of(new DisabledTemplateInvocationContext());
+		}
 		return Stream.of(Dsl.values()).map(DslTestTemplateInvocationContext::new);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleProjectBuilder.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleProjectBuilder.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.gradle.junit;
+
+import java.io.File;
+
+import org.gradle.api.JavaVersion;
+import org.gradle.api.Project;
+import org.gradle.internal.nativeintegration.services.NativeServices;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.gradle.testfixtures.internal.ProjectBuilderImpl;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Helper class to build Gradle {@link Project Projects} for test fixtures. Wraps
+ * functionality of Gradle's own {@link ProjectBuilder} in order to workaround an issue on
+ * JDK 17.
+ *
+ * @author Christoph Dreis
+ * @see <a href="https://github.com/gradle/gradle/issues/16857">Gradle Support JDK 17</a>
+ */
+public final class GradleProjectBuilder {
+
+	private File projectDir;
+
+	private String name;
+
+	private GradleProjectBuilder() {
+	}
+
+	public static GradleProjectBuilder builder() {
+		return new GradleProjectBuilder();
+	}
+
+	public GradleProjectBuilder withProjectDir(File dir) {
+		this.projectDir = dir;
+		return this;
+	}
+
+	public GradleProjectBuilder withName(String name) {
+		this.name = name;
+		return this;
+	}
+
+	public Project build() {
+		Assert.notNull(this.projectDir, "ProjectDir must not be null");
+		ProjectBuilder builder = ProjectBuilder.builder();
+		builder.withProjectDir(this.projectDir);
+		File userHome = new File(this.projectDir, "userHome");
+		builder.withGradleUserHomeDir(userHome);
+		if (StringUtils.hasText(this.name)) {
+			builder.withName(this.name);
+		}
+		if (JavaVersion.current() == JavaVersion.VERSION_17) {
+			NativeServices.initialize(userHome);
+			try {
+				ProjectBuilderImpl.getGlobalServices();
+			}
+			catch (Throwable ignore) {
+			}
+		}
+		return builder.build();
+	}
+
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/SpringBootPluginTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/SpringBootPluginTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,10 @@ import java.io.File;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.springframework.boot.gradle.junit.GradleProjectBuilder;
 import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,7 +42,7 @@ class SpringBootPluginTests {
 
 	@Test
 	void bootArchivesConfigurationsCannotBeResolved() {
-		Project project = ProjectBuilder.builder().withProjectDir(this.temp).build();
+		Project project = GradleProjectBuilder.builder().withProjectDir(this.temp).build();
 		project.getPlugins().apply(SpringBootPlugin.class);
 		Configuration bootArchives = project.getConfigurations()
 				.getByName(SpringBootPlugin.BOOT_ARCHIVES_CONFIGURATION_NAME);

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,10 @@ import java.util.Properties;
 import org.gradle.api.Project;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.initialization.GradlePropertiesController;
-import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.springframework.boot.gradle.junit.GradleProjectBuilder;
 import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -131,7 +131,7 @@ class BuildInfoTests {
 
 	private Project createProject(String projectName) {
 		File projectDir = new File(this.temp, projectName);
-		Project project = ProjectBuilder.builder().withProjectDir(projectDir).withName(projectName).build();
+		Project project = GradleProjectBuilder.builder().withProjectDir(projectDir).withName(projectName).build();
 		((ProjectInternal) project).getServices().get(GradlePropertiesController.class)
 				.loadGradlePropertiesFrom(projectDir);
 		return project;

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/AbstractBootArchiveTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/AbstractBootArchiveTests.java
@@ -61,11 +61,11 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.file.archive.ZipCopyAction;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.api.tasks.bundling.Jar;
-import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.springframework.boot.gradle.junit.GradleProjectBuilder;
 import org.springframework.boot.loader.tools.DefaultLaunchScript;
 import org.springframework.boot.loader.tools.JarModeLibrary;
 
@@ -115,7 +115,7 @@ abstract class AbstractBootArchiveTests<T extends Jar & BootArchive> {
 		try {
 			File projectDir = new File(this.temp, "project");
 			projectDir.mkdirs();
-			this.project = ProjectBuilder.builder().withProjectDir(projectDir).build();
+			this.project = GradleProjectBuilder.builder().withProjectDir(projectDir).build();
 			this.project.setDescription("Test project for " + this.taskClass.getSimpleName());
 			this.task = configure(this.project.getTasks().create("testArchive", this.taskClass));
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageTests.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
-import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -32,6 +31,7 @@ import org.springframework.boot.buildpack.platform.build.BuildRequest;
 import org.springframework.boot.buildpack.platform.build.BuildpackReference;
 import org.springframework.boot.buildpack.platform.build.PullPolicy;
 import org.springframework.boot.buildpack.platform.docker.type.Binding;
+import org.springframework.boot.gradle.junit.GradleProjectBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -55,7 +55,7 @@ class BootBuildImageTests {
 	BootBuildImageTests() {
 		File projectDir = new File(this.temp, "project");
 		projectDir.mkdirs();
-		this.project = ProjectBuilder.builder().withProjectDir(projectDir).withName("build-image-test").build();
+		this.project = GradleProjectBuilder.builder().withProjectDir(projectDir).withName("build-image-test").build();
 		this.project.setDescription("Test project for BootBuildImage");
 		this.buildImage = this.project.getTasks().create("buildImage", BootBuildImage.class);
 	}


### PR DESCRIPTION
Hi,

this is the last open item before we can create a JDK 17 pipeline - see #26767.
I wanted to make an effort to not just exclude the whole module (or all of its tests) via CI, but test as much as we can. The added helper classes that we need to workaround the shortcomings of Gradle, will be likely removed again as soon as Gradle is ready for JDK 17. Since they're not published and only test relevant, I figured this to be acceptable. The fact that it's more fine-grained and explicit was appealing to me, but I could also exclude all tests with some hackery in CI (we did this in the past). Neither solution is beautiful if you ask me, but I went for the one that keeps more test coverage.

Let me know what you think.
Cheers,
Christoph