### PR TITLE
Restore Ehcache 3 Support 

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-autoconfigure/build.gradle
@@ -88,6 +88,11 @@ dependencies {
 	optional("org.eclipse.jetty.websocket:websocket-jetty-server") {
 		exclude(group: "org.eclipse.jetty", module: "jetty-jndi")
 	}
+	optional("org.ehcache:ehcache") {
+		artifact {
+			classifier = 'jakarta'
+		}
+	}
 	optional("org.elasticsearch.client:elasticsearch-rest-client") {
 		exclude group: "commons-logging", module: "commons-logging"
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/EhCache3CacheAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/EhCache3CacheAutoConfigurationTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.cache;
+
+import org.ehcache.jsr107.EhcacheCachingProvider;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.cache.CacheAutoConfigurationTests.DefaultCacheConfiguration;
+import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
+import org.springframework.cache.jcache.JCacheCacheManager;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CacheAutoConfiguration} with EhCache 3.
+ *
+ * @author Stephane Nicoll
+ * @author Andy Wilkinson
+ */
+@ClassPathExclusions("ehcache-2*.jar")
+class EhCache3CacheAutoConfigurationTests extends AbstractCacheAutoConfigurationTests {
+
+	@Test
+	void ehcache3AsJCacheWithCaches() {
+		String cachingProviderFqn = EhcacheCachingProvider.class.getName();
+		this.contextRunner.withUserConfiguration(DefaultCacheConfiguration.class)
+				.withPropertyValues("spring.cache.type=jcache", "spring.cache.jcache.provider=" + cachingProviderFqn,
+						"spring.cache.cacheNames[0]=foo", "spring.cache.cacheNames[1]=bar")
+				.run((context) -> {
+					JCacheCacheManager cacheManager = getCacheManager(context, JCacheCacheManager.class);
+					assertThat(cacheManager.getCacheNames()).containsOnly("foo", "bar");
+				});
+	}
+
+	@Test
+	void ehcache3AsJCacheWithConfig() {
+		String cachingProviderFqn = EhcacheCachingProvider.class.getName();
+		String configLocation = "ehcache3.xml";
+		this.contextRunner.withUserConfiguration(DefaultCacheConfiguration.class)
+				.withPropertyValues("spring.cache.type=jcache", "spring.cache.jcache.provider=" + cachingProviderFqn,
+						"spring.cache.jcache.config=" + configLocation)
+				.run((context) -> {
+					JCacheCacheManager cacheManager = getCacheManager(context, JCacheCacheManager.class);
+
+					Resource configResource = new ClassPathResource(configLocation);
+					assertThat(cacheManager.getCacheManager().getURI()).isEqualTo(configResource.getURI());
+					assertThat(cacheManager.getCacheNames()).containsOnly("foo", "bar");
+				});
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/ehcache3.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/ehcache3.xml
@@ -3,8 +3,8 @@
 		xmlns='http://www.ehcache.org/v3'
 		xmlns:jsr107='http://www.ehcache.org/v3/jsr107'
 		xsi:schemaLocation="
-        http://www.ehcache.org/v3 https://www.ehcache.org/schema/ehcache-core-3.1.xsd
-        http://www.ehcache.org/v3/jsr107 https://www.ehcache.org/schema/ehcache-107-ext-3.1.xsd">
+        http://www.ehcache.org/v3 https://www.ehcache.org/schema/ehcache-core-3.10.xsd
+        http://www.ehcache.org/v3/jsr107 https://www.ehcache.org/schema/ehcache-107-ext-3.10.xsd">
 
 	<cache-template name="example">
 		<heap unit="entries">200</heap>

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -191,6 +191,19 @@ bom {
 			]
 		}
 	}
+	library("Ehcache3", "3.10.0") {
+		group("org.ehcache") {
+			modules = [
+					"ehcache" {
+						classifier = 'jakarta'
+					},
+					"ehcache-clustered",
+					"ehcache-transactions" {
+						classifier = 'jakarta'
+					}
+			]
+		}
+	}
 	library("Elasticsearch", "7.17.0") {
 		group("org.elasticsearch") {
 			modules = [

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/documentation/io.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/documentation/io.adoc
@@ -2,7 +2,7 @@
 == IO
 If your application needs IO capabilities, see one or more of the following sections:
 
-* *Caching:* <<io#io.caching, Caching support with Hazelcast and more>>
+* *Caching:* <<io#io.caching, Caching support with EhCache, Hazelcast and more>>
 * *Quartz:* <<io#io.quartz, Quartz Scheduling>>
 * *Mail:* <<io#io.email, Sending Email>>
 * *Validation:* <<io#io.validation, JSR-303 Validation>>

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/io/caching.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/io/caching.adoc
@@ -37,7 +37,7 @@ The cache abstraction does not provide an actual store and relies on abstraction
 If you have not defined a bean of type `CacheManager` or a `CacheResolver` named `cacheResolver` (see {spring-framework-api}/cache/annotation/CachingConfigurer.html[`CachingConfigurer`]), Spring Boot tries to detect the following providers (in the indicated order):
 
 . <<io#io.caching.provider.generic,Generic>>
-. <<io#io.caching.provider.jcache,JCache (JSR-107)>> (Hazelcast and others)
+. <<io#io.caching.provider.jcache,JCache (JSR-107)>> (EhCache 3, Hazelcast, and others)
 . <<io#io.caching.provider.hazelcast,Hazelcast>>
 . <<io#io.caching.provider.couchbase,Couchbase>>
 . <<io#io.caching.provider.redis,Redis>>

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-cache/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-cache/build.gradle
@@ -12,6 +12,14 @@ def caches = [
 	"couchbase": [
 			project(":spring-boot-project:spring-boot-starters:spring-boot-starter-data-couchbase")
 	],
+	"ehcache": [
+		"javax.cache:cache-api",
+		dependencies.create("org.ehcache:ehcache") {
+			artifact {
+				classifier = 'jakarta'
+			}
+		}
+	],
 	"hazelcast": [
 		"com.hazelcast:hazelcast",
 		"com.hazelcast:hazelcast-spring"


### PR DESCRIPTION
This is a prototype of the restoration of Ehcache 3 support to Spring Boot. Ehcache uses Gradle feature variants (with appropriate capabilities) to model the split "Jakarta/Java EE" landscape. These are exposed in Maven as artifacts with 'jakarta' classifiers with appropriate optional dependencies. I've therefore implemented a solution to #29298 as a prerequisite here.

Currently this is depending on an alpha release of Ehcache 3.10, hence it's only a draft PR, but I wanted to get this out there for two reasons:
1. To confirm the acceptability of the classifier/feature variant approach for Jakarta support.
2. To understand the need for the `ehcache-transactions` module. The transactions module allows Ehcache instances to be exposed as XA resources and participate in 2PC managed by a JTA transaction manager. It's not clear to me how this relates to Springs caching support - I'm not sure how or why a user would need this dependency in a Spring (Boot) context. 