### PR TITLE
Various typos fixes

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/dynatrace/DynatraceProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/dynatrace/DynatraceProperties.java
@@ -43,7 +43,7 @@ public class DynatraceProperties extends StepRegistryProperties {
 	private String apiToken;
 
 	/**
-	 * URI to ship metrics to. Should be used for SaaS, self managed instances or to
+	 * URI to ship metrics to. Should be used for SaaS, self-managed instances or to
 	 * en-route through an internal proxy.
 	 */
 	private String uri;

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/availability/AvailabilityStateHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/availability/AvailabilityStateHealthIndicator.java
@@ -50,7 +50,7 @@ public class AvailabilityStateHealthIndicator extends AbstractHealthIndicator {
 	 * @param <S> the availability state type
 	 * @param applicationAvailability the application availability
 	 * @param stateType the availability state type
-	 * @param statusMappings consumer used to setup the status mappings
+	 * @param statusMappings consumer used to set up the status mappings
 	 */
 	public <S extends AvailabilityState> AvailabilityStateHealthIndicator(
 			ApplicationAvailability applicationAvailability, Class<S> stateType,

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/EndpointDiscoverer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/EndpointDiscoverer.java
@@ -357,7 +357,7 @@ public abstract class EndpointDiscoverer<E extends ExposableEndpoint<O>, O exten
 		/**
 		 * Create a new {@link OperationKey} instance.
 		 * @param key the underlying key for the operation
-		 * @param description a human readable description of the key
+		 * @param description a human-readable description of the key
 		 */
 		public OperationKey(Object key, Supplier<String> description) {
 			Assert.notNull(key, "Key must not be null");

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/MetricsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/MetricsEndpoint.java
@@ -225,7 +225,7 @@ public class MetricsEndpoint {
 	}
 
 	/**
-	 * A set of tags for further dimensional drilldown and their potential values.
+	 * A set of tags for further dimensional drill-down and their potential values.
 	 */
 	public static final class AvailableTag {
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusPushGatewayManager.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusPushGatewayManager.java
@@ -115,7 +115,7 @@ public class PrometheusPushGatewayManager {
 			this.pushGateway.delete(this.job, this.groupingKey);
 		}
 		catch (Throwable ex) {
-			logger.warn("Unexpected exception thrown while deleting metrics from Promethues Pushgateway", ex);
+			logger.warn("Unexpected exception thrown while deleting metrics from Prometheus Pushgateway", ex);
 		}
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/cassandra/CassandraDriverHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/cassandra/CassandraDriverHealthIndicatorTests.java
@@ -133,7 +133,7 @@ class CassandraDriverHealthIndicatorTests {
 	}
 
 	@Test
-	void healthWithcassandraDownShouldReturnDown() {
+	void healthWithCassandraDownShouldReturnDown() {
 		CqlSession session = mock(CqlSession.class);
 		given(session.getMetadata()).willThrow(new DriverTimeoutException("Test Exception"));
 		CassandraDriverHealthIndicator healthIndicator = new CassandraDriverHealthIndicator(session);

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/startup/StartupTimeMetricsListenerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/startup/StartupTimeMetricsListenerTests.java
@@ -73,9 +73,9 @@ class StartupTimeMetricsListenerTests {
 	void metricRecordedWithoutMainAppClassTag() {
 		SpringApplication application = mock(SpringApplication.class);
 		this.listener.onApplicationEvent(new ApplicationStartedEvent(application, null, null, Duration.ofSeconds(2)));
-		TimeGauge applicationStartedGague = this.registry.find("application.started.time").timeGauge();
-		assertThat(applicationStartedGague).isNotNull();
-		assertThat(applicationStartedGague.getId().getTags()).isEmpty();
+		TimeGauge applicationStartedGauge = this.registry.find("application.started.time").timeGauge();
+		assertThat(applicationStartedGauge).isNotNull();
+		assertThat(applicationStartedGauge.getId().getTags()).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/quartz/QuartzEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/quartz/QuartzEndpointTests.java
@@ -659,7 +659,7 @@ class QuartzEndpointTests {
 	}
 
 	@Test
-	void quartzJobWithSensitiveDataMapAndCustomSanitizier() throws SchedulerException {
+	void quartzJobWithSensitiveDataMapAndCustomSanitizer() throws SchedulerException {
 		JobDetail job = JobBuilder.newJob(Job.class).withIdentity("hello", "samples").usingJobData("test", "value")
 				.usingJobData("secret", "value").build();
 		mockJobs(job);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/BackgroundPreinitializer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/BackgroundPreinitializer.java
@@ -37,7 +37,7 @@ import org.springframework.http.converter.support.AllEncompassingFormHttpMessage
 
 /**
  * {@link ApplicationListener} to trigger early initialization in a background thread of
- * time consuming tasks.
+ * time-consuming tasks.
  * <p>
  * Set the {@link #IGNORE_BACKGROUNDPREINITIALIZER_PROPERTY_NAME} system property to
  * {@code true} to disable this mechanism and let such initialization happen in the

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
@@ -264,7 +264,7 @@ public class CassandraProperties {
 		private DefaultConsistencyLevel serialConsistency;
 
 		/**
-		 * How many rows will be retrieved simultaneously in a single network roundtrip.
+		 * How many rows will be retrieved simultaneously in a single network round-trip.
 		 */
 		private int pageSize;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/ClusterEnvironmentBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/couchbase/ClusterEnvironmentBuilderCustomizer.java
@@ -22,8 +22,7 @@ import com.couchbase.client.java.env.ClusterEnvironment;
  * Callback interface that can be implemented by beans wishing to customize the
  * {@link ClusterEnvironment} via a
  * {@link com.couchbase.client.java.env.ClusterEnvironment.Builder
- * ClusterEnvironment.Builder} whilst retaining default auto-configuration.whilst
- * retaining default auto-configuration.
+ * ClusterEnvironment.Builder} whilst retaining default auto-configuration.
  *
  * @author Stephane Nicoll
  * @since 2.3.0

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/gson/GsonProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/gson/GsonProperties.java
@@ -32,7 +32,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class GsonProperties {
 
 	/**
-	 * Whether to generate non executable JSON by prefixing the output with some special
+	 * Whether to generate non-executable JSON by prefixing the output with some special
 	 * text.
 	 */
 	private Boolean generateNonExecutableJson;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryOptionsBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryOptionsBuilderCustomizer.java
@@ -22,7 +22,7 @@ import io.r2dbc.spi.ConnectionFactoryOptions.Builder;
 /**
  * Callback interface that can be implemented by beans wishing to customize the
  * {@link ConnectionFactoryOptions} via a {@link Builder} whilst retaining default
- * auto-configuration.whilst retaining default auto-configuration.
+ * auto-configuration.
  *
  * @author Mark Paluch
  * @since 2.3.0

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/MultipartAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/MultipartAutoConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.web.multipart.support.StandardServletMultipartResolve
 import org.springframework.web.servlet.DispatcherServlet;
 
 /**
- * {@link EnableAutoConfiguration Auto-configuration} for multi-part uploads. Adds a
+ * {@link EnableAutoConfiguration Auto-configuration} for multipart uploads. Adds a
  * {@link StandardServletMultipartResolver} if none is present, and adds a
  * {@link jakarta.servlet.MultipartConfigElement multipartConfigElement} if none is
  * otherwise defined. The {@link ServletWebServerApplicationContext} will associate the

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/websocket/reactive/WebSocketReactiveAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/websocket/reactive/WebSocketReactiveAutoConfiguration.java
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Auto configuration for WebSocket reactive server in Tomcat, Jetty or Undertow. Requires
+ * Auto-configuration for WebSocket reactive server in Tomcat, Jetty or Undertow. Requires
  * the appropriate WebSocket modules to be on the classpath.
  * <p>
  * If Tomcat's WebSocket support is detected on the classpath we add a customizer that

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1673,7 +1673,7 @@
       "description": "Check the change log location exists.",
       "defaultValue": true,
       "deprecation": {
-        "reason": "Liquibase has it's own check that checks if the change log location exists making this property redundant.",
+        "reason": "Liquibase has its own check that checks if the change log location exists making this property redundant.",
         "level": "error"
       }
     },

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitStreamConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitStreamConfigurationTests.java
@@ -81,7 +81,7 @@ class RabbitStreamConfigurationTests {
 	}
 
 	@Test
-	void whenCustomEnvironmenIsDefinedThenAutoConfiguredEnvironmentBacksOff() {
+	void whenCustomEnvironmentIsDefinedThenAutoConfiguredEnvironmentBacksOff() {
 		this.contextRunner.withUserConfiguration(CustomEnvironmentConfiguration.class).run((context) -> {
 			assertThat(context).hasSingleBean(Environment.class);
 			assertThat(context.getBean(Environment.class))

--- a/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/ProjectGenerationRequest.java
+++ b/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/ProjectGenerationRequest.java
@@ -191,7 +191,7 @@ class ProjectGenerationRequest {
 	}
 
 	/**
-	 * The type of project to generate. Should match one of the advertized type that the
+	 * The type of project to generate. Should match one of the advertised type that the
 	 * service supports. If not set, the default is retrieved from the service metadata.
 	 * @return the project type
 	 */

--- a/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/CompilerAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-cli/src/main/java/org/springframework/boot/cli/compiler/CompilerAutoConfiguration.java
@@ -37,7 +37,7 @@ public abstract class CompilerAutoConfiguration {
 	 * Strategy method used to determine when compiler auto-configuration should be
 	 * applied. Defaults to always.
 	 * @param classNode the class node
-	 * @return {@code true} if the compiler should be auto configured using this class. If
+	 * @return {@code true} if the compiler should be auto-configured using this class. If
 	 * this method returns {@code false} no other strategy methods will be called.
 	 */
 	public boolean matches(ClassNode classNode) {

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/actuator.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/actuator.adoc
@@ -62,11 +62,11 @@ Sanitization can be customized in two different ways.
 The default patterns used by the `env` and `configprops` endpoints can be replaced using configprop:management.endpoint.env.keys-to-sanitize[] and configprop:management.endpoint.configprops.keys-to-sanitize[] respectively.
 Alternatively, additional patterns can be configured using configprop:management.endpoint.env.additional-keys-to-sanitize[] and configprop:management.endpoint.configprops.additional-keys-to-sanitize[].
 
-To take more control over the santization, define a `SanitizingFunction` bean.
+To take more control over the sanitization, define a `SanitizingFunction` bean.
 The `SanitizableData` with which the function is called provides access to the key and value as well as the `PropertySource` from which they came.
 This allows you to, for example, sanitize every value that comes from a particular property source.
-Each `SanitizingFunction` is called in order until a function changes the value of the santizable data.
-If no function changes its value, the built-in key-based santization is performed.
+Each `SanitizingFunction` is called in order until a function changes the value of the sanitizable data.
+If no function changes its value, the built-in key-based sanitization is performed.
 
 
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/EphemeralBuilder.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/EphemeralBuilder.java
@@ -27,7 +27,7 @@ import org.springframework.boot.buildpack.platform.io.Content;
 import org.springframework.boot.buildpack.platform.io.Owner;
 
 /**
- * A short lived builder that is created for each {@link Lifecycle} run.
+ * A short-lived builder that is created for each {@link Lifecycle} run.
  *
  * @author Phillip Webb
  * @author Scott Frederick

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/ImageReference.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/ImageReference.java
@@ -155,7 +155,7 @@ public final class ImageReference {
 
 	/**
 	 * Return an {@link ImageReference} containing either a tag or a digest. If neither
-	 * the digest or the tag has been defined then tag {@code latest} is used.
+	 * the digest nor the tag has been defined then tag {@code latest} is used.
 	 * @return the image reference in tagged or digest form
 	 */
 	public ImageReference inTaggedOrDigestForm() {

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildpackReferenceTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildpackReferenceTests.java
@@ -64,7 +64,7 @@ class BuildpackReferenceTests {
 	}
 
 	@Test
-	void hasPrefixWhenPrifixMismatchReturnsFalse() {
+	void hasPrefixWhenPrefixMismatchReturnsFalse() {
 		BuildpackReference reference = BuildpackReference.of("test");
 		assertThat(reference.hasPrefix("st")).isFalse();
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/Metadata.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/Metadata.java
@@ -213,7 +213,7 @@ public final class Metadata {
 					.filter((item) -> item.isOfItemType(this.itemType) && name.equals(item.getName()))
 					.collect(Collectors.toList());
 			if (candidates.size() > 1) {
-				throw new IllegalStateException("More that one metadata item with name '" + name + "': " + candidates);
+				throw new IllegalStateException("More than one metadata item with name '" + name + "': " + candidates);
 			}
 			return (candidates.size() == 1) ? candidates.get(0) : null;
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/docs/RunningDocumentationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/docs/RunningDocumentationTests.java
@@ -80,7 +80,7 @@ class RunningDocumentationTests {
 	}
 
 	@TestTemplate
-	void bootRunSystemPropetry() {
+	void bootRunSystemProperty() {
 		assertThat(this.gradleBuild.script("src/docs/gradle/running/boot-run-system-property")
 				.build("-Pexample=custom", "configuredSystemProperties").getOutput())
 						.contains("com.example.property = custom");

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleProjectBuilder.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/junit/GradleProjectBuilder.java
@@ -29,8 +29,8 @@ import org.springframework.util.StringUtils;
 
 /**
  * Helper class to build Gradle {@link Project Projects} for test fixtures. Wraps
- * functionality of Gradle's own {@link ProjectBuilder} in order to workaround an issue on
- * JDK 17 and 18.
+ * functionality of Gradle's own {@link ProjectBuilder} in order to work around an issue
+ * on JDK 17 and 18.
  *
  * @author Christoph Dreis
  * @see <a href="https://github.com/gradle/gradle/issues/16857">Gradle Support JDK 17</a>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarFileEntries.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarFileEntries.java
@@ -350,7 +350,7 @@ class JarFileEntries implements CentralDirectoryVisitor, Iterable<JarEntry> {
 		JarEntryCertification[] certifications = this.certifications;
 		if (certifications == null) {
 			certifications = new JarEntryCertification[this.size];
-			// We fallback to use JarInputStream to obtain the certs. This isn't that
+			// We fall back to use JarInputStream to obtain the certs. This isn't that
 			// fast, but hopefully doesn't happen too often.
 			try (JarInputStream certifiedJarStream = new JarInputStream(this.jarFile.getData().getInputStream())) {
 				java.util.jar.JarEntry certifiedEntry = null;

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildImageMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildImageMojo.java
@@ -187,7 +187,7 @@ public class BuildImageMojo extends AbstractPackagerMojo {
 	private LayoutFactory layoutFactory;
 
 	/**
-	 * Return the type of archive that should be used when buiding the image.
+	 * Return the type of archive that should be used when building the image.
 	 * @return the value of the {@code layout} parameter, or {@code null} if the parameter
 	 * is not provided
 	 */

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StartMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StartMojo.java
@@ -69,7 +69,7 @@ public class StartMojo extends AbstractRunMojo {
 	private int jmxPort;
 
 	/**
-	 * The number of milli-seconds to wait between each attempt to check if the spring
+	 * The number of milliseconds to wait between each attempt to check if the spring
 	 * application is ready.
 	 */
 	@Parameter(property = "spring-boot.start.wait", defaultValue = "500")

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/BeanDefinitionLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/BeanDefinitionLoader.java
@@ -251,7 +251,7 @@ class BeanDefinitionLoader {
 		if (resource instanceof ClassPathResource) {
 			// A simple package without a '.' may accidentally get loaded as an XML
 			// document if we're not careful. The result of getInputStream() will be
-			// a file list of the package content. We double check here that it's not
+			// a file list of the package content. We double-check here that it's not
 			// actually a package.
 			String path = ((ClassPathResource) resource).getPath();
 			if (path.indexOf('.') == -1) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudFoundryVcapEnvironmentPostProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudFoundryVcapEnvironmentPostProcessor.java
@@ -39,13 +39,13 @@ import org.springframework.util.StringUtils;
 
 /**
  * An {@link EnvironmentPostProcessor} that knows where to find VCAP (a.k.a. Cloud
- * Foundry) meta data in the existing environment. It parses out the VCAP_APPLICATION and
- * VCAP_SERVICES meta data and dumps it in a form that is easily consumed by
- * {@link Environment} users. If the app is running in Cloud Foundry then both meta data
+ * Foundry) metadata in the existing environment. It parses out the VCAP_APPLICATION and
+ * VCAP_SERVICES metadata and dumps it in a form that is easily consumed by
+ * {@link Environment} users. If the app is running in Cloud Foundry then both metadata
  * items are JSON objects encoded in OS environment variables. VCAP_APPLICATION is a
  * shallow hash with basic information about the application (name, instance id, instance
  * index, etc.), and VCAP_SERVICES is a hash of lists where the keys are service labels
- * and the values are lists of hashes of service instance meta data. Examples are:
+ * and the values are lists of hashes of service instance metadata. Examples are:
  *
  * <pre class="code">
  * VCAP_APPLICATION: {"instance_id":"2ce0ac627a6c8e47e936d829a3a47b5b","instance_index":0,

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBean.java
@@ -203,7 +203,7 @@ public final class ConfigurationPropertiesBean {
 	 * @param applicationContext the source application context
 	 * @param bean the bean to consider
 	 * @param beanName the bean name
-	 * @return a configuration properties bean or {@code null} if the neither the bean or
+	 * @return a configuration properties bean or {@code null} if the neither the bean nor
 	 * factory method are annotated with
 	 * {@link ConfigurationProperties @ConfigurationProperties}
 	 */

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -29,7 +29,7 @@ import org.springframework.util.StringUtils;
 /**
  * A configuration property name composed of elements separated by dots. User created
  * names may contain the characters "{@code a-z}" "{@code 0-9}") and "{@code -}", they
- * must be lower-case and must start with an alpha-numeric character. The "{@code -}" is
+ * must be lower-case and must start with an alphanumeric character. The "{@code -}" is
  * used purely for formatting, i.e. "{@code foo-bar}" and "{@code foobar}" are considered
  * equivalent.
  * <p>
@@ -448,7 +448,7 @@ public final class ConfigurationPropertyName implements Comparable<Configuration
 		int i2 = 0;
 		while (i1 < l1) {
 			if (i2 >= l2) {
-				return remainderIsNotAlphaNumberic(e1, i, i1);
+				return remainderIsNotAlphanumeric(e1, i, i1);
 			}
 			char ch1 = indexed1 ? e1.charAt(i, i1) : Character.toLowerCase(e1.charAt(i, i1));
 			char ch2 = indexed2 ? e2.charAt(i, i2) : Character.toLowerCase(e2.charAt(i, i2));
@@ -467,12 +467,12 @@ public final class ConfigurationPropertyName implements Comparable<Configuration
 			}
 		}
 		if (i2 < l2) {
-			return remainderIsNotAlphaNumberic(e2, i, i2);
+			return remainderIsNotAlphanumeric(e2, i, i2);
 		}
 		return true;
 	}
 
-	private boolean remainderIsNotAlphaNumberic(Elements elements, int element, int index) {
+	private boolean remainderIsNotAlphanumeric(Elements elements, int element, int index) {
 		if (elements.getType(element).isIndexed()) {
 			return false;
 		}
@@ -1049,7 +1049,7 @@ public final class ConfigurationPropertyName implements Comparable<Configuration
 		DASHED(false),
 
 		/**
-		 * The element contains non uniform characters and will need to be converted.
+		 * The element contains non-uniform characters and will need to be converted.
 		 */
 		NON_UNIFORM(false),
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringConfigurationPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringConfigurationPropertySource.java
@@ -39,7 +39,7 @@ import org.springframework.util.Assert;
  * getConfigurationProperty} call attempts to
  * {@link PropertyMapper#map(ConfigurationPropertyName) map} the
  * {@link ConfigurationPropertyName} to one or more {@code String} based names. This
- * allows fast property resolution for well formed property sources.
+ * allows fast property resolution for well-formed property sources.
  * <p>
  * When possible the {@link SpringIterableConfigurationPropertySource} will be used in
  * preference to this implementation since it supports full "relaxed" style resolution.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/origin/OriginLookup.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/origin/OriginLookup.java
@@ -59,7 +59,7 @@ public interface OriginLookup<K> {
 	}
 
 	/**
-	 * Attempt to lookup the origin from the given source. If the source is not a
+	 * Attempt to look up the origin from the given source. If the source is not a
 	 * {@link OriginLookup} or if an exception occurs during lookup then {@code null} is
 	 * returned.
 	 * @param source the source object

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/task/TaskExecutorBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/task/TaskExecutorBuilder.java
@@ -137,8 +137,8 @@ public class TaskExecutorBuilder {
 	}
 
 	/**
-	 * Set whether core threads are allow to time out. When enabled, this enables dynamic
-	 * growing and shrinking of the pool.
+	 * Set whether core threads are allowed to time out. When enabled, this enables
+	 * dynamic growing and shrinking of the pool.
 	 * @param allowCoreThreadTimeOut if core threads are allowed to time out
 	 * @return a new builder instance
 	 */

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/ConfigurableWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/ConfigurableWebServerFactory.java
@@ -31,7 +31,7 @@ public interface ConfigurableWebServerFactory extends WebServerFactory, ErrorPag
 
 	/**
 	 * Sets the port that the web server should listen on. If not specified port '8080'
-	 * will be used. Use port -1 to disable auto-start (i.e start the web application
+	 * will be used. Use port -1 to disable auto-start (i.e. start the web application
 	 * context but not have it listen to any port).
 	 * @param port the port to set
 	 */

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletRegistrationBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletRegistrationBean.java
@@ -151,7 +151,7 @@ public class ServletRegistrationBean<T extends Servlet> extends DynamicRegistrat
 
 	/**
 	 * Set the {@link MultipartConfigElement multi-part configuration}.
-	 * @param multipartConfig the multi-part configuration to set or {@code null}
+	 * @param multipartConfig the multipart configuration to set or {@code null}
 	 */
 	public void setMultipartConfig(MultipartConfigElement multipartConfig) {
 		this.multipartConfig = multipartConfig;

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigTreeConfigDataLocationResolverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigTreeConfigDataLocationResolverTests.java
@@ -65,7 +65,7 @@ class ConfigTreeConfigDataLocationResolverTests {
 	}
 
 	@Test
-	void resolveWilcardPattern() throws Exception {
+	void resolveWildcardPattern() throws Exception {
 		File directoryA = new File(this.temp, "a");
 		File directoryB = new File(this.temp, "b");
 		directoryA.mkdirs();

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/CharSequenceToObjectConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/CharSequenceToObjectConverterTests.java
@@ -57,8 +57,8 @@ class CharSequenceToObjectConverterTests {
 		StringBuilder source = new StringBuilder("1,2,3");
 		TypeDescriptor sourceType = TypeDescriptor.valueOf(StringBuilder.class);
 		TypeDescriptor targetType = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(String.class));
-		List<String> conveted = (List<String>) conversionService.convert(source, sourceType, targetType);
-		assertThat(conveted).containsExactly("1", "2", "3");
+		List<String> converted = (List<String>) conversionService.convert(source, sourceType, targetType);
+		assertThat(converted).containsExactly("1", "2", "3");
 	}
 
 	@Test
@@ -69,8 +69,8 @@ class CharSequenceToObjectConverterTests {
 		StringBuilder source = new StringBuilder("1,2,3");
 		TypeDescriptor sourceType = TypeDescriptor.valueOf(StringBuilder.class);
 		TypeDescriptor targetType = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(String.class));
-		List<String> conveted = (List<String>) conversionService.convert(source, sourceType, targetType);
-		assertThat(conveted).containsExactly("1", "2", "3");
+		List<String> converted = (List<String>) conversionService.convert(source, sourceType, targetType);
+		assertThat(converted).containsExactly("1", "2", "3");
 	}
 
 	static Stream<? extends Arguments> conversionServices() {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BindFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BindFailureAnalyzerTests.java
@@ -80,7 +80,7 @@ class BindFailureAnalyzerTests {
 	}
 
 	@Test // gh-27028
-	void bindExceptionDueToClassNotFoundConvertionFailure() {
+	void bindExceptionDueToClassNotFoundConversionFailure() {
 		FailureAnalysis analysis = performAnalysis(GenericFailureConfiguration.class,
 				"test.foo.type=com.example.Missing");
 		assertThat(analysis.getDescription()).contains(failure("test.foo.type", "com.example.Missing",

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/r2dbc/ConnectionFactoryBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/r2dbc/ConnectionFactoryBuilderTests.java
@@ -139,9 +139,9 @@ class ConnectionFactoryBuilderTests {
 
 	@Test
 	void buildWhenDerivedWithNewDatabaseReturnsNewConnectionFactory() {
-		String intialDatabaseName = UUID.randomUUID().toString();
+		String initialDatabaseName = UUID.randomUUID().toString();
 		ConnectionFactory connectionFactory = ConnectionFactoryBuilder
-				.withUrl(EmbeddedDatabaseConnection.H2.getUrl(intialDatabaseName)).build();
+				.withUrl(EmbeddedDatabaseConnection.H2.getUrl(initialDatabaseName)).build();
 		ConnectionFactoryOptions initialOptions = ((OptionsCapableConnectionFactory) connectionFactory).getOptions();
 		String derivedDatabaseName = UUID.randomUUID().toString();
 		ConnectionFactory derived = ConnectionFactoryBuilder.derivedFrom(connectionFactory)
@@ -208,7 +208,7 @@ class ConnectionFactoryBuilderTests {
 	@ParameterizedTest
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@MethodSource("primitivePoolingConnectionProviderOptions")
-	void stringlyTypedOptionIsMappedWhenCreatingPoolConfiguration(Option option) {
+	void stronglyTypedOptionIsMappedWhenCreatingPoolConfiguration(Option option) {
 		String url = "r2dbc:pool:h2:mem:///" + UUID.randomUUID();
 		ExpectedOption expectedOption = ExpectedOption.get(option);
 		ConnectionFactoryOptions options = ConnectionFactoryBuilder.withUrl(url)

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/security/servlet/ApplicationContextRequestMatcherTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/security/servlet/ApplicationContextRequestMatcherTests.java
@@ -220,7 +220,7 @@ class ApplicationContextRequestMatcherTests {
 		private volatile Throwable ex;
 
 		@Override
-		public void uncaughtException(Thread thead, Throwable ex) {
+		public void uncaughtException(Thread thread, Throwable ex) {
 			this.ex = ex;
 		}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-bootstrap-registry/src/test/java/smoketest/bootstrapregistry/app/SampleBootstrapRegistryApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-bootstrap-registry/src/test/java/smoketest/bootstrapregistry/app/SampleBootstrapRegistryApplicationTests.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SampleBootstrapRegistryApplicationTests {
 
 	@Test
-	void testBootrapper(CapturedOutput output) {
+	void testBootstrapper(CapturedOutput output) {
 		SampleBootstrapRegistryApplication.main(new String[0]);
 		assertThat(output).contains("svn my-data from svn / example.com[secret]")
 				.contains("client smoketest.bootstrapregistry.app.MySubversionClient");

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/src/test/java/smoketest/profile/ActiveProfilesTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/src/test/java/smoketest/profile/ActiveProfilesTests.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.ActiveProfiles;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests that profiles are activited in the correct order from an
+ * Tests that profiles are activated in the correct order from an
  * {@link EnvironmentPostProcessor}.
  *
  * @author Madhura Bhave

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-session-webflux/src/test/java/smoketest/session/SampleSessionWebFluxApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-session-webflux/src/test/java/smoketest/session/SampleSessionWebFluxApplicationTests.java
@@ -56,12 +56,12 @@ class SampleSessionWebFluxApplicationTests {
 			return response.bodyToMono(String.class)
 					.map((sessionId) -> Tuples.of(response.cookies().getFirst("SESSION").getValue(), sessionId));
 		}).flatMap((tuple) -> {
-			String sesssionCookie = tuple.getT1();
-			return client.get().cookie("SESSION", sesssionCookie).exchangeToMono((response) -> {
+			String sessionCookie = tuple.getT1();
+			return client.get().cookie("SESSION", sessionCookie).exchangeToMono((response) -> {
 				assertThat(response.statusCode()).isEqualTo(HttpStatus.OK);
 				return response.bodyToMono(String.class)
 						.doOnNext((sessionId) -> assertThat(sessionId).isEqualTo(tuple.getT2()))
-						.thenReturn(sesssionCookie);
+						.thenReturn(sessionCookie);
 			});
 		}).delayElement(Duration.ofSeconds(10))
 				.flatMap((sessionCookie) -> client.get().cookie("SESSION", sessionCookie).exchangeToMono((response) -> {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-groovy-templates/src/test/java/smoketest/groovytemplates/MessageControllerWebTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-groovy-templates/src/test/java/smoketest/groovytemplates/MessageControllerWebTests.java
@@ -37,7 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * A Basic Spring MVC Test for the Sample Controller"
+ * A Basic Spring MVC Test for the Sample Controller.
  *
  * @author Biju Kunjummen
  * @author Doo-Hwan, Kwak

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-thymeleaf/src/test/java/smoketest/web/thymeleaf/MessageControllerWebTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-thymeleaf/src/test/java/smoketest/web/thymeleaf/MessageControllerWebTests.java
@@ -37,7 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * A Basic Spring MVC Test for the Sample Controller"
+ * A Basic Spring MVC Test for the Sample Controller.
  *
  * @author Biju Kunjummen
  * @author Doo-Hwan, Kwak

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/main/java/smoketest/websocket/jetty/snake/SnakeTimer.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/main/java/smoketest/websocket/jetty/snake/SnakeTimer.java
@@ -28,7 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 /**
- * Sets up the timer for the multi-player snake game WebSocket example.
+ * Sets up the timer for the multiplayer snake game WebSocket example.
  */
 public final class SnakeTimer {
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/main/java/smoketest/websocket/tomcat/snake/SnakeTimer.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/main/java/smoketest/websocket/tomcat/snake/SnakeTimer.java
@@ -28,7 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 /**
- * Sets up the timer for the multi-player snake game WebSocket example.
+ * Sets up the timer for the multiplayer snake game WebSocket example.
  */
 public final class SnakeTimer {
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/main/java/smoketest/websocket/undertow/snake/SnakeTimer.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/main/java/smoketest/websocket/undertow/snake/SnakeTimer.java
@@ -28,7 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 /**
- * Sets up the timer for the multi-player snake game WebSocket example.
+ * Sets up the timer for the multiplayer snake game WebSocket example.
  */
 public final class SnakeTimer {
 


### PR DESCRIPTION
This PR fixes various typos in :
- spring-boot-cli and spring-boot-actuator-autoconfigure javadoc,
- spring-boot-autoconfigure, spring-boot-actuator, spring-boot-tools, spring-boot-smoke-tests javadoc / tests,
- spring-boot tests, javadoc and code (the private method `remainderIsNotAlphaNumberic`'s name has been fixed),
- actuator documentation,
- `Metadata.MetadataItemCondition#findItem` `IllegalStateException` message,
- `spring.liquibase.check-change-log-location` deprecation reason,
- `PrometheusPushGatewayManager` log message.

The last three commits may be problematic and need special attention.

Multiple commits has been made. Let me know if you need multiple PRs.


