### PR TITLE
Expose redis configuration beans

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/JedisConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/JedisConnectionConfiguration.java
@@ -41,21 +41,23 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Paluch
  * @author Stephane Nicoll
+ * @author Yanming Zhou
+ * @since 2.6.0
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass({ GenericObjectPool.class, JedisConnection.class, Jedis.class })
 @ConditionalOnMissingBean(RedisConnectionFactory.class)
 @ConditionalOnProperty(name = "spring.redis.client-type", havingValue = "jedis", matchIfMissing = true)
-class JedisConnectionConfiguration extends RedisConnectionConfiguration {
+public class JedisConnectionConfiguration extends RedisConnectionConfiguration {
 
-	JedisConnectionConfiguration(RedisProperties properties,
+	public JedisConnectionConfiguration(RedisProperties properties,
 			ObjectProvider<RedisSentinelConfiguration> sentinelConfiguration,
 			ObjectProvider<RedisClusterConfiguration> clusterConfiguration) {
 		super(properties, sentinelConfiguration, clusterConfiguration);
 	}
 
 	@Bean
-	JedisConnectionFactory redisConnectionFactory(
+	public JedisConnectionFactory redisConnectionFactory(
 			ObjectProvider<JedisClientConfigurationBuilderCustomizer> builderCustomizers) {
 		return createJedisConnectionFactory(builderCustomizers);
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
@@ -51,13 +51,15 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Paluch
  * @author Andy Wilkinson
+ * @author Yanming Zhou
+ * @since 2.6.0
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(RedisClient.class)
 @ConditionalOnProperty(name = "spring.redis.client-type", havingValue = "lettuce", matchIfMissing = true)
-class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
+public class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 
-	LettuceConnectionConfiguration(RedisProperties properties,
+	public LettuceConnectionConfiguration(RedisProperties properties,
 			ObjectProvider<RedisSentinelConfiguration> sentinelConfigurationProvider,
 			ObjectProvider<RedisClusterConfiguration> clusterConfigurationProvider) {
 		super(properties, sentinelConfigurationProvider, clusterConfigurationProvider);
@@ -65,7 +67,7 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 
 	@Bean(destroyMethod = "shutdown")
 	@ConditionalOnMissingBean(ClientResources.class)
-	DefaultClientResources lettuceClientResources(ObjectProvider<ClientResourcesBuilderCustomizer> customizers) {
+	public DefaultClientResources lettuceClientResources(ObjectProvider<ClientResourcesBuilderCustomizer> customizers) {
 		DefaultClientResources.Builder builder = DefaultClientResources.builder();
 		customizers.orderedStream().forEach((customizer) -> customizer.customize(builder));
 		return builder.build();
@@ -73,7 +75,7 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(RedisConnectionFactory.class)
-	LettuceConnectionFactory redisConnectionFactory(
+	public LettuceConnectionFactory redisConnectionFactory(
 			ObjectProvider<LettuceClientConfigurationBuilderCustomizer> builderCustomizers,
 			ClientResources clientResources) {
 		LettuceClientConfiguration clientConfig = getLettuceClientConfiguration(builderCustomizers, clientResources,

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionConfiguration.java
@@ -39,8 +39,10 @@ import org.springframework.util.StringUtils;
  * @author Stephane Nicoll
  * @author Alen Turkovic
  * @author Scott Frederick
+ * @author Yanming Zhou
+ * @since 2.6.0
  */
-abstract class RedisConnectionConfiguration {
+public abstract class RedisConnectionConfiguration {
 
 	private static final boolean COMMONS_POOL2_AVAILABLE = ClassUtils.isPresent("org.apache.commons.pool2.ObjectPool",
 			RedisConnectionConfiguration.class.getClassLoader());


### PR DESCRIPTION
Allow application to extends those configurations
mitigate gh-27834

for example I have two redis services, the default one is `@Primary`, the global one must be injected with prefix `global` in `@Qualifier`
```java
@Primary
@Component
@ConfigurationProperties(prefix = "spring.redis")
public class DefaultRedisProperties extends RedisProperties {

}

@Configuration(proxyBeanMethods = false)
public class DefaultConnectionConfiguration extends LettuceConnectionConfiguration {

	DefaultConnectionConfiguration(RedisProperties properties,
			ObjectProvider<RedisSentinelConfiguration> sentinelConfigurationProvider,
			ObjectProvider<RedisClusterConfiguration> clusterConfigurationProvider) {
		super(properties, sentinelConfigurationProvider, clusterConfigurationProvider);
	}

	@Primary
	@Bean(destroyMethod = "shutdown")
	public DefaultClientResources lettuceClientResources() {
		return super.lettuceClientResources();
	}

	@Primary
	@Bean
	public LettuceConnectionFactory redisConnectionFactory(
			ObjectProvider<LettuceClientConfigurationBuilderCustomizer> builderCustomizers,
			ClientResources globalLettuceClientResources) {
		return super.redisConnectionFactory(builderCustomizers, globalLettuceClientResources);
	}

}

@Configuration(proxyBeanMethods = false)
public class DefaultRedisConfiguration {

	@Bean
	public RedisTemplate<Object, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
		RedisTemplate<Object, Object> template = new RedisTemplate<>();
		template.setConnectionFactory(redisConnectionFactory);
		return template;
	}

	@Bean
	public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
		return new StringRedisTemplate(redisConnectionFactory);
	}

}
```
```java

@Component
@ConfigurationProperties(prefix = "global.redis")
public class GlobalRedisProperties extends RedisProperties {

}

@Configuration(proxyBeanMethods = false)
public class GlobalConnectionConfiguration extends LettuceConnectionConfiguration {

	GlobalConnectionConfiguration(GlobalRedisProperties properties,
			ObjectProvider<RedisSentinelConfiguration> sentinelConfigurationProvider,
			ObjectProvider<RedisClusterConfiguration> clusterConfigurationProvider) {
		super(properties, sentinelConfigurationProvider, clusterConfigurationProvider);
	}

	@Bean(destroyMethod = "shutdown")
	DefaultClientResources globalLettuceClientResources() {
		return super.lettuceClientResources();
	}

	@Bean
	LettuceConnectionFactory globalRedisConnectionFactory(
			ObjectProvider<LettuceClientConfigurationBuilderCustomizer> builderCustomizers,
			@Qualifier("globalLettuceClientResources") ClientResources globalLettuceClientResources) {
		return super.redisConnectionFactory(builderCustomizers, globalLettuceClientResources);
	}

}

@Configuration(proxyBeanMethods = false)
public class GlobalRedisConfiguration {

	@Bean
	public RedisTemplate<Object, Object> globalRedisTemplate(
			@Qualifier("globalRedisConnectionFactory") RedisConnectionFactory globalRedisConnectionFactory) {
		RedisTemplate<Object, Object> template = new RedisTemplate<>();
		template.setConnectionFactory(globalRedisConnectionFactory);
		return template;
	}

	@Bean
	public StringRedisTemplate globalStringRedisTemplate(
			@Qualifier("globalRedisConnectionFactory") RedisConnectionFactory globalRedisConnectionFactory) {
		return new StringRedisTemplate(globalRedisConnectionFactory);
	}

}
```