### PR TITLE
Support comma-separated values in EntityScan's basePackages placeholders

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/domain/EntityScanPackages.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/domain/EntityScanPackages.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.Environment;
@@ -141,7 +142,10 @@ public class EntityScanPackages {
 					.fromMap(metadata.getAnnotationAttributes(EntityScan.class.getName()));
 			Set<String> packagesToScan = new LinkedHashSet<>();
 			for (String basePackage : attributes.getStringArray("basePackages")) {
-				addResolvedPackage(basePackage, packagesToScan);
+				String[] tokenized = StringUtils.tokenizeToStringArray(
+						this.environment.resolvePlaceholders(basePackage),
+						ConfigurableApplicationContext.CONFIG_LOCATION_DELIMITERS);
+				Collections.addAll(packagesToScan, tokenized);
 			}
 			for (Class<?> basePackageClass : attributes.getClassArray("basePackageClasses")) {
 				addResolvedPackage(ClassUtils.getPackageName(basePackageClass), packagesToScan);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/domain/EntityScannerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/domain/EntityScannerTests.java
@@ -25,6 +25,7 @@ import javax.persistence.Entity;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import org.springframework.boot.autoconfigure.data.jpa.city.City;
 import org.springframework.boot.autoconfigure.domain.scan.a.EmbeddableA;
 import org.springframework.boot.autoconfigure.domain.scan.a.EntityA;
 import org.springframework.boot.autoconfigure.domain.scan.b.EmbeddableB;
@@ -117,6 +118,20 @@ class EntityScannerTests {
 				.findCandidateComponents("org.springframework.boot.autoconfigure.domain.scan");
 		verifyNoMoreInteractions(candidateComponentProvider);
 		assertThat(annotationTypeFilter.getValue().getAnnotationType()).isEqualTo(Entity.class);
+	}
+
+	@Test
+	void scanShouldScanCommaSeparatedPackagesInPlaceholderPackage() throws Exception {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		TestPropertyValues.of(
+				"com.example.entity-package=org.springframework.boot.autoconfigure.domain.scan,org.springframework.boot.autoconfigure.data.jpa.city")
+				.applyTo(context);
+		context.register(ScanPlaceholderConfig.class);
+		context.refresh();
+		EntityScanner scanner = new EntityScanner(context);
+		Set<Class<?>> scanned = scanner.scan(Entity.class);
+		assertThat(scanned).containsOnly(EntityA.class, EntityB.class, EntityC.class, City.class);
+		context.close();
 	}
 
 	private static class TestEntityScanner extends EntityScanner {


### PR DESCRIPTION
With this change, EntityScan can now support comma-separated values when resolving placeholders in its base packages or value attributes. Existing test cases passed and a new test case was added.

Fixes #25415

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
