### PR TITLE
Drop dependency management for Oracle drivers with old groupId

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1295,30 +1295,6 @@ bom {
 			]
 		}
 	}
-	library("OJDBC", "19.3.0.0") {
-		group("com.oracle.ojdbc") {
-			modules = [
-				"dms",
-				"ojdbc10",
-				"ojdbc10_g",
-				"ojdbc10dms",
-				"ojdbc10dms_g",
-				"ojdbc8",
-				"ojdbc8_g",
-				"ojdbc8dms",
-				"ojdbc8dms_g",
-				"ons",
-				"oraclepki",
-				"orai18n",
-				"osdt_cert",
-				"osdt_core",
-				"simplefan",
-				"ucp",
-				"xdb",
-				"xmlparserv2"
-			]
-		}
-	}
 	library("OkHttp3", "3.14.9") {
 		prohibit("[4.0.0-alpha01,)") {
 			because "it requires Kotlin"


### PR DESCRIPTION
There is an 'ojdbc-bom' v21 already included with groupId 'com.oracle.database.jdbc' covering all jars listed explicitly for v19.3 here (excluding ojdbc10).

Check out the content of Oracle's Maven bom here:
https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc-bom/21.1.0.0/ojdbc-bom-21.1.0.0.pom

Also see Oracle's announcements:
https://medium.com/oracledevs/all-in-and-new-groupids-oracle-jdbc-drivers-on-maven-central-a76d545954c6
https://blogs.oracle.com/developers/post/oracle-database-client-libraries-for-java-now-on-maven-central

The `com.oracle.ojdbc` version management was originally introduced in: #18242