### PR TITLE
Fix yaml sample format in reference doc

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
@@ -470,10 +470,16 @@ For example, the following file has two logical documents:
 
 [source,yaml,indent=0,subs="verbatim"]
 ----
-	spring.application.name: MyApp
+	spring:
+	  application:
+	    name: "MyApp"
 	---
-	spring.config.activate.on-cloud-platform: kubernetes
-	spring.application.name: MyCloudApp
+	spring:
+	  application:
+	    name: "MyCloudApp"
+	  config:
+	    activate:
+	      on-cloud-platform: kubernetes
 ----
 
 For `application.properties` files a special `#---` comment is used to mark the document splits:

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
@@ -475,11 +475,11 @@ For example, the following file has two logical documents:
 	    name: "MyApp"
 	---
 	spring:
-	  application:
-	    name: "MyCloudApp"
 	  config:
 	    activate:
 	      on-cloud-platform: kubernetes
+	  application:
+	    name: "MyCloudApp"
 ----
 
 For `application.properties` files a special `#---` comment is used to mark the document splits:


### PR DESCRIPTION
The original configuration block is not a valid yaml syntax format.