### PR TITLE
NullBean check in ApplicationContextAssert.doesNotHaveBean(String)

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssert.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssert.java
@@ -198,7 +198,8 @@ public class ApplicationContextAssert<C extends ApplicationContext>
 		}
 		try {
 			Object bean = getApplicationContext().getBean(name);
-			throwAssertionError(new BasicErrorMessageFactory(
+			if(!bean.equals(null))
+				throwAssertionError(new BasicErrorMessageFactory(
 					"%nExpecting:%n <%s>%nnot to have a bean of name:%n <%s>%nbut found:%n <%s>",
 					getApplicationContext(), name, bean));
 		}


### PR DESCRIPTION
getApplicationContext().getBean(name) may return a org.springframework.beans.factory.support.NullBean bean and does not throw the expected NoSuchBeanDefinitionException that validates the assertion. However, this NullBean is not meant to be, therefore it must be checked prior throwing the assertion error.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Describing Your Changes
If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug (YES), please
describe the broken behaviour (DONE) and how the changes fix it (DONE).
-->
