### PR TITLE
Fix typo in "Ant-style path matching"

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging.adoc
@@ -353,7 +353,7 @@ These closures are evaluated in the order that they are defined, from top to bot
 Any content not claimed by an earlier `intoLayer` closure remains available for subsequent ones to consider.
 
 The `intoLayer` closure claims content using nested `include` and `exclude` calls.
-The `application` closure uses Ant-style patch matching for include/exclude parameters.
+The `application` closure uses Ant-style path matching for include/exclude parameters.
 The `dependencies` section uses `group:artifact[:version]` patterns.
 It also provides `includeProjectDependencies()` and `excludeProjectDependencies()` methods that can be used to include or exclude project dependencies.
 


### PR DESCRIPTION
When reading the documentation I stumbled upon this typo. I know ANT-style path matching... patch matching I never heard of.