### PR TITLE
Expose Stackdriver's useSemanticMetricTypes property

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverProperties.java
@@ -47,6 +47,14 @@ public class StackdriverProperties extends StepRegistryProperties {
 	 */
 	private Map<String, String> resourceLabels;
 
+	/**
+	 * Whether to use semantically correct metric types. When this is false, counter
+	 * metrics are published as the GAUGE MetricKind. When this is true, counter metrics
+	 * are published as the CUMULATIVE MetricKind. This is false by default for the sake
+	 * of backwards compatibility.
+	 */
+	private boolean useSemanticMetricTypes = false;
+
 	public String getProjectId() {
 		return this.projectId;
 	}
@@ -69,6 +77,14 @@ public class StackdriverProperties extends StepRegistryProperties {
 
 	public void setResourceLabels(Map<String, String> resourceLabels) {
 		this.resourceLabels = resourceLabels;
+	}
+
+	boolean isUseSemanticMetricTypes() {
+		return this.useSemanticMetricTypes;
+	}
+
+	void setUseSemanticMetricTypes(boolean useSemanticMetricTypes) {
+		this.useSemanticMetricTypes = useSemanticMetricTypes;
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverPropertiesConfigAdapter.java
@@ -55,4 +55,9 @@ public class StackdriverPropertiesConfigAdapter extends StepRegistryPropertiesCo
 		return get(StackdriverProperties::getResourceLabels, StackdriverConfig.super::resourceLabels);
 	}
 
+	@Override
+	public boolean useSemanticMetricTypes() {
+		return get(StackdriverProperties::isUseSemanticMetricTypes, StackdriverConfig.super::useSemanticMetricTypes);
+	}
+
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverPropertiesConfigAdapterTests.java
@@ -55,4 +55,13 @@ class StackdriverPropertiesConfigAdapterTests {
 				.containsExactlyInAnyOrderEntriesOf(labels);
 	}
 
+	@Test
+	void whenPropertiesUseSemanticMetricTypesIsSetAdapterResourceTypeReturnsIt() {
+		StackdriverProperties properties = new StackdriverProperties();
+		properties.setUseSemanticMetricTypes(true);
+		assertThat(new StackdriverPropertiesConfigAdapter(properties).useSemanticMetricTypes()).isTrue();
+		properties.setUseSemanticMetricTypes(false);
+		assertThat(new StackdriverPropertiesConfigAdapter(properties).useSemanticMetricTypes()).isFalse();
+	}
+
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/stackdriver/StackdriverPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ class StackdriverPropertiesTests extends StepRegistryPropertiesTests {
 		StackdriverConfig config = (key) -> null;
 		assertStepRegistryDefaultValues(properties, config);
 		assertThat(properties.getResourceType()).isEqualTo(config.resourceType());
+		assertThat(properties.isUseSemanticMetricTypes()).isEqualTo(config.useSemanticMetricTypes());
 	}
 
 }


### PR DESCRIPTION
Exposes 'useSemanticMetricTypes' property for Stackdriver, recently added to Micrometer:
- https://github.com/micrometer-metrics/micrometer/issues/2773
- https://github.com/micrometer-metrics/micrometer/pull/2232
