### PR TITLE
Switch to Adoptium JDK builds in CI

### DIFF
--- a/ci/images/get-jdk-url.sh
+++ b/ci/images/get-jdk-url.sh
@@ -3,16 +3,16 @@ set -e
 
 case "$1" in
 	java8)
-		 echo "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u292b10.tar.gz"
+		 echo "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u302b08.tar.gz"
 	;;
 	java11)
-		 echo "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.11_9.tar.gz"
+		 echo "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.12_7.tar.gz"
 	;;
 	java16)
-		 echo "https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16.0.1%2B9/OpenJDK16U-jdk_x64_linux_hotspot_16.0.1_9.tar.gz"
+		 echo "https://github.com/adoptium/temurin16-binaries/releases/download/jdk-16.0.2%2B7/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz"
 	;;
 	java17)
-		 echo "https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_x64_linux_hotspot_2021-05-06-23-30.tar.gz"
+		 echo "https://github.com/adoptium/temurin17-binaries/releases/download/jdk17-2021-07-23-03-09-beta/OpenJDK17-jdk_x64_linux_hotspot_2021-07-23-03-09.tar.gz"
 	;;
   *)
 		echo $"Unknown java version"

--- a/ci/scripts/detect-jdk-updates.sh
+++ b/ci/scripts/detect-jdk-updates.sh
@@ -29,7 +29,7 @@ case "$JDK_VERSION" in
 		exit 1;
 esac
 
-response=$( curl -s ${BASE_URL}\?architecture\=x64\&heap_size\=normal\&image_type\=jdk\&jvm_impl\=hotspot\&os\=linux\&sort_order\=DESC\&vendor\=adoptopenjdk )
+response=$( curl -s ${BASE_URL}\?architecture\=x64\&heap_size\=normal\&image_type\=jdk\&jvm_impl\=hotspot\&os\=linux\&sort_order\=DESC\&vendor\=adoptium )
 latest=$( jq -r '.[0].binaries[0].package.link' <<< "$response" )
 if [[ ${latest} = "null" || ${latest} = "" ]]; then
 	echo "Could not parse JDK response: $response"

--- a/ci/scripts/detect-jdk-updates.sh
+++ b/ci/scripts/detect-jdk-updates.sh
@@ -9,19 +9,19 @@ trap 'report_error $? $LINENO' ERR
 
 case "$JDK_VERSION" in
 	java8)
-		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ga"
+		 BASE_URL="https://api.adoptium.net/v3/assets/feature_releases/8/ga"
 		 ISSUE_TITLE="Upgrade Java 8 version in CI image"
 	;;
 	java11)
-		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga"
+		 BASE_URL="https://api.adoptium.net/v3/assets/feature_releases/11/ga"
 		 ISSUE_TITLE="Upgrade Java 11 version in CI image"
 	;;
 	java16)
-		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/16/ga"
+		 BASE_URL="https://api.adoptium.net/v3/assets/feature_releases/16/ga"
 		 ISSUE_TITLE="Upgrade Java 16 version in CI image"
 	;;
 	java17)
-		 BASE_URL="https://api.adoptopenjdk.net/v3/assets/feature_releases/17/ea"
+		 BASE_URL="https://api.adoptium.net/v3/assets/feature_releases/17/ea"
 		 ISSUE_TITLE="Upgrade Java 17 version in CI image"
 	;;
 	*)


### PR DESCRIPTION
Hi,

this PR switches the AdoptOpenJDK builds over to the new Adoptium builds. The side-effect of this are updated versions as the previous equivalents are not available anymore.

For completeness reasons, I should also mention that the previous JDK 17 build didn't include JEP 403 yet, because apparently AdoptOpenJDK didn't update things for quite a while anymore. My local tests used always the latest OpenJDK builds (30 or 32) with JEP 403 included and were successful, so I'm hopeful CI will be as well. But you never know.

Cheers,
Christoph