### PR TITLE
Add SpringInfoContributor to expose Spring Framework/Boot version on info actuator

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.boot.actuate.info.EnvironmentInfoContributor;
 import org.springframework.boot.actuate.info.GitInfoContributor;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.actuate.info.JavaInfoContributor;
+import org.springframework.boot.actuate.info.SpringInfoContributor;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -84,6 +85,13 @@ public class InfoContributorAutoConfiguration {
 	@Order(DEFAULT_ORDER)
 	public JavaInfoContributor javaInfoContributor() {
 		return new JavaInfoContributor();
+	}
+
+	@Bean
+	@ConditionalOnEnabledInfoContributor(value = "spring", fallback = InfoContributorFallback.DISABLE)
+	@Order(DEFAULT_ORDER)
+	public SpringInfoContributor springInfoContributor() {
+		return new SpringInfoContributor();
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfigurationTests.java
@@ -27,10 +27,12 @@ import org.springframework.boot.actuate.info.GitInfoContributor;
 import org.springframework.boot.actuate.info.Info;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.actuate.info.JavaInfoContributor;
+import org.springframework.boot.actuate.info.SpringInfoContributor;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.boot.info.GitProperties;
 import org.springframework.boot.info.JavaInfo;
+import org.springframework.boot.info.SpringInfo;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -148,6 +150,23 @@ class InfoContributorAutoConfigurationTests {
 			Map<String, Object> content = invokeContributor(context.getBean(JavaInfoContributor.class));
 			assertThat(content).containsKey("java");
 			assertThat(content.get("java")).isInstanceOf(JavaInfo.class);
+		});
+	}
+
+	@Test
+	void springInfoContributor() {
+		this.contextRunner.withPropertyValues("management.info.spring.enabled=true").run((context) -> {
+			assertThat(context).hasSingleBean(SpringInfoContributor.class);
+			Map<String, Object> content = invokeContributor(context.getBean(SpringInfoContributor.class));
+			assertThat(content).containsKey("spring");
+			assertThat(content.get("spring")).isInstanceOf(SpringInfo.class);
+		});
+	}
+
+	@Test
+	void springInfoContributorDisabled() {
+		this.contextRunner.withPropertyValues("management.info.spring.enabled=false").run((context) -> {
+			assertThat(context).doesNotHaveBean(SpringInfoContributor.class);
 		});
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/endpoints.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/endpoints.adoc
@@ -1165,6 +1165,11 @@ When appropriate, Spring auto-configures the following `InfoContributor` beans:
 | Exposes Java runtime information.
 | None.
 
+| `spring`
+| {spring-boot-actuator-module-code}/info/SpringInfoContributor.java[`SpringInfoContributor`]
+| Exposes Spring Boot runtime information.
+| None.
+
 |===
 
 Whether or not an individual contributor is enabled is controlled by its `management.info.<id>.enabled` property.


### PR DESCRIPTION
This PR provides an opt-in InfoContributor that exposes the Spring and SpringBoot versions on the `info` actuator endpoint. 

This is controlled by the property `management.info.spring.enabled=true`

If true it will expose the data as:

```
"spring:" {
  "springBootVersion": "x.x.x",
  "springFrameworkVersion": "y.y.y"
}
```

though, there is likely a better naming convention, open to suggestions