### PR TITLE
Add a cache to LaunchedURLClassloader to improve startup performance

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/ClassLoaderCache.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/ClassLoaderCache.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.loader;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A class/resource cache used by {@link LaunchedURLClassLoader} .
+ *
+ * @author Bingjie Lv
+ * @since 2.7.0
+ *
+ */
+public class ClassLoaderCache {
+
+	private boolean enableCache = Boolean.getBoolean("loader.cache.enable");
+
+	private final int cacheSize = Integer.getInteger("loader.cache.size", 3000);
+
+	private Map<String, ClassNotFoundException> classNotFoundExceptionCache;
+
+	private Map<String, Optional<URL>> resourceUrlCache;
+
+	private Map<String, Optional<Enumeration<URL>>> resourcesUrlCache;
+
+	public ClassLoaderCache() {
+		this.classNotFoundExceptionCache = createCache(this.cacheSize);
+		this.resourceUrlCache = createCache(this.cacheSize);
+		this.resourcesUrlCache = createCache(this.cacheSize);
+	}
+
+	public void fastClassNotFoundException(String name) throws ClassNotFoundException {
+		if (!this.enableCache) {
+			return;
+		}
+		ClassNotFoundException classNotFoundException = this.classNotFoundExceptionCache.get(name);
+		if (classNotFoundException != null) {
+			throw classNotFoundException;
+		}
+	}
+
+	public void cacheClassNotFoundException(String name, ClassNotFoundException exception) {
+		if (!this.enableCache) {
+			return;
+		}
+		this.classNotFoundExceptionCache.put(name, exception);
+	}
+
+	public Optional<URL> getResourceCache(String name) {
+		if (!this.enableCache) {
+			return null;
+		}
+		return this.resourceUrlCache.get(name);
+	}
+
+	public URL cacheResourceUrl(String name, URL url) {
+		if (!this.enableCache) {
+			return url;
+		}
+		this.resourceUrlCache.put(name, (url != null) ? Optional.of(url) : Optional.empty());
+		return url;
+	}
+
+	public Optional<Enumeration<URL>> getResourcesCache(String name) {
+		if (!this.enableCache) {
+			return null;
+		}
+		return this.resourcesUrlCache.get(name);
+	}
+
+	public Enumeration<URL> cacheResourceUrls(String name, Enumeration<URL> urlEnumeration) {
+		if (!this.enableCache) {
+			return urlEnumeration;
+		}
+		if (!urlEnumeration.hasMoreElements()) {
+			this.resourcesUrlCache.put(name, Optional.of(urlEnumeration));
+		}
+		return urlEnumeration;
+	}
+
+	public void clearCache() {
+		if (this.enableCache) {
+			this.classNotFoundExceptionCache.clear();
+			this.resourceUrlCache.clear();
+			this.resourcesUrlCache.clear();
+		}
+	}
+
+	public void setEnableCache(boolean enableCache) {
+		this.enableCache = enableCache;
+	}
+
+	protected <K, V> Map<K, V> createCache(int maxSize) {
+		return Collections.synchronizedMap(new LinkedHashMap<K, V>(maxSize, 0.75f, true) {
+			@Override
+			protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+				return size() >= maxSize;
+			}
+		});
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/LaunchedURLClassLoaderTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/LaunchedURLClassLoaderTests.java
@@ -108,4 +108,54 @@ class LaunchedURLClassLoaderTests {
 		}
 	}
 
+	@Test
+	void enableLoaderCache() throws Exception {
+		resolveResourceFromArchive();
+		resolveResourcesFromArchive();
+		resolveRootPathFromArchive();
+		resolveRootResourcesFromArchive();
+		resolveFromNested();
+		resolveFromNestedWhileThreadIsInterrupted();
+
+		LaunchedURLClassLoader loader = new LaunchedURLClassLoader(
+				new URL[] { new URL("jar:file:src/test/resources/jars/app.jar!/") }, getClass().getClassLoader());
+		loader.setEnableCache(true);
+		assertThat(loader.getResource("demo/Application.java")).isEqualTo(loader.getResource("demo/Application.java"));
+		assertThat(loader.loadClass("demo.Application")).isEqualTo(loader.loadClass("demo.Application"));
+		assertThat(loader.getResource("demo/ApplicationNotExist.java")).isNull();
+		assertThat(loader.getResources("demo/ApplicationNotExist.java").hasMoreElements()).isNotEqualTo(true);
+		assertThat(loader.getResources("demo/ApplicationNotExist.java").hasMoreElements()).isNotEqualTo(true);
+		ClassNotFoundException ex = null;
+		ClassNotFoundException ex1 = null;
+		ClassNotFoundException ex2 = null;
+		ClassNotFoundException ex3 = null;
+		try {
+			loader.loadClass("demo.ApplicationNotExist");
+		} catch (ClassNotFoundException exception){
+			ex = exception;
+		}
+		try {
+			loader.loadClass("demo.ApplicationNotExist");
+		} catch (ClassNotFoundException exception){
+			ex1 = exception;
+		}
+		try {
+			loader.setEnableCache(false);
+			loader.loadClass("demo.ApplicationNotExist");
+		} catch (ClassNotFoundException exception){
+			ex2 = exception;
+			loader.setEnableCache(true);
+		}
+		try {
+			loader.clearCache();
+			loader.loadClass("demo.ApplicationNotExist");
+		} catch (ClassNotFoundException exception){
+			ex3 = exception;
+		}
+		assertThat(ex).isNotNull();
+		assertThat(ex1).isNotNull().isEqualTo(ex);
+		assertThat(ex2).isNotNull().isNotEqualTo(ex).isNotEqualTo(ex1);
+		assertThat(ex3).isNotNull().isNotEqualTo(ex2).isNotEqualTo(ex1).isNotEqualTo(ex);
+	}
+
 }


### PR DESCRIPTION
### Motivation
URLClassLoader shows awful performance when finding Classes/Resources which doesn't exist . `URLClassPath` takes linear time to find a resource  and it will traverse all over if the resource doesn't exist. This will obviously slow down the startup when , which is even worse when running from an executable fat jar or the application's class path is a long list.
``` java
 public Resource getResource(String name, boolean check) {
        if (DEBUG) {
            System.err.println("URLClassPath.getResource(\"" + name + "\")");
        }

        Loader loader;
        for (int i = 0; (loader = getLoader(i)) != null; i++) {
            Resource res = loader.getResource(name, check);
            if (res != null) {
                return res;
            }
        }
        return null;
    }
```
Typical cases in practice which may lead to this issue are as follows.
#### 1.Find a class repeatedly which apparently doesn't exist
- **java.beans.Introspector.findCustomizerClass** 
``` java
private static Class<?> findCustomizerClass(Class<?> type) {
      String name = type.getName() + "Customizer";
      try {
          type = ClassFinder.findClass(name, type.getClassLoader());
          // Each customizer should inherit java.awt.Component and implement java.beans.Customizer
          // according to the section 9.3 of JavaBeans specification
          if (Component.class.isAssignableFrom(type) && Customizer.class.isAssignableFrom(type)) {
              return type;
          }
      }
      catch (Exception exception) {
          // ignore any exceptions
      }
      return null;
  }
```
related issue：
 https://github.com/spring-projects/spring-framework/issues/13653

Here are the top 10 calls of `loadClass` in the startup of my application
```
Calls ClassName
480  java.lang.ObjectCustomizer
 249  org.springframework.beans.factory.AwareCustomizer
  99  org.springframework.beans.factory.InitializingBeanCustomizer
  93  org.springframework.core.OrderedCustomizer
  87  org.springframework.context.ApplicationContextAwareCustomizer
  61  org.springframework.beans.factory.BeanFactoryAwareCustomizer
  49  org.springframework.context.annotation.ConfigurationClassEnhancer$EnhancedConfigurationCustomizer
  41  org.springframework.context.ApplicationListenerCustomizer
  31  org.springframework.web.context.ServletContextAwareCustomizer
  29  org.springframework.beans.factory.BeanNameAwareCustomizer
```
- **org.apache.logging.log4j.core.lookup.Interpolator**
``` java
 if (Constants.IS_WEB_APP) {
            try {
                strLookupMap.put(LOOKUP_KEY_WEB,
                    Loader.newCheckedInstanceOf("org.apache.logging.log4j.web.WebLookup", StrLookup.class));
            } catch (final Exception ignored) {
                handleError(LOOKUP_KEY_WEB, ignored);
            }
        } else {
            LOGGER.debug("Not in a ServletContext environment, thus not loading WebLookup plugin.");
        }
        try {
            strLookupMap.put(LOOKUP_KEY_DOCKER,
                Loader.newCheckedInstanceOf("org.apache.logging.log4j.docker.DockerLookup", StrLookup.class));
        } catch (final Exception ignored) {
            handleError(LOOKUP_KEY_DOCKER, ignored);
        }
        try {
            strLookupMap.put(LOOKUP_KEY_SPRING,
                    Loader.newCheckedInstanceOf("org.apache.logging.log4j.spring.boot.SpringLookup", StrLookup.class));
        } catch (final Exception ignored) {
            handleError(LOOKUP_KEY_SPRING, ignored);
        }
        try {
            strLookupMap.put(LOOKUP_KEY_KUBERNETES,
                    Loader.newCheckedInstanceOf("org.apache.logging.log4j.kubernetes.KubernetesLookup", StrLookup.class));
        } catch (final Exception | NoClassDefFoundError error) {
            handleError(LOOKUP_KEY_KUBERNETES, error);
        }
```
Here are the top 4 calls of `loadClass` in the startup of my application
```
Calls ClassName
225 org.apache.logging.log4j.docker.DockerLookup
225 org.apache.logging.log4j.kubernetes.KubernetesLookup
225 org.apache.logging.log4j.spring.cloud.config.client.SpringLookup
225 org.apache.logging.log4j.web.WebLookup
```
- **Many other techniques or frameworks  which use loadClass to check class existence**
For example，org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
``` java
private void registerWellKnownModulesIfAvailable(MultiValueMap<Object, Module> modulesToRegister) {
        Class kotlinModuleClass;
        Module kotlinModule;
        try {
            kotlinModuleClass = ClassUtils.forName("com.fasterxml.jackson.datatype.jdk8.Jdk8Module", this.moduleClassLoader);
            kotlinModule = (Module)BeanUtils.instantiateClass(kotlinModuleClass);
            modulesToRegister.set(kotlinModule.getTypeId(), kotlinModule);
        } catch (ClassNotFoundException var6) {
        }
```

#### 2.Find resource repeatedly which doesn't exist
Here are the top 4 calls of `findResource/findResources` in the startup of my application
```
Calls  Resource
106 META-INF/services/org.apache.logging.log4j.core.util.WatchEventService
  92 log4j2.system.properties
  64 META-INF/services/javax.xml.parsers.DocumentBuilderFactory
  29 META-INF/spring.components
  28 META-INF/services/javax.xml.transform.TransformerFactory
  18 java/lang/com.class
  18 Throwable.class
  18 Object.class
  18 Class.class
  17 String.class
   8 META-INF/services/javax.xml.datatype.DatatypeFactory
   5 config/application.yml
   5 config/application.yaml
   5 config/application.xml
   5 application.yml
   5 application.yaml
   5 application.xml
```
#### 4.Find resource repeatedly which doesn't exist


#### 5.Reflection triggers `sun.reflect.GeneratedMethodAccessor<N>` class loading in runtime
All the cases  listed above happen at startup time, while there are cases in runtime. This will make runtime performance worst. Here is a case which triggers `sun.reflect.GeneratedMethodAccessor<N>` class loading : https://blog.actorsfit.com/a?ID=00001-e5b50c75-c8a5-4cdb-9b0c-5558fb985a60
```
  at java.lang.ClassLoader.loadClass(ClassLoader.java:404)
        - waiting to lock <0x0000000088104b60> (a java.lang.Object)
        at org.springframework.boot.loader.LaunchedURLClassLoader.loadClass(LaunchedURLClassLoader.java:94)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        at org.apache.logging.log4j.core.impl.ThrowableProxy.loadClass(ThrowableProxy.java:539)
        at org.apache.logging.log4j.core.impl.ThrowableProxy.toExtendedStackTrace(ThrowableProxy.java:660)
        at org.apache.logging.log4j.core.impl.ThrowableProxy.<init>(ThrowableProxy.java:137)
        at org.springframework.boot.loader.LaunchedURLClassLoader.loadClass(LaunchedURLClassLoader.java:94)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        at org.apache.logging.log4j.core.impl.ThrowableProxy.loadClass(ThrowableProxy.java:539)
        at org.apache.logging.log4j.core.impl.ThrowableProxy.toExtendedStackTrace(ThrowableProxy.java:660)
        at org.apache.logging.log4j.core.impl.ThrowableProxy.<init>(ThrowableProxy.java:137)
        at org.apache.logging.log4j.core.impl.ThrowableProxy.<init>(ThrowableProxy.java:121)
        at org.apache.logging.log4j.core.impl.Log4jLogEvent.getThrownProxy(Log4jLogEvent.java:555)
        at org.apache.logging.log4j.core.pattern.ExtendedThrowablePatternConverter.format(ExtendedThrowablePatternConverter.java:61)
```

We generally solve these issues  mentioned above case by case and solutions are normally tricky. Is there any final solution to solve this fundamentally？

### Modification
This commit trying to solve this fundamentally  by adding a ClassLoaderCache to LaunchedURLClassLoader .

- Cache `ClassNotFoundException` and fast throw it for the next time
- Cache 'getResource' result  directly
- Cache 'getResources'  NOT-EXIST result

### Benefit
Here are the result of our applications after this enhancement, which shows a 50% optimization on average
App|No Cache | Cache | Improvement
--|-- | -- | --
app1|75s | 39s | 48%
app2|83s | 32s | 61%
app3|152s | 87s | 43%
app4|318s | 137s | 57%
