### PR TITLE
Update smoke tests to avoid conflicts with NAME environment variable

### DIFF
--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-aop/src/main/java/smoketest/aop/service/HelloWorldService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-aop/src/main/java/smoketest/aop/service/HelloWorldService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class HelloWorldService {
 
-	@Value("${name:World}")
+	@Value("${test.name:World}")
 	private String name;
 
 	public String getHelloMessage() {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-aop/src/main/resources/application.properties
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-aop/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-name: Phil
+test.name: Phil

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-aop/src/test/java/smoketest/aop/SampleAopApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-aop/src/test/java/smoketest/aop/SampleAopApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ class SampleAopApplicationTests {
 
 	@Test
 	void testCommandLineOverrides(CapturedOutput output) {
-		SampleAopApplication.main(new String[] { "--name=Gordon" });
+		SampleAopApplication.main(new String[] { "--test.name=Gordon" });
 		assertThat(output).contains("Hello Gordon");
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/service/HelloWorldService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/service/HelloWorldService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class HelloWorldService {
 
-	@Value("${name:World}")
+	@Value("${test.name:World}")
 	private String name;
 
 	public String getHelloMessage() {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/application.yml
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/application.yml
@@ -1,1 +1,1 @@
-hello: Bonjour
+test.hello: Bonjour

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/src/main/java/smoketest/profile/SampleProfileApplication.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/src/main/java/smoketest/profile/SampleProfileApplication.java
@@ -30,7 +30,7 @@ public class SampleProfileApplication implements CommandLineRunner {
 
 	// Simple example shows how a command line spring application can execute an
 	// injected bean service. Also demonstrates how you can use @Value to inject
-	// command line args ('--name=whatever') or application properties
+	// command line args ('--test.name=whatever') or application properties
 
 	@Autowired
 	private MessageService helloWorldService;

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/src/main/java/smoketest/profile/service/GenericService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/src/main/java/smoketest/profile/service/GenericService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,10 @@ import org.springframework.stereotype.Component;
 @Profile({ "generic" })
 public class GenericService implements MessageService {
 
-	@Value("${hello:Hello}")
+	@Value("${test.hello:Hello}")
 	private String hello;
 
-	@Value("${name:World}")
+	@Value("${test.name:World}")
 	private String name;
 
 	@Override

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/src/main/java/smoketest/profile/service/GoodbyeWorldService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/src/main/java/smoketest/profile/service/GoodbyeWorldService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Component;
 @Profile("goodbye")
 public class GoodbyeWorldService implements MessageService {
 
-	@Value("${name:World}")
+	@Value("${test.name:World}")
 	private String name;
 
 	@Override

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/src/main/java/smoketest/profile/service/HelloWorldService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/src/main/java/smoketest/profile/service/HelloWorldService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Component;
 @Profile({ "hello", "default" })
 public class HelloWorldService implements MessageService {
 
-	@Value("${name:World}")
+	@Value("${test.name:World}")
 	private String name;
 
 	@Override

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/src/main/resources/application.yml
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/src/main/resources/application.yml
@@ -1,6 +1,6 @@
-name: Phil
+test.name: Phil
 
 ---
 
 spring.config.activate.on-profile: goodbye | dev
-name: Everyone
+test.name: Everyone

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/src/test/java/smoketest/profile/SampleProfileApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-profile/src/test/java/smoketest/profile/SampleProfileApplicationTests.java
@@ -65,7 +65,7 @@ class SampleProfileApplicationTests {
 		 * This is a profile that requires a new environment property, and one which is
 		 * only overridden in the current working directory. That file also only contains
 		 * partial overrides, and the default application.yml should still supply the
-		 * "name" property.
+		 * "test.name" property.
 		 */
 		System.setProperty("spring.profiles.active", "generic");
 		SampleProfileApplication.main();

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-simple/src/main/java/smoketest/simple/SampleSimpleApplication.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-simple/src/main/java/smoketest/simple/SampleSimpleApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ public class SampleSimpleApplication implements CommandLineRunner {
 
 	// Simple example shows how a command line spring application can execute an
 	// injected bean service. Also demonstrates how you can use @Value to inject
-	// command line args ('--name=whatever') or application properties
+	// command line args ('--test.name=whatever') or application properties
 
 	@Autowired
 	private HelloWorldService helloWorldService;

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-simple/src/main/java/smoketest/simple/service/HelloWorldService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-simple/src/main/java/smoketest/simple/service/HelloWorldService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class HelloWorldService {
 
-	@Value("${name:World}")
+	@Value("${test.name:World}")
 	private String name;
 
-	@Value("${duration:10s}")
+	@Value("${test.duration:10s}")
 	private Duration duration;
 
 	public String getHelloMessage() {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-simple/src/main/resources/application.properties
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-simple/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-name=Phil
+test.name=Phil
 sample.name=Andy
 
 spring.banner.image.bitdepth=8

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-simple/src/test/java/smoketest/simple/SampleSimpleApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-simple/src/test/java/smoketest/simple/SampleSimpleApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ class SampleSimpleApplicationTests {
 
 	@Test
 	void testCommandLineOverrides(CapturedOutput output) {
-		SampleSimpleApplication.main(new String[] { "--name=Gordon", "--duration=1m" });
+		SampleSimpleApplication.main(new String[] { "--test.name=Gordon", "--test.duration=1m" });
 		assertThat(output).contains("Hello Gordon for 60 seconds");
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-testng/src/main/java/smoketest/testng/service/HelloWorldService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-testng/src/main/java/smoketest/testng/service/HelloWorldService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class HelloWorldService {
 
-	@Value("${name:World}")
+	@Value("${test.name:World}")
 	private String name;
 
 	public String getHelloMessage() {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/service/HelloWorldService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/service/HelloWorldService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class HelloWorldService {
 
-	@Value("${name:World}")
+	@Value("${test.name:World}")
 	private String name;
 
 	public String getHelloMessage() {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-xml/src/main/java/smoketest/xml/service/HelloWorldService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-xml/src/main/java/smoketest/xml/service/HelloWorldService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class HelloWorldService {
 
-	@Value("${name:World}")
+	@Value("${test.name:World}")
 	private String name;
 
 	public String getHelloMessage() {


### PR DESCRIPTION
This commit updates several smoke tests in order to avoid conflicts with `NAME` environment variable that is present in WSL and causes project build to fail. Previous attempt to fix this in 7da42d71 (see #31076) was incomplete.