### PR TITLE
Disable H2 Optimize Reuse Results

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.java
@@ -53,7 +53,8 @@ public enum EmbeddedDatabaseConnection {
 	 * H2 Database Connection.
 	 */
 	H2(EmbeddedDatabaseType.H2, DatabaseDriver.H2.getDriverClassName(),
-			"jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE", (url) -> url.contains(":h2:mem")),
+			"jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;OPTIMIZE_REUSE_RESULTS=FALSE",
+			(url) -> url.contains(":h2:mem")),
 
 	/**
 	 * Derby Database Connection.

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnectionTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnectionTests.java
@@ -46,7 +46,7 @@ class EmbeddedDatabaseConnectionTests {
 	@Test
 	void h2CustomDatabaseName() {
 		assertThat(EmbeddedDatabaseConnection.H2.getUrl("mydb"))
-				.isEqualTo("jdbc:h2:mem:mydb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+				.isEqualTo("jdbc:h2:mem:mydb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;OPTIMIZE_REUSE_RESULTS=FALSE");
 	}
 
 	@Test


### PR DESCRIPTION
We recently updated to Spring Boot 2.7 and were hit by some strange issues with the new H2 2.x. After some analysis it turns out that there is some bug in how subqueries are evaluated and sometimes leading to wrong query results. 

The issue has been reported to H2 (https://github.com/h2database/h2database/issues/3534). The workaround currently is to disable optmize reuse of results by setting `;OPTIMIZE_REUSE_RESULTS=FALSE`. 

My proposal would be to automatically disable this for the Spring Boot auto generated in memory URL and remove it once the bug is fixed in H2 and Spring Boot upgrades to the new H2 version. 

I would also understand if you decide not to go down this path and reject this PR.