### PR TITLE
Fix links to Spring Security Reference Guide in Accessing the H2 Console in a Secured Application

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/sql.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/sql.adoc
@@ -345,7 +345,7 @@ If your application uses Spring Security, you need to configure it to
 * disable CSRF protection for requests against the console,
 * set the header `X-Frame-Options` to `SAMEORIGIN` on responses from the console.
 
-More information on {spring-security-docs}#csrf[CSRF] and the header {spring-security-docs}#headers-frame-options[X-Frame-Options] can be found in the Spring Security Reference Guide.
+More information on {spring-security-docs}/features/exploits/csrf.html[CSRF] and the header {spring-security-docs}/features/exploits/headers.html#headers-frame-options[X-Frame-Options] can be found in the Spring Security Reference Guide.
 
 In simple setups, a `SecurityFilterChain` like the following can be used:
 


### PR DESCRIPTION
Thanks for merging #29932! Configuring Spring Security can be a challenge for beginners, and I think the added paragraph will be helpful.

I checked the deployed snapshot versions of the documentation. Unfortunately, only the 2.5.x version has working links to the Spring Security reference guide. For Spring Boot 2.6.x, they need to be adjusted against the new structure of the Spring Security documentation that came with 5.6: https://docs.spring.io/spring-boot/docs/2.6.5-SNAPSHOT/reference/htmlsingle/#data.sql.h2-web-console.spring-security

This PR is only half the solution, as `{spring-security-docs}` resolves to `https://docs.spring.io/spring-security/reference/5.6.2`. But all links with this particular version do not work while they do e.g. for `5.6.1` or `5.6`. It seem to be the same problem as in #28407 but the fix for that has been basically reverted for #28618. As I don't know, what the best approach for this problem is, the PR doesn't address this.