### PR TITLE
Ignore JUnit annotations when caching test contexts

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/ImportsContextCustomizer.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/ImportsContextCustomizer.java
@@ -223,6 +223,7 @@ class ImportsContextCustomizer implements ContextCustomizer {
 			filters.add(new JavaLangAnnotationFilter());
 			filters.add(new KotlinAnnotationFilter());
 			filters.add(new SpockAnnotationFilter());
+			filters.add(new JunitAnnotationFilter());
 			ANNOTATION_FILTERS = Collections.unmodifiableSet(filters);
 		}
 
@@ -385,4 +386,15 @@ class ImportsContextCustomizer implements ContextCustomizer {
 
 	}
 
+	/**
+	 * {@link AnnotationFilter} for Spock annotations.
+	 */
+	private static final class JunitAnnotationFilter implements AnnotationFilter {
+
+		@Override
+		public boolean isIgnored(Annotation annotation) {
+			return annotation.annotationType().getName().startsWith("org.junit.");
+		}
+
+	}
 }


### PR DESCRIPTION
Hello spring-team :wave:

As JUnit Jupiter comes with many new features through annotations (such as `@TestInstance` or `@Order`), it makes sens that they be ignored by the *key* created by `ImportsContextCustomizer`.

This is a small patch, but one can wonder if the *key* should not consider only `org.springframework.*` annotations or supply an extension point for custom user-defined annotations to be ignored when creating the context caching key (part).

Let me know if you need more contexts.

Best regards !