### PR TITLE
Add consistent quotes in YAML samples of reference doc

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
@@ -461,10 +461,10 @@ The following example `scrape_config` adds to `prometheus.yml`:
 [source,yaml,indent=0,subs="verbatim"]
 ----
 	scrape_configs:
-	  - job_name: 'spring'
-		metrics_path: '/actuator/prometheus'
+	  - job_name: "spring"
+		metrics_path: "/actuator/prometheus"
 		static_configs:
-		  - targets: ['HOST:PORT']
+		  - targets: ["HOST:PORT"]
 ----
 
 For ephemeral or batch jobs that may not exist long enough to be scraped, you can use https://github.com/prometheus/pushgateway[Prometheus Pushgateway] support to expose the metrics to Prometheus.

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/monitoring.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/monitoring.adoc
@@ -77,7 +77,7 @@ For example, doing so lets a management server be available over HTTP while the 
 	  ssl:
 	    enabled: true
 	    key-store: "classpath:store.jks"
-	    key-password: secret
+	    key-password: "secret"
 	management:
 	  server:
 	    port: 8080

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/nosql.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/nosql.adoc
@@ -308,8 +308,8 @@ You can further tune how `Sniffer` is configured, as shown in the following exam
 	  elasticsearch:
 	    restclient:
 	      sniffer:
-	        interval: 10m
-	        delay-after-failure: 30s
+	        interval: "10m"
+	        delay-after-failure: "30s"
 ----
 
 
@@ -327,7 +327,7 @@ In addition to the properties described previously, the `spring.elasticsearch.we
 	spring:
 	  elasticsearch:
 	    webclient:
-	      max-in-memory-size: 1MB
+	      max-in-memory-size: "1MB"
 ----
 
 If the `spring.elasticsearch.*` and `spring.elasticsearch.webclient.*` configuration properties are not enough and you'd like to fully control the client configuration, you can register a custom `ClientConfiguration` bean.
@@ -604,8 +604,8 @@ In yaml files, you can use the yaml list notation. In properties files, you must
 [source,yaml,indent=0,subs="verbatim",configprops,configblocks]
 ----
 	spring.ldap.embedded.base-dn:
-	  - dc=spring,dc=io
-	  - dc=pivotal,dc=io
+	  - "dc=spring,dc=io"
+	  - "dc=pivotal,dc=io"
 ----
 ====
 


### PR DESCRIPTION
Fix #28709

- Added quotes in all YAML samples from the .adoc files where they were missing
- Replaced ' with " in one YAML sample for consistency
