### PR TITLE
Update examples in the Dynatrace documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
@@ -182,7 +182,7 @@ The URLs of the Metrics API v2 ingest endpoint are:
 	    export:
 	      dynatrace:
 	        uri: "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest"
-	        api-token: "YOUR_TOKEN" # should be read from a secure source and not hard-coded.
+	        api-token: "YOUR_TOKEN"
 ----
 
 Depending on your setup, the environment variables `+DT_METRICS_INGEST_URL+` and `+DT_METRICS_INGEST_API_TOKEN+` might be populated accordingly already and can be used via the Spring placeholder notation:
@@ -204,17 +204,16 @@ When using the Dynatrace v2 API, the following optional features are available:
 * Default dimensions: Specify key-value pairs that are added to all exported metrics.
   If tags with the same key are specified with Micrometer, they overwrite the default dimensions.
 
+In the example below URI and API token are not specified, therefore the local OneAgent endpoint is used.
+It is also possible to explicitly use the `uri` and `api-token` properties as shown in the examples above.
+
 [source,yaml,indent=0,subs="verbatim",configprops,configblocks]
 ----
 	management:
 	  metrics:
 	    export:
 	      dynatrace:
-	        # Specify API token and URI or leave blank for OneAgent export, e.g:
-	        # uri: "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest"
-	        # api-token: "YOUR_TOKEN" # should be read from a secure source and not hard-coded.
-
-	        # Configure v2-specific properties:
+	        # Specify uri and api-token here if not using the local OneAgent endpoint.
 	        v2:
 	          metric-key-prefix: "your.key.prefix"
 	          enrich-with-dynatrace-metadata: true
@@ -237,9 +236,7 @@ To export metrics to {micrometer-registry-docs}/dynatrace[Dynatrace], your API t
 	  metrics:
 	    export:
 	      dynatrace:
-	        # uri: "https://{your-domain}/e/{your-environment-id}" on managed deployments.
 	        uri: "https://{your-environment-id}.live.dynatrace.com"
-	        # should be read from a secure property source
 	        api-token: "YOUR_TOKEN"
 	        v1:
 	          device-id: "YOUR_DEVICE_ID"

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
@@ -176,9 +176,13 @@ You must ensure that the endpoint URI contains the path (for example, `/api/v2/m
 	  metrics:
 	    export:
 	      dynatrace:
-	        # uri: "https://{your-domain}/e/{your-environment-id}/api/v2/metrics/ingest" for managed deployments.
-	        uri: "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest"
-	        api-token: "YOUR_TOKEN" # should be read from a secure source and not hard-coded.
+	        # uri: "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest" # for SaaS
+	        # uri: "https://{your-domain}/e/{your-environment-id}/api/v2/metrics/ingest"    # for managed deployments
+	        # or use the Spring placeholder notation to read it from an environment variable:
+	        uri: ${DT_METRICS_INGEST_URL}
+
+	        # should be read from a secure source and not hard-coded.
+	        api-token: ${DT_METRICS_INGEST_API_TOKEN}
 ----
 
 When using the Dynatrace v2 API, the following optional features are available:
@@ -194,7 +198,11 @@ When using the Dynatrace v2 API, the following optional features are available:
 	  metrics:
 	    export:
 	      dynatrace:
-	        # specify token and uri or leave blank for OneAgent export
+	        # Specify API token and URI or leave blank for OneAgent export, e.g.:
+	        # uri: ${DT_METRICS_INGEST_URL}
+	        # api-token: ${DT_METRICS_INGEST_API_TOKEN}
+
+	        # Configure v2-specific properties:
 	        v2:
 	          metric-key-prefix: "your.key.prefix"
 	          enrich-with-dynatrace-metadata: true
@@ -219,7 +227,8 @@ To export metrics to {micrometer-registry-docs}/dynatrace[Dynatrace], your API t
 	      dynatrace:
 	        # uri: "https://{your-domain}/e/{your-environment-id}" on managed deployments.
 	        uri: "https://{your-environment-id}.live.dynatrace.com"
-	        api-token: "YOUR_TOKEN" # should be read from a secure property source
+	        # should be read from a secure property source
+	        api-token: "YOUR_TOKEN"
 	        v1:
 	          device-id: "YOUR_DEVICE_ID"
 ----

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
@@ -185,18 +185,6 @@ The URLs of the Metrics API v2 ingest endpoint are:
 	        api-token: "YOUR_TOKEN"
 ----
 
-Depending on your setup, the environment variables `+DT_METRICS_INGEST_URL+` and `+DT_METRICS_INGEST_API_TOKEN+` might be populated accordingly already and can be used via the Spring placeholder notation:
-
-[source,yaml,indent=0,subs="verbatim",configprops,configblocks]
-----
-	management:
-	  metrics:
-	    export:
-	      dynatrace:
-	        uri: ${DT_METRICS_INGEST_URL}
-	        api-token: ${DT_METRICS_INGEST_API_TOKEN}
-----
-
 When using the Dynatrace v2 API, the following optional features are available:
 
 * Metric key prefix: Sets a prefix that is prepended to all exported metric keys.

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
@@ -170,18 +170,30 @@ The {dynatrace-help}/dynatrace-api/basics/dynatrace-api-authentication/[API toke
 We recommend limiting the scope of the token to this one permission.
 You must ensure that the endpoint URI contains the path (for example, `/api/v2/metrics/ingest`):
 
+The URLs of the Metrics API v2 ingest endpoint are:
+
+- `+https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest+` for SaaS and
+- `+https://{your-domain}/e/{your-environment-id}/api/v2/metrics/ingest+` for Managed Deployments
+
 [source,yaml,indent=0,subs="verbatim",configprops,configblocks]
 ----
 	management:
 	  metrics:
 	    export:
 	      dynatrace:
-	        # uri: "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest" # for SaaS
-	        # uri: "https://{your-domain}/e/{your-environment-id}/api/v2/metrics/ingest"    # for managed deployments
-	        # or use the Spring placeholder notation to read it from an environment variable:
-	        uri: ${DT_METRICS_INGEST_URL}
+	        uri: "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest"
+	        api-token: "YOUR_TOKEN" # should be read from a secure source and not hard-coded.
+----
 
-	        # should be read from a secure source and not hard-coded.
+Depending on your setup, the environment variables `+DT_METRICS_INGEST_URL+` and `+DT_METRICS_INGEST_API_TOKEN+` might be populated accordingly already and can be used via the Spring placeholder notation:
+
+[source,yaml,indent=0,subs="verbatim",configprops,configblocks]
+----
+	management:
+	  metrics:
+	    export:
+	      dynatrace:
+	        uri: ${DT_METRICS_INGEST_URL}
 	        api-token: ${DT_METRICS_INGEST_API_TOKEN}
 ----
 
@@ -198,9 +210,9 @@ When using the Dynatrace v2 API, the following optional features are available:
 	  metrics:
 	    export:
 	      dynatrace:
-	        # Specify API token and URI or leave blank for OneAgent export, e.g.:
-	        # uri: ${DT_METRICS_INGEST_URL}
-	        # api-token: ${DT_METRICS_INGEST_API_TOKEN}
+	        # Specify API token and URI or leave blank for OneAgent export, e.g:
+	        # uri: "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest"
+	        # api-token: "YOUR_TOKEN" # should be read from a secure source and not hard-coded.
 
 	        # Configure v2-specific properties:
 	        v2:


### PR DESCRIPTION
This PR updates the documentation to include Spring Placeholder notation for the v2 exporter in order to make the setup process even easier.