### PR TITLE
Import OkHttp's bom rather than declaring modules individually

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1052,16 +1052,8 @@ bom {
 	}
 	library("OkHttp", "4.9.3") {
 		group("com.squareup.okhttp3") {
-			modules = [
-				"logging-interceptor",
-				"mockwebserver",
-				"okcurl",
-				"okhttp",
-				"okhttp-brotli",
-				"okhttp-dnsoverhttps",
-				"okhttp-sse",
-				"okhttp-tls",
-				"okhttp-urlconnection"
+			imports = [
+				"okhttp-bom"
 			]
 		}
 	}


### PR DESCRIPTION
According to the OkHttp document, it provides bill of materials. 
And it have same modules Spring's and OkHttp BOM.

So, replaces modules definition with BOM.

- Refrence documents
  - OkHttp Document: https://github.com/square/okhttp#releases
  - Maven Repository Informtion: https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp-bom/4.9.3