### PR TITLE
Make JSON comparisons in tests more robust

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-autoconfigure/build.gradle
@@ -213,6 +213,7 @@ dependencies {
 	testImplementation("org.junit.jupiter:junit-jupiter")
 	testImplementation("org.mockito:mockito-core")
 	testImplementation("org.mockito:mockito-junit-jupiter")
+	testImplementation("org.skyscreamer:jsonassert")
 	testImplementation("org.springframework:spring-test")
 	testImplementation("org.springframework.kafka:spring-kafka-test")
 	testImplementation("org.springframework.security:spring-security-test")

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfigurationTests.java
@@ -18,10 +18,8 @@ package org.springframework.boot.autoconfigure.gson;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import com.google.gson.ExclusionStrategy;
@@ -31,6 +29,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.LongSerializationPolicy;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -152,8 +151,7 @@ class GsonAutoConfigurationTests {
 	void customGsonBuilder() {
 		this.contextRunner.withUserConfiguration(GsonBuilderConfig.class).run((context) -> {
 			Gson gson = context.getBean(Gson.class);
-			List<String> expectedJson = Arrays.asList("{\"data\":1,\"owner\":null}", "{\"owner\":null,\"data\":1}");
-			assertThat(gson.toJson(new DataObject())).isIn(expectedJson);
+			JSONAssert.assertEquals(gson.toJson(new DataObject()), "{\"data\":1,\"owner\":null}", false);
 		});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfigurationTests.java
@@ -18,11 +18,11 @@ package org.springframework.boot.autoconfigure.gson;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfigurationTests.java
@@ -21,6 +21,8 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Arrays;
+import java.util.List;
 
 import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
@@ -150,7 +152,9 @@ class GsonAutoConfigurationTests {
 	void customGsonBuilder() {
 		this.contextRunner.withUserConfiguration(GsonBuilderConfig.class).run((context) -> {
 			Gson gson = context.getBean(Gson.class);
-			assertThat(gson.toJson(new DataObject())).isEqualTo("{\"data\":1,\"owner\":null}");
+			// assertThat(gson.toJson(new DataObject())).isEqualTo("{\"dat\":1,\"owner\":null}");
+			List<String> expectedJson = Arrays.asList("{\"data\":1,\"owner\":null}", "{\"owner\":null,\"data\":1}");
+			assertThat(gson.toJson(new DataObject())).isIn(expectedJson);
 		});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/gson/GsonAutoConfigurationTests.java
@@ -152,7 +152,6 @@ class GsonAutoConfigurationTests {
 	void customGsonBuilder() {
 		this.contextRunner.withUserConfiguration(GsonBuilderConfig.class).run((context) -> {
 			Gson gson = context.getBean(Gson.class);
-			// assertThat(gson.toJson(new DataObject())).isEqualTo("{\"dat\":1,\"owner\":null}");
 			List<String> expectedJson = Arrays.asList("{\"data\":1,\"owner\":null}", "{\"owner\":null,\"data\":1}");
 			assertThat(gson.toJson(new DataObject())).isIn(expectedJson);
 		});


### PR DESCRIPTION
Hi,

The test `customGsonBuilder()` is non deterministic or flaky. `Gson.toJson()` function does not promise any ordering of fields in the returned JSON string (at least not by itself). Therefore, the result of `gson.toJson(new DataObject())` could be `{data: 1, owner: null}` or `{owner: null, data: 1}`. Both of them are the same JSON objects, and ideally, application should not differentiate based on the ordering of JSON fields. These tests may start to fail in the near future and ring a false alarm. Here's a SO post for more details: https://stackoverflow.com/questions/6365851/how-to-keep-fields-sequence-in-gson-serialization.

I ran the test again after my changes to confirm it passes: `./gradlew :spring-boot-project:spring-boot-autoconfigure:test --tests org.springframework.boot.autoconfigure.gson.GsonAutoConfigurationTests.customGsonBuilder`.


Please let me know if you have any questions. There are some more flaky tests in this repository. If you like this fix, I can open more PRs for the other flaky tests. 