### PR TITLE
Add Netty in "Enable HTTP Response Compression" 

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/webserver.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/webserver.adoc
@@ -150,7 +150,7 @@ Contrary to a test, application code callbacks are processed early (before the v
 
 [[howto.webserver.enable-response-compression]]
 === Enable HTTP Response Compression
-HTTP response compression is supported by Jetty, Tomcat, and Undertow.
+HTTP response compression is supported by Jetty, Tomcat, Undertow and Netty.
 It can be enabled in `application.properties`, as follows:
 
 [source,yaml,indent=0,subs="verbatim",configprops,configblocks]


### PR DESCRIPTION
Silly change, just adds Netty to list of webservers that support compression.

We observer compression works fine in spring-cloud-gateway which uses Netty but docs dont mention it. It's implemented in `org.springframework.boot.web.embedded.netty.CompressionCustomizer`.


