### PR TITLE
Update documentation of spring.redis.jedis.pool.enabled to note that pooling is implicitly enabled in Sentinel mode

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -235,7 +235,8 @@ public class RedisProperties {
 
 		/**
 		 * Whether to enable the pool. Enabled automatically if "commons-pool2" is
-		 * available.
+		 * available.This setting only applies to Jedis when using non-sentinel mode and
+		 * that pooling is implicitly enabled in sentinel mode.
 		 */
 		private Boolean enabled;
 


### PR DESCRIPTION
Closing #27826 

Clarify pooling is implicitly enabled in Sentinel mode.