### PR TITLE
Add WebClient based sender for Zipkin

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/HttpSender.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/HttpSender.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+import zipkin2.Call;
+import zipkin2.Callback;
+import zipkin2.CheckResult;
+import zipkin2.codec.Encoding;
+import zipkin2.reporter.BytesMessageEncoder;
+import zipkin2.reporter.ClosedSenderException;
+import zipkin2.reporter.Sender;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.unit.DataSize;
+
+/**
+ * A Zipkin {@link Sender} that uses an HTTP client to send JSON spans. Supports automatic
+ * compression with gzip.
+ *
+ * @author Moritz Halbritter
+ * @author Stefan Bratanov
+ */
+abstract class HttpSender extends Sender {
+
+	private static final DataSize MESSAGE_MAX_BYTES = DataSize.ofKilobytes(512);
+
+	volatile boolean closed;
+
+	@Override
+	public Encoding encoding() {
+		return Encoding.JSON;
+	}
+
+	@Override
+	public int messageMaxBytes() {
+		return (int) MESSAGE_MAX_BYTES.toBytes();
+	}
+
+	@Override
+	public int messageSizeInBytes(List<byte[]> encodedSpans) {
+		return encoding().listSizeInBytes(encodedSpans);
+	}
+
+	@Override
+	public int messageSizeInBytes(int encodedSizeInBytes) {
+		return encoding().listSizeInBytes(encodedSizeInBytes);
+	}
+
+	@Override
+	public CheckResult check() {
+		try {
+			sendSpans(List.of()).execute();
+			return CheckResult.OK;
+		}
+		catch (IOException | RuntimeException ex) {
+			return CheckResult.failed(ex);
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		this.closed = true;
+	}
+
+	/**
+	 * The returned {@link HttpPostCall} will send span(s) as a POST to a zipkin endpoint
+	 * when executed.
+	 * @param batchedEncodedSpans list of encoded spans as a byte array
+	 * @return an instance of a Zipkin {@link Call} which can be executed
+	 */
+	protected abstract HttpPostCall sendSpans(byte[] batchedEncodedSpans);
+
+	@Override
+	public Call<Void> sendSpans(List<byte[]> encodedSpans) {
+		if (this.closed) {
+			throw new ClosedSenderException();
+		}
+		return sendSpans(BytesMessageEncoder.JSON.encode(encodedSpans));
+	}
+
+	abstract static class HttpPostCall extends Call.Base<Void> {
+
+		byte[] body;
+
+		protected HttpPostCall(byte[] body) {
+			this.body = body;
+		}
+
+		/**
+		 * Only use gzip compression on data which is bigger than this in bytes.
+		 */
+		private static final DataSize COMPRESSION_THRESHOLD = DataSize.ofKilobytes(1);
+
+		/**
+		 * Implementations should send a POST request.
+		 * @param body the body to send as bytes
+		 * @param defaultHeaders the headers for the POST request. They can be further
+		 * modified if necessary.
+		 */
+		abstract void post(byte[] body, HttpHeaders defaultHeaders);
+
+		@Override
+		protected Void doExecute() throws IOException {
+			HttpHeaders headers = new HttpHeaders();
+			headers.set("b3", "0");
+			headers.set("Content-Type", "application/json");
+			byte[] body;
+			if (needsCompression()) {
+				headers.set("Content-Encoding", "gzip");
+				body = compress(this.body);
+			}
+			else {
+				body = this.body;
+			}
+			post(body, headers);
+			return null;
+		}
+
+		@Override
+		protected void doEnqueue(Callback<Void> callback) {
+			try {
+				doExecute();
+				callback.onSuccess(null);
+			}
+			catch (IOException | RuntimeException ex) {
+				callback.onError(ex);
+			}
+		}
+
+		private boolean needsCompression() {
+			return this.body.length > COMPRESSION_THRESHOLD.toBytes();
+		}
+
+		private byte[] compress(byte[] input) throws IOException {
+			ByteArrayOutputStream result = new ByteArrayOutputStream();
+			try (GZIPOutputStream gzip = new GZIPOutputStream(result)) {
+				gzip.write(input);
+			}
+			return result.toByteArray();
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/HttpSender.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/HttpSender.java
@@ -106,19 +106,19 @@ abstract class HttpSender extends Sender {
 
 		private final byte[] body;
 
-		public HttpPostCall(byte[] body) {
+		HttpPostCall(byte[] body) {
 			this.body = body;
 		}
 
-		public byte[] getBody() {
+		protected byte[] getBody() {
 			return getBody(true);
 		}
 
-		public byte[] getBody(boolean compressIfNeeded) {
-			return compressIfNeeded && needsCompression() ? compress(this.body) : this.body;
+		protected byte[] getBody(boolean compressIfNeeded) {
+			return (compressIfNeeded && needsCompression()) ? compress(this.body) : this.body;
 		}
 
-		public HttpHeaders getDefaultHeaders() {
+		protected HttpHeaders getDefaultHeaders() {
 			HttpHeaders headers = new HttpHeaders();
 			headers.set("b3", "0");
 			headers.set("Content-Type", "application/json");

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/HttpSender.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/HttpSender.java
@@ -111,7 +111,11 @@ abstract class HttpSender extends Sender {
 		}
 
 		public byte[] getBody() {
-			return needsCompression() ? compress(this.body) : this.body;
+			return getBody(true);
+		}
+
+		public byte[] getBody(boolean compressIfNeeded) {
+			return compressIfNeeded && needsCompression() ? compress(this.body) : this.body;
 		}
 
 		public HttpHeaders getDefaultHeaders() {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
@@ -16,10 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
 
-import io.netty.channel.ChannelOption;
-import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
-import reactor.netty.http.client.HttpClient;
 import zipkin2.Span;
 import zipkin2.codec.BytesEncoder;
 import zipkin2.reporter.AsyncReporter;
@@ -37,7 +34,6 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -96,11 +92,7 @@ class ZipkinConfigurations {
 		@ConditionalOnMissingBean(Sender.class)
 		@ConditionalOnBean(WebClient.Builder.class)
 		ZipkinWebClientSender webClientSender(ZipkinProperties properties, WebClient.Builder webClientBuilder) {
-			HttpClient client = HttpClient.create()
-					.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) properties.getConnectTimeout().toMillis())
-					.doOnConnected((conn) -> conn
-							.addHandlerLast(new ReadTimeoutHandler((int) properties.getReadTimeout().toSeconds())));
-			WebClient webClient = webClientBuilder.clientConnector(new ReactorClientHttpConnector(client)).build();
+			WebClient webClient = webClientBuilder.build();
 			return new ZipkinWebClientSender(properties.getEndpoint(), webClient);
 		}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateSender.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateSender.java
@@ -26,7 +26,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.web.client.RestTemplate;
 
 /**
- * A Zipkin {@link HttpSender} which uses {@link RestTemplate} for HTTP communication.
+ * A {@link HttpSender} which uses {@link RestTemplate} for HTTP communication.
  *
  * @author Moritz Halbritter
  * @author Stefan Bratanov

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateSender.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateSender.java
@@ -67,7 +67,7 @@ class ZipkinRestTemplateSender extends HttpSender {
 		@Override
 		protected Void doExecute() {
 			HttpEntity<byte[]> request = new HttpEntity<>(getBody(), getDefaultHeaders());
-			restTemplate.exchange(this.endpoint, HttpMethod.POST, request, Void.class);
+			this.restTemplate.exchange(this.endpoint, HttpMethod.POST, request, Void.class);
 			return null;
 		}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateSender.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateSender.java
@@ -16,8 +16,6 @@
 
 package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
 
-import java.util.concurrent.CompletableFuture;
-
 import zipkin2.Call;
 import zipkin2.Callback;
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateSender.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateSender.java
@@ -61,7 +61,7 @@ class ZipkinRestTemplateSender extends HttpSender {
 
 		@Override
 		public Call<Void> clone() {
-			return new RestTemplateHttpPostCall(this.endpoint, getBody(), this.restTemplate);
+			return new RestTemplateHttpPostCall(this.endpoint, getBody(false), this.restTemplate);
 		}
 
 		@Override

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateSender.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateSender.java
@@ -73,14 +73,13 @@ class ZipkinRestTemplateSender extends HttpSender {
 
 		@Override
 		protected void doEnqueue(Callback<Void> callback) {
-			CompletableFuture.supplyAsync(this::doExecute).whenComplete((__, throwable) -> {
-				if (throwable != null) {
-					callback.onError(throwable);
-				}
-				else {
-					callback.onSuccess(null);
-				}
-			});
+			try {
+				doExecute();
+				callback.onSuccess(null);
+			}
+			catch (Exception ex) {
+				callback.onError(ex);
+			}
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinWebClientSender.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinWebClientSender.java
@@ -69,7 +69,7 @@ class ZipkinWebClientSender extends HttpSender {
 
 		@Override
 		protected void doEnqueue(Callback<Void> callback) {
-			sendRequest().subscribe(__ -> callback.onSuccess(null), callback::onError);
+			sendRequest().subscribe((__) -> callback.onSuccess(null), callback::onError);
 		}
 
 		private Mono<ResponseEntity<Void>> sendRequest() {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinWebClientSender.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinWebClientSender.java
@@ -58,7 +58,7 @@ class ZipkinWebClientSender extends HttpSender {
 
 		@Override
 		public Call<Void> clone() {
-			return new WebClientHttpPostCall(this.endpoint, getBody(), this.webClient);
+			return new WebClientHttpPostCall(this.endpoint, getBody(false), this.webClient);
 		}
 
 		@Override

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinWebClientSender.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinWebClientSender.java
@@ -24,7 +24,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /**
- * A Zipkin {@link HttpSender} which uses {@link WebClient} for HTTP communication.
+ * A {@link HttpSender} which uses {@link WebClient} for HTTP communication.
  *
  * @author Stefan Bratanov
  */

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinHttpSenderTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinHttpSenderTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
 
 import java.io.IOException;
@@ -92,11 +108,11 @@ abstract class ZipkinHttpSenderTests {
 		}
 
 		public boolean isSuccess() {
-			return isSuccess;
+			return this.isSuccess;
 		}
 
 		public Throwable getError() {
-			return error;
+			return this.error;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinHttpSenderTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinHttpSenderTests.java
@@ -10,18 +10,21 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import zipkin2.Callback;
+import zipkin2.reporter.ClosedSenderException;
 import zipkin2.reporter.Sender;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Abstract base test class which is used for testing the different implementations of the
- * Zipkin {@link Sender}.
+ * {@link HttpSender}.
  *
  * @author Stefan Bratanov
  */
-abstract class ZipkinSenderTests {
+abstract class ZipkinHttpSenderTests {
 
 	protected Sender senderUnderTest;
 
@@ -30,6 +33,12 @@ abstract class ZipkinSenderTests {
 	@BeforeEach
 	void setUp() {
 		this.senderUnderTest = getZipkinSender();
+	}
+
+	@Test
+	void sendSpansShouldThrowIfCloseWasCalled() throws IOException {
+		this.senderUnderTest.close();
+		assertThatThrownBy(() -> this.senderUnderTest.sendSpans(List.of())).isInstanceOf(ClosedSenderException.class);
 	}
 
 	protected void makeRequest(List<byte[]> encodedSpans, boolean async) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateSenderTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateSenderTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
 
-import java.io.IOException;
 import java.util.Base64;
 import java.util.List;
 
@@ -25,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import zipkin2.CheckResult;
-import zipkin2.reporter.ClosedSenderException;
 import zipkin2.reporter.Sender;
 
 import org.springframework.http.HttpMethod;
@@ -47,7 +45,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  * @author Moritz Halbritter
  * @author Stefan Bratanov
  */
-class ZipkinRestTemplateSenderTests extends ZipkinSenderTests {
+class ZipkinRestTemplateSenderTests extends ZipkinHttpSenderTests {
 
 	private static final String ZIPKIN_URL = "http://localhost:9411/api/v2/spans";
 
@@ -103,12 +101,6 @@ class ZipkinRestTemplateSenderTests extends ZipkinSenderTests {
 		else {
 			assertThatThrownBy(() -> this.makeSyncRequest(List.of())).hasMessageContaining("500 Internal Server Error");
 		}
-	}
-
-	@Test
-	void sendSpansShouldThrowIfCloseWasCalled() throws IOException {
-		this.senderUnderTest.close();
-		assertThatThrownBy(() -> this.senderUnderTest.sendSpans(List.of())).isInstanceOf(ClosedSenderException.class);
 	}
 
 	@ParameterizedTest

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinSenderTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinSenderTests.java
@@ -1,0 +1,95 @@
+package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import zipkin2.Callback;
+import zipkin2.reporter.Sender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Abstract base test class which is used for testing the different implementations of the
+ * Zipkin {@link Sender}.
+ *
+ * @author Stefan Bratanov
+ */
+abstract class ZipkinSenderTests {
+
+	protected Sender senderUnderTest;
+
+	abstract Sender getZipkinSender();
+
+	@BeforeEach
+	void setUp() {
+		this.senderUnderTest = getZipkinSender();
+	}
+
+	protected void makeRequest(List<byte[]> encodedSpans, boolean async) {
+		if (async) {
+			CallbackResult callbackResult = this.makeAsyncRequest(encodedSpans);
+			assertThat(callbackResult.isSuccess()).isTrue();
+		}
+		else {
+			try {
+				this.makeSyncRequest(encodedSpans);
+			}
+			catch (IOException ex) {
+				Assertions.fail(ex);
+			}
+		}
+	}
+
+	protected CallbackResult makeAsyncRequest(List<byte[]> encodedSpans) {
+		AtomicReference<CallbackResult> callbackResult = new AtomicReference<>();
+		this.senderUnderTest.sendSpans(encodedSpans).enqueue(new Callback<>() {
+			@Override
+			public void onSuccess(Void value) {
+				callbackResult.set(new CallbackResult(true, null));
+			}
+
+			@Override
+			public void onError(Throwable t) {
+				callbackResult.set(new CallbackResult(false, t));
+			}
+		});
+		return Awaitility.await().atMost(Duration.ofSeconds(5)).until(callbackResult::get, Objects::nonNull);
+	}
+
+	protected void makeSyncRequest(List<byte[]> encodedSpans) throws IOException {
+		this.senderUnderTest.sendSpans(encodedSpans).execute();
+	}
+
+	protected byte[] toByteArray(String input) {
+		return input.getBytes(StandardCharsets.UTF_8);
+	}
+
+	protected static final class CallbackResult {
+
+		private final boolean isSuccess;
+
+		private final Throwable error;
+
+		private CallbackResult(boolean isSuccess, Throwable error) {
+			this.isSuccess = isSuccess;
+			this.error = error;
+		}
+
+		public boolean isSuccess() {
+			return isSuccess;
+		}
+
+		public Throwable getError() {
+			return error;
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinWebClientSenderTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinWebClientSenderTests.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import zipkin2.CheckResult;
-import zipkin2.reporter.ClosedSenderException;
 import zipkin2.reporter.Sender;
 
 import org.springframework.web.reactive.function.client.WebClient;
@@ -44,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Stefan Bratanov
  */
-class ZipkinWebClientSenderTests extends ZipkinSenderTests {
+class ZipkinWebClientSenderTests extends ZipkinHttpSenderTests {
 
 	private static MockWebServer mockBackEnd;
 
@@ -117,12 +116,6 @@ class ZipkinWebClientSenderTests extends ZipkinSenderTests {
 		}
 
 		requestAssertions((request) -> assertThat(request.getMethod()).isEqualTo("POST"));
-	}
-
-	@Test
-	void sendSpansShouldThrowIfCloseWasCalled() throws IOException {
-		this.senderUnderTest.close();
-		assertThatThrownBy(() -> this.senderUnderTest.sendSpans(List.of())).isInstanceOf(ClosedSenderException.class);
 	}
 
 	@ParameterizedTest

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinWebClientSenderTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinWebClientSenderTests.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.function.Consumer;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import zipkin2.CheckResult;
+import zipkin2.reporter.ClosedSenderException;
+
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link ZipkinWebClientSender}.
+ *
+ * @author Stefan Bratanov
+ */
+class ZipkinWebClientSenderTests {
+
+	public static MockWebServer mockBackEnd;
+
+	private static String ZIPKIN_URL;
+
+	private ZipkinWebClientSender sut;
+
+	@BeforeAll
+	static void beforeAll() throws IOException {
+		mockBackEnd = new MockWebServer();
+		mockBackEnd.start();
+		ZIPKIN_URL = "http://localhost:%s/api/v2/spans".formatted(mockBackEnd.getPort());
+	}
+
+	@AfterAll
+	static void tearDown() throws IOException {
+		mockBackEnd.shutdown();
+	}
+
+	@BeforeEach
+	void setUp() {
+		WebClient webClient = WebClient.builder().build();
+		this.sut = new ZipkinWebClientSender(ZIPKIN_URL, webClient);
+	}
+
+	@Test
+	void checkShouldSendEmptySpanList() {
+		mockBackEnd.enqueue(new MockResponse());
+		assertThat(this.sut.check()).isEqualTo(CheckResult.OK);
+
+		requestAssertions((request) -> {
+			assertThat(request.getMethod()).isEqualTo("POST");
+			assertThat(request.getBody().readUtf8()).isEqualTo("[]");
+		});
+	}
+
+	@Test
+	void checkShouldNotRaiseExceptionBecauseItIsNotBlocking() {
+		mockBackEnd.enqueue(new MockResponse().setResponseCode(500));
+		CheckResult result = this.sut.check();
+		assertThat(result.ok()).isTrue();
+
+		requestAssertions((request) -> assertThat(request.getMethod()).isEqualTo("POST"));
+	}
+
+	@Test
+	void sendSpansShouldSendSpansToZipkin() throws IOException {
+		mockBackEnd.enqueue(new MockResponse());
+		this.sut.sendSpans(List.of(toByteArray("span1"), toByteArray("span2"))).execute();
+
+		requestAssertions((request) -> {
+			assertThat(request.getMethod()).isEqualTo("POST");
+			assertThat(request.getHeader("Content-Type")).isEqualTo("application/json");
+			assertThat(request.getBody().readUtf8()).isEqualTo("[span1,span2]");
+		});
+	}
+
+	@Test
+	void sendSpansShouldNotThrowOnHttpFailureBecauseItIsNonBlocking() throws IOException {
+		mockBackEnd.enqueue(new MockResponse().setResponseCode(500));
+		this.sut.sendSpans(List.of()).execute();
+
+		requestAssertions((request) -> assertThat(request.getMethod()).isEqualTo("POST"));
+	}
+
+	@Test
+	void sendSpansShouldThrowIfCloseWasCalled() throws IOException {
+		this.sut.close();
+		assertThatThrownBy(() -> this.sut.sendSpans(List.of())).isInstanceOf(ClosedSenderException.class);
+	}
+
+	@Test
+	void sendSpansShouldCompressData() throws IOException {
+		String uncompressed = "a".repeat(10000);
+		// This is gzip compressed 10000 times 'a'
+		byte[] compressed = Base64.getDecoder()
+				.decode("H4sIAAAAAAAA/+3BMQ0AAAwDIKFLj/k3UR8NcA8AAAAAAAAAAAADUsAZfeASJwAA");
+
+		mockBackEnd.enqueue(new MockResponse());
+		this.sut.sendSpans(List.of(toByteArray(uncompressed))).execute();
+
+		requestAssertions((request) -> {
+			assertThat(request.getMethod()).isEqualTo("POST");
+			assertThat(request.getHeader("Content-Type")).isEqualTo("application/json");
+			assertThat(request.getHeader("Content-Encoding")).isEqualTo("gzip");
+			assertThat(request.getBody().readByteArray()).isEqualTo(compressed);
+		});
+
+	}
+
+	private void requestAssertions(Consumer<RecordedRequest> assertions) {
+		try {
+			RecordedRequest request = mockBackEnd.takeRequest();
+			assertThat(request).satisfies(assertions);
+		}
+		catch (InterruptedException ex) {
+			Assertions.fail(ex);
+		}
+	}
+
+	private byte[] toByteArray(String input) {
+		return input.getBytes(StandardCharsets.UTF_8);
+	}
+
+}


### PR DESCRIPTION
## PR Description

- Introduce abstract `HttpSender` class
- Introduce `ZipkinWebClientSender`
- Add `ZipkinWebClientSender` bean to configuration

related to #30661 
