### PR TITLE
Remove Flyway references from AbstractDependsOnBeanFactoryPostProcessors for Liquibase

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
@@ -138,8 +138,7 @@ public class BatchAutoConfiguration {
 		@Bean
 		@ConditionalOnClass(name = "liquibase.integration.spring.SpringLiquibase")
 		JobRepositoryDependsOnBeanFactoryPostProcessor liquibaseJobRepositoryDependsOnBeanFactoryPostProcessor() {
-			return new JobRepositoryDependsOnBeanFactoryPostProcessor(FlywayMigrationInitializer.class,
-					SpringLiquibase.class);
+			return new JobRepositoryDependsOnBeanFactoryPostProcessor(SpringLiquibase.class);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java
@@ -104,8 +104,7 @@ class JdbcSessionConfiguration {
 		@Bean
 		@ConditionalOnClass(name = "liquibase.integration.spring.SpringLiquibase")
 		JdbcIndexedSessionRepositoryDependsOnBeanFactoryPostProcessor liquibaseJdbcIndexedSessionRepositoryDependsOnBeanFactoryPostProcessor() {
-			return new JdbcIndexedSessionRepositoryDependsOnBeanFactoryPostProcessor(FlywayMigrationInitializer.class,
-					SpringLiquibase.class);
+			return new JdbcIndexedSessionRepositoryDependsOnBeanFactoryPostProcessor(SpringLiquibase.class);
 		}
 
 	}


### PR DESCRIPTION
This PR removes `FlywayMigrationInitializer` references from `AbstractDependsOnBeanFactoryPostProcessor`s for Liquibase as they seem to have been added accidentally.