### PR TITLE
Migrate to AuthorizationFilter in Spring Security auto-config

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/ManagementWebSecurityAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/ManagementWebSecurityAutoConfiguration.java
@@ -58,7 +58,7 @@ public class ManagementWebSecurityAutoConfiguration {
 	@Bean
 	@Order(SecurityProperties.BASIC_AUTH_ORDER)
 	SecurityFilterChain managementSecurityFilterChain(HttpSecurity http) throws Exception {
-		http.authorizeRequests((requests) -> {
+		http.authorizeHttpRequests((requests) -> {
 			requests.requestMatchers(EndpointRequest.to(HealthEndpoint.class)).permitAll();
 			requests.anyRequest().authenticated();
 		});

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/AbstractEndpointRequestIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/AbstractEndpointRequestIntegrationTests.java
@@ -183,7 +183,7 @@ abstract class AbstractEndpointRequestIntegrationTests {
 
 				@Override
 				protected void configure(HttpSecurity http) throws Exception {
-					http.authorizeRequests((requests) -> {
+					http.authorizeHttpRequests((requests) -> {
 						requests.requestMatchers(EndpointRequest.toLinks()).permitAll();
 						requests.requestMatchers(EndpointRequest.to(TestEndpoint1.class)).permitAll();
 						requests.requestMatchers(EndpointRequest.toAnyEndpoint()).authenticated();

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/ManagementWebSecurityAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/ManagementWebSecurityAutoConfigurationTests.java
@@ -179,7 +179,7 @@ class ManagementWebSecurityAutoConfigurationTests {
 
 		@Override
 		protected void configure(HttpSecurity http) throws Exception {
-			http.authorizeRequests((requests) -> {
+			http.authorizeHttpRequests((requests) -> {
 				requests.antMatchers("/foo").permitAll();
 				requests.anyRequest().authenticated();
 			});
@@ -194,7 +194,7 @@ class ManagementWebSecurityAutoConfigurationTests {
 
 		@Bean
 		SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
-			return http.antMatcher("/**").authorizeRequests((authorize) -> authorize.anyRequest().authenticated())
+			return http.antMatcher("/**").authorizeHttpRequests((authorize) -> authorize.anyRequest().authenticated())
 					.build();
 		}
 
@@ -206,8 +206,8 @@ class ManagementWebSecurityAutoConfigurationTests {
 		@Bean
 		@Order(SecurityProperties.BASIC_AUTH_ORDER - 1)
 		SecurityFilterChain testRemoteDevToolsSecurityFilterChain(HttpSecurity http) throws Exception {
-			return http.requestMatcher(new AntPathRequestMatcher("/**")).authorizeRequests().anyRequest().anonymous()
-					.and().csrf().disable().build();
+			return http.requestMatcher(new AntPathRequestMatcher("/**")).authorizeHttpRequests().anyRequest()
+					.anonymous().and().csrf().disable().build();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/servlet/OAuth2WebSecurityConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/servlet/OAuth2WebSecurityConfiguration.java
@@ -58,7 +58,7 @@ class OAuth2WebSecurityConfiguration {
 
 		@Bean
 		SecurityFilterChain oauth2SecurityFilterChain(HttpSecurity http) throws Exception {
-			http.authorizeRequests((requests) -> requests.anyRequest().authenticated());
+			http.authorizeHttpRequests((requests) -> requests.anyRequest().authenticated());
 			http.oauth2Login(Customizer.withDefaults());
 			http.oauth2Client();
 			return http.build();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
@@ -153,7 +153,7 @@ class OAuth2ResourceServerJwtConfiguration {
 		@Bean
 		@ConditionalOnBean(JwtDecoder.class)
 		SecurityFilterChain jwtSecurityFilterChain(HttpSecurity http) throws Exception {
-			http.authorizeRequests((requests) -> requests.anyRequest().authenticated());
+			http.authorizeHttpRequests((requests) -> requests.anyRequest().authenticated());
 			http.oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
 			return http.build();
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerOpaqueTokenConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerOpaqueTokenConfiguration.java
@@ -60,7 +60,7 @@ class OAuth2ResourceServerOpaqueTokenConfiguration {
 		@Bean
 		@ConditionalOnBean(OpaqueTokenIntrospector.class)
 		SecurityFilterChain opaqueTokenSecurityFilterChain(HttpSecurity http) throws Exception {
-			http.authorizeRequests((requests) -> requests.anyRequest().authenticated());
+			http.authorizeHttpRequests((requests) -> requests.anyRequest().authenticated());
 			http.oauth2ResourceServer(OAuth2ResourceServerConfigurer::opaqueToken);
 			return http.build();
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/saml2/Saml2LoginConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/saml2/Saml2LoginConfiguration.java
@@ -37,7 +37,7 @@ class Saml2LoginConfiguration {
 
 	@Bean
 	SecurityFilterChain samlSecurityFilterChain(HttpSecurity http) throws Exception {
-		http.authorizeRequests((requests) -> requests.anyRequest().authenticated()).saml2Login();
+		http.authorizeHttpRequests((requests) -> requests.anyRequest().authenticated()).saml2Login();
 		http.saml2Logout();
 		return http.build();
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/SpringBootWebSecurityConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/SpringBootWebSecurityConfiguration.java
@@ -54,7 +54,7 @@ class SpringBootWebSecurityConfiguration {
 		@Bean
 		@Order(SecurityProperties.BASIC_AUTH_ORDER)
 		SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
-			http.authorizeRequests().anyRequest().authenticated();
+			http.authorizeHttpRequests().anyRequest().authenticated();
 			http.formLogin();
 			http.httpBasic();
 			return http.build();

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/graphql/security/GraphQlWebMvcSecurityAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/graphql/security/GraphQlWebMvcSecurityAutoConfigurationTests.java
@@ -160,7 +160,7 @@ class GraphQlWebMvcSecurityAutoConfigurationTests {
 			return http.csrf((c) -> c.disable())
 					// Demonstrate that method security works
 					// Best practice to use both for defense in depth
-					.authorizeRequests((requests) -> requests.anyRequest().permitAll()).httpBasic(withDefaults())
+					.authorizeHttpRequests((requests) -> requests.anyRequest().permitAll()).httpBasic(withDefaults())
 					.build();
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/client/servlet/OAuth2WebSecurityConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/client/servlet/OAuth2WebSecurityConfigurationTests.java
@@ -241,7 +241,7 @@ class OAuth2WebSecurityConfigurationTests {
 
 		@Bean
 		SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
-			return http.antMatcher("/**").authorizeRequests((authorize) -> authorize.anyRequest().authenticated())
+			return http.antMatcher("/**").authorizeHttpRequests((authorize) -> authorize.anyRequest().authenticated())
 					.build();
 
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
@@ -692,7 +692,7 @@ class OAuth2ResourceServerAutoConfigurationTests {
 
 		@Bean
 		SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
-			return http.antMatcher("/**").authorizeRequests((authorize) -> authorize.anyRequest().authenticated())
+			return http.antMatcher("/**").authorizeHttpRequests((authorize) -> authorize.anyRequest().authenticated())
 					.build();
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyAutoConfigurationTests.java
@@ -321,7 +321,7 @@ class Saml2RelyingPartyAutoConfigurationTests {
 
 		@Bean
 		SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
-			return http.antMatcher("/**").authorizeRequests((authorize) -> authorize.anyRequest().authenticated())
+			return http.antMatcher("/**").authorizeHttpRequests((authorize) -> authorize.anyRequest().authenticated())
 					.build();
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/servlet/SecurityAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/servlet/SecurityAutoConfigurationTests.java
@@ -298,7 +298,7 @@ class SecurityAutoConfigurationTests {
 
 		@Bean
 		SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
-			return http.antMatcher("/**").authorizeRequests((authorize) -> authorize.anyRequest().authenticated())
+			return http.antMatcher("/**").authorizeHttpRequests((authorize) -> authorize.anyRequest().authenticated())
 					.build();
 
 		}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/RemoteDevtoolsSecurityConfiguration.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/RemoteDevtoolsSecurityConfiguration.java
@@ -50,7 +50,7 @@ class RemoteDevtoolsSecurityConfiguration {
 	@ConditionalOnMissingBean(org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter.class)
 	@SuppressWarnings("deprecation")
 	SecurityFilterChain devtoolsSecurityFilterChain(HttpSecurity http) throws Exception {
-		http.requestMatcher(new AntPathRequestMatcher(this.url)).authorizeRequests().anyRequest().anonymous().and()
+		http.requestMatcher(new AntPathRequestMatcher(this.url)).authorizeHttpRequests().anyRequest().anonymous().and()
 				.csrf().disable();
 		return http.build();
 	}

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/RemoteDevToolsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/RemoteDevToolsAutoConfigurationTests.java
@@ -277,7 +277,7 @@ class RemoteDevToolsAutoConfigurationTests {
 
 		@Override
 		protected void configure(HttpSecurity http) throws Exception {
-			http.antMatcher("/foo/**").authorizeRequests().anyRequest().authenticated().and().httpBasic();
+			http.antMatcher("/foo/**").authorizeHttpRequests().anyRequest().authenticated().and().httpBasic();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/actuator/endpoints/security/exposeall/MySecurityConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/actuator/endpoints/security/exposeall/MySecurityConfiguration.java
@@ -28,7 +28,7 @@ public class MySecurityConfiguration {
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http.requestMatcher(EndpointRequest.toAnyEndpoint());
-		http.authorizeRequests((requests) -> requests.anyRequest().permitAll());
+		http.authorizeHttpRequests((requests) -> requests.anyRequest().permitAll());
 		return http.build();
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/actuator/endpoints/security/typical/MySecurityConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/actuator/endpoints/security/typical/MySecurityConfiguration.java
@@ -30,7 +30,7 @@ public class MySecurityConfiguration {
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http.requestMatcher(EndpointRequest.toAnyEndpoint());
-		http.authorizeRequests((requests) -> requests.anyRequest().hasRole("ENDPOINT_ADMIN"));
+		http.authorizeHttpRequests((requests) -> requests.anyRequest().hasRole("ENDPOINT_ADMIN"));
 		http.httpBasic(withDefaults());
 		return http.build();
 	}

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/data/sql/h2webconsole/springsecurity/DevProfileSecurityConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/data/sql/h2webconsole/springsecurity/DevProfileSecurityConfiguration.java
@@ -34,7 +34,7 @@ public class DevProfileSecurityConfiguration {
 	@Order(Ordered.HIGHEST_PRECEDENCE)
 	SecurityFilterChain h2ConsoleSecurityFilterChain(HttpSecurity http) throws Exception {
 		http.requestMatcher(PathRequest.toH2Console());
-		http.authorizeRequests(yourCustomAuthorization());
+		http.authorizeHttpRequests(yourCustomAuthorization());
 		http.csrf((csrf) -> csrf.disable());
 		http.headers((headers) -> headers.frameOptions().sameOrigin());
 		return http.build();

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MyConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MyConfiguration.java
@@ -30,7 +30,7 @@ public class MyConfiguration {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.authorizeRequests((requests) -> requests.anyRequest().authenticated());
+		http.authorizeHttpRequests((requests) -> requests.anyRequest().authenticated());
 		return http.build();
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MySecurityConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MySecurityConfiguration.java
@@ -26,7 +26,7 @@ public class MySecurityConfiguration {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.authorizeRequests((requests) -> requests.anyRequest().authenticated());
+		http.authorizeHttpRequests((requests) -> requests.anyRequest().authenticated());
 		return http.build();
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/web/security/oauth2/client/MyOAuthClientConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/web/security/oauth2/client/MyOAuthClientConfiguration.java
@@ -26,7 +26,7 @@ public class MyOAuthClientConfiguration {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.authorizeRequests((requests) -> requests.anyRequest().authenticated());
+		http.authorizeHttpRequests((requests) -> requests.anyRequest().authenticated());
 		http.oauth2Login((login) -> login.redirectionEndpoint().baseUri("custom-callback"));
 		return http.build();
 	}

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/web/security/saml2/relyingparty/MySamlRelyingPartyConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/web/security/saml2/relyingparty/MySamlRelyingPartyConfiguration.java
@@ -26,7 +26,7 @@ public class MySamlRelyingPartyConfiguration {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.authorizeRequests().anyRequest().authenticated();
+		http.authorizeHttpRequests().anyRequest().authenticated();
 		http.saml2Login();
 		http.saml2Logout((saml2) -> saml2.logoutRequest((request) -> request.logoutUrl("/SLOService.saml2"))
 				.logoutResponse((response) -> response.logoutUrl("/SLOService.saml2")));

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/actuator/endpoints/security/exposeall/MySecurityConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/actuator/endpoints/security/exposeall/MySecurityConfiguration.kt
@@ -27,7 +27,7 @@ class MySecurityConfiguration {
 
 	@Bean
 	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-		http.requestMatcher(EndpointRequest.toAnyEndpoint()).authorizeRequests {
+		http.requestMatcher(EndpointRequest.toAnyEndpoint()).authorizeHttpRequests {
 				requests -> requests.anyRequest().permitAll() }
 		return http.build()
 	}

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/actuator/endpoints/security/typical/MySecurityConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/actuator/endpoints/security/typical/MySecurityConfiguration.kt
@@ -27,7 +27,7 @@ class MySecurityConfiguration {
 
 	@Bean
 	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-		http.requestMatcher(EndpointRequest.toAnyEndpoint()).authorizeRequests { requests ->
+		http.requestMatcher(EndpointRequest.toAnyEndpoint()).authorizeHttpRequests { requests ->
 			requests.anyRequest().hasRole("ENDPOINT_ADMIN")
 		}
 		http.httpBasic()

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/web/security/oauth2/client/MyOAuthClientConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/web/security/oauth2/client/MyOAuthClientConfiguration.kt
@@ -26,7 +26,7 @@ class MyOAuthClientConfiguration {
 
 	@Bean
 	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-		http.authorizeRequests().anyRequest().authenticated()
+		http.authorizeHttpRequests().anyRequest().authenticated()
 		http.oauth2Login().redirectionEndpoint().baseUri("custom-callback")
 		return http.build()
 	}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator-custom-security/src/main/java/smoketest/actuator/customsecurity/SecurityConfiguration.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator-custom-security/src/main/java/smoketest/actuator/customsecurity/SecurityConfiguration.java
@@ -55,7 +55,7 @@ public class SecurityConfiguration {
 
 	@Bean
 	SecurityFilterChain configure(HttpSecurity http) throws Exception {
-		http.authorizeRequests((requests) -> {
+		http.authorizeHttpRequests((requests) -> {
 			requests.mvcMatchers("/actuator/beans").hasRole("BEANS");
 			requests.requestMatchers(EndpointRequest.to("health")).permitAll();
 			requests.requestMatchers(EndpointRequest.toAnyEndpoint().excluding(MappingsEndpoint.class))

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-graphql/src/main/java/smoketest/graphql/SecurityConfig.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-graphql/src/main/java/smoketest/graphql/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
 		return http.csrf((csrf) -> csrf.disable())
 				// Demonstrate that method security works
 				// Best practice to use both for defense in depth
-				.authorizeRequests((requests) -> requests.anyRequest().permitAll()).httpBasic(withDefaults()).build();
+				.authorizeHttpRequests((requests) -> requests.anyRequest().permitAll()).httpBasic(withDefaults())
+				.build();
 	}
 
 	@Bean

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-secure-jersey/src/main/java/smoketest/secure/jersey/SecurityConfiguration.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-secure-jersey/src/main/java/smoketest/secure/jersey/SecurityConfiguration.java
@@ -41,7 +41,7 @@ public class SecurityConfiguration {
 	@Bean
 	SecurityFilterChain configure(HttpSecurity http) throws Exception {
 		// @formatter:off
-		http.authorizeRequests()
+		http.authorizeHttpRequests()
 				.requestMatchers(EndpointRequest.to("health")).permitAll()
 				.requestMatchers(EndpointRequest.toAnyEndpoint().excluding(MappingsEndpoint.class)).hasRole("ACTUATOR")
 				.antMatchers("/**").hasRole("USER")

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-method-security/src/main/java/smoketest/security/method/SampleMethodSecurityApplication.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-method-security/src/main/java/smoketest/security/method/SampleMethodSecurityApplication.java
@@ -69,8 +69,8 @@ public class SampleMethodSecurityApplication implements WebMvcConfigurer {
 		@Bean
 		SecurityFilterChain configure(HttpSecurity http) throws Exception {
 			http.csrf().disable();
-			http.authorizeRequests((requests) -> requests.anyRequest().fullyAuthenticated()
-					.filterSecurityInterceptorOncePerRequest(true));
+			http.authorizeHttpRequests(
+					(requests) -> requests.anyRequest().fullyAuthenticated().shouldFilterAllDispatcherTypes(false));
 			http.formLogin((form) -> form.loginPage("/login").permitAll());
 			http.exceptionHandling((exceptions) -> exceptions.accessDeniedPage("/access"));
 			return http.build();
@@ -86,8 +86,8 @@ public class SampleMethodSecurityApplication implements WebMvcConfigurer {
 		SecurityFilterChain actuatorSecurity(HttpSecurity http) throws Exception {
 			http.csrf().disable();
 			http.requestMatcher(EndpointRequest.toAnyEndpoint());
-			http.authorizeRequests(
-					(requests) -> requests.anyRequest().authenticated().filterSecurityInterceptorOncePerRequest(true));
+			http.authorizeHttpRequests(
+					(requests) -> requests.anyRequest().authenticated().shouldFilterAllDispatcherTypes(false));
 			http.httpBasic();
 			return http.build();
 		}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure-custom/src/main/java/smoketest/web/secure/custom/SampleWebSecureCustomApplication.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure-custom/src/main/java/smoketest/web/secure/custom/SampleWebSecureCustomApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public class SampleWebSecureCustomApplication implements WebMvcConfigurer {
 		@Bean
 		SecurityFilterChain configure(HttpSecurity http) throws Exception {
 			http.csrf().disable();
-			http.authorizeRequests((requests) -> requests.anyRequest().fullyAuthenticated());
+			http.authorizeHttpRequests((requests) -> requests.anyRequest().fullyAuthenticated());
 			http.formLogin((form) -> form.loginPage("/login").permitAll());
 			return http.build();
 		}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure-jdbc/src/main/java/smoketest/web/secure/jdbc/SampleWebSecureJdbcApplication.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure-jdbc/src/main/java/smoketest/web/secure/jdbc/SampleWebSecureJdbcApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ public class SampleWebSecureJdbcApplication implements WebMvcConfigurer {
 		@Bean
 		SecurityFilterChain configure(HttpSecurity http) throws Exception {
 			http.csrf().disable();
-			http.authorizeRequests((requests) -> requests.anyRequest().fullyAuthenticated());
+			http.authorizeHttpRequests((requests) -> requests.anyRequest().fullyAuthenticated());
 			http.formLogin((form) -> form.loginPage("/login").permitAll());
 			return http.build();
 		}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure/src/test/java/smoketest/web/secure/AbstractErrorPageTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure/src/test/java/smoketest/web/secure/AbstractErrorPageTests.java
@@ -50,7 +50,7 @@ abstract class AbstractErrorPageTests {
 	@Test
 	void testBadCredentials() {
 		final ResponseEntity<JsonNode> response = this.testRestTemplate.withBasicAuth("username", "wrongpassword")
-				.exchange("/test", HttpMethod.GET, null, JsonNode.class);
+				.exchange(this.pathPrefix + "/test", HttpMethod.GET, null, JsonNode.class);
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
 		JsonNode jsonResponse = response.getBody();
 		assertThat(jsonResponse).isNull();

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure/src/test/java/smoketest/web/secure/CustomServletPathErrorPageTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure/src/test/java/smoketest/web/secure/CustomServletPathErrorPageTests.java
@@ -44,10 +44,10 @@ class CustomServletPathErrorPageTests extends AbstractErrorPageTests {
 
 		@Bean
 		SecurityFilterChain configure(HttpSecurity http) throws Exception {
-			http.authorizeRequests((requests) -> {
+			http.authorizeHttpRequests((requests) -> {
 				requests.antMatchers("/custom/servlet/path/public/**").permitAll();
 				requests.anyRequest().fullyAuthenticated();
-				requests.filterSecurityInterceptorOncePerRequest(true);
+				requests.shouldFilterAllDispatcherTypes(false);
 			});
 			http.httpBasic();
 			http.formLogin((form) -> form.loginPage("/custom/servlet/path/login").permitAll());

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure/src/test/java/smoketest/web/secure/CustomServletPathUnauthenticatedErrorPageTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure/src/test/java/smoketest/web/secure/CustomServletPathUnauthenticatedErrorPageTests.java
@@ -43,7 +43,7 @@ class CustomServletPathUnauthenticatedErrorPageTests extends AbstractUnauthentic
 
 		@Bean
 		SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
-			http.authorizeRequests((requests) -> {
+			http.authorizeHttpRequests((requests) -> {
 				requests.antMatchers("/custom/servlet/path/error").permitAll();
 				requests.antMatchers("/custom/servlet/path/public/**").permitAll();
 				requests.anyRequest().authenticated();

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure/src/test/java/smoketest/web/secure/ErrorPageTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure/src/test/java/smoketest/web/secure/ErrorPageTests.java
@@ -43,10 +43,10 @@ class ErrorPageTests extends AbstractErrorPageTests {
 
 		@Bean
 		SecurityFilterChain configure(HttpSecurity http) throws Exception {
-			http.authorizeRequests((requests) -> {
+			http.authorizeHttpRequests((requests) -> {
 				requests.antMatchers("/public/**").permitAll();
 				requests.anyRequest().fullyAuthenticated();
-				requests.filterSecurityInterceptorOncePerRequest(true);
+				requests.shouldFilterAllDispatcherTypes(false);
 			});
 			http.httpBasic();
 			http.formLogin((form) -> form.loginPage("/login").permitAll());

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure/src/test/java/smoketest/web/secure/NoSessionErrorPageTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure/src/test/java/smoketest/web/secure/NoSessionErrorPageTests.java
@@ -45,10 +45,10 @@ class NoSessionErrorPageTests extends AbstractErrorPageTests {
 		@Bean
 		SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
 			http.sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-					.authorizeRequests((requests) -> {
+					.authorizeHttpRequests((requests) -> {
 						requests.antMatchers("/public/**").permitAll();
 						requests.anyRequest().authenticated();
-						requests.filterSecurityInterceptorOncePerRequest(true);
+						requests.shouldFilterAllDispatcherTypes(false);
 					});
 			http.httpBasic();
 			return http.build();

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure/src/test/java/smoketest/web/secure/SampleWebSecureApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure/src/test/java/smoketest/web/secure/SampleWebSecureApplicationTests.java
@@ -95,7 +95,7 @@ class SampleWebSecureApplicationTests {
 		@Bean
 		SecurityFilterChain configure(HttpSecurity http) throws Exception {
 			http.csrf().disable();
-			http.authorizeRequests((requests) -> {
+			http.authorizeHttpRequests((requests) -> {
 				requests.antMatchers("/public/**").permitAll();
 				requests.anyRequest().fullyAuthenticated();
 			});

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure/src/test/java/smoketest/web/secure/UnauthenticatedErrorPageTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-secure/src/test/java/smoketest/web/secure/UnauthenticatedErrorPageTests.java
@@ -43,7 +43,7 @@ class UnauthenticatedErrorPageTests extends AbstractUnauthenticatedErrorPageTest
 
 		@Bean
 		SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
-			http.authorizeRequests((requests) -> {
+			http.authorizeHttpRequests((requests) -> {
 				requests.antMatchers("/error").permitAll();
 				requests.antMatchers("/public/**").permitAll();
 				requests.anyRequest().authenticated();


### PR DESCRIPTION
This commit updates Servlet based Spring Security auto-configuration to use `AuthorizationFilter`, which is intended to superseed `FilterSecurityInterceptor`.

See note in [Authorize HttpServletRequests with AuthorizationFilter section](https://docs.spring.io/spring-security/reference/6.0.0-M5/servlet/authorization/authorize-http-requests.html) of Spring Security's reference manual.

Note that `SampleActuatorCustomSecurityApplicationTests#testInsecureApplicationPath` fails after migrating to the new authorization model, meaning further changes might be needed in either Spring Boot or Spring Security.