### PR TITLE
Add missing configuration metadata for "management.endpoint.health.probes.add-additional-paths"

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -49,6 +49,12 @@
       ]
     },
     {
+      "name": "management.endpoint.health.probes.add-additional-paths",
+      "type": "java.lang.Boolean",
+      "description": "Whether to make the liveness and readiness health groups available on the main server port.",
+      "defaultValue": false
+    },
+    {
       "name": "management.endpoint.health.probes.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable liveness and readiness probes.",


### PR DESCRIPTION
According to the documentation of spring-boot-actuator, we can define "management.endpoint.health.probes.add-additional-paths=true" to enable `liveness` and `readiness`. However, the configuration metadata for this is missing.

> If your Actuator endpoints are deployed on a separate management context, the endpoints do not use the same web infrastructure (port, connection pools, framework components) as the main application. In this case, a probe check could be successful even if the main application does not work properly (for example, it cannot accept new connections). For this reason, is it a good idea to make the liveness and readiness health groups available on the main server port. This can be done by setting the following property:
> ```java
> management.endpoint.health.probes.add-additional-paths=true
> ```
https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#actuator.endpoints.kubernetes-probes
