### PR TITLE
include liquibase-cdi in spring-boot-dependencies.

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -768,7 +768,8 @@ bom {
 	library("Liquibase", "4.7.0") {
 		group("org.liquibase") {
 			modules = [
-				"liquibase-core"
+				"liquibase-core",
+				"liquibase-cdi"
 			]
 			plugins = [
 				"liquibase-maven-plugin"


### PR DESCRIPTION
fix issue [29676](https://github.com/spring-projects/spring-boot/issues/29676)