### PR TITLE
Document `WebSecurityCustomizer` for H2 Console

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/sql.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/sql.adoc
@@ -322,6 +322,21 @@ You can customize the console's path by using the configprop:spring.h2.console.p
 
 
 
+[[features.sql.h2-web-console.spring-security]]
+==== Configuring Spring Security for H2 Console
+H2 Console uses frames and, as it's intended for development only, does not implement CSRF protection measures. If your application uses Spring Security, you need to configure it accordingly.
+
+For example, Spring Security will ignore the console if the following `WebSecurityCustomizer` is exposed:
+
+[source,java,indent=0,subs="verbatim"]
+----
+include::{docs-java}/features/sql/h2webconsole/springsecurity/MySecurityConfiguration.java[]
+----
+
+TIP: `PathRequest.toH2Console()` returns the correct request matcher also when the console's path has been customized.
+
+
+
 [[features.sql.jooq]]
 === Using jOOQ
 jOOQ Object Oriented Querying (https://www.jooq.org/[jOOQ]) is a popular product from https://www.datageekery.com/[Data Geekery] which generates Java code from your database and lets you build type-safe SQL queries through its fluent API.

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/sql/h2webconsole/springsecurity/MySecurityConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/sql/h2webconsole/springsecurity/MySecurityConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docs.features.sql.h2webconsole.springsecurity;
+
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+
+@Configuration(proxyBeanMethods = false)
+public class MySecurityConfiguration {
+
+	@Bean
+	public WebSecurityCustomizer webSecurityCustomizer() {
+		return (web) -> web.ignoring().requestMatchers(PathRequest.toH2Console());
+	}
+
+}


### PR DESCRIPTION
Resolves #28268.

The `WebSecurityCustomizer` is a bit blunt. But for a development setup, a proper `SecurityFilterChain` seems overly ceremonial, in my opinion. 😄 