### PR TITLE
Add option to create tags for the built image

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/AbstractBuildLog.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/AbstractBuildLog.java
@@ -31,6 +31,7 @@ import org.springframework.boot.buildpack.platform.docker.type.VolumeName;
  * @author Phillip Webb
  * @author Scott Frederick
  * @author Andrey Shlykov
+ * @author Rafael Ceccone
  * @since 2.3.0
  */
 public abstract class AbstractBuildLog implements BuildLog {
@@ -86,6 +87,12 @@ public abstract class AbstractBuildLog implements BuildLog {
 	public void executedLifecycle(BuildRequest request) {
 		log();
 		log("Successfully built image '" + request.getName() + "'");
+		log();
+	}
+
+	@Override
+	public void createdTag(ImageReference tag) {
+		log("Successfully created image tag '" + tag + "'");
 		log();
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildLog.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildLog.java
@@ -31,6 +31,7 @@ import org.springframework.boot.buildpack.platform.docker.type.VolumeName;
  * @author Phillip Webb
  * @author Scott Frederick
  * @author Andrey Shlykov
+ * @author Rafael Ceccone
  * @since 2.3.0
  * @see #toSystemOut()
  */
@@ -98,6 +99,12 @@ public interface BuildLog {
 	 * @param request the build request
 	 */
 	void executedLifecycle(BuildRequest request);
+
+	/**
+	 * Log that a tag has been created.
+	 * @param tag the tag reference
+	 */
+	void createdTag(ImageReference tag);
 
 	/**
 	 * Factory method that returns a {@link BuildLog} the outputs to {@link System#out}.

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildRequest.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildRequest.java
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  * @author Phillip Webb
  * @author Scott Frederick
  * @author Andrey Shlykov
+ * @author Rafael Ceccone
  * @since 2.3.0
  */
 public class BuildRequest {
@@ -68,6 +69,8 @@ public class BuildRequest {
 
 	private final List<Binding> bindings;
 
+	private final List<ImageReference> tags;
+
 	BuildRequest(ImageReference name, Function<Owner, TarArchive> applicationContent) {
 		Assert.notNull(name, "Name must not be null");
 		Assert.notNull(applicationContent, "ApplicationContent must not be null");
@@ -83,12 +86,13 @@ public class BuildRequest {
 		this.creator = Creator.withVersion("");
 		this.buildpacks = Collections.emptyList();
 		this.bindings = Collections.emptyList();
+		this.tags = Collections.emptyList();
 	}
 
 	BuildRequest(ImageReference name, Function<Owner, TarArchive> applicationContent, ImageReference builder,
 			ImageReference runImage, Creator creator, Map<String, String> env, boolean cleanCache,
 			boolean verboseLogging, PullPolicy pullPolicy, boolean publish, List<BuildpackReference> buildpacks,
-			List<Binding> bindings) {
+			List<Binding> bindings, List<ImageReference> tags) {
 		this.name = name;
 		this.applicationContent = applicationContent;
 		this.builder = builder;
@@ -101,6 +105,7 @@ public class BuildRequest {
 		this.publish = publish;
 		this.buildpacks = buildpacks;
 		this.bindings = bindings;
+		this.tags = tags;
 	}
 
 	/**
@@ -112,7 +117,7 @@ public class BuildRequest {
 		Assert.notNull(builder, "Builder must not be null");
 		return new BuildRequest(this.name, this.applicationContent, builder.inTaggedOrDigestForm(), this.runImage,
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
-				this.buildpacks, this.bindings);
+				this.buildpacks, this.bindings, this.tags);
 	}
 
 	/**
@@ -123,7 +128,7 @@ public class BuildRequest {
 	public BuildRequest withRunImage(ImageReference runImageName) {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, runImageName.inTaggedOrDigestForm(),
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
-				this.buildpacks, this.bindings);
+				this.buildpacks, this.bindings, this.tags);
 	}
 
 	/**
@@ -134,7 +139,8 @@ public class BuildRequest {
 	public BuildRequest withCreator(Creator creator) {
 		Assert.notNull(creator, "Creator must not be null");
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.runImage, creator, this.env,
-				this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish, this.buildpacks, this.bindings);
+				this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish, this.buildpacks, this.bindings,
+				this.tags);
 	}
 
 	/**
@@ -150,7 +156,7 @@ public class BuildRequest {
 		env.put(name, value);
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.runImage, this.creator,
 				Collections.unmodifiableMap(env), this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
-				this.buildpacks, this.bindings);
+				this.buildpacks, this.bindings, this.tags);
 	}
 
 	/**
@@ -164,7 +170,7 @@ public class BuildRequest {
 		updatedEnv.putAll(env);
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.runImage, this.creator,
 				Collections.unmodifiableMap(updatedEnv), this.cleanCache, this.verboseLogging, this.pullPolicy,
-				this.publish, this.buildpacks, this.bindings);
+				this.publish, this.buildpacks, this.bindings, this.tags);
 	}
 
 	/**
@@ -174,7 +180,8 @@ public class BuildRequest {
 	 */
 	public BuildRequest withCleanCache(boolean cleanCache) {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.runImage, this.creator, this.env,
-				cleanCache, this.verboseLogging, this.pullPolicy, this.publish, this.buildpacks, this.bindings);
+				cleanCache, this.verboseLogging, this.pullPolicy, this.publish, this.buildpacks, this.bindings,
+				this.tags);
 	}
 
 	/**
@@ -184,7 +191,8 @@ public class BuildRequest {
 	 */
 	public BuildRequest withVerboseLogging(boolean verboseLogging) {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.runImage, this.creator, this.env,
-				this.cleanCache, verboseLogging, this.pullPolicy, this.publish, this.buildpacks, this.bindings);
+				this.cleanCache, verboseLogging, this.pullPolicy, this.publish, this.buildpacks, this.bindings,
+				this.tags);
 	}
 
 	/**
@@ -194,7 +202,8 @@ public class BuildRequest {
 	 */
 	public BuildRequest withPullPolicy(PullPolicy pullPolicy) {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.runImage, this.creator, this.env,
-				this.cleanCache, this.verboseLogging, pullPolicy, this.publish, this.buildpacks, this.bindings);
+				this.cleanCache, this.verboseLogging, pullPolicy, this.publish, this.buildpacks, this.bindings,
+				this.tags);
 	}
 
 	/**
@@ -204,7 +213,8 @@ public class BuildRequest {
 	 */
 	public BuildRequest withPublish(boolean publish) {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.runImage, this.creator, this.env,
-				this.cleanCache, this.verboseLogging, this.pullPolicy, publish, this.buildpacks, this.bindings);
+				this.cleanCache, this.verboseLogging, this.pullPolicy, publish, this.buildpacks, this.bindings,
+				this.tags);
 	}
 
 	/**
@@ -227,7 +237,8 @@ public class BuildRequest {
 	public BuildRequest withBuildpacks(List<BuildpackReference> buildpacks) {
 		Assert.notNull(buildpacks, "Buildpacks must not be null");
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.runImage, this.creator, this.env,
-				this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish, buildpacks, this.bindings);
+				this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish, buildpacks, this.bindings,
+				this.tags);
 	}
 
 	/**
@@ -250,7 +261,30 @@ public class BuildRequest {
 	public BuildRequest withBindings(List<Binding> bindings) {
 		Assert.notNull(bindings, "Bindings must not be null");
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.runImage, this.creator, this.env,
-				this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish, this.buildpacks, bindings);
+				this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish, this.buildpacks, bindings,
+				this.tags);
+	}
+
+	/**
+	 * Return a new {@link BuildRequest} with updated tags.
+	 * @param tags a collection of tags to be created for the built image
+	 * @return an updated build request
+	 */
+	public BuildRequest withTags(ImageReference... tags) {
+		Assert.notEmpty(tags, "Tags must not be empty");
+		return withTags(Arrays.asList(tags));
+	}
+
+	/**
+	 * Return a new {@link BuildRequest} with updated tags.
+	 * @param tags a collection of tags to be created for the built image
+	 * @return an updated build request
+	 */
+	public BuildRequest withTags(List<ImageReference> tags) {
+		Assert.notNull(tags, "Tags must not be null");
+		return new BuildRequest(this.name, this.applicationContent, this.builder, this.runImage, this.creator, this.env,
+				this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish, this.buildpacks, this.bindings,
+				tags);
 	}
 
 	/**
@@ -351,6 +385,14 @@ public class BuildRequest {
 	 */
 	public List<Binding> getBindings() {
 		return this.bindings;
+	}
+
+	/**
+	 * Return the collection of tags that should be created.
+	 * @return the tags
+	 */
+	public List<ImageReference> getTags() {
+		return this.tags;
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/DockerApi.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/DockerApi.java
@@ -52,6 +52,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Rafael Ceccone
  * @since 2.3.0
  */
 public class DockerApi {
@@ -298,6 +299,13 @@ public class DockerApi {
 			try (Response response = http().get(imageUri)) {
 				return Image.of(response.getContent());
 			}
+		}
+
+		public void tag(ImageReference sourceReference, ImageReference targetReference) throws IOException {
+			Assert.notNull(sourceReference, "SourceReference must not be null");
+			Assert.notNull(targetReference, "TargetReference must not be null");
+			URI uri = buildUrl("/images/" + sourceReference + "/tag", "repo", targetReference.toString());
+			http().post(uri);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildRequestTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildRequestTests.java
@@ -45,6 +45,7 @@ import static org.assertj.core.api.Assertions.entry;
  *
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Rafael Ceccone
  */
 public class BuildRequestTests {
 
@@ -197,6 +198,25 @@ public class BuildRequestTests {
 		BuildRequest request = BuildRequest.forJarFile(writeTestJarFile("my-app-0.0.1.jar"));
 		assertThatIllegalArgumentException().isThrownBy(() -> request.withBindings((List<Binding>) null))
 				.withMessage("Bindings must not be null");
+	}
+
+	@Test
+	void withTagsAddsTags() throws IOException {
+		BuildRequest request = BuildRequest.forJarFile(writeTestJarFile("my-app-0.0.1.jar"));
+		BuildRequest witTags = request.withTags(ImageReference.of("docker.io/library/my-app:latest"),
+				ImageReference.of("example.com/custom/my-app:0.0.1"),
+				ImageReference.of("example.com/custom/my-app:latest"));
+		assertThat(request.getTags()).isEmpty();
+		assertThat(witTags.getTags()).containsExactly(ImageReference.of("docker.io/library/my-app:latest"),
+				ImageReference.of("example.com/custom/my-app:0.0.1"),
+				ImageReference.of("example.com/custom/my-app:latest"));
+	}
+
+	@Test
+	void withTagsWhenTagsIsNullThrowsException() throws IOException {
+		BuildRequest request = BuildRequest.forJarFile(writeTestJarFile("my-app-0.0.1.jar"));
+		assertThatIllegalArgumentException().isThrownBy(() -> request.withTags((List<ImageReference>) null))
+				.withMessage("Tags must not be null");
 	}
 
 	private void hasExpectedJarContent(TarArchive archive) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/PrintStreamBuildLogTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/PrintStreamBuildLogTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link PrintStreamBuildLog}.
  *
  * @author Phillip Webb
+ * @author Rafael Ceccone
  */
 class PrintStreamBuildLogTests {
 
@@ -56,6 +57,8 @@ class PrintStreamBuildLogTests {
 		Image runImage = mock(Image.class);
 		given(runImage.getDigests()).willReturn(Collections.singletonList("00000002"));
 		given(request.getName()).willReturn(name);
+		ImageReference tag = ImageReference.of("my-app:1.0");
+		given(request.getTags()).willReturn(Collections.singletonList(tag));
 		log.start(request);
 		Consumer<TotalProgressEvent> pullBuildImageConsumer = log.pullingImage(builderImageReference,
 				ImageType.BUILDER);
@@ -73,6 +76,7 @@ class PrintStreamBuildLogTests {
 		phase2Consumer.accept(mockLogEvent("spring"));
 		phase2Consumer.accept(mockLogEvent("boot"));
 		log.executedLifecycle(request);
+		log.createdTag(tag);
 		String expected = FileCopyUtils.copyToString(new InputStreamReader(
 				getClass().getResourceAsStream("print-stream-build-log.txt"), StandardCharsets.UTF_8));
 		assertThat(out.toString()).isEqualToIgnoringNewLines(expected);

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/DockerApiTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/DockerApiTests.java
@@ -71,6 +71,7 @@ import static org.mockito.Mockito.verify;
  *
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Rafael Ceccone
  */
 @ExtendWith(MockitoExtension.class)
 class DockerApiTests {
@@ -346,6 +347,30 @@ class DockerApiTests {
 					"93cd584bb189bfca4f51744bd19d836fd36da70710395af5a1523ee88f208c6a/layer.tar");
 			assertThat(contents.get("1bf6c63a1e9ed1dd7cb961273bf60b8e0f440361faf273baf866f408e4910601/layer.tar"))
 					.containsExactly("etc/", "etc/apt/", "etc/apt/sources.list");
+		}
+
+		@Test
+		void tagWhenReferenceIsNullThrowsException() {
+			ImageReference tag = ImageReference.of("localhost:5000/ubuntu");
+			assertThatIllegalArgumentException().isThrownBy(() -> this.api.tag(null, tag))
+					.withMessage("SourceReference must not be null");
+		}
+
+		@Test
+		void tagWhenTargetIsNullThrowsException() {
+			ImageReference reference = ImageReference.of("localhost:5000/ubuntu");
+			assertThatIllegalArgumentException().isThrownBy(() -> this.api.tag(reference, null))
+					.withMessage("TargetReference must not be null");
+		}
+
+		@Test
+		void tagTagsImage() throws Exception {
+			ImageReference sourceReference = ImageReference.of("localhost:5000/ubuntu");
+			ImageReference targetReference = ImageReference.of("localhost:5000/ubuntu:tagged");
+			URI tagURI = new URI(IMAGES_URL + "/localhost:5000/ubuntu/tag?repo=localhost%3A5000%2Fubuntu%3Atagged");
+			given(http().post(tagURI)).willReturn(emptyResponse());
+			this.api.tag(sourceReference, targetReference);
+			verify(http()).post(tagURI);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/resources/org/springframework/boot/buildpack/platform/build/print-stream-build-log.txt
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/resources/org/springframework/boot/buildpack/platform/build/print-stream-build-log.txt
@@ -17,3 +17,5 @@ Building image 'docker.io/library/my-app:latest'
     [basket]      boot
 
 Successfully built image 'docker.io/library/my-app:latest'
+
+Successfully created image tag 'docker.io/library/my-app:1.0'

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging-oci-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging-oci-image.adoc
@@ -169,6 +169,11 @@ Where `<options>` can contain:
 | `--publishImage`
 | Whether to publish the generated image to a Docker registry.
 | `false`
+
+| `tags`
+|
+| Multiple {spring-boot-api}/buildpack/platform/docker/type/ImageReference.html#of-java.lang.String-[tag names] to be created for the generated image.
+|
 |===
 
 NOTE: The plugin detects the target Java compatibility of the project using the JavaPlugin's `targetCompatibility` property.

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImage.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImage.java
@@ -58,6 +58,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Andy Wilkinson
  * @author Scott Frederick
+ * @author Rafael Ceccone
  * @since 2.3.0
  */
 public class BootBuildImage extends DefaultTask {
@@ -92,6 +93,8 @@ public class BootBuildImage extends DefaultTask {
 
 	private final ListProperty<String> bindings;
 
+	private final ListProperty<String> tags;
+
 	private final DockerSpec docker = new DockerSpec();
 
 	public BootBuildImage() {
@@ -103,6 +106,7 @@ public class BootBuildImage extends DefaultTask {
 		this.projectVersion.set(getProject().provider(() -> project.getVersion().toString()));
 		this.buildpacks = getProject().getObjects().listProperty(String.class);
 		this.bindings = getProject().getObjects().listProperty(String.class);
+		this.tags = getProject().getObjects().listProperty(String.class);
 	}
 
 	/**
@@ -377,6 +381,40 @@ public class BootBuildImage extends DefaultTask {
 	}
 
 	/**
+	 * Returns the tags that will be created for the built image.
+	 * @return the tags
+	 */
+	@Input
+	@Optional
+	public List<String> getTags() {
+		return this.tags.getOrNull();
+	}
+
+	/**
+	 * Sets the tags that will be created for the built image.
+	 * @param tags the tags
+	 */
+	public void setTags(List<String> tags) {
+		this.tags.set(tags);
+	}
+
+	/**
+	 * Add an entry to the tags that will be created for the built image.
+	 * @param tag the tag
+	 */
+	public void tag(String tag) {
+		this.tags.add(tag);
+	}
+
+	/**
+	 * Add entries to the tags that will be created for the built image.
+	 * @param tags the tags
+	 */
+	public void tags(List<String> tags) {
+		this.tags.addAll(tags);
+	}
+
+	/**
 	 * Returns the Docker configuration the builder will use.
 	 * @return docker configuration.
 	 * @since 2.4.0
@@ -438,6 +476,7 @@ public class BootBuildImage extends DefaultTask {
 		request = customizePublish(request);
 		request = customizeBuildpacks(request);
 		request = customizeBindings(request);
+		request = customizeTags(request);
 		return request;
 	}
 
@@ -502,6 +541,14 @@ public class BootBuildImage extends DefaultTask {
 		List<String> bindings = this.bindings.getOrNull();
 		if (bindings != null && !bindings.isEmpty()) {
 			return request.withBindings(bindings.stream().map(Binding::of).collect(Collectors.toList()));
+		}
+		return request;
+	}
+
+	private BuildRequest customizeTags(BuildRequest request) {
+		List<String> tags = this.tags.getOrNull();
+		if (tags != null && !tags.isEmpty()) {
+			return request.withTags(tags.stream().map(ImageReference::of).collect(Collectors.toList()));
 		}
 		return request;
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageIntegrationTests.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import org.springframework.boot.buildpack.platform.docker.DockerApi;
-import org.springframework.boot.buildpack.platform.docker.type.ImageName;
 import org.springframework.boot.buildpack.platform.docker.type.ImageReference;
 import org.springframework.boot.buildpack.platform.io.FilePermissions;
 import org.springframework.boot.gradle.junit.GradleCompatibility;
@@ -54,6 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Andy Wilkinson
  * @author Scott Frederick
+ * @author Rafael Ceccone
  */
 @GradleCompatibility(configurationCache = true)
 @DisabledIfDockerUnavailable
@@ -235,6 +235,21 @@ class BootBuildImageIntegrationTests {
 	}
 
 	@TestTemplate
+	void buildsImageWithTag() throws IOException {
+		writeMainClass();
+		writeLongNameResource();
+		BuildResult result = this.gradleBuild.build("bootBuildImage", "--pullPolicy=IF_NOT_PRESENT");
+		String projectName = this.gradleBuild.getProjectDir().getName();
+		assertThat(result.task(":bootBuildImage").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+		assertThat(result.getOutput()).contains("docker.io/library/" + projectName);
+		assertThat(result.getOutput()).contains("---> Test Info buildpack building");
+		assertThat(result.getOutput()).contains("---> Test Info buildpack done");
+		assertThat(result.getOutput()).contains("example.com/myapp:latest");
+		removeImage(projectName);
+		removeImage("example.com/myapp:latest");
+	}
+
+	@TestTemplate
 	void buildsImageWithLaunchScript() throws IOException {
 		writeMainClass();
 		writeLongNameResource();
@@ -283,6 +298,16 @@ class BootBuildImageIntegrationTests {
 		BuildResult result = this.gradleBuild.buildAndFail("bootBuildImage", "--pullPolicy=IF_NOT_PRESENT");
 		assertThat(result.task(":bootBuildImage").getOutcome()).isEqualTo(TaskOutcome.FAILED);
 		assertThat(result.getOutput()).contains("'urn:cnb:builder:example/does-not-exist:0.0.1' not found in builder");
+	}
+
+	@TestTemplate
+	void failsWithInvalidTagName() throws IOException {
+		writeMainClass();
+		writeLongNameResource();
+		BuildResult result = this.gradleBuild.buildAndFail("bootBuildImage", "--pullPolicy=IF_NOT_PRESENT");
+		assertThat(result.task(":bootBuildImage").getOutcome()).isEqualTo(TaskOutcome.FAILED);
+		assertThat(result.getOutput()).containsPattern("Unable to parse image reference")
+				.containsPattern("example/Invalid-Tag-Name");
 	}
 
 	private void writeMainClass() throws IOException {
@@ -408,7 +433,7 @@ class BootBuildImageIntegrationTests {
 	}
 
 	private void removeImage(String name) throws IOException {
-		ImageReference imageReference = ImageReference.of(ImageName.of(name));
+		ImageReference imageReference = ImageReference.of(name);
 		new DockerApi().image().remove(imageReference, false);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageTests.java
@@ -31,6 +31,7 @@ import org.springframework.boot.buildpack.platform.build.BuildRequest;
 import org.springframework.boot.buildpack.platform.build.BuildpackReference;
 import org.springframework.boot.buildpack.platform.build.PullPolicy;
 import org.springframework.boot.buildpack.platform.docker.type.Binding;
+import org.springframework.boot.buildpack.platform.docker.type.ImageReference;
 import org.springframework.boot.gradle.junit.GradleProjectBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Andy Wilkinson
  * @author Scott Frederick
  * @author Andrey Shlykov
+ * @author Rafael Ceccone
  */
 class BootBuildImageTests {
 
@@ -276,6 +278,36 @@ class BootBuildImageTests {
 		this.buildImage.binding("volume-name:container-dest:rw");
 		assertThat(this.buildImage.createRequest().getBindings())
 				.containsExactly(Binding.of("host-src:container-dest:ro"), Binding.of("volume-name:container-dest:rw"));
+	}
+
+	@Test
+	void whenNoTagsAreConfiguredThenRequestHasNoTags() {
+		assertThat(this.buildImage.createRequest().getTags()).isEmpty();
+	}
+
+	@Test
+	void whenTagsAreConfiguredThenRequestHasTags() {
+		this.buildImage.setTags(
+				Arrays.asList("my-app:latest", "example.com/my-app:0.0.1-SNAPSHOT", "example.com/my-app:latest"));
+		assertThat(this.buildImage.createRequest().getTags()).containsExactly(ImageReference.of("my-app:latest"),
+				ImageReference.of("example.com/my-app:0.0.1-SNAPSHOT"), ImageReference.of("example.com/my-app:latest"));
+	}
+
+	@Test
+	void whenEntriesAreAddedToTagsThenRequestHasTags() {
+		this.buildImage
+				.tags(Arrays.asList("my-app:latest", "example.com/my-app:0.0.1-SNAPSHOT", "example.com/my-app:latest"));
+		assertThat(this.buildImage.createRequest().getTags()).containsExactly(ImageReference.of("my-app:latest"),
+				ImageReference.of("example.com/my-app:0.0.1-SNAPSHOT"), ImageReference.of("example.com/my-app:latest"));
+	}
+
+	@Test
+	void whenIndividualEntriesAreAddedToTagsThenRequestHasTags() {
+		this.buildImage.tag("my-app:latest");
+		this.buildImage.tag("example.com/my-app:0.0.1-SNAPSHOT");
+		this.buildImage.tag("example.com/my-app:latest");
+		assertThat(this.buildImage.createRequest().getTags()).containsExactly(ImageReference.of("my-app:latest"),
+				ImageReference.of("example.com/my-app:0.0.1-SNAPSHOT"), ImageReference.of("example.com/my-app:latest"));
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootBuildImageIntegrationTests-buildsImageWithTag.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootBuildImageIntegrationTests-buildsImageWithTag.gradle
@@ -1,0 +1,12 @@
+plugins {
+	id 'java'
+	id 'org.springframework.boot' version '{version}'
+}
+
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
+
+bootBuildImage {
+	builder = "projects.registry.vmware.com/springboot/spring-boot-cnb-builder:0.0.1"
+	tags = [ "example.com/myapp:latest" ]
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootBuildImageIntegrationTests-failsWithInvalidTagName.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootBuildImageIntegrationTests-failsWithInvalidTagName.gradle
@@ -1,0 +1,12 @@
+plugins {
+	id 'java'
+	id 'org.springframework.boot' version '{version}'
+}
+
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
+
+bootBuildImage {
+	builder = "projects.registry.vmware.com/springboot/spring-boot-cnb-builder:0.0.1"
+	tags = [ "example/Invalid-Tag-Name" ]
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging-oci-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging-oci-image.adoc
@@ -176,6 +176,10 @@ Where `<options>` can contain:
 (`spring-boot.build-image.publish`)
 | Whether to publish the generated image to a Docker registry.
 | `false`
+
+| `tags`
+| Multiple {spring-boot-api}/buildpack/platform/docker/type/ImageReference.html#of-java.lang.String-[tag names] to be created for the generated image.
+|
 |===
 
 NOTE: The plugin detects the target Java compatibility of the project using the compiler's plugin configuration or the `maven.compiler.target` property.

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/BuildImageTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/BuildImageTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Stephane Nicoll
  * @author Scott Frederick
+ * @author Rafael Ceccone
  */
 @ExtendWith(MavenBuildExtension.class)
 @DisabledIfDockerUnavailable
@@ -278,6 +279,19 @@ public class BuildImageTests extends AbstractArchiveIntegrationTests {
 							.contains("docker.io/library/build-image-multi-module-app:0.0.1.BUILD-SNAPSHOT")
 							.contains("Successfully built image");
 					removeImage("build-image-multi-module-app", "0.0.1.BUILD-SNAPSHOT");
+				});
+	}
+
+	@TestTemplate
+	void whenBuildImageIsInvokedWithTags(MavenBuild mavenBuild) {
+		mavenBuild.project("build-image-tags").goals("package")
+				.systemProperty("spring-boot.build-image.pullPolicy", "IF_NOT_PRESENT").execute((project) -> {
+					assertThat(buildLog(project)).contains("Building image")
+							.contains("docker.io/library/build-image-tags:0.0.1.BUILD-SNAPSHOT")
+							.contains("Successfully built image").contains("docker.io/library/build-image-tags:latest")
+							.contains("Successfully created image tag");
+					removeImage("build-image-tags", "0.0.1.BUILD-SNAPSHOT");
+					removeImage("build-image-tags", "latest");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-image-tags/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-image-tags/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.boot.maven.it</groupId>
+	<artifactId>build-image-tags</artifactId>
+	<version>0.0.1.BUILD-SNAPSHOT</version>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>@java.version@</maven.compiler.source>
+		<maven.compiler.target>@java.version@</maven.compiler.target>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>build-image</goal>
+						</goals>
+						<configuration>
+							<image>
+								<builder>projects.registry.vmware.com/springboot/spring-boot-cnb-builder:0.0.1</builder>
+								<tags>
+									<tag>${project.artifactId}:latest</tag>
+								</tags>
+							</image>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-image-tags/src/main/java/org/test/SampleApplication.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-image-tags/src/main/java/org/test/SampleApplication.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.test;
+
+public class SampleApplication {
+
+	public static void main(String[] args) throws Exception {
+		System.out.println("Launched");
+		synchronized(args) {
+			args.wait(); // Prevent exit
+		}
+	}
+
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/Image.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/Image.java
@@ -39,6 +39,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Rafael Ceccone
  * @since 2.3.0
  */
 public class Image {
@@ -62,6 +63,8 @@ public class Image {
 	List<String> buildpacks;
 
 	List<String> bindings;
+
+	List<String> tags;
 
 	/**
 	 * The name of the created image.
@@ -189,6 +192,9 @@ public class Image {
 		}
 		if (!CollectionUtils.isEmpty(this.bindings)) {
 			request = request.withBindings(this.bindings.stream().map(Binding::of).collect(Collectors.toList()));
+		}
+		if (!CollectionUtils.isEmpty(this.tags)) {
+			request = request.withTags(this.tags.stream().map(ImageReference::of).collect(Collectors.toList()));
 		}
 		return request;
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ImageTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ImageTests.java
@@ -30,6 +30,7 @@ import org.springframework.boot.buildpack.platform.build.BuildRequest;
 import org.springframework.boot.buildpack.platform.build.BuildpackReference;
 import org.springframework.boot.buildpack.platform.build.PullPolicy;
 import org.springframework.boot.buildpack.platform.docker.type.Binding;
+import org.springframework.boot.buildpack.platform.docker.type.ImageReference;
 import org.springframework.boot.buildpack.platform.io.Owner;
 import org.springframework.boot.buildpack.platform.io.TarArchive;
 
@@ -41,6 +42,7 @@ import static org.assertj.core.api.Assertions.entry;
  *
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Rafael Ceccone
  */
 class ImageTests {
 
@@ -144,6 +146,15 @@ class ImageTests {
 		BuildRequest request = image.getBuildRequest(createArtifact(), mockApplicationContent());
 		assertThat(request.getBindings()).containsExactly(Binding.of("host-src:container-dest:ro"),
 				Binding.of("volume-name:container-dest:rw"));
+	}
+
+	@Test
+	void getBuildRequestWhenHasTagsUsesTags() {
+		Image image = new Image();
+		image.tags = Arrays.asList("my-app:latest", "example.com/my-app:0.0.1-SNAPSHOT", "example.com/my-app:latest");
+		BuildRequest request = image.getBuildRequest(createArtifact(), mockApplicationContent());
+		assertThat(request.getTags()).containsExactly(ImageReference.of("my-app:latest"),
+				ImageReference.of("example.com/my-app:0.0.1-SNAPSHOT"), ImageReference.of("example.com/my-app:latest"));
 	}
 
 	private Artifact createArtifact() {


### PR DESCRIPTION
This commit adds configuration to the Maven and Gradle plugins to allow specifying multiple tag names to be created for the built image.

Resolves #20560
