### PR TITLE
Static-import Mockito.mock()

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfigurationTests.java
@@ -21,7 +21,6 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.wavefront.WavefrontConfig;
 import io.micrometer.wavefront.WavefrontMeterRegistry;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -98,7 +97,7 @@ class WavefrontMetricsExportAutoConfigurationTests {
 
 		@Bean
 		WavefrontSender customWavefrontSender() {
-			return Mockito.mock(WavefrontSender.class);
+			return mock(WavefrontSender.class);
 		}
 
 		@Bean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationAutoConfigurationTests.java
@@ -36,7 +36,6 @@ import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.handler.TracingObservationHandler;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
-import org.mockito.Mockito;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.test.MetricsRun;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -49,6 +48,7 @@ import org.springframework.core.annotation.Order;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link ObservationAutoConfiguration}.
@@ -290,7 +290,7 @@ class ObservationAutoConfigurationTests {
 
 	private static class CustomTracingObservationHandler implements TracingObservationHandler<Context> {
 
-		private final Tracer tracer = Mockito.mock(Tracer.class, Answers.RETURNS_MOCKS);
+		private final Tracer tracer = mock(Tracer.class, Answers.RETURNS_MOCKS);
 
 		private final String name;
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfigurationTests.java
@@ -34,7 +34,6 @@ import io.micrometer.tracing.brave.bridge.BraveHttpServerHandler;
 import io.micrometer.tracing.brave.bridge.BraveTracer;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
-import org.mockito.Mockito;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -43,6 +42,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link BraveAutoConfiguration}.
@@ -157,43 +157,43 @@ class BraveAutoConfigurationTests {
 
 		@Bean
 		Tracing customTracing() {
-			return Mockito.mock(Tracing.class);
+			return mock(Tracing.class);
 		}
 
 		@Bean
 		Tracer customTracer() {
-			return Mockito.mock(Tracer.class);
+			return mock(Tracer.class);
 		}
 
 		@Bean
 		CurrentTraceContext customCurrentTraceContext() {
-			return Mockito.mock(CurrentTraceContext.class);
+			return mock(CurrentTraceContext.class);
 		}
 
 		@Bean
 		Factory customFactory() {
-			return Mockito.mock(Factory.class);
+			return mock(Factory.class);
 		}
 
 		@Bean
 		Sampler customSampler() {
-			return Mockito.mock(Sampler.class);
+			return mock(Sampler.class);
 		}
 
 		@Bean
 		HttpTracing customHttpTracing() {
-			return Mockito.mock(HttpTracing.class);
+			return mock(HttpTracing.class);
 		}
 
 		@Bean
 		HttpServerHandler<HttpServerRequest, HttpServerResponse> customHttpServerHandler() {
-			HttpTracing httpTracing = Mockito.mock(HttpTracing.class, Answers.RETURNS_MOCKS);
+			HttpTracing httpTracing = mock(HttpTracing.class, Answers.RETURNS_MOCKS);
 			return HttpServerHandler.create(httpTracing);
 		}
 
 		@Bean
 		HttpClientHandler<HttpClientRequest, HttpClientResponse> customHttpClientHandler() {
-			HttpTracing httpTracing = Mockito.mock(HttpTracing.class, Answers.RETURNS_MOCKS);
+			HttpTracing httpTracing = mock(HttpTracing.class, Answers.RETURNS_MOCKS);
 			return HttpClientHandler.create(httpTracing);
 		}
 
@@ -204,22 +204,22 @@ class BraveAutoConfigurationTests {
 
 		@Bean
 		BraveTracer customBraveTracer() {
-			return Mockito.mock(BraveTracer.class);
+			return mock(BraveTracer.class);
 		}
 
 		@Bean
 		BraveBaggageManager customBraveBaggageManager() {
-			return Mockito.mock(BraveBaggageManager.class);
+			return mock(BraveBaggageManager.class);
 		}
 
 		@Bean
 		BraveHttpServerHandler customBraveHttpServerHandler() {
-			return Mockito.mock(BraveHttpServerHandler.class);
+			return mock(BraveHttpServerHandler.class);
 		}
 
 		@Bean
 		BraveHttpClientHandler customBraveHttpClientHandler() {
-			return Mockito.mock(BraveHttpClientHandler.class);
+			return mock(BraveHttpClientHandler.class);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/MicrometerTracingAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/MicrometerTracingAutoConfigurationTests.java
@@ -26,7 +26,6 @@ import io.micrometer.tracing.handler.TracingObservationHandler;
 import io.micrometer.tracing.http.HttpClientHandler;
 import io.micrometer.tracing.http.HttpServerHandler;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -35,6 +34,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link MicrometerTracingAutoConfiguration}.
@@ -133,7 +133,7 @@ class MicrometerTracingAutoConfigurationTests {
 
 		@Bean
 		Tracer tracer() {
-			return Mockito.mock(Tracer.class);
+			return mock(Tracer.class);
 		}
 
 	}
@@ -143,7 +143,7 @@ class MicrometerTracingAutoConfigurationTests {
 
 		@Bean
 		HttpClientHandler httpClientHandler() {
-			return Mockito.mock(HttpClientHandler.class);
+			return mock(HttpClientHandler.class);
 		}
 
 	}
@@ -153,7 +153,7 @@ class MicrometerTracingAutoConfigurationTests {
 
 		@Bean
 		HttpServerHandler httpServerHandler() {
-			return Mockito.mock(HttpServerHandler.class);
+			return mock(HttpServerHandler.class);
 		}
 
 	}
@@ -163,17 +163,17 @@ class MicrometerTracingAutoConfigurationTests {
 
 		@Bean
 		DefaultTracingObservationHandler customDefaultTracingObservationHandler() {
-			return Mockito.mock(DefaultTracingObservationHandler.class);
+			return mock(DefaultTracingObservationHandler.class);
 		}
 
 		@Bean
 		HttpServerTracingObservationHandler customHttpServerTracingObservationHandler() {
-			return Mockito.mock(HttpServerTracingObservationHandler.class);
+			return mock(HttpServerTracingObservationHandler.class);
 		}
 
 		@Bean
 		HttpClientTracingObservationHandler customHttpClientTracingObservationHandler() {
-			return Mockito.mock(HttpClientTracingObservationHandler.class);
+			return mock(HttpClientTracingObservationHandler.class);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurationsMicrometerConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurationsMicrometerConfigurationTests.java
@@ -25,7 +25,6 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
-import org.mockito.Mockito;
 
 import org.springframework.boot.actuate.autoconfigure.tracing.OpenTelemetryConfigurations.MicrometerConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -35,6 +34,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link MicrometerConfiguration}.
@@ -104,27 +104,27 @@ class OpenTelemetryConfigurationsMicrometerConfigurationTests {
 
 		@Bean
 		OtelTracer customOtelTracer() {
-			return Mockito.mock(OtelTracer.class);
+			return mock(OtelTracer.class);
 		}
 
 		@Bean
 		EventPublisher customEventPublisher() {
-			return Mockito.mock(EventPublisher.class);
+			return mock(EventPublisher.class);
 		}
 
 		@Bean
 		OtelCurrentTraceContext customOtelCurrentTraceContext() {
-			return Mockito.mock(OtelCurrentTraceContext.class);
+			return mock(OtelCurrentTraceContext.class);
 		}
 
 		@Bean
 		OtelHttpClientHandler customOtelHttpClientHandler() {
-			return Mockito.mock(OtelHttpClientHandler.class);
+			return mock(OtelHttpClientHandler.class);
 		}
 
 		@Bean
 		OtelHttpServerHandler customOtelHttpServerHandler() {
-			return Mockito.mock(OtelHttpServerHandler.class);
+			return mock(OtelHttpServerHandler.class);
 		}
 
 	}
@@ -134,7 +134,7 @@ class OpenTelemetryConfigurationsMicrometerConfigurationTests {
 
 		@Bean
 		Tracer tracer() {
-			return Mockito.mock(Tracer.class);
+			return mock(Tracer.class);
 		}
 
 	}
@@ -144,7 +144,7 @@ class OpenTelemetryConfigurationsMicrometerConfigurationTests {
 
 		@Bean
 		OpenTelemetry openTelemetry() {
-			return Mockito.mock(OpenTelemetry.class, Answers.RETURNS_MOCKS);
+			return mock(OpenTelemetry.class, Answers.RETURNS_MOCKS);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurationsSdkConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurationsSdkConfigurationTests.java
@@ -22,7 +22,6 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import org.springframework.boot.actuate.autoconfigure.tracing.OpenTelemetryConfigurations.SdkConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -31,6 +30,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link SdkConfiguration}.
@@ -84,7 +84,7 @@ class OpenTelemetryConfigurationsSdkConfigurationTests {
 
 		@Bean
 		OpenTelemetry customOpenTelemetry() {
-			return Mockito.mock(OpenTelemetry.class);
+			return mock(OpenTelemetry.class);
 		}
 
 		@Bean
@@ -94,17 +94,17 @@ class OpenTelemetryConfigurationsSdkConfigurationTests {
 
 		@Bean
 		ContextPropagators customContextPropagators() {
-			return Mockito.mock(ContextPropagators.class);
+			return mock(ContextPropagators.class);
 		}
 
 		@Bean
 		Sampler customSampler() {
-			return Mockito.mock(Sampler.class);
+			return mock(Sampler.class);
 		}
 
 		@Bean
 		SpanProcessor customSpanProcessor() {
-			return Mockito.mock(SpanProcessor.class);
+			return mock(SpanProcessor.class);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurationsTracerConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurationsTracerConfigurationTests.java
@@ -19,7 +19,6 @@ package org.springframework.boot.actuate.autoconfigure.tracing;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import org.springframework.boot.actuate.autoconfigure.tracing.OpenTelemetryConfigurations.TracerConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -29,6 +28,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link TracerConfiguration}.
@@ -71,7 +71,7 @@ class OpenTelemetryConfigurationsTracerConfigurationTests {
 
 		@Bean
 		OpenTelemetry openTelemetry() {
-			return Mockito.mock(OpenTelemetry.class);
+			return mock(OpenTelemetry.class);
 		}
 
 	}
@@ -81,7 +81,7 @@ class OpenTelemetryConfigurationsTracerConfigurationTests {
 
 		@Bean
 		Tracer customTracer() {
-			return Mockito.mock(Tracer.class);
+			return mock(Tracer.class);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/wavefront/WavefrontTracingAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/wavefront/WavefrontTracingAutoConfigurationTests.java
@@ -25,7 +25,6 @@ import io.micrometer.tracing.reporter.wavefront.WavefrontBraveSpanHandler;
 import io.micrometer.tracing.reporter.wavefront.WavefrontOtelSpanHandler;
 import io.micrometer.tracing.reporter.wavefront.WavefrontSpanHandler;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -156,27 +155,27 @@ class WavefrontTracingAutoConfigurationTests {
 
 		@Bean
 		ApplicationTags customApplicationTags() {
-			return Mockito.mock(ApplicationTags.class);
+			return mock(ApplicationTags.class);
 		}
 
 		@Bean
 		WavefrontSpanHandler customWavefrontSpanHandler() {
-			return Mockito.mock(WavefrontSpanHandler.class);
+			return mock(WavefrontSpanHandler.class);
 		}
 
 		@Bean
 		SpanMetrics customSpanMetrics() {
-			return Mockito.mock(SpanMetrics.class);
+			return mock(SpanMetrics.class);
 		}
 
 		@Bean
 		WavefrontBraveSpanHandler customWavefrontBraveSpanHandler() {
-			return Mockito.mock(WavefrontBraveSpanHandler.class);
+			return mock(WavefrontBraveSpanHandler.class);
 		}
 
 		@Bean
 		WavefrontOtelSpanHandler customWavefrontOtelSpanHandler() {
-			return Mockito.mock(WavefrontOtelSpanHandler.class);
+			return mock(WavefrontOtelSpanHandler.class);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsBraveConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsBraveConfigurationTests.java
@@ -18,7 +18,6 @@ package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
 
 import brave.handler.SpanHandler;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import zipkin2.Span;
 import zipkin2.reporter.Reporter;
 import zipkin2.reporter.brave.ZipkinSpanHandler;
@@ -31,6 +30,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link BraveConfiguration}.
@@ -85,7 +85,7 @@ class ZipkinConfigurationsBraveConfigurationTests {
 		@Bean
 		@SuppressWarnings("unchecked")
 		Reporter<Span> reporter() {
-			return Mockito.mock(Reporter.class);
+			return mock(Reporter.class);
 		}
 
 	}
@@ -96,7 +96,7 @@ class ZipkinConfigurationsBraveConfigurationTests {
 		@Bean
 		@SuppressWarnings("unchecked")
 		ZipkinSpanHandler customZipkinSpanHandler() {
-			return (ZipkinSpanHandler) ZipkinSpanHandler.create(Mockito.mock(Reporter.class));
+			return (ZipkinSpanHandler) ZipkinSpanHandler.create(mock(Reporter.class));
 		}
 
 	}
@@ -106,7 +106,7 @@ class ZipkinConfigurationsBraveConfigurationTests {
 
 		@Bean
 		SpanHandler customSpanHandler() {
-			return Mockito.mock(SpanHandler.class);
+			return mock(SpanHandler.class);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsReporterConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsReporterConfigurationTests.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import zipkin2.Span;
 import zipkin2.codec.BytesEncoder;
 import zipkin2.codec.SpanBytesEncoder;
@@ -32,6 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link ReporterConfiguration}.
@@ -78,7 +78,7 @@ class ZipkinConfigurationsReporterConfigurationTests {
 		@Bean
 		@SuppressWarnings("unchecked")
 		Reporter<Span> customReporter() {
-			return Mockito.mock(Reporter.class);
+			return mock(Reporter.class);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
 
@@ -30,6 +29,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link SenderConfiguration}.
@@ -83,7 +83,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 
 		@Bean
 		Sender customSender() {
-			return Mockito.mock(Sender.class);
+			return mock(Sender.class);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfigurationTests.java
@@ -24,7 +24,6 @@ import javax.sql.DataSource;
 import jakarta.persistence.EntityManagerFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
@@ -614,7 +613,7 @@ class BatchAutoConfigurationTests {
 
 		@Bean
 		Job job2() {
-			return Mockito.mock(Job.class);
+			return mock(Job.class);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jRepositoriesAutoConfigurationTests.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.autoconfigure.data.neo4j;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.TestAutoConfigurationPackage;
@@ -36,6 +35,7 @@ import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
 import org.springframework.data.neo4j.repository.support.ReactiveNeo4jRepositoryFactoryBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link Neo4jRepositoriesAutoConfiguration}.
@@ -98,7 +98,7 @@ class Neo4jRepositoriesAutoConfigurationTests {
 
 		@Bean
 		ReactiveNeo4jRepositoryFactoryBean<?, ?, ?> reactiveNeo4jRepositoryFactoryBean() {
-			return Mockito.mock(ReactiveNeo4jRepositoryFactoryBean.class);
+			return mock(ReactiveNeo4jRepositoryFactoryBean.class);
 		}
 
 	}


### PR DESCRIPTION
This PR changes to use `import static org.mockito.Mockito.mock;`.