### PR TITLE
Fix abstract class's constructor access modifier

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/AbstractBindHandler.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/AbstractBindHandler.java
@@ -24,6 +24,7 @@ import org.springframework.util.Assert;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Lee SeoJune
  * @since 2.0.0
  */
 public abstract class AbstractBindHandler implements BindHandler {
@@ -33,7 +34,7 @@ public abstract class AbstractBindHandler implements BindHandler {
 	/**
 	 * Create a new binding handler instance.
 	 */
-	public AbstractBindHandler() {
+	protected AbstractBindHandler() {
 		this(BindHandler.DEFAULT);
 	}
 
@@ -41,7 +42,7 @@ public abstract class AbstractBindHandler implements BindHandler {
 	 * Create a new binding handler instance with a specific parent.
 	 * @param parent the parent handler
 	 */
-	public AbstractBindHandler(BindHandler parent) {
+	protected AbstractBindHandler(BindHandler parent) {
 		Assert.notNull(parent, "Parent must not be null");
 		this.parent = parent;
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/AbstractDataSourceInitializerDatabaseInitializerDetector.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/AbstractDataSourceInitializerDatabaseInitializerDetector.java
@@ -25,6 +25,7 @@ import org.springframework.boot.sql.init.dependency.DatabaseInitializerDetector;
 /**
  * A {@link DatabaseInitializerDetector} for {@link AbstractDataSourceInitializer}.
  *
+ * @deprecated
  * @author Henning Pöttker
  */
 @Deprecated

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/AbstractLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/AbstractLoggingSystem.java
@@ -34,6 +34,7 @@ import org.springframework.util.SystemPropertyUtils;
  *
  * @author Phillip Webb
  * @author Dave Syer
+ * @author Lee SeoJune
  * @since 1.0.0
  */
 public abstract class AbstractLoggingSystem extends LoggingSystem {
@@ -43,7 +44,7 @@ public abstract class AbstractLoggingSystem extends LoggingSystem {
 
 	private final ClassLoader classLoader;
 
-	public AbstractLoggingSystem(ClassLoader classLoader) {
+	protected AbstractLoggingSystem(ClassLoader classLoader) {
 		this.classLoader = classLoader;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/server/AbstractReactiveWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/server/AbstractReactiveWebServerFactory.java
@@ -22,15 +22,16 @@ import org.springframework.boot.web.server.AbstractConfigurableWebServerFactory;
  * Abstract base class for {@link ReactiveWebServerFactory} implementations.
  *
  * @author Brian Clozel
+ * @author Lee SeoJune
  * @since 2.0.0
  */
 public abstract class AbstractReactiveWebServerFactory extends AbstractConfigurableWebServerFactory
 		implements ConfigurableReactiveWebServerFactory {
 
-	public AbstractReactiveWebServerFactory() {
+	protected AbstractReactiveWebServerFactory() {
 	}
 
-	public AbstractReactiveWebServerFactory(int port) {
+	protected AbstractReactiveWebServerFactory(int port) {
 		super(port);
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/AbstractConfigurableWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/AbstractConfigurableWebServerFactory.java
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  * @author Ivan Sopov
  * @author Eddú Meléndez
  * @author Brian Clozel
+ * @author Lee SeoJune
  * @since 2.0.0
  */
 public abstract class AbstractConfigurableWebServerFactory implements ConfigurableWebServerFactory {
@@ -61,7 +62,7 @@ public abstract class AbstractConfigurableWebServerFactory implements Configurab
 	/**
 	 * Create a new {@link AbstractConfigurableWebServerFactory} instance.
 	 */
-	public AbstractConfigurableWebServerFactory() {
+	protected AbstractConfigurableWebServerFactory() {
 	}
 
 	/**
@@ -69,7 +70,7 @@ public abstract class AbstractConfigurableWebServerFactory implements Configurab
 	 * specified port.
 	 * @param port the port number for the web server
 	 */
-	public AbstractConfigurableWebServerFactory(int port) {
+	protected AbstractConfigurableWebServerFactory(int port) {
 		this.port = port;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactory.java
@@ -332,7 +332,7 @@ public abstract class AbstractServletWebServerFactory extends AbstractConfigurab
 
 		private Set<javax.servlet.SessionTrackingMode> unwrap(Set<Session.SessionTrackingMode> modes) {
 			if (modes == null) {
-				return Collections.emptySet();
+				return null;
 			}
 			Set<javax.servlet.SessionTrackingMode> result = new LinkedHashSet<>();
 			for (Session.SessionTrackingMode mode : modes) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactory.java
@@ -55,6 +55,7 @@ import org.springframework.util.ClassUtils;
  * @author Ivan Sopov
  * @author Eddú Meléndez
  * @author Brian Clozel
+ * @author Lee SeoJune
  * @since 2.0.0
  */
 public abstract class AbstractServletWebServerFactory extends AbstractConfigurableWebServerFactory
@@ -89,7 +90,7 @@ public abstract class AbstractServletWebServerFactory extends AbstractConfigurab
 	/**
 	 * Create a new {@link AbstractServletWebServerFactory} instance.
 	 */
-	public AbstractServletWebServerFactory() {
+	protected AbstractServletWebServerFactory() {
 	}
 
 	/**
@@ -97,7 +98,7 @@ public abstract class AbstractServletWebServerFactory extends AbstractConfigurab
 	 * port.
 	 * @param port the port number for the web server
 	 */
-	public AbstractServletWebServerFactory(int port) {
+	protected AbstractServletWebServerFactory(int port) {
 		super(port);
 	}
 
@@ -107,7 +108,7 @@ public abstract class AbstractServletWebServerFactory extends AbstractConfigurab
 	 * @param contextPath the context path for the web server
 	 * @param port the port number for the web server
 	 */
-	public AbstractServletWebServerFactory(String contextPath, int port) {
+	protected AbstractServletWebServerFactory(String contextPath, int port) {
 		super(port);
 		checkContextPath(contextPath);
 		this.contextPath = contextPath;
@@ -331,7 +332,7 @@ public abstract class AbstractServletWebServerFactory extends AbstractConfigurab
 
 		private Set<javax.servlet.SessionTrackingMode> unwrap(Set<Session.SessionTrackingMode> modes) {
 			if (modes == null) {
-				return null;
+				return Collections.emptySet();
 			}
 			Set<javax.servlet.SessionTrackingMode> result = new LinkedHashSet<>();
 			for (Session.SessionTrackingMode mode : modes) {


### PR DESCRIPTION
abstract class's constructor was public access modifier, so i changed to protected because we must use the most restricted range available.

and i add deprecated in javadoc