### PR TITLE
WebFluxTest include user defined security configuration

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/reactive/WebFluxTypeExcludeFilterTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/reactive/WebFluxTypeExcludeFilterTests.java
@@ -23,11 +23,15 @@ import org.junit.jupiter.api.Test;
 import org.thymeleaf.dialect.IDialect;
 import reactor.core.publisher.Mono;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.core.type.classreading.MetadataReader;
 import org.springframework.core.type.classreading.MetadataReaderFactory;
 import org.springframework.core.type.classreading.SimpleMetadataReaderFactory;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.stereotype.Controller;
 import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
@@ -58,6 +62,7 @@ class WebFluxTypeExcludeFilterTests {
 		assertThat(excludes(filter, ExampleWeb.class)).isFalse();
 		assertThat(excludes(filter, ExampleService.class)).isTrue();
 		assertThat(excludes(filter, ExampleRepository.class)).isTrue();
+		assertThat(excludes(filter, ExampleSecurityConfiguration.class)).isFalse();
 		assertThat(excludes(filter, ExampleWebFilter.class)).isFalse();
 		assertThat(excludes(filter, ExampleModule.class)).isFalse();
 		assertThat(excludes(filter, ExampleDialect.class)).isFalse();
@@ -175,6 +180,16 @@ class WebFluxTypeExcludeFilterTests {
 
 	@Repository
 	static class ExampleRepository {
+
+	}
+
+	@Configuration
+	static class ExampleSecurityConfiguration {
+
+		@Bean
+		SecurityWebFilterChain springWebFilterChain(ServerHttpSecurity http) {
+			return http.build();
+		}
 
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-secure-webflux/src/main/java/smoketest/secure/webflux/CustomSecurityConfiguration.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-secure-webflux/src/main/java/smoketest/secure/webflux/CustomSecurityConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.secure.webflux;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Profile("custom-security")
+@Configuration
+public class CustomSecurityConfiguration {
+
+	@Bean
+	SecurityWebFilterChain security(ServerHttpSecurity http) {
+		http.authorizeExchange((auth) -> auth.pathMatchers(HttpMethod.GET, "/api/resource").permitAll()
+				.pathMatchers(HttpMethod.POST, "/api/resource").authenticated()).httpBasic(Customizer.withDefaults())
+				.csrf().disable();
+
+		return http.build();
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-secure-webflux/src/main/java/smoketest/secure/webflux/ResourceController.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-secure-webflux/src/main/java/smoketest/secure/webflux/ResourceController.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.secure.webflux;
+
+import java.security.Principal;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/resource")
+public class ResourceController {
+
+	@GetMapping
+	Mono<String> getResource() {
+		return Mono.just("test resource");
+	}
+
+	@PostMapping
+	Mono<String> createResource(Principal principal) {
+		return Mono.just("resource created by " + principal.getName());
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-secure-webflux/src/test/java/smoketest/secure/webflux/WebFluxTestWithCustomSecurityTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-secure-webflux/src/test/java/smoketest/secure/webflux/WebFluxTestWithCustomSecurityTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.secure.webflux;
+
+import java.util.Base64;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTypeExcludeFilter;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Integration test for {@link WebFluxTest}. This test verifies that
+ * {@link WebFluxTypeExcludeFilter} includes a user defined security configuration.
+ *
+ * @author Daniil Razorenov
+ */
+@MockBean(EchoHandler.class)
+@WebFluxTest
+@ActiveProfiles("custom-security")
+class WebFluxTestWithCustomSecurityTests {
+
+	@Autowired
+	WebTestClient testClient;
+
+	@Test
+	void shouldBePermitted() {
+		this.testClient.get().uri("/api/resource").accept(MediaType.APPLICATION_JSON).exchange().expectStatus().isOk()
+				.expectBody(String.class).isEqualTo("test resource");
+	}
+
+	@Test
+	void shouldBeAccessDenied() {
+		this.testClient.post().uri("/api/resource").accept(MediaType.APPLICATION_JSON).exchange().expectStatus()
+				.isUnauthorized();
+	}
+
+	@Test
+	void shouldBeAuthenticatedWithBasicAuth() {
+		this.testClient.post().uri("/api/resource").accept(MediaType.APPLICATION_JSON)
+				.header("Authorization", getBasicAuth()).exchange().expectStatus().isOk().expectBody(String.class)
+				.isEqualTo("resource created by user");
+	}
+
+	private String getBasicAuth() {
+		return "Basic " + Base64.getEncoder().encodeToString("user:password".getBytes());
+	}
+
+}


### PR DESCRIPTION
Fix #16088
In order to `WebFluxTypeExcludeFilter` include user defined security configuration, I check that the class annotated with `@ Configuration` has a method with` @ Bean` and return `SecurityWebFilterChain`. I understand that someone might call this solution a dirty trick. But it seems to me that this is the only possible solution that does not introduce a large number of architectural changes.

I also added a smoke test. But not sure if I did it in the right place. If you see fit, I will change or remove this test.
