### PR TITLE
Use `mainClassName` in `BootJarIntegrationTests-basicBuildUsingDeprecatedMainClassName.gradle`

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-basicBuildUsingDeprecatedMainClassName.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-basicBuildUsingDeprecatedMainClassName.gradle
@@ -4,5 +4,5 @@ plugins {
 }
 
 bootJar {
-	mainClass = 'com.example.Application'
+	mainClassName = 'com.example.Application'
 }


### PR DESCRIPTION
This PR changes to use `mainClassName` in `BootJarIntegrationTests-basicBuildUsingDeprecatedMainClassName.gradle` as it seems to be a copy and paste error.

See 5d9da7206efb421ab7baba773f13095e08a09cf1