### PR TITLE
Provide a configuration property for setting the path used by auto-configured disk space metrics

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsProperties.java
@@ -354,16 +354,16 @@ public class MetricsProperties {
 
 	public static class System {
 
-		private final DiskSpace diskspace = new DiskSpace();
+		private final Diskspace diskspace = new Diskspace();
 
-		public DiskSpace getDiskspace() {
+		public Diskspace getDiskspace() {
 			return this.diskspace;
 		}
 
-		public static class DiskSpace {
+		public static class Diskspace {
 
 			/**
-			 * Paths to report disk metrics for.
+			 * Comma-separated list of paths to report disk metrics for.
 			 */
 			private List<File> paths = Arrays.asList(new File("."));
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsProperties.java
@@ -16,8 +16,11 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics;
 
+import java.io.File;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -30,6 +33,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  * @author Jon Schneider
  * @author Alexander Abramov
  * @author Tadaya Tsuyukubo
+ * @author Chris Bono
  * @since 2.0.0
  */
 @ConfigurationProperties("management.metrics")
@@ -56,6 +60,8 @@ public class MetricsProperties {
 	private final Web web = new Web();
 
 	private final Data data = new Data();
+
+	private final System system = new System();
 
 	private final Distribution distribution = new Distribution();
 
@@ -85,6 +91,10 @@ public class MetricsProperties {
 
 	public Distribution getDistribution() {
 		return this.distribution;
+	}
+
+	public System getSystem() {
+		return this.system;
 	}
 
 	public static class Web {
@@ -338,6 +348,33 @@ public class MetricsProperties {
 
 		public Map<String, Integer> getBufferLength() {
 			return this.bufferLength;
+		}
+
+	}
+
+	public static class System {
+
+		private final DiskSpace diskspace = new DiskSpace();
+
+		public DiskSpace getDiskspace() {
+			return this.diskspace;
+		}
+
+		public static class DiskSpace {
+
+			/**
+			 * Paths to report disk metrics for.
+			 */
+			private List<File> paths = Arrays.asList(new File("."));
+
+			public List<File> getPaths() {
+				return this.paths;
+			}
+
+			public void setPaths(List<File> paths) {
+				this.paths = paths;
+			}
+
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/SystemMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/SystemMetricsAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,13 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics;
 
-import java.io.File;
-
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.jvm.DiskSpaceMetrics;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 
+import org.springframework.boot.actuate.metrics.system.DiskSpaceMetricsBinder;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -36,6 +35,7 @@ import org.springframework.context.annotation.Configuration;
  * {@link EnableAutoConfiguration Auto-configuration} for system metrics.
  *
  * @author Stephane Nicoll
+ * @author Chris Bono
  * @since 2.1.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -43,6 +43,12 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass(MeterRegistry.class)
 @ConditionalOnBean(MeterRegistry.class)
 public class SystemMetricsAutoConfiguration {
+
+	private final MetricsProperties properties;
+
+	public SystemMetricsAutoConfiguration(MetricsProperties properties) {
+		this.properties = properties;
+	}
 
 	@Bean
 	@ConditionalOnMissingBean
@@ -64,8 +70,8 @@ public class SystemMetricsAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public DiskSpaceMetrics diskSpaceMetrics() {
-		return new DiskSpaceMetrics(new File("."));
+	public DiskSpaceMetricsBinder diskSpaceMetrics() {
+		return new DiskSpaceMetricsBinder(this.properties.getSystem().getDiskspace().getPaths(), Tags.empty());
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/system/DiskSpaceMetricsBinder.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/system/DiskSpaceMetricsBinder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.metrics.system;
+
+import java.io.File;
+import java.util.List;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.jvm.DiskSpaceMetrics;
+
+import org.springframework.util.Assert;
+
+/**
+ * A {@link MeterBinder} that binds one or more {@link DiskSpaceMetrics}.
+ *
+ * @author Chris Bono
+ * @since 2.6.0
+ */
+public class DiskSpaceMetricsBinder implements MeterBinder {
+
+	private final List<File> paths;
+
+	private final Iterable<Tag> tags;
+
+	public DiskSpaceMetricsBinder(List<File> paths, Iterable<Tag> tags) {
+		Assert.notEmpty(paths, "Paths must not be empty");
+		this.paths = paths;
+		this.tags = tags;
+	}
+
+	@Override
+	public void bindTo(MeterRegistry registry) {
+		this.paths.forEach((path) -> new DiskSpaceMetrics(path, this.tags).bindTo(registry));
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/system/package-info.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/system/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Actuator support for system metrics.
+ */
+package org.springframework.boot.actuate.metrics.system;

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/system/DiskSpaceMetricsBinderTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/system/DiskSpaceMetricsBinderTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.metrics.system;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DiskSpaceMetricsBinder}.
+ *
+ * @author Chris Bono
+ */
+class DiskSpaceMetricsBinderTests {
+
+	@Test
+	void diskSpaceMetricsWithSinglePath() {
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		File path = new File(".");
+		DiskSpaceMetricsBinder metricsBinder = new DiskSpaceMetricsBinder(Collections.singletonList(path),
+				Tags.empty());
+		metricsBinder.bindTo(meterRegistry);
+
+		Tags tags = Tags.of("path", path.getAbsolutePath());
+		assertThat(meterRegistry.get("disk.free").tags(tags).gauge()).isNotNull();
+		assertThat(meterRegistry.get("disk.total").tags(tags).gauge()).isNotNull();
+	}
+
+	@Test
+	void diskSpaceMetricsWithMultiplePaths() {
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		File path1 = new File(".");
+		File path2 = new File("..");
+		DiskSpaceMetricsBinder metricsBinder = new DiskSpaceMetricsBinder(Arrays.asList(path1, path2), Tags.empty());
+		metricsBinder.bindTo(meterRegistry);
+
+		Tags tags = Tags.of("path", path1.getAbsolutePath());
+		assertThat(meterRegistry.get("disk.free").tags(tags).gauge()).isNotNull();
+		assertThat(meterRegistry.get("disk.total").tags(tags).gauge()).isNotNull();
+		tags = Tags.of("path", path2.getAbsolutePath());
+		assertThat(meterRegistry.get("disk.free").tags(tags).gauge()).isNotNull();
+		assertThat(meterRegistry.get("disk.total").tags(tags).gauge()).isNotNull();
+	}
+
+	@Test
+	void diskSpaceMetricsWithCustomTags() {
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		File path = new File(".");
+		Tags customTags = Tags.of("foo", "bar");
+		DiskSpaceMetricsBinder metricsBinder = new DiskSpaceMetricsBinder(Collections.singletonList(path), customTags);
+		metricsBinder.bindTo(meterRegistry);
+
+		Tags tags = Tags.of("path", path.getAbsolutePath(), "foo", "bar");
+		assertThat(meterRegistry.get("disk.free").tags(tags).gauge()).isNotNull();
+		assertThat(meterRegistry.get("disk.total").tags(tags).gauge()).isNotNull();
+	}
+
+}


### PR DESCRIPTION
@wilkinsona I was playing around w/ the options listed in the ticket and had this simple approach coded up so went ahead and submitted this proposal. I know I did not wait for feedback on the ticket and am more than happy to close this out if If you end up leaning another direction.

This goes w/ the simple approach of not sharing properties w/ the `DiskSpaceHealthIndicator` and only configures a single path for now (in the `MetricsProperties`). 

Fixed gh-27306