### PR TITLE
feat: spring.config.exclude-file-extensions

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigFileApplicationListener.java
@@ -296,6 +296,8 @@ public class ConfigFileApplicationListener implements EnvironmentPostProcessor, 
 
 		private final List<PropertySourceLoader> propertySourceLoaders;
 
+		 private final Set<String> excludeFileExtentions;
+
 		private Deque<Profile> profiles;
 
 		private List<Profile> processedProfiles;
@@ -312,6 +314,13 @@ public class ConfigFileApplicationListener implements EnvironmentPostProcessor, 
 			this.resourceLoader = (resourceLoader != null) ? resourceLoader : new DefaultResourceLoader(null);
 			this.propertySourceLoaders = SpringFactoriesLoader.loadFactories(PropertySourceLoader.class,
 					getClass().getClassLoader());
+			String excludes = environment.getProperty("spring.config.exclude-file-extensions");
+			excludeFileExtentions = new HashSet<>();
+			if (excludes != null) {
+				for (String ext : excludes.split("[,; ]+")) {
+					excludeFileExtentions.add(ext);
+				}
+			}
 		}
 
 		void load() {
@@ -459,6 +468,9 @@ public class ConfigFileApplicationListener implements EnvironmentPostProcessor, 
 						+ "a directory, it must end in '/'");
 			}
 			Set<String> processed = new HashSet<>();
+			if (!excludeFileExtentions.isEmpty()) {
+				processed.addAll(excludeFileExtentions);
+			}
 			for (PropertySourceLoader loader : this.propertySourceLoaders) {
 				for (String fileExtension : loader.getFileExtensions()) {
 					if (processed.add(fileExtension)) {


### PR DESCRIPTION
if custom project do not have some file extensions for the config, we use the property to exclude these execution(such as the file exists)
ie:
-Dspring.config.exclude-file-extensions=xml,json,yaml
means we do not have xml/json/yaml extensions for the spring boot config

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
