### PR TITLE
Remove non-existent spring.data.cassandra.connection.connection-timeout property from the documentation

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -520,7 +520,7 @@
       "defaultValue": "none"
     },
     {
-      "name": "spring.data.cassandra.connection.connection-timeout",
+      "name": "spring.data.cassandra.connection.connect-timeout",
       "defaultValue": "5s"
     },
     {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cassandra/CassandraPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cassandra/CassandraPropertiesTests.java
@@ -40,7 +40,7 @@ class CassandraPropertiesTests {
 	@Test
 	void defaultValuesInManualMetadataAreConsistent() {
 		OptionsMap driverDefaults = OptionsMap.driverDefaults();
-		// spring.data.cassandra.connection.connection-timeout
+		// spring.data.cassandra.connection.connect-timeout
 		assertThat(driverDefaults.get(TypedDriverOption.CONNECTION_CONNECT_TIMEOUT)).isEqualTo(Duration.ofSeconds(5));
 		// spring.data.cassandra.connection.init-query-timeout
 		assertThat(driverDefaults.get(TypedDriverOption.CONNECTION_INIT_QUERY_TIMEOUT))


### PR DESCRIPTION
Since 2.5.0,

- `spring.data.cassandra.connection.connect-timeout` and
- `spring.data.cassandra.connection.connection-timeout`

are listed in the reference document,
but the latter does not exists in CassandraProperties.java.

I think it is caused by a small typo in 9b0cdac97aded723ef003cd9c503a9792e586848.


- Reference documents
    - [2.4.13](https://docs.spring.io/spring-boot/docs/2.4.13/reference/html/appendix-application-properties.html#spring.data.cassandra.connection.connect-timeout)
    - [2.5.0](https://docs.spring.io/spring-boot/docs/2.5.0/reference/html/application-properties.html#application-properties.data.spring.data.cassandra.connection.connect-timeout)
    - [current](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.data.spring.data.cassandra.connection.connect-timeout)
- [Property Class](https://github.com/spring-projects/spring-boot/blob/c755e0d1f880baa0abe4e8b80a3ef014aaa3eada/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java)