### PR TITLE
Parameters in spring.data.cassandra.config file will override defaults

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraAutoConfiguration.java
@@ -23,7 +23,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLContext;
 
@@ -126,7 +125,10 @@ public class CassandraAutoConfiguration {
 
 	private Config applyDefaultFallback(Config config) {
 		ConfigFactory.invalidateCaches();
-		return ConfigFactory.defaultOverrides().withFallback(config).withFallback(mapConfig(CassandraProperties.defaults())).withFallback(ConfigFactory.defaultReference())
+		return ConfigFactory.defaultOverrides()
+				.withFallback(config)
+				.withFallback(mapConfig(CassandraProperties.defaults()))
+				.withFallback(ConfigFactory.defaultReference())
 				.resolve();
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
@@ -38,6 +38,18 @@ import org.springframework.core.io.Resource;
 @ConfigurationProperties(prefix = "spring.data.cassandra")
 public class CassandraProperties {
 
+	static CassandraProperties defaults() {
+		var properties = new CassandraProperties();
+		properties.setContactPoints(new ArrayList<>(Collections.singleton("127.0.0.1:9042")));
+		properties.setPort(9042);
+		properties.setCompression(Compression.NONE);
+		properties.setSchemaAction("none");
+		properties.setSsl(false);
+
+		properties.getControlconnection().setTimeout(Duration.ofSeconds(5));
+
+		return properties;
+	}
 	/**
 	 * Location of the configuration file to use.
 	 */
@@ -57,12 +69,12 @@ public class CassandraProperties {
 	 * Cluster node addresses in the form 'host:port', or a simple 'host' to use the
 	 * configured port.
 	 */
-	private final List<String> contactPoints = new ArrayList<>(Collections.singleton("127.0.0.1:9042"));
+	private List<String> contactPoints;
 
 	/**
 	 * Port to use if a contact point does not specify one.
 	 */
-	private int port = 9042;
+	private Integer port;
 
 	/**
 	 * Datacenter that is considered "local". Contact points should be from this
@@ -83,17 +95,17 @@ public class CassandraProperties {
 	/**
 	 * Compression supported by the Cassandra binary protocol.
 	 */
-	private Compression compression = Compression.NONE;
+	private Compression compression;
 
 	/**
 	 * Schema action to take at startup.
 	 */
-	private String schemaAction = "none";
+	private String schemaAction;
 
 	/**
 	 * Enable SSL support.
 	 */
-	private boolean ssl = false;
+	private Boolean ssl;
 
 	/**
 	 * Connection configuration.
@@ -143,7 +155,11 @@ public class CassandraProperties {
 		return this.contactPoints;
 	}
 
-	public int getPort() {
+	public void setContactPoints(List<String> contactPoints) {
+		this.contactPoints = contactPoints;
+	}
+
+	public Integer getPort() {
 		return this.port;
 	}
 
@@ -183,7 +199,7 @@ public class CassandraProperties {
 		this.compression = compression;
 	}
 
-	public boolean isSsl() {
+	public Boolean isSsl() {
 		return this.ssl;
 	}
 
@@ -266,7 +282,7 @@ public class CassandraProperties {
 		/**
 		 * How many rows will be retrieved simultaneously in a single network round-trip.
 		 */
-		private int pageSize;
+		private Integer pageSize;
 
 		private final Throttler throttler = new Throttler();
 
@@ -294,7 +310,7 @@ public class CassandraProperties {
 			this.serialConsistency = serialConsistency;
 		}
 
-		public int getPageSize() {
+		public Integer getPageSize() {
 			return this.pageSize;
 		}
 
@@ -347,7 +363,7 @@ public class CassandraProperties {
 		/**
 		 * Timeout to use for control queries.
 		 */
-		private Duration timeout = Duration.ofSeconds(5);
+		private Duration timeout;
 
 		public Duration getTimeout() {
 			return this.timeout;
@@ -370,17 +386,17 @@ public class CassandraProperties {
 		 * Maximum number of requests that can be enqueued when the throttling threshold
 		 * is exceeded.
 		 */
-		private int maxQueueSize;
+		private Integer maxQueueSize;
 
 		/**
 		 * Maximum number of requests that are allowed to execute in parallel.
 		 */
-		private int maxConcurrentRequests;
+		private Integer maxConcurrentRequests;
 
 		/**
 		 * Maximum allowed request rate.
 		 */
-		private int maxRequestsPerSecond;
+		private Integer maxRequestsPerSecond;
 
 		/**
 		 * How often the throttler attempts to dequeue requests. Set this high enough that
@@ -397,7 +413,7 @@ public class CassandraProperties {
 			this.type = type;
 		}
 
-		public int getMaxQueueSize() {
+		public Integer getMaxQueueSize() {
 			return this.maxQueueSize;
 		}
 
@@ -405,7 +421,7 @@ public class CassandraProperties {
 			this.maxQueueSize = maxQueueSize;
 		}
 
-		public int getMaxConcurrentRequests() {
+		public Integer getMaxConcurrentRequests() {
 			return this.maxConcurrentRequests;
 		}
 
@@ -413,7 +429,7 @@ public class CassandraProperties {
 			this.maxConcurrentRequests = maxConcurrentRequests;
 		}
 
-		public int getMaxRequestsPerSecond() {
+		public Integer getMaxRequestsPerSecond() {
 			return this.maxRequestsPerSecond;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
@@ -40,16 +40,14 @@ public class CassandraProperties {
 
 	static CassandraProperties defaults() {
 		var properties = new CassandraProperties();
-		properties.setContactPoints(new ArrayList<>(Collections.singleton("127.0.0.1:9042")));
-		properties.setPort(9042);
-		properties.setCompression(Compression.NONE);
-		properties.setSchemaAction("none");
-		properties.setSsl(false);
 
+		properties.setContactPoints(new ArrayList<>(Collections.singleton("127.0.0.1:9042")));
+		properties.setCompression(Compression.NONE);
 		properties.getControlconnection().setTimeout(Duration.ofSeconds(5));
 
 		return properties;
 	}
+
 	/**
 	 * Location of the configuration file to use.
 	 */
@@ -74,7 +72,7 @@ public class CassandraProperties {
 	/**
 	 * Port to use if a contact point does not specify one.
 	 */
-	private Integer port;
+	private int port = 9042;
 
 	/**
 	 * Datacenter that is considered "local". Contact points should be from this
@@ -100,12 +98,12 @@ public class CassandraProperties {
 	/**
 	 * Schema action to take at startup.
 	 */
-	private String schemaAction;
+	private String schemaAction = "none";
 
 	/**
 	 * Enable SSL support.
 	 */
-	private Boolean ssl;
+	private boolean ssl = false;
 
 	/**
 	 * Connection configuration.
@@ -159,7 +157,7 @@ public class CassandraProperties {
 		this.contactPoints = contactPoints;
 	}
 
-	public Integer getPort() {
+	public int getPort() {
 		return this.port;
 	}
 
@@ -199,7 +197,7 @@ public class CassandraProperties {
 		this.compression = compression;
 	}
 
-	public Boolean isSsl() {
+	public boolean isSsl() {
 		return this.ssl;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/cassandra/override-defaults.conf
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/cassandra/override-defaults.conf
@@ -1,0 +1,20 @@
+datastax-java-driver {
+  basic {
+    session-name = advanced session
+    load-balancing-policy {
+      local-datacenter = datacenter1
+    }
+    request.page-size = 11
+    contact-points = [ "1.2.3.4:5678" ]
+  }
+  advanced {
+    throttler {
+      max-concurrent-requests = 22
+      max-requests-per-second = 33
+      max-queue-size = 44
+    }
+    control-connection.timeout = 5555
+    protocol.compression = SNAPPY
+    resolve-contact-points = false
+  }
+}


### PR DESCRIPTION
This commit changes two things:

1. Most primitives on `CassandraProperties` are replaced with object values.    This allows distinguishing between default-values and no-values. Then   `CassandraAutoConfiguration.mapConfig()` can use `whenNonNull()` predicate    to ignore those.

2. `CassandraProperties` no longer populate default values that are overridable by `spring.data.cassandra.config` file. This let the defaults to be applied on top of the file   `spring.data.cassandra.config`; i.e. the config file have higher    precedence than the defaults, but lower that any `spring.data.cassandra.*`    property.

On the test side, the file `override-defaults.conf` is defined to override the values that were non-overridable with values which are different from the default.

---

In this proposal, the `spring.data.cassandra.port` configuration has a bit rough behaviour:

1. In case property `spring.data.cassandra.contact-points` is configured without a port - the value of `spring.data.cassandra.port` (which defaults to 9042) is used.

2. Otherwise, in case `contact-points` on `spring.data.cassandra.config` file are defined -- then the contact-points must be configured with a port (as the conf file provides no separate port property).

3. Otherwise, `contact-points` defaults to `127.0.0.1:9042` regardless of `spring.data.cassandra.port` configuration.

---

Closes gh-31025