### PR TITLE
Add link to 'Error Handling Spring Boot Starter'

### DIFF
--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -97,6 +97,9 @@ do as they were designed before this was clarified.
 | ErroREST exception handler
 | https://github.com/mkopylec/errorest-spring-boot-starter
 
+| Error Handling Spring Boot Starter
+| https://github.com/wimdeblauwe/error-handling-spring-boot-starter
+
 | https://www.flowable.org/[Flowable]
 | https://github.com/flowable/flowable-engine/tree/master/modules/flowable-spring-boot/flowable-spring-boot-starters
 


### PR DESCRIPTION
This adds my spring boot starter called 'Error Handling Spring Boot Starter' to list of 3rd party spring boot starters.