### PR TITLE
Use log4j-bom to manage log4j-to-slf4j dependency

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -759,9 +759,6 @@ bom {
 	}
 	library("Log4j2", "2.15.0") {
 		group("org.apache.logging.log4j") {
-			modules = [
-				"log4j-to-slf4j"
-			]
 			imports = [
 				"log4j-bom"
 			]


### PR DESCRIPTION
log4j-to-slf4j is already in [log4j-bom](https://github.com/apache/logging-log4j2/blob/master/log4j-bom/pom.xml#L151) since this [commit](https://github.com/apache/logging-log4j2/commit/9b0345931e978633b80d24c37610cd021d719ed4), so we should remove it to keep clear。