### PR TITLE
Implement InputStream.available() for RandomAccessDataFile-backed input streams

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/data/RandomAccessDataFile.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/data/RandomAccessDataFile.java
@@ -179,11 +179,11 @@ public class RandomAccessDataFile implements RandomAccessData {
 		public long skip(long n) throws IOException {
 			return (n <= 0) ? 0 : moveOn(cap(n));
 		}
-		
+
 		@Override
-	    public int available() throws IOException {
+		public int available() throws IOException {
 			return (int) RandomAccessDataFile.this.length - this.position;
-	    }
+		}
 
 		/**
 		 * Cap the specified value such that it cannot exceed the number of bytes

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/data/RandomAccessDataFile.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/data/RandomAccessDataFile.java
@@ -182,7 +182,7 @@ public class RandomAccessDataFile implements RandomAccessData {
 		
 		@Override
 	    public int available() throws IOException {
-		    return RandomAccessDataFile.this.length - this.position;
+			return (int) RandomAccessDataFile.this.length - this.position;
 	    }
 
 		/**

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/data/RandomAccessDataFile.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/data/RandomAccessDataFile.java
@@ -179,6 +179,11 @@ public class RandomAccessDataFile implements RandomAccessData {
 		public long skip(long n) throws IOException {
 			return (n <= 0) ? 0 : moveOn(cap(n));
 		}
+		
+		@Override
+	    public int available() throws IOException {
+		    return RandomAccessDataFile.this.length - this.position;
+	    }
 
 		/**
 		 * Cap the specified value such that it cannot exceed the number of bytes


### PR DESCRIPTION
When someone calles new `ClassPathResource("a.file").getInputStream().available()` in application, they will get 0 if  "a.file"(eg:"a.xlsx") is a `ZipEntry.Store` entry in the executable jar of that application. See [JarFileEntries](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarFileEntries.java)#getInputStream(FileHeader entry) method.
