### PR TITLE
Add Kotlin Symbol Processor for auto configuration

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id "java-library"
+	id "org.jetbrains.kotlin.jvm"
 	id "org.springframework.boot.conventions"
 	id "org.springframework.boot.deployed"
 	id "org.springframework.boot.annotation-processor"
@@ -8,10 +9,14 @@ plugins {
 description = "Spring Boot AutoConfigure Annotation Processor"
 
 dependencies {
+	implementation("com.google.devtools.ksp:symbol-processing-api:1.5.31-1.0.1")
+
+	testImplementation(project(":spring-boot-project:spring-boot-autoconfigure"))
 	testImplementation(enforcedPlatform(project(":spring-boot-project:spring-boot-dependencies")))
 	testImplementation(project(":spring-boot-project:spring-boot-tools:spring-boot-test-support"))
 	testImplementation("org.assertj:assertj-core")
 	testImplementation("org.springframework:spring-core")
 	testImplementation("org.springframework:spring-core-test")
 	testImplementation("org.junit.jupiter:junit-jupiter")
+	testImplementation("com.github.tschuchortdev:kotlin-compile-testing-ksp:1.4.5")
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/BaseAnnotationProcessor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/BaseAnnotationProcessor.java
@@ -1,0 +1,28 @@
+package org.springframework.boot.autoconfigureprocessor;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public class BaseAnnotationProcessor {
+
+	public static void writeProperties(
+			Map<String, String> properties,
+			OutputStream outputStream
+	) throws IOException {
+		if (properties.isEmpty()) {
+			return;
+		}
+		try (Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+			for (Map.Entry<String, String> entry : properties.entrySet()) {
+				writer.append(entry.getKey());
+				writer.append("=");
+				writer.append(entry.getValue());
+				writer.append(System.lineSeparator());
+			}
+		}
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/Elements.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/Elements.java
@@ -26,12 +26,12 @@ import javax.lang.model.type.TypeMirror;
  *
  * @author Phillip Webb
  */
-final class Elements {
+public final class Elements {
 
 	private Elements() {
 	}
 
-	static String getQualifiedName(Element element) {
+	public static String getQualifiedName(Element element) {
 		if (element != null) {
 			TypeElement enclosingElement = getEnclosingTypeElement(element.asType());
 			if (enclosingElement != null) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/extractor/AbstractValueExtractor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/extractor/AbstractValueExtractor.java
@@ -1,0 +1,54 @@
+package org.springframework.boot.autoconfigureprocessor.extractor;
+
+import com.google.devtools.ksp.symbol.KSName;
+import com.google.devtools.ksp.symbol.KSType;
+import com.google.devtools.ksp.symbol.KSValueArgument;
+import org.springframework.boot.autoconfigureprocessor.Elements;
+
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.type.DeclaredType;
+import java.util.List;
+import java.util.stream.Stream;
+
+abstract class AbstractValueExtractor implements ValueExtractor {
+
+	Object getValue(Object annotation) {
+		if (annotation instanceof AnnotationValue) {
+			return ((AnnotationValue) annotation).getValue();
+		}
+		if (annotation instanceof KSValueArgument) {
+			return ((KSValueArgument) annotation).getValue();
+		}
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	protected Stream<Object> extractValues(Object annotationValue) {
+		if (annotationValue == null) {
+			return Stream.empty();
+		}
+		Object value = getValue(annotationValue);
+		if (value instanceof List) {
+			return ((List<AnnotationValue>) value).stream()
+					.map((annotation) -> extractValue(annotation.getValue()));
+		}
+		return Stream.of(extractValue(value));
+	}
+
+	private Object extractValue(Object value) {
+		if (value instanceof DeclaredType) {
+			return Elements.getQualifiedName(((DeclaredType) value).asElement());
+		}
+		if (value instanceof KSType) {
+			KSName name = ((KSType) value).getDeclaration().getQualifiedName();
+			if (name != null) {
+				return name.asString();
+			} else {
+				return null;
+			}
+		}
+		return value;
+	}
+
+
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/extractor/NamedValuesExtractor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/extractor/NamedValuesExtractor.java
@@ -1,0 +1,54 @@
+package org.springframework.boot.autoconfigureprocessor.extractor;
+
+import com.google.devtools.ksp.symbol.KSAnnotation;
+
+import javax.lang.model.element.AnnotationMirror;
+import java.util.*;
+
+public class NamedValuesExtractor extends AbstractValueExtractor {
+
+
+	private final Set<String> names;
+
+	public NamedValuesExtractor(String... names) {
+		this.names = new HashSet<>(Arrays.asList(names));
+	}
+
+	@Override
+	public List<Object> getValues(Object annotation) {
+		if (annotation instanceof AnnotationMirror) {
+			return getValues2((AnnotationMirror) annotation);
+		}
+		if (annotation instanceof KSAnnotation) {
+			return getValues2((KSAnnotation) annotation);
+		}
+		return Collections.emptyList();
+	}
+
+	private List<Object> getValues2(AnnotationMirror annotation) {
+		List<Object> result = new ArrayList<>();
+		annotation.getElementValues().forEach((key, value) -> {
+			if (this.names.contains(key.getSimpleName().toString())) {
+				extractValues(value).forEach(result::add);
+			}
+		});
+		return result;
+	}
+
+	private List<Object> getValues2(KSAnnotation annotation) {
+		List<Object> result = new ArrayList<>();
+		annotation.getArguments().forEach((arg) -> {
+			String argName;
+			if (arg.getName() != null) {
+				argName = arg.getName().getShortName();
+			} else {
+				argName = null;
+			}
+
+			if (this.names.contains(argName)) {
+				extractValues(arg.getValue()).forEach(result::add);
+			}
+		});
+		return result;
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/extractor/OnBeanConditionValueExtractor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/extractor/OnBeanConditionValueExtractor.java
@@ -1,0 +1,39 @@
+package org.springframework.boot.autoconfigureprocessor.extractor;
+
+import com.google.devtools.ksp.symbol.KSAnnotation;
+import com.google.devtools.ksp.symbol.KSName;
+
+import javax.lang.model.element.AnnotationMirror;
+import java.util.*;
+
+public class OnBeanConditionValueExtractor extends AbstractValueExtractor {
+
+	@Override
+	public List<Object> getValues(Object annotation) {
+		Map<String, Object> attributes = new LinkedHashMap<>();
+		if (annotation instanceof AnnotationMirror) {
+			((AnnotationMirror) annotation).getElementValues()
+					.forEach((key, value) -> attributes.put(key.getSimpleName().toString(), value));
+		}
+		if (annotation instanceof KSAnnotation) {
+			((KSAnnotation) annotation).getArguments()
+					.forEach((key) -> {
+						KSName kName = key.getName();
+						if (kName != null) {
+							attributes.put(kName.getShortName(), key);
+						}
+					});
+		}
+
+		// TODO add check for kotlin
+		Object kek = attributes.get("name");
+		if (kek != null) {
+			return Collections.emptyList();
+		}
+
+		List<Object> result = new ArrayList<>();
+		extractValues(attributes.get("value")).forEach(result::add);
+		extractValues(attributes.get("type")).forEach(result::add);
+		return result;
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/extractor/OnClassConditionValueExtractor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/extractor/OnClassConditionValueExtractor.java
@@ -1,0 +1,27 @@
+package org.springframework.boot.autoconfigureprocessor.extractor;
+
+import java.util.Comparator;
+import java.util.List;
+
+public class OnClassConditionValueExtractor extends NamedValuesExtractor {
+
+	public OnClassConditionValueExtractor() {
+		super("value", "name");
+	}
+
+	@Override
+	public List<Object> getValues(Object annotation) {
+		List<Object> values = super.getValues(annotation);
+		values.sort(this::compare);
+		return values;
+	}
+
+	private int compare(Object o1, Object o2) {
+		return Comparator.comparing(this::isSpringClass).thenComparing(String.CASE_INSENSITIVE_ORDER)
+				.compare(o1.toString(), o2.toString());
+	}
+
+	private boolean isSpringClass(String type) {
+		return type.startsWith("org.springframework");
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/extractor/ValueExtractor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/extractor/ValueExtractor.java
@@ -1,0 +1,9 @@
+package org.springframework.boot.autoconfigureprocessor.extractor;
+
+import java.util.List;
+
+public interface ValueExtractor {
+
+	List<Object> getValues(Object annotation);
+
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/AutoConfigureKotlinSymbolProcessor.kt
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/AutoConfigureKotlinSymbolProcessor.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigureprocessor.ksp
+
+import com.google.devtools.ksp.processing.Dependencies.Companion.ALL_FILES
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.symbol.KSAnnotated
+import org.springframework.boot.autoconfigureprocessor.ksp.visitor.AnnotationInfo
+import org.springframework.boot.autoconfigureprocessor.ksp.visitor.NamedValuesExtractorVisitor
+import org.springframework.boot.autoconfigureprocessor.ksp.visitor.OnBeanConditionValueExtractor
+import org.springframework.boot.autoconfigureprocessor.ksp.visitor.OnClassConditionValueExtractorVisitor
+import java.io.OutputStreamWriter
+import java.nio.charset.StandardCharsets
+
+internal const val PROPERTIES_FILE_NAME = "META-INF/spring-autoconfigure-metadata"
+internal const val PROPERTIES_FILE_EXT = "properties"
+internal const val PROPERTIES_FILE_FULL_NAME = "$PROPERTIES_FILE_NAME.$PROPERTIES_FILE_EXT"
+
+
+/**
+ * Kotlin Symbol Processor to store certain annotations from auto-configuration classes in a
+ * property file.
+ *
+ * @author Pavel Pletnev
+ * @since 2.6.0
+ */
+class AutoConfigureKotlinSymbolProcessor(
+		private val environment: SymbolProcessorEnvironment
+) : SymbolProcessor {
+
+	private val propertiesExtractors: Map<AnnotationInfo, (k: KSAnnotated, info: AnnotationInfo) -> Map<String, String>> = mapOf(
+			AnnotationInfo("org.springframework.boot.autoconfigure.condition.ConditionalOnClass") to { k: KSAnnotated, info: AnnotationInfo ->
+				k.accept(OnClassConditionValueExtractorVisitor(info), Unit)
+			},
+
+			AnnotationInfo("org.springframework.boot.autoconfigure.condition.ConditionalOnBean") to { k: KSAnnotated, info: AnnotationInfo ->
+				k.accept(OnBeanConditionValueExtractor(info), Unit)
+			},
+
+			AnnotationInfo("org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate") to { k: KSAnnotated, info: AnnotationInfo ->
+				k.accept(OnBeanConditionValueExtractor(info), Unit)
+			},
+
+
+			AnnotationInfo("org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication") to { k: KSAnnotated, info: AnnotationInfo ->
+				k.accept(NamedValuesExtractorVisitor(info, "type"), Unit)
+			},
+
+			AnnotationInfo("org.springframework.boot.autoconfigure.AutoConfigureBefore") to { k: KSAnnotated, info: AnnotationInfo ->
+				k.accept(NamedValuesExtractorVisitor(info, "value", "name"), Unit)
+			},
+
+			AnnotationInfo("org.springframework.boot.autoconfigure.AutoConfigureAfter") to { k: KSAnnotated, info: AnnotationInfo ->
+				k.accept(NamedValuesExtractorVisitor(info, "value", "name"), Unit)
+			},
+
+			AnnotationInfo("org.springframework.boot.autoconfigure.AutoConfigureOrder") to { k: KSAnnotated, info: AnnotationInfo ->
+				k.accept(NamedValuesExtractorVisitor(info, "value"), Unit)
+			}
+	)
+
+
+	override fun process(resolver: Resolver): List<KSAnnotated> {
+		val properties: MutableMap<String, String> = mutableMapOf()
+
+		propertiesExtractors.forEach { (info, extractor) ->
+			val elements = resolver.getSymbolsWithAnnotation(info.qualifiedName, true)
+			elements.forEach {
+				properties.putAll(extractor.invoke(it, info))
+			}
+		}
+
+		if (properties.isNotEmpty()) {
+			environment.codeGenerator.createNewFile(
+					ALL_FILES,
+					"",
+					PROPERTIES_FILE_NAME,
+					PROPERTIES_FILE_EXT
+			).use {
+				OutputStreamWriter(it, StandardCharsets.UTF_8).use { writer ->
+					for ((key, value) in properties.entries) {
+						writer.append(key)
+						writer.append("=")
+						writer.append(value)
+						writer.append(System.lineSeparator())
+					}
+				}
+			}
+		}
+
+		return emptyList()
+	}
+
+}
+
+class AutoConfigureSymbolProcessorProvider : SymbolProcessorProvider {
+
+	override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+		return AutoConfigureKotlinSymbolProcessor(environment)
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/AutoConfigureKotlinSymbolProcessor.kt
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/AutoConfigureKotlinSymbolProcessor.kt
@@ -22,12 +22,11 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.google.devtools.ksp.symbol.KSAnnotated
+import org.springframework.boot.autoconfigureprocessor.BaseAnnotationProcessor.writeProperties
 import org.springframework.boot.autoconfigureprocessor.ksp.visitor.AnnotationInfo
 import org.springframework.boot.autoconfigureprocessor.ksp.visitor.NamedValuesExtractorVisitor
 import org.springframework.boot.autoconfigureprocessor.ksp.visitor.OnBeanConditionValueExtractor
 import org.springframework.boot.autoconfigureprocessor.ksp.visitor.OnClassConditionValueExtractorVisitor
-import java.io.OutputStreamWriter
-import java.nio.charset.StandardCharsets
 
 internal const val PROPERTIES_FILE_NAME = "META-INF/spring-autoconfigure-metadata"
 internal const val PROPERTIES_FILE_EXT = "properties"
@@ -87,23 +86,16 @@ class AutoConfigureKotlinSymbolProcessor(
 			}
 		}
 
-		if (properties.isNotEmpty()) {
-			environment.codeGenerator.createNewFile(
-					ALL_FILES,
-					"",
-					PROPERTIES_FILE_NAME,
-					PROPERTIES_FILE_EXT
-			).use {
-				OutputStreamWriter(it, StandardCharsets.UTF_8).use { writer ->
-					for ((key, value) in properties.entries) {
-						writer.append(key)
-						writer.append("=")
-						writer.append(value)
-						writer.append(System.lineSeparator())
-					}
-				}
-			}
-		}
+
+		writeProperties(
+				properties,
+				environment.codeGenerator.createNewFile(
+						ALL_FILES,
+						"",
+						PROPERTIES_FILE_NAME,
+						PROPERTIES_FILE_EXT
+				)
+		)
 
 		return emptyList()
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/visitor/AnnotationInfo.kt
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/visitor/AnnotationInfo.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigureprocessor.ksp.visitor
+
+/**
+ * Information about the annotation
+ *
+ * @author Pavel Pletnev
+ */
+data class AnnotationInfo(
+		val qualifiedName: String,
+		val simpleName: String = qualifiedName.substringAfterLast(".")
+)

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/visitor/BaseVisitor.kt
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/visitor/BaseVisitor.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigureprocessor.ksp.visitor
+
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.visitor.KSDefaultVisitor
+
+/**
+ * @author Pavel Pletnev
+ */
+internal abstract class BaseVisitor(
+		private val annotationInfo: AnnotationInfo
+) : KSDefaultVisitor<Unit, Map<String, String>>() {
+
+	override fun defaultHandler(node: KSNode, data: Unit): Map<String, String> {
+		return emptyMap()
+	}
+
+	override fun visitClassDeclaration(
+			classDeclaration: KSClassDeclaration,
+			data: Unit
+	): Map<String, String> {
+		val properties: MutableMap<String, String> = mutableMapOf()
+		classDeclaration.annotations.forEach { ann ->
+			val annName = ann.annotationType.resolve().declaration.qualifiedName?.asString()
+			with(annotationInfo) {
+				if (qualifiedName == annName) {
+					val values: List<Any?> = getValues(ann)
+
+					val className = classDeclaration.qualifiedName!!.asString()
+
+					properties["$className.$simpleName"] = values.joinToString(separator = ",")
+					properties[className] = ""
+				}
+			}
+		}
+
+		return properties
+	}
+
+	abstract fun getValues(annotation: KSAnnotation): List<Any?>
+
+	protected fun extractValues(valueArgument: KSValueArgument?): List<Any?> {
+		val value = valueArgument?.value ?: return emptyList()
+		return if (value is List<*>) {
+			value.map { extractValue(it) }
+		} else {
+			listOf(extractValue(value))
+		}
+	}
+
+	private fun extractValue(value: Any?): Any? {
+		if (value is KSType) {
+			return value.declaration.qualifiedName?.asString()
+		}
+		return value
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/visitor/NamedValuesExtractorVisitor.kt
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/visitor/NamedValuesExtractorVisitor.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigureprocessor.ksp.visitor
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+
+/**
+ * @author Pavel Pletnev
+ */
+internal open class NamedValuesExtractorVisitor(
+		annotationInfo: AnnotationInfo,
+		vararg names: String
+) : BaseVisitor(annotationInfo) {
+
+	private val names: Set<String> = names.toHashSet()
+
+	override fun getValues(annotation: KSAnnotation): List<Any?> {
+		val values: MutableList<Any?> = mutableListOf()
+
+		annotation.arguments.forEach { arg ->
+			val argName = arg.name?.getShortName()
+			if (names.contains(argName)) {
+				values.addAll(extractValues(arg))
+			}
+		}
+
+		return values
+	}
+
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/visitor/OnBeanConditionValueExtractor.kt
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/visitor/OnBeanConditionValueExtractor.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigureprocessor.ksp.visitor
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSValueArgument
+
+
+/**
+ * @author Pavel Pletnev
+ */
+internal class OnBeanConditionValueExtractor(
+		annotationInfo: AnnotationInfo
+) : BaseVisitor(annotationInfo) {
+
+	override fun getValues(annotation: KSAnnotation): List<Any?> {
+		val valuesByName = annotation.arguments.associateBy { it.name?.getShortName() }
+		return if (isNotEmpty(valuesByName["name"])) {
+			listOf()
+		} else {
+			(extractValues(valuesByName["value"]) + extractValues(valuesByName["type"])).sortedBy { it.toString() }
+		}
+	}
+
+	private fun isNotEmpty(value: KSValueArgument?): Boolean {
+		if (value == null) {
+			return false
+		}
+		return when (value.value) {
+			is Array<*> -> (value.value as Array<*>).isNotEmpty()
+			is Collection<*> -> (value.value as Collection<*>).isNotEmpty()
+			else -> false
+		}
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/visitor/OnClassConditionValueExtractorVisitor.kt
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/visitor/OnClassConditionValueExtractorVisitor.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigureprocessor.ksp.visitor
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+
+
+/**
+ * @author Pavel Pletnev
+ */
+internal class OnClassConditionValueExtractorVisitor(
+		annotationInfo: AnnotationInfo
+) : NamedValuesExtractorVisitor(annotationInfo, "value", "name") {
+
+	override fun getValues(annotation: KSAnnotation): List<Any?> {
+		return super.getValues(annotation)
+				.sortedWith(java.util.Comparator { o1: Any?, o2: Any? -> compare(o1!!, o2!!) })
+	}
+
+	private fun compare(o1: Any, o2: Any): Int {
+		return Comparator.comparing<String, Boolean> { type: String -> this.isSpringClass(type) }
+				.thenComparing(java.lang.String.CASE_INSENSITIVE_ORDER)
+				.compare(o1.toString(), o2.toString())
+	}
+
+	private fun isSpringClass(type: String): Boolean {
+		return type.startsWith("org.springframework")
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigureprocessor.ksp.AutoConfigureSymbolProcessorProvider

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/test/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/AutoConfigureKotlinSymbolProcessorTest.kt
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/test/kotlin/org/springframework/boot/autoconfigureprocessor/ksp/AutoConfigureKotlinSymbolProcessorTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigureprocessor.ksp
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.KotlinCompilation.Result
+import com.tschuchort.compiletesting.SourceFile.Companion.kotlin
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.util.FileCopyUtils.copyToByteArray
+import java.io.File
+import java.io.FileInputStream
+import java.nio.charset.StandardCharsets
+import java.util.*
+
+/**
+ * Tests for [AutoConfigureKotlinSymbolProcessor].
+ *
+ * @author Pavel Pletnev
+ */
+class AutoConfigureKotlinSymbolProcessorTest {
+
+	private var compiler: KotlinCompilation? = null
+
+	@BeforeEach
+	fun createCompiler() {
+		compiler = KotlinCompilation().apply {
+			inheritClassPath = true
+			symbolProcessorProviders = listOf(AutoConfigureSymbolProcessorProvider())
+		}
+	}
+
+	@Test
+	fun annotatedClass() {
+		val properties: Properties = compileAndGetResultProperties("TestClassConfiguration.kt")!!
+
+		assertThat(properties).hasSize(7)
+		assertThat(properties).containsEntry(
+				"org.springframework.boot.autoconfigureprocessor.TestClassConfiguration.ConditionalOnClass",
+				"java.io.InputStream,org.springframework.boot.autoconfigureprocessor.TestClassConfiguration.Nested,org.springframework.foo"
+		)
+		assertThat(properties).containsKey("org.springframework.boot.autoconfigureprocessor.TestClassConfiguration")
+		assertThat(properties).containsEntry(
+				"org.springframework.boot.autoconfigureprocessor.TestClassConfiguration.Nested",
+				""
+		)
+		assertThat(properties).containsEntry(
+				"org.springframework.boot.autoconfigureprocessor.TestClassConfiguration.Nested.AutoConfigureOrder",
+				"0"
+		)
+		assertThat(properties).containsEntry(
+				"org.springframework.boot.autoconfigureprocessor.TestClassConfiguration.ConditionalOnBean",
+				"java.io.OutputStream"
+		)
+		// TODO IN KSP annotations args include default value
+		assertThat(properties).containsEntry(
+				"org.springframework.boot.autoconfigureprocessor.TestClassConfiguration.ConditionalOnSingleCandidate",
+				"java.io.OutputStream,kotlin.Any"
+		)
+
+		// TODO IN KSP ENUM IS KSType, but IN JAP IS NOT DeclaredType
+		assertThat(properties).containsEntry(
+				"org.springframework.boot.autoconfigureprocessor.TestClassConfiguration.ConditionalOnWebApplication",
+				"org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type.SERVLET"
+		)
+	}
+
+	@Test
+	fun annotatedClassWithOnBeanThatHasName() {
+		val properties: Properties = compileAndGetResultProperties("TestOnBeanWithNameClassConfiguration.kt")!!
+
+		assertThat(properties).hasSize(2)
+		assertThat(properties).containsEntry(
+				"org.springframework.boot.autoconfigureprocessor.TestOnBeanWithNameClassConfiguration.ConditionalOnBean",
+				""
+		)
+	}
+
+	@Test
+	fun annotatedMethod() {
+		val properties: Properties? = compileAndGetResultProperties("TestMethodConfiguration.kt")
+
+		assertThat(properties).isNull()
+	}
+
+	@Test
+	fun annotatedClassWithOrder() {
+		val properties: Properties = compileAndGetResultProperties("TestOrderedClassConfiguration.kt")!!
+
+		assertThat(properties).containsEntry(
+				"org.springframework.boot.autoconfigureprocessor.TestOrderedClassConfiguration.ConditionalOnClass",
+				"java.io.InputStream,java.io.OutputStream"
+		)
+		assertThat(properties).containsEntry(
+				"org.springframework.boot.autoconfigureprocessor.TestOrderedClassConfiguration.AutoConfigureBefore",
+				"test.before1,test.before2"
+		)
+		assertThat(properties).containsEntry(
+				"org.springframework.boot.autoconfigureprocessor.TestOrderedClassConfiguration.AutoConfigureAfter",
+				"java.io.ObjectInputStream"
+		)
+		assertThat(properties).containsEntry(
+				"org.springframework.boot.autoconfigureprocessor.TestOrderedClassConfiguration.AutoConfigureOrder",
+				"123"
+		)
+	}
+
+	@Test// gh-19370
+	fun propertiesAreFullRepeatable() {
+		val first = String(copyToByteArray(compileAndGetResultFile("TestOrderedClassConfiguration.kt")!!))
+		val second = String(copyToByteArray(compileAndGetResultFile("TestOrderedClassConfiguration.kt")!!))
+
+		assertThat(first).isEqualTo(second).doesNotContain("#")
+	}
+
+	private fun compileAndGetResultFile(fileName: String): File? {
+		compiler?.apply {
+			sources = listOf(kotlin(fileName, loadFileContent(fileName)))
+		}
+
+		return compiler?.compile()?.getResultFile()
+	}
+
+	private fun compileAndGetResultProperties(fileName: String): Properties? {
+		return compileAndGetResultFile(fileName)?.let {
+			loadProperties(it)
+		}
+	}
+
+	private fun Result.getResultFile(): File {
+		val workingDir: File = outputDirectory.parentFile
+		val resultFile = workingDir.resolve("ksp")
+				.resolve("sources")
+				.resolve("resources")
+				.resolve(PROPERTIES_FILE_FULL_NAME)
+
+
+		if (!resultFile.exists()) {
+			throw IllegalArgumentException("Not found result file: $PROPERTIES_FILE_FULL_NAME")
+		}
+		return resultFile
+	}
+
+	private fun loadProperties(file: File): Properties {
+		return FileInputStream(file).use { inputStream ->
+			Properties().also {
+				it.load(inputStream)
+			}
+		}
+	}
+
+	private fun loadFileContent(name: String): String {
+		return javaClass.classLoader.getResourceAsStream(name).use {
+			String(it.readBytes(), StandardCharsets.UTF_8)
+		}
+	}
+
+
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/test/resources/TestClassConfiguration.kt
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/test/resources/TestClassConfiguration.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigureprocessor
+
+import org.springframework.boot.autoconfigure.AutoConfigureOrder
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+
+/**
+ * @author Pavel Pletnev
+ */
+@ConditionalOnClass(name = ["org.springframework.foo", "java.io.InputStream"], value = [TestClassConfiguration.Nested::class])
+@ConditionalOnBean(type = ["java.io.OutputStream"])
+@ConditionalOnSingleCandidate(type = "java.io.OutputStream")
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+class TestClassConfiguration {
+	@AutoConfigureOrder
+	internal class Nested
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/test/resources/TestMethodConfiguration.kt
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/test/resources/TestMethodConfiguration.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigureprocessor
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import java.io.OutputStream
+
+/**
+ * @author Pavel Pletnev
+ */
+class TestMethodConfiguration {
+	@ConditionalOnClass(name = ["java.io.InputStream"], value = [OutputStream::class])
+	fun method(): Any? {
+		return null
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/test/resources/TestOnBeanWithNameClassConfiguration.kt
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/test/resources/TestOnBeanWithNameClassConfiguration.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigureprocessor
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+
+/**
+ * @author Pavel Pletnev
+ */
+@ConditionalOnBean(name = ["test"], type = ["java.io.OutputStream"])
+class TestOnBeanWithNameClassConfiguration

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/test/resources/TestOrderedClassConfiguration.kt
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/test/resources/TestOrderedClassConfiguration.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigureprocessor
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter
+import org.springframework.boot.autoconfigure.AutoConfigureBefore
+import org.springframework.boot.autoconfigure.AutoConfigureOrder
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import java.io.ObjectInputStream
+import java.io.OutputStream
+
+
+/**
+ * @author Pavel Pletnev
+ */
+@AutoConfigureBefore(name = ["test.before1", "test.before2"])
+@AutoConfigureAfter(ObjectInputStream::class)
+@ConditionalOnClass(name = ["java.io.InputStream"], value = [OutputStream::class])
+@AutoConfigureOrder(123)
+class TestOrderedClassConfiguration


### PR DESCRIPTION
KSP issue - https://github.com/spring-projects/spring-boot/issues/28046
I made a draft in which I added support for ksp.
I have a few questions:
1. Сan I use kotlin?
2. Do I need to create a separate gradle module for ksp?
3. Is there a description of the `spring-autoconfigure-metadata.properies` file somewhere? The result of processing java annotations is slightly different from the results of ksp and it is unclear whether these differences affect something.

If you tell me what fixes are needed now, then after that I will start doing ksp support for `spring-boot-configuration-processor`