### PR TITLE
order ExitCodeGenerator in ExitCodeGenerators by Ordered and @Order b…

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/spring-application.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/spring-application.adoc
@@ -352,6 +352,7 @@ include::code:MyApplication[]
 Also, the `ExitCodeGenerator` interface may be implemented by exceptions.
 When such an exception is encountered, Spring Boot returns the exit code provided by the implemented `getExitCode()` method.
 
+If several `ExitCodeGenerator` are registered in a `ExitCodeGenerators` that must be called in a specific order, you can additionally implement the `org.springframework.core.Ordered` interface or use the `org.springframework.core.annotation.Order` annotation.
 
 
 [[features.spring-application.admin]]

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ExitCodeGenerators.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ExitCodeGenerators.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.util.Assert;
 
 /**
@@ -84,6 +85,7 @@ class ExitCodeGenerators implements Iterable<ExitCodeGenerator> {
 	 */
 	int getExitCode() {
 		int exitCode = 0;
+		AnnotationAwareOrderComparator.sort(generators);
 		for (ExitCodeGenerator generator : this.generators) {
 			try {
 				int value = generator.getExitCode();


### PR DESCRIPTION
### Describing Your Changes

Different order in `ExitCodeGenerators#generators` will lead to different exitCode. I suggest add ‘order’ support in order to sort `ExitCodeGenerators#generators` by `Ordered` and `@Order`.
