### PR TITLE
Add .sdkmanrc with latest java version

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=8.0.332-librca


### PR DESCRIPTION
Using java 8 as the lowest jdk supported by 2.7.x. For 3.x, `17.0.3-librca` can be used.

See gh-31121