### PR TITLE
Fix property in CustomHibernateJpaAutoConfigurationTests.defaultDatabaseIsSet()

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/CustomHibernateJpaAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/CustomHibernateJpaAutoConfigurationTests.java
@@ -96,8 +96,7 @@ class CustomHibernateJpaAutoConfigurationTests {
 
 	@Test
 	void defaultDatabaseIsSet() {
-		this.contextRunner
-				.withPropertyValues("spring.datasource.url:jdbc:h2:mem:testdb", "spring.sql.init.mode:never:never")
+		this.contextRunner.withPropertyValues("spring.datasource.url:jdbc:h2:mem:testdb", "spring.sql.init.mode:never")
 				.run((context) -> {
 					HibernateJpaVendorAdapter bean = context.getBean(HibernateJpaVendorAdapter.class);
 					Database database = (Database) ReflectionTestUtils.getField(bean, "database");


### PR DESCRIPTION
This PR fixes a property in `CustomHibernateJpaAutoConfigurationTests.defaultDatabaseIsSet()`.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
