### PR TITLE
Set ExtractingRoot as context ressources to avoid first load slow

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/TomcatServletWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/TomcatServletWebServerFactoryCustomizer.java
@@ -22,6 +22,7 @@ import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactor
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.core.Ordered;
 import org.springframework.util.ObjectUtils;
+import org.apache.catalina.webresources.ExtractingRoot;
 
 /**
  * {@link WebServerFactoryCustomizer} to apply {@link ServerProperties} to Tomcat web
@@ -56,6 +57,7 @@ public class TomcatServletWebServerFactoryCustomizer
 		}
 		customizeUseRelativeRedirects(factory, tomcatProperties.isUseRelativeRedirects());
 		factory.setDisableMBeanRegistry(!tomcatProperties.getMbeanregistry().isEnabled());
+		factory.addContextCustomizers((context) -> context.setResources(new ExtractingRoot()));
 	}
 
 	private void customizeRedirectContextRoot(ConfigurableTomcatWebServerFactory factory, boolean redirectContextRoot) {


### PR DESCRIPTION
At fisrt load into browser response is very slow. Set ExtractingRoot as context ressources fix this issue by pre-extracting the resources.
Maybe this commit can be linked this issue #6177

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
