### PR TITLE
Support both kebab-case and camelCase as Spring init CLI Options

### DIFF
--- a/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/InitCommand.java
+++ b/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/InitCommand.java
@@ -128,16 +128,20 @@ public class InitCommand extends OptionParsingCommand {
 			otherOptions();
 		}
 
+		/**
+		 * Supports both kebab-case and camelCase as project CLI Options camelCase to be
+		 * deprecated in future releases
+		 */
 		private void projectGenerationOptions() {
-			this.groupId = option(Arrays.asList("groupId", "g"), "Project coordinates (for example 'org.test')")
-					.withRequiredArg();
-			this.artifactId = option(Arrays.asList("artifactId", "a"),
+			this.groupId = option(Arrays.asList("groupId", "group-id", "g"),
+					"Project coordinates (for example 'org.test')").withRequiredArg();
+			this.artifactId = option(Arrays.asList("artifactId", "artifact-id", "a"),
 					"Project coordinates; infer archive name (for example 'test')").withRequiredArg();
 			this.version = option(Arrays.asList("version", "v"), "Project version (for example '0.0.1-SNAPSHOT')")
 					.withRequiredArg();
 			this.name = option(Arrays.asList("name", "n"), "Project name; infer application name").withRequiredArg();
 			this.description = option("description", "Project description").withRequiredArg();
-			this.packageName = option("package-name", "Package name").withRequiredArg();
+			this.packageName = option(Arrays.asList("packageName", "package-name"), "Package name").withRequiredArg();
 			this.type = option(Arrays.asList("type", "t"),
 					"Project type. Not normally needed if you use --build "
 							+ "and/or --format. Check the capabilities of the service (--list) for more details")
@@ -148,11 +152,11 @@ public class InitCommand extends OptionParsingCommand {
 					.defaultsTo("maven");
 			this.format = option("format", "Format of the generated content (for example 'build' for a build file, "
 					+ "'project' for a project archive)").withRequiredArg().defaultsTo("project");
-			this.javaVersion = option(Arrays.asList("java-version", "j"), "Language level (for example '1.8')")
-					.withRequiredArg();
+			this.javaVersion = option(Arrays.asList("javaVersion", "java-version", "j"),
+					"Language level (for example '1.8')").withRequiredArg();
 			this.language = option(Arrays.asList("language", "l"), "Programming language  (for example 'java')")
 					.withRequiredArg();
-			this.bootVersion = option(Arrays.asList("boot-version", "b"),
+			this.bootVersion = option(Arrays.asList("bootVersion", "boot-version", "b"),
 					"Spring Boot version (for example '1.2.0.RELEASE')").withRequiredArg();
 			this.dependencies = option(Arrays.asList("dependencies", "d"),
 					"Comma-separated list of dependency identifiers to include in the generated project")

--- a/spring-boot-project/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/init/InitCommandTests.java
+++ b/spring-boot-project/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/init/InitCommandTests.java
@@ -273,6 +273,32 @@ class InitCommandTests extends AbstractHttpClientMockTests {
 	}
 
 	@Test
+	void parseProjectWithKebabCaseCLIOptions() throws Exception {
+		this.handler.disableProjectGeneration();
+		this.command.run("--group-id=org.demo", "--artifact-id=acme", "--version=1.2.3-SNAPSHOT", "--name=acme-sample",
+				"--description=Acme sample project", "--package-name=demo.foo", "--type=ant-project", "--build=grunt",
+				"--format=web", "--packaging=war", "--java-version=1.9", "--language=groovy",
+				"--boot-version=1.2.0.RELEASE", "--dependencies=web,data-jpa");
+		assertThat(this.handler.lastRequest.getGroupId()).isEqualTo("org.demo");
+		assertThat(this.handler.lastRequest.getArtifactId()).isEqualTo("acme");
+		assertThat(this.handler.lastRequest.getVersion()).isEqualTo("1.2.3-SNAPSHOT");
+		assertThat(this.handler.lastRequest.getName()).isEqualTo("acme-sample");
+		assertThat(this.handler.lastRequest.getDescription()).isEqualTo("Acme sample project");
+		assertThat(this.handler.lastRequest.getPackageName()).isEqualTo("demo.foo");
+		assertThat(this.handler.lastRequest.getType()).isEqualTo("ant-project");
+		assertThat(this.handler.lastRequest.getBuild()).isEqualTo("grunt");
+		assertThat(this.handler.lastRequest.getFormat()).isEqualTo("web");
+		assertThat(this.handler.lastRequest.getPackaging()).isEqualTo("war");
+		assertThat(this.handler.lastRequest.getJavaVersion()).isEqualTo("1.9");
+		assertThat(this.handler.lastRequest.getLanguage()).isEqualTo("groovy");
+		assertThat(this.handler.lastRequest.getBootVersion()).isEqualTo("1.2.0.RELEASE");
+		List<String> dependencies = this.handler.lastRequest.getDependencies();
+		assertThat(dependencies).hasSize(2);
+		assertThat(dependencies.contains("web")).isTrue();
+		assertThat(dependencies.contains("data-jpa")).isTrue();
+	}
+
+	@Test
 	void overwriteFileInArchive(@TempDir File tempDir) throws Exception {
 		File conflict = new File(tempDir, "test.txt");
 		assertThat(conflict.createNewFile()).as("Should have been able to create file").isTrue();


### PR DESCRIPTION
Spring init CLI to support both kebab-case and camelCase as project generation options. This PR addresses the issue #26878