### PR TITLE
NullPointerException in RoutingDataSourceHealthContributor when a routing data source has a target with a null routing key

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/jdbc/DataSourceHealthContributorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/jdbc/DataSourceHealthContributorAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.boot.actuate.autoconfigure.jdbc;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -125,11 +126,13 @@ public class DataSourceHealthContributorAutoConfiguration implements Initializin
 
 		private final CompositeHealthContributor delegate;
 
+		private static final String UNNAMED_DATASOURCE_KEY = "unnamed";
+
 		RoutingDataSourceHealthContributor(AbstractRoutingDataSource routingDataSource,
 				Function<DataSource, HealthContributor> contributorFunction) {
 			Map<String, DataSource> routedDataSources = routingDataSource.getResolvedDataSources().entrySet().stream()
-					.filter((e) -> e.getKey() != null)
-					.collect(Collectors.toMap((e) -> e.getKey().toString(), Map.Entry::getValue));
+					.collect(Collectors.toMap((e) -> Optional.ofNullable(e.getKey()).map(Object::toString)
+									.orElse(UNNAMED_DATASOURCE_KEY), Map.Entry::getValue));
 			this.delegate = CompositeHealthContributor.fromMap(routedDataSources, contributorFunction);
 		}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/jdbc/DataSourceHealthContributorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/jdbc/DataSourceHealthContributorAutoConfiguration.java
@@ -127,6 +127,7 @@ public class DataSourceHealthContributorAutoConfiguration implements Initializin
 		RoutingDataSourceHealthContributor(AbstractRoutingDataSource routingDataSource,
 				Function<DataSource, HealthContributor> contributorFunction) {
 			Map<String, DataSource> routedDataSources = routingDataSource.getResolvedDataSources().entrySet().stream()
+					.filter((e) -> e.getKey() != null)
 					.collect(Collectors.toMap((e) -> e.getKey().toString(), Map.Entry::getValue));
 			this.delegate = CompositeHealthContributor.fromMap(routedDataSources, contributorFunction);
 		}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/jdbc/DataSourceHealthContributorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/jdbc/DataSourceHealthContributorAutoConfiguration.java
@@ -57,6 +57,7 @@ import org.springframework.util.Assert;
  * @author Stephane Nicoll
  * @author Arthur Kalimullin
  * @author Julio Gomez
+ * @author Safeer Ansari
  * @since 2.0.0
  */
 @Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/jdbc/DataSourceHealthContributorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/jdbc/DataSourceHealthContributorAutoConfigurationTests.java
@@ -49,6 +49,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Phillip Webb
  * @author Julio Gomez
+ * @author Safeer Ansari
  */
 class DataSourceHealthContributorAutoConfigurationTests {
 
@@ -102,10 +103,11 @@ class DataSourceHealthContributorAutoConfigurationTests {
 			assertThat(context).hasSingleBean(RoutingDataSourceHealthContributor.class);
 			RoutingDataSourceHealthContributor routingHealthContributor = context
 					.getBean(RoutingDataSourceHealthContributor.class);
+			assertThat(routingHealthContributor.getContributor("unnamed")).isInstanceOf(DataSourceHealthIndicator.class);
 			assertThat(routingHealthContributor.getContributor("one")).isInstanceOf(DataSourceHealthIndicator.class);
 			assertThat(routingHealthContributor.getContributor("two")).isInstanceOf(DataSourceHealthIndicator.class);
 			assertThat(routingHealthContributor.iterator()).toIterable().extracting("name")
-					.containsExactlyInAnyOrder("one", "two");
+					.containsExactlyInAnyOrder("unnamed", "one", "two");
 		});
 	}
 
@@ -155,6 +157,7 @@ class DataSourceHealthContributorAutoConfigurationTests {
 		@Bean
 		AbstractRoutingDataSource routingDataSource() {
 			Map<Object, DataSource> dataSources = new HashMap<>();
+			dataSources.put(null, mock(DataSource.class));
 			dataSources.put("one", mock(DataSource.class));
 			dataSources.put("two", mock(DataSource.class));
 			AbstractRoutingDataSource routingDataSource = mock(AbstractRoutingDataSource.class);


### PR DESCRIPTION
The RoutingDataSourceHealthContributor constructor throws a NullPointerException (NPE) if the provided map has a null key. With this commit the NPE issue has been fixed by filtering the entries that are not-null. 

Alternatively, a constant value can be added when the key for a datasource in the ‘Map’ is null. 

This closes #27694 