### PR TITLE
Allow configuring WebDriver with TestNG

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebDriverScope.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebDriverScope.java
@@ -38,6 +38,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @see WebDriverContextCustomizerFactory
  * @see WebDriverTestExecutionListener
+ * @since 2.6.0
  */
 public class WebDriverScope implements Scope {
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebDriverScope.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebDriverScope.java
@@ -39,7 +39,7 @@ import org.springframework.util.StringUtils;
  * @see WebDriverContextCustomizerFactory
  * @see WebDriverTestExecutionListener
  */
-class WebDriverScope implements Scope {
+public class WebDriverScope implements Scope {
 
 	public static final String NAME = "webDriver";
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebDriverScope.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebDriverScope.java
@@ -36,12 +36,15 @@ import org.springframework.util.StringUtils;
  * {@link WebDriverTestExecutionListener}.
  *
  * @author Phillip Webb
+ * @since 2.6.0
  * @see WebDriverContextCustomizerFactory
  * @see WebDriverTestExecutionListener
- * @since 2.6.0
  */
 public class WebDriverScope implements Scope {
 
+	/**
+	 * WebDriver bean scope name.
+	 */
 	public static final String NAME = "webDriver";
 
 	private static final String WEB_DRIVER_CLASS = "org.openqa.selenium.WebDriver";

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebDriverTestExecutionListener.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebDriverTestExecutionListener.java
@@ -26,9 +26,9 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
  * {@link TestExecutionListener} to reset the {@link WebDriverScope}.
  *
  * @author Phillip Webb
+ * @since 2.6.0
  * @see WebDriverContextCustomizerFactory
  * @see WebDriverScope
- * @since 2.6.0
  */
 public class WebDriverTestExecutionListener extends AbstractTestExecutionListener {
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebDriverTestExecutionListener.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebDriverTestExecutionListener.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
  * @see WebDriverContextCustomizerFactory
  * @see WebDriverScope
  */
-class WebDriverTestExecutionListener extends AbstractTestExecutionListener {
+public class WebDriverTestExecutionListener extends AbstractTestExecutionListener {
 
 	@Override
 	public int getOrder() {

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebDriverTestExecutionListener.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/web/servlet/WebDriverTestExecutionListener.java
@@ -28,6 +28,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
  * @author Phillip Webb
  * @see WebDriverContextCustomizerFactory
  * @see WebDriverScope
+ * @since 2.6.0
  */
 public class WebDriverTestExecutionListener extends AbstractTestExecutionListener {
 


### PR DESCRIPTION
Accessible webdriver test execution listener for testng:
`@TestExecutionListeners({WebDriverTestExecutionListener.class})`

Access `WebDriverScope.NAME` outside package to be used by user webdriver implementations. Needs matching name to be picked up by autoconfiguration.
```
@Bean(name = WebDriverScope.NAME)
public WebDriver customWebDriver() {...
```

See https://github.com/spring-projects/spring-boot/issues/27921