### PR TITLE
Upgrade Java version to 17 in spring-boot-starter-parent's pom

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
@@ -19,7 +19,7 @@ publishing.publications.withType(MavenPublication) {
 		root.remove(root.version)
 		root.description.plus {
 			properties {
-				delegate."java.version"('1.8')
+				delegate."java.version"('17')
 				delegate."resource.delimiter"('@')
 				delegate."maven.compiler.source"('${java.version}')
 				delegate."maven.compiler.target"('${java.version}')


### PR DESCRIPTION
Although spring boot 3.0 has upgraded to java 17, but the parent maven pom in spring-boot-starter-parent has not been upgraded yet