### PR TITLE
Fix typo in name of imports file in javadoc of ImportCandidates.from

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/annotation/ImportCandidates.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/annotation/ImportCandidates.java
@@ -61,7 +61,7 @@ public final class ImportCandidates implements Iterable<String> {
 	 * Loads the names of import candidates from the classpath.
 	 *
 	 * The names of the import candidates are stored in files named
-	 * {@code META-INF/spring/full-qualified-annotation-name.import} on the classpath.
+	 * {@code META-INF/spring/full-qualified-annotation-name.imports} on the classpath.
 	 * Every line contains the full qualified name of the candidate class. Comments are
 	 * supported using the # character.
 	 * @param annotation annotation to load


### PR DESCRIPTION
As the title says.