### PR TITLE
add equals and hashCode to MongoProperties

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.autoconfigure.mongo;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 import com.mongodb.ConnectionString;
 import org.bson.UuidRepresentation;
 
@@ -208,6 +211,26 @@ public class MongoProperties {
 		this.autoIndexCreation = autoIndexCreation;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		MongoProperties that = (MongoProperties) o;
+		return Objects.equals(host, that.host) && Objects.equals(port, that.port) && Objects.equals(uri, that.uri) && Objects.equals(database, that.database) && Objects.equals(authenticationDatabase, that.authenticationDatabase) && Objects.equals(gridfs, that.gridfs) && Objects.equals(username, that.username) && Arrays.equals(password, that.password) && Objects.equals(replicaSetName, that.replicaSetName) && Objects.equals(fieldNamingStrategy, that.fieldNamingStrategy) && uuidRepresentation == that.uuidRepresentation && Objects.equals(autoIndexCreation, that.autoIndexCreation);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = Objects.hash(host, port, uri, database, authenticationDatabase, gridfs, username, replicaSetName,
+				fieldNamingStrategy, uuidRepresentation, autoIndexCreation);
+		result = 31 * result + Arrays.hashCode(password);
+		return result;
+	}
+
 	public static class Gridfs {
 
 		/**
@@ -234,6 +257,23 @@ public class MongoProperties {
 
 		public void setBucket(String bucket) {
 			this.bucket = bucket;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			Gridfs gridfs = (Gridfs) o;
+			return Objects.equals(database, gridfs.database) && Objects.equals(bucket, gridfs.bucket);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(database, bucket);
 		}
 
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Add equals and hashCode to MongoProperties

Because in my company we want to use them as key in HashMap, thus build a map from properties to MongoClient, and make it a cache pool.

Yes we have a mechanism to config multiple MongoProperties, and some of them are same, others not.
