### PR TITLE
Prepend additional keys to sanitize

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Sanitizer.java
@@ -132,11 +132,12 @@ public class Sanitizer {
 	 */
 	public void keysToSanitize(String... keysToSanitize) {
 		Assert.notNull(keysToSanitize, "KeysToSanitize must not be null");
-		int existingKeys = this.keysToSanitize.length;
-		this.keysToSanitize = Arrays.copyOf(this.keysToSanitize, this.keysToSanitize.length + keysToSanitize.length);
+		Pattern[] keyPatterns = new Pattern[this.keysToSanitize.length + keysToSanitize.length];
 		for (int i = 0; i < keysToSanitize.length; i++) {
-			this.keysToSanitize[i + existingKeys] = getPattern(keysToSanitize[i]);
+			keyPatterns[i] = getPattern(keysToSanitize[i]);
 		}
+		System.arraycopy(this.keysToSanitize, 0, keyPatterns, keysToSanitize.length, this.keysToSanitize.length);
+		this.keysToSanitize = keyPatterns;
 	}
 
 	private Pattern getPattern(String value) {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/SanitizerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/SanitizerTests.java
@@ -59,7 +59,7 @@ class SanitizerTests {
 	@Test
 	void whenAdditionalKeysAreAddedValuesOfBothThemAndTheDefaultKeysAreSanitized() {
 		Sanitizer sanitizer = new Sanitizer();
-		sanitizer.keysToSanitize("find", "confidential");
+		sanitizer.keysToSanitize("find", "confidential", "my-uri");
 		assertThat(sanitizer.sanitize("password", "secret")).isEqualTo("******");
 		assertThat(sanitizer.sanitize("my-password", "secret")).isEqualTo("******");
 		assertThat(sanitizer.sanitize("my-OTHER.paSSword", "secret")).isEqualTo("******");
@@ -70,6 +70,7 @@ class SanitizerTests {
 		assertThat(sanitizer.sanitize("find", "secret")).isEqualTo("******");
 		assertThat(sanitizer.sanitize("sun.java.command", "--spring.redis.password=pa55w0rd")).isEqualTo("******");
 		assertThat(sanitizer.sanitize("confidential", "secret")).isEqualTo("******");
+		assertThat(sanitizer.sanitize("my-uri", "secret")).isEqualTo("******");
 		assertThat(sanitizer.sanitize("private", "secret")).isEqualTo("secret");
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Per discussion in #30832, this change prepends additional keys to sanitize ahead of the defaults. This allows users to sanitize keys that would otherwise be handled by the defaults but still expose credentials.