### PR TITLE
Add redis sentinel username support for authentication with ACL

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionConfiguration.java
@@ -99,6 +99,7 @@ abstract class RedisConnectionConfiguration {
 			if (this.properties.getPassword() != null) {
 				config.setPassword(RedisPassword.of(this.properties.getPassword()));
 			}
+			config.setSentinelUsername(sentinelProperties.getUsername());
 			if (sentinelProperties.getPassword() != null) {
 				config.setSentinelPassword(RedisPassword.of(sentinelProperties.getPassword()));
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -377,6 +377,11 @@ public class RedisProperties {
 		 */
 		private String password;
 
+		/**
+		 * Login username for authenticating with sentinel(s).
+		 */
+		private String username;
+
 		public String getMaster() {
 			return this.master;
 		}
@@ -399,6 +404,14 @@ public class RedisProperties {
 
 		public void setPassword(String password) {
 			this.password = password;
+		}
+
+		public String getUsername() {
+			return this.username;
+		}
+
+		public void setUsername(String username) {
+			this.username = username;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -315,6 +315,25 @@ class RedisAutoConfigurationTests {
 					assertThat(getUserName(connectionFactory)).isNull();
 					assertThat(connectionFactory.getPassword()).isEqualTo("password");
 					RedisSentinelConfiguration sentinelConfiguration = connectionFactory.getSentinelConfiguration();
+					assertThat(sentinelConfiguration.getSentinelUsername()).isNull();
+					assertThat(new String(sentinelConfiguration.getSentinelPassword().get())).isEqualTo("secret");
+					Set<RedisNode> sentinels = sentinelConfiguration.getSentinels();
+					assertThat(sentinels.stream().map(Object::toString).collect(Collectors.toSet()))
+							.contains("127.0.0.1:26379", "127.0.0.1:26380");
+				});
+	}
+
+	@Test
+	void testRedisConfigurationWithSentinelAuthenticationAndDataNodeAuthentication() {
+		this.contextRunner.withPropertyValues("spring.redis.username=username", "spring.redis.password=password",
+				"spring.redis.sentinel.username=sentinel", "spring.redis.sentinel.password=secret",
+				"spring.redis.sentinel.master:mymaster",
+				"spring.redis.sentinel.nodes:127.0.0.1:26379,  127.0.0.1:26380").run((context) -> {
+					LettuceConnectionFactory connectionFactory = context.getBean(LettuceConnectionFactory.class);
+					assertThat(getUserName(connectionFactory)).isEqualTo("username");
+					assertThat(connectionFactory.getPassword()).isEqualTo("password");
+					RedisSentinelConfiguration sentinelConfiguration = connectionFactory.getSentinelConfiguration();
+					assertThat(sentinelConfiguration.getSentinelUsername()).isEqualTo("sentinel");
 					assertThat(new String(sentinelConfiguration.getSentinelPassword().get())).isEqualTo("secret");
 					Set<RedisNode> sentinels = sentinelConfiguration.getSentinels();
 					assertThat(sentinels.stream().map(Object::toString).collect(Collectors.toSet()))


### PR DESCRIPTION
Hello, this pull request tends to update spring-boot-autoconfigure module regarding latest spring-data-redis evolutions with redis sentinel username support addition. 

Actually spring boot autoconfigure doesn't allow to use connect sentinel with specific ACL and default user disabled, it has been fixed on springframework just remain the spring boot integration.  

Linkes issues 

https://github.com/spring-projects/spring-data-redis/issues/2218

https://github.com/spring-projects/spring-boot/issues/22702