### PR TITLE
Allow build info properties to be disabled

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,12 +60,9 @@ public class BuildInfo extends ConventionTask {
 	public void generateBuildProperties() {
 		try {
 			new BuildPropertiesWriter(new File(getDestinationDir(), "build-info.properties"))
-					.writeBuildProperties(
-							new ProjectDetails(this.properties.getGroup(),
-									(this.properties.getArtifact() != null) ? this.properties.getArtifact()
-											: "unspecified",
-									this.properties.getVersion(), this.properties.getName(), this.properties.getTime(),
-									coerceToStringValues(this.properties.getAdditional())));
+					.writeBuildProperties(new ProjectDetails(this.properties.getGroup(), this.properties.getArtifact(),
+							this.properties.getVersion(), this.properties.getName(), this.properties.getTime(),
+							coerceToStringValues(this.properties.getAdditional())));
 		}
 		catch (IOException ex) {
 			throw new TaskExecutionException(this, ex);

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for the {@link BuildInfo} task.
  *
  * @author Andy Wilkinson
+ * @author Vedran Pavic
  */
 @GradleCompatibility(configurationCache = true)
 class BuildInfoIntegrationTests {
@@ -50,8 +51,8 @@ class BuildInfoIntegrationTests {
 		assertThat(this.gradleBuild.build("buildInfo").task(":buildInfo").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
 		Properties buildInfoProperties = buildInfoProperties();
 		assertThat(buildInfoProperties).containsKey("build.time");
-		assertThat(buildInfoProperties).containsEntry("build.artifact", "unspecified");
-		assertThat(buildInfoProperties).containsEntry("build.group", "");
+		assertThat(buildInfoProperties).doesNotContainKey("build.artifact");
+		assertThat(buildInfoProperties).doesNotContainKey("build.group");
 		assertThat(buildInfoProperties).containsEntry("build.name", this.gradleBuild.getProjectDir().getName());
 		assertThat(buildInfoProperties).containsEntry("build.version", "unspecified");
 	}
@@ -120,6 +121,26 @@ class BuildInfoIntegrationTests {
 				.isEqualTo(TaskOutcome.SUCCESS);
 		String secondHash = FileUtils.sha1Hash(buildInfoProperties);
 		assertThat(firstHash).isEqualTo(secondHash);
+	}
+
+	@TestTemplate
+	void removePropertiesUsingNulls() {
+		assertThat(this.gradleBuild.build("buildInfo").task(":buildInfo").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+		Properties buildInfoProperties = buildInfoProperties();
+		assertThat(buildInfoProperties).doesNotContainKey("build.group");
+		assertThat(buildInfoProperties).doesNotContainKey("build.artifact");
+		assertThat(buildInfoProperties).doesNotContainKey("build.version");
+		assertThat(buildInfoProperties).doesNotContainKey("build.name");
+	}
+
+	@TestTemplate
+	void removePropertiesUsingEmptyStrings() {
+		assertThat(this.gradleBuild.build("buildInfo").task(":buildInfo").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+		Properties buildInfoProperties = buildInfoProperties();
+		assertThat(buildInfoProperties).doesNotContainKey("build.group");
+		assertThat(buildInfoProperties).doesNotContainKey("build.artifact");
+		assertThat(buildInfoProperties).doesNotContainKey("build.version");
+		assertThat(buildInfoProperties).doesNotContainKey("build.name");
 	}
 
 	private Properties buildInfoProperties() {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link BuildInfo}.
  *
  * @author Andy Wilkinson
+ * @author Vedran Pavic
  */
 @ClassPathExclusions("kotlin-daemon-client-*")
 class BuildInfoTests {
@@ -49,8 +50,8 @@ class BuildInfoTests {
 	void basicExecution() {
 		Properties properties = buildInfoProperties(createTask(createProject("test")));
 		assertThat(properties).containsKey("build.time");
-		assertThat(properties).containsEntry("build.artifact", "unspecified");
-		assertThat(properties).containsEntry("build.group", "");
+		assertThat(properties).doesNotContainKey("build.artifact");
+		assertThat(properties).doesNotContainKey("build.group");
 		assertThat(properties).containsEntry("build.name", "test");
 		assertThat(properties).containsEntry("build.version", "unspecified");
 	}
@@ -60,6 +61,20 @@ class BuildInfoTests {
 		BuildInfo task = createTask(createProject("test"));
 		task.getProperties().setArtifact("custom");
 		assertThat(buildInfoProperties(task)).containsEntry("build.artifact", "custom");
+	}
+
+	@Test
+	void artifactCanBeRemovedFromPropertiesUsingNull() {
+		BuildInfo task = createTask(createProject("test"));
+		task.getProperties().setArtifact(null);
+		assertThat(buildInfoProperties(task)).doesNotContainKey("build.artifact");
+	}
+
+	@Test
+	void artifactCanBeRemovedFromPropertiesUsingEmptyString() {
+		BuildInfo task = createTask(createProject("test"));
+		task.getProperties().setArtifact("");
+		assertThat(buildInfoProperties(task)).doesNotContainKey("build.artifact");
 	}
 
 	@Test
@@ -77,10 +92,38 @@ class BuildInfoTests {
 	}
 
 	@Test
+	void groupCanBeRemovedFromPropertiesUsingNull() {
+		BuildInfo task = createTask(createProject("test"));
+		task.getProperties().setGroup(null);
+		assertThat(buildInfoProperties(task)).doesNotContainKey("build.group");
+	}
+
+	@Test
+	void groupCanBeRemovedFromPropertiesUsingEmptyString() {
+		BuildInfo task = createTask(createProject("test"));
+		task.getProperties().setGroup("");
+		assertThat(buildInfoProperties(task)).doesNotContainKey("build.group");
+	}
+
+	@Test
 	void customNameIsReflectedInProperties() {
 		BuildInfo task = createTask(createProject("test"));
 		task.getProperties().setName("Example");
 		assertThat(buildInfoProperties(task)).containsEntry("build.name", "Example");
+	}
+
+	@Test
+	void nameCanBeRemovedFromPropertiesUsingNull() {
+		BuildInfo task = createTask(createProject("test"));
+		task.getProperties().setName(null);
+		assertThat(buildInfoProperties(task)).doesNotContainKey("build.name");
+	}
+
+	@Test
+	void nameCanBeRemovedFromPropertiesUsingEmptyString() {
+		BuildInfo task = createTask(createProject("test"));
+		task.getProperties().setName("");
+		assertThat(buildInfoProperties(task)).doesNotContainKey("build.name");
 	}
 
 	@Test
@@ -95,6 +138,20 @@ class BuildInfoTests {
 		BuildInfo task = createTask(createProject("test"));
 		task.getProperties().setVersion("2.3.4");
 		assertThat(buildInfoProperties(task)).containsEntry("build.version", "2.3.4");
+	}
+
+	@Test
+	void versionCanBeRemovedFromPropertiesUsingNull() {
+		BuildInfo task = createTask(createProject("test"));
+		task.getProperties().setVersion(null);
+		assertThat(buildInfoProperties(task)).doesNotContainKey("build.version");
+	}
+
+	@Test
+	void versionCanBeRemovedFromPropertiesUsingEmptyString() {
+		BuildInfo task = createTask(createProject("test"));
+		task.getProperties().setVersion("");
+		assertThat(buildInfoProperties(task)).doesNotContainKey("build.version");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-removePropertiesUsingEmptyStrings.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-removePropertiesUsingEmptyStrings.gradle
@@ -1,0 +1,16 @@
+plugins {
+	id 'org.springframework.boot' version '{version}' apply false
+}
+
+group = 'foo'
+version = '0.1.0'
+
+task buildInfo(type: org.springframework.boot.gradle.tasks.buildinfo.BuildInfo) {
+	destinationDir project.buildDir
+	properties {
+		group = ''
+		artifact = ''
+		version = ''
+		name = ''
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-removePropertiesUsingNulls.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-removePropertiesUsingNulls.gradle
@@ -1,0 +1,16 @@
+plugins {
+	id 'org.springframework.boot' version '{version}' apply false
+}
+
+group = 'foo'
+version = '0.1.0'
+
+task buildInfo(type: org.springframework.boot.gradle.tasks.buildinfo.BuildInfo) {
+	destinationDir project.buildDir
+	properties {
+		group = null
+		artifact = null
+		version = null
+		name = null
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/BuildPropertiesWriter.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/BuildPropertiesWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.springframework.core.CollectionFactory;
+import org.springframework.util.StringUtils;
 
 /**
  * A {@code BuildPropertiesWriter} writes the {@code build-info.properties} for
@@ -32,6 +33,7 @@ import org.springframework.core.CollectionFactory;
  *
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author Vedran Pavic
  * @since 1.0.0
  */
 public final class BuildPropertiesWriter {
@@ -71,10 +73,18 @@ public final class BuildPropertiesWriter {
 
 	protected Properties createBuildInfo(ProjectDetails project) {
 		Properties properties = CollectionFactory.createSortedProperties(true);
-		properties.put("build.group", project.getGroup());
-		properties.put("build.artifact", project.getArtifact());
-		properties.put("build.name", project.getName());
-		properties.put("build.version", project.getVersion());
+		if (StringUtils.hasText(project.getGroup())) {
+			properties.put("build.group", project.getGroup());
+		}
+		if (StringUtils.hasText(project.getArtifact())) {
+			properties.put("build.artifact", project.getArtifact());
+		}
+		if (StringUtils.hasText(project.getName())) {
+			properties.put("build.name", project.getName());
+		}
+		if (StringUtils.hasText(project.getVersion())) {
+			properties.put("build.version", project.getVersion());
+		}
 		if (project.getTime() != null) {
 			properties.put("build.time", DateTimeFormatter.ISO_INSTANT.format(project.getTime()));
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/BuildInfoIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/BuildInfoIntegrationTests.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for the Maven plugin's build info support.
  *
  * @author Andy Wilkinson
+ * @author Vedran Pavic
  */
 @ExtendWith(MavenBuildExtension.class)
 public class BuildInfoIntegrationTests {
@@ -89,6 +90,13 @@ public class BuildInfoIntegrationTests {
 				.doesNotContainBuildTime()));
 	}
 
+	@TestTemplate
+	void whenProjectNameIsNotSetItDoesNotAppearInGeneratedBuildInfo(MavenBuild mavenBuild) {
+		mavenBuild.project("build-info-disable-build-name").execute(buildInfo((buildInfo) -> assertThat(buildInfo)
+				.hasBuildGroup("org.springframework.boot.maven.it").hasBuildArtifact("build-info-disable-build-name")
+				.doesNotContainBuildName().hasBuildVersion("0.0.1.BUILD-SNAPSHOT").containsBuildTime()));
+	}
+
 	private ProjectCallback buildInfo(Consumer<AssertProvider<BuildInfoAssert>> buildInfo) {
 		return buildInfo("target/classes/META-INF/build-info.properties", buildInfo);
 	}
@@ -136,6 +144,10 @@ public class BuildInfoIntegrationTests {
 
 		BuildInfoAssert hasBuildName(String expected) {
 			return containsEntry("build.name", expected);
+		}
+
+		BuildInfoAssert doesNotContainBuildName() {
+			return doesNotContainKey("build.name");
 		}
 
 		BuildInfoAssert hasBuildVersion(String expected) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-info-disable-build-name/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-info-disable-build-name/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.boot.maven.it</groupId>
+	<artifactId>build-info-disable-build-name</artifactId>
+	<version>0.0.1.BUILD-SNAPSHOT</version>
+	<name/>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>@java.version@</maven.compiler.source>
+		<maven.compiler.target>@java.version@</maven.compiler.target>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>build-info</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-info-disable-build-name/src/main/java/org/test/SampleApplication.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-info-disable-build-name/src/main/java/org/test/SampleApplication.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.test;
+
+public class SampleApplication {
+
+	public static void main(String[] args) {
+	}
+
+}


### PR DESCRIPTION
At present, `BuildPropertiesWriter` can fail with a NPE if build properties (`group`, `artifact`, `name`, `version`) are set to `null`.

This is specifically problematic with the Gradle plugin, since its DSL can be used to set `group`, `name` and `version` properties to `null` in an attempt to remove them from the generated `build-info.properties`. Additionally, setting `artifact` property to `null` results in the value `unspecified`.

This PR updates `BuildPropertiesWriter` to write the properties only if they are not null and have non-whitespace characters.

This closes #27092
