### PR TITLE
Expose RestClientBuilder when RestHighLevelClient is not available

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticSearchRestHealthContributorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticSearchRestHealthContributorAutoConfiguration.java
@@ -16,43 +16,31 @@
 
 package org.springframework.boot.actuate.autoconfigure.elasticsearch;
 
-import java.util.Map;
-
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestHighLevelClient;
 
-import org.springframework.boot.actuate.autoconfigure.health.CompositeHealthContributorConfiguration;
+import org.springframework.boot.actuate.autoconfigure.elasticsearch.ElasticSearchRestHealthContributorConfigurations.RestClientHealthContributorConfiguration;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
-import org.springframework.boot.actuate.elasticsearch.ElasticsearchRestHealthIndicator;
-import org.springframework.boot.actuate.health.HealthContributor;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 /**
- * {@link EnableAutoConfiguration Auto-configuration} for
- * {@link ElasticsearchRestHealthIndicator} using the {@link RestClient}.
+ * {@link EnableAutoConfiguration Auto-configuration} for for Elasticsearch health
+ * incidator using REST clients.
  *
  * @author Artsiom Yudovin
  * @since 2.1.1
  */
+@SuppressWarnings("deprecation")
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass(RestHighLevelClient.class)
-@ConditionalOnBean(RestHighLevelClient.class)
+@ConditionalOnClass(RestClient.class)
 @ConditionalOnEnabledHealthIndicator("elasticsearch")
 @AutoConfigureAfter(ElasticsearchRestClientAutoConfiguration.class)
-public class ElasticSearchRestHealthContributorAutoConfiguration
-		extends CompositeHealthContributorConfiguration<ElasticsearchRestHealthIndicator, RestHighLevelClient> {
-
-	@Bean
-	@ConditionalOnMissingBean(name = { "elasticsearchHealthIndicator", "elasticsearchHealthContributor" })
-	public HealthContributor elasticsearchHealthContributor(Map<String, RestHighLevelClient> clients) {
-		return createContributor(clients);
-	}
+@Import({ ElasticSearchRestHealthContributorConfigurations.RestHighLevelClientHealthContributorConfiguration.class,
+		RestClientHealthContributorConfiguration.class })
+public class ElasticSearchRestHealthContributorAutoConfiguration {
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticSearchRestHealthContributorConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticSearchRestHealthContributorConfigurations.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.elasticsearch;
+
+import java.util.Map;
+
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+
+import org.springframework.boot.actuate.autoconfigure.health.CompositeHealthContributorConfiguration;
+import org.springframework.boot.actuate.elasticsearch.ElasticsearchRestClientHealthIndicator;
+import org.springframework.boot.actuate.health.HealthContributor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Elasticsearch rest client health contributor configurations.
+ *
+ * @author Filip Hrisafov
+ */
+class ElasticSearchRestHealthContributorConfigurations {
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(RestHighLevelClient.class)
+	@ConditionalOnBean(RestHighLevelClient.class)
+	@Deprecated
+	static class RestHighLevelClientHealthContributorConfiguration extends
+			CompositeHealthContributorConfiguration<org.springframework.boot.actuate.elasticsearch.ElasticsearchRestHealthIndicator, RestHighLevelClient> {
+
+		@Bean
+		@ConditionalOnMissingBean(name = { "elasticsearchHealthIndicator", "elasticsearchHealthContributor" })
+		HealthContributor elasticsearchHealthContributor(Map<String, RestHighLevelClient> clients) {
+			return createContributor(clients);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnBean(RestClient.class)
+	@ConditionalOnMissingBean(RestHighLevelClient.class)
+	static class RestClientHealthContributorConfiguration
+			extends CompositeHealthContributorConfiguration<ElasticsearchRestClientHealthIndicator, RestClient> {
+
+		@Bean
+		@ConditionalOnMissingBean(name = { "elasticsearchHealthIndicator", "elasticsearchHealthContributor" })
+		HealthContributor elasticsearchHealthContributor(Map<String, RestClient> clients) {
+			return createContributor(clients);
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticsearchRestHealthContributorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/elasticsearch/ElasticsearchRestHealthContributorAutoConfigurationTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.elasticsearch;
+
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
+import org.springframework.boot.actuate.elasticsearch.ElasticsearchRestClientHealthIndicator;
+import org.springframework.boot.actuate.elasticsearch.ElasticsearchRestHealthIndicator;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ElasticsearchRestClientAutoConfiguration}.
+ *
+ * @author Filip Hrisafov
+ */
+class ElasticsearchRestHealthContributorAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(ElasticsearchRestClientAutoConfiguration.class,
+					ElasticSearchRestHealthContributorAutoConfiguration.class,
+					HealthContributorAutoConfiguration.class));
+
+	@Test
+	@SuppressWarnings("deprecation")
+	void runShouldCreateIndicator() {
+		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(ElasticsearchRestHealthIndicator.class)
+				.hasBean("elasticsearchHealthContributor"));
+	}
+
+	@Test
+	void runWithoutRestHighLevelClientAndWithoutRestClientShouldNotCreateIndicator() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader(RestHighLevelClient.class))
+				.run((context) -> assertThat(context).doesNotHaveBean(ElasticsearchRestClientHealthIndicator.class)
+						.doesNotHaveBean("elasticsearchHealthContributor"));
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	void runWithoutRestHighLevelClientAndWithRestClientShouldCreateIndicator() {
+		this.contextRunner.withUserConfiguration(CustomRestClientConfiguration.class)
+				.run((context) -> assertThat(context).hasSingleBean(ElasticsearchRestClientHealthIndicator.class)
+						.doesNotHaveBean(ElasticsearchRestHealthIndicator.class)
+						.hasBean("elasticsearchHealthContributor"));
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	void runWithRestHighLevelClientAndWithRestClientShouldCreateIndicator() {
+		this.contextRunner.withUserConfiguration(CustomRestClientConfiguration.class)
+				.run((context) -> assertThat(context).hasSingleBean(ElasticsearchRestHealthIndicator.class)
+						.hasBean("elasticsearchHealthContributor"));
+	}
+
+	@Test
+	void runWhenDisabledShouldNotCreateIndicator() {
+		this.contextRunner.withPropertyValues("management.health.elasticsearch.enabled:false")
+				.run((context) -> assertThat(context).doesNotHaveBean(ElasticsearchRestClientHealthIndicator.class)
+						.doesNotHaveBean("elasticsearchHealthContributor"));
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomRestClientConfiguration {
+
+		@Bean
+		RestClient customRestClient(RestClientBuilder builder) {
+			return builder.build();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomRestHighClientConfiguration {
+
+		@Bean
+		RestHighLevelClient customRestHighClient(RestClientBuilder builder) {
+			return new RestHighLevelClient(builder);
+		}
+
+		@Bean
+		RestClient customClient(RestHighLevelClient restHighLevelClient) {
+			return restHighLevelClient.getLowLevelClient();
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/elasticsearch/ElasticsearchRestClientHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/elasticsearch/ElasticsearchRestClientHealthIndicator.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.elasticsearch;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.json.JsonParser;
+import org.springframework.boot.json.JsonParserFactory;
+import org.springframework.util.StreamUtils;
+
+/**
+ * {@link HealthIndicator} for an Elasticsearch cluster using a {@link RestClient}.
+ *
+ * @author Artsiom Yudovin
+ * @author Brian Clozel
+ * @author Filip Hrisafov
+ * @since 2.6
+ */
+public class ElasticsearchRestClientHealthIndicator extends AbstractHealthIndicator {
+
+	private static final String RED_STATUS = "red";
+
+	private final RestClient client;
+
+	private final JsonParser jsonParser;
+
+	public ElasticsearchRestClientHealthIndicator(RestClient client) {
+		super("Elasticsearch health check failed");
+		this.client = client;
+		this.jsonParser = JsonParserFactory.getJsonParser();
+	}
+
+	@Override
+	protected void doHealthCheck(Health.Builder builder) throws Exception {
+		Response response = this.client.performRequest(new Request("GET", "/_cluster/health/"));
+		StatusLine statusLine = response.getStatusLine();
+		if (statusLine.getStatusCode() != HttpStatus.SC_OK) {
+			builder.down();
+			builder.withDetail("statusCode", statusLine.getStatusCode());
+			builder.withDetail("reasonPhrase", statusLine.getReasonPhrase());
+			return;
+		}
+		try (InputStream inputStream = response.getEntity().getContent()) {
+			doHealthCheck(builder, StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8));
+		}
+	}
+
+	private void doHealthCheck(Health.Builder builder, String json) {
+		Map<String, Object> response = this.jsonParser.parseMap(json);
+		String status = (String) response.get("status");
+		if (RED_STATUS.equals(status)) {
+			builder.outOfService();
+		}
+		else {
+			builder.up();
+		}
+		builder.withDetails(response);
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/elasticsearch/ElasticsearchRestHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/elasticsearch/ElasticsearchRestHealthIndicator.java
@@ -16,75 +16,31 @@
 
 package org.springframework.boot.actuate.elasticsearch;
 
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
-
-import org.apache.http.HttpStatus;
-import org.apache.http.StatusLine;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 
-import org.springframework.boot.actuate.health.AbstractHealthIndicator;
-import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.boot.json.JsonParser;
-import org.springframework.boot.json.JsonParserFactory;
-import org.springframework.util.StreamUtils;
 
 /**
- * {@link HealthIndicator} for an Elasticsearch cluster using a {@link RestClient}.
+ * {@link HealthIndicator} for an Elasticsearch cluster using a {@link RestClient} or a
+ * {@link RestHighLevelClient}.
  *
  * @author Artsiom Yudovin
  * @author Brian Clozel
  * @author Filip Hrisafov
  * @since 2.1.1
+ * @deprecated since 2.6.0 for removal in 2.8.0 in favor of
+ * {@link ElasticsearchRestClientHealthIndicator}
  */
-public class ElasticsearchRestHealthIndicator extends AbstractHealthIndicator {
-
-	private static final String RED_STATUS = "red";
-
-	private final RestClient client;
-
-	private final JsonParser jsonParser;
+@Deprecated
+public class ElasticsearchRestHealthIndicator extends ElasticsearchRestClientHealthIndicator {
 
 	public ElasticsearchRestHealthIndicator(RestHighLevelClient client) {
 		this(client.getLowLevelClient());
 	}
 
 	public ElasticsearchRestHealthIndicator(RestClient client) {
-		super("Elasticsearch health check failed");
-		this.client = client;
-		this.jsonParser = JsonParserFactory.getJsonParser();
-	}
-
-	@Override
-	protected void doHealthCheck(Health.Builder builder) throws Exception {
-		Response response = this.client.performRequest(new Request("GET", "/_cluster/health/"));
-		StatusLine statusLine = response.getStatusLine();
-		if (statusLine.getStatusCode() != HttpStatus.SC_OK) {
-			builder.down();
-			builder.withDetail("statusCode", statusLine.getStatusCode());
-			builder.withDetail("reasonPhrase", statusLine.getReasonPhrase());
-			return;
-		}
-		try (InputStream inputStream = response.getEntity().getContent()) {
-			doHealthCheck(builder, StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8));
-		}
-	}
-
-	private void doHealthCheck(Health.Builder builder, String json) {
-		Map<String, Object> response = this.jsonParser.parseMap(json);
-		String status = (String) response.get("status");
-		if (RED_STATUS.equals(status)) {
-			builder.outOfService();
-		}
-		else {
-			builder.up();
-		}
-		builder.withDetails(response);
+		super(client);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/elasticsearch/ElasticsearchRestClientHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/elasticsearch/ElasticsearchRestClientHealthIndicatorTests.java
@@ -37,17 +37,16 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 /**
- * Tests for {@link ElasticsearchRestHealthIndicator}.
+ * Tests for {@link ElasticsearchRestClientHealthIndicator}.
  *
  * @author Artsiom Yudovin
  * @author Filip Hrisafov
  */
-@Deprecated
-class ElasticsearchRestHealthIndicatorTests {
+class ElasticsearchRestClientHealthIndicatorTests {
 
 	private final RestClient restClient = mock(RestClient.class);
 
-	private final ElasticsearchRestHealthIndicator elasticsearchRestHealthIndicator = new ElasticsearchRestHealthIndicator(
+	private final ElasticsearchRestClientHealthIndicator elasticsearchRestHealthIndicator = new ElasticsearchRestClientHealthIndicator(
 			this.restClient);
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfiguration.java
@@ -16,12 +16,10 @@
 
 package org.springframework.boot.autoconfigure.elasticsearch;
 
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.RestClientBuilder;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientConfigurations.RestClientBuilderConfiguration;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientConfigurations.RestClientSnifferConfiguration;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientConfigurations.RestHighLevelClientConfiguration;
@@ -38,8 +36,7 @@ import org.springframework.context.annotation.Import;
  */
 @SuppressWarnings("deprecation")
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass(RestHighLevelClient.class)
-@ConditionalOnMissingBean(RestClient.class)
+@ConditionalOnClass(RestClientBuilder.class)
 @EnableConfigurationProperties({ ElasticsearchProperties.class, ElasticsearchRestClientProperties.class,
 		DeprecatedElasticsearchRestClientProperties.class })
 @Import({ RestClientBuilderConfiguration.class, RestHighLevelClientConfiguration.class,

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java
@@ -112,7 +112,8 @@ class ElasticsearchRestClientConfigurations {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnMissingBean(RestHighLevelClient.class)
+	@ConditionalOnClass(RestHighLevelClient.class)
+	@ConditionalOnMissingBean({ RestHighLevelClient.class, RestClient.class })
 	static class RestHighLevelClientConfiguration {
 
 		@Bean


### PR DESCRIPTION
This commits exposes the RestClientBuilder as a bean even when the RestHighLevelClient is not available
It allows users to create their own RestClient beans using the Spring Boot configured RestClientBuilder
when they are not using the RestHighLevelClient.

In addition to that a new ElasticsearchRestClientHealthIndicator decoupled from the RestHighLevelClient has been added
and is used as an elasticsearch health contributor when there are no RestHighLevelClient beans.

This is similar to PR #28496, with the difference being that this is a potential proposal for 2.6.0. With this people can freely remove the dependency on the `RestHighLevelClient` and have all the benefits from Spring Boot in 2.6.