### PR TITLE
Allow Prometheus PushGateway to be configured to perform a PUT on shutdown

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusPushGatewayManager.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusPushGatewayManager.java
@@ -110,6 +110,15 @@ public class PrometheusPushGatewayManager {
 		}
 	}
 
+	private void put() {
+		try {
+			this.pushGateway.push(this.registry, this.job, this.groupingKey);
+		}
+		catch (Throwable ex) {
+			logger.warn("Unexpected exception thrown while pushing metrics to Prometheus Pushgateway", ex);
+		}
+	}
+
 	private void delete() {
 		try {
 			this.pushGateway.delete(this.job, this.groupingKey);
@@ -135,6 +144,9 @@ public class PrometheusPushGatewayManager {
 		case PUSH:
 			push();
 			break;
+		case PUT:
+			put();
+			break;
 		case DELETE:
 			delete();
 			break;
@@ -152,9 +164,14 @@ public class PrometheusPushGatewayManager {
 		NONE,
 
 		/**
-		 * Perform a 'push' before shutdown.
+		 * Perform a 'push' with POST method before shutdown.
 		 */
 		PUSH,
+
+		/**
+		 * Perform a 'push' with PUT method before shutdown.
+		 */
+		PUT,
 
 		/**
 		 * Perform a 'delete' before shutdown.

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusPushGatewayManagerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusPushGatewayManagerTests.java
@@ -145,6 +145,16 @@ class PrometheusPushGatewayManagerTests {
 	}
 
 	@Test
+	void shutdownWhenShutdownOperationIsPutPerformsPushOnShutdown() throws Exception {
+		givenScheduleAtFixedRateWithReturnFuture();
+		PrometheusPushGatewayManager manager = new PrometheusPushGatewayManager(this.pushGateway, this.registry,
+				this.scheduler, this.pushRate, "job", this.groupingKey, ShutdownOperation.PUT);
+		manager.shutdown();
+		then(this.future).should().cancel(false);
+		then(this.pushGateway).should().push(this.registry, "job", this.groupingKey);
+	}
+
+	@Test
 	void shutdownWhenShutdownOperationIsDeletePerformsDeleteOnShutdown() throws Exception {
 		givenScheduleAtFixedRateWithReturnFuture();
 		PrometheusPushGatewayManager manager = new PrometheusPushGatewayManager(this.pushGateway, this.registry,


### PR DESCRIPTION
Metrics push to Prometheus Pushgateway can happen in two different ways:

- with PUT HTTP method, all existing metrics with the same grouping keys are replaced by new metrics
- with POST HTTP method, works exactly like the PUT method but only metrics with the same name as the newly pushed metrics are replaced (among those with the same grouping key)

from [Prometheus Pushgateway README](https://github.com/prometheus/pushgateway#post-method).

Right now, PrometheusPushGatewayManager is only configurable to use the POST method by specifying the `PUSH` shutdown operation (could be useful to rename it to `POST`, not done yet).

The present PR expands the `ShutdownOperation` enum with a new `PUT` value that will be used by PrometheusPushGatewayManager to use the correspondent method of the internal PushGateway instance.