### PR TITLE
Upgrade version of gradle-git-properties in reference doc

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/build.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/build.adoc
@@ -72,7 +72,7 @@ Gradle users can achieve the same result by using the https://plugins.gradle.org
 [source,gradle,indent=0,subs="verbatim"]
 ----
 	plugins {
-		id "com.gorylenko.gradle-git-properties" version "2.2.4"
+		id "com.gorylenko.gradle-git-properties" version "2.3.2"
 	}
 ----
 


### PR DESCRIPTION
- Change docs to use version 2.3.2 as 2.2.4 doesn't work with jdk 17.
- Issue was fixed in https://github.com/n0mer/gradle-git-properties/issues/171

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
