### PR TITLE
Include AbstractJdbcConfiguration beans in @DataJdbcTest

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/data/jdbc/DataJdbcTypeExcludeFilter.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/data/jdbc/DataJdbcTypeExcludeFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/data/jdbc/DataJdbcTypeExcludeFilter.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/data/jdbc/DataJdbcTypeExcludeFilter.java
@@ -18,17 +18,34 @@ package org.springframework.boot.test.autoconfigure.data.jdbc;
 
 import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.test.autoconfigure.filter.StandardAnnotationCustomizableTypeExcludeFilter;
+import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * {@link TypeExcludeFilter} for {@link DataJdbcTest @DataJdbcTest}.
  *
  * @author Andy Wilkinson
+ * @author Ravi Undupitiya
  * @since 2.2.1
  */
 public final class DataJdbcTypeExcludeFilter extends StandardAnnotationCustomizableTypeExcludeFilter<DataJdbcTest> {
+
+	private static final Set<Class<?>> DEFAULT_INCLUDES;
+	static {
+		Set<Class<?>> includes = new LinkedHashSet<>();
+		includes.add(AbstractJdbcConfiguration.class);
+		DEFAULT_INCLUDES = Collections.unmodifiableSet(includes);
+	}
 
 	DataJdbcTypeExcludeFilter(Class<?> testClass) {
 		super(testClass);
 	}
 
+	@Override
+	protected Set<Class<?>> getDefaultIncludes() {
+		return DEFAULT_INCLUDES;
+	}
 }

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/jdbc/DataJdbcTypeExcludeFilterTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/jdbc/DataJdbcTypeExcludeFilterTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.test.autoconfigure.data.jdbc;
 
 import org.junit.jupiter.api.Test;

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/jdbc/DataJdbcTypeExcludeFilterTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/jdbc/DataJdbcTypeExcludeFilterTests.java
@@ -1,0 +1,49 @@
+package org.springframework.boot.test.autoconfigure.data.jdbc;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.type.classreading.MetadataReader;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.core.type.classreading.SimpleMetadataReaderFactory;
+import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DataJdbcTypeExcludeFilter}.
+ *
+ * @author Ravi Undupitiya
+ */
+public class DataJdbcTypeExcludeFilterTests {
+
+	private MetadataReaderFactory metadataReaderFactory = new SimpleMetadataReaderFactory();
+
+	@Test
+	void matchNotUsingDefaultFilters() throws Exception {
+		DataJdbcTypeExcludeFilter filter = new DataJdbcTypeExcludeFilter(NotUsingDefaultFilters.class);
+		assertThat(excludes(filter, AbstractJdbcConfiguration.class)).isTrue();
+	}
+
+	@Test
+	void matchUsingDefaultFilters() throws Exception {
+		DataJdbcTypeExcludeFilter filter = new DataJdbcTypeExcludeFilter(UsingDefaultFilters.class);
+		assertThat(excludes(filter, AbstractJdbcConfiguration.class)).isFalse();
+	}
+
+	private boolean excludes(DataJdbcTypeExcludeFilter filter, Class<?> type) throws IOException {
+		MetadataReader metadataReader = this.metadataReaderFactory.getMetadataReader(type.getName());
+		return filter.match(metadataReader, this.metadataReaderFactory);
+	}
+
+	@DataJdbcTest
+	static class UsingDefaultFilters {
+
+	}
+
+	@DataJdbcTest(useDefaultFilters = false)
+	static class NotUsingDefaultFilters {
+
+	}
+
+}


### PR DESCRIPTION
Addresses enhancement issue https://github.com/spring-projects/spring-boot/issues/28918

Adds `AbstractJdbcConfiguration` to default includes. 
