### PR TITLE
Adds support for Log4j SpringLookup

### DIFF
--- a/spring-boot-project/spring-boot/build.gradle
+++ b/spring-boot-project/spring-boot/build.gradle
@@ -10,9 +10,11 @@ plugins {
 description = "Spring Boot"
 
 def tomcatConfigProperties = "$buildDir/tomcat-config-properties"
+def log4jSpringBoot = "$buildDir/log4j-spring-boot"
 
 configurations {
 	tomcatDistribution
+	log4jSpringBootJar
 }
 
 dependencies {
@@ -145,6 +147,7 @@ dependencies {
 	}
 
 	tomcatDistribution("org.apache.tomcat:tomcat:${tomcatVersion}@zip")
+	log4jSpringBootJar("org.apache.logging.log4j:log4j-spring-boot:2.17.1@jar")
 }
 
 task extractTomcatConfigProperties(type: Sync) {
@@ -156,9 +159,17 @@ task extractTomcatConfigProperties(type: Sync) {
 	}
 }
 
+task extractLog4jSpringBoot(type: Copy) {
+	from(zipTree(configurations.log4jSpringBootJar.incoming.files.singleFile)) {
+		exclude "log4j2.system.properties"
+	}
+	into file(log4jSpringBoot)
+}
+
 sourceSets {
 	test {
 		output.dir(tomcatConfigProperties, builtBy: "extractTomcatConfigProperties")
+		output.dir(log4jSpringBoot, builtBy: "extractLog4jSpringBoot")
 	}
 }
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -75,6 +75,9 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 
 	private static final String FILE_PROTOCOL = "file";
 
+	/** Must be the same as the one used in 'log4j-spring-boot'. */
+	private static final String ENVIRONMENT_KEY = "SpringEnvironment";
+
 	private static final LogLevels<Level> LEVELS = new LogLevels<>();
 
 	static {
@@ -166,6 +169,7 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 			return;
 		}
 		loggerContext.getConfiguration().removeFilter(FILTER);
+		loggerContext.putObject(ENVIRONMENT_KEY, initializationContext.getEnvironment());
 		super.initialize(initializationContext, configLocation, logFile);
 		markAsInitialized(loggerContext);
 	}
@@ -380,6 +384,7 @@ public class Log4J2LoggingSystem extends Slf4JLoggingSystem {
 	public void cleanUp() {
 		super.cleanUp();
 		LoggerContext loggerContext = getLoggerContext();
+		loggerContext.removeObject(ENVIRONMENT_KEY);
 		markAsUninitialized(loggerContext);
 		loggerContext.getConfiguration().removeFilter(FILTER);
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.Reconfigurable;
 import org.apache.logging.log4j.core.config.composite.CompositeConfiguration;
+import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 import org.apache.logging.log4j.core.util.ShutdownCallbackRegistry;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -400,6 +401,17 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		this.environment.setProperty("logging.log4j2.config.override", "src/test/resources/log4j2-override.xml");
 		this.loggingSystem.initialize(this.initializationContext, null, null);
 		assertThat(this.loggingSystem.getConfiguration()).isInstanceOf(CompositeConfiguration.class);
+	}
+
+	@Test
+	void springLookupWorks() {
+		final String value = "Hello world!";
+		this.environment.setProperty("spring.property.test", value);
+		this.loggingSystem.beforeInitialize();
+		this.loggingSystem.initialize(this.initializationContext, null, null);
+		final LoggerContext context = LoggerContext.getContext(false);
+		final StrSubstitutor substitutor = context.getConfiguration().getConfigurationStrSubstitutor();
+		assertThat(substitutor.replace("${spring:spring.property.test}")).isEqualTo(value);
 	}
 
 	private String getRelativeClasspathLocation(String fileName) {


### PR DESCRIPTION
Since Log4j 2.14.0, configuration files can resolve properties from Spring's `Environment`.

While this is already possible with the custom `Log4j2CloudConfigLoggingSystem`, this PR enables this feature in the
standard `Log4j2LoggingSystem`.
