### PR TITLE
The name of the matching-strategy property is incorrect in the action message of the failure analysis for a PatternParseException

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/PatternParseFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/PatternParseFailureAnalyzer.java
@@ -32,7 +32,7 @@ class PatternParseFailureAnalyzer extends AbstractFailureAnalyzer<PatternParseEx
 	protected FailureAnalysis analyze(Throwable rootFailure, PatternParseException cause) {
 		return new FailureAnalysis("Invalid mapping pattern detected: " + cause.toDetailedString(),
 				"Fix this pattern in your application or switch to the legacy parser implementation with "
-						+ "'spring.mvc.pathpattern.matching-strategy=ant_path_matcher'.",
+						+ "'spring.mvc.pathmatch.matching-strategy=ant_path_matcher'.",
 				cause);
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/PatternParseFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/PatternParseFailureAnalyzerTests.java
@@ -39,7 +39,7 @@ class PatternParseFailureAnalyzerTests {
 		assertThat(failureAnalysis.getDescription()).contains("Invalid mapping pattern detected: /spring/**/framework");
 		assertThat(failureAnalysis.getAction())
 				.contains("Fix this pattern in your application or switch to the legacy parser"
-						+ " implementation with 'spring.mvc.pathpattern.matching-strategy=ant_path_matcher'.");
+						+ " implementation with 'spring.mvc.pathmatch.matching-strategy=ant_path_matcher'.");
 	}
 
 	private FailureAnalysis performAnalysis(String pattern) {


### PR DESCRIPTION
For [issue 28791](https://github.com/spring-projects/spring-boot/issues/28791).