### PR TITLE
AbstractMethodError in org.springframework.boot.web.servlet.filter.ErrorPageSecurityFilter when deployed to a Servlet 3.1-compatible container

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/filter/ErrorPageSecurityFilter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/filter/ErrorPageSecurityFilter.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -52,6 +53,11 @@ public class ErrorPageSecurityFilter implements Filter {
 
 	public ErrorPageSecurityFilter(ApplicationContext context) {
 		this.context = context;
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+		// Intentionally blank
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #28854
