### PR TITLE
Thread safe about ApplicationAvailabilityBean

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/availability/ApplicationAvailabilityBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/availability/ApplicationAvailabilityBean.java
@@ -16,8 +16,8 @@
 
 package org.springframework.boot.availability;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -38,7 +38,7 @@ import org.springframework.util.Assert;
 public class ApplicationAvailabilityBean
 		implements ApplicationAvailability, ApplicationListener<AvailabilityChangeEvent<?>> {
 
-	private final Map<Class<? extends AvailabilityState>, AvailabilityChangeEvent<?>> events = new HashMap<>();
+	private final Map<Class<? extends AvailabilityState>, AvailabilityChangeEvent<?>> events = new ConcurrentHashMap<>();
 
 	private final Log logger;
 


### PR DESCRIPTION
It seems that `onApplicationEvent ` could be invoked concurrently, at least events map could be written and read concurrently.

Replace event map with ConcurrentHashMap. Details in [jdk - `HashMap.java` - L89](https://github.com/openjdk/jdk/blob/3e73a0b726a97df0a4e92f9cf917429346090f45/src/java.base/share/classes/java/util/HashMap.java#L89)

>Note that this implementation is not synchronized. If multiple threads access a hash map concurrently, and at least one of the threads modifies the map structurally, it must be synchronized externally.