### PR TITLE
Upgrade to Logback 1.2.5

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1020,7 +1020,7 @@ bom {
 			]
 		}
 	}
-	library("Logback", "1.2.3") {
+	library("Logback", "1.2.5") {
 		group("ch.qos.logback") {
 			modules = [
 				"logback-access",


### PR DESCRIPTION
The current version (1.2.3) has bugs

I have seen that many branches have already upgraded to 1.2.5, except the 2.3.x branch.

https://jira.qos.ch/browse/LOGBACK-1297