### PR TITLE
Provide a callback mechanism for customizing LocalValidatorFactoryBean's configuration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/ValidationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/ValidationAutoConfiguration.java
@@ -60,7 +60,8 @@ public class ValidationAutoConfiguration {
 	@Bean
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	@ConditionalOnMissingBean(Validator.class)
-	public static LocalValidatorFactoryBean defaultValidator(ApplicationContext applicationContext, List<ValueExtractor> valueExtractors) {
+	public static LocalValidatorFactoryBean defaultValidator(ApplicationContext applicationContext,
+			List<ValueExtractor> valueExtractors) {
 		AddValueExtractorsLocalValidatorFactoryBean factoryBean = new AddValueExtractorsLocalValidatorFactoryBean();
 		factoryBean.setValueExtractors(valueExtractors);
 		MessageInterpolatorFactory interpolatorFactory = new MessageInterpolatorFactory(applicationContext);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/ValidationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/ValidationAutoConfiguration.java
@@ -16,8 +16,11 @@
 
 package org.springframework.boot.autoconfigure.validation;
 
+import java.util.List;
+
 import jakarta.validation.Validator;
 import jakarta.validation.executable.ExecutableValidator;
+import jakarta.validation.valueextraction.ValueExtractor;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -27,6 +30,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnResource;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.boot.validation.MessageInterpolatorFactory;
+import org.springframework.boot.validation.beanvalidation.AddValueExtractorsLocalValidatorFactoryBean;
 import org.springframework.boot.validation.beanvalidation.FilteredMethodValidationPostProcessor;
 import org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter;
 import org.springframework.context.ApplicationContext;
@@ -56,8 +60,9 @@ public class ValidationAutoConfiguration {
 	@Bean
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	@ConditionalOnMissingBean(Validator.class)
-	public static LocalValidatorFactoryBean defaultValidator(ApplicationContext applicationContext) {
-		LocalValidatorFactoryBean factoryBean = new LocalValidatorFactoryBean();
+	public static LocalValidatorFactoryBean defaultValidator(ApplicationContext applicationContext, List<ValueExtractor> valueExtractors) {
+		AddValueExtractorsLocalValidatorFactoryBean factoryBean = new AddValueExtractorsLocalValidatorFactoryBean();
+		factoryBean.setValueExtractors(valueExtractors);
 		MessageInterpolatorFactory interpolatorFactory = new MessageInterpolatorFactory(applicationContext);
 		factoryBean.setMessageInterpolator(interpolatorFactory.getObject());
 		return factoryBean;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/ValidationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/ValidationAutoConfiguration.java
@@ -30,9 +30,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnResource;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.boot.validation.MessageInterpolatorFactory;
-import org.springframework.boot.validation.beanvalidation.AddValueExtractorsLocalValidatorFactoryBean;
+import org.springframework.boot.validation.beanvalidation.CustomizableLocalValidatorFactoryBean;
 import org.springframework.boot.validation.beanvalidation.FilteredMethodValidationPostProcessor;
 import org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter;
+import org.springframework.boot.validation.beanvalidation.customize.AddValueExtractorCustomizer;
+import org.springframework.boot.validation.beanvalidation.customize.Customizer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -58,12 +60,19 @@ import org.springframework.validation.beanvalidation.MethodValidationPostProcess
 public class ValidationAutoConfiguration {
 
 	@Bean
+	public static AddValueExtractorCustomizer autoAddValueExtractorCustomizer(
+			@SuppressWarnings({ "rawtypes", "unchecked" }) List<ValueExtractor> valueExtractors) {
+
+		return new AddValueExtractorCustomizer(valueExtractors);
+	}
+
+	@Bean
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	@ConditionalOnMissingBean(Validator.class)
 	public static LocalValidatorFactoryBean defaultValidator(ApplicationContext applicationContext,
-			@SuppressWarnings({ "rawtypes", "unchecked" }) List<ValueExtractor> valueExtractors) {
-		AddValueExtractorsLocalValidatorFactoryBean factoryBean = new AddValueExtractorsLocalValidatorFactoryBean();
-		factoryBean.setValueExtractors(valueExtractors);
+			List<Customizer> customizers) {
+		CustomizableLocalValidatorFactoryBean factoryBean = new CustomizableLocalValidatorFactoryBean();
+		factoryBean.setCustomizers(customizers);
 		MessageInterpolatorFactory interpolatorFactory = new MessageInterpolatorFactory(applicationContext);
 		factoryBean.setMessageInterpolator(interpolatorFactory.getObject());
 		return factoryBean;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/ValidationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/ValidationAutoConfiguration.java
@@ -61,7 +61,7 @@ public class ValidationAutoConfiguration {
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	@ConditionalOnMissingBean(Validator.class)
 	public static LocalValidatorFactoryBean defaultValidator(ApplicationContext applicationContext,
-			List<ValueExtractor> valueExtractors) {
+			@SuppressWarnings({ "rawtypes", "unchecked" }) List<ValueExtractor> valueExtractors) {
 		AddValueExtractorsLocalValidatorFactoryBean factoryBean = new AddValueExtractorsLocalValidatorFactoryBean();
 		factoryBean.setValueExtractors(valueExtractors);
 		MessageInterpolatorFactory interpolatorFactory = new MessageInterpolatorFactory(applicationContext);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/validation/beanvalidation/AddValueExtractorsLocalValidatorFactoryBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/validation/beanvalidation/AddValueExtractorsLocalValidatorFactoryBean.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import jakarta.validation.Configuration;
 import jakarta.validation.valueextraction.ValueExtractor;
+
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 /**
@@ -37,25 +38,26 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
  *     }
  * }
  * }</pre>
+ *
  * @author Dang Zhicairang
+ * @since 2.6.2
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
+@SuppressWarnings({ "rawtypes", "unchecked" })
 public class AddValueExtractorsLocalValidatorFactoryBean extends LocalValidatorFactoryBean {
 
 	private List<ValueExtractor> valueExtractors;
 
 	public List<ValueExtractor> getValueExtractors() {
-		return valueExtractors;
+		return this.valueExtractors;
 	}
 
 	public void setValueExtractors(List<ValueExtractor> valueExtractors) {
 		this.valueExtractors = valueExtractors;
 	}
 
-
 	@Override
 	protected void postProcessConfiguration(Configuration<?> configuration) {
-		valueExtractors.forEach(configuration::addValueExtractor);
+		this.valueExtractors.forEach(configuration::addValueExtractor);
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/validation/beanvalidation/AddValueExtractorsLocalValidatorFactoryBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/validation/beanvalidation/AddValueExtractorsLocalValidatorFactoryBean.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.validation.beanvalidation;
+
+import java.util.List;
+
+import jakarta.validation.Configuration;
+import jakarta.validation.valueextraction.ValueExtractor;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+/**
+ * Custom {@link LocalValidatorFactoryBean} that applies
+ * {@link ValueExtractor} custom ValueExtractor(s)
+ *
+ * These custom ValueExtractor(s) should be Spring components.
+ * For example:
+ * <pre>{@code
+ * @Component
+ * public class CustomValueExtractor implements ValueExtractor<CustomResult<@ExtractedValue ?>> {
+ *
+ *     @Override
+ *     public void extractValues(CustomResult<?> result, ValueReceiver valueReceiver) {
+ *         valueReceiver.value(null, result.getData());
+ *     }
+ * }
+ * }</pre>
+ *
+ * @author Dang Zhicairang
+ */
+public class AddValueExtractorsLocalValidatorFactoryBean extends LocalValidatorFactoryBean {
+
+	private List<ValueExtractor> valueExtractors;
+
+	public List<ValueExtractor> getValueExtractors() {
+		return valueExtractors;
+	}
+
+	public void setValueExtractors(List<ValueExtractor> valueExtractors) {
+		this.valueExtractors = valueExtractors;
+	}
+
+	@Override
+	protected void postProcessConfiguration(Configuration<?> configuration) {
+		valueExtractors.forEach(configuration::addValueExtractor);
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/validation/beanvalidation/AddValueExtractorsLocalValidatorFactoryBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/validation/beanvalidation/AddValueExtractorsLocalValidatorFactoryBean.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.validation.beanvalidation;
 
 import java.util.List;
+import java.util.Optional;
 
 import jakarta.validation.Configuration;
 import jakarta.validation.valueextraction.ValueExtractor;
@@ -57,7 +58,8 @@ public class AddValueExtractorsLocalValidatorFactoryBean extends LocalValidatorF
 
 	@Override
 	protected void postProcessConfiguration(Configuration<?> configuration) {
-		this.valueExtractors.forEach(configuration::addValueExtractor);
+		Optional.ofNullable(this.getValueExtractors())
+				.ifPresent((list) -> list.forEach(configuration::addValueExtractor));
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/validation/beanvalidation/AddValueExtractorsLocalValidatorFactoryBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/validation/beanvalidation/AddValueExtractorsLocalValidatorFactoryBean.java
@@ -23,24 +23,23 @@ import jakarta.validation.valueextraction.ValueExtractor;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 /**
- * Custom {@link LocalValidatorFactoryBean} that applies
- * {@link ValueExtractor} custom ValueExtractor(s)
+ * Custom {@link LocalValidatorFactoryBean} that applies {@link ValueExtractor} custom
+ * ValueExtractor(s)
  *
- * These custom ValueExtractor(s) should be Spring components.
- * For example:
- * <pre>{@code
- * @Component
+ * These custom ValueExtractor(s) should be Spring components. For example: <pre>{@code
+ * &#64;Component
  * public class CustomValueExtractor implements ValueExtractor<CustomResult<@ExtractedValue ?>> {
  *
- *     @Override
+
+ *     &#64;Override
  *     public void extractValues(CustomResult<?> result, ValueReceiver valueReceiver) {
  *         valueReceiver.value(null, result.getData());
  *     }
  * }
  * }</pre>
- *
  * @author Dang Zhicairang
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class AddValueExtractorsLocalValidatorFactoryBean extends LocalValidatorFactoryBean {
 
 	private List<ValueExtractor> valueExtractors;
@@ -52,6 +51,7 @@ public class AddValueExtractorsLocalValidatorFactoryBean extends LocalValidatorF
 	public void setValueExtractors(List<ValueExtractor> valueExtractors) {
 		this.valueExtractors = valueExtractors;
 	}
+
 
 	@Override
 	protected void postProcessConfiguration(Configuration<?> configuration) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/validation/beanvalidation/CustomizableLocalValidatorFactoryBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/validation/beanvalidation/CustomizableLocalValidatorFactoryBean.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.validation.beanvalidation;
+
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.validation.Configuration;
+
+import org.springframework.boot.validation.beanvalidation.customize.Customizer;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+/**
+ * This class will callback the {@link Customizer} which supply by application. For
+ * example:
+ *
+ * <pre>{@code
+ * &#64;Bean
+ * public Customizer customizer() {
+ *		return configuration -> {
+ *			configuration.addValueExtractor(new CustomResultValueExtractor());
+ *			configuration.xxx
+ *			...
+ *		};
+ * }
+ * }</pre>
+ *
+ * @author Dang Zhicairang
+ * @since 2.6.2
+ */
+public class CustomizableLocalValidatorFactoryBean extends LocalValidatorFactoryBean {
+
+	private List<Customizer> customizers;
+
+	public void setCustomizers(List<Customizer> customizers) {
+		this.customizers = customizers;
+	}
+
+	@Override
+	protected void postProcessConfiguration(Configuration<?> configuration) {
+		Optional.ofNullable(this.customizers)
+				.ifPresent((list) -> list.forEach((customizer) -> customizer.customize(configuration)));
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/validation/beanvalidation/customize/AddValueExtractorCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/validation/beanvalidation/customize/AddValueExtractorCustomizer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.validation.beanvalidation;
+package org.springframework.boot.validation.beanvalidation.customize;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,31 +22,20 @@ import java.util.Optional;
 import jakarta.validation.Configuration;
 import jakarta.validation.valueextraction.ValueExtractor;
 
-import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
-
 /**
- * Custom {@link LocalValidatorFactoryBean} that applies {@link ValueExtractor} custom
- * ValueExtractor(s)
- *
- * These custom ValueExtractor(s) should be Spring components. For example: <pre>{@code
- * &#64;Component
- * public class CustomValueExtractor implements ValueExtractor<CustomResult<@ExtractedValue ?>> {
- *
-
- *     &#64;Override
- *     public void extractValues(CustomResult<?> result, ValueReceiver valueReceiver) {
- *         valueReceiver.value(null, result.getData());
- *     }
- * }
- * }</pre>
+ * Add given collection of {@link ValueExtractor} into {@link Configuration}.
  *
  * @author Dang Zhicairang
  * @since 2.6.2
  */
 @SuppressWarnings({ "rawtypes", "unchecked" })
-public class AddValueExtractorsLocalValidatorFactoryBean extends LocalValidatorFactoryBean {
+public class AddValueExtractorCustomizer implements Customizer {
 
 	private List<ValueExtractor> valueExtractors;
+
+	public AddValueExtractorCustomizer(List<ValueExtractor> valueExtractors) {
+		this.valueExtractors = valueExtractors;
+	}
 
 	public List<ValueExtractor> getValueExtractors() {
 		return this.valueExtractors;
@@ -57,7 +46,7 @@ public class AddValueExtractorsLocalValidatorFactoryBean extends LocalValidatorF
 	}
 
 	@Override
-	protected void postProcessConfiguration(Configuration<?> configuration) {
+	public void customize(Configuration<?> configuration) {
 		Optional.ofNullable(this.getValueExtractors())
 				.ifPresent((list) -> list.forEach(configuration::addValueExtractor));
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/validation/beanvalidation/customize/Customizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/validation/beanvalidation/customize/Customizer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.validation.beanvalidation.customize;
+
+import jakarta.validation.Configuration;
+
+/**
+ * Callback interface that can be used to customize {@link Configuration}.
+ *
+ * @author Dang Zhicairang
+ * @since 2.6.2
+ * @see AddValueExtractorCustomizer
+ */
+@FunctionalInterface
+public interface Customizer {
+
+	void customize(Configuration<?> configuration);
+
+}


### PR DESCRIPTION
Add a AddValueExtractorsLocalValidatorFactoryBean that expand LocalValidatorFactoryBean which based SpringFramework, it can support user add custom ValueExtractor(s). For example, user can define ValueExtractor like this in their application:
```
@Component
public class CustomValueExtractor implements ValueExtractor<CustomResult<@ExtractedValue ?>> {
 
     @Override
     public void extractValues(CustomResult<?> result, ValueReceiver valueReceiver) {
         valueReceiver.value(null, result.getData());
     }
}
```

And modify the class ValidationAutoConfiguration, auto-configure an instance of type AddValueExtractorsLocalValidatorFactoryBean instead of type LocalValidatorFactoryBean