### PR TITLE
spring-boot-starter-oauth2-client has an unnecessary dependency on com.sun.mail:jakarta.mail

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-oauth2-client/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-oauth2-client/build.gradle
@@ -6,11 +6,8 @@ description = "Starter for using Spring Security's OAuth2/OpenID Connect client 
 
 dependencies {
 	api(project(":spring-boot-project:spring-boot-starters:spring-boot-starter"))
-	api("com.sun.mail:jakarta.mail")
 	api("org.springframework.security:spring-security-config")
 	api("org.springframework.security:spring-security-core")
-	api("org.springframework.security:spring-security-oauth2-client") {
-		exclude group: "com.sun.mail", module: "javax.mail"
-	}
+	api("org.springframework.security:spring-security-oauth2-client")
 	api("org.springframework.security:spring-security-oauth2-jose")
 }


### PR DESCRIPTION
oauth2-client don't depend on any mail dependency, so it's just confusing and causing problems with `javax.mail.*` to `jakarta.mail.*` package name change.

Was introduced with d6a869fa98eaeb3c180a8a3d94dcce8e3f51e204, probably there are more similar cases.