### PR TITLE
fix: BackgroundPreinitializer only init Jackson2ObjectMapperBuilder once

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/BackgroundPreinitializer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/BackgroundPreinitializer.java
@@ -31,7 +31,6 @@ import org.springframework.boot.context.logging.LoggingApplicationListener;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.format.support.DefaultFormattingConversionService;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.support.AllEncompassingFormHttpMessageConverter;
 
 /**
@@ -101,7 +100,6 @@ public class BackgroundPreinitializer implements ApplicationListener<SpringAppli
 					runSafely(new ConversionServiceInitializer());
 					runSafely(new ValidationInitializer());
 					runSafely(new MessageConverterInitializer());
-					runSafely(new JacksonInitializer());
 					runSafely(new CharsetInitializer());
 					preinitializationComplete.countDown();
 				}
@@ -147,18 +145,6 @@ public class BackgroundPreinitializer implements ApplicationListener<SpringAppli
 		public void run() {
 			Configuration<?> configuration = Validation.byDefaultProvider().configure();
 			configuration.buildValidatorFactory().getValidator();
-		}
-
-	}
-
-	/**
-	 * Early initializer for Jackson.
-	 */
-	private static class JacksonInitializer implements Runnable {
-
-		@Override
-		public void run() {
-			Jackson2ObjectMapperBuilder.json().build();
 		}
 
 	}


### PR DESCRIPTION
AllEncompassingFormHttpMessageConverter will invoke Jackson2ObjectMapperBuilder,
so there no need invoke Jackson2ObjectMapperBuilder again

![](https://raw.githubusercontent.com/qxo/public/main/spring-boot-preinit-jackson-1.png)
![](https://raw.githubusercontent.com/qxo/public/main/spring-boot-preinit-jackson-2.png)

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
