### PR TITLE
Avoid split java.xml packages in docs project that cause compilation errors in Eclipse with Java 9 and later

### DIFF
--- a/spring-boot-project/spring-boot-docs/build.gradle
+++ b/spring-boot-project/spring-boot-docs/build.gradle
@@ -83,6 +83,7 @@ dependencies {
 	implementation("jakarta.validation:jakarta.validation-api")
 	implementation("net.sourceforge.htmlunit:htmlunit") {
 		exclude group: "commons-logging", module: "commons-logging"
+		exclude group: "xerces", module: "xercesImpl"
 	}
 	implementation("org.apache.commons:commons-dbcp2") {
 		exclude group: "commons-logging", module: "commons-logging"


### PR DESCRIPTION
Without this change I get compiler errors from JDT in the IDE (VSCode). It seems to be harmless from the point of view of the command line build with the JDK.