### PR TITLE
Use Log4jBridgeHandler to route JUL-based logging into Log4j 2

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-log4j2/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-log4j2/build.gradle
@@ -8,5 +8,4 @@ dependencies {
 	api("org.apache.logging.log4j:log4j-slf4j-impl")
 	api("org.apache.logging.log4j:log4j-core")
 	api("org.apache.logging.log4j:log4j-jul")
-	api("org.slf4j:jul-to-slf4j")
 }

--- a/spring-boot-project/spring-boot/build.gradle
+++ b/spring-boot-project/spring-boot/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 	optional("org.apache.httpcomponents.client5:httpclient5")
 	optional("org.apache.logging.log4j:log4j-api")
 	optional("org.apache.logging.log4j:log4j-core")
+	optional("org.apache.logging.log4j:log4j-jul")
 	optional("org.apache.tomcat.embed:tomcat-embed-core")
 	optional("org.apache.tomcat.embed:tomcat-embed-jasper")
 	optional("org.apache.tomcat:tomcat-jdbc")

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/Slf4JLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/Slf4JLoggingSystem.java
@@ -103,7 +103,7 @@ public abstract class Slf4JLoggingSystem extends AbstractLoggingSystem {
 		}
 	}
 
-	private void removeDefaultRootHandler() {
+	protected void removeDefaultRootHandler() {
 		try {
 			Logger rootLogger = LogManager.getLogManager().getLogger("");
 			Handler[] handlers = rootLogger.getHandlers();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/Slf4JLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/Slf4JLoggingSystem.java
@@ -16,11 +16,14 @@
 
 package org.springframework.boot.logging;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
+import org.apache.logging.log4j.jul.Log4jBridgeHandler;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import org.springframework.util.Assert;
@@ -34,10 +37,21 @@ import org.springframework.util.ClassUtils;
  */
 public abstract class Slf4JLoggingSystem extends AbstractLoggingSystem {
 
-	private static final String BRIDGE_HANDLER = "org.slf4j.bridge.SLF4JBridgeHandler";
+	private static final String SLF4J_BRIDGE_HANDLER = "org.slf4j.bridge.SLF4JBridgeHandler";
+
+	private static final String LOG4J_BRIDGE_HANDLER = "org.apache.logging.log4j.jul.Log4jBridgeHandler";
+
+	private static final String LOG4J_LOG_MANAGER = "org.apache.logging.log4j.jul.LogManager";
+
+	private final List<BridgeHandler> handlers;
 
 	public Slf4JLoggingSystem(ClassLoader classLoader) {
+		this(classLoader, Collections.singletonList(new Slf4jHandler(classLoader)));
+	}
+
+	protected Slf4JLoggingSystem(ClassLoader classLoader, List<BridgeHandler> handlers) {
 		super(classLoader);
+		this.handlers = handlers;
 	}
 
 	@Override
@@ -48,9 +62,7 @@ public abstract class Slf4JLoggingSystem extends AbstractLoggingSystem {
 
 	@Override
 	public void cleanUp() {
-		if (isBridgeHandlerAvailable()) {
-			removeJdkLoggingBridgeHandler();
-		}
+		this.handlers.stream().filter(BridgeHandler::isAvailable).forEach(BridgeHandler::remove);
 	}
 
 	@Override
@@ -64,9 +76,8 @@ public abstract class Slf4JLoggingSystem extends AbstractLoggingSystem {
 
 	private void configureJdkLoggingBridgeHandler() {
 		try {
-			if (isBridgeJulIntoSlf4j()) {
-				removeJdkLoggingBridgeHandler();
-				SLF4JBridgeHandler.install();
+			if (isJulUsingASingleConsoleHandlerAtMost() && !isLog4jLogManagerInstalled()) {
+				this.handlers.stream().filter(BridgeHandler::isAvailable).findFirst().ifPresent(BridgeHandler::install);
 			}
 		}
 		catch (Throwable ex) {
@@ -80,11 +91,12 @@ public abstract class Slf4JLoggingSystem extends AbstractLoggingSystem {
 	 * @since 2.0.4
 	 */
 	protected final boolean isBridgeJulIntoSlf4j() {
-		return isBridgeHandlerAvailable() && isJulUsingASingleConsoleHandlerAtMost();
+		return this.handlers.stream().filter(Slf4jHandler.class::isInstance).anyMatch(BridgeHandler::isAvailable)
+				&& isJulUsingASingleConsoleHandlerAtMost();
 	}
 
 	protected final boolean isBridgeHandlerAvailable() {
-		return ClassUtils.isPresent(BRIDGE_HANDLER, getClassLoader());
+		return this.handlers.stream().anyMatch(BridgeHandler::isAvailable);
 	}
 
 	private boolean isJulUsingASingleConsoleHandlerAtMost() {
@@ -93,17 +105,12 @@ public abstract class Slf4JLoggingSystem extends AbstractLoggingSystem {
 		return handlers.length == 0 || (handlers.length == 1 && handlers[0] instanceof ConsoleHandler);
 	}
 
-	private void removeJdkLoggingBridgeHandler() {
-		try {
-			removeDefaultRootHandler();
-			SLF4JBridgeHandler.uninstall();
-		}
-		catch (Throwable ex) {
-			// Ignore and continue
-		}
+	private boolean isLog4jLogManagerInstalled() {
+		final String logManagerClassName = LogManager.getLogManager().getClass().getName();
+		return LOG4J_LOG_MANAGER.equals(logManagerClassName);
 	}
 
-	private void removeDefaultRootHandler() {
+	static void removeDefaultRootHandler() {
 		try {
 			Logger rootLogger = LogManager.getLogManager().getLogger("");
 			Handler[] handlers = rootLogger.getHandlers();
@@ -114,6 +121,73 @@ public abstract class Slf4JLoggingSystem extends AbstractLoggingSystem {
 		catch (Throwable ex) {
 			// Ignore and continue
 		}
+	}
+
+	public interface BridgeHandler {
+
+		boolean isAvailable();
+
+		void install();
+
+		void remove();
+
+	}
+
+	protected static class Slf4jHandler implements BridgeHandler {
+
+		private final ClassLoader classLoader;
+
+		public Slf4jHandler(ClassLoader classLoader) {
+			this.classLoader = classLoader;
+		}
+
+		@Override
+		public boolean isAvailable() {
+			return ClassUtils.isPresent(SLF4J_BRIDGE_HANDLER, this.classLoader);
+		}
+
+		@Override
+		public void install() {
+			removeDefaultRootHandler();
+			SLF4JBridgeHandler.install();
+		}
+
+		@Override
+		public void remove() {
+			SLF4JBridgeHandler.uninstall();
+		}
+
+	}
+
+	protected static class Log4jHandler implements BridgeHandler {
+
+		private final ClassLoader classLoader;
+
+		public Log4jHandler(ClassLoader classLoader) {
+			this.classLoader = classLoader;
+		}
+
+		@Override
+		public boolean isAvailable() {
+			return ClassUtils.isPresent(LOG4J_BRIDGE_HANDLER, this.classLoader);
+		}
+
+		@Override
+		public void install() {
+			Log4jBridgeHandler.install(true, null, true);
+		}
+
+		@Override
+		public void remove() {
+			Logger rootLogger = LogManager.getLogManager().getLogger("");
+			for (final Handler handler : rootLogger.getHandlers()) {
+				if (handler instanceof Log4jBridgeHandler) {
+					handler.close();
+					rootLogger.removeHandler(handler);
+				}
+			}
+		}
+
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -171,6 +171,7 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 		try {
 			if (isJulUsingASingleConsoleHandlerAtMost() && !isLog4jLogManagerInstalled()) {
 				if (isLog4jBridgeHandlerAvailable()) {
+					removeDefaultRootHandler();
 					installLog4jBridgeHandler();
 					return true;
 				}
@@ -192,7 +193,7 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 	}
 
 	private void installLog4jBridgeHandler() {
-		Log4jBridgeHandler.install(true, null, true);
+		Log4jBridgeHandler.install(false, null, true);
 	}
 
 	private void removeLog4jBridgeHandler() {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -112,7 +113,7 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 	};
 
 	public Log4J2LoggingSystem(ClassLoader classLoader) {
-		super(classLoader);
+		super(classLoader, Arrays.asList(new Log4jHandler(classLoader), new Slf4jHandler(classLoader)));
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -20,12 +20,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Handler;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Level;
@@ -43,6 +43,7 @@ import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.composite.CompositeConfiguration;
 import org.apache.logging.log4j.core.filter.AbstractFilter;
 import org.apache.logging.log4j.core.util.NameUtil;
+import org.apache.logging.log4j.jul.Log4jBridgeHandler;
 import org.apache.logging.log4j.message.Message;
 
 import org.springframework.boot.context.properties.bind.BindResult;
@@ -75,6 +76,10 @@ import org.springframework.util.StringUtils;
 public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 
 	private static final String FILE_PROTOCOL = "file";
+
+	private static final String LOG4J_BRIDGE_HANDLER = "org.apache.logging.log4j.jul.Log4jBridgeHandler";
+
+	private static final String LOG4J_LOG_MANAGER = "org.apache.logging.log4j.jul.LogManager";
 
 	private static final LogLevels<Level> LEVELS = new LogLevels<>();
 
@@ -113,7 +118,7 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 	};
 
 	public Log4J2LoggingSystem(ClassLoader classLoader) {
-		super(classLoader, Arrays.asList(new Log4jHandler(classLoader), new Slf4jHandler(classLoader)));
+		super(classLoader);
 	}
 
 	@Override
@@ -156,8 +161,48 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 		if (isAlreadyInitialized(loggerContext)) {
 			return;
 		}
-		super.beforeInitialize();
+		if (!configureJdkLoggingBridgeHandler()) {
+			super.beforeInitialize();
+		}
 		loggerContext.getConfiguration().addFilter(FILTER);
+	}
+
+	private boolean configureJdkLoggingBridgeHandler() {
+		try {
+			if (isJulUsingASingleConsoleHandlerAtMost() && !isLog4jLogManagerInstalled()) {
+				if (isLog4jBridgeHandlerAvailable()) {
+					installLog4jBridgeHandler();
+					return true;
+				}
+			}
+		}
+		catch (Throwable ex) {
+			// Ignore. No java.util.logging bridge is installed.
+		}
+		return false;
+	}
+
+	private boolean isLog4jLogManagerInstalled() {
+		final String logManagerClassName = java.util.logging.LogManager.getLogManager().getClass().getName();
+		return LOG4J_LOG_MANAGER.equals(logManagerClassName);
+	}
+
+	private boolean isLog4jBridgeHandlerAvailable() {
+		return ClassUtils.isPresent(LOG4J_BRIDGE_HANDLER, getClassLoader());
+	}
+
+	private void installLog4jBridgeHandler() {
+		Log4jBridgeHandler.install(true, null, true);
+	}
+
+	private void removeLog4jBridgeHandler() {
+		java.util.logging.Logger rootLogger = java.util.logging.LogManager.getLogManager().getLogger("");
+		for (final Handler handler : rootLogger.getHandlers()) {
+			if (handler instanceof Log4jBridgeHandler) {
+				handler.close();
+				rootLogger.removeHandler(handler);
+			}
+		}
 	}
 
 	@Override
@@ -379,6 +424,9 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 
 	@Override
 	public void cleanUp() {
+		if (isLog4jBridgeHandlerAvailable()) {
+			removeLog4jBridgeHandler();
+		}
 		super.cleanUp();
 		LoggerContext loggerContext = getLoggerContext();
 		markAsUninitialized(loggerContext);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -20,6 +20,7 @@ import java.net.URL;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Handler;
@@ -100,7 +101,7 @@ public class LogbackLoggingSystem extends Slf4JLoggingSystem {
 	};
 
 	public LogbackLoggingSystem(ClassLoader classLoader) {
-		super(classLoader);
+		super(classLoader, Arrays.asList(new Slf4jHandler(classLoader), new Log4jHandler(classLoader)));
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -20,7 +20,6 @@ import java.net.URL;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Handler;
@@ -101,7 +100,7 @@ public class LogbackLoggingSystem extends Slf4JLoggingSystem {
 	};
 
 	public LogbackLoggingSystem(ClassLoader classLoader) {
-		super(classLoader, Arrays.asList(new Slf4jHandler(classLoader), new Log4jHandler(classLoader)));
+		super(classLoader);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
@@ -43,7 +43,6 @@ import org.apache.logging.log4j.jul.Log4jBridgeHandler;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -250,7 +249,6 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	@Test
-	@Disabled("Uses Logback unintentionally")
 	void loggingThatUsesJulIsCaptured(CapturedOutput output) {
 		this.loggingSystem.beforeInitialize();
 		this.loggingSystem.initialize(this.initializationContext, null, null);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
@@ -25,6 +25,8 @@ import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Handler;
+import java.util.logging.Level;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.logging.Log;
@@ -37,6 +39,7 @@ import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.Reconfigurable;
 import org.apache.logging.log4j.core.config.composite.CompositeConfiguration;
 import org.apache.logging.log4j.core.util.ShutdownCallbackRegistry;
+import org.apache.logging.log4j.jul.Log4jBridgeHandler;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -379,6 +382,22 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		LoggerConfiguration updatedConfiguration = this.loggingSystem.getLoggerConfiguration("com.example.test");
 		assertThat(updatedConfiguration)
 				.isEqualTo(new LoggerConfiguration("com.example.test", LogLevel.WARN, LogLevel.WARN));
+	}
+
+	@Test
+	void log4jLevelsArePropagatedToJul() {
+		this.loggingSystem.beforeInitialize();
+		java.util.logging.Logger rootLogger = java.util.logging.Logger.getLogger("");
+		// check if Log4jBridgeHandler is used
+		Handler[] handlers = rootLogger.getHandlers();
+		assertThat(handlers.length).isEqualTo(1);
+		assertThat(handlers[0]).isInstanceOf(Log4jBridgeHandler.class);
+
+		this.loggingSystem.initialize(this.initializationContext, null, null);
+		java.util.logging.Logger logger = java.util.logging.Logger.getLogger(Log4J2LoggingSystemTests.class.getName());
+		assertThat(logger.getLevel()).isNull();
+		this.loggingSystem.setLogLevel(Log4J2LoggingSystemTests.class.getName(), LogLevel.DEBUG);
+		assertThat(logger.getLevel()).isEqualTo(Level.FINE);
 	}
 
 	@Test


### PR DESCRIPTION
Since version 2.15.0 `log4j-jul` contains a `Log4jBridgeHandler`, that allows to forward JUL to Log4j 2.x and synchronizes the logger levels of the two frameworks.

This PR adds support for the `Log4jBridgeHandler` and sets it as default bridge handler for the Log4j 2.x stack and fallback handler for Logback.

It also removes `jul-to-slf4j` from the `spring-boot-starter-log4j2`, hence leaving a pure Log4j 2.x stack.
