### PR TITLE
Detect JDK 17 GA builds

### DIFF
--- a/ci/scripts/detect-jdk-updates.sh
+++ b/ci/scripts/detect-jdk-updates.sh
@@ -17,7 +17,7 @@ case "$JDK_VERSION" in
 		 ISSUE_TITLE="Upgrade Java 11 version in CI image"
 	;;
 	java17)
-		 BASE_URL="https://api.adoptium.net/v3/assets/feature_releases/17/ea"
+		 BASE_URL="https://api.adoptium.net/v3/assets/feature_releases/17/ga"
 		 ISSUE_TITLE="Upgrade Java 17 version in CI image"
 	;;
 	*)


### PR DESCRIPTION
Hi,

somewhen this morning https://api.adoptium.net/v3/assets/feature_releases/17/ga?architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&os=linux&page=0&page_size=10&project=jdk&sort_method=DEFAULT&sort_order=DESC&vendor=adoptium finally started to return GA builds from Adoptium.

This PR changes the update detection to use the GA routes instead of EA. I didn't update the actual JDK urls on purpose, because I wanted to leave this to the CI automation.

Cheers,
Christoph