### PR TITLE
Polish javadoc comments

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonProperties.java
@@ -98,7 +98,7 @@ public class JacksonProperties {
 	private Boolean defaultLeniency;
 
 	/**
-	 * Strategy to use to to auto-detect constructor, and in particular behavior with
+	 * Strategy to use to auto-detect constructor, and in particular behavior with
 	 * single-argument constructors.
 	 */
 	private ConstructorDetectorStrategy constructorDetector;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLoader.java
@@ -26,10 +26,9 @@ import org.springframework.boot.ConfigurableBootstrapContext;
 import org.springframework.boot.logging.DeferredLogFactory;
 
 /**
- * Strategy class that can be used used to load {@link ConfigData} for a given
- * {@link ConfigDataResource}. Implementations should be added as a
- * {@code spring.factories} entries. The following constructor parameter types are
- * supported:
+ * Strategy class that can be used to load {@link ConfigData} for a given
+ * {@link ConfigDataResource}. Implementations should be added as {@code spring.factories}
+ * entries. The following constructor parameter types are supported:
  * <ul>
  * <li>{@link Log} or {@link DeferredLogFactory} - if the loader needs deferred
  * logging</li>

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLocation.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLocation.java
@@ -53,7 +53,7 @@ public final class ConfigDataLocation implements OriginProvider {
 	}
 
 	/**
-	 * Return the the location is optional and should ignore
+	 * Return if the location is optional and should ignore
 	 * {@link ConfigDataNotFoundException}.
 	 * @return if the location is optional
 	 */

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/NotConstructorBoundInjectionFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/NotConstructorBoundInjectionFailureAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.core.annotation.MergedAnnotation;
 import org.springframework.core.annotation.MergedAnnotations;
 
 /**
- * An {@AbstractInjectionFailureAnalyzer} for
+ * An {@link AbstractInjectionFailureAnalyzer} for
  * {@link ConfigurationProperties @ConfigurationProperties} that are intended to use
  * {@link ConstructorBinding constructor binding} but did not.
  *

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/ConfigTreePropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/ConfigTreePropertySource.java
@@ -165,7 +165,7 @@ public class ConfigTreePropertySource extends EnumerablePropertySource<Path> imp
 	}
 
 	/**
-	 * A single property file that was found when when the source was created.
+	 * A single property file that was found when the source was created.
 	 */
 	private static final class PropertyFile {
 

--- a/spring-boot-system-tests/spring-boot-image-tests/src/systemTest/java/org/springframework/boot/image/assertions/ContainerConfigAssert.java
+++ b/spring-boot-system-tests/spring-boot-image-tests/src/systemTest/java/org/springframework/boot/image/assertions/ContainerConfigAssert.java
@@ -108,8 +108,7 @@ public class ContainerConfigAssert extends AbstractAssert<ContainerConfigAssert,
 	}
 
 	/**
-	 * Asserts for the the JSON content in the {@code io.buildpacks.lifecycle.metadata}
-	 * label.
+	 * Asserts for the JSON content in the {@code io.buildpacks.lifecycle.metadata} label.
 	 *
 	 * See <a href=
 	 * "https://github.com/buildpacks/spec/blob/main/platform.md#iobuildpackslifecyclemetadata-json">the


### PR DESCRIPTION
Hi,

this PR polishes a couple of javadoc comments. Mainly by removing duplicate consecutive words.

Cheers,
Christoph