### PR TITLE
Restore custom favicon documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/anchor-rewrite.properties
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/anchor-rewrite.properties
@@ -773,6 +773,7 @@ features.developing-web-applications.spring-mvc.json=web.servlet.spring-mvc.json
 features.developing-web-applications.spring-mvc.message-codes=web.servlet.spring-mvc.message-codes
 features.developing-web-applications.spring-mvc.static-content=web.servlet.spring-mvc.static-content
 features.developing-web-applications.spring-mvc.welcome-page=web.servlet.spring-mvc.welcome-page
+features.developing-web-applications.spring-mvc.favicon=web.servlet.spring-mvc.favicon
 features.developing-web-applications.spring-mvc.content-negotiation=web.servlet.spring-mvc.content-negotiation
 features.developing-web-applications.spring-mvc.binding-initializer=web.servlet.spring-mvc.binding-initializer
 features.developing-web-applications.spring-mvc.template-engines=web.servlet.spring-mvc.template-engines

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/web/servlet.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/web/servlet.adoc
@@ -216,6 +216,13 @@ If either is found, it is automatically used as the welcome page of the applicat
 
 
 
+[[web.servlet.spring-mvc.favicon]]
+==== Custom Favicon
+As with other static resources, Spring Boot checks for a `favicon.ico` in the configured static content locations.
+If such a file is present, it is automatically used as the favicon of the application.
+
+
+
 [[web.servlet.spring-mvc.content-negotiation]]
 ==== Path Matching and Content Negotiation
 Spring MVC can map incoming HTTP requests to handlers by looking at the request path and matching it to the mappings defined in your application (for example, `@GetMapping` annotations on Controller methods).


### PR DESCRIPTION
This PR restores the favicon documentation mistakenly removed in 5fceb9d.

The 5fceb9d commit did not change the default behavior at all, just opened the option to define non-default `favicon.ico` files, such as `"/favicon.ico"`, `"/favicon.png"` and `"/icons/icon-48x48.png"`.

What it did change is overriding the lookup for the `favicon.ico` from anywhere in the resources (`/**/`) to a sub directory (`/*/`). Thus I changed the doc wording a bit from 
> Spring Boot looks for a `favicon.ico`

to
> Spring Boot checks for a `favicon.ico`


This PR closes gh-31026
