### PR TITLE
Fix JsonSerializer example in reference guide

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/web/servlet/springmvc/json/MyJsonComponent.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/web/servlet/springmvc/json/MyJsonComponent.java
@@ -36,8 +36,10 @@ public class MyJsonComponent {
 
 		@Override
 		public void serialize(MyObject value, JsonGenerator jgen, SerializerProvider serializers) throws IOException {
+			jgen.writeStartObject();
 			jgen.writeStringField("name", value.getName());
 			jgen.writeNumberField("age", value.getAge());
+			jgen.writeEndObject();
 		}
 
 	}


### PR DESCRIPTION

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

If you follow the docs writing custom json serializer, it throws  an exception "JsonGenerationException". Of course, if there is an existing Json Generator, it is applicable code, but users (including myself) who usually follow docs are more likely to write the code first. Therefore, I think that the text should be modified as an example with the addition of JsonGenerator.writeStartObject()/writeEndObject() or a separate notice should exist for that part.
