### PR TITLE
Link directly to the Integration Properties section of the appendix when cross-referencing Kafka properties

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/messaging/kafka.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/messaging/kafka.adoc
@@ -74,7 +74,7 @@ You can customize this behavior using the configprop:spring.kafka.streams.auto-s
 
 [[messaging.kafka.additional-properties]]
 === Additional Kafka Properties
-The properties supported by auto configuration are shown in <<appendix.application-properties#application-properties>>.
+The properties supported by auto configuration are shown in the <<application-properties#appendix.application-properties.integration, "`Integration Properties`">> section of the Appendix.
 Note that, for the most part, these properties (hyphenated or camelCase) map directly to the Apache Kafka dotted properties.
 See the Apache Kafka documentation for details.
 


### PR DESCRIPTION
Hi,

this PR fixes a link in the docs, which leads to a 404 at the moment.
I also took the freedom to polish this a bit more and align this with other sections where we link to the application.properties Appendix.

## Before
<img width="964" alt="image" src="https://user-images.githubusercontent.com/6304496/153752558-2df33a4b-68e0-4c8c-8011-7ae17818dde6.png">

## After
<img width="964" alt="image" src="https://user-images.githubusercontent.com/6304496/153752533-5b048766-6f3b-4e5c-a93c-49a07390d05c.png">

Cheers,
Christoph