### PR TITLE
Deprecate DataSourceInitializationMode

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DataSourceInitializationMode.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DataSourceInitializationMode.java
@@ -28,6 +28,7 @@ import org.springframework.boot.sql.init.DatabaseInitializationMode;
  * @deprecated since 2.6.0 for removal in 2.8.0 in favor of
  * {@link DatabaseInitializationMode}
  */
+@Deprecated
 public enum DataSourceInitializationMode {
 
 	/**


### PR DESCRIPTION
Hi,

this PR adds a missing `@Deprecated` annotation to `DataSourceInitializationMode`.

Cheers,
Christoph