### PR TITLE
spring-boot-starter-test has an unnecessary dependency on jakarta.xml.bind-api

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-test/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-test/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 	api(project(":spring-boot-project:spring-boot-test"))
 	api(project(":spring-boot-project:spring-boot-test-autoconfigure"))
 	api("com.jayway.jsonpath:json-path")
-	api("jakarta.xml.bind:jakarta.xml.bind-api")
 	api("org.assertj:assertj-core")
 	api("org.hamcrest:hamcrest")
 	api("org.junit.jupiter:junit-jupiter")


### PR DESCRIPTION
Same reason as in gh-28308 introduced with d6a869fa98eaeb3c180a8a3d94dcce8e3f51e204

@wilkinsona exclusion was removed in 2fb8c8d27e277150c4f5bf1037f5c76e24292a42