### PR TITLE
Enable Links for the Javadoc of the Gradle Plugin

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
@@ -97,6 +97,8 @@ javadoc {
 		splitIndex = true
 		use = true
 		windowTitle = "Spring Boot Gradle Plugin ${project.version} API"
+		links "https://docs.gradle.org/$gradle.gradleVersion/javadoc/"
+		links "https://docs.oracle.com/javase/8/docs/api/"
 	}
 }
 


### PR DESCRIPTION
The main "api" Javadoc has its links configured here: https://github.com/spring-projects/spring-boot/blob/4c23d2c45b429f47633358ac77d9012d3815aa60/spring-boot-project/spring-boot-docs/build.gradle#L207-L214

The Javadoc for the Gradle Plugin does not have links at the moment.