### PR TITLE
Avoid explicit initialization of Atomics with their default values

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/client/MetricsRestTemplateCustomizerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/client/MetricsRestTemplateCustomizerTests.java
@@ -157,7 +157,7 @@ class MetricsRestTemplateCustomizerTests {
 
 	@Test
 	void whenAutoTimingIsDisabledUriTemplateHandlerDoesNotCaptureUris() {
-		AtomicBoolean enabled = new AtomicBoolean(false);
+		AtomicBoolean enabled = new AtomicBoolean();
 		AutoTimer autoTimer = new AutoTimer() {
 
 			@Override

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/MetricsWebFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/reactive/server/MetricsWebFilterTests.java
@@ -260,7 +260,7 @@ class MetricsWebFilterTests {
 
 	class FaultyWebFluxTagsProvider extends DefaultWebFluxTagsProvider {
 
-		private final AtomicBoolean fail = new AtomicBoolean(false);
+		private final AtomicBoolean fail = new AtomicBoolean();
 
 		FaultyWebFluxTagsProvider() {
 			super(true);

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/FaultyWebMvcTagsProvider.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/web/servlet/FaultyWebMvcTagsProvider.java
@@ -31,7 +31,7 @@ import io.micrometer.core.instrument.Tag;
  */
 class FaultyWebMvcTagsProvider extends DefaultWebMvcTagsProvider {
 
-	private final AtomicBoolean fail = new AtomicBoolean(false);
+	private final AtomicBoolean fail = new AtomicBoolean();
 
 	FaultyWebMvcTagsProvider() {
 		super(true);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplicationShutdownHook.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplicationShutdownHook.java
@@ -60,7 +60,7 @@ class SpringApplicationShutdownHook implements Runnable {
 
 	private final ApplicationContextClosedListener contextCloseListener = new ApplicationContextClosedListener();
 
-	private final AtomicBoolean shutdownHookAdded = new AtomicBoolean(false);
+	private final AtomicBoolean shutdownHookAdded = new AtomicBoolean();
 
 	private boolean inProgress;
 


### PR DESCRIPTION
Hi,

this PR changes calls like `new AtomicBoolean(false)` to `new AtomicBoolean()` as they cause a volatile write which can be saved in cases where the constructor parameter is the default value.

Cheers,
Christoph