### PR TITLE
Use Runtime.version() instead of reflection

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarFileEntries.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/JarFileEntries.java
@@ -57,19 +57,7 @@ class JarFileEntries implements CentralDirectoryVisitor, Iterable<JarEntry> {
 
 	private static final int BASE_VERSION = 8;
 
-	private static final int RUNTIME_VERSION;
-
-	static {
-		int version;
-		try {
-			Object runtimeVersion = Runtime.class.getMethod("version").invoke(null);
-			version = (int) runtimeVersion.getClass().getMethod("major").invoke(runtimeVersion);
-		}
-		catch (Throwable ex) {
-			version = BASE_VERSION;
-		}
-		RUNTIME_VERSION = version;
-	}
+	private static final int RUNTIME_VERSION = Runtime.version().feature();
 
 	private static final long LOCAL_FILE_HEADER_SIZE = 30;
 
@@ -110,9 +98,6 @@ class JarFileEntries implements CentralDirectoryVisitor, Iterable<JarEntry> {
 	JarFileEntries(JarFile jarFile, JarEntryFilter filter) {
 		this.jarFile = jarFile;
 		this.filter = filter;
-		if (RUNTIME_VERSION == BASE_VERSION) {
-			this.multiReleaseJar = false;
-		}
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
@@ -560,7 +560,7 @@ class JarFileTests {
 			assertThat(entry.getName()).isEqualTo("multi-release.dat");
 			InputStream inputStream = multiRelease.getInputStream(entry);
 			assertThat(inputStream.available()).isEqualTo(1);
-			assertThat(inputStream.read()).isEqualTo(getJavaVersion());
+			assertThat(inputStream.read()).isEqualTo(Runtime.version().feature());
 		}
 	}
 
@@ -730,16 +730,6 @@ class JarFileTests {
 
 	private void assertThatZipFileClosedIsThrownBy(ThrowingCallable throwingCallable) {
 		assertThatIllegalStateException().isThrownBy(throwingCallable).withMessage("zip file closed");
-	}
-
-	private int getJavaVersion() {
-		try {
-			Object runtimeVersion = Runtime.class.getMethod("version").invoke(null);
-			return (int) runtimeVersion.getClass().getMethod("major").invoke(runtimeVersion);
-		}
-		catch (Throwable ex) {
-			return 8;
-		}
 	}
 
 }


### PR DESCRIPTION
Hi,

this PR removes some reflection code in order to get the runtime version and replaces it with `Runtime.version()`.

Have a good weekend,
Christoph