### PR TITLE
Add ErrorWebFluxAutoConfiguration to Actuator ManagementContext

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -110,7 +110,8 @@ org.springframework.boot.actuate.autoconfigure.web.jersey.JerseySameManagementCo
 org.springframework.boot.actuate.autoconfigure.web.jersey.JerseyChildManagementContextConfiguration,\
 org.springframework.boot.actuate.autoconfigure.web.reactive.ReactiveManagementChildContextConfiguration,\
 org.springframework.boot.actuate.autoconfigure.web.servlet.ServletManagementChildContextConfiguration,\
-org.springframework.boot.actuate.autoconfigure.web.servlet.WebMvcEndpointChildContextConfiguration
+org.springframework.boot.actuate.autoconfigure.web.servlet.WebMvcEndpointChildContextConfiguration,\
+org.springframework.boot.autoconfigure.web.reactive.error.ErrorWebFluxAutoConfiguration
 
 org.springframework.boot.diagnostics.FailureAnalyzer=\
 org.springframework.boot.actuate.autoconfigure.metrics.ValidationFailureAnalyzer

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/web/reactive/ReactiveManagementChildContextConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/web/reactive/ReactiveManagementChildContextConfigurationIntegrationTests.java
@@ -76,6 +76,15 @@ class ReactiveManagementChildContextConfigurationIntegrationTests {
 				}));
 	}
 
+	@Test
+	void whenRequestUriIsErrorThenResponseBodyIsNotNull() {
+		this.runner.withPropertyValues("management.server.port:0").run(withWebTestClient((client) -> {
+			String body = client.get().uri("/404").accept(MediaType.APPLICATION_JSON)
+					.exchangeToMono((response) -> response.bodyToMono(String.class)).block();
+			assertThat(body).isNotNull();
+		}));
+	}
+
 	private ContextConsumer<AssertableReactiveWebApplicationContext> withWebTestClient(Consumer<WebClient> webClient) {
 		return (context) -> {
 			String port = context.getEnvironment().getProperty("local.management.port");


### PR DESCRIPTION
Fix #27504

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
The reason of this bug is managment ApplicationContext do not get order in `@Order(-1) DefaultErrorWebExceptionHandler` in parent ApplicationContext.
`@Order(0) ResponseStatusExceptionHandler` has higher level in ExceptionHandlers.
so let us config ErrorWebFluxAutoConfiguration in ManagementContextConfiguration, the DefaultErrorWebExceptionHandler will be the highest ExceptionHandler and the response body will not be null.
 