### PR TITLE
add Tomcat locale mapping for Japanese to preserve UTF-8 charset

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
@@ -266,6 +266,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 	private void resetDefaultLocaleMapping(TomcatEmbeddedContext context) {
 		context.addLocaleEncodingMappingParameter(Locale.ENGLISH.toString(), DEFAULT_CHARSET.displayName());
 		context.addLocaleEncodingMappingParameter(Locale.FRENCH.toString(), DEFAULT_CHARSET.displayName());
+		context.addLocaleEncodingMappingParameter(Locale.JAPANESE.toString(), DEFAULT_CHARSET.displayName());
 	}
 
 	private void addLocaleMappings(TomcatEmbeddedContext context) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactoryTests.java
@@ -410,6 +410,7 @@ class TomcatServletWebServerFactoryTests extends AbstractServletWebServerFactory
 		// override defaults, see org.apache.catalina.util.CharsetMapperDefault.properties
 		assertThat(getCharset(Locale.ENGLISH)).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(getCharset(Locale.FRENCH)).isEqualTo(StandardCharsets.UTF_8);
+		assertThat(getCharset(Locale.JAPANESE)).isEqualTo(StandardCharsets.UTF_8);
 	}
 
 	@Test


### PR DESCRIPTION
Tomcat 9.0.59 [added](https://github.com/apache/tomcat/commit/ad8d837ea335928d74833509e4f96747b97b503b) a charset mapping for Japanese to default to `Shift_JIS` encoding.

This results in corrupted rendering if the client expects UTF-8 and can be easily seen by setting the `Accept-Language: ja` header (by changing the primary language in Chrome settings to Japanese).

The fix is to apply the same override mapping in `TomcatServletWebServerFactory.java` that already existed for `en` and `fr` (in those cases, to override `ISO-8559-1` to `UTF-8`):


**index.html:**
```html
<!DOCTYPE html>
<html lang="ja">
<head>
  <meta charset="UTF-8">
  <title>こんにちは世界</title> <!-- "Hello, World" -->
</head>
<body>
管理者画面 <!-- "Admin" -->
</body>
</html>
```
