### PR TITLE
LettuceMetricsAutoConfiguration should not build ClientResources instance

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/redis/LettuceMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/redis/LettuceMetricsAutoConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.context.annotation.Configuration;
  * Auto-configuration for Lettuce metrics.
  *
  * @author Antonin Arquey
+ * @author Yanming Zhou
  * @since 2.6.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -48,8 +49,7 @@ public class LettuceMetricsAutoConfiguration {
 	@Bean
 	public ClientResourcesBuilderCustomizer lettuceMetrics(MeterRegistry meterRegistry) {
 		MicrometerOptions options = MicrometerOptions.builder().histogram(true).build();
-		return (client) -> client.commandLatencyRecorder(new MicrometerCommandLatencyRecorder(meterRegistry, options))
-				.build();
+		return (client) -> client.commandLatencyRecorder(new MicrometerCommandLatencyRecorder(meterRegistry, options));
 	}
 
 }


### PR DESCRIPTION
It is not the responsibility of `ClientResourcesBuilderCustomizer` to build `ClientResources` instance.

Fix:
```
i.l.c.r.DefaultClientResources WARN io.lettuce.core.resource.DefaultClientResources was not shut down properly, shutdown() was not called before it's garbage-collected. Call shutdown() or shutdown(long,long,TimeUnit)
```

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
