### PR TITLE
Use Lambda-based API in Spring Security examples

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/sql.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/sql.adoc
@@ -351,7 +351,7 @@ In simple setups, a `SecurityFilterChain` like the following can be used:
 
 [source,java,indent=0,subs="verbatim"]
 ----
-include::{docs-java}/data/sql/h2webconsole/springsecurity/DevProfileSecurityConfiguration.java[]
+include::{docs-java}/data/sql/h2webconsole/springsecurity/DevProfileSecurityConfiguration.java[tag=!customizer]
 ----
 
 WARNING: The H2 console is only intended for use during development.

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/actuator/endpoints/security/exposeall/MySecurityConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/actuator/endpoints/security/exposeall/MySecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@ public class MySecurityConfiguration {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.requestMatcher(EndpointRequest.toAnyEndpoint())
-				.authorizeRequests((requests) -> requests.anyRequest().permitAll());
+		http.requestMatcher(EndpointRequest.toAnyEndpoint());
+		http.authorizeRequests((requests) -> requests.anyRequest().permitAll());
 		return http.build();
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/actuator/endpoints/security/typical/MySecurityConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/actuator/endpoints/security/typical/MySecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,14 +22,16 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 @Configuration(proxyBeanMethods = false)
 public class MySecurityConfiguration {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.requestMatcher(EndpointRequest.toAnyEndpoint())
-				.authorizeRequests((requests) -> requests.anyRequest().hasRole("ENDPOINT_ADMIN"));
-		http.httpBasic();
+		http.requestMatcher(EndpointRequest.toAnyEndpoint());
+		http.authorizeRequests((requests) -> requests.anyRequest().hasRole("ENDPOINT_ADMIN"));
+		http.httpBasic(withDefaults());
 		return http.build();
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/data/sql/h2webconsole/springsecurity/DevProfileSecurityConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/data/sql/h2webconsole/springsecurity/DevProfileSecurityConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -32,13 +33,18 @@ public class DevProfileSecurityConfiguration {
 	@Bean
 	@Order(Ordered.HIGHEST_PRECEDENCE)
 	SecurityFilterChain h2ConsoleSecurityFilterChain(HttpSecurity http) throws Exception {
-		// @formatter:off
-		return http.requestMatcher(PathRequest.toH2Console())
-				// ... configuration for authorization
-				.csrf().disable()
-				.headers().frameOptions().sameOrigin().and()
-				.build();
-		// @formatter:on
+		http.requestMatcher(PathRequest.toH2Console());
+		http.authorizeRequests(yourCustomAuthorization());
+		http.csrf((csrf) -> csrf.disable());
+		http.headers((headers) -> headers.frameOptions().sameOrigin());
+		return http.build();
 	}
+
+	// tag::customizer[]
+	<T> Customizer<T> yourCustomAuthorization() {
+		return (t) -> {
+		};
+	}
+	// end::customizer[]
 
 }

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/security/oauth2/client/MyOAuthClientConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/security/oauth2/client/MyOAuthClientConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ public class MyOAuthClientConfiguration {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.authorizeRequests().anyRequest().authenticated();
-		http.oauth2Login().redirectionEndpoint().baseUri("custom-callback");
+		http.authorizeRequests((requests) -> requests.anyRequest().authenticated());
+		http.oauth2Login((login) -> login.redirectionEndpoint().baseUri("custom-callback"));
 		return http.build();
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/security/springwebflux/MyWebFluxSecurityConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/security/springwebflux/MyWebFluxSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,16 +22,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 @Configuration(proxyBeanMethods = false)
 public class MyWebFluxSecurityConfiguration {
 
 	@Bean
 	public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
-		http.authorizeExchange((spec) -> {
-			spec.matchers(PathRequest.toStaticResources().atCommonLocations()).permitAll();
-			spec.pathMatchers("/foo", "/bar").authenticated();
+		http.authorizeExchange((exchange) -> {
+			exchange.matchers(PathRequest.toStaticResources().atCommonLocations()).permitAll();
+			exchange.pathMatchers("/foo", "/bar").authenticated();
 		});
-		http.formLogin();
+		http.formLogin(withDefaults());
 		return http.build();
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/security/enablehttps/MySecurityConfig.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/security/enablehttps/MySecurityConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ public class MySecurityConfig {
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		// Customize the application security ...
-		http.requiresChannel().anyRequest().requiresSecure();
+		http.requiresChannel((channel) -> channel.anyRequest().requiresSecure());
 		return http.build();
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MyConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MyConfiguration.java
@@ -30,7 +30,7 @@ public class MyConfiguration {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.authorizeRequests().anyRequest().authenticated();
+		http.authorizeRequests((requests) -> requests.anyRequest().authenticated());
 		return http.build();
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MySecurityConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MySecurityConfiguration.java
@@ -26,7 +26,7 @@ public class MySecurityConfiguration {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.authorizeRequests().anyRequest().authenticated();
+		http.authorizeRequests((requests) -> requests.anyRequest().authenticated());
 		return http.build();
 	}
 


### PR DESCRIPTION
This PR is intended to resolve #30432.

I've formatted the Spring Security examples consistently such that
- the last word of the respective method name is chosen as the variable name in the lambda,
- `withDefaults()` is used where no actual `Customizer` is used,
- chaining is not used as that is sometimes hard to style nicely if lines are continued.

If a different style is preferred, I'll be happy to change it.