### PR TITLE
OAuth2 Resource Server Auto-Configuration can only configure a single JWS algorithm

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerJwkConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerJwkConfiguration.java
@@ -20,6 +20,7 @@ import java.security.KeyFactory;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
@@ -49,6 +50,7 @@ import org.springframework.security.oauth2.jwt.ReactiveJwtDecoders;
 import org.springframework.security.oauth2.jwt.SupplierReactiveJwtDecoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Configures a {@link ReactiveJwtDecoder} when a JWK Set URI, OpenID Connect Issuer URI
@@ -79,7 +81,12 @@ class ReactiveOAuth2ResourceServerJwkConfiguration {
 		ReactiveJwtDecoder jwtDecoder() {
 			NimbusReactiveJwtDecoder nimbusReactiveJwtDecoder = NimbusReactiveJwtDecoder
 					.withJwkSetUri(this.properties.getJwkSetUri())
-					.jwsAlgorithm(SignatureAlgorithm.from(this.properties.getJwsAlgorithm())).build();
+					.jwsAlgorithms(algorithms ->
+						Arrays.stream(StringUtils.commaDelimitedListToStringArray(this.properties.getJwsAlgorithm()))
+								.map(String::trim)
+								.map(SignatureAlgorithm::from)
+								.forEach(algorithms::add)
+					).build();
 			String issuerUri = this.properties.getIssuerUri();
 			Supplier<OAuth2TokenValidator<Jwt>> defaultValidator = (issuerUri != null)
 					? () -> JwtValidators.createDefaultWithIssuer(issuerUri) : JwtValidators::createDefault;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerJwkConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerJwkConfiguration.java
@@ -81,7 +81,7 @@ class ReactiveOAuth2ResourceServerJwkConfiguration {
 		ReactiveJwtDecoder jwtDecoder() {
 			NimbusReactiveJwtDecoder nimbusReactiveJwtDecoder = NimbusReactiveJwtDecoder
 					.withJwkSetUri(this.properties.getJwkSetUri())
-					.jwsAlgorithms(algorithms ->
+					.jwsAlgorithms((algorithms) ->
 						Arrays.stream(StringUtils.commaDelimitedListToStringArray(this.properties.getJwsAlgorithm()))
 								.map(String::trim)
 								.map(SignatureAlgorithm::from)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerJwkConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerJwkConfiguration.java
@@ -76,6 +76,7 @@ class ReactiveOAuth2ResourceServerJwkConfiguration {
 			this.properties = properties.getJwt();
 		}
 
+		// @formatter:off
 		@Bean
 		@ConditionalOnProperty(name = "spring.security.oauth2.resourceserver.jwt.jwk-set-uri")
 		ReactiveJwtDecoder jwtDecoder() {
@@ -93,6 +94,7 @@ class ReactiveOAuth2ResourceServerJwkConfiguration {
 			nimbusReactiveJwtDecoder.setJwtValidator(getValidators(defaultValidator));
 			return nimbusReactiveJwtDecoder;
 		}
+		// @formatter:on
 
 		private OAuth2TokenValidator<Jwt> getValidators(Supplier<OAuth2TokenValidator<Jwt>> defaultValidator) {
 			OAuth2TokenValidator<Jwt> defaultValidators = defaultValidator.get();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
@@ -20,6 +20,7 @@ import java.security.KeyFactory;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
@@ -50,6 +51,7 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.SupplierJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Configures a {@link JwtDecoder} when a JWK Set URI, OpenID Connect Issuer URI or Public
@@ -78,7 +80,12 @@ class OAuth2ResourceServerJwtConfiguration {
 		@ConditionalOnProperty(name = "spring.security.oauth2.resourceserver.jwt.jwk-set-uri")
 		JwtDecoder jwtDecoderByJwkKeySetUri() {
 			NimbusJwtDecoder nimbusJwtDecoder = NimbusJwtDecoder.withJwkSetUri(this.properties.getJwkSetUri())
-					.jwsAlgorithm(SignatureAlgorithm.from(this.properties.getJwsAlgorithm())).build();
+					.jwsAlgorithms(algorithms ->
+						Arrays.stream(StringUtils.commaDelimitedListToStringArray(this.properties.getJwsAlgorithm()))
+								.map(String::trim)
+								.map(SignatureAlgorithm::from)
+								.forEach(algorithms::add)
+					).build();
 			String issuerUri = this.properties.getIssuerUri();
 			Supplier<OAuth2TokenValidator<Jwt>> defaultValidator = (issuerUri != null)
 					? () -> JwtValidators.createDefaultWithIssuer(issuerUri) : JwtValidators::createDefault;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
@@ -76,6 +76,7 @@ class OAuth2ResourceServerJwtConfiguration {
 			this.properties = properties.getJwt();
 		}
 
+		// @formatter:off
 		@Bean
 		@ConditionalOnProperty(name = "spring.security.oauth2.resourceserver.jwt.jwk-set-uri")
 		JwtDecoder jwtDecoderByJwkKeySetUri() {
@@ -92,6 +93,7 @@ class OAuth2ResourceServerJwtConfiguration {
 			nimbusJwtDecoder.setJwtValidator(getValidators(defaultValidator));
 			return nimbusJwtDecoder;
 		}
+		// @formatter:on
 
 		private OAuth2TokenValidator<Jwt> getValidators(Supplier<OAuth2TokenValidator<Jwt>> defaultValidator) {
 			OAuth2TokenValidator<Jwt> defaultValidators = defaultValidator.get();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
@@ -80,7 +80,7 @@ class OAuth2ResourceServerJwtConfiguration {
 		@ConditionalOnProperty(name = "spring.security.oauth2.resourceserver.jwt.jwk-set-uri")
 		JwtDecoder jwtDecoderByJwkKeySetUri() {
 			NimbusJwtDecoder nimbusJwtDecoder = NimbusJwtDecoder.withJwkSetUri(this.properties.getJwkSetUri())
-					.jwsAlgorithms(algorithms ->
+					.jwsAlgorithms((algorithms) ->
 						Arrays.stream(StringUtils.commaDelimitedListToStringArray(this.properties.getJwsAlgorithm()))
 								.map(String::trim)
 								.map(SignatureAlgorithm::from)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
@@ -119,18 +119,20 @@ class ReactiveOAuth2ResourceServerAutoConfigurationTests {
 				});
 	}
 
-	static Stream<Arguments> autoConfigurationUsingJwkSetUriShouldConfigureResourceServerUsingJwsAlgorithm() { return Stream.of(
-		Arguments.of("single", Collections.singleton(JWSAlgorithm.RS384), "RS384"),
-		Arguments.of("multiple",            Arrays.asList(JWSAlgorithm.RS512, JWSAlgorithm.ES512), "RS512,ES512"),
-		Arguments.of("multiple+whitespace", Arrays.asList(JWSAlgorithm.RS512, JWSAlgorithm.ES512), "RS512, ES512")
-	);}
-	@SuppressWarnings("unchecked")
-	@ParameterizedTest(name="{0}")@MethodSource
+	static Stream<Arguments> autoConfigurationUsingJwkSetUriShouldConfigureResourceServerUsingJwsAlgorithm() {
+		return Stream.of(
+			Arguments.of("single", Collections.singleton(JWSAlgorithm.RS384), "RS384"),
+			Arguments.of("multiple",            Arrays.asList(JWSAlgorithm.RS512, JWSAlgorithm.ES512), "RS512,ES512"),
+			Arguments.of("multiple+whitespace", Arrays.asList(JWSAlgorithm.RS512, JWSAlgorithm.ES512), "RS512, ES512")
+		);
+	}
+	@ParameterizedTest(name = "{0}")
+	@MethodSource
 	void autoConfigurationUsingJwkSetUriShouldConfigureResourceServerUsingJwsAlgorithm(
 			@SuppressWarnings("unused") String desc, Collection<JWSAlgorithm> expected, String propValue) {
 		this.contextRunner
 				.withPropertyValues("spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://jwk-set-uri.com",
-						"spring.security.oauth2.resourceserver.jwt.jws-algorithm="+propValue)
+						"spring.security.oauth2.resourceserver.jwt.jws-algorithm=" + propValue)
 				.run((context) -> {
 					NimbusReactiveJwtDecoder nimbusReactiveJwtDecoder = context.getBean(NimbusReactiveJwtDecoder.class);
 					assertThat(nimbusReactiveJwtDecoder).extracting("jwtProcessor.arg$2.arg$1.jwsAlgs")

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
@@ -119,6 +119,7 @@ class ReactiveOAuth2ResourceServerAutoConfigurationTests {
 				});
 	}
 
+	// @formatter:off
 	static Stream<Arguments> autoConfigurationUsingJwkSetUriShouldConfigureResourceServerUsingJwsAlgorithm() {
 		return Stream.of(
 			Arguments.of("single", Collections.singleton(JWSAlgorithm.RS384), "RS384"),
@@ -126,6 +127,7 @@ class ReactiveOAuth2ResourceServerAutoConfigurationTests {
 			Arguments.of("multiple+whitespace", Arrays.asList(JWSAlgorithm.RS512, JWSAlgorithm.ES512), "RS512, ES512")
 		);
 	}
+	// @formatter:on
 	@ParameterizedTest(name = "{0}")
 	@MethodSource
 	void autoConfigurationUsingJwkSetUriShouldConfigureResourceServerUsingJwsAlgorithm(

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
@@ -124,6 +124,7 @@ class OAuth2ResourceServerAutoConfigurationTests {
 				});
 	}
 
+	// @formatter:off
 	static Stream<Arguments> autoConfigurationShouldConfigureResourceServerWithJwsAlgorithm() {
 		return Stream.of(
 			Arguments.of("single", Collections.singleton(JWSAlgorithm.RS384), "RS384"),
@@ -131,10 +132,11 @@ class OAuth2ResourceServerAutoConfigurationTests {
 			Arguments.of("multiple+whitespace", Arrays.asList(JWSAlgorithm.RS512, JWSAlgorithm.ES512), "RS512, ES512")
 		);
 	}
+	// @formatter:on
 	@ParameterizedTest(name = "{0}")
 	@MethodSource
-	void autoConfigurationShouldConfigureResourceServerWithJwsAlgorithm(
-			@SuppressWarnings("unused") String desc, Collection<JWSAlgorithm> expected, String propValue) {
+	void autoConfigurationShouldConfigureResourceServerWithJwsAlgorithm(@SuppressWarnings("unused") String desc,
+			Collection<JWSAlgorithm> expected, String propValue) {
 		this.contextRunner
 				.withPropertyValues("spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://jwk-set-uri.com",
 						"spring.security.oauth2.resourceserver.jwt.jws-algorithm=" + propValue)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
@@ -124,17 +124,20 @@ class OAuth2ResourceServerAutoConfigurationTests {
 				});
 	}
 
-	static Stream<Arguments> autoConfigurationShouldConfigureResourceServerWithJwsAlgorithm() { return Stream.of(
-		Arguments.of("single", Collections.singleton(JWSAlgorithm.RS384), "RS384"),
-		Arguments.of("multiple",            Arrays.asList(JWSAlgorithm.RS512, JWSAlgorithm.ES512), "RS512,ES512"),
-		Arguments.of("multiple+whitespace", Arrays.asList(JWSAlgorithm.RS512, JWSAlgorithm.ES512), "RS512, ES512")
-	);}
-	@ParameterizedTest(name="{0}")@MethodSource
+	static Stream<Arguments> autoConfigurationShouldConfigureResourceServerWithJwsAlgorithm() {
+		return Stream.of(
+			Arguments.of("single", Collections.singleton(JWSAlgorithm.RS384), "RS384"),
+			Arguments.of("multiple",            Arrays.asList(JWSAlgorithm.RS512, JWSAlgorithm.ES512), "RS512,ES512"),
+			Arguments.of("multiple+whitespace", Arrays.asList(JWSAlgorithm.RS512, JWSAlgorithm.ES512), "RS512, ES512")
+		);
+	}
+	@ParameterizedTest(name = "{0}")
+	@MethodSource
 	void autoConfigurationShouldConfigureResourceServerWithJwsAlgorithm(
 			@SuppressWarnings("unused") String desc, Collection<JWSAlgorithm> expected, String propValue) {
 		this.contextRunner
 				.withPropertyValues("spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://jwk-set-uri.com",
-						"spring.security.oauth2.resourceserver.jwt.jws-algorithm="+propValue)
+						"spring.security.oauth2.resourceserver.jwt.jws-algorithm=" + propValue)
 				.run((context) -> {
 					JwtDecoder jwtDecoder = context.getBean(JwtDecoder.class);
 					Object processor = ReflectionTestUtils.getField(jwtDecoder, "jwtProcessor");


### PR DESCRIPTION
Spring Security added support for specifying multiple JWS algorithms in https://github.com/spring-projects/spring-security/pull/7162

However, since the auto-configuration was not updated, it was only possible to leverage that enhancement via a custom bean.
_(a bit clunky and undesirable compared to setting it in yml)_

This PR fills the gap by allowing the existing property to contain a comma-delimited list of algorithms.
_(if only one algorithm is defined as before, then it will behave no differently)_

I'd like to get this backported to `2.7` as well as `2.6` if at all possible.
**Please let me know if/when you would like me to do this.**