### PR TITLE
Log a debug message with the reason for restarting devtools

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/classpath/ClassPathFileChangeListener.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/classpath/ClassPathFileChangeListener.java
@@ -65,7 +65,7 @@ class ClassPathFileChangeListener implements FileChangeListener {
 	@Override
 	public void onChange(Set<ChangedFiles> changeSet) {
 		boolean restart = isRestartRequired(changeSet);
-		if (logger.isDebugEnabled()) {
+		if (restart && logger.isDebugEnabled()) {
 			logger.debug("Restarting dev tools due to changes in the following files: " + changeSet);
 		}
 		publishEvent(new ClassPathChangedEvent(this, changeSet, restart));

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/classpath/ClassPathFileChangeListener.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/classpath/ClassPathFileChangeListener.java
@@ -18,6 +18,9 @@ package org.springframework.boot.devtools.classpath;
 
 import java.util.Set;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.boot.devtools.filewatch.ChangedFile;
 import org.springframework.boot.devtools.filewatch.ChangedFiles;
 import org.springframework.boot.devtools.filewatch.FileChangeListener;
@@ -34,6 +37,8 @@ import org.springframework.util.Assert;
  * @see ClassPathFileSystemWatcher
  */
 class ClassPathFileChangeListener implements FileChangeListener {
+
+	private static final Log logger = LogFactory.getLog(ClassPathFileChangeListener.class);
 
 	private final ApplicationEventPublisher eventPublisher;
 
@@ -60,6 +65,9 @@ class ClassPathFileChangeListener implements FileChangeListener {
 	@Override
 	public void onChange(Set<ChangedFiles> changeSet) {
 		boolean restart = isRestartRequired(changeSet);
+		if (logger.isDebugEnabled()) {
+			logger.debug("Restarting dev tools due to changes in the following files: " + changeSet);
+		}
 		publishEvent(new ClassPathChangedEvent(this, changeSet, restart));
 	}
 


### PR DESCRIPTION
This helps with debugging certain situations when Spring Boot keeps restarting and the reason is unclear