### PR TITLE
Allow users to specify protocol for lettuce

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.java
@@ -25,6 +25,7 @@ import io.lettuce.core.TimeoutOptions;
 import io.lettuce.core.cluster.ClusterClientOptions;
 import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
 import io.lettuce.core.cluster.ClusterTopologyRefreshOptions.Builder;
+import io.lettuce.core.protocol.ProtocolVersion;
 import io.lettuce.core.resource.ClientResources;
 import io.lettuce.core.resource.DefaultClientResources;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
@@ -52,6 +53,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Paluch
  * @author Andy Wilkinson
+ * @author Gaurav Ojha
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(RedisClient.class)
@@ -139,6 +141,11 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 		Duration connectTimeout = getProperties().getConnectTimeout();
 		if (connectTimeout != null) {
 			builder.socketOptions(SocketOptions.builder().connectTimeout(connectTimeout).build());
+		}
+		// allow clients to specify the protocol version to use
+		ProtocolVersion protocolVersion = getProperties().getLettuce().getProtocolVersion();
+		if (protocolVersion != null) {
+			builder.protocolVersion(getProperties().getLettuce().getProtocolVersion());
 		}
 		return builder.timeoutOptions(TimeoutOptions.enabled()).build();
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.List;
 
 import io.lettuce.core.protocol.ProtocolVersion;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -445,9 +445,9 @@ public class RedisProperties {
 		private Duration shutdownTimeout = Duration.ofMillis(100);
 
 		/**
-		 * The protocol version to use for Redis. Defaults to RESP3
+		 * The protocol version to use for Redis. Defaults to the newest supported version
 		 */
-		private ProtocolVersion protocolVersion = ProtocolVersion.RESP3;
+		private ProtocolVersion protocolVersion = ProtocolVersion.newestSupported();
 
 		/**
 		 * Lettuce pool configuration.

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.data.redis;
 import java.time.Duration;
 import java.util.List;
 
+import io.lettuce.core.protocol.ProtocolVersion;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -30,6 +31,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Marco Aust
  * @author Mark Paluch
  * @author Stephane Nicoll
+ * @author Gaurav Ojha
  * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "spring.redis")
@@ -443,6 +445,11 @@ public class RedisProperties {
 		private Duration shutdownTimeout = Duration.ofMillis(100);
 
 		/**
+		 * The protocol version to use for Redis. Defaults to RESP3
+		 */
+		private ProtocolVersion protocolVersion = ProtocolVersion.RESP3;
+
+		/**
 		 * Lettuce pool configuration.
 		 */
 		private final Pool pool = new Pool();
@@ -463,6 +470,14 @@ public class RedisProperties {
 
 		public Cluster getCluster() {
 			return this.cluster;
+		}
+
+		public ProtocolVersion getProtocolVersion() {
+			return protocolVersion;
+		}
+
+		public void setProtocolVersion(ProtocolVersion protocolVersion) {
+			this.protocolVersion = protocolVersion;
 		}
 
 		public static class Cluster {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -473,7 +473,7 @@ public class RedisProperties {
 		}
 
 		public ProtocolVersion getProtocolVersion() {
-			return protocolVersion;
+			return this.protocolVersion;
 		}
 
 		public void setProtocolVersion(ProtocolVersion protocolVersion) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -467,7 +467,7 @@ class RedisAutoConfigurationTests {
 			assertThat(cf.getHostName()).isEqualTo("foo");
 			assertThat(cf.getDatabase()).isEqualTo(1);
 			assertThat(cf.getClientConfiguration().getClientOptions().isPresent()).isTrue();
-			assertThat(cf.getClientConfiguration().getClientOptions().get().getConfiguredProtocolVersion())
+			assertThat(cf.getClientConfiguration().getClientOptions().get().getProtocolVersion())
 					.isEqualTo(ProtocolVersion.RESP3);
 		});
 	}
@@ -480,7 +480,7 @@ class RedisAutoConfigurationTests {
 					assertThat(cf.getHostName()).isEqualTo("foo");
 					assertThat(cf.getDatabase()).isEqualTo(1);
 					assertThat(cf.getClientConfiguration().getClientOptions().isPresent()).isTrue();
-					assertThat(cf.getClientConfiguration().getClientOptions().get().getConfiguredProtocolVersion())
+					assertThat(cf.getClientConfiguration().getClientOptions().get().getProtocolVersion())
 							.isEqualTo(ProtocolVersion.RESP2);
 				});
 	}


### PR DESCRIPTION
Since v6.0 of lettuce-core, Lettuce supports different Protocol versions (RESP2 and the newer RESP3). This PR aims to bring in support for easy configuration of the protocol from the properties directly, instead of having to define a Configuration.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
