### PR TITLE
Add configuration propertie media types (reactive) with Mustache views.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,17 @@
 
 package org.springframework.boot.autoconfigure.mustache;
 
+import java.util.List;
+
 import org.springframework.boot.autoconfigure.template.AbstractTemplateViewResolverProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.http.MediaType;
 
 /**
  * {@link ConfigurationProperties @ConfigurationProperties} for Mustache.
  *
  * @author Dave Syer
+ * @author Leo Li
  * @since 1.2.2
  */
 @ConfigurationProperties(prefix = "spring.mustache")
@@ -41,6 +45,8 @@ public class MustacheProperties extends AbstractTemplateViewResolverProperties {
 	 * Suffix to apply to template names.
 	 */
 	private String suffix = DEFAULT_SUFFIX;
+
+	private final Reactive reactive = new Reactive();
 
 	public MustacheProperties() {
 		super(DEFAULT_PREFIX, DEFAULT_SUFFIX);
@@ -64,6 +70,27 @@ public class MustacheProperties extends AbstractTemplateViewResolverProperties {
 	@Override
 	public void setSuffix(String suffix) {
 		this.suffix = suffix;
+	}
+
+	public Reactive getReactive() {
+		return this.reactive;
+	}
+
+	public static class Reactive {
+
+		/**
+		 * Media types supported by the view technology.
+		 */
+		private List<MediaType> mediaTypes;
+
+		public List<MediaType> getMediaTypes() {
+			return this.mediaTypes;
+		}
+
+		public void setMediaTypes(List<MediaType> mediaTypes) {
+			this.mediaTypes = mediaTypes;
+		}
+
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheReactiveWebConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheReactiveWebConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ class MustacheReactiveWebConfiguration {
 		resolver.setRequestContextAttribute(mustache.getRequestContextAttribute());
 		resolver.setCharset(mustache.getCharsetName());
 		resolver.setOrder(Ordered.LOWEST_PRECEDENCE - 10);
+		resolver.setSupportedMediaTypes(mustache.getReactive().getMediaTypes());
 		return resolver;
 	}
 


### PR DESCRIPTION
For [issue 28858](https://github.com/spring-projects/spring-boot/issues/28858).
Now I just add media types, and here are some questions:
1. `content-type` is supported as `spring.mustache.content-type` now, do we need to migrate to servlet?
2. Does freemaker need the same change?
Because these problems are uncertain, the current changes may not be in the final code location.
Hi @wilkinsona , can you help to check?