### PR TITLE
Support PEM format for Kafka SSL certificates and private key (KIP-651)

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
@@ -1047,6 +1047,16 @@ public class KafkaProperties {
 		private String keyPassword;
 
 		/**
+		 * Certificate chain in the format specified by 'ssl.keystore.type'.
+		 */
+		private String keyStoreCertificateChain;
+
+		/**
+		 * Private key in the format specified by 'ssl.keystore.type'.
+		 */
+		private String keyStoreKey;
+
+		/**
 		 * Location of the key store file.
 		 */
 		private Resource keyStoreLocation;
@@ -1060,6 +1070,11 @@ public class KafkaProperties {
 		 * Type of the key store.
 		 */
 		private String keyStoreType;
+
+		/**
+		 * Trusted certificates in the format specified by 'ssl.truststore.type'.
+		 */
+		private String trustStoreCertificates;
 
 		/**
 		 * Location of the trust store file.
@@ -1089,6 +1104,22 @@ public class KafkaProperties {
 			this.keyPassword = keyPassword;
 		}
 
+		public String getKeyStoreCertificateChain() {
+			return keyStoreCertificateChain;
+		}
+
+		public void setKeyStoreCertificateChain(String keyStoreCertificateChain) {
+			this.keyStoreCertificateChain = keyStoreCertificateChain;
+		}
+
+		public String getKeyStoreKey() {
+			return keyStoreKey;
+		}
+
+		public void setKeyStoreKey(String keyStoreKey) {
+			this.keyStoreKey = keyStoreKey;
+		}
+
 		public Resource getKeyStoreLocation() {
 			return this.keyStoreLocation;
 		}
@@ -1111,6 +1142,14 @@ public class KafkaProperties {
 
 		public void setKeyStoreType(String keyStoreType) {
 			this.keyStoreType = keyStoreType;
+		}
+
+		public String getTrustStoreCertificates() {
+			return trustStoreCertificates;
+		}
+
+		public void setTrustStoreCertificates(String trustStoreCertificates) {
+			this.trustStoreCertificates = trustStoreCertificates;
 		}
 
 		public Resource getTrustStoreLocation() {
@@ -1149,10 +1188,14 @@ public class KafkaProperties {
 			Properties properties = new Properties();
 			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 			map.from(this::getKeyPassword).to(properties.in(SslConfigs.SSL_KEY_PASSWORD_CONFIG));
+			map.from(this::getKeyStoreCertificateChain)
+					.to(properties.in(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG));
+			map.from(this::getKeyStoreKey).to(properties.in(SslConfigs.SSL_KEYSTORE_KEY_CONFIG));
 			map.from(this::getKeyStoreLocation).as(this::resourceToPath)
 					.to(properties.in(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG));
 			map.from(this::getKeyStorePassword).to(properties.in(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG));
 			map.from(this::getKeyStoreType).to(properties.in(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG));
+			map.from(this::getTrustStoreCertificates).to(properties.in(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG));
 			map.from(this::getTrustStoreLocation).as(this::resourceToPath)
 					.to(properties.in(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
 			map.from(this::getTrustStorePassword).to(properties.in(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG));


### PR DESCRIPTION
Before [KIP-651](https://cwiki.apache.org/confluence/display/KAFKA/KIP-651+-+Support+PEM+format+for+SSL+certificates+and+private+key) Kafka only supported file-based key and trust stores for SSL.
After KIP-651 it's now also possible to use PEM, which can be passed as environment variables rather than files.
This frees us from having to write files to the Docker images that run our application, and enables us to use build pack images.

Not sure if I've covered all corners in this initial implementation; please let me know if you would like me to make any changes. Tests had not covered Kafka SSL configuration before, and since we're merely passing values I'd not thought to add those now.
Had also thought these changes are not notable enough to include my name as author at the top of the file, but not sure if it would be breaking convention to leave it out.

One thing to note is that the referenced properties were only added in Spring Kafka 2.7, so any users that both downgrade to Kafka 2.6 _and_ use SSL might now pass unknown properties to Kafka, leading to a warning. (Provided the org.apache.kafka.common.config.SslConfigs constants are inlined by the compiler.)