### PR TITLE
Add null check on throws exception indicating malformed json if null

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
@@ -16,10 +16,7 @@
 
 package org.springframework.boot.json;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.springframework.util.StringUtils;
 
@@ -100,6 +97,9 @@ public class BasicJsonParser extends AbstractJsonParser {
 		json = trimLeadingCharacter(trimTrailingCharacter(json, '}'), '{').trim();
 		for (String pair : tokenize(json)) {
 			String[] values = StringUtils.trimArrayElements(StringUtils.split(pair, ":"));
+			if (values == null) {
+				throw new JsonParseException();
+			}
 			String key = trimLeadingCharacter(trimTrailingCharacter(values[0], '"'), '"');
 			Object value = parseInternal(values[1]);
 			map.put(key, value);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/json/AbstractJsonParserTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/json/AbstractJsonParserTests.java
@@ -38,13 +38,6 @@ abstract class AbstractJsonParserTests {
 	protected abstract JsonParser getParser();
 
 	@Test
-	void malformedJson() {
-		String input = "[tru,erqett,{\"foo\":fatrue,true,true,true,tr''ue}]";
-		List<Object> list = this.parser.parseList(input);
-		assertThat(list).hasSize(3);
-	}
-
-	@Test
 	void simpleMap() {
 		Map<String, Object> map = this.parser.parseMap("{\"foo\":\"bar\",\"spam\":1}");
 		assertThat(map).hasSize(2);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/json/AbstractJsonParserTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/json/AbstractJsonParserTests.java
@@ -38,6 +38,13 @@ abstract class AbstractJsonParserTests {
 	protected abstract JsonParser getParser();
 
 	@Test
+	void malformedJson() {
+		String input = "[tru,erqett,{\"foo\":fatrue,true,true,true,tr''ue}]";
+		List<Object> list = this.parser.parseList(input);
+		assertThat(list).hasSize(3);
+	}
+
+	@Test
 	void simpleMap() {
 		Map<String, Object> map = this.parser.parseMap("{\"foo\":\"bar\",\"spam\":1}");
 		assertThat(map).hasSize(2);


### PR DESCRIPTION
This fixes this issue [#31301 ](https://github.com/spring-projects/spring-boot/issues/31301 ). 

This problem only applies to the BasicJsonParser since the other parser return exceptions that give details of the malformed JSON.

I choose the exception that the JacksonJsonParser returns on malformed JSON, JsonParseException. the GsonJsonParser returns a MalformedJsonException.

![image](https://user-images.githubusercontent.com/28783306/172761551-eff80ba8-e8cd-4d4b-8192-ba8d5fd8a82f.png)


Not sure exactly if the project has a preferable way of handling null cases like this. 

Didn't add the proposed test from the issue because I suspect there will be another PR to write tests for malformed JSON that assert the exception on malformed JSON parsing. 



