### PR TITLE
Configuration property for Statsd's buffered and step properties are missing

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdProperties.java
@@ -76,6 +76,11 @@ public class StatsdProperties {
 	 */
 	private boolean publishUnchangedMeters = true;
 
+	/**
+	 * Whether measurements should be buffered before sending to the StatsD server.
+	 */
+	private boolean buffered = true;
+
 	public boolean isEnabled() {
 		return this.enabled;
 	}
@@ -138,6 +143,14 @@ public class StatsdProperties {
 
 	public void setPublishUnchangedMeters(boolean publishUnchangedMeters) {
 		this.publishUnchangedMeters = publishUnchangedMeters;
+	}
+
+	public boolean isBuffered() {
+		return this.buffered;
+	}
+
+	public void setBuffered(boolean buffered) {
+		this.buffered = buffered;
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdProperties.java
@@ -72,6 +72,13 @@ public class StatsdProperties {
 	private Duration pollingFrequency = Duration.ofSeconds(10);
 
 	/**
+	 * The step size to use in computing windowed statistics like max. The default is 1
+	 * minute. To get the most out of these statistics, align the step interval to be
+	 * close to your scrape interval.
+	 */
+	private Duration step = Duration.ofMinutes(1);
+
+	/**
 	 * Whether to send unchanged meters to the StatsD server.
 	 */
 	private boolean publishUnchangedMeters = true;
@@ -135,6 +142,14 @@ public class StatsdProperties {
 
 	public void setPollingFrequency(Duration pollingFrequency) {
 		this.pollingFrequency = pollingFrequency;
+	}
+
+	public Duration getStep() {
+		return this.step;
+	}
+
+	public void setStep(Duration step) {
+		this.step = step;
 	}
 
 	public boolean isPublishUnchangedMeters() {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapter.java
@@ -82,6 +82,11 @@ public class StatsdPropertiesConfigAdapter extends PropertiesConfigAdapter<Stats
 	}
 
 	@Override
+	public Duration step() {
+		return get(StatsdProperties::getStep, StatsdConfig.super::step);
+	}
+
+	@Override
 	public boolean publishUnchangedMeters() {
 		return get(StatsdProperties::isPublishUnchangedMeters, StatsdConfig.super::publishUnchangedMeters);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapter.java
@@ -86,4 +86,9 @@ public class StatsdPropertiesConfigAdapter extends PropertiesConfigAdapter<Stats
 		return get(StatsdProperties::isPublishUnchangedMeters, StatsdConfig.super::publishUnchangedMeters);
 	}
 
+	@Override
+	public boolean buffered() {
+		return get(StatsdProperties::isBuffered, StatsdConfig.super::buffered);
+	}
+
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapterTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics.export.statsd;
+
+import java.time.Duration;
+
+import io.micrometer.statsd.StatsdFlavor;
+import io.micrometer.statsd.StatsdProtocol;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link StatsdPropertiesConfigAdapter}.
+ *
+ * @author Johnny Lim
+ */
+class StatsdPropertiesConfigAdapterTests {
+
+	@Test
+	void whenPropertiesEnabledIsSetAdapterEnabledReturnsIt() {
+		StatsdProperties properties = new StatsdProperties();
+		properties.setEnabled(false);
+		assertThat(new StatsdPropertiesConfigAdapter(properties).enabled()).isEqualTo(properties.isEnabled());
+	}
+
+	@Test
+	void whenPropertiesFlavorIsSetAdapterFlavorReturnsIt() {
+		StatsdProperties properties = new StatsdProperties();
+		properties.setFlavor(StatsdFlavor.ETSY);
+		assertThat(new StatsdPropertiesConfigAdapter(properties).flavor()).isEqualTo(properties.getFlavor());
+	}
+
+	@Test
+	void whenPropertiesHostIsSetAdapterHostReturnsIt() {
+		StatsdProperties properties = new StatsdProperties();
+		properties.setHost("my-host");
+		assertThat(new StatsdPropertiesConfigAdapter(properties).host()).isEqualTo(properties.getHost());
+	}
+
+	@Test
+	void whenPropertiesPortIsSetAdapterPortReturnsIt() {
+		StatsdProperties properties = new StatsdProperties();
+		properties.setPort(1234);
+		assertThat(new StatsdPropertiesConfigAdapter(properties).port()).isEqualTo(properties.getPort());
+	}
+
+	@Test
+	void whenPropertiesProtocolIsSetAdapterProtocolReturnsIt() {
+		StatsdProperties properties = new StatsdProperties();
+		properties.setProtocol(StatsdProtocol.TCP);
+		assertThat(new StatsdPropertiesConfigAdapter(properties).protocol()).isEqualTo(properties.getProtocol());
+	}
+
+	@Test
+	void whenPropertiesMaxPacketLengthIsSetAdapterMaxPacketLengthReturnsIt() {
+		StatsdProperties properties = new StatsdProperties();
+		properties.setMaxPacketLength(1234);
+		assertThat(new StatsdPropertiesConfigAdapter(properties).maxPacketLength())
+				.isEqualTo(properties.getMaxPacketLength());
+	}
+
+	@Test
+	void whenPropertiesPollingFrequencyIsSetAdapterPollingFrequencyReturnsIt() {
+		StatsdProperties properties = new StatsdProperties();
+		properties.setPollingFrequency(Duration.ofSeconds(1));
+		assertThat(new StatsdPropertiesConfigAdapter(properties).pollingFrequency())
+				.isEqualTo(properties.getPollingFrequency());
+	}
+
+	@Test
+	void whenPropertiesPublishUnchangedMetersIsSetAdapterPublishUnchangedMetersReturnsIt() {
+		StatsdProperties properties = new StatsdProperties();
+		properties.setPublishUnchangedMeters(false);
+		assertThat(new StatsdPropertiesConfigAdapter(properties).publishUnchangedMeters())
+				.isEqualTo(properties.isPublishUnchangedMeters());
+	}
+
+	@Test
+	void whenPropertiesBufferedIsSetAdapterBufferedReturnsIt() {
+		StatsdProperties properties = new StatsdProperties();
+		properties.setBuffered(false);
+		assertThat(new StatsdPropertiesConfigAdapter(properties).buffered()).isEqualTo(properties.isBuffered());
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesConfigAdapterTests.java
@@ -83,6 +83,13 @@ class StatsdPropertiesConfigAdapterTests {
 	}
 
 	@Test
+	void whenPropertiesStepIsSetAdapterStepReturnsIt() {
+		StatsdProperties properties = new StatsdProperties();
+		properties.setStep(Duration.ofSeconds(1));
+		assertThat(new StatsdPropertiesConfigAdapter(properties).step()).isEqualTo(properties.getStep());
+	}
+
+	@Test
 	void whenPropertiesPublishUnchangedMetersIsSetAdapterPublishUnchangedMetersReturnsIt() {
 		StatsdProperties properties = new StatsdProperties();
 		properties.setPublishUnchangedMeters(false);

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ class StatsdPropertiesTests {
 		assertThat(properties.getMaxPacketLength()).isEqualTo(config.maxPacketLength());
 		assertThat(properties.getPollingFrequency()).isEqualTo(config.pollingFrequency());
 		assertThat(properties.isPublishUnchangedMeters()).isEqualTo(config.publishUnchangedMeters());
+		assertThat(properties.isBuffered()).isEqualTo(config.buffered());
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdPropertiesTests.java
@@ -39,6 +39,7 @@ class StatsdPropertiesTests {
 		assertThat(properties.getProtocol()).isEqualTo(config.protocol());
 		assertThat(properties.getMaxPacketLength()).isEqualTo(config.maxPacketLength());
 		assertThat(properties.getPollingFrequency()).isEqualTo(config.pollingFrequency());
+		assertThat(properties.getStep()).isEqualTo(config.step());
 		assertThat(properties.isPublishUnchangedMeters()).isEqualTo(config.publishUnchangedMeters());
 		assertThat(properties.isBuffered()).isEqualTo(config.buffered());
 	}


### PR DESCRIPTION
This PR changes to expose `buffered` property for `StatsdConfig`.

See https://github.com/micrometer-metrics/micrometer/issues/1375