### PR TITLE
Warn about the dangers of early bean initialization when using @ConditionalOnExpression

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnExpression.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnExpression.java
@@ -39,9 +39,11 @@ public @interface ConditionalOnExpression {
 
 	/**
 	 * The SpEL expression to evaluate. Expression should return {@code true} if the
-	 * condition passes or {@code false} if it fails. Note: Referencing a bean in the
-	 * expression will cause that bean to be initialized very early in context refresh
-	 * processing. As a result, the bean will load with default property values.
+	 * condition passes or {@code false} if it fails.
+	 * <p>
+	 * NOTE: Referencing a bean in the expression will cause that bean to be initialized
+	 * very early in context refresh processing. As a result, the bean will load with
+	 * default property values.
 	 * @return the SpEL expression
 	 */
 	String value() default "true";

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnExpression.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnExpression.java
@@ -39,9 +39,9 @@ public @interface ConditionalOnExpression {
 
 	/**
 	 * The SpEL expression to evaluate. Expression should return {@code true} if the
-	 * condition passes or {@code false} if it fails.
-	 * NOTE: Referencing a bean in the expression will cause that bean to be initialized very early
-	 * in context refresh processing. As a result, the bean will load with default property values.
+	 * condition passes or {@code false} if it fails. Note: Referencing a bean in the
+	 * expression will cause that bean to be initialized very early in context refresh
+	 * processing. As a result, the bean will load with default property values.
 	 * @return the SpEL expression
 	 */
 	String value() default "true";

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnExpression.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnExpression.java
@@ -40,9 +40,8 @@ public @interface ConditionalOnExpression {
 	/**
 	 * The SpEL expression to evaluate. Expression should return {@code true} if the
 	 * condition passes or {@code false} if it fails.
-	 * WARNING: Referencing a bean will cause the bean to be initialized very early in
-	 *          context refresh processing. As a result, this will cause the bean
-	 *          properties not to be loaded accordingly.
+	 * NOTE: Referencing a bean in the expression will cause that bean to be initialized very early
+	 * in context refresh processing. As a result, the bean will load with default property values.
 	 * @return the SpEL expression
 	 */
 	String value() default "true";

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnExpression.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnExpression.java
@@ -40,6 +40,9 @@ public @interface ConditionalOnExpression {
 	/**
 	 * The SpEL expression to evaluate. Expression should return {@code true} if the
 	 * condition passes or {@code false} if it fails.
+	 * WARNING: Referencing a bean will cause the bean to be initialized very early in
+	 *          context refresh processing. As a result, this will cause the bean
+	 *          properties not to be loaded accordingly.
 	 * @return the SpEL expression
 	 */
 	String value() default "true";

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/developing-auto-configuration.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/developing-auto-configuration.adoc
@@ -143,6 +143,7 @@ This condition will not match for applications that are run with an embedded ser
 ==== SpEL Expression Conditions
 The `@ConditionalOnExpression` annotation lets configuration be included based on the result of a {spring-framework-docs}/core.html#expressions[SpEL expression].
 
+NOTE: Referencing a bean in the expression will cause that bean to be initialized very early in context refresh processing. As a result, the bean will load with default property values.
 
 
 [[features.developing-auto-configuration.testing]]


### PR DESCRIPTION
Fix #28771

- added a note on using beans in `@ConditionalOnExpression` in the Javadoc and .adoc