### PR TITLE
Fix typo in forward-merge script

### DIFF
--- a/git/hooks/forward-merge
+++ b/git/hooks/forward-merge
@@ -18,7 +18,7 @@ class ForwardMerge
 end
 
 def find_forward_merges(message_file)
-  $log.debug "Searching for for forward merge"
+  $log.debug "Searching for forward merge"
   rev=`git rev-parse -q --verify MERGE_HEAD`.strip
   $log.debug "Found #{rev} from git rev-parse"
   return nil unless rev


### PR DESCRIPTION
$log.debug "Searching **for** for forward merge" changed to $log.debug "Searching for forward merge"