### PR TITLE
The active profiles log message is ambiguous when a profile's name contains a comma

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -620,19 +620,19 @@ public class SpringApplication {
 		Log log = getApplicationLog();
 		if (log.isInfoEnabled()) {
 			String[] activeProfiles = context.getEnvironment().getActiveProfiles();
-			for (int i = 0; i<activeProfiles.length; i++) {
+			for (int i = 0; i < activeProfiles.length; i++) {
 				activeProfiles[i] = "\"" + activeProfiles[i] + "\"";
 			}
 			if (ObjectUtils.isEmpty(activeProfiles)) {
 				String[] defaultProfiles = context.getEnvironment().getDefaultProfiles();
-				for (int i = 0; i<defaultProfiles.length; i++) {
+				for (int i = 0; i < defaultProfiles.length; i++) {
 					defaultProfiles[i] = "\"" + defaultProfiles[i] + "\"";
 				}
-				log.info("No active profile set, falling back to " + defaultProfiles.length +" default profile(s): "
+				log.info("No active profile set, falling back to " + defaultProfiles.length + " default profile(s): "
 						+ StringUtils.arrayToCommaDelimitedString(defaultProfiles));
 			}
 			else {
-				log.info("The following "+ activeProfiles.length +" profile(s) are active: "
+				log.info("The following " + activeProfiles.length + " profile(s) are active: "
 						+ StringUtils.arrayToCommaDelimitedString(activeProfiles));
 			}
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -620,13 +620,19 @@ public class SpringApplication {
 		Log log = getApplicationLog();
 		if (log.isInfoEnabled()) {
 			String[] activeProfiles = context.getEnvironment().getActiveProfiles();
+			for (int i = 0; i<activeProfiles.length; i++) {
+				activeProfiles[i] = "\"" + activeProfiles[i] + "\"";
+			}
 			if (ObjectUtils.isEmpty(activeProfiles)) {
 				String[] defaultProfiles = context.getEnvironment().getDefaultProfiles();
-				log.info("No active profile set, falling back to default profiles: "
+				for (int i = 0; i<defaultProfiles.length; i++) {
+					defaultProfiles[i] = "\"" + defaultProfiles[i] + "\"";
+				}
+				log.info("No active profile set, falling back to " + defaultProfiles.length +" default profile(s): "
 						+ StringUtils.arrayToCommaDelimitedString(defaultProfiles));
 			}
 			else {
-				log.info("The following profiles are active: "
+				log.info("The following "+ activeProfiles.length +" profile(s) are active: "
 						+ StringUtils.arrayToCommaDelimitedString(activeProfiles));
 			}
 		}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
@@ -232,7 +232,7 @@ class SpringApplicationTests {
 		SpringApplication application = new SpringApplication(ExampleConfig.class);
 		application.setWebApplicationType(WebApplicationType.NONE);
 		this.context = application.run();
-		assertThat(output).contains("No active profile set, falling back to default profiles: default");
+		assertThat(output).contains("No active profile set, falling back to 1 default profile(s): \"default\"");
 	}
 
 	@Test
@@ -240,7 +240,7 @@ class SpringApplicationTests {
 		SpringApplication application = new SpringApplication(ExampleConfig.class);
 		application.setWebApplicationType(WebApplicationType.NONE);
 		this.context = application.run("--spring.profiles.active=myprofiles");
-		assertThat(output).contains("The following profiles are active: myprofile");
+		assertThat(output).contains("The following 1 profile(s) are active: \"myprofiles\"");
 	}
 
 	@Test
@@ -250,6 +250,15 @@ class SpringApplicationTests {
 		this.context = application.run("--spring.main.banner-mode=log");
 		then(application).should(atLeastOnce()).setBannerMode(Banner.Mode.LOG);
 		assertThat(output).contains("o.s.b.SpringApplication");
+	}
+
+	@Test
+	void logsMultipleActiveProfilesWithComma(CapturedOutput output) {
+		SpringApplication application = new SpringApplication(ExampleConfig.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+		application.setAdditionalProfiles("p1,p2", "p3");
+		application.run();
+		assertThat(output).contains("The following 2 profile(s) are active: \"p1,p2\",\"p3\"");
 	}
 
 	@Test


### PR DESCRIPTION
Pull request for my original issue #29739 and the subsequent discussion on #29891

 - Quoted the profiles with double quotes, added a `(s)` for a simple plural support
 - Updated two test cases and added the one provided by @philwebb

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
