### PR TITLE
Resolve the maven plugin layers name error, fixed #31115

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging.adoc
@@ -102,7 +102,7 @@ Any content not claimed by an earlier block remains available for subsequent blo
 The `<into>` block claims content using nested `<include>` and `<exclude>` elements.
 The `<application>` section uses Ant-style path matching for include/exclude expressions.
 The `<dependencies>` section uses `group:artifact[:version]` patterns.
-It also provides `<includeModuleDependencies />` and `<excludeModuleDependencies />` elements that can be used to include or exclude local module dependencies.
+It also provides `<includeProjectDependencies />` and `<excludeProjectDependencies />` elements that can be used to include or exclude local module dependencies.
 
 If no `<include>` is defined, then all content (not claimed by an earlier block) is considered.
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/maven/packaging/layers.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/maven/packaging/layers.xml
@@ -11,7 +11,7 @@
 	</application>
 	<dependencies>
 		<into layer="application">
-			<includeModuleDependencies />
+			<includeProjectDependencies />
 		</into>
 		<into layer="snapshot-dependencies">
 			<include>*:*:*SNAPSHOT</include>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/jar-layered-custom/jar/src/layers.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/jar-layered-custom/jar/src/layers.xml
@@ -10,7 +10,7 @@
 	</application>
 	<dependencies>
 		<into layer="application">
-			<includeModuleDependencies />
+			<includeProjectDependencies />
 		</into>
 		<into layer="snapshot-dependencies">
 			<include>*:*:*-SNAPSHOT</include>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/war-layered-custom/war/src/layers.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/war-layered-custom/war/src/layers.xml
@@ -10,7 +10,7 @@
 	</application>
 	<dependencies>
 		<into layer="application">
-			<includeModuleDependencies />
+			<includeProjectDependencies />
 		</into>
 		<into layer="snapshot-dependencies">
 			<include>*:*:*-SNAPSHOT</include>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/CustomLayersProvider.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/CustomLayersProvider.java
@@ -98,15 +98,15 @@ class CustomLayersProvider {
 		Layer layer = new Layer(element.getAttribute("layer"));
 		List<String> includes = getChildNodeTextContent(element, "include");
 		List<String> excludes = getChildNodeTextContent(element, "exclude");
-		Element includeModuleDependencies = getChildElement(element, "includeModuleDependencies");
-		Element excludeModuleDependencies = getChildElement(element, "excludeModuleDependencies");
+		Element includeProjectDependencies = getChildElement(element, "includeProjectDependencies");
+		Element excludeProjectDependencies = getChildElement(element, "excludeProjectDependencies");
 		List<ContentFilter<Library>> includeFilters = includes.stream().map(filterFactory).collect(Collectors.toList());
-		if (includeModuleDependencies != null) {
+		if (includeProjectDependencies != null) {
 			includeFilters = new ArrayList<>(includeFilters);
 			includeFilters.add(Library::isLocal);
 		}
 		List<ContentFilter<Library>> excludeFilters = excludes.stream().map(filterFactory).collect(Collectors.toList());
-		if (excludeModuleDependencies != null) {
+		if (excludeProjectDependencies != null) {
 			excludeFilters = new ArrayList<>(excludeFilters);
 			excludeFilters.add(Library::isLocal);
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/resources/layers.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/resources/layers.xml
@@ -15,10 +15,10 @@
 	<dependencies>
 		<into layer="snapshot-dependencies">
 			<include>*:*:*-SNAPSHOT</include>
-			<excludeModuleDependencies/>
+			<excludeProjectDependencies/>
 		</into>
 		<into layer="application">
-			<includeModuleDependencies/>
+			<includeProjectDependencies/>
 		</into>
 		<into layer="my-deps">
 			<include>com.acme:*</include>


### PR DESCRIPTION
issues: https://github.com/spring-projects/spring-boot/issues/31115

Change name from `includeModuleDependencies` to `includeProjectDependencies`.