### PR TITLE
Add ability to match Endpoint requests by HTTP method

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/reactive/EndpointRequest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/reactive/EndpointRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.springframework.boot.security.reactive.ApplicationContextServerWebExc
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.MergedAnnotation;
 import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.web.server.util.matcher.OrServerWebExchangeMatcher;
 import org.springframework.security.web.server.util.matcher.PathPatternParserServerWebExchangeMatcher;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
@@ -52,6 +53,7 @@ import org.springframework.web.server.ServerWebExchange;
  * endpoint locations.
  *
  * @author Madhura Bhave
+ * @author Chris Bono
  * @since 2.0.0
  */
 public final class EndpointRequest {
@@ -157,41 +159,55 @@ public final class EndpointRequest {
 
 		private final boolean includeLinks;
 
+		private final HttpMethod httpMethod;
+
 		private volatile ServerWebExchangeMatcher delegate;
 
 		private EndpointServerWebExchangeMatcher(boolean includeLinks) {
-			this(Collections.emptyList(), Collections.emptyList(), includeLinks);
+			this(Collections.emptyList(), Collections.emptyList(), includeLinks, null);
 		}
 
 		private EndpointServerWebExchangeMatcher(Class<?>[] endpoints, boolean includeLinks) {
-			this(Arrays.asList((Object[]) endpoints), Collections.emptyList(), includeLinks);
+			this(Arrays.asList((Object[]) endpoints), Collections.emptyList(), includeLinks, null);
 		}
 
 		private EndpointServerWebExchangeMatcher(String[] endpoints, boolean includeLinks) {
-			this(Arrays.asList((Object[]) endpoints), Collections.emptyList(), includeLinks);
+			this(Arrays.asList((Object[]) endpoints), Collections.emptyList(), includeLinks, null);
 		}
 
-		private EndpointServerWebExchangeMatcher(List<Object> includes, List<Object> excludes, boolean includeLinks) {
+		private EndpointServerWebExchangeMatcher(List<Object> includes, List<Object> excludes, boolean includeLinks,
+				HttpMethod httpMethod) {
 			super(PathMappedEndpoints.class);
 			this.includes = includes;
 			this.excludes = excludes;
 			this.includeLinks = includeLinks;
+			this.httpMethod = httpMethod;
 		}
 
 		public EndpointServerWebExchangeMatcher excluding(Class<?>... endpoints) {
 			List<Object> excludes = new ArrayList<>(this.excludes);
 			excludes.addAll(Arrays.asList((Object[]) endpoints));
-			return new EndpointServerWebExchangeMatcher(this.includes, excludes, this.includeLinks);
+			return new EndpointServerWebExchangeMatcher(this.includes, excludes, this.includeLinks, null);
 		}
 
 		public EndpointServerWebExchangeMatcher excluding(String... endpoints) {
 			List<Object> excludes = new ArrayList<>(this.excludes);
 			excludes.addAll(Arrays.asList((Object[]) endpoints));
-			return new EndpointServerWebExchangeMatcher(this.includes, excludes, this.includeLinks);
+			return new EndpointServerWebExchangeMatcher(this.includes, excludes, this.includeLinks, null);
 		}
 
 		public EndpointServerWebExchangeMatcher excludingLinks() {
-			return new EndpointServerWebExchangeMatcher(this.includes, this.excludes, false);
+			return new EndpointServerWebExchangeMatcher(this.includes, this.excludes, false, null);
+		}
+
+		/**
+		 * Restricts the matcher to only consider requests with a particular http method.
+		 * @param httpMethod the http method to include
+		 * @return a copy of the matcher further restricted to only match requests with
+		 * the specified http method
+		 */
+		public EndpointServerWebExchangeMatcher withHttpMethod(HttpMethod httpMethod) {
+			return new EndpointServerWebExchangeMatcher(this.includes, this.excludes, false, httpMethod);
 		}
 
 		@Override
@@ -246,7 +262,8 @@ public final class EndpointRequest {
 		}
 
 		private List<ServerWebExchangeMatcher> getDelegateMatchers(Set<String> paths) {
-			return paths.stream().map((path) -> new PathPatternParserServerWebExchangeMatcher(path + "/**"))
+			return paths.stream()
+					.map((path) -> new PathPatternParserServerWebExchangeMatcher(path + "/**", this.httpMethod))
 					.collect(Collectors.toList());
 		}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/AbstractEndpointRequestIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/AbstractEndpointRequestIntegrationTests.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
@@ -33,6 +33,7 @@ import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoint;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
 import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpoint;
 import org.springframework.boot.autoconfigure.security.servlet.RequestMatcherProvider;
+import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.security.web.util.matcher.RequestMatcher;
@@ -48,6 +49,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Chris Bono
  */
 class EndpointRequestTests {
 
@@ -59,6 +61,14 @@ class EndpointRequestTests {
 		assertMatcher(matcher, "/actuator").matches("/actuator/bar");
 		assertMatcher(matcher, "/actuator").matches("/actuator/bar/baz");
 		assertMatcher(matcher, "/actuator").matches("/actuator");
+	}
+
+	@Test
+	void toAnyEndpointWithHttpMethodShouldRespectRequestMethod() {
+		EndpointRequest.EndpointRequestMatcher matcher = EndpointRequest.toAnyEndpoint()
+				.withHttpMethod(HttpMethod.POST);
+		assertMatcher(matcher, "/actuator").matches(HttpMethod.POST, "/actuator/foo");
+		assertMatcher(matcher, "/actuator").doesNotMatch(HttpMethod.GET, "/actuator/foo");
 	}
 
 	@Test
@@ -195,7 +205,7 @@ class EndpointRequestTests {
 		RequestMatcher matcher = EndpointRequest.toAnyEndpoint();
 		RequestMatcher mockRequestMatcher = (request) -> false;
 		RequestMatcherAssert assertMatcher = assertMatcher(matcher, mockPathMappedEndpoints(""),
-				(pattern) -> mockRequestMatcher);
+				(pattern, method) -> mockRequestMatcher);
 		assertMatcher.doesNotMatch("/foo");
 		assertMatcher.doesNotMatch("/bar");
 	}
@@ -205,7 +215,7 @@ class EndpointRequestTests {
 		RequestMatcher matcher = EndpointRequest.toLinks();
 		RequestMatcher mockRequestMatcher = (request) -> false;
 		RequestMatcherAssert assertMatcher = assertMatcher(matcher, mockPathMappedEndpoints("/actuator"),
-				(pattern) -> mockRequestMatcher);
+				(pattern, method) -> mockRequestMatcher);
 		assertMatcher.doesNotMatch("/actuator");
 	}
 
@@ -271,7 +281,11 @@ class EndpointRequestTests {
 		}
 
 		void matches(String servletPath) {
-			matches(mockRequest(servletPath));
+			matches(mockRequest(null, servletPath));
+		}
+
+		void matches(HttpMethod httpMethod, String servletPath) {
+			matches(mockRequest(httpMethod, servletPath));
 		}
 
 		private void matches(HttpServletRequest request) {
@@ -279,19 +293,26 @@ class EndpointRequestTests {
 		}
 
 		void doesNotMatch(String servletPath) {
-			doesNotMatch(mockRequest(servletPath));
+			doesNotMatch(mockRequest(null, servletPath));
+		}
+
+		void doesNotMatch(HttpMethod httpMethod, String servletPath) {
+			doesNotMatch(mockRequest(httpMethod, servletPath));
 		}
 
 		private void doesNotMatch(HttpServletRequest request) {
 			assertThat(this.matcher.matches(request)).as("Does not match " + getRequestPath(request)).isFalse();
 		}
 
-		private MockHttpServletRequest mockRequest(String servletPath) {
+		private MockHttpServletRequest mockRequest(HttpMethod httpMethod, String servletPath) {
 			MockServletContext servletContext = new MockServletContext();
 			servletContext.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, this.context);
 			MockHttpServletRequest request = new MockHttpServletRequest(servletContext);
 			if (servletPath != null) {
 				request.setServletPath(servletPath);
+			}
+			if (httpMethod != null) {
+				request.setMethod(httpMethod.name());
 			}
 			return request;
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/AntPathRequestMatcherProvider.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/AntPathRequestMatcherProvider.java
@@ -18,6 +18,8 @@ package org.springframework.boot.autoconfigure.security.servlet;
 
 import java.util.function.Function;
 
+import org.springframework.http.HttpMethod;
+import org.springframework.lang.Nullable;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
@@ -25,6 +27,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
  * {@link RequestMatcherProvider} that provides an {@link AntPathRequestMatcher}.
  *
  * @author Madhura Bhave
+ * @author Chris Bono
  * @since 2.1.8
  */
 public class AntPathRequestMatcherProvider implements RequestMatcherProvider {
@@ -36,8 +39,9 @@ public class AntPathRequestMatcherProvider implements RequestMatcherProvider {
 	}
 
 	@Override
-	public RequestMatcher getRequestMatcher(String pattern) {
-		return new AntPathRequestMatcher(this.pathFactory.apply(pattern));
+	public RequestMatcher getRequestMatcher(String pattern, @Nullable HttpMethod httpMethod) {
+		return new AntPathRequestMatcher(this.pathFactory.apply(pattern),
+				(httpMethod != null) ? httpMethod.name() : null);
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/RequestMatcherProvider.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/RequestMatcherProvider.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.autoconfigure.security.servlet;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
 /**
@@ -23,6 +24,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
  * Spring Security.
  *
  * @author Madhura Bhave
+ * @author Chris Bono
  * @since 2.0.5
  */
 @FunctionalInterface
@@ -33,6 +35,17 @@ public interface RequestMatcherProvider {
 	 * @param pattern the request pattern
 	 * @return a request matcher
 	 */
-	RequestMatcher getRequestMatcher(String pattern);
+	default RequestMatcher getRequestMatcher(String pattern) {
+		return getRequestMatcher(pattern, null);
+	}
+
+	/**
+	 * Return the {@link RequestMatcher} to be used for the specified pattern and http
+	 * method.
+	 * @param pattern the request pattern
+	 * @param httpMethod the http method
+	 * @return a request matcher
+	 */
+	RequestMatcher getRequestMatcher(String pattern, HttpMethod httpMethod);
 
 }


### PR DESCRIPTION
### What
This proposal adds the ability to match Actuator endpoint requests by http method. 

### Why
This provides a finer grained matching of requests. One example use is allowing unrestricted access to an endpoint for GET requests but restricting access to the endpoint for POST requests. 

### How
- Support has been added to both servlet and reactive flavors of EndpointRequest