### PR TITLE
Add support for redis-sentinel in spring.redis.url (Lettuce only)

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
@@ -136,18 +136,20 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 
 	private boolean urlConfiguredForSentinelScheme(String url) {
 		String scheme = getUrlScheme(url);
-		return scheme != null
-				&& RedisURI.URI_SCHEME_REDIS_SENTINEL.equals(scheme) || RedisURI.URI_SCHEME_REDIS_SENTINEL_SECURE.equals(scheme);
+		return scheme != null && RedisURI.URI_SCHEME_REDIS_SENTINEL.equals(scheme)
+				|| RedisURI.URI_SCHEME_REDIS_SENTINEL_SECURE.equals(scheme);
 	}
 
 	private boolean urlConfiguredForSocketScheme(String url) {
 		String scheme = getUrlScheme(url);
-		return scheme != null && (RedisURI.URI_SCHEME_REDIS_SOCKET.equals(scheme) || RedisURI.URI_SCHEME_REDIS_SOCKET_ALT.equals(scheme));
+		return scheme != null && (RedisURI.URI_SCHEME_REDIS_SOCKET.equals(scheme)
+				|| RedisURI.URI_SCHEME_REDIS_SOCKET_ALT.equals(scheme));
 	}
 
 	private boolean urlConfiguredForNonStandardStandaloneScheme(String url) {
 		String scheme = getUrlScheme(url);
-		return scheme != null && !RedisURI.URI_SCHEME_REDIS.equals(scheme) && !RedisURI.URI_SCHEME_REDIS_SECURE.equals(scheme);
+		return scheme != null && !RedisURI.URI_SCHEME_REDIS.equals(scheme)
+				&& !RedisURI.URI_SCHEME_REDIS_SECURE.equals(scheme);
 	}
 
 	private String getUrlScheme(String url) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
@@ -169,7 +169,7 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 	}
 
 	private void customizeConfigurationFromUrl(LettuceClientConfiguration.LettuceClientConfigurationBuilder builder) {
-		RedisURI redisURI = createRedisUri(this.getProperties().getUrl());
+		RedisURI redisURI = createRedisUri(getProperties().getUrl());
 		builder.apply(redisURI);
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionConfiguration.java
@@ -68,6 +68,12 @@ abstract class RedisConnectionConfiguration {
 		if (this.standaloneConfiguration != null) {
 			return this.standaloneConfiguration;
 		}
+
+		RedisStandaloneConfiguration customConfig = maybeGetCustomStandaloneConfig();
+		if (customConfig != null) {
+			return customConfig;
+		}
+
 		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
 		if (StringUtils.hasText(this.properties.getUrl())) {
 			ConnectionInfo connectionInfo = parseUrl(this.properties.getUrl());
@@ -86,10 +92,20 @@ abstract class RedisConnectionConfiguration {
 		return config;
 	}
 
+	RedisStandaloneConfiguration maybeGetCustomStandaloneConfig() {
+		return null;
+	}
+
 	protected final RedisSentinelConfiguration getSentinelConfig() {
 		if (this.sentinelConfiguration != null) {
 			return this.sentinelConfiguration;
 		}
+
+		RedisSentinelConfiguration customConfig = maybeGetCustomSentinelConfig();
+		if (customConfig != null) {
+			return customConfig;
+		}
+
 		RedisProperties.Sentinel sentinelProperties = this.properties.getSentinel();
 		if (sentinelProperties != null) {
 			RedisSentinelConfiguration config = new RedisSentinelConfiguration();
@@ -105,6 +121,10 @@ abstract class RedisConnectionConfiguration {
 			config.setDatabase(this.properties.getDatabase());
 			return config;
 		}
+		return null;
+	}
+
+	RedisSentinelConfiguration maybeGetCustomSentinelConfig() {
 		return null;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationJedisTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationJedisTests.java
@@ -32,6 +32,7 @@ import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
  * Tests for {@link RedisAutoConfiguration} when Lettuce is not on the classpath.
@@ -39,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Paluch
  * @author Stephane Nicoll
  * @author Weix Sun
+ * @author Chris Bono
  */
 @ClassPathExclusions("lettuce-core-*.jar")
 class RedisAutoConfigurationJedisTests {
@@ -207,6 +209,17 @@ class RedisAutoConfigurationJedisTests {
 					assertThat(getUserName(JedisConnectionFactoryCaptor.connectionFactory)).isEqualTo("user");
 					assertThat(JedisConnectionFactoryCaptor.connectionFactory.getPassword()).isEqualTo("password");
 				});
+	}
+
+	@Test
+	void testRedisSentinelUrlConfiguration() {
+		this.contextRunner
+				.withPropertyValues(
+						"spring.redis.url=redis-sentinel://username:password@127.0.0.1:26379,127.0.0.1:26380/mymaster")
+				.run((context) -> assertThatIllegalStateException()
+						.isThrownBy(() -> context.getBean(JedisConnectionFactory.class))
+						.withRootCauseInstanceOf(RedisUrlSyntaxException.class).havingRootCause().withMessageContaining(
+								"Invalid Redis URL 'redis-sentinel://username:password@127.0.0.1:26379,127.0.0.1:26380/mymaster'"));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationLettuceUrlTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationLettuceUrlTests.java
@@ -39,7 +39,6 @@ class RedisAutoConfigurationLettuceUrlTests {
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(RedisAutoConfiguration.class));
 
-
 	private String getUserName(LettuceConnectionFactory factory) {
 		return ReflectionTestUtils.invokeMethod(factory, "getRedisUsername");
 	}
@@ -49,60 +48,65 @@ class RedisAutoConfigurationLettuceUrlTests {
 
 		@Test
 		void withMinimalFields() {
-			RedisAutoConfigurationLettuceUrlTests.this.contextRunner.withPropertyValues("spring.redis.url=redis://host1:6379").run((context) -> {
-				LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
-				assertThat(cf.getHostName()).isEqualTo("host1");
-				assertThat(cf.getPort()).isEqualTo(6379);
-				assertThat(getUserName(cf)).isNullOrEmpty();
-				assertThat(cf.getPassword()).isNullOrEmpty();
-				assertThat(cf.isUseSsl()).isFalse();
-			});
+			RedisAutoConfigurationLettuceUrlTests.this.contextRunner
+					.withPropertyValues("spring.redis.url=redis://host1:6379").run((context) -> {
+						LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+						assertThat(cf.getHostName()).isEqualTo("host1");
+						assertThat(cf.getPort()).isEqualTo(6379);
+						assertThat(getUserName(cf)).isNullOrEmpty();
+						assertThat(cf.getPassword()).isNullOrEmpty();
+						assertThat(cf.isUseSsl()).isFalse();
+					});
 		}
 
 		@Test
 		void withAllFields() {
-			RedisAutoConfigurationLettuceUrlTests.this.contextRunner.withPropertyValues("spring.redis.url=redis://user:password@host1:33").run((context) -> {
-				LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
-				assertThat(cf.getHostName()).isEqualTo("host1");
-				assertThat(cf.getPort()).isEqualTo(33);
-				assertThat(getUserName(cf)).isEqualTo("user");
-				assertThat(cf.getPassword()).isEqualTo("password");
-				assertThat(cf.isUseSsl()).isFalse();
-			});
+			RedisAutoConfigurationLettuceUrlTests.this.contextRunner
+					.withPropertyValues("spring.redis.url=redis://user:password@host1:33").run((context) -> {
+						LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+						assertThat(cf.getHostName()).isEqualTo("host1");
+						assertThat(cf.getPort()).isEqualTo(33);
+						assertThat(getUserName(cf)).isEqualTo("user");
+						assertThat(cf.getPassword()).isEqualTo("password");
+						assertThat(cf.isUseSsl()).isFalse();
+					});
 		}
 
 		@Test
 		void withSsl() {
-			RedisAutoConfigurationLettuceUrlTests.this.contextRunner.withPropertyValues("spring.redis.url=rediss://user:password@host1:33").run((context) -> {
-				LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
-				assertThat(cf.getHostName()).isEqualTo("host1");
-				assertThat(cf.getPort()).isEqualTo(33);
-				assertThat(getUserName(cf)).isEqualTo("user");
-				assertThat(cf.getPassword()).isEqualTo("password");
-				assertThat(cf.isUseSsl()).isTrue();
-			});
+			RedisAutoConfigurationLettuceUrlTests.this.contextRunner
+					.withPropertyValues("spring.redis.url=rediss://user:password@host1:33").run((context) -> {
+						LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+						assertThat(cf.getHostName()).isEqualTo("host1");
+						assertThat(cf.getPort()).isEqualTo(33);
+						assertThat(getUserName(cf)).isEqualTo("user");
+						assertThat(cf.getPassword()).isEqualTo("password");
+						assertThat(cf.isUseSsl()).isTrue();
+					});
 		}
 
 		@Test
 		void withoutUsernameWithPasswordContainingColon() {
-			RedisAutoConfigurationLettuceUrlTests.this.contextRunner.withPropertyValues("spring.redis.url=redis://:pass:word@host1:33").run((context) -> {
-				LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
-				assertThat(cf.getHostName()).isEqualTo("host1");
-				assertThat(cf.getPort()).isEqualTo(33);
-				assertThat(getUserName(cf)).isNullOrEmpty();
-				assertThat(cf.getPassword()).isEqualTo("pass:word");
-			});
+			RedisAutoConfigurationLettuceUrlTests.this.contextRunner
+					.withPropertyValues("spring.redis.url=redis://:pass:word@host1:33").run((context) -> {
+						LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+						assertThat(cf.getHostName()).isEqualTo("host1");
+						assertThat(cf.getPort()).isEqualTo(33);
+						assertThat(getUserName(cf)).isNullOrEmpty();
+						assertThat(cf.getPassword()).isEqualTo("pass:word");
+					});
 		}
 
 		@Test
 		void withUsernameWithPasswordStartsWithColonAndContainsColon() {
-			RedisAutoConfigurationLettuceUrlTests.this.contextRunner.withPropertyValues("spring.redis.url=redis://user::pass:word@host1:33").run((context) -> {
-				LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
-				assertThat(cf.getHostName()).isEqualTo("host1");
-				assertThat(cf.getPort()).isEqualTo(33);
-				assertThat(getUserName(cf)).isEqualTo("user");
-				assertThat(cf.getPassword()).isEqualTo(":pass:word");
-			});
+			RedisAutoConfigurationLettuceUrlTests.this.contextRunner
+					.withPropertyValues("spring.redis.url=redis://user::pass:word@host1:33").run((context) -> {
+						LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+						assertThat(cf.getHostName()).isEqualTo("host1");
+						assertThat(cf.getPort()).isEqualTo(33);
+						assertThat(getUserName(cf)).isEqualTo("user");
+						assertThat(cf.getPassword()).isEqualTo(":pass:word");
+					});
 		}
 
 	}
@@ -112,29 +116,31 @@ class RedisAutoConfigurationLettuceUrlTests {
 
 		@Test
 		void withAltSsl() {
-			RedisAutoConfigurationLettuceUrlTests.this.contextRunner.withPropertyValues("spring.redis.url=redis+ssl://user:password@host1:33/7").run((context) -> {
-				LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
-				assertThat(cf.getHostName()).isEqualTo("host1");
-				assertThat(cf.getPort()).isEqualTo(33);
-				assertThat(getUserName(cf)).isEqualTo("user");
-				assertThat(cf.getPassword()).isEqualTo("password");
-				assertThat(cf.getDatabase()).isEqualTo(7);
-				assertThat(cf.isUseSsl()).isTrue();
-			});
+			RedisAutoConfigurationLettuceUrlTests.this.contextRunner
+					.withPropertyValues("spring.redis.url=redis+ssl://user:password@host1:33/7").run((context) -> {
+						LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+						assertThat(cf.getHostName()).isEqualTo("host1");
+						assertThat(cf.getPort()).isEqualTo(33);
+						assertThat(getUserName(cf)).isEqualTo("user");
+						assertThat(cf.getPassword()).isEqualTo("password");
+						assertThat(cf.getDatabase()).isEqualTo(7);
+						assertThat(cf.isUseSsl()).isTrue();
+					});
 		}
 
 		@Test
 		void withAltTls() {
-			RedisAutoConfigurationLettuceUrlTests.this.contextRunner.withPropertyValues("spring.redis.url=redis+tls://user:password@host1:33/7").run((context) -> {
-				LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
-				assertThat(cf.getHostName()).isEqualTo("host1");
-				assertThat(cf.getPort()).isEqualTo(33);
-				assertThat(getUserName(cf)).isEqualTo("user");
-				assertThat(cf.getPassword()).isEqualTo("password");
-				assertThat(cf.getDatabase()).isEqualTo(7);
-				assertThat(cf.isUseSsl()).isTrue();
-				assertThat(cf.isStartTls()).isTrue();
-			});
+			RedisAutoConfigurationLettuceUrlTests.this.contextRunner
+					.withPropertyValues("spring.redis.url=redis+tls://user:password@host1:33/7").run((context) -> {
+						LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+						assertThat(cf.getHostName()).isEqualTo("host1");
+						assertThat(cf.getPort()).isEqualTo(33);
+						assertThat(getUserName(cf)).isEqualTo("user");
+						assertThat(cf.getPassword()).isEqualTo("password");
+						assertThat(cf.getDatabase()).isEqualTo(7);
+						assertThat(cf.isUseSsl()).isTrue();
+						assertThat(cf.isStartTls()).isTrue();
+					});
 		}
 
 		@Test
@@ -156,9 +162,11 @@ class RedisAutoConfigurationLettuceUrlTests {
 
 		@Test
 		void withClientOptionPropsSetOnUrlOverridesAndRespectsPropsSetInConfig() {
-			RedisAutoConfigurationLettuceUrlTests.this.contextRunner.withPropertyValues("spring.redis.url=redis+ssl://host1?timeout=47s&clientName=zuser",
-					"spring.redis.timeout=1200", "spring.redis.connect-timeout=2400",
-					"spring.redis.lettuce.shutdown-timeout=3600").run((context) -> {
+			RedisAutoConfigurationLettuceUrlTests.this.contextRunner
+					.withPropertyValues("spring.redis.url=redis+ssl://host1?timeout=47s&clientName=zuser",
+							"spring.redis.timeout=1200", "spring.redis.connect-timeout=2400",
+							"spring.redis.lettuce.shutdown-timeout=3600")
+					.run((context) -> {
 						LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
 						assertThat(cf.getClientName()).isEqualTo("zuser");
 						assertThat(cf.getTimeout()).isEqualTo(47000);
@@ -170,14 +178,15 @@ class RedisAutoConfigurationLettuceUrlTests {
 
 		@Test
 		void withoutClientOptionPropsSetOnUrlUsesDefaultCientOptions() {
-			RedisAutoConfigurationLettuceUrlTests.this.contextRunner.withPropertyValues("spring.redis.url=redis+ssl://host1").run((context) -> {
-				LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
-				assertThat(cf.getClientName()).isNullOrEmpty();
-				assertThat(cf.getTimeout()).isEqualTo(60000);
-				assertThat(cf.getShutdownTimeout()).isEqualTo(100);
-				assertThat(cf.getClientConfiguration().getClientOptions().get().getSocketOptions().getConnectTimeout()
-						.toMillis()).isEqualTo(10000);
-			});
+			RedisAutoConfigurationLettuceUrlTests.this.contextRunner
+					.withPropertyValues("spring.redis.url=redis+ssl://host1").run((context) -> {
+						LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+						assertThat(cf.getClientName()).isNullOrEmpty();
+						assertThat(cf.getTimeout()).isEqualTo(60000);
+						assertThat(cf.getShutdownTimeout()).isEqualTo(100);
+						assertThat(cf.getClientConfiguration().getClientOptions().get().getSocketOptions()
+								.getConnectTimeout().toMillis()).isEqualTo(10000);
+					});
 		}
 
 	}
@@ -187,7 +196,8 @@ class RedisAutoConfigurationLettuceUrlTests {
 
 		@Test
 		void withMinimalFields() {
-			RedisAutoConfigurationLettuceUrlTests.this.contextRunner.withPropertyValues("spring.redis.url=redis-sentinel://127.0.0.1?sentinelMasterId=5150")
+			RedisAutoConfigurationLettuceUrlTests.this.contextRunner
+					.withPropertyValues("spring.redis.url=redis-sentinel://127.0.0.1?sentinelMasterId=5150")
 					.run((context) -> {
 						LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
 						assertThat(getUserName(cf)).isNullOrEmpty();
@@ -225,7 +235,8 @@ class RedisAutoConfigurationLettuceUrlTests {
 
 		@Test
 		void withSsl() {
-			RedisAutoConfigurationLettuceUrlTests.this.contextRunner.withPropertyValues("spring.redis.url=rediss-sentinel://127.0.0.1?sentinelMasterId=5150")
+			RedisAutoConfigurationLettuceUrlTests.this.contextRunner
+					.withPropertyValues("spring.redis.url=rediss-sentinel://127.0.0.1?sentinelMasterId=5150")
 					.run((context) -> {
 						LettuceConnectionFactory connectionFactory = context.getBean(LettuceConnectionFactory.class);
 						assertThat(connectionFactory.isRedisSentinelAware()).isTrue();
@@ -259,19 +270,21 @@ class RedisAutoConfigurationLettuceUrlTests {
 
 		@Test
 		void withMinimalFields() {
-			RedisAutoConfigurationLettuceUrlTests.this.contextRunner.withPropertyValues("spring.redis.url=redis-socket:///mysocket").run((context) -> {
-				LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
-				assertThat(getUserName(cf)).isNullOrEmpty();
-				assertThat(cf.getPassword()).isNullOrEmpty();
-				assertThat(cf.getDatabase()).isEqualTo(0);
-				assertThat(cf.getSocketConfiguration()).extracting(RedisSocketConfiguration::getSocket)
-						.isEqualTo("/mysocket");
-			});
+			RedisAutoConfigurationLettuceUrlTests.this.contextRunner
+					.withPropertyValues("spring.redis.url=redis-socket:///mysocket").run((context) -> {
+						LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+						assertThat(getUserName(cf)).isNullOrEmpty();
+						assertThat(cf.getPassword()).isNullOrEmpty();
+						assertThat(cf.getDatabase()).isEqualTo(0);
+						assertThat(cf.getSocketConfiguration()).extracting(RedisSocketConfiguration::getSocket)
+								.isEqualTo("/mysocket");
+					});
 		}
 
 		@Test
 		void withAllFields() {
-			RedisAutoConfigurationLettuceUrlTests.this.contextRunner.withPropertyValues("spring.redis.url=redis-socket://user:password@/mysocket?database=7")
+			RedisAutoConfigurationLettuceUrlTests.this.contextRunner
+					.withPropertyValues("spring.redis.url=redis-socket://user:password@/mysocket?database=7")
 					.run((context) -> {
 						LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
 						assertThat(getUserName(cf)).isEqualTo("user");
@@ -284,7 +297,8 @@ class RedisAutoConfigurationLettuceUrlTests {
 
 		@Test
 		void withAltScheme() {
-			RedisAutoConfigurationLettuceUrlTests.this.contextRunner.withPropertyValues("spring.redis.url=redis+socket://user:password@/mysocket?database=7")
+			RedisAutoConfigurationLettuceUrlTests.this.contextRunner
+					.withPropertyValues("spring.redis.url=redis+socket://user:password@/mysocket?database=7")
 					.run((context) -> {
 						LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
 						assertThat(getUserName(cf)).isEqualTo("user");

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationLettuceUrlTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationLettuceUrlTests.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.redis;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.data.redis.connection.RedisSentinelConfiguration;
+import org.springframework.data.redis.connection.RedisSocketConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests {@link RedisAutoConfiguration} when using {@code Lettuce} and configuring via the
+ * {@code spring.redis.url} property.
+ *
+ * @author Chris Bono
+ */
+class RedisAutoConfigurationLettuceUrlTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(RedisAutoConfiguration.class));
+
+	@Test
+	void redisStandaloneUrlWithMinimalFields() {
+		this.contextRunner.withPropertyValues("spring.redis.url=redis://host1").run((context) -> {
+			LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+			assertThat(cf.getHostName()).isEqualTo("host1");
+			assertThat(cf.getPort()).isEqualTo(6379);
+			assertThat(getUserName(cf)).isNullOrEmpty();
+			assertThat(cf.getPassword()).isNullOrEmpty();
+			assertThat(cf.isUseSsl()).isFalse();
+		});
+	}
+
+	@Test
+	void redisStandaloneUrlWithAllFields() {
+		this.contextRunner.withPropertyValues("spring.redis.url=redis://user:password@host1:33/7").run((context) -> {
+			LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+			assertThat(cf.getHostName()).isEqualTo("host1");
+			assertThat(cf.getPort()).isEqualTo(33);
+			assertThat(getUserName(cf)).isEqualTo("user");
+			assertThat(cf.getPassword()).isEqualTo("password");
+			assertThat(cf.getDatabase()).isEqualTo(7);
+			assertThat(cf.isUseSsl()).isFalse();
+		});
+	}
+
+	@Test
+	void redisStandaloneUrlIgnoresOtherProps() {
+		this.contextRunner.withPropertyValues("spring.redis.url=redis://user:password@host1:33/7",
+				"spring.redis.username=abc", "spring.redis.password=xyz", "spring.redis.host=foo",
+				"spring.redis.port=1000", "spring.redis.database=2", "spring.redis.ssl=true").run((context) -> {
+					LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+					assertThat(cf.getHostName()).isEqualTo("host1");
+					assertThat(cf.getPort()).isEqualTo(33);
+					assertThat(getUserName(cf)).isEqualTo("user");
+					assertThat(cf.getPassword()).isEqualTo("password");
+					assertThat(cf.getDatabase()).isEqualTo(7);
+					assertThat(cf.isUseSsl()).isFalse();
+				});
+	}
+
+	@Test
+	void redisStandaloneWithSslUrl() {
+		this.contextRunner.withPropertyValues("spring.redis.url=rediss://user:password@host1:33/7").run((context) -> {
+			LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+			assertThat(cf.getHostName()).isEqualTo("host1");
+			assertThat(cf.getPort()).isEqualTo(33);
+			assertThat(getUserName(cf)).isEqualTo("user");
+			assertThat(cf.getPassword()).isEqualTo("password");
+			assertThat(cf.getDatabase()).isEqualTo(7);
+			assertThat(cf.isUseSsl()).isTrue();
+		});
+	}
+
+	@Test
+	void redisStandaloneWithAltSslUrl() {
+		this.contextRunner.withPropertyValues("spring.redis.url=redis+ssl://user:password@host1:33/7")
+				.run((context) -> {
+					LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+					assertThat(cf.getHostName()).isEqualTo("host1");
+					assertThat(cf.getPort()).isEqualTo(33);
+					assertThat(getUserName(cf)).isEqualTo("user");
+					assertThat(cf.getPassword()).isEqualTo("password");
+					assertThat(cf.getDatabase()).isEqualTo(7);
+					assertThat(cf.isUseSsl()).isTrue();
+				});
+	}
+
+	@Test
+	void redisStandaloneWithAltTlsUrl() {
+		this.contextRunner.withPropertyValues("spring.redis.url=redis+tls://user:password@host1:33/7")
+				.run((context) -> {
+					LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+					assertThat(cf.getHostName()).isEqualTo("host1");
+					assertThat(cf.getPort()).isEqualTo(33);
+					assertThat(getUserName(cf)).isEqualTo("user");
+					assertThat(cf.getPassword()).isEqualTo("password");
+					assertThat(cf.getDatabase()).isEqualTo(7);
+					assertThat(cf.isUseSsl()).isTrue();
+					assertThat(cf.isStartTls()).isTrue();
+				});
+	}
+
+	@Test
+	void redisStandaloneUrlWithoutUsernameWithPasswordContainingColon() {
+		this.contextRunner.withPropertyValues("spring.redis.url=redis://:pass:word@host1:33").run((context) -> {
+			LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+			assertThat(cf.getHostName()).isEqualTo("host1");
+			assertThat(cf.getPort()).isEqualTo(33);
+			assertThat(getUserName(cf)).isNullOrEmpty();
+			assertThat(cf.getPassword()).isEqualTo("pass:word");
+		});
+	}
+
+	@Test
+	void redisStandaloneUrlWithUsernameWithPasswordStartsWithColonAndContainsColon() {
+		this.contextRunner.withPropertyValues("spring.redis.url=redis://user::pass:word@host1:33").run((context) -> {
+			LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+			assertThat(cf.getHostName()).isEqualTo("host1");
+			assertThat(cf.getPort()).isEqualTo(33);
+			assertThat(getUserName(cf)).isEqualTo("user");
+			assertThat(cf.getPassword()).isEqualTo(":pass:word");
+		});
+	}
+
+	@Test
+	void redisSentinelUrlMinimalFields() {
+		this.contextRunner.withPropertyValues("spring.redis.url=redis-sentinel://127.0.0.1?sentinelMasterId=5150")
+				.run((context) -> {
+					LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+					assertThat(getUserName(cf)).isNullOrEmpty();
+					assertThat(cf.getPassword()).isNullOrEmpty();
+					assertThat(cf.getDatabase()).isEqualTo(0);
+					assertThat(cf.isUseSsl()).isFalse();
+					assertThat(cf.isRedisSentinelAware()).isTrue();
+					RedisSentinelConfiguration sentinelConfiguration = cf.getSentinelConfiguration();
+					assertThat(sentinelConfiguration.getSentinels()).flatMap(Object::toString)
+							.containsExactlyInAnyOrder("127.0.0.1:26379");
+					assertThat(sentinelConfiguration.getMaster().getName()).isEqualTo("5150");
+					assertThat(sentinelConfiguration.getSentinelPassword().isPresent()).isFalse();
+				});
+	}
+
+	@Test
+	void redisSentinelUrlWithAllFields() {
+		this.contextRunner.withPropertyValues(
+				"spring.redis.url=redis-sentinel://username:password@127.0.0.1:26379,127.0.0.1:26380/7?sentinelMasterId=5150",
+				"spring.redis.sentinel.password: secret").run((context) -> {
+					LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+					assertThat(getUserName(cf)).isEqualTo("username");
+					assertThat(cf.getPassword()).isEqualTo("password");
+					assertThat(cf.getDatabase()).isEqualTo(7);
+					assertThat(cf.isUseSsl()).isFalse();
+					assertThat(cf.isRedisSentinelAware()).isTrue();
+					RedisSentinelConfiguration sentinelConfiguration = cf.getSentinelConfiguration();
+					assertThat(sentinelConfiguration.getSentinels()).flatMap(Object::toString)
+							.containsExactlyInAnyOrder("127.0.0.1:26379", "127.0.0.1:26380");
+					assertThat(sentinelConfiguration.getMaster().getName()).isEqualTo("5150");
+					assertThat(sentinelConfiguration.getSentinelPassword().get()).isEqualTo("secret".toCharArray());
+				});
+
+	}
+
+	@Test
+	void redisSentinelUrlIgnoresOtherProps() {
+		this.contextRunner.withPropertyValues(
+				"spring.redis.url=redis-sentinel://username:password@127.0.0.1:26379,127.0.0.1:26380/7?sentinelMasterId=5150",
+				"spring.redis.sentinel.master=mymaster", "spring.redis.sentinel.nodes=server1:111, server2:222")
+				.run((context) -> {
+					LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+					assertThat(getUserName(cf)).isEqualTo("username");
+					assertThat(cf.getPassword()).isEqualTo("password");
+					assertThat(cf.getDatabase()).isEqualTo(7);
+					assertThat(cf.isUseSsl()).isFalse();
+					assertThat(cf.isRedisSentinelAware()).isTrue();
+					RedisSentinelConfiguration sentinelConfiguration = cf.getSentinelConfiguration();
+					assertThat(sentinelConfiguration.getSentinels()).flatMap(Object::toString)
+							.containsExactlyInAnyOrder("127.0.0.1:26379", "127.0.0.1:26380");
+					assertThat(sentinelConfiguration.getMaster().getName()).isEqualTo("5150");
+				});
+	}
+
+	@Test
+	void redisSentinelWithSslUrl() {
+		this.contextRunner.withPropertyValues("spring.redis.url=rediss-sentinel://127.0.0.1?sentinelMasterId=5150")
+				.run((context) -> {
+					LettuceConnectionFactory connectionFactory = context.getBean(LettuceConnectionFactory.class);
+					assertThat(connectionFactory.isRedisSentinelAware()).isTrue();
+					assertThat(connectionFactory.isUseSsl()).isTrue();
+				});
+	}
+
+	@Test
+	void redisSocketUrlWithMinimalFields() {
+		this.contextRunner.withPropertyValues("spring.redis.url=redis-socket:///mysocket").run((context) -> {
+			LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+			assertThat(getUserName(cf)).isNullOrEmpty();
+			assertThat(cf.getPassword()).isNullOrEmpty();
+			assertThat(cf.getDatabase()).isEqualTo(0);
+			assertThat(cf.getSocketConfiguration()).extracting(RedisSocketConfiguration::getSocket)
+					.isEqualTo("/mysocket");
+		});
+	}
+
+	@Test
+	void redisSocketUrlWithAllFields() {
+		this.contextRunner.withPropertyValues("spring.redis.url=redis-socket://user:password@/mysocket?database=7")
+				.run((context) -> {
+					LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+					assertThat(getUserName(cf)).isEqualTo("user");
+					assertThat(cf.getPassword()).isEqualTo("password");
+					assertThat(cf.getDatabase()).isEqualTo(7);
+					assertThat(cf.getSocketConfiguration()).extracting(RedisSocketConfiguration::getSocket)
+							.isEqualTo("/mysocket");
+				});
+	}
+
+	@Test
+	void redisSocketUrlWithAltScheme() {
+		this.contextRunner.withPropertyValues("spring.redis.url=redis+socket://user:password@/mysocket?database=7")
+				.run((context) -> {
+					LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+					assertThat(getUserName(cf)).isEqualTo("user");
+					assertThat(cf.getPassword()).isEqualTo("password");
+					assertThat(cf.getDatabase()).isEqualTo(7);
+					assertThat(cf.getSocketConfiguration()).extracting(RedisSocketConfiguration::getSocket)
+							.isEqualTo("/mysocket");
+				});
+	}
+
+	@Test
+	void redisUrlWithCientOptionParamsOverridesAndRespectsOtherProps() {
+		this.contextRunner.withPropertyValues("spring.redis.url=redis://host1?timeout=47s&clientName=zuser",
+				"spring.redis.timeout=1200", "spring.redis.connect-timeout=2400",
+				"spring.redis.lettuce.shutdown-timeout=3600").run((context) -> {
+					LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+					assertThat(cf.getClientName()).isEqualTo("zuser");
+					assertThat(cf.getTimeout()).isEqualTo(47000);
+					assertThat(cf.getShutdownTimeout()).isEqualTo(3600);
+					assertThat(cf.getClientConfiguration().getClientOptions().get().getSocketOptions()
+							.getConnectTimeout().toMillis()).isEqualTo(2400);
+				});
+	}
+
+	@Test
+	void redisUrlWithDefaultCientOptions() {
+		this.contextRunner.withPropertyValues("spring.redis.url=redis://host1").run((context) -> {
+			LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+			assertThat(cf.getClientName()).isNullOrEmpty();
+			assertThat(cf.getTimeout()).isEqualTo(60000);
+			assertThat(cf.getShutdownTimeout()).isEqualTo(100);
+			assertThat(cf.getClientConfiguration().getClientOptions().get().getSocketOptions().getConnectTimeout()
+					.toMillis()).isEqualTo(10000);
+		});
+	}
+
+	private String getUserName(LettuceConnectionFactory factory) {
+		return ReflectionTestUtils.invokeMethod(factory, "getRedisUsername");
+	}
+
+}

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/nosql.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/nosql.adoc
@@ -49,7 +49,7 @@ additional settings as shown in the following example:
 	spring:
 	  data:
 	    redis:
-	      url: "redis://user:secret@redis.example.com:6399
+	      url: "redis://user:secret@redis.example.com:6379"
 ----
 
 Alternatively, you can specify connection details using discrete properties. For example, you might
@@ -61,7 +61,7 @@ declare the following settings in your `application.yml`:
 	  data:
 	    redis:
 	      host: "redis.example.com"
-	      port: 6399
+	      port: 6379
 	      username: "user"
 	      password: "secret"
 ----

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/nosql.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/nosql.adoc
@@ -41,6 +41,41 @@ The following listing shows an example of such a bean:
 include::{docs-java}/data/nosql/redis/connecting/MyBean.java[]
 ----
 
+You can set the configprop:spring.data.redis.url[] property to change the URL and configure
+additional settings as shown in the following example:
+
+[source,yaml,indent=0,subs="verbatim",configprops,configblocks]
+----
+	spring:
+	  data:
+	    redis:
+	      url: "redis://user:secret@redis.example.com:6399
+----
+
+Alternatively, you can specify connection details using discrete properties. For example, you might
+declare the following settings in your `application.yml`:
+
+[source,yaml,indent=0,subs="verbatim",configprops,configblocks]
+----
+	spring:
+	  data:
+	    redis:
+	      host: "redis.example.com"
+	      port: 6399
+	      username: "user"
+	      password: "secret"
+----
+When using both the URL and the discrete properties, any values that are set in the URL will take precedence over the values set in the properties.
+
+The url property supports the `redis` and `rediss` schemes as well as the following additional schemes when using Lettuce:
+
+* `redis+ssl`
+* `redis+tls`
+* `redis-sentinel`
+* `rediss-sentinel`
+* `redis-socket`
+* `redis+socket`
+
 TIP: You can also register an arbitrary number of beans that implement `LettuceClientConfigurationBuilderCustomizer` for more advanced customizations.
 `ClientResources` can also be customized using `ClientResourcesBuilderCustomizer`.
 If you use Jedis, `JedisClientConfigurationBuilderCustomizer` is also available.

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/nosql.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/nosql.adoc
@@ -41,15 +41,14 @@ The following listing shows an example of such a bean:
 include::{docs-java}/data/nosql/redis/connecting/MyBean.java[]
 ----
 
-You can set the configprop:spring.data.redis.url[] property to change the URL and configure
+You can set the configprop:spring.redis.url[] property to change the URL and configure
 additional settings as shown in the following example:
 
 [source,yaml,indent=0,subs="verbatim",configprops,configblocks]
 ----
-	spring:
-	  data:
-	    redis:
-	      url: "redis://user:secret@redis.example.com:6379"
+    spring:
+      redis:
+        url: "redis://user:secret@redis.example.com:6379"
 ----
 
 Alternatively, you can specify connection details using discrete properties. For example, you might
@@ -58,12 +57,11 @@ declare the following settings in your `application.yml`:
 [source,yaml,indent=0,subs="verbatim",configprops,configblocks]
 ----
 	spring:
-	  data:
-	    redis:
-	      host: "redis.example.com"
-	      port: 6379
-	      username: "user"
-	      password: "secret"
+	  redis:
+	    host: "redis.example.com"
+	    port: 6379
+	    username: "user"
+	    password: "secret"
 ----
 When using both the URL and the discrete properties, any values that are set in the URL will take precedence over the values set in the properties.
 


### PR DESCRIPTION

Adds support for setting the following `spring.redis.uri` when Lettuce is used:

- `redis-sentnel`
- `rediss-sentinel`
- `redis-socket`

⚠️  This also implicitly adds support for `redis-socket://` (#22273) 

### Alt Schemes
ℹ️ : Because the RedisURI is being used to parse the url string, other url schemes are [actually supported](https://github.com/lettuce-io/lettuce-core/blob/b161915eefbc1ea92131c65086787230ea227253/src/main/java/io/lettuce/core/RedisURI.java#L143) - namely:
- `redis+ssl`
- `redis+tls`
- `redis+socket`

Should we block user's from using these alt schemes? It seems that if we don't block, we at least don't advertise the ability to use these alt schemes. @wilkinsona  @snicoll  wdyt?

### Config Validation 
I was tempted to add a validateConfiguration` that asserted that if the url was used, only the relevant other props could be used. This would of course, potentially break existing users (both Lettuce and Jedis). Just wanted to get your opinions here as well. 

```java
private void validateConfiguration() {
    if (!StringUtils.hasText(getProperties().getUrl())) {
        return;
    }

    Assert.state(getProperties().getSentinel() == null || !StringUtils.hasText(getProperties().getSentinel().getMaster()),
            "Invalid redis configuration, 'sentinel.master' not supported when 'url' is specified");

    Assert.state(getProperties().getSentinel() == null || ObjectUtils.isEmpty(getProperties().getSentinel().getNodes()),
            "Invalid redis configuration, 'sentinel.nodes' not supported when 'url' is specified");

    Assert.state(this.getProperties().getCluster() == null,
            "Invalid redis configuration, 'cluster' properties not supported when 'url' is specified");
}
```

### TODO 

- [x] Get resolution on "Alt Schemes" (above)
- [x] Get resolution on "Config Validation" and adjust (or not) accordingly
- [x] Update docs