### PR TITLE
Fix references to JDK 1.8 in READMEs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -75,7 +75,7 @@ We like to know the Spring Boot version, operating system, and JVM version you'r
 
 == Building from Source
 You don't need to build from source to use Spring Boot (binaries in https://repo.spring.io[repo.spring.io]), but if you want to try out the latest and greatest, Spring Boot can be built and published to your local Maven cache using the https://docs.gradle.org/current/userguide/gradle_wrapper.html[Gradle wrapper].
-You also need JDK 11.
+You also need JDK 17.
 
 [indent=0]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -75,7 +75,7 @@ We like to know the Spring Boot version, operating system, and JVM version you'r
 
 == Building from Source
 You don't need to build from source to use Spring Boot (binaries in https://repo.spring.io[repo.spring.io]), but if you want to try out the latest and greatest, Spring Boot can be built and published to your local Maven cache using the https://docs.gradle.org/current/userguide/gradle_wrapper.html[Gradle wrapper].
-You also need JDK 1.8.
+You also need JDK 11.
 
 [indent=0]
 ----

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/README.adoc
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/README.adoc
@@ -38,9 +38,6 @@ user to be able to connect to the daemon.
 
 == Running the tests
 
-NOTE: You need Java 8 to run the integration tests as they are currently skipped for Java
-9 and later.
-
 You're now ready to run the tests. Assuming that you're in the same directory as this
 README, the tests can be launched as follows:
 


### PR DESCRIPTION
Hi,

just noticed two places in READMEs that still pointed to JDK 8 being the baseline.

Cheers,
Christoph