### PR TITLE
Remove checks for Java 9 compatibility in build.gradle files

### DIFF
--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/build.gradle
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/build.gradle
@@ -40,5 +40,4 @@ task buildApp(type: GradleBuild) {
 
 intTest {
 	dependsOn buildApp
-	enabled = !JavaVersion.current().java9Compatible
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jpa/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jpa/build.gradle
@@ -9,9 +9,7 @@ dependencies {
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-freemarker"))
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-web"))
 	implementation("jakarta.persistence:jakarta.persistence-api")
-	if (JavaVersion.current().java9Compatible) {
-		implementation("jakarta.xml.bind:jakarta.xml.bind-api")
-	}
+	implementation("jakarta.xml.bind:jakarta.xml.bind-api")
 	implementation("org.hibernate:hibernate-core-jakarta") {
 		exclude group: "javax.activation", module: "javax.activation-api"
 		exclude group: "javax.persistence", module: "javax.persistence-api"

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-liquibase/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-liquibase/build.gradle
@@ -9,9 +9,7 @@ dependencies {
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-actuator"))
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-jdbc"))
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-web"))
-	if (JavaVersion.current().java9Compatible) {
-		implementation("jakarta.xml.bind:jakarta.xml.bind-api")
-	}
+	implementation("jakarta.xml.bind:jakarta.xml.bind-api")
 	implementation("org.liquibase:liquibase-core") {
 		exclude group: "javax.activation", module: "javax.activation-api"
 		exclude group: "javax.xml.bind", module: "jaxb-api"

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-groovy-templates/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-groovy-templates/build.gradle
@@ -8,9 +8,7 @@ description = "Spring Boot web Groovy Templates smoke test"
 dependencies {
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-groovy-templates"))
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-validation"))
-	if (JavaVersion.current().java9Compatible) {
-		implementation("jakarta.xml.bind:jakarta.xml.bind-api")
-	}
+	implementation("jakarta.xml.bind:jakarta.xml.bind-api")
 
 	testImplementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-test"))
 }


### PR DESCRIPTION
Hi,

this PR removes some obsolete checks for Java 9 compatibility in build.gradle files, due to the new Java 17 baseline. For completeness reasons: In the case of `spring-boot-launch-script-tests` this will cause some longer build times (at least when things are not cached).

Cheers,
Christoph