### PR TITLE
Fix incorrect link in kafka.adoc

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/messaging/kafka.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/messaging/kafka.adoc
@@ -61,7 +61,7 @@ The former can be configured using `spring.kafka.streams.application-id`, defaul
 The latter can be set globally or specifically overridden only for streams.
 
 Several additional properties are available using dedicated properties; other arbitrary Kafka properties can be set using the `spring.kafka.streams.properties` namespace.
-See also <<features#messaging.kafka.additional-properties>> for more information.
+See also <<kafka#messaging.kafka.additional-properties>> for more information.
 
 To use the factory bean, wire `StreamsBuilder` into your `@Bean` as shown in the following example:
 


### PR DESCRIPTION
I think the document about kafka might be moved from [`features`](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html) to [`messaging`](https://docs.spring.io/spring-boot/docs/current/reference/html/messaging.html#messaging.kafka.streams), but there is still an old link.