### PR TITLE
Do not set ConversionService on AnnotatedControllerConfigurer

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/GraphQlAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/GraphQlAutoConfiguration.java
@@ -39,7 +39,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
-import org.springframework.format.support.DefaultFormattingConversionService;
 import org.springframework.graphql.GraphQlService;
 import org.springframework.graphql.data.method.annotation.support.AnnotatedControllerConfigurer;
 import org.springframework.graphql.execution.BatchLoaderRegistry;
@@ -132,9 +131,7 @@ public class GraphQlAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public AnnotatedControllerConfigurer annotatedControllerConfigurer() {
-		AnnotatedControllerConfigurer annotatedControllerConfigurer = new AnnotatedControllerConfigurer();
-		annotatedControllerConfigurer.setConversionService(new DefaultFormattingConversionService());
-		return annotatedControllerConfigurer;
+		return new AnnotatedControllerConfigurer();
 	}
 
 	private <T> List<T> toList(ObjectProvider<T> provider) {


### PR DESCRIPTION
After https://github.com/spring-projects/spring-graphql/commit/0b449d89e1d9e8754d42ad5e5af7f780c705ce32, the `ConversionService` on `AnnotatedControllerConfigurer` is an internally managed instance that is customized with `FormatterRegistrar` callbacks rather than set.
