### PR TITLE
Allow injection of Spring-managed beans into Hazelcast components

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastServerConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastServerConfiguration.java
@@ -105,6 +105,7 @@ class HazelcastServerConfiguration {
 
 	}
 
+	@FunctionalInterface
 	private interface ConfigurationCustomizer {
 		ConfigurationCustomizer EMPTY_CUSTOMIZER = c -> c;
 		Config customize(Config configuration);


### PR DESCRIPTION
Fixes #19487

When Spring Boot creates Hazelcast configuration and the Hazelcast-Spring
integration module is available on a classpath then inject SpringManagedContext
into Hazelcast configuration. 

This change makes it possible to inject Spring managed beans into objects
instantiated by Hazelcast. 

I'm not too familiar with Spring Boot so chances are the code is not idiomatic. It looks rather complex for what is basically an if-else condition. Any guidance is very much appreciated. 