### PR TITLE
update doc about "RestTemplate Customization"

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/io/rest-client.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/io/rest-client.adoc
@@ -39,7 +39,7 @@ include::{docs-java}/io/restclient/resttemplate/customization/MyRestTemplateCust
 ----
 
 Finally, you can also create your own `RestTemplateBuilder` bean.
-To prevent switching off the auto-configuration of a `RestTemplateBuilder` and prevent any `RestTemplateCustomizer` beans from being used, make sure to configure your custom instance with a `RestTemplateBuilderConfigurer`.
+To prevent switching off the auto-configuration of a `RestTemplateBuilder` and prevent any `RestTemplateCustomizer` beans from not being used, make sure to configure your custom instance with a `RestTemplateBuilderConfigurer`.
 The following example exposes a `RestTemplateBuilder` with what Spring Boot would auto-configure, except that custom connect and read timeouts are also specified:
 
 [source,java,indent=0,subs="verbatim"]


### PR DESCRIPTION
I think document about "RestTemplate Customization" is a little wrong.
It seems creating a RestTemplateBuilder with and without a configurer both prevent any RestTemplateCustomizer beans from being used.