### PR TITLE
Fix broken links in docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/io/caching.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/io/caching.adoc
@@ -39,18 +39,18 @@ The cache abstraction does not provide an actual store and relies on abstraction
 
 If you have not defined a bean of type `CacheManager` or a `CacheResolver` named `cacheResolver` (see {spring-framework-api}/cache/annotation/CachingConfigurer.html[`CachingConfigurer`]), Spring Boot tries to detect the following providers (in the indicated order):
 
-. <<caching#io.caching.provider.generic,Generic>>
-. <<caching#io.caching.provider.jcache,JCache (JSR-107)>> (EhCache 3, Hazelcast, Infinispan, and others)
-. <<caching#io.caching.provider.ehcache2,EhCache 2.x>>
-. <<caching#io.caching.provider.hazelcast,Hazelcast>>
-. <<caching#io.caching.provider.infinispan,Infinispan>>
-. <<caching#io.caching.provider.couchbase,Couchbase>>
-. <<caching#io.caching.provider.redis,Redis>>
-. <<caching#io.caching.provider.caffeine,Caffeine>>
-. <<caching#io.caching.provider.simple,Simple>>
+. <<io.caching.provider.generic,Generic>>
+. <<io.caching.provider.jcache,JCache (JSR-107)>> (EhCache 3, Hazelcast, Infinispan, and others)
+. <<io.caching.provider.ehcache2,EhCache 2.x>>
+. <<io.caching.provider.hazelcast,Hazelcast>>
+. <<io.caching.provider.infinispan,Infinispan>>
+. <<io.caching.provider.couchbase,Couchbase>>
+. <<io.caching.provider.redis,Redis>>
+. <<io.caching.provider.caffeine,Caffeine>>
+. <<io.caching.provider.simple,Simple>>
 
 TIP: It is also possible to _force_ a particular cache provider by setting the configprop:spring.cache.type[] property.
-Use this property if you need to <<caching#io.caching.provider.none,disable caching altogether>> in certain environment (such as tests).
+Use this property if you need to <<io.caching.provider.none,disable caching altogether>> in certain environments (such as tests).
 
 TIP: Use the `spring-boot-starter-cache` "`Starter`" to quickly add basic caching dependencies.
 The starter brings in `spring-context-support`.

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/web/servlet.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/web/servlet.adoc
@@ -181,7 +181,7 @@ A "fixed" strategy adds a static version string in the URL without changing the 
 
 With this configuration, JavaScript modules located under `"/js/lib/"` use a fixed versioning strategy (`"/v12/js/lib/mymodule.js"`), while other resources still use the content one (`<link href="/css/spring-2a2d595e6ed9a0b24f027f2b63b134d6.css"/>`).
 
-See {spring-boot-autoconfigure-module-code}/web/ResourceProperties.java[`ResourceProperties`] for more supported options.
+See {spring-boot-autoconfigure-module-code}/web/WebProperties.java[`WebProperties.Resources`] for more supported options.
 
 [TIP]
 ====
@@ -631,7 +631,7 @@ JSPs are not supported when using an executable jar.
 
 * Undertow does not support JSPs.
 
-* Creating a custom `error.jsp` page does not override the default view for <<servlet#web.servlet.spring-mvc.error-handling,error handling>>.
-  <<servlet#web.servlet.spring-mvc.error-handling.error-pages,Custom error pages>> should be used instead.
+* Creating a custom `error.jsp` page does not override the default view for <<web.servlet.spring-mvc.error-handling,error handling>>.
+  <<web.servlet.spring-mvc.error-handling.error-pages,Custom error pages>> should be used instead.
 
 


### PR DESCRIPTION
Hi,

I just noticed a couple of broken links on https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/.

Cheers,
Christoph