### PR TITLE
Add support for cache2k in memory caching

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -92,6 +92,8 @@ dependencies {
 	optional("org.apache.tomcat.embed:tomcat-embed-el")
 	optional("org.apache.tomcat:tomcat-jdbc")
 	optional("org.aspectj:aspectjweaver")
+	optional("org.cache2k:cache2k-micrometer")
+	optional("org.cache2k:cache2k-spring")
 	optional("org.eclipse.jetty:jetty-server") {
 		exclude group: "javax.servlet", module: "javax.servlet-api"
 	}
@@ -155,6 +157,7 @@ dependencies {
 	testImplementation("org.aspectj:aspectjrt")
 	testImplementation("org.assertj:assertj-core")
 	testImplementation("org.awaitility:awaitility")
+	testImplementation("org.cache2k:cache2k-api")
 	testImplementation("org.eclipse.jetty:jetty-webapp") {
 		exclude group: "javax.servlet", module: "javax.servlet-api"
 	}
@@ -176,6 +179,7 @@ dependencies {
 
 	testRuntimeOnly("jakarta.management.j2ee:jakarta.management.j2ee-api")
 	testRuntimeOnly("jakarta.transaction:jakarta.transaction-api")
+	testRuntimeOnly("org.cache2k:cache2k-core")
 	testRuntimeOnly("org.springframework.security:spring-security-oauth2-jose")
 	testRuntimeOnly("org.springframework.security:spring-security-oauth2-resource-server")
 	testRuntimeOnly("org.springframework.security:spring-security-saml2-service-provider")

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/cache/CacheMeterBinderProvidersConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/cache/CacheMeterBinderProvidersConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,11 @@ package org.springframework.boot.actuate.autoconfigure.metrics.cache;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.spring.cache.HazelcastCache;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import org.cache2k.Cache2kBuilder;
+import org.cache2k.extra.micrometer.Cache2kCacheMetrics;
+import org.cache2k.extra.spring.SpringCache2kCache;
 
+import org.springframework.boot.actuate.metrics.cache.Cache2kCacheMeterBinderProvider;
 import org.springframework.boot.actuate.metrics.cache.CacheMeterBinderProvider;
 import org.springframework.boot.actuate.metrics.cache.CaffeineCacheMeterBinderProvider;
 import org.springframework.boot.actuate.metrics.cache.HazelcastCacheMeterBinderProvider;
@@ -40,6 +44,17 @@ import org.springframework.data.redis.cache.RedisCache;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(MeterBinder.class)
 class CacheMeterBinderProvidersConfiguration {
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass({ Cache2kBuilder.class, SpringCache2kCache.class, Cache2kCacheMetrics.class })
+	static class Cache2kCacheMeterBinderProviderConfiguration {
+
+		@Bean
+		Cache2kCacheMeterBinderProvider cache2kCacheMeterBinderProvider() {
+			return new Cache2kCacheMeterBinderProvider();
+		}
+
+	}
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass({ CaffeineCache.class, com.github.benmanes.caffeine.cache.Cache.class })

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/cache/CacheMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/cache/CacheMetricsAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,16 @@ class CacheMetricsAutoConfigurationTests {
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().with(MetricsRun.simple())
 			.withUserConfiguration(CachingConfiguration.class).withConfiguration(
 					AutoConfigurations.of(CacheAutoConfiguration.class, CacheMetricsAutoConfiguration.class));
+
+	@Test
+	void autoConfiguredCache2kIsInstrumented() {
+		this.contextRunner.withPropertyValues("spring.cache.type=cache2k", "spring.cache.cache-names=cache1,cache2")
+				.run((context) -> {
+					MeterRegistry registry = context.getBean(MeterRegistry.class);
+					registry.get("cache.gets").tags("name", "cache1").tags("cacheManager", "cacheManager").meter();
+					registry.get("cache.gets").tags("name", "cache2").tags("cacheManager", "cacheManager").meter();
+				});
+	}
 
 	@Test
 	void autoConfiguredCacheManagerIsInstrumented() {

--- a/spring-boot-project/spring-boot-actuator/build.gradle
+++ b/spring-boot-project/spring-boot-actuator/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 	}
 	optional("org.apache.tomcat.embed:tomcat-embed-core")
 	optional("org.aspectj:aspectjweaver")
+	optional("org.cache2k:cache2k-micrometer")
+	optional("org.cache2k:cache2k-spring")
 	optional("org.eclipse.jetty:jetty-server") {
 		exclude(group: "javax.servlet", module: "javax.servlet-api")
 	}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/cache/Cache2kCacheMeterBinderProvider.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/cache/Cache2kCacheMeterBinderProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.metrics.cache;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.cache2k.extra.micrometer.Cache2kCacheMetrics;
+import org.cache2k.extra.spring.SpringCache2kCache;
+
+/**
+ * {@link CacheMeterBinderProvider} implementation for cache2k.
+ *
+ * @author Jens Wilke
+ * @since 2.7.0
+ */
+public class Cache2kCacheMeterBinderProvider implements CacheMeterBinderProvider<SpringCache2kCache> {
+
+	@Override
+	public MeterBinder getMeterBinder(SpringCache2kCache cache, Iterable<Tag> tags) {
+		return new Cache2kCacheMetrics(cache.getNativeCache(), tags);
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/cache/Cache2kCacheMeterBinderProviderTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/cache/Cache2kCacheMeterBinderProviderTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.metrics.cache;
+
+import java.util.Collections;
+
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.cache2k.extra.micrometer.Cache2kCacheMetrics;
+import org.cache2k.extra.spring.SpringCache2kCacheManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link Cache2kCacheMeterBinderProvider}.
+ *
+ * @author Stephane Nicoll
+ */
+class Cache2kCacheMeterBinderProviderTests {
+
+	@Test
+	void cache2kCacheProvider() {
+		SpringCache2kCacheManager cacheManager = new SpringCache2kCacheManager()
+				.addCaches((builder) -> builder.name("test"));
+		MeterBinder meterBinder = new Cache2kCacheMeterBinderProvider().getMeterBinder(cacheManager.getCache("test"),
+				Collections.emptyList());
+		assertThat(meterBinder).isInstanceOf(Cache2kCacheMetrics.class);
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-autoconfigure/build.gradle
@@ -77,6 +77,8 @@ dependencies {
 	optional("com.zaxxer:HikariCP")
 	optional("nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect")
 	optional("org.aspectj:aspectjweaver")
+	optional("org.cache2k:cache2k-spring")
+	optional("org.cache2k:cache2k-micrometer")
 	optional("org.eclipse.jetty:jetty-webapp") {
 		exclude group: "javax.servlet", module: "javax.servlet-api"
 		exclude(group: "org.eclipse.jetty", module: "jetty-jndi")

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/Cache2kCacheConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/Cache2kCacheConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import java.util.Collection;
+
+import org.cache2k.Cache2kBuilder;
+import org.cache2k.extra.spring.SpringCache2kCacheManager;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * Cache2k cache configuration.
+ *
+ * @author Jens Wilke
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass({ Cache2kBuilder.class, SpringCache2kCacheManager.class })
+@ConditionalOnMissingBean(CacheManager.class)
+@Conditional(CacheCondition.class)
+class Cache2kCacheConfiguration {
+
+	@Bean
+	SpringCache2kCacheManager cacheManager(CacheProperties cacheProperties, CacheManagerCustomizers customizers,
+			ObjectProvider<Cache2kDefaults> defaults) {
+		SpringCache2kCacheManager cacheManager = new SpringCache2kCacheManager();
+		Cache2kDefaults specifiedDefaults = defaults.getIfAvailable();
+		if (specifiedDefaults != null) {
+			cacheManager.defaultSetup((builder) -> {
+				specifiedDefaults.customize(builder);
+				return builder;
+			});
+		}
+		Collection<String> cacheNames = cacheProperties.getCacheNames();
+		if (!CollectionUtils.isEmpty(cacheNames)) {
+			cacheManager.setDefaultCacheNames(cacheNames);
+		}
+		return customizers.customize(cacheManager);
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/Cache2kDefaults.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/Cache2kDefaults.java
@@ -16,59 +16,17 @@
 
 package org.springframework.boot.autoconfigure.cache;
 
+import org.cache2k.Cache2kBuilder;
+
 /**
- * Supported cache types (defined in order of precedence).
+ * Default configuration for cache2k when Spring boot auto configuration is creating the
+ * Cache Manager.
  *
- * @author Stephane Nicoll
- * @author Phillip Webb
- * @author Eddú Meléndez
- * @since 1.3.0
+ * @author Jens Wilke
+ * @since 2.7.0
  */
-public enum CacheType {
+public interface Cache2kDefaults {
 
-	/**
-	 * Generic caching using 'Cache' beans from the context.
-	 */
-	GENERIC,
-
-	/**
-	 * JCache (JSR-107) backed caching.
-	 */
-	JCACHE,
-
-	/**
-	 * Hazelcast backed caching.
-	 */
-	HAZELCAST,
-
-	/**
-	 * Couchbase backed caching.
-	 */
-	COUCHBASE,
-
-	/**
-	 * Redis backed caching.
-	 */
-	REDIS,
-
-	/**
-	 * Cache2k backed caching.
-	 */
-	CACHE2K,
-
-	/**
-	 * Caffeine backed caching.
-	 */
-	CAFFEINE,
-
-	/**
-	 * Simple in-memory caching.
-	 */
-	SIMPLE,
-
-	/**
-	 * No caching.
-	 */
-	NONE
+	void customize(Cache2kBuilder<?, ?> builder);
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheConfigurations.java
@@ -41,6 +41,7 @@ final class CacheConfigurations {
 		mappings.put(CacheType.COUCHBASE, CouchbaseCacheConfiguration.class.getName());
 		mappings.put(CacheType.REDIS, RedisCacheConfiguration.class.getName());
 		mappings.put(CacheType.CAFFEINE, CaffeineCacheConfiguration.class.getName());
+		mappings.put(CacheType.CACHE2K, Cache2kCacheConfiguration.class.getName());
 		mappings.put(CacheType.SIMPLE, SimpleCacheConfiguration.class.getName());
 		mappings.put(CacheType.NONE, NoOpCacheConfiguration.class.getName());
 		MAPPINGS = Collections.unmodifiableMap(mappings);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/AbstractCacheAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/AbstractCacheAutoConfigurationTests.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.hazelcast.spring.cache.HazelcastCacheManager;
+import org.cache2k.extra.spring.SpringCache2kCacheManager;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
@@ -115,6 +116,13 @@ abstract class AbstractCacheAutoConfigurationTests {
 		@Bean
 		CacheManagerCustomizer<HazelcastCacheManager> hazelcastCacheManagerCustomizer() {
 			return new CacheManagerTestCustomizer<>() {
+
+			};
+		}
+
+		@Bean
+		CacheManagerCustomizer<SpringCache2kCacheManager> cache2kCacheManagerCustomizer() {
+			return new CacheManagerTestCustomizer<SpringCache2kCacheManager>() {
 
 			};
 		}

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -87,6 +87,18 @@ bom {
 			]
 		}
 	}
+	library("cache2k", "2.6.1.Final") {
+		group("org.cache2k") {
+			modules = [
+					"cache2k-api",
+					"cache2k-config",
+					"cache2k-core",
+					"cache2k-jcache",
+					"cache2k-micrometer",
+					"cache2k-spring"
+			]
+		}
+	}
 	library("Caffeine", "3.0.5") {
 		group("com.github.ben-manes.caffeine") {
 			modules = [


### PR DESCRIPTION
cache2k is a highly efficient in memory cache with low memory overhead and high throughput.
Cache2k outperforms all other caches by a factor of two or more for cache friendly workloads,
see the latest benchmarks at: https://cache2k.org/benchmarks.html.

Cache2k has a bunch of features not available in other caches, that help to build
low latency and resilient applications, e.g. refresh ahead, resilience and exception support.

There is a well defined Java caching API (see: https://cache2k.org/docs/latest/apidocs/cache2k-api/index.html) as well as an extensive user guide (see: https://cache2k.org/docs/latest/user-guide.html).

Additional goodies are support for JSR107/JCache, JMX statistics and management like online cache size tuning,
Spring Framework integration and micrometer statistics export.

With 400kB cache2k is one of the most compact and feature rich caching libraries. It supports pure
Java 8 without making use of `sun.misc.Unsafe`. With the next version of cache2k it is planed to 
require Java 11 and use its advanced features to improve the performance and efficiency even more.

Spring framework support in cache2k is available for a while. Comparing to Caffeine it supports 
configuration of individual caches out of the box, see: 
https://cache2k.org/docs/latest/user-guide.html#spring

This pull request adds Spring Boot support for cache2k.
