### PR TITLE
Expose Elastic's apiKeyCredentials property

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/elastic/ElasticProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/elastic/ElasticProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,12 +60,14 @@ public class ElasticProperties extends StepRegistryProperties {
 	private boolean autoCreateIndex = true;
 
 	/**
-	 * Login user of the Elastic server.
+	 * Login user of the Elastic server. If API key is configured, it will be used for
+	 * authentication instead of username/password.
 	 */
 	private String userName;
 
 	/**
-	 * Login password of the Elastic server.
+	 * Login password of the Elastic server. If API key is configured, it will be used for
+	 * authentication instead of username/password.
 	 */
 	private String password;
 
@@ -73,6 +75,12 @@ public class ElasticProperties extends StepRegistryProperties {
 	 * Ingest pipeline name. By default, events are not pre-processed.
 	 */
 	private String pipeline;
+
+	/**
+	 * Base64-encoded credentials string. If configured, it will be used for
+	 * authentication instead of username/password.
+	 */
+	private String apiKeyCredentials;
 
 	public String getHost() {
 		return this.host;
@@ -144,6 +152,14 @@ public class ElasticProperties extends StepRegistryProperties {
 
 	public void setPipeline(String pipeline) {
 		this.pipeline = pipeline;
+	}
+
+	public String getApiKeyCredentials() {
+		return this.apiKeyCredentials;
+	}
+
+	public void setApiKeyCredentials(String apiKeyCredentials) {
+		this.apiKeyCredentials = apiKeyCredentials;
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/elastic/ElasticPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/elastic/ElasticPropertiesConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,6 +80,11 @@ class ElasticPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter
 	@Override
 	public String pipeline() {
 		return get(ElasticProperties::getPipeline, ElasticConfig.super::pipeline);
+	}
+
+	@Override
+	public String apiKeyCredentials() {
+		return get(ElasticProperties::getApiKeyCredentials, ElasticConfig.super::apiKeyCredentials);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/elastic/ElasticPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/elastic/ElasticPropertiesConfigAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,6 +88,13 @@ class ElasticPropertiesConfigAdapterTests {
 		ElasticProperties properties = new ElasticProperties();
 		properties.setPipeline("testPipeline");
 		assertThat(new ElasticPropertiesConfigAdapter(properties).pipeline()).isEqualTo("testPipeline");
+	}
+
+	@Test
+	void whenPropertiesApiKeyCredentialsIsSetAdapterPipelineReturnsIt() {
+		ElasticProperties properties = new ElasticProperties();
+		properties.setApiKeyCredentials("secret");
+		assertThat(new ElasticPropertiesConfigAdapter(properties).apiKeyCredentials()).isEqualTo("secret");
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/elastic/ElasticPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/elastic/ElasticPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ class ElasticPropertiesTests extends StepRegistryPropertiesTests {
 		assertThat(properties.getUserName()).isEqualTo(config.userName());
 		assertThat(properties.isAutoCreateIndex()).isEqualTo(config.autoCreateIndex());
 		assertThat(properties.getPipeline()).isEqualTo(config.pipeline());
+		assertThat(properties.getApiKeyCredentials()).isEqualTo(config.apiKeyCredentials());
 	}
 
 }


### PR DESCRIPTION
Exposes `apiKeyCredentials` property for Elastic API Key authentication feature, recently added to Micrometer:
- https://github.com/micrometer-metrics/micrometer/issues/2712
- https://github.com/micrometer-metrics/micrometer/pull/2714