### PR TITLE
Auto-configure Micrometer's JVM info metrics

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmInfoMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 
@@ -34,6 +35,7 @@ import org.springframework.context.annotation.Bean;
  * {@link EnableAutoConfiguration Auto-configuration} for JVM metrics.
  *
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  * @since 2.1.0
  */
 @AutoConfiguration(after = { MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class })
@@ -69,6 +71,12 @@ public class JvmMetricsAutoConfiguration {
 	@ConditionalOnMissingBean
 	public ClassLoaderMetrics classLoaderMetrics() {
 		return new ClassLoaderMetrics();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public JvmInfoMetrics jvmInfoMetrics() {
+		return new JvmInfoMetrics();
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfigurationTests.java
@@ -19,6 +19,7 @@ package org.springframework.boot.actuate.autoconfigure.metrics;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmInfoMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  */
 class JvmMetricsAutoConfigurationTests {
 
@@ -79,10 +81,17 @@ class JvmMetricsAutoConfigurationTests {
 				assertMetricsBeans().andThen((context) -> assertThat(context).hasBean("customClassLoaderMetrics")));
 	}
 
+	@Test
+	void allowsCustomJvmInfoMetricsToBeUsed() {
+		this.contextRunner.withUserConfiguration(CustomJvmInfoMetricsConfiguration.class)
+				.run(assertMetricsBeans().andThen((context) -> assertThat(context).hasBean("customJvmInfoMetrics")));
+	}
+
 	private ContextConsumer<AssertableApplicationContext> assertMetricsBeans() {
 		return (context) -> assertThat(context).hasSingleBean(JvmGcMetrics.class)
 				.hasSingleBean(JvmHeapPressureMetrics.class).hasSingleBean(JvmMemoryMetrics.class)
-				.hasSingleBean(JvmThreadMetrics.class).hasSingleBean(ClassLoaderMetrics.class);
+				.hasSingleBean(JvmThreadMetrics.class).hasSingleBean(ClassLoaderMetrics.class)
+				.hasSingleBean(JvmInfoMetrics.class);
 	}
 
 	@Configuration(proxyBeanMethods = false)
@@ -131,6 +140,16 @@ class JvmMetricsAutoConfigurationTests {
 		@Bean
 		ClassLoaderMetrics customClassLoaderMetrics() {
 			return new ClassLoaderMetrics();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomJvmInfoMetricsConfiguration {
+
+		@Bean
+		JvmInfoMetrics customJvmInfoMetrics() {
+			return new JvmInfoMetrics();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
@@ -638,6 +638,7 @@ The following JVM metrics are provided:
 * Statistics related to garbage collection
 * Thread utilization
 * The number of classes loaded and unloaded
+* JVM version information
 
 
 


### PR DESCRIPTION
Micrometer 1.7 provides `JvmInfoMetrics` and this commit provides
auto-configuration.

See gh-30797
