### PR TITLE
Dependency management for mimepull is redundant and the managed version is incompatible with Java 8

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1029,13 +1029,6 @@ bom {
 			]
 		}
 	}
-	library("MIMEPull", "1.10.0") {
-		group("org.jvnet.mimepull") {
-			modules = [
-				"mimepull"
-			]
-		}
-	}
 	library("Mockito", "4.5.1") {
 		group("org.mockito") {
 			imports = [


### PR DESCRIPTION
Mimepull dependency was introduced in 1c18fd8 for gh-14924 to force the
version as the one coming from saaj-impl was not on Maven Central.
This is no longer the case.

Version 1.10.0 of Mimepull has been built with Java 11, breaking
compatibility with Java 8 for Spring Boot.

Closes gh-31133
