### PR TITLE
Exclude additional-config-metadata.json from JAR

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
@@ -45,6 +45,7 @@ publishing.publications.withType(MavenPublication) {
 							delegate.exclude('**/application*.yml')
 							delegate.exclude('**/application*.yaml')
 							delegate.exclude('**/application*.properties')
+							delegate.exclude('META-INF/additional-spring-configuration-metadata.json')
 						}
 					}
 				}


### PR DESCRIPTION
The additional-spring-configuration-metadata.json file is unnecessarily landing in generated modules JARs: refer to spring-boot-autoconfigure.jar as an example.

I assume this is unnecessary as the contents are already merged on spring-configuration-metadata.json produced by spring-boot-configuration-processor, and STS/plugins will not read it when the source is a JAR file.

The proposal is to exclude it from build resources so that build plugins can ignore it when producing the JAR artifact.

ps: Im not creating an issue since this is a very small contribution