### PR TITLE
Expose Operating System information as an info contributor

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.boot.actuate.info.EnvironmentInfoContributor;
 import org.springframework.boot.actuate.info.GitInfoContributor;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.actuate.info.JavaInfoContributor;
+import org.springframework.boot.actuate.info.OsInfoContributor;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -84,6 +85,13 @@ public class InfoContributorAutoConfiguration {
 	@Order(DEFAULT_ORDER)
 	public JavaInfoContributor javaInfoContributor() {
 		return new JavaInfoContributor();
+	}
+
+	@Bean
+	@ConditionalOnEnabledInfoContributor(value = "os", fallback = InfoContributorFallback.DISABLE)
+	@Order(DEFAULT_ORDER)
+	public OsInfoContributor osInfoContributor() {
+		return new OsInfoContributor();
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -280,6 +280,12 @@
       "defaultValue": false
     },
     {
+      "name": "management.info.os.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable OS info.",
+      "defaultValue": false
+    },
+    {
       "name": "management.metrics.binders.files.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable files metrics.",

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfigurationTests.java
@@ -27,10 +27,12 @@ import org.springframework.boot.actuate.info.GitInfoContributor;
 import org.springframework.boot.actuate.info.Info;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.actuate.info.JavaInfoContributor;
+import org.springframework.boot.actuate.info.OsInfoContributor;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.boot.info.GitProperties;
 import org.springframework.boot.info.JavaInfo;
+import org.springframework.boot.info.OsInfo;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -148,6 +150,16 @@ class InfoContributorAutoConfigurationTests {
 			Map<String, Object> content = invokeContributor(context.getBean(JavaInfoContributor.class));
 			assertThat(content).containsKey("java");
 			assertThat(content.get("java")).isInstanceOf(JavaInfo.class);
+		});
+	}
+
+	@Test
+	void osInfoContributor() {
+		this.contextRunner.withPropertyValues("management.info.os.enabled=true").run((context) -> {
+			assertThat(context).hasSingleBean(OsInfoContributor.class);
+			Map<String, Object> content = invokeContributor(context.getBean(OsInfoContributor.class));
+			assertThat(content).containsKey("os");
+			assertThat(content.get("os")).isInstanceOf(OsInfo.class);
 		});
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/OsInfoContributor.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/OsInfoContributor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.info;
+
+import org.springframework.boot.info.OsInfo;
+
+/**
+ * An {@link InfoContributor} that exposes {@link OsInfo}.
+ *
+ * @author Jonatan Ivanov
+ * @since 2.7.0
+ */
+public class OsInfoContributor implements InfoContributor {
+
+	private final OsInfo osInfo;
+
+	public OsInfoContributor() {
+		this.osInfo = new OsInfo();
+	}
+
+	@Override
+	public void contribute(Info.Builder builder) {
+		builder.withDetail("os", this.osInfo);
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/info/OsInfoContributorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/info/OsInfoContributorTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.info;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.info.JavaInfo;
+import org.springframework.boot.info.OsInfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link OsInfoContributor}
+ *
+ * @author Jonatan Ivanov
+ */
+public class OsInfoContributorTests {
+
+	@Test
+	void osInfoShouldBeAdded() {
+		OsInfoContributor osInfoContributor = new OsInfoContributor();
+		Info.Builder builder = new Info.Builder();
+		osInfoContributor.contribute(builder);
+		Info info = builder.build();
+		assertThat(info.getDetails().get("os")).isInstanceOf(OsInfo.class);
+	}
+
+}

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/endpoints.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/endpoints.adoc
@@ -1169,13 +1169,18 @@ When appropriate, Spring auto-configures the following `InfoContributor` beans:
 | Exposes Java runtime information.
 | None.
 
+| `os`
+| {spring-boot-actuator-module-code}/info/OsInfoContributor.java[`OsInfoContributor`]
+| Exposes Operating System information.
+| None.
+
 |===
 
 Whether or not an individual contributor is enabled is controlled by its `management.info.<id>.enabled` property.
 Different contributors have different defaults for this property, depending on their prerequisites and the nature of the information that they expose.
 
-With no prerequisites to indicate that they should be enabled, the `env` and `java` contributors are disabled by default.
-You can enable them by setting the configprop:management.info.env.enabled[] or configprop:management.info.java.enabled[] properties to `true`.
+With no prerequisites to indicate that they should be enabled, the `env`, `java` and `os` contributors are disabled by default.
+You can enable them by setting the configprop:management.info.env.enabled[], configprop:management.info.java.enabled[] or configprop:management.info.os.enabled[] properties to `true`.
 
 The `build` and `git` info contributors are enabled by default.
 Each can be disabled by setting its `management.info.<id>.enabled` property to `false`.
@@ -1263,6 +1268,12 @@ See "<<howto#howto.build.generate-info,how to generate build information>>" for 
 [[actuator.endpoints.info.java-information]]
 ==== Java Information
 The `info` endpoint publishes information about your Java runtime environment, see {spring-boot-module-api}/info/JavaInfo.html[`JavaInfo`] for more details.
+
+
+
+[[actuator.endpoints.info.os-information]]
+==== OS Information
+The `info` endpoint publishes information about your Operating System, see {spring-boot-module-api}/info/OsInfo.html[`OsInfo`] for more details.
 
 
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/OsInfo.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/OsInfo.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.info;
+
+/**
+ * Information about the Operating System the application is running on.
+ *
+ * @author Jonatan Ivanov
+ * @since 2.7.0
+ */
+public class OsInfo {
+
+	private final String name;
+
+	private final String version;
+
+	private final String arch;
+
+	public OsInfo() {
+		this.name = System.getProperty("os.name");
+		this.version = System.getProperty("os.version");
+		this.arch = System.getProperty("os.arch");
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public String getVersion() {
+		return this.version;
+	}
+
+	public String getArch() {
+		return this.arch;
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/info/OsInfoTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/info/OsInfoTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.info;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link OsInfo}.
+ *
+ * @author Jonatan Ivanov
+ */
+public class OsInfoTests {
+
+	@Test
+	void osInfoIsAvailable() {
+		OsInfo osInfo = new OsInfo();
+		assertThat(osInfo.getName()).isEqualTo(System.getProperty("os.name"));
+		assertThat(osInfo.getVersion()).isEqualTo(System.getProperty("os.version"));
+		assertThat(osInfo.getArch()).isEqualTo(System.getProperty("os.arch"));
+	}
+
+}


### PR DESCRIPTION
This `InfoContributor` adds Operating System related details to actuator's info endpoint as part of the Enhanced Observability effort: https://github.com/spring-projects/spring-boot/issues/25476
When configured, it looks like this:
```json
{
  "os": {
    "name": "Mac OS X",
    "version": "10.16",
    "arch": "x86_64"
  }
}
```
or
```json
{
  "os": {
    "name": "Linux",
    "version": "5.4.0-1051-gke",
    "arch": "amd64"
  }
}
```

I'm thinking if we should call out in the docs that the version is the `os.version` Java system property and because certain Operating Systems use multiple versions for the same thing, on these Operating Systems, the version string can be different on different JVMs (but on the same OS) if the JVM implementations use different version sources.
E.g.: on my Mac, Java 8 says `10.16` while Java 17 says `11.5`. Both mean the same thing but 10.16 is the "backward-compatible" version from the OS X era while 11.5 is the new version from the macOS times. As far as I saw, Linux does not have such problems (did not try on Windows). :)