### PR TITLE
Update list of default internal proxies in Web Server howto

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/webserver.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/webserver.adoc
@@ -444,7 +444,7 @@ If you use Tomcat, you can additionally configure the names of the headers used 
 ----
 
 Tomcat is also configured with a default regular expression that matches internal proxies that are to be trusted.
-By default, IP addresses in `10/8`, `192.168/16`, `169.254/16` and `127/8` are trusted.
+By default, IP addresses in `10/8`, `192.168/16`, `169.254/16`, `127/8`, `172.16/12` and `::1` are trusted.
 You can customize the valve's configuration by adding an entry to `application.properties`, as shown in the following example:
 
 [source,yaml,indent=0,subs="verbatim",configprops,configblocks]

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/webserver.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/webserver.adoc
@@ -444,7 +444,7 @@ If you use Tomcat, you can additionally configure the names of the headers used 
 ----
 
 Tomcat is also configured with a default regular expression that matches internal proxies that are to be trusted.
-By default, IP addresses in `10/8`, `192.168/16`, `169.254/16`, `127/8`, `172.16/12` and `::1` are trusted.
+See the `server.tomcat.remoteip.internal-proxies` property in section <<application-properties#appendix.application-properties.server>> for more details.
 You can customize the valve's configuration by adding an entry to `application.properties`, as shown in the following example:
 
 [source,yaml,indent=0,subs="verbatim",configprops,configblocks]


### PR DESCRIPTION
The documentation lags a bit behind the code in terms of default internal proxies.
I was using IPv6 and it took me some time to figure out what was going on.
