### PR TITLE
Add support for descriptions of record components in configuration metadata generation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/configuration-metadata/annotation-processor.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/configuration-metadata/annotation-processor.adoc
@@ -79,6 +79,8 @@ The Javadoc on fields is used to populate the `description` attribute. For insta
 
 NOTE: You should only use plain text with `@ConfigurationProperties` field Javadoc, since they are not processed before being added to the JSON.
 
+If you use `@ConfigurationProperties` with record class then record components' descriptions should be provided via class-level Javadoc tag `@param` (there are no explicit instance fields in record classes to put regular field-level Javadocs on).
+
 The annotation processor applies a number of heuristics to extract the default value from the source model.
 Default values have to be provided statically. In particular, do not refer to a constant defined in another class.
 Also, the annotation processor cannot auto-detect default values for ``Enum``s and ``Collections``s.

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/developing-auto-configuration.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/developing-auto-configuration.adoc
@@ -256,6 +256,8 @@ include::{docs-java}/features/developingautoconfiguration/customstarter/configur
 
 NOTE: You should only use plain text with `@ConfigurationProperties` field Javadoc, since they are not processed before being added to the JSON.
 
+If you use `@ConfigurationProperties` with record class then record components' descriptions should be provided via class-level Javadoc tag `@param` (there are no explicit instance fields in record classes to put regular field-level Javadocs on).
+
 Here are some rules we follow internally to make sure descriptions are consistent:
 
 * Do not start the description by "The" or "A".

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConstructorParameterPropertyDescriptor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConstructorParameterPropertyDescriptor.java
@@ -66,8 +66,7 @@ class ConstructorParameterPropertyDescriptor extends PropertyDescriptor<Variable
 
 	@Override
 	protected String resolveDescription(MetadataGenerationEnvironment environment) {
-		// record components descriptions are written using @param notation and require
-		// special processing
+		// record components descriptions are written using @param tag
 		if (this.recordComponent != null) {
 			return environment.getTypeUtils().getJavaDoc(this.recordComponent);
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,7 +155,7 @@ abstract class PropertyDescriptor<S extends Element> {
 		return environment.getTypeUtils().getType(getOwnerElement(), getType());
 	}
 
-	private String resolveDescription(MetadataGenerationEnvironment environment) {
+	protected String resolveDescription(MetadataGenerationEnvironment environment) {
 		return environment.getTypeUtils().getJavaDoc(getField());
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolver.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.NestingKind;
+import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
@@ -35,6 +36,7 @@ import javax.lang.model.util.ElementFilter;
  *
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Pavel Anisimov
  */
 class PropertyDescriptorResolver {
 
@@ -82,8 +84,9 @@ class PropertyDescriptorResolver {
 			ExecutableElement getter = members.getPublicGetter(name, propertyType);
 			ExecutableElement setter = members.getPublicSetter(name, propertyType);
 			VariableElement field = members.getFields().get(name);
+			RecordComponentElement recordComponent = members.getRecordComponents().get(name);
 			register(candidates, new ConstructorParameterPropertyDescriptor(type, factoryMethod, parameter, name,
-					propertyType, field, getter, setter));
+					propertyType, field, recordComponent, getter, setter));
 		});
 		return candidates.values().stream();
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.function.Function;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeKind;
@@ -38,6 +39,7 @@ import javax.lang.model.util.ElementFilter;
  *
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Pavel Anisimov
  */
 class TypeElementMembers {
 
@@ -48,6 +50,8 @@ class TypeElementMembers {
 	private final TypeElement targetType;
 
 	private final Map<String, VariableElement> fields = new LinkedHashMap<>();
+
+	private final Map<String, RecordComponentElement> recordComponents = new LinkedHashMap<>();
 
 	private final Map<String, List<ExecutableElement>> publicGetters = new LinkedHashMap<>();
 
@@ -65,6 +69,9 @@ class TypeElementMembers {
 		}
 		for (VariableElement field : ElementFilter.fieldsIn(element.getEnclosedElements())) {
 			processField(field);
+		}
+		for (RecordComponentElement recordComponent : ElementFilter.recordComponentsIn(element.getEnclosedElements())) {
+			processRecordComponent(recordComponent);
 		}
 		Element superType = this.env.getTypeUtils().asElement(element.getSuperclass());
 		if (superType instanceof TypeElement && !OBJECT_CLASS_NAME.equals(superType.toString())) {
@@ -163,8 +170,19 @@ class TypeElementMembers {
 		}
 	}
 
+	private void processRecordComponent(RecordComponentElement recordComponent) {
+		String name = recordComponent.getSimpleName().toString();
+		if (!this.recordComponents.containsKey(name)) {
+			this.recordComponents.put(name, recordComponent);
+		}
+	}
+
 	Map<String, VariableElement> getFields() {
 		return Collections.unmodifiableMap(this.fields);
+	}
+
+	Map<String, RecordComponentElement> getRecordComponents() {
+		return Collections.unmodifiableMap(this.recordComponents);
 	}
 
 	Map<String, List<ExecutableElement>> getPublicGetters() {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
@@ -180,7 +180,7 @@ class TypeUtils {
 
 	String getJavaDoc(Element element) {
 		if (element instanceof RecordComponentElement) {
-			return getJavadoc((RecordComponentElement) element);
+			return getJavaDoc((RecordComponentElement) element);
 		}
 		String javadoc = (element != null) ? this.env.getElementUtils().getDocComment(element) : null;
 		if (javadoc != null) {
@@ -252,7 +252,7 @@ class TypeUtils {
 		}
 	}
 
-	private String getJavadoc(RecordComponentElement recordComponent) {
+	private String getJavaDoc(RecordComponentElement recordComponent) {
 		String recordJavadoc = this.env.getElementUtils().getDocComment(recordComponent.getEnclosingElement());
 		if (recordJavadoc != null) {
 			Pattern paramJavadocPattern = paramJavadocPattern(recordComponent.getSimpleName().toString());

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
@@ -180,7 +180,7 @@ class TypeUtils {
 
 	String getJavaDoc(Element element) {
 		if (element instanceof RecordComponentElement) {
-			return getJavaDoc((RecordComponentElement) element);
+			return getJavadoc((RecordComponentElement) element);
 		}
 		String javadoc = (element != null) ? this.env.getElementUtils().getDocComment(element) : null;
 		if (javadoc != null) {
@@ -252,20 +252,20 @@ class TypeUtils {
 		}
 	}
 
-	private String getJavaDoc(RecordComponentElement recordComponent) {
-		String recordJavaDoc = this.env.getElementUtils().getDocComment(recordComponent.getEnclosingElement());
-		if (recordJavaDoc != null) {
-			Pattern paramJavaDocPattern = paramJavaDocPattern(recordComponent.getSimpleName().toString());
-			Matcher paramJavaDocMatcher = paramJavaDocPattern.matcher(recordJavaDoc);
-			if (paramJavaDocMatcher.find()) {
-				String paramJavaDoc = NEW_LINE_PATTERN.matcher(paramJavaDocMatcher.group()).replaceAll("").trim();
-				return paramJavaDoc.isEmpty() ? null : paramJavaDoc;
+	private String getJavadoc(RecordComponentElement recordComponent) {
+		String recordJavadoc = this.env.getElementUtils().getDocComment(recordComponent.getEnclosingElement());
+		if (recordJavadoc != null) {
+			Pattern paramJavadocPattern = paramJavadocPattern(recordComponent.getSimpleName().toString());
+			Matcher paramJavadocMatcher = paramJavadocPattern.matcher(recordJavadoc);
+			if (paramJavadocMatcher.find()) {
+				String paramJavadoc = NEW_LINE_PATTERN.matcher(paramJavadocMatcher.group()).replaceAll("").trim();
+				return paramJavadoc.isEmpty() ? null : paramJavadoc;
 			}
 		}
 		return null;
 	}
 
-	private Pattern paramJavaDocPattern(String paramName) {
+	private Pattern paramJavadocPattern(String paramName) {
 		String pattern = String.format("(?<=@param +%s).*?(?=([\r\n]+ *@)|$)", paramName);
 		return Pattern.compile(pattern, Pattern.DOTALL);
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -476,6 +476,7 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 			writer.println(" *    @param   someBoolean   description with extra spaces");
 			writer.println(" *@param someLong description without space after asterisk");
 			writer.println(" * @since 1.0.0");
+			writer.println(" * @param someByte last description in Javadoc");
 			writer.println(" */");
 			writer.println(
 					"@org.springframework.boot.configurationsample.ConfigurationProperties(\"record.descriptions\")");
@@ -483,7 +484,8 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 			writer.println("String someString,");
 			writer.println("Integer someInteger,");
 			writer.println("Boolean someBoolean,");
-			writer.println("Long someLong");
+			writer.println("Long someLong,");
+			writer.println("Byte someByte");
 			writer.println(") {");
 			writer.println("}");
 		}
@@ -496,6 +498,8 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 				.withDescription("description with extra spaces"));
 		assertThat(metadata).has(Metadata.withProperty("record.descriptions.some-long", Long.class)
 				.withDescription("description without space after asterisk"));
+		assertThat(metadata).has(Metadata.withProperty("record.descriptions.some-byte", Byte.class)
+				.withDescription("last description in Javadoc"));
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConstructorParameterPropertyDescriptorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConstructorParameterPropertyDescriptorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,7 +126,7 @@ class ConstructorParameterPropertyDescriptorTests extends PropertyDescriptorTest
 			VariableElement field = getField(ownerElement, "flag");
 			VariableElement constructorParameter = getConstructorParameter(ownerElement, "flag");
 			ConstructorParameterPropertyDescriptor property = new ConstructorParameterPropertyDescriptor(ownerElement,
-					null, constructorParameter, "flag", field.asType(), field, getter, null);
+					null, constructorParameter, "flag", field.asType(), field, null, getter, null);
 			assertItemMetadata(metadataEnv, property).isProperty().isDeprecatedWithNoInformation();
 		});
 	}
@@ -213,7 +213,7 @@ class ConstructorParameterPropertyDescriptorTests extends PropertyDescriptorTest
 		ExecutableElement getter = getMethod(ownerElement, createAccessorMethodName("get", name));
 		ExecutableElement setter = getMethod(ownerElement, createAccessorMethodName("set", name));
 		return new ConstructorParameterPropertyDescriptor(ownerElement, null, constructorParameter, name,
-				field.asType(), field, getter, setter);
+				field.asType(), field, null, getter, setter);
 	}
 
 	private VariableElement getConstructorParameter(TypeElement ownerElement, String name) {


### PR DESCRIPTION
Hello everyone!

While working on PR #29010 I've noticed that now there is no way to automatically generate descriptions in configuration metadata if you use `@ConfigurationProperties` with record class. Indeed, there are no explicit fields to put regular field-level Javadocs on. But there is an official way for records to do so: descriptions should be provided via class-level Javadoc tag `@param`.

I've added support for such usage, added test and mentioned it in reference documentation. I assume test is clear enough for understanding what I've done. Hope build will pass :)