### PR TITLE
 Add configuration property for Reactor Netty's idle timeout

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -1300,6 +1300,11 @@ public class ServerProperties {
 		 */
 		private boolean validateHeaders = true;
 
+		/**
+		 * IdleTimeout for netty server .If an idletimeout is not specified, this indicates no timeout(infinite).
+		 */
+		private Duration idleTimeout;
+
 		public Duration getConnectionTimeout() {
 			return this.connectionTimeout;
 		}
@@ -1346,6 +1351,14 @@ public class ServerProperties {
 
 		public void setValidateHeaders(boolean validateHeaders) {
 			this.validateHeaders = validateHeaders;
+		}
+
+		public Duration getIdleTimeout() {
+			return idleTimeout;
+		}
+
+		public void setIdleTimeout(Duration idleTimeout) {
+			this.idleTimeout = idleTimeout;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -1355,7 +1355,7 @@ public class ServerProperties {
 		}
 
 		public Duration getIdleTimeout() {
-			return idleTimeout;
+			return this.idleTimeout;
 		}
 
 		public void setIdleTimeout(Duration idleTimeout) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -1301,7 +1301,8 @@ public class ServerProperties {
 		private boolean validateHeaders = true;
 
 		/**
-		 * IdleTimeout for netty server .If an idletimeout is not specified, this indicates no timeout(infinite).
+		 * IdleTimeout for netty server .If an idletimeout is not specified, this
+		 * indicates no timeout(infinite).
 		 */
 		private Duration idleTimeout;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizer.java
@@ -60,6 +60,8 @@ public class NettyWebServerFactoryCustomizer
 		ServerProperties.Netty nettyProperties = this.serverProperties.getNetty();
 		propertyMapper.from(nettyProperties::getConnectionTimeout).whenNonNull()
 				.to((connectionTimeout) -> customizeConnectionTimeout(factory, connectionTimeout));
+		propertyMapper.from(nettyProperties::getIdleTimeout).whenNonNull()
+				.to((idleTimeout) -> customizeIdleTimeout(factory, idleTimeout));
 		customizeRequestDecoder(factory, propertyMapper);
 	}
 
@@ -96,6 +98,10 @@ public class NettyWebServerFactoryCustomizer
 					.to(httpRequestDecoderSpec::validateHeaders);
 			return httpRequestDecoderSpec;
 		}));
+	}
+
+	private void customizeIdleTimeout(NettyReactiveWebServerFactory factory, Duration idleTimeout) {
+		factory.addServerCustomizers((httpServer) -> httpServer.idleTimeout(idleTimeout));
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -535,6 +535,12 @@ class ServerPropertiesTests {
 				.isEqualTo(HttpDecoderSpec.DEFAULT_INITIAL_BUFFER_SIZE);
 	}
 
+	@Test
+	void testCustomizeNettyIdleTimeout() {
+		bind("server.netty.idle-timeout", "10s");
+		assertThat(this.properties.getNetty().getIdleTimeout()).isEqualTo(Duration.ofSeconds(10));
+	}
+
 	private Connector getDefaultConnector() {
 		return new Connector(TomcatServletWebServerFactory.DEFAULT_PROTOCOL);
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizerTests.java
@@ -104,7 +104,8 @@ class NettyWebServerFactoryCustomizerTests {
 
 	@Test
 	void setConnectionTimeout() {
-		setupConnectionTimeout(Duration.ofSeconds(1));
+		setServerProperties();
+		this.serverProperties.getNetty().setConnectionTimeout(Duration.ofSeconds(1));
 		NettyReactiveWebServerFactory factory = mock(NettyReactiveWebServerFactory.class);
 		this.customizer.customize(factory);
 		verifyConnectionTimeout(factory, 1000);
@@ -112,7 +113,8 @@ class NettyWebServerFactoryCustomizerTests {
 
 	@Test
 	void setIdleTimeout() {
-		setupIdleTimeout(Duration.ofSeconds(1));
+		setServerProperties();
+		this.serverProperties.getNetty().setIdleTimeout(Duration.ofSeconds(1));
 		NettyReactiveWebServerFactory factory = mock(NettyReactiveWebServerFactory.class);
 		this.customizer.customize(factory);
 		verifyIdleTimeout(factory, Duration.ofSeconds(1));
@@ -128,7 +130,7 @@ class NettyWebServerFactoryCustomizerTests {
 		nettyProperties.setMaxInitialLineLength(DataSize.ofKilobytes(32));
 		NettyReactiveWebServerFactory factory = mock(NettyReactiveWebServerFactory.class);
 		this.customizer.customize(factory);
-		verify(factory, times(2)).addServerCustomizers(this.customizerCaptor.capture());
+		verify(factory, times(1)).addServerCustomizers(this.customizerCaptor.capture());
 		NettyServerCustomizer serverCustomizer = this.customizerCaptor.getValue();
 		HttpServer httpServer = serverCustomizer.apply(HttpServer.create());
 		HttpRequestDecoderSpec decoder = httpServer.configuration().decoder();
@@ -144,17 +146,11 @@ class NettyWebServerFactoryCustomizerTests {
 			verify(factory, never()).addServerCustomizers(any(NettyServerCustomizer.class));
 			return;
 		}
-		verify(factory, times(3)).addServerCustomizers(this.customizerCaptor.capture());
+		verify(factory, times(2)).addServerCustomizers(this.customizerCaptor.capture());
 		NettyServerCustomizer serverCustomizer = this.customizerCaptor.getAllValues().get(0);
 		HttpServer httpServer = serverCustomizer.apply(HttpServer.create());
 		Map<ChannelOption<?>, ?> options = httpServer.configuration().options();
 		assertThat(options.get(ChannelOption.CONNECT_TIMEOUT_MILLIS)).isEqualTo(expected);
-	}
-
-	private void setupConnectionTimeout(Duration connectionTimeout) {
-		this.serverProperties.setForwardHeadersStrategy(ForwardHeadersStrategy.NONE);
-		this.serverProperties.setMaxHttpHeaderSize(null);
-		this.serverProperties.getNetty().setConnectionTimeout(connectionTimeout);
 	}
 
 	private void verifyIdleTimeout(NettyReactiveWebServerFactory factory, Duration expected) {
@@ -169,10 +165,9 @@ class NettyWebServerFactoryCustomizerTests {
 		assertThat(idleTimeout).isEqualTo(expected);
 	}
 
-	private void setupIdleTimeout(Duration idleTimeout) {
+	private void setServerProperties() {
 		this.serverProperties.setForwardHeadersStrategy(ForwardHeadersStrategy.NONE);
 		this.serverProperties.setMaxHttpHeaderSize(null);
-		this.serverProperties.getNetty().setIdleTimeout(idleTimeout);
 	}
 
 }


### PR DESCRIPTION
Through this change,Spring boot is setting its idleTimeout property for netty server to infinite.This is done by introducing a configuration property "server.netty.idle-timeout".

Fixes #27312 
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
