### PR TITLE
Fix indentation in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,24 +24,23 @@ Here is a quick teaser of a complete Spring Boot application in Java:
 
 [source,java,indent=0]
 ----
-	import org.springframework.boot.*;
-	import org.springframework.boot.autoconfigure.*;
-	import org.springframework.web.bind.annotation.*;
+import org.springframework.boot.*;
+import org.springframework.boot.autoconfigure.*;
+import org.springframework.web.bind.annotation.*;
 
-	@RestController
-	@SpringBootApplication
-	public class Example {
+@RestController
+@SpringBootApplication
+public class Example {
 
-		@RequestMapping("/")
-		String home() {
-			return "Hello World!";
-		}
+    @RequestMapping("/")
+    String home() {
+        return "Hello World!";
+    }
 
-		public static void main(String[] args) {
-			SpringApplication.run(Example.class, args);
-		}
-
-	}
+    public static void main(String[] args) {
+	SpringApplication.run(Example.class, args);
+    }
+}
 ----
 
 


### PR DESCRIPTION
This PR only changes the indents in the README.adoc file because the current rendering looks weird on GitHub. The following images show the difference. I am using macOS Monterey 12.1 and Google Chrome 97.

Edit: Added screenshots (before, after)
<img width="515" alt="Screenshot 2022-01-20 at 18 18 29" src="https://user-images.githubusercontent.com/17139385/150389228-d99c4322-e83c-485e-92ba-cdffc5fd95a4.png">
<img width="515" alt="Screenshot 2022-01-20 at 18 18 56" src="https://user-images.githubusercontent.com/17139385/150389235-cd94799b-1323-4e0d-a873-9c2eb790e2c5.png">

