### PR TITLE
Add PropertyMapper toInstance that tolerates filtered values

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/PropertyMapper.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/PropertyMapper.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.util.function.SingletonSupplier;
@@ -302,27 +303,31 @@ public final class PropertyMapper {
 		 * @throws NoSuchElementException if the value has been filtered
 		 */
 		public <R> R toInstance(Function<T, R> factory) {
-			Assert.notNull(factory, "Factory must not be null");
-			T value = this.supplier.get();
-			if (!this.predicate.test(value)) {
-				throw new NoSuchElementException("No value present");
-			}
-			return factory.apply(value);
+			return toInstance(factory, true);
 		}
 
 		/**
-		 * Complete the mapping by creating a new instance
+		 * Complete the mapping by creating a new instance from the non-filtered value.
 		 * @param <R> the resulting type
 		 * @param factory the factory used to create the instance
-		 * @return the created instance or empty when the value is filtered
+		 * @param failIfFiltered whether to throw exception or return {@code null} if the
+		 * value has been filtered
+		 * @return the instance or {@code null} if the value has been filtered and
+		 * {@code failIfFiltered} is {@code false}
+		 * @throws NoSuchElementException if the value has been filtered and
+		 * {@code failIfFiltered} is {@code true}
 		 */
-		public <R> Optional<R> toOptionalInstance(Function<T, R> factory) {
+		@Nullable
+		public <R> R toInstance(Function<T, R> factory, boolean failIfFiltered) {
 			Assert.notNull(factory, "Factory must not be null");
 			T value = this.supplier.get();
 			if (!this.predicate.test(value)) {
-				return Optional.empty();
+				if (failIfFiltered) {
+					throw new NoSuchElementException("No value present");
+				}
+				return null;
 			}
-			return Optional.ofNullable(factory.apply(value));
+			return factory.apply(value);
 		}
 
 		/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/PropertyMapper.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/PropertyMapper.java
@@ -18,6 +18,7 @@ package org.springframework.boot.context.properties;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -310,20 +311,18 @@ public final class PropertyMapper {
 		}
 
 		/**
-		 * Complete the mapping by creating a new instance from the non-filtered value or
-		 * using the specified default instance when the value is filtered.
+		 * Complete the mapping by creating a new instance from the non-filtered value.
 		 * @param <R> the resulting type
 		 * @param factory the factory used to create the instance
-		 * @param defaultInstance the instance to use if the value has been filtered
-		 * @return the instance
+		 * @return the created instance or empty when the value is filtered
 		 */
-		public <R> R toInstance(Function<T, R> factory, R defaultInstance) {
+		public <R> Optional<R> toOptionalInstance(Function<T, R> factory) {
 			Assert.notNull(factory, "Factory must not be null");
 			T value = this.supplier.get();
 			if (!this.predicate.test(value)) {
-				return defaultInstance;
+				return Optional.empty();
 			}
-			return factory.apply(value);
+			return Optional.ofNullable(factory.apply(value));
 		}
 
 		/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/PropertyMapper.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/PropertyMapper.java
@@ -311,7 +311,7 @@ public final class PropertyMapper {
 		}
 
 		/**
-		 * Complete the mapping by creating a new instance from the non-filtered value.
+		 * Complete the mapping by creating a new instance
 		 * @param <R> the resulting type
 		 * @param factory the factory used to create the instance
 		 * @return the created instance or empty when the value is filtered

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/PropertyMapper.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/PropertyMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ import org.springframework.util.function.SingletonSupplier;
  *
  * @author Phillip Webb
  * @author Artsiom Yudovin
+ * @author Chris Bono
  * @since 2.0.0
  */
 public final class PropertyMapper {
@@ -304,6 +305,23 @@ public final class PropertyMapper {
 			T value = this.supplier.get();
 			if (!this.predicate.test(value)) {
 				throw new NoSuchElementException("No value present");
+			}
+			return factory.apply(value);
+		}
+
+		/**
+		 * Complete the mapping by creating a new instance from the non-filtered value or
+		 * using the specified default instance when the value is filtered.
+		 * @param <R> the resulting type
+		 * @param factory the factory used to create the instance
+		 * @param defaultInstance the instance to use if the value has been filtered
+		 * @return the instance
+		 */
+		public <R> R toInstance(Function<T, R> factory, R defaultInstance) {
+			Assert.notNull(factory, "Factory must not be null");
+			T value = this.supplier.get();
+			if (!this.predicate.test(value)) {
+				return defaultInstance;
 			}
 			return factory.apply(value);
 		}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/PropertyMapperTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/PropertyMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  *
  * @author Phillip Webb
  * @author Artsiom Yudovin
+ * @author Chris Bono
  */
 class PropertyMapperTests {
 
@@ -205,6 +206,24 @@ class PropertyMapperTests {
 	void whenWhenValueMatchesShouldSupportChainedCalls() {
 		String result = this.map.from("123").when((s) -> s.contains("2")).when("123"::equals).toInstance(String::new);
 		assertThat(result).isEqualTo("123");
+	}
+
+	@Test
+	void whenValueNotFilteredIsInstanceWithDefaultShouldReturnFactoryInstance() {
+		String result = this.map.from("123").when((s) -> s.contains("2")).toInstance(String::new, "foo");
+		assertThat(result).isEqualTo("123");
+	}
+
+	@Test
+	void whenValueFilteredIsInstanceWithDefaultShouldReturnDefault() {
+		String result = this.map.from("123").when((s) -> s.contains("x")).toInstance(String::new, "foo");
+		assertThat(result).isEqualTo("foo");
+	}
+
+	@Test
+	void whenValueFilteredIsInstanceWithNullDefaultShouldReturnNull() {
+		String result = this.map.from("123").when((s) -> s.contains("x")).toInstance(String::new, null);
+		assertThat(result).isNull();
 	}
 
 	static class Count<T> implements Supplier<T> {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/PropertyMapperTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/PropertyMapperTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.context.properties;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Assertions;
@@ -209,21 +210,21 @@ class PropertyMapperTests {
 	}
 
 	@Test
-	void whenValueNotFilteredIsInstanceWithDefaultShouldReturnFactoryInstance() {
-		String result = this.map.from("123").when((s) -> s.contains("2")).toInstance(String::new, "foo");
-		assertThat(result).isEqualTo("123");
+	void toOptionalInstanceWithNonFilteredValueShouldReturnFactoryValue() {
+		Optional<String> result = this.map.from("123").whenEqualTo("123").toOptionalInstance(String::new);
+		assertThat(result).isNotEmpty().hasValue("123");
 	}
 
 	@Test
-	void whenValueFilteredIsInstanceWithDefaultShouldReturnDefault() {
-		String result = this.map.from("123").when((s) -> s.contains("x")).toInstance(String::new, "foo");
-		assertThat(result).isEqualTo("foo");
+	void toOptionalInstanceWithNonFilteredValueShouldTolerateNullFactoryValue() {
+		Optional<String> result = this.map.from("123").whenEqualTo("123").toOptionalInstance((s) -> null);
+		assertThat(result).isEmpty();
 	}
 
 	@Test
-	void whenValueFilteredIsInstanceWithNullDefaultShouldReturnNull() {
-		String result = this.map.from("123").when((s) -> s.contains("x")).toInstance(String::new, null);
-		assertThat(result).isNull();
+	void toOptionalInstanceWithFilteredValueShouldReturnEmpty() {
+		Optional<String> result = this.map.from("123").whenEqualTo("foo").toOptionalInstance(String::new);
+		assertThat(result).isEmpty();
 	}
 
 	static class Count<T> implements Supplier<T> {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/PropertyMapperTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/PropertyMapperTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.context.properties;
 
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Assertions;
@@ -210,21 +209,21 @@ class PropertyMapperTests {
 	}
 
 	@Test
-	void toOptionalInstanceWithNonFilteredValueShouldReturnFactoryValue() {
-		Optional<String> result = this.map.from("123").whenEqualTo("123").toOptionalInstance(String::new);
-		assertThat(result).isNotEmpty().hasValue("123");
+	void toInstanceWithoutFailFlagWithNonFilteredValueShouldReturnFactoryValue() {
+		String result = this.map.from("123").whenEqualTo("123").toInstance(String::new, false);
+		assertThat(result).isEqualTo("123");
 	}
 
 	@Test
-	void toOptionalInstanceWithNonFilteredValueShouldTolerateNullFactoryValue() {
-		Optional<String> result = this.map.from("123").whenEqualTo("123").toOptionalInstance((s) -> null);
-		assertThat(result).isEmpty();
+	void toInstanceWithoutFailFlagWithNonFilteredValueShouldTolerateNullFactoryValue() {
+		String result = this.map.from("123").whenEqualTo("123").toInstance((s) -> null, false);
+		assertThat(result).isNull();
 	}
 
 	@Test
-	void toOptionalInstanceWithFilteredValueShouldReturnEmpty() {
-		Optional<String> result = this.map.from("123").whenEqualTo("foo").toOptionalInstance(String::new);
-		assertThat(result).isEmpty();
+	void toInstanceWithoutFailFlagWithFilteredValueShouldReturnNull() {
+		String result = this.map.from("123").whenEqualTo("foo").toInstance(String::new, false);
+		assertThat(result).isNull();
 	}
 
 	static class Count<T> implements Supplier<T> {


### PR DESCRIPTION
### Overview 
This proposal adds an API to `PropertyMapper.isInstance` that returns a user-specified default instance when the mapped value has been filtered. The current behavior is to throw an exception when the mapped value has been filtered.

###  Motivation
Some target objects are immutable and return a new instance w/ the mapped value rather than updating the value on the target instance. Consider the following example:

```java
class Target {

  private String foo;

  Target(String foo) {
     this.foo = foo;
  }
  
  Target updateFoo(String foo) {
    return new Target(foo);
  }
}
```
And suppose we have some config prop for "foo" and we want to update the target object's "foo" w/ that value. Typically we would use something like:
```java
PropertyMapper.get().from(someProps::foo).to(someTarget::updateFoo);
```
However, `Source.to()` does not work in the immutable case because `updateFoo` returns the new updated instance. Ok, lets instead use `Source.toInstance()` such as:
```java
someTarget =  PropertyMapper.get().from(someProps::foo).toInstance(someTarget::updateFoo);
```
This works fine when the value is not filtered. However, if we add some constraints on the mapper such as:
```java
someTarget =  PropertyMapper.get().from(someProps::foo).whenNonNull().toInstance(someTarget::updateFoo);
```
throws a `NoSuchElementException` when `someProps::foo` is null. This results in having to test the filter predicate manually prior to calling `toInstance`. 

### Proposed Solution
Allow the caller to pass in a default instance to use when the value is filtered (rather than throw exception). Something like this:
```java
someTarget =  PropertyMapper.get().from(someProps::foo).whenNonNull().toInstance(someTarget::updateFoo, someTarget);
```

You can see where I have worked around this in https://github.com/spring-projects/spring-boot/pull/31258/files#diff-7f2cc68fbde121f72bcff98a44dc29738be96efb911ffc54b80b6a6dd334b5ccR60

