### PR TITLE
Support empty issuer-uri in OAuth2 provider

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2ClientPropertiesRegistrationAdapter.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2ClientPropertiesRegistrationAdapter.java
@@ -79,7 +79,7 @@ public final class OAuth2ClientPropertiesRegistrationAdapter {
 		if (providers.containsKey(providerId)) {
 			Provider provider = providers.get(providerId);
 			String issuer = provider.getIssuerUri();
-			if (issuer != null) {
+			if (StringUtils.hasText(issuer)) {
 				Builder builder = ClientRegistrations.fromIssuerLocation(issuer).registrationId(registrationId);
 				return getBuilder(builder, provider);
 			}


### PR DESCRIPTION
When using a custom OAuth2 provider then its discovery occurs during the application startup which complicate the use of HTTP mock servers.

If the application defines a default issuer-uri - in order to ease configuration management in multiple environments - then it is not possible to reset the value to null in unit tests.


```yaml
spring:
  security:
    oauth2:
      client:
        registration:
          example-client-api1:
            provider: my-company-oauth2-server
            client-id: xxx
            client-secret: xxx
            authorization-grant-type: client_credentials
            scope: scope1
        provider:
          my-company-oauth2-server:
            issuer-uri: https://my-company-oauth2-server/oauth2
```

Defining ``spring.security.oauth2.client.provider.my-company-oauth2-server.issuer-uri=`` results in the property being an empty string. The consequence is that the unit test will call the discovery endpoint even if we define a custom endpoint (access_token in this case). This is due to the behavior of [OAuth2ClientPropertiesRegistrationAdapter#getBuilderFromIssuerIfPossible](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/OAuth2ClientPropertiesRegistrationAdapter.java#L81)

I often use mock-server which allows an actual connection made to an HTTP server with dynamic port.
Since the OAuth2 discovery occurs during the application start, many mock server (in this case [mock-server](https://mock-server.com/)) make it difficult or complicated to use a dynamic port and set up expectations before the Spring application initialization.

This evolution make Spring Boot consider that an empty issuer-uri is similar to an unspecified one, thus making easy to configure a test with no issuer:

```java
	@MockServerTest({
		"spring.security.oauth2.client.provider.my-company-oauth2-server.issuer-uri=",
		"spring.security.oauth2.client.provider.my-company-oauth2-server.token-uri=http://localhost:${mockServerPort}/oauth2/access_token"
	})
```

An alternative with the current implementation is to define the issuer-uri in a profile, which is activated by default and deactivated in the tests.