### PR TITLE
layers.xsd is out of sync with the documentation and implementation for including and excluding module dependencies

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/xsd/layers-2.4.xsd
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/xsd/layers-2.4.xsd
@@ -78,14 +78,14 @@
 		<xsd:complexContent>
 			<xsd:extension base="intoType">
 				<xsd:choice minOccurs="0">
-					<xsd:element type="xsd:string" name="includeProjectDependencies" minOccurs="0">
+					<xsd:element type="xsd:string" name="includeModuleDependencies" minOccurs="0">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
 	Include dependencies on other modules in the build.
 							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element type="xsd:string" name="excludeProjectDependencies" minOccurs="0">
+					<xsd:element type="xsd:string" name="excludeModuleDependencies" minOccurs="0">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
 	Exclude dependencies on other modules in the build.

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/xsd/layers-2.5.xsd
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/xsd/layers-2.5.xsd
@@ -78,14 +78,14 @@
 		<xsd:complexContent>
 			<xsd:extension base="intoType">
 				<xsd:choice minOccurs="0">
-					<xsd:element type="xsd:string" name="includeProjectDependencies" minOccurs="0">
+					<xsd:element type="xsd:string" name="includeModuleDependencies" minOccurs="0">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
 	Include dependencies on other modules in the build.
 							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element type="xsd:string" name="excludeProjectDependencies" minOccurs="0">
+					<xsd:element type="xsd:string" name="excludeModuleDependencies" minOccurs="0">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
 	Exclude dependencies on other modules in the build.

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/xsd/layers-2.6.xsd
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/xsd/layers-2.6.xsd
@@ -78,14 +78,14 @@
 		<xsd:complexContent>
 			<xsd:extension base="intoType">
 				<xsd:choice minOccurs="0">
-					<xsd:element type="xsd:string" name="includeProjectDependencies" minOccurs="0">
+					<xsd:element type="xsd:string" name="includeModuleDependencies" minOccurs="0">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
 	Include dependencies on other modules in the build.
 							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element type="xsd:string" name="excludeProjectDependencies" minOccurs="0">
+					<xsd:element type="xsd:string" name="excludeModuleDependencies" minOccurs="0">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
 	Exclude dependencies on other modules in the build.

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/xsd/layers-2.7.xsd
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/xsd/layers-2.7.xsd
@@ -78,14 +78,14 @@
 		<xsd:complexContent>
 			<xsd:extension base="intoType">
 				<xsd:choice minOccurs="0">
-					<xsd:element type="xsd:string" name="includeProjectDependencies" minOccurs="0">
+					<xsd:element type="xsd:string" name="includeModuleDependencies" minOccurs="0">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
 	Include dependencies on other modules in the build.
 							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element type="xsd:string" name="excludeProjectDependencies" minOccurs="0">
+					<xsd:element type="xsd:string" name="excludeModuleDependencies" minOccurs="0">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
 	Exclude dependencies on other modules in the build.

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/xsd/layers-3.0.xsd
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/xsd/layers-3.0.xsd
@@ -78,14 +78,14 @@
 		<xsd:complexContent>
 			<xsd:extension base="intoType">
 				<xsd:choice minOccurs="0">
-					<xsd:element type="xsd:string" name="includeProjectDependencies" minOccurs="0">
+					<xsd:element type="xsd:string" name="includeModuleDependencies" minOccurs="0">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
 	Include dependencies on other modules in the build.
 							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element type="xsd:string" name="excludeProjectDependencies" minOccurs="0">
+					<xsd:element type="xsd:string" name="excludeModuleDependencies" minOccurs="0">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
 	Exclude dependencies on other modules in the build.


### PR DESCRIPTION
I found some inconsistencies between maven plugin documentation and code, which one should I use?

## The contents of the document are as follows

```xml
<layers xmlns="http://www.springframework.org/schema/boot/layers"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/boot/layers
                          https://www.springframework.org/schema/boot/layers/layers-2.6.xsd">
    <application>
        <into layer="spring-boot-loader">
            <include>org/springframework/boot/loader/**</include>
        </into>
        <into layer="application" />
    </application>
    <dependencies>
        <into layer="application">
            <includeModuleDependencies />
        </into>
        <into layer="snapshot-dependencies">
            <include>*:*:*SNAPSHOT</include>
        </into>
        <into layer="dependencies" />
    </dependencies>
    <layerOrder>
        <layer>dependencies</layer>
        <layer>spring-boot-loader</layer>
        <layer>snapshot-dependencies</layer>
        <layer>application</layer>
    </layerOrder>
</layers>
```

> It also provides `<includeModuleDependencies />` and `<excludeModuleDependencies />` elements that can be used to include or exclude local module dependencies.

## Code 

### [layers-2.6.xsd](https://www.springframework.org/schema/boot/layers/layers-2.6.xsd)

```xml
<xsd:complexType name="dependenciesIntoType">
<xsd:complexContent>
	<xsd:extension base="intoType">
		<xsd:choice minOccurs="0">
			<xsd:element type="xsd:string" name="includeProjectDependencies" minOccurs="0">
				<xsd:annotation>
					<xsd:documentation><![CDATA[
Include dependencies on other modules in the build.
					]]></xsd:documentation>
				</xsd:annotation>
			</xsd:element>
			<xsd:element type="xsd:string" name="excludeProjectDependencies" minOccurs="0">
				<xsd:annotation>
					<xsd:documentation><![CDATA[
Exclude dependencies on other modules in the build.
					]]></xsd:documentation>
				</xsd:annotation>
			</xsd:element>
		</xsd:choice>				
	</xsd:extension>
</xsd:complexContent>
</xsd:complexType>
```
Here is `includeProjectDependencies` and `excludeProjectDependencies`.

### CustomLayersProvider.java

```java
	private <T> ContentSelector<Library> getLibrarySelector(Element element,
			Function<String, ContentFilter<Library>> filterFactory) {
		Layer layer = new Layer(element.getAttribute("layer"));
		List<String> includes = getChildNodeTextContent(element, "include");
		List<String> excludes = getChildNodeTextContent(element, "exclude");
		Element includeModuleDependencies = getChildElement(element, "includeModuleDependencies");
		Element excludeModuleDependencies = getChildElement(element, "excludeModuleDependencies");
		List<ContentFilter<Library>> includeFilters = includes.stream().map(filterFactory).collect(Collectors.toList());
		if (includeModuleDependencies != null) {
			includeFilters = new ArrayList<>(includeFilters);
			includeFilters.add(Library::isLocal);
		}
		List<ContentFilter<Library>> excludeFilters = excludes.stream().map(filterFactory).collect(Collectors.toList());
		if (excludeModuleDependencies != null) {
			excludeFilters = new ArrayList<>(excludeFilters);
			excludeFilters.add(Library::isLocal);
		}
		return new IncludeExcludeContentSelector<>(layer, includeFilters, excludeFilters);
	}
```

Here is `includeModuleDependencies` and `excludeModuleDependencies`.

