### PR TITLE
Added details to failed SpringBootCondition

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/SpringBootCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/SpringBootCondition.java
@@ -57,7 +57,8 @@ public abstract class SpringBootCondition implements Condition {
 					+ "put a @ComponentScan in the default package by mistake)", ex);
 		}
 		catch (RuntimeException ex) {
-			throw new IllegalStateException("Error processing condition on " + getName(metadata), ex);
+			throw new IllegalStateException("Error processing condition on " + getName(metadata) + " due to " 
+					+ ex.getClass().getCanonicalName() + ": " + ex.getMessage(), ex);
 		}
 	}
 


### PR DESCRIPTION
It would appear, at least under some logging configurations, that the
exception cause is not actually being logged in the shown stacktrace
when the failed condition exception occurs (at least, in Spring Boot 2.5.2).
This means when the condition throws an IllegalStateException, there is
no details as to what actually went wrong. This change amends the logged
message to include the cause exception name and the associated message
to assist in debugging.