### PR TITLE
Add Spring Integration default poller auto-config

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -124,7 +124,7 @@ public class IntegrationAutoConfiguration {
 			map.from(poller::getMaxMessagesPerPoll).to(pollerMetadata::setMaxMessagesPerPoll);
 			map.from(poller::getReceiveTimeout).as(Duration::toMillis).to(pollerMetadata::setReceiveTimeout);
 			map.from(poller::getCron).whenHasText().as(CronTrigger::new).to(pollerMetadata::setTrigger);
-			map.from(poller.getFixedDelay() != null ? poller.getFixedDelay() : poller.getFixedRate())
+			map.from((poller.getFixedDelay() != null) ? poller.getFixedDelay() : poller.getFixedRate())
 					.as(Duration::toMillis).as(PeriodicTrigger::new).as((trigger) -> {
 						map.from(poller::getInitialDelay).as(Duration::toMillis).to(trigger::setInitialDelay);
 						trigger.setFixedRate(poller.getFixedRate() != null);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -65,6 +65,7 @@ import org.springframework.messaging.rsocket.annotation.support.RSocketMessageHa
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.scheduling.support.PeriodicTrigger;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
@@ -119,6 +120,11 @@ public class IntegrationAutoConfiguration {
 		@ConditionalOnMissingBean(name = PollerMetadata.DEFAULT_POLLER)
 		public PollerMetadata defaultPoller(IntegrationProperties integrationProperties) {
 			IntegrationProperties.Poller poller = integrationProperties.getPoller();
+			int hasCron = poller.getCron() != null ? 1 : 0;
+			int hasFixedDelay = poller.getFixedDelay() != null ? 1 : 0;
+			int hasFixedRate = poller.getFixedRate() != null ? 1 : 0;
+			Assert.isTrue((hasCron + hasFixedDelay + hasFixedRate) <= 1,
+					"The 'cron', 'fixedDelay' and 'fixedRate' are mutually exclusive 'spring.integration.poller' properties.");
 			PollerMetadata pollerMetadata = new PollerMetadata();
 			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 			map.from(poller::getMaxMessagesPerPoll).to(pollerMetadata::setMaxMessagesPerPoll);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationProperties.java
@@ -307,38 +307,42 @@ public class IntegrationProperties {
 		/**
 		 * Maximum of messages to poll per polling cycle.
 		 */
-		private Long maxMessagesPerPoll;
+		private int maxMessagesPerPoll = Integer.MIN_VALUE; // PollerMetadata.MAX_MESSAGES_UNBOUNDED
 
 		/**
 		 * How long to wait for messages on poll.
 		 */
-		private Duration receiveTimeout;
+		private Duration receiveTimeout = Duration.ofSeconds(1); // PollerMetadata.DEFAULT_RECEIVE_TIMEOUT
 
 		/**
 		 * Polling delay period.
+		 * Mutually explusive with 'cron' and 'fixedRate'.
 		 */
 		private Duration fixedDelay;
 
 		/**
 		 * Polling rate period.
+		 * Mutually explusive with 'fixedDelay' and 'cron'.
 		 */
 		private Duration fixedRate;
 
 		/**
 		 * Polling initial delay.
+		 * Applied for 'fixedDelay' and 'fixedRate'; ignored for 'cron'.
 		 */
 		private Duration initialDelay;
 
 		/**
 		 * Cron expression for polling.
+		 * Mutually explusive with 'fixedDelay' and 'fixedRate'.
 		 */
 		private String cron;
 
-		public Long getMaxMessagesPerPoll() {
+		public int getMaxMessagesPerPoll() {
 			return this.maxMessagesPerPoll;
 		}
 
-		public void setMaxMessagesPerPoll(Long maxMessagesPerPoll) {
+		public void setMaxMessagesPerPoll(int maxMessagesPerPoll) {
 			this.maxMessagesPerPoll = maxMessagesPerPoll;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationProperties.java
@@ -315,26 +315,24 @@ public class IntegrationProperties {
 		private Duration receiveTimeout = Duration.ofSeconds(1); // PollerMetadata.DEFAULT_RECEIVE_TIMEOUT
 
 		/**
-		 * Polling delay period.
-		 * Mutually explusive with 'cron' and 'fixedRate'.
+		 * Polling delay period. Mutually explusive with 'cron' and 'fixedRate'.
 		 */
 		private Duration fixedDelay;
 
 		/**
-		 * Polling rate period.
-		 * Mutually explusive with 'fixedDelay' and 'cron'.
+		 * Polling rate period. Mutually explusive with 'fixedDelay' and 'cron'.
 		 */
 		private Duration fixedRate;
 
 		/**
-		 * Polling initial delay.
-		 * Applied for 'fixedDelay' and 'fixedRate'; ignored for 'cron'.
+		 * Polling initial delay. Applied for 'fixedDelay' and 'fixedRate'; ignored for
+		 * 'cron'.
 		 */
 		private Duration initialDelay;
 
 		/**
-		 * Cron expression for polling.
-		 * Mutually explusive with 'fixedDelay' and 'fixedRate'.
+		 * Cron expression for polling. Mutually explusive with 'fixedDelay' and
+		 * 'fixedRate'.
 		 */
 		private String cron;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.integration;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,6 +45,8 @@ public class IntegrationProperties {
 
 	private final RSocket rsocket = new RSocket();
 
+	private final Poller poller = new Poller();
+
 	public Channel getChannel() {
 		return this.channel;
 	}
@@ -62,6 +65,10 @@ public class IntegrationProperties {
 
 	public RSocket getRsocket() {
 		return this.rsocket;
+	}
+
+	public Poller getPoller() {
+		return this.poller;
 	}
 
 	public static class Channel {
@@ -291,6 +298,88 @@ public class IntegrationProperties {
 				this.messageMappingEnabled = messageMappingEnabled;
 			}
 
+		}
+
+	}
+
+	public static class Poller {
+
+		/**
+		 * Maximum of messages to poll per polling cycle.
+		 */
+		private Long maxMessagesPerPoll;
+
+		/**
+		 * How long to wait for messages on poll.
+		 */
+		private Duration receiveTimeout;
+
+		/**
+		 * Polling delay period.
+		 */
+		private Duration fixedDelay;
+
+		/**
+		 * Polling rate period.
+		 */
+		private Duration fixedRate;
+
+		/**
+		 * Polling initial delay.
+		 */
+		private Duration initialDelay;
+
+		/**
+		 * Cron expression for polling.
+		 */
+		private String cron;
+
+		public Long getMaxMessagesPerPoll() {
+			return this.maxMessagesPerPoll;
+		}
+
+		public void setMaxMessagesPerPoll(Long maxMessagesPerPoll) {
+			this.maxMessagesPerPoll = maxMessagesPerPoll;
+		}
+
+		public Duration getReceiveTimeout() {
+			return this.receiveTimeout;
+		}
+
+		public void setReceiveTimeout(Duration receiveTimeout) {
+			this.receiveTimeout = receiveTimeout;
+		}
+
+		public Duration getFixedDelay() {
+			return this.fixedDelay;
+		}
+
+		public void setFixedDelay(Duration fixedDelay) {
+			this.fixedDelay = fixedDelay;
+		}
+
+		public Duration getFixedRate() {
+			return this.fixedRate;
+		}
+
+		public void setFixedRate(Duration fixedRate) {
+			this.fixedRate = fixedRate;
+		}
+
+		public Duration getInitialDelay() {
+			return this.initialDelay;
+		}
+
+		public void setInitialDelay(Duration initialDelay) {
+			this.initialDelay = initialDelay;
+		}
+
+		public String getCron() {
+			return this.cron;
+		}
+
+		public void setCron(String cron) {
+			this.cron = cron;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
@@ -16,13 +16,16 @@
 
 package org.springframework.boot.autoconfigure.integration;
 
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
 import javax.management.MBeanServer;
 import javax.sql.DataSource;
 
 import io.rsocket.transport.ClientTransport;
 import io.rsocket.transport.netty.client.TcpClientTransport;
 import org.junit.jupiter.api.Test;
-
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.DirectFieldAccessor;
@@ -75,10 +78,6 @@ import org.springframework.scheduling.support.CronTrigger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
-
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Tests for {@link IntegrationAutoConfiguration}.
@@ -523,7 +522,7 @@ class IntegrationAutoConfigurationTests {
 
 		@ServiceActivator(inputChannel = "testChannel")
 		@Bean
-		public MessageHandler handler(BlockingQueue<Message<?>> sink) {
+		MessageHandler handler(BlockingQueue<Message<?>> sink) {
 			return sink::add;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
@@ -420,6 +420,16 @@ class IntegrationAutoConfigurationTests {
 				});
 	}
 
+	@Test
+	void triggerPropertiesAreMutuallyExclusive() {
+		this.contextRunner
+				.withPropertyValues("spring.integration.poller.cron=* * * ? * *",
+						"spring.integration.poller.fixed-delay=1s")
+				.run((context) -> assertThat(context).hasFailed().getFailure()
+						.hasRootCauseExactlyInstanceOf(IllegalArgumentException.class).hasMessageContaining(
+								"The 'cron', 'fixedDelay' and 'fixedRate' are mutually exclusive 'spring.integration.poller' properties."));
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class CustomMBeanExporter {
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/messaging/spring-integration.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/messaging/spring-integration.adoc
@@ -5,6 +5,7 @@ Spring Integration provides abstractions over messaging and also other transport
 If Spring Integration is available on your classpath, it is initialized through the `@EnableIntegration` annotation.
 
 Spring Integration polling logic relies <<features#features.task-execution-and-scheduling,on the auto-configured `TaskScheduler`>>.
+The default `PollerMetadata` (poll unbounded number of messages every second) can be customized with `spring.integration.poller.*` configuration properties.
 
 Spring Boot also configures some features that are triggered by the presence of additional Spring Integration modules.
 If `spring-integration-jmx` is also on the classpath, message processing statistics are published over JMX.


### PR DESCRIPTION
When polling consumers or source polling channel adapters
are used in Spring Integration applications, they require
some polling policy to be configured

* Add some sensitive default bean `PollerMetadata` auto-configured
bean which can be overridden by end-user or customized via
respective newly added `spring.integration.poller.*` configuration
properties

For reference a recent StackOverflow question:
https://stackoverflow.com/questions/69175808

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
