### PR TITLE
Auto-configure JvmCompilationMetrics

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.boot.actuate.autoconfigure.metrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmCompilationMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmInfoMetrics;
@@ -77,6 +78,12 @@ public class JvmMetricsAutoConfiguration {
 	@ConditionalOnMissingBean
 	public JvmInfoMetrics jvmInfoMetrics() {
 		return new JvmInfoMetrics();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public JvmCompilationMetrics jvmCompilationMetrics() {
+		return new JvmCompilationMetrics();
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfigurationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.actuate.autoconfigure.metrics;
 
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmCompilationMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmInfoMetrics;
@@ -87,11 +88,17 @@ class JvmMetricsAutoConfigurationTests {
 				.run(assertMetricsBeans().andThen((context) -> assertThat(context).hasBean("customJvmInfoMetrics")));
 	}
 
+	@Test
+	void allowsCustomJvmCompilationMetricsToBeUsed() {
+		this.contextRunner.withUserConfiguration(CustomJvmCompilationMetricsConfiguration.class).run(
+				assertMetricsBeans().andThen((context) -> assertThat(context).hasBean("customJvmCompilationMetrics")));
+	}
+
 	private ContextConsumer<AssertableApplicationContext> assertMetricsBeans() {
 		return (context) -> assertThat(context).hasSingleBean(JvmGcMetrics.class)
 				.hasSingleBean(JvmHeapPressureMetrics.class).hasSingleBean(JvmMemoryMetrics.class)
 				.hasSingleBean(JvmThreadMetrics.class).hasSingleBean(ClassLoaderMetrics.class)
-				.hasSingleBean(JvmInfoMetrics.class);
+				.hasSingleBean(JvmInfoMetrics.class).hasSingleBean(JvmCompilationMetrics.class);
 	}
 
 	@Configuration(proxyBeanMethods = false)
@@ -150,6 +157,16 @@ class JvmMetricsAutoConfigurationTests {
 		@Bean
 		JvmInfoMetrics customJvmInfoMetrics() {
 			return new JvmInfoMetrics();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomJvmCompilationMetricsConfiguration {
+
+		@Bean
+		JvmCompilationMetrics customJvmCompilationMetrics() {
+			return new JvmCompilationMetrics();
 		}
 
 	}


### PR DESCRIPTION
This PR changes to auto-configure `JvmCompilationMetrics` as it seems to have been missed somehow.