### PR TITLE
Upgrade to Mockito 4.5.0

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1002,12 +1002,10 @@ bom {
 			]
 		}
 	}
-	library("Mockito", "4.4.0") {
+	library("Mockito", "4.5.0") {
 		group("org.mockito") {
-			modules = [
-				"mockito-core",
-				"mockito-inline",
-				"mockito-junit-jupiter"
+			imports = [
+				"mockito-bom"
 			]
 		}
 	}


### PR DESCRIPTION
Other than simply upgrading to the latest Mockito version, this also uses the BOM introduced in versions [4.3.0](https://github.com/mockito/mockito/releases/tag/v4.3.0) / [4.3.1](https://github.com/mockito/mockito/releases/tag/v4.3.1).