### PR TITLE
Add testing for AbstractFailureAnalyzer.findCause

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/AbstractFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/AbstractFailureAnalyzer.java
@@ -31,10 +31,8 @@ public abstract class AbstractFailureAnalyzer<T extends Throwable> implements Fa
 	@Override
 	public FailureAnalysis analyze(Throwable failure) {
 		T cause = findCause(failure, getCauseType());
-		if (cause != null) {
-			return analyze(failure, cause);
-		}
-		return null;
+
+		return (cause != null) ? analyze(failure, cause) : null;
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/AbstractFailureAnalyzerTest.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/AbstractFailureAnalyzerTest.java
@@ -38,13 +38,24 @@ class AbstractFailureAnalyzerTest {
 	}
 
 	static class FailureAnalyzerConcrete extends AbstractFailureAnalyzer<Throwable> {
+
 		@Override
 		protected FailureAnalysis analyze(Throwable rootFailure, Throwable cause) {
 			return null;
 		}
+
 	}
 
-	static class ThrowableExtendsException extends Throwable { }
-	static class ExtendsThrowableExtendsException extends ThrowableExtendsException { }
-	static class OtherException extends Throwable { }
+	static class ThrowableExtendsException extends Throwable {
+
+	}
+
+	static class ExtendsThrowableExtendsException extends ThrowableExtendsException {
+
+	}
+
+	static class OtherException extends Throwable {
+
+	}
+
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/AbstractFailureAnalyzerTest.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/AbstractFailureAnalyzerTest.java
@@ -1,0 +1,50 @@
+package org.springframework.boot.diagnostics;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AbstractFailureAnalyzerTest {
+
+	private FailureAnalyzerConcrete failureAnalyzerConcrete;
+
+	@BeforeEach
+	void configureFailureAnalyzer() {
+		failureAnalyzerConcrete = new FailureAnalyzerConcrete();
+	}
+
+	@Test
+	void findCauseExtendsThrowable() {
+		ThrowableExtendsException ex = new ThrowableExtendsException();
+		assertNotNull(failureAnalyzerConcrete.findCause(ex, Throwable.class).getClass());
+	}
+
+	@Test
+	void findCauseExtendsOtherException() {
+		ExtendsThrowableExtendsException ex = new ExtendsThrowableExtendsException();
+		assertNotNull(failureAnalyzerConcrete.findCause(ex, ThrowableExtendsException.class).getClass());
+	}
+
+	@Test
+	void findCauseOtherException() {
+		ThrowableExtendsException ex = new ThrowableExtendsException();
+		assertNull(failureAnalyzerConcrete.findCause(ex, OtherException.class));
+	}
+
+	@Test
+	void findCauseNullObject() {
+		assertNull(failureAnalyzerConcrete.findCause(null, Throwable.class));
+	}
+
+	static class FailureAnalyzerConcrete extends AbstractFailureAnalyzer<Throwable> {
+		@Override
+		protected FailureAnalysis analyze(Throwable rootFailure, Throwable cause) {
+			return null;
+		}
+	}
+
+	static class ThrowableExtendsException extends Throwable { }
+	static class ExtendsThrowableExtendsException extends ThrowableExtendsException { }
+	static class OtherException extends Throwable { }
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/AbstractFailureAnalyzerTest.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/AbstractFailureAnalyzerTest.java
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.diagnostics;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class AbstractFailureAnalyzerTest {
 
@@ -11,30 +27,30 @@ class AbstractFailureAnalyzerTest {
 
 	@BeforeEach
 	void configureFailureAnalyzer() {
-		failureAnalyzerConcrete = new FailureAnalyzerConcrete();
+		this.failureAnalyzerConcrete = new FailureAnalyzerConcrete();
 	}
 
 	@Test
 	void findCauseExtendsThrowable() {
 		ThrowableExtendsException ex = new ThrowableExtendsException();
-		assertNotNull(failureAnalyzerConcrete.findCause(ex, Throwable.class).getClass());
+		assertThat(this.failureAnalyzerConcrete.findCause(ex, Throwable.class).getClass()).isNotNull();
 	}
 
 	@Test
 	void findCauseExtendsOtherException() {
 		ExtendsThrowableExtendsException ex = new ExtendsThrowableExtendsException();
-		assertNotNull(failureAnalyzerConcrete.findCause(ex, ThrowableExtendsException.class).getClass());
+		assertThat(this.failureAnalyzerConcrete.findCause(ex, ThrowableExtendsException.class).getClass()).isNotNull();
 	}
 
 	@Test
 	void findCauseOtherException() {
 		ThrowableExtendsException ex = new ThrowableExtendsException();
-		assertNull(failureAnalyzerConcrete.findCause(ex, OtherException.class));
+		assertThat(this.failureAnalyzerConcrete.findCause(ex, OtherException.class)).isNull();
 	}
 
 	@Test
 	void findCauseNullObject() {
-		assertNull(failureAnalyzerConcrete.findCause(null, Throwable.class));
+		assertThat(this.failureAnalyzerConcrete.findCause(null, Throwable.class)).isNull();
 	}
 
 	static class FailureAnalyzerConcrete extends AbstractFailureAnalyzer<Throwable> {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/AbstractFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/AbstractFailureAnalyzerTests.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class AbstractFailureAnalyzerTest {
+class AbstractFailureAnalyzerTests {
 
 	private FailureAnalyzerConcrete failureAnalyzerConcrete;
 


### PR DESCRIPTION
Added testing for ```findCause``` in```AbstractFailureAnalyzer```.

* ```findCauseExtendsThrowable``` and ```findCauseExtendsOtherException``` are to check if it is working properly when an exception contains generic class type.
* ```findCauseOtherException``` is to check if it returns null when an exception doesn't contain generic class type.
* ```findCauseNullObject``` is to check if it returns ```null``` when providing ```null``` as throwable parameter.