### PR TITLE
Event handling in JobExecutionExitCodeGenerator is not thread-safe

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobExecutionExitCodeGenerator.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobExecutionExitCodeGenerator.java
@@ -16,8 +16,8 @@
 
 package org.springframework.boot.autoconfigure.batch;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.springframework.batch.core.JobExecution;
 import org.springframework.boot.ExitCodeGenerator;
@@ -31,7 +31,7 @@ import org.springframework.context.ApplicationListener;
  */
 public class JobExecutionExitCodeGenerator implements ApplicationListener<JobExecutionEvent>, ExitCodeGenerator {
 
-	private final List<JobExecution> executions = new ArrayList<>();
+	private final List<JobExecution> executions = new CopyOnWriteArrayList<>();
 
 	@Override
 	public void onApplicationEvent(JobExecutionEvent event) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfigurationTests.java
@@ -19,13 +19,13 @@ package org.springframework.boot.autoconfigure.orm.jpa;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
 import javax.sql.DataSource;
@@ -600,7 +600,7 @@ class HibernateJpaAutoConfigurationTests extends AbstractJpaAutoConfigurationTes
 
 		static class EventCapturingApplicationListener implements ApplicationListener<ApplicationEvent> {
 
-			private final List<ApplicationEvent> events = new CopyOnWriteArrayList<>();
+			private final List<ApplicationEvent> events = new ArrayList<>();
 
 			@Override
 			public void onApplicationEvent(ApplicationEvent event) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfigurationTests.java
@@ -19,13 +19,13 @@ package org.springframework.boot.autoconfigure.orm.jpa;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
 import javax.sql.DataSource;
@@ -600,7 +600,7 @@ class HibernateJpaAutoConfigurationTests extends AbstractJpaAutoConfigurationTes
 
 		static class EventCapturingApplicationListener implements ApplicationListener<ApplicationEvent> {
 
-			private final List<ApplicationEvent> events = new ArrayList<>();
+			private final List<ApplicationEvent> events = new CopyOnWriteArrayList<>();
 
 			@Override
 			public void onApplicationEvent(ApplicationEvent event) {

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/classpath/ClassPathFileSystemWatcherTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/classpath/ClassPathFileSystemWatcherTests.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -116,7 +117,7 @@ class ClassPathFileSystemWatcherTests {
 
 	static class Listener implements ApplicationListener<ClassPathChangedEvent> {
 
-		private List<ClassPathChangedEvent> events = new ArrayList<>();
+		private List<ClassPathChangedEvent> events = new CopyOnWriteArrayList<>();
 
 		@Override
 		public void onApplicationEvent(ClassPathChangedEvent event) {


### PR DESCRIPTION
The listener could be invoked concurrently by multiple thread, we should make them threadsafe.

[SimpleApplicationEventMulticaster doc](https://github.com/spring-projects/spring-framework/blob/f40a391916ed6c1f9e1130638a0bf19479e514dd/spring-context/src/main/java/org/springframework/context/event/SimpleApplicationEventMulticaster.java#L40): 
>By default, all listeners are invoked in the calling thread.