### PR TITLE
A URI with non-alpha characters in its scheme is not sanitized

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
@@ -50,7 +50,7 @@ public class Sanitizer {
 	private static final Set<String> URI_USERINFO_KEYS = new LinkedHashSet<>(
 			Arrays.asList("uri", "uris", "url", "urls", "address", "addresses"));
 
-	private static final Pattern URI_USERINFO_PATTERN = Pattern.compile("\\[?[A-Za-z]+://.+:(.*)@.+$");
+	private static final Pattern URI_USERINFO_PATTERN = Pattern.compile("^[A-Za-z][\\w\\+\\.\\-]+://.+:(.*)@.+$");
 
 	private Pattern[] keysToSanitize;
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
@@ -50,7 +50,7 @@ public class Sanitizer {
 	private static final Set<String> URI_USERINFO_KEYS = new LinkedHashSet<>(
 			Arrays.asList("uri", "uris", "url", "urls", "address", "addresses"));
 
-	private static final Pattern URI_USERINFO_PATTERN = Pattern.compile("^[A-Za-z][\\w\\+\\.\\-]+://.+:(.*)@.+$");
+	private static final Pattern URI_USERINFO_PATTERN = Pattern.compile("^[A-Za-z][A-Za-z0-9\\+\\.\\-]+://.+:(.*)@.+$");
 
 	private Pattern[] keysToSanitize;
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/SanitizerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/SanitizerTests.java
@@ -69,8 +69,8 @@ class SanitizerTests {
 	@MethodSource("matchingUriUserInfoKeys")
 	void uriWithSingleValueWithPasswordShouldBeSanitized(String key) {
 		Sanitizer sanitizer = new Sanitizer();
-		assertThat(sanitizer.sanitize(key, "http://user:password@localhost:8080"))
-				.isEqualTo("http://user:******@localhost:8080");
+		assertThat(sanitizer.sanitize(key, "view-source://user:password@localhost:8080"))
+				.isEqualTo("view-source://user:******@localhost:8080");
 	}
 
 	@ParameterizedTest(name = "key = {0}")


### PR DESCRIPTION

The Sanitizer.java class infers that the scheme portion of a URI can only contain letters, but as described in[ RFC2396](https://datatracker.ietf.org/doc/html/rfc2396#section-3.1) it can follow:

`scheme        = alpha *( alpha | digit | "+" | "-" | "." )`
 
We have a use case where a valid URI with the scheme `mongodb+sr`, won't get the password token sanitized due to the current regex pattern.


<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
