### PR TITLE
server.servlet.session.cookie.same-site isn't applied to Spring Session's SESSION cookie

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionAutoConfiguration.java
@@ -48,6 +48,7 @@ import org.springframework.boot.autoconfigure.web.reactive.WebFluxProperties;
 import org.springframework.boot.autoconfigure.web.reactive.WebSessionIdResolverAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.boot.web.server.Cookie.SameSite;
 import org.springframework.boot.web.servlet.server.Session.Cookie;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -106,6 +107,7 @@ public class SessionAutoConfiguration {
 			map.from(cookie::getHttpOnly).to(cookieSerializer::setUseHttpOnlyCookie);
 			map.from(cookie::getSecure).to(cookieSerializer::setUseSecureCookie);
 			map.from(cookie::getMaxAge).asInt(Duration::getSeconds).to(cookieSerializer::setCookieMaxAge);
+			map.from(cookie::getSameSite).as(SameSite::attributeValue).to(cookieSerializer::setSameSite);
 			cookieSerializerCustomizers.orderedStream().forEach((customizer) -> customizer.customize(cookieSerializer));
 			return cookieSerializer;
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,7 +143,7 @@ class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurationTest
 				.withPropertyValues("server.servlet.session.cookie.name=sid",
 						"server.servlet.session.cookie.domain=spring", "server.servlet.session.cookie.path=/test",
 						"server.servlet.session.cookie.httpOnly=false", "server.servlet.session.cookie.secure=false",
-						"server.servlet.session.cookie.maxAge=10s")
+						"server.servlet.session.cookie.maxAge=10s", "server.servlet.session.cookie.sameSite=strict")
 				.run((context) -> {
 					DefaultCookieSerializer cookieSerializer = context.getBean(DefaultCookieSerializer.class);
 					assertThat(cookieSerializer).hasFieldOrPropertyWithValue("cookieName", "sid");
@@ -152,6 +152,7 @@ class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurationTest
 					assertThat(cookieSerializer).hasFieldOrPropertyWithValue("useHttpOnlyCookie", false);
 					assertThat(cookieSerializer).hasFieldOrPropertyWithValue("useSecureCookie", false);
 					assertThat(cookieSerializer).hasFieldOrPropertyWithValue("cookieMaxAge", 10);
+					assertThat(cookieSerializer).hasFieldOrPropertyWithValue("sameSite", "Strict");
 				});
 	}
 


### PR DESCRIPTION
This commit adds the mapping of `server.servlet.session.cookie.same-site` configuration property to `DefaultCookieSerializer` bean configured in the Spring Session auto-configuration.

See gh-28772