### PR TITLE
Upgrade to Bouncycastle 1.71

### DIFF
--- a/ci/images/releasescripts/pom.xml
+++ b/ci/images/releasescripts/pom.xml
@@ -21,8 +21,8 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcpg-jdk15to18</artifactId>
-			<version>1.68</version>
+			<artifactId>bcpg-jdk18on</artifactId>
+			<version>1.71</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/build.gradle
@@ -17,6 +17,6 @@ dependencies {
 	testImplementation("org.springframework:spring-test")
 
 	testRuntimeOnly("ch.qos.logback:logback-classic")
-	testRuntimeOnly("org.bouncycastle:bcprov-jdk16:1.46")
+	testRuntimeOnly("org.bouncycastle:bcprov-jdk18on:1.71")
 	testRuntimeOnly("org.springframework:spring-webmvc")
 }

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-loader-tests/spring-boot-loader-tests-signed-jar-unpack-app/build.gradle
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-loader-tests/spring-boot-loader-tests-signed-jar-unpack-app/build.gradle
@@ -14,7 +14,7 @@ repositories {
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter")
-	implementation("org.bouncycastle:bcprov-jdk15on:1.70")
+	implementation("org.bouncycastle:bcprov-jdk18on:1.71")
 }
 
 bootJar {


### PR DESCRIPTION
BouncyCastle changed its artifact name suffix from `jdk15on` to `jdk18on` in the latest releases, as it now requires at least Java 1.8
