### PR TITLE
Avoid duplicate AOP proxy class definition with FilteredClassLoader

### DIFF
--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/FilteredClassLoaderTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/FilteredClassLoaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.core.io.ClassPathResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  * Tests for {@link FilteredClassLoader}.
@@ -108,6 +109,15 @@ class FilteredClassLoaderTests {
 		try (FilteredClassLoader classLoader = new FilteredClassLoader((resourceName) -> false)) {
 			final InputStream loaded = classLoader.getResourceAsStream(TEST_RESOURCE.getPath());
 			assertThat(loaded).isNotNull();
+		}
+	}
+
+	@Test
+	void publicDefineClassWhenFilteredThrowsException() throws Exception {
+		Class<FilteredClassLoaderTests> hiddenClass = FilteredClassLoaderTests.class;
+		try (FilteredClassLoader classLoader = new FilteredClassLoader(hiddenClass)) {
+			assertThatIllegalArgumentException()
+					.isThrownBy(() -> classLoader.publicDefineClass(hiddenClass.getName(), new byte[] {}, null));
 		}
 	}
 

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/runner/AbstractApplicationContextRunnerTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/runner/AbstractApplicationContextRunnerTests.java
@@ -28,6 +28,8 @@ import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.annotation.UserConfigurations;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.assertj.ApplicationContextAssertProvider;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -36,6 +38,7 @@ import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.util.ClassUtils;
@@ -169,6 +172,15 @@ abstract class AbstractApplicationContextRunnerTests<T extends AbstractApplicati
 	}
 
 	@Test
+	void consecutiveRunWithFilteredClassLoaderShouldHaveBeanWithLazyProperties() {
+		get().withClassLoader(new FilteredClassLoader(Gson.class)).withUserConfiguration(LazyConfig.class)
+				.run((context) -> assertThat(context).hasSingleBean(ExampleBeanWithLazyProperties.class));
+
+		get().withClassLoader(new FilteredClassLoader(Gson.class)).withUserConfiguration(LazyConfig.class)
+				.run((context) -> assertThat(context).hasSingleBean(ExampleBeanWithLazyProperties.class));
+	}
+
+	@Test
 	void thrownRuleWorksWithCheckedException() {
 		get().run((context) -> assertThatIOException().isThrownBy(() -> throwCheckedException("Expected message"))
 				.withMessageContaining("Expected message"));
@@ -257,6 +269,30 @@ abstract class AbstractApplicationContextRunnerTests<T extends AbstractApplicati
 	@Configuration(proxyBeanMethods = false)
 	@Conditional(FilteredClassLoaderCondition.class)
 	static class ConditionalConfig {
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableConfigurationProperties(ExampleProperties.class)
+	static class LazyConfig {
+
+		@Bean
+		ExampleBeanWithLazyProperties exampleBeanWithLazyProperties() {
+			return new ExampleBeanWithLazyProperties();
+		}
+
+	}
+
+	static class ExampleBeanWithLazyProperties {
+
+		@Autowired
+		@Lazy
+		ExampleProperties exampleProperties;
+
+	}
+
+	@ConfigurationProperties
+	public static class ExampleProperties {
 
 	}
 


### PR DESCRIPTION
Hi,

this is an attempt to fix #28528, which I believe is a similar case like https://github.com/spring-projects/spring-framework/issues/26601.

In a nutshell this PR therefore implements `SmartClassLoader` in `FilteredClassLoader`.

Let me know what you think.
Cheers,
Christoph