### PR TITLE
log4j 2.15.0 CVE-2021-44228

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -757,7 +757,7 @@ bom {
 			]
 		}
 	}
-	library("Log4j2", "2.14.1") {
+	library("Log4j2", "2.15.0") {
 		group("org.apache.logging.log4j") {
 			modules = [
 				"log4j-to-slf4j"


### PR DESCRIPTION
https://logging.apache.org/log4j/2.x/security.html

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228

