### PR TITLE
In Gradle plugin docs, replace classifier (deprecated) with archiveClassifier in examples

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-jar-and-jar-classifiers.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-jar-and-jar-classifiers.gradle
@@ -5,11 +5,11 @@ plugins {
 
 // tag::classifiers[]
 bootJar {
-	classifier = 'boot'
+	archiveClassifier = 'boot'
 }
 
 jar {
-	classifier = ''
+	archiveClassifier = ''
 }
 // end::classifiers[]
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-jar-and-jar-classifiers.gradle.kts
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-jar-and-jar-classifiers.gradle.kts
@@ -7,11 +7,11 @@ plugins {
 
 // tag::classifiers[]
 tasks.getByName<BootJar>("bootJar") {
-	classifier = "boot"
+	archiveClassifier.set("boot")
 }
 
 tasks.getByName<Jar>("jar") {
-	classifier = ""
+	archiveClassifier.set("")
 }
 // end::classifiers[]
 


### PR DESCRIPTION
The [Spring Boot Gradle Reference Guide](https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/#packaging-executable.and-plain-archives) uses `AbstractArchiveTask.classifier` which is [deprecated as of Gradle 5.1](https://discuss.gradle.org/t/publishing-jars-with-classifiers-after-v5-0/30144/3) and replaced by `archiveClassifier`. As [the plugin requires Gradle 6.8, 6.9, or 7.x](https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/#introduction), the example should be updated.

Originally submitted as #29610.