### PR TITLE
Expose database initialization settings creator

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/sql/init/SqlInitializationProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/sql/init/SqlInitializationProperties.java
@@ -21,12 +21,14 @@ import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.sql.init.DatabaseInitializationMode;
+import org.springframework.boot.sql.init.DatabaseInitializationSettings;
 
 /**
  * {@link ConfigurationProperties Configuration properties} for initializing an SQL
  * database.
  *
  * @author Andy Wilkinson
+ * @author Radosław Dąbrowski
  * @since 2.5.0
  */
 @ConfigurationProperties("spring.sql.init")
@@ -150,6 +152,15 @@ public class SqlInitializationProperties {
 
 	public void setMode(DatabaseInitializationMode mode) {
 		this.mode = mode;
+	}
+
+	/**
+	 * Adapts {@link SqlInitializationProperties SQL initialization properties} to
+	 * {@link DatabaseInitializationSettings}.
+	 * @return a new {@link DatabaseInitializationSettings} instance
+	 */
+	public DatabaseInitializationSettings toDatabaseInitializationSettings() {
+		return SettingsCreator.createFrom(this);
 	}
 
 }


### PR DESCRIPTION
~~I've created a class to provide exposing of `SettingsCreator#createFrom`. As it is now public, name `SettingsCreator` is not very helpful, and that's why I created another class for exposing purpose (backward compatibility is kept)~~

Link: https://github.com/spring-projects/spring-boot/issues/26657