### PR TITLE
Remove unnecessary quotes from examples

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/endpoints.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/endpoints.adoc
@@ -736,7 +736,7 @@ Additional `HealthIndicators` are available but are not enabled by default:
 
 
 
-[[actuator.endpoints.health.writing-custom-health-indicators]]
+[[actuator.endpoints.health.writing-totom-health-indicators]]
 ==== Writing Custom HealthIndicators
 To provide custom health information, you can register Spring beans that implement the {spring-boot-actuator-module-code}/health/HealthIndicator.java[`HealthIndicator`] interface.
 You need to provide an implementation of the `health()` method and return a `Health` response.
@@ -1020,7 +1020,7 @@ You can, for example, configure additional Health Indicators:
 	    health:
 	      group:
 	        readiness:
-	          include: "readinessState,customCheck"
+	          include: readinessState,customCheck
 ----
 
 By default, Spring Boot does not add other health indicators to these groups.


### PR DESCRIPTION
`include: "readinessState,customCheck"` > `include: readinessState,customCheck`

I did not find Spring Boot recommendations for YAML style, then I assume default should be applied: https://yaml.org/spec/1.2.2/

I think readability should be promoted 

 > The plain (unquoted) style has no identifying indicators and provides no form of escaping. It is therefore the most readable

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
