### PR TITLE
Custom applicationContextException failure analyzer for webflux 

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/ReactiveMissingWebServerFactoryFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/ReactiveMissingWebServerFactoryFailureAnalyzer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.diagnostics.analyzer;
+
+import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+import org.springframework.context.ApplicationContextException;
+import org.springframework.util.ClassUtils;
+
+/**
+ * A {@code FailureAnalyzer} that performs analysis of failures caused by a
+ * {@code ApplicationContextException}.
+ *
+ * @author Zhao Xianming
+ */
+class ReactiveMissingWebServerFactoryFailureAnalyzer extends AbstractFailureAnalyzer<ApplicationContextException> {
+
+	private static final String MISSING_WEBSERVER_FACTORY_MESSAGE = "due to missing ReactiveWebServerFactory bean.";
+
+	private static final String REACTIVE_WEB_APPLICATION_CLASS = "org.springframework.web.reactive.HandlerResult";
+
+	@Override
+	protected FailureAnalysis analyze(Throwable rootFailure, ApplicationContextException cause) {
+		if (cause.getMessage().contains(MISSING_WEBSERVER_FACTORY_MESSAGE)
+				&& !ClassUtils.isPresent(REACTIVE_WEB_APPLICATION_CLASS, null)) {
+			return new FailureAnalysis(
+					"The web-application_type is set to reactive but webflux related classes are missing.",
+					"Add spring-boot-starter-webflux dependency.", cause);
+		}
+		return null;
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/spring.factories
@@ -73,7 +73,8 @@ org.springframework.boot.diagnostics.analyzer.ValidationExceptionFailureAnalyzer
 org.springframework.boot.diagnostics.analyzer.InvalidConfigurationPropertyNameFailureAnalyzer,\
 org.springframework.boot.diagnostics.analyzer.InvalidConfigurationPropertyValueFailureAnalyzer,\
 org.springframework.boot.diagnostics.analyzer.PatternParseFailureAnalyzer,\
-org.springframework.boot.liquibase.LiquibaseChangelogMissingFailureAnalyzer
+org.springframework.boot.liquibase.LiquibaseChangelogMissingFailureAnalyzer,\
+org.springframework.boot.diagnostics.analyzer.ReactiveMissingWebServerFactoryFailureAnalyzer
 
 # Failure Analysis Reporters
 org.springframework.boot.diagnostics.FailureAnalysisReporter=\

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/ReactiveMissingWebServerFactoryFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/ReactiveMissingWebServerFactoryFailureAnalyzerTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.diagnostics.analyzer;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.diagnostics.FailureAnalysis;
+import org.springframework.context.ApplicationContextException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ReactiveMissingWebServerFactoryFailureAnalyzer}
+ *
+ * @author Zhao Xianming
+ */
+public class ReactiveMissingWebServerFactoryFailureAnalyzerTests {
+
+	@Test
+	void missingWebServerFactoryFailure() {
+		ApplicationContextException ex = createFailureMissingBean();
+		FailureAnalysis failureAnalysis = new ReactiveMissingWebServerFactoryFailureAnalyzer().analyze(null, ex);
+		assertThat(failureAnalysis).isNull();
+	}
+
+	@Test
+	void multipleWebServerFactoryFailure() {
+		ApplicationContextException ex = createFailureMultipleBean();
+		FailureAnalysis failureAnalysis = new ReactiveMissingWebServerFactoryFailureAnalyzer().analyze(null, ex);
+		assertThat(failureAnalysis).isNull();
+	}
+
+	private ApplicationContextException createFailureMissingBean() {
+		return new ApplicationContextException(
+				"Unable to start ReactiveWebApplicationContext due to missing ReactiveWebServerFactory bean.");
+	}
+
+	private ApplicationContextException createFailureMultipleBean() {
+		return new ApplicationContextException(
+				"Unable to start ReactiveWebApplicationContext due to multiple ReactiveWebServerFactory beans.");
+	}
+
+}


### PR DESCRIPTION
I have customized an applicationContextException failure analyzer for webflux, mainly for the project where the web-application-type is reactive but there is no exception message that the corresponding class file is missing. 
