### PR TITLE
DataSourceBuilder throws an UnsupportedDataSourcePropertyException when trying to derive a DataSource from an unknown DataSource type

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DataSourceBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DataSourceBuilder.java
@@ -281,17 +281,22 @@ public final class DataSourceBuilder<T extends DataSource> {
 		}
 
 		Method findSetter(Class<?> type) {
-			return extracted("set", type);
+			return extracted("set", type, true);
 		}
 
 		Method findGetter(Class<?> type) {
-			return extracted("get", type);
+			return extracted("get", type, false);
 		}
 
-		private Method extracted(String prefix, Class<?> type) {
+		private Method extracted(String prefix, Class<?> type, boolean hasParameter) {
 			for (String candidate : this.names) {
-				Method method = ReflectionUtils.findMethod(type, prefix + StringUtils.capitalize(candidate),
-						String.class);
+				Method method;
+				if (hasParameter) {
+					method = ReflectionUtils.findMethod(type, prefix + StringUtils.capitalize(candidate), String.class);
+				}
+				else {
+					method = ReflectionUtils.findMethod(type, prefix + StringUtils.capitalize(candidate));
+				}
 				if (method != null) {
 					return method;
 				}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DataSourceBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DataSourceBuilderTests.java
@@ -331,6 +331,19 @@ class DataSourceBuilderTests {
 		assertThat(built.getUrl()).isEqualTo("jdbc:postgresql://localhost:5432/postgres");
 	}
 
+	@Test // gh -27295
+	void buildWhenDerivedFromCustomTypeSpecifiedReturnsDataSource() {
+		CustomDataSource dataSource = new CustomDataSource();
+		dataSource.setUsername("test");
+		dataSource.setPassword("secret");
+		dataSource.setUrl("jdbc:postgresql://localhost:5432/postgres");
+		DataSourceBuilder<?> builder = DataSourceBuilder.derivedFrom(dataSource).type(SimpleDriverDataSource.class);
+		SimpleDriverDataSource testSource = (SimpleDriverDataSource) builder.build();
+		assertThat(testSource.getUsername()).isEqualTo("test");
+		assertThat(testSource.getUrl()).isEqualTo("jdbc:postgresql://localhost:5432/postgres");
+		assertThat(testSource.getPassword()).isEqualTo("secret");
+	}
+
 	final class HidePackagesClassLoader extends URLClassLoader {
 
 		private final String[] hiddenPackages;


### PR DESCRIPTION

This fix eliminates the unsupported datasource property exception thrown when trying to derive a datasource from an unknown datasource type  by calling ReflectionUtils on the getters and setters of the unknown datasource type.

Fixes #27295 

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
