### PR TITLE
Improve property placeholder documentation to mention environment variables and default values

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
@@ -440,8 +440,8 @@ For example, if a secret named `db.password` is mounted at location `/run/secret
 
 [[features.external-config.files.property-placeholders]]
 ==== Property Placeholders
-The values in `application.properties` and `application.yml` are filtered through the existing `Environment` when they are used, so you can refer back to previously defined values (for example, from System properties).
-The standard `$\{name}` property-placeholder syntax can be used anywhere within a value.
+The values in `application.properties` and `application.yml` are filtered through the existing `Environment` when they are used, so you can refer back to previously defined values (for example, from System properties or environment variables).
+The standard `$\{name:default}` property-placeholder syntax can be used anywhere within a value.
 
 For example, the following file will set `app.description` to "`MyApp is a Spring Boot application`":
 
@@ -449,7 +449,7 @@ For example, the following file will set `app.description` to "`MyApp is a Sprin
 ----
 	app:
 	  name: "MyApp"
-	  description: "${app.name} is a Spring Boot application"
+	  description: "${app.name} is a Spring Boot application written by ${USERNAME:john.doe}"
 ----
 
 TIP: You can also use this technique to create "`short`" variants of existing Spring Boot properties.
@@ -607,19 +607,6 @@ The preceding example would be transformed into these properties:
 
 TIP: Properties that use the `[index]` notation can be bound to Java `List` or `Set` objects using Spring Boot's `Binder` class.
 For more details see the "`<<features#features.external-config.typesafe-configuration-properties>>`" section below.
-
-[[features.external-config.yaml.using-env-variables-in-yaml]]
-==== Using environment variables and default values in YAML property definitions
-
-In order to use environment variable as a source for application property, one can use placeholders like this: 
-
-[source,yaml,indent=0,subs="verbatim"]
-----
-	environments:
-	  dev:
-	    url: ${DEV_ENV_URL}
-	    name: ${DEV_ENV_NAME:development-environment}
-----
 
 WARNING: YAML files cannot be loaded by using the `@PropertySource` or `@TestPropertySource` annotations.
 So, in the case that you need to load values that way, you need to use a properties file.

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
@@ -443,7 +443,7 @@ For example, if a secret named `db.password` is mounted at location `/run/secret
 The values in `application.properties` and `application.yml` are filtered through the existing `Environment` when they are used, so you can refer back to previously defined values (for example, from System properties or environment variables).
 The standard `$\{name:default}` property-placeholder syntax can be used anywhere within a value.
 
-For example, the following file will set `app.description` to "`MyApp is a Spring Boot application`":
+For example, the following file will set `app.description` to "`MyApp is a Spring Boot application written by john.doe`":
 
 [source,yaml,indent=0,subs="verbatim",configblocks]
 ----

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
@@ -608,6 +608,19 @@ The preceding example would be transformed into these properties:
 TIP: Properties that use the `[index]` notation can be bound to Java `List` or `Set` objects using Spring Boot's `Binder` class.
 For more details see the "`<<features#features.external-config.typesafe-configuration-properties>>`" section below.
 
+[[features.external-config.yaml.using-env-variables-in-yaml]]
+==== Using environment variables and default values in YAML property definitions
+
+In order to use environment variable as a source for application property, one can use placeholders like this: 
+
+[source,yaml,indent=0,subs="verbatim"]
+----
+	environments:
+	  dev:
+	    url: ${DEV_ENV_URL}
+	    name: ${DEV_ENV_NAME:development-environment}
+----
+
 WARNING: YAML files cannot be loaded by using the `@PropertySource` or `@TestPropertySource` annotations.
 So, in the case that you need to load values that way, you need to use a properties file.
 


### PR DESCRIPTION
I've figured that way too often I try to find an example in official reference documentation, and invariably end up on this SO question: https://stackoverflow.com/questions/23027315/does-application-yml-support-environment-variables

given it's popularity, I think this deserves to be added in the documentation

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
