### PR TITLE
Fix inconsistent devtools doc

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/using/devtools.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/using/devtools.adoc
@@ -53,7 +53,7 @@ Cache options are usually configured by settings in your `application.properties
 For example, Thymeleaf offers the configprop:spring.thymeleaf.cache[] property.
 Rather than needing to set these properties manually, the `spring-boot-devtools` module automatically applies sensible development-time configuration.
 
-Because you need more information about web requests while developing Spring MVC and Spring WebFlux applications, developer tools will enable `DEBUG` logging for the `web` logging group.
+Because you need more information about web requests while developing Spring MVC and Spring WebFlux applications, developer tools will suggest you enable `DEBUG` logging for the `web` logging group.
 This will give you information about the incoming request, which handler is processing it, the response outcome, etc.
 If you wish to log all request details (including potentially sensitive information), you can turn on the configprop:spring.mvc.log-request-details[] or configprop:spring.codec.log-request-details[] configuration properties.
 


### PR DESCRIPTION
DevTools only log a message and doesn't set `logging.level.web` to `DEBUG`

https://github.com/spring-projects/spring-boot/blob/dc5acb00191c2eac09907c39e4d890343bf9848d/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsPropertyDefaultsPostProcessor.java#L90-L94
