### PR TITLE
Fix Integration `fixedRate` property setting

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -140,10 +140,10 @@ public class IntegrationAutoConfiguration {
 				return new CronTrigger(poller.getCron());
 			}
 			if (poller.getFixedDelay() != null) {
-				return createPeriodicTrigger(poller.getFixedDelay(), poller.getInitialDelay(), true);
+				return createPeriodicTrigger(poller.getFixedDelay(), poller.getInitialDelay(), false);
 			}
 			if (poller.getFixedRate() != null) {
-				return createPeriodicTrigger(poller.getFixedRate(), poller.getInitialDelay(), false);
+				return createPeriodicTrigger(poller.getFixedRate(), poller.getInitialDelay(), true);
 			}
 			return null;
 		}


### PR DESCRIPTION
The `spring.integration.poller.fixed-rate` property
must be set to the constructor of the `PeriodicTrigger`
and its `fixedRate` flag should be set to `true`.
The current code-base has it exactly opposite:
the flag is set to `true` when `fixed-delay` is provided

* Fix `IntegrationAutoConfiguration.asTrigger()` method
for the proper `fixedRate` setting logic
* Cover the change with a new test-case
* Add a message handling verification to the `defaultPoller()`
test to be sure that poller auto-configuration works as it is claimed

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
