### PR TITLE
Update initialization of WebSocket handler in GraphQlWebMvcAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/servlet/GraphQlWebMvcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/servlet/GraphQlWebMvcAutoConfiguration.java
@@ -191,7 +191,7 @@ public class GraphQlWebMvcAutoConfiguration {
 			WebSocketHandlerMapping mapping = new WebSocketHandlerMapping();
 			mapping.setWebSocketUpgradeMatch(true);
 			mapping.setUrlMap(Collections.singletonMap(path,
-					new WebSocketHttpRequestHandler(handler, new DefaultHandshakeHandler())));
+					handler.asWebSocketHttpRequestHandler(new DefaultHandshakeHandler())));
 			mapping.setOrder(2); // Ahead of HTTP endpoint ("routerFunctionMapping" bean)
 			return mapping;
 		}


### PR DESCRIPTION
`GraphQlWebSocketHandler` now exposes a method to create the `WebSocketHttpRequestHandler` instance to use, that's pre-configured with a `HandshakeInterceptor` for context propagation. This is a result of changes for  https://github.com/spring-projects/spring-graphql/issues/342.

This pull request updates how the `WebSocketHttpRequestHandler` is created in the auto configuration, making use of this new method, in order to complete the fix for https://github.com/spring-projects/spring-graphql/issues/342.

