### PR TITLE
Extend documentation on Datadog metrics

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/datadog/DatadogProperties.java
@@ -53,8 +53,8 @@ public class DatadogProperties extends StepRegistryProperties {
 	private String hostTag = "instance";
 
 	/**
-	 * URI to ship metrics to. If you need to publish metrics to an internal proxy
-	 * en-route to Datadog, you can define the location of the proxy with this.
+	 * URI to ship metrics to. Set this if you need to publish metrics to a Datadog site
+	 * other than US, or to an internal proxy en-route to Datadog.
 	 */
 	private String uri = "https://api.datadoghq.com";
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
@@ -121,24 +121,47 @@ To export metrics to {micrometer-registry-docs}/datadog[Datadog], you must provi
 
 [source,yaml,indent=0,subs="verbatim",configprops,configblocks]
 ----
-	management:
-      datadog:
-        metrics:
-	      export:
-	        api-key: "YOUR_KEY"
+  management:
+    datadog:
+      metrics:
+        export:
+          api-key: "YOUR_KEY"
+----
+
+If you additionally provide an application key (optional), then metadata such as meter descriptions, types, and base units will also be exported:
+
+[source,yaml,indent=0,subs="verbatim",configprops,configblocks]
+----
+  management:
+    datadog:
+      metrics:
+        export:
+          api-key: "YOUR_API_KEY"
+          application-key: "YOUR_APPLICATION_KEY"
+----
+
+By default, metrics are sent to the Datadog US https://docs.datadoghq.com/getting_started/site[site] (`https://api.datadoghq.com`).
+In case your Datadog project is hosted on one of the other sites, or you need to send metrics through a proxy, change the API base URL accordingly:
+
+[source,yaml,indent=0,subs="verbatim",configprops,configblocks]
+----
+  management:
+    datadog:
+      metrics:
+        export:
+          uri: "https://api.datadoghq.eu"
 ----
 
 You can also change the interval at which metrics are sent to Datadog:
 
 [source,yaml,indent=0,subs="verbatim",configprops,configblocks]
 ----
-	management:
-	  datadog:
-	    metrics:
-	      export:
-	        step: "30s"
+  management:
+    datadog:
+      metrics:
+        export:
+          step: "30s"
 ----
-
 
 
 [[actuator.metrics.export.dynatrace]]


### PR DESCRIPTION
- Document that an application key must be set to publish metadata
  for the exported metrics.

- Point out that using a non-US Datadog site (e.g., EU) requires
  changing the `uri` property.