### PR TITLE
Fix output of "spring --version" in reference documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/getting-started/installing.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/getting-started/installing.adoc
@@ -97,7 +97,7 @@ Get SDKMAN! from https://sdkman.io and install Spring Boot by using the followin
 ----
 	$ sdk install springboot
 	$ spring --version
-	Spring Boot v{spring-boot-version}
+	Spring CLI v{spring-boot-version}
 ----
 
 If you develop features for the CLI and want access to the version you built, use the following commands:


### PR DESCRIPTION
Line 100 should be the same line 110. 
The result of spring --version is : Spring CLI v2.X.X and not Spring Boot v2.x.x.
