### PR TITLE
Allow disabling the Dynatrace instruments in Micrometer

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/dynatrace/DynatraceProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/dynatrace/DynatraceProperties.java
@@ -168,6 +168,14 @@ public class DynatraceProperties extends StepRegistryProperties {
 		 */
 		private String metricKeyPrefix;
 
+		/**
+		 * Since version 1.9.0 of Micrometer, the Dynatrace registry uses specialized
+		 * instruments to make sure data is exported in an optimal format. This behavior
+		 * is the new default. This toggle allows switching back to the original
+		 * implementation.
+		 */
+		private boolean useDynatraceSummaryInstruments = true;
+
 		public Map<String, String> getDefaultDimensions() {
 			return this.defaultDimensions;
 		}
@@ -190,6 +198,14 @@ public class DynatraceProperties extends StepRegistryProperties {
 
 		public void setMetricKeyPrefix(String metricKeyPrefix) {
 			this.metricKeyPrefix = metricKeyPrefix;
+		}
+
+		public boolean isUseDynatraceSummaryInstruments() {
+			return useDynatraceSummaryInstruments;
+		}
+
+		public void setUseDynatraceSummaryInstruments(boolean useDynatraceSummaryInstruments) {
+			this.useDynatraceSummaryInstruments = useDynatraceSummaryInstruments;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/dynatrace/DynatraceProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/dynatrace/DynatraceProperties.java
@@ -201,7 +201,7 @@ public class DynatraceProperties extends StepRegistryProperties {
 		}
 
 		public boolean isUseDynatraceSummaryInstruments() {
-			return useDynatraceSummaryInstruments;
+			return this.useDynatraceSummaryInstruments;
 		}
 
 		public void setUseDynatraceSummaryInstruments(boolean useDynatraceSummaryInstruments) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/dynatrace/DynatracePropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/dynatrace/DynatracePropertiesConfigAdapter.java
@@ -90,6 +90,11 @@ class DynatracePropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapt
 		return get(v2(V2::isEnrichWithDynatraceMetadata), DynatraceConfig.super::enrichWithDynatraceMetadata);
 	}
 
+	@Override
+	public boolean useDynatraceSummaryInstruments() {
+		return get(v2(V2::isUseDynatraceSummaryInstruments), DynatraceConfig.super::useDynatraceSummaryInstruments);
+	}
+
 	private <V> Function<DynatraceProperties, V> v1(Function<V1, V> getter) {
 		return (properties) -> getter.apply(properties.getV1());
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/dynatrace/DynatracePropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/dynatrace/DynatracePropertiesConfigAdapterTests.java
@@ -126,6 +126,13 @@ class DynatracePropertiesConfigAdapterTests {
 	}
 
 	@Test
+	void whenPropertiesUseDynatraceInstrumentsIsSetAdapterUseDynatraceInstrumentsReturnsIt() {
+		DynatraceProperties properties = new DynatraceProperties();
+		properties.getV2().setUseDynatraceSummaryInstruments(false);
+		assertThat(new DynatracePropertiesConfigAdapter(properties).useDynatraceSummaryInstruments()).isFalse();
+	}
+
+	@Test
 	void whenPropertiesDefaultDimensionsIsSetAdapterDefaultDimensionsReturnsIt() {
 		DynatraceProperties properties = new DynatraceProperties();
 		HashMap<String, String> defaultDimensions = new HashMap<>();
@@ -148,6 +155,7 @@ class DynatracePropertiesConfigAdapterTests {
 		assertThat(properties.getV2().getMetricKeyPrefix()).isNull();
 		assertThat(properties.getV2().isEnrichWithDynatraceMetadata()).isTrue();
 		assertThat(properties.getV2().getDefaultDimensions()).isNull();
+		assertThat(properties.getV2().isUseDynatraceSummaryInstruments()).isTrue();
 		assertThat(properties.getDeviceId()).isNull();
 		assertThat(properties.getTechnologyType()).isEqualTo("java");
 		assertThat(properties.getGroup()).isNull();


### PR DESCRIPTION
In the Micrometer PR https://github.com/micrometer-metrics/micrometer/pull/3093 we introduced a couple of custom built instruments in order to export metrics in the most optimal format. These new instruments are the ones used by default starting from Micrometer 1.9.0.

This PR introduces a new flag, that allow users to switch back to the previous behavior - where the original instruments from Micrometer are used.




