### PR TITLE
Add support for multiple paths in DiskSpaceHealthIndicator

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/system/DiskSpaceHealthContributorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/system/DiskSpaceHealthContributorAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,14 @@
 
 package org.springframework.boot.actuate.autoconfigure.system;
 
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.system.DiskSpaceHealthIndicatorProperties.PathInfo;
 import org.springframework.boot.actuate.system.DiskSpaceHealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -25,6 +31,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.unit.DataSize;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for
@@ -32,6 +39,7 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Mattias Severson
  * @author Andy Wilkinson
+ * @author Chris Bono
  * @since 2.0.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -43,7 +51,9 @@ public class DiskSpaceHealthContributorAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(name = "diskSpaceHealthIndicator")
 	public DiskSpaceHealthIndicator diskSpaceHealthIndicator(DiskSpaceHealthIndicatorProperties properties) {
-		return new DiskSpaceHealthIndicator(properties.getPath(), properties.getThreshold());
+		Map<File, DataSize> paths = properties.getPaths().stream()
+				.collect(Collectors.toMap(PathInfo::getPath, PathInfo::getThreshold, (u, v) -> u, LinkedHashMap::new));
+		return new DiskSpaceHealthIndicator(paths);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/system/DiskSpaceHealthIndicatorProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/system/DiskSpaceHealthIndicatorProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.boot.actuate.autoconfigure.system;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 
 import org.springframework.boot.actuate.system.DiskSpaceHealthIndicator;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -28,36 +30,54 @@ import org.springframework.util.unit.DataSize;
  *
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author Chris Bono
  * @since 1.2.0
  */
 @ConfigurationProperties(prefix = "management.health.diskspace")
 public class DiskSpaceHealthIndicatorProperties {
 
 	/**
-	 * Path used to compute the available disk space.
+	 * Paths to consider for computing the available disk space.
 	 */
-	private File path = new File(".");
+	private List<PathInfo> paths = Arrays.asList(new PathInfo());
 
-	/**
-	 * Minimum disk space that should be available.
-	 */
-	private DataSize threshold = DataSize.ofMegabytes(10);
-
-	public File getPath() {
-		return this.path;
+	public List<PathInfo> getPaths() {
+		return this.paths;
 	}
 
-	public void setPath(File path) {
-		this.path = path;
+	public void setPaths(List<PathInfo> paths) {
+		this.paths = paths;
 	}
 
-	public DataSize getThreshold() {
-		return this.threshold;
-	}
+	public static class PathInfo {
 
-	public void setThreshold(DataSize threshold) {
-		Assert.isTrue(!threshold.isNegative(), "threshold must be greater than or equal to 0");
-		this.threshold = threshold;
+		/**
+		 * Path used to compute the available disk space.
+		 */
+		private File path = new File(".");
+
+		/**
+		 * Minimum disk space that should be available.
+		 */
+		private DataSize threshold = DataSize.ofMegabytes(10);
+
+		public File getPath() {
+			return this.path;
+		}
+
+		public void setPath(File path) {
+			this.path = path;
+		}
+
+		public DataSize getThreshold() {
+			return this.threshold;
+		}
+
+		public void setThreshold(DataSize threshold) {
+			Assert.isTrue(!threshold.isNegative(), "threshold must be greater than or equal to 0");
+			this.threshold = threshold;
+		}
+
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/system/DiskSpaceHealthContributorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/system/DiskSpaceHealthContributorAutoConfigurationTests.java
@@ -103,9 +103,9 @@ class DiskSpaceHealthContributorAutoConfigurationTests {
 	@SuppressWarnings("varargs")
 	private final ContextConsumer<AssertableApplicationContext> validateIndicatorHasPathsExactly(
 			Map.Entry<File, DataSize>... entries) {
-		return (context -> assertThat(context).hasSingleBean(DiskSpaceHealthIndicator.class)
+		return (context) -> assertThat(context).hasSingleBean(DiskSpaceHealthIndicator.class)
 				.getBean(DiskSpaceHealthIndicator.class).extracting("paths")
-				.asInstanceOf(InstanceOfAssertFactories.map(File.class, DataSize.class)).containsExactly(entries));
+				.asInstanceOf(InstanceOfAssertFactories.map(File.class, DataSize.class)).containsExactly(entries);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/system/DiskSpaceHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/system/DiskSpaceHealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.boot.actuate.system;
 
 import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -29,46 +31,66 @@ import org.springframework.core.log.LogMessage;
 import org.springframework.util.unit.DataSize;
 
 /**
- * A {@link HealthIndicator} that checks available disk space and reports a status of
- * {@link Status#DOWN} when it drops below a configurable threshold.
+ * A {@link HealthIndicator} that checks one or more paths for available disk space and
+ * reports a status of {@link Status#DOWN} when any of the paths drops below a
+ * configurable threshold.
  *
  * @author Mattias Severson
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author Chris Bono
  * @since 2.0.0
  */
 public class DiskSpaceHealthIndicator extends AbstractHealthIndicator {
 
 	private static final Log logger = LogFactory.getLog(DiskSpaceHealthIndicator.class);
 
-	private final File path;
-
-	private final DataSize threshold;
+	private final Map<File, DataSize> paths = new LinkedHashMap<>();
 
 	/**
-	 * Create a new {@code DiskSpaceHealthIndicator} instance.
+	 * Create a new {@code DiskSpaceHealthIndicator} instance for a single path.
 	 * @param path the Path used to compute the available disk space
 	 * @param threshold the minimum disk space that should be available
 	 */
 	public DiskSpaceHealthIndicator(File path, DataSize threshold) {
 		super("DiskSpace health check failed");
-		this.path = path;
-		this.threshold = threshold;
+		this.paths.put(path, threshold);
+	}
+
+	/**
+	 * Create a new {@code DiskSpaceHealthIndicator} instance for one or more paths.
+	 * @param paths the paths to compute available disk space for and their corresponding
+	 * minimum disk space that should be available.
+	 */
+	public DiskSpaceHealthIndicator(Map<File, DataSize> paths) {
+		super("DiskSpace health check failed");
+		this.paths.putAll(paths);
 	}
 
 	@Override
 	protected void doHealthCheck(Health.Builder builder) throws Exception {
-		long diskFreeInBytes = this.path.getUsableSpace();
-		if (diskFreeInBytes >= this.threshold.toBytes()) {
-			builder.up();
-		}
-		else {
-			logger.warn(LogMessage.format("Free disk space below threshold. Available: %d bytes (threshold: %s)",
-					diskFreeInBytes, this.threshold));
+		// assume all is well - prove otherwise when checking paths
+		builder.up();
+
+		Map<String, Map<String, Object>> details = new LinkedHashMap<>();
+		this.paths.forEach((path, threshold) -> details.put(path.getAbsolutePath(),
+				checkPathAndGetDetails(path, threshold, builder)));
+		builder.withDetail("paths", details);
+	}
+
+	private Map<String, Object> checkPathAndGetDetails(File path, DataSize threshold, Health.Builder builder) {
+		long diskFreeInBytes = path.getUsableSpace();
+		if (diskFreeInBytes < threshold.toBytes()) {
+			logger.warn(LogMessage.format("Free disk space in %s below threshold. Available: %d bytes (threshold: %s)",
+					path.getAbsolutePath(), diskFreeInBytes, threshold));
 			builder.down();
 		}
-		builder.withDetail("total", this.path.getTotalSpace()).withDetail("free", diskFreeInBytes)
-				.withDetail("threshold", this.threshold.toBytes()).withDetail("exists", this.path.exists());
+		Map<String, Object> pathDetails = new LinkedHashMap<>();
+		pathDetails.put("total", path.getTotalSpace());
+		pathDetails.put("free", diskFreeInBytes);
+		pathDetails.put("threshold", threshold.toBytes());
+		pathDetails.put("exists", path.exists());
+		return pathDetails;
 	}
 
 }


### PR DESCRIPTION
Fixed gh-18359

#### Assumption
I know there was a previous proposal that was closed due to concerns around breaking compatibility of the actuator output when configuring each path's threshold. This code proposal assumes that breaking the output is ok since this is going into 2.6. 

#### Etiquette
I am not sure what the etiquette is in the situation where there is a dated closed proposal. I am starting to work on the [counterpart of this for the DiskSpaceMetrics](https://github.com/spring-projects/spring-boot/issues/27306) and figured I would put this together. If instead, we should resurrect the elder proposal I am totally fine w/ that as well. This newer implementation does support configuring the threshold per each path. I am not trying to be rude or step on toes. 

#### Usage

The config props now look like the following:
```yaml
management.health.diskspace.paths:

  - path: /some/dir/path1
    threshold: 10GB

  - path: /some/other/path2
  
  - path: /some/extra/path3
    threshold: 100MB
```
* I am not super excited about the "paths.path" 
* With low effort we could also keep the existing "management.health.diskspace.path" for the singular case. Thoughts? 
