### PR TITLE
Remove obsolete info about Spring Integration's metrics support

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/spring-integration.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/spring-integration.adoc
@@ -45,6 +45,3 @@ Spring Boot can also auto-configure an `ClientRSocketConnector` using configurat
 ----
 
 See the {spring-boot-autoconfigure-module-code}/integration/IntegrationAutoConfiguration.java[`IntegrationAutoConfiguration`] and {spring-boot-autoconfigure-module-code}/integration/IntegrationProperties.java[`IntegrationProperties`] classes for more details.
-
-By default, if a Micrometer `meterRegistry` bean is present, Spring Integration metrics will be managed by Micrometer.
-If you wish to use legacy Spring Integration metrics, add a `DefaultMetricsFactory` bean to the application context.


### PR DESCRIPTION
The `DefaultMetricsFactory` was removed from Spring Integration starting with version `5.4`
The Micrometer is only an engine for metrics, therefore no reason to mention it in the docs at all

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
