### PR TITLE
Use 3.0.0 for Javadoc since tags

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebResourcesRuntimeHintsRegistrar.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/WebResourcesRuntimeHintsRegistrar.java
@@ -25,7 +25,7 @@ import org.springframework.aot.hint.RuntimeHintsRegistrar;
  * {@link RuntimeHintsRegistrar} for default locations of web resources.
  *
  * @author Stephane Nicoll
- * @since 3.0
+ * @since 3.0.0
  */
 public class WebResourcesRuntimeHintsRegistrar implements RuntimeHintsRegistrar {
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/aot/GenerateAotSources.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/aot/GenerateAotSources.java
@@ -31,7 +31,7 @@ import org.gradle.api.tasks.TaskAction;
  * Custom {@link JavaExec} task for generating sources ahead of time.
  *
  * @author Andy Wilkinson
- * @since 3.0
+ * @since 3.0.0
  */
 @CacheableTask
 public class GenerateAotSources extends JavaExec {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/AotProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/AotProcessor.java
@@ -55,7 +55,7 @@ import org.springframework.util.FileSystemUtils;
  * @author Stephane Nicoll
  * @author Andy Wilkinson
  * @author Phillip Webb
- * @since 3.0
+ * @since 3.0.0
  */
 public class AotProcessor {
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudFoundryVcapEnvironmentPostProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudFoundryVcapEnvironmentPostProcessor.java
@@ -103,7 +103,7 @@ public class CloudFoundryVcapEnvironmentPostProcessor implements EnvironmentPost
 	/**
 	 * Create a new {@link CloudFoundryVcapEnvironmentPostProcessor} instance.
 	 * @param logFactory the log factory to use
-	 * @since 3.0
+	 * @since 3.0.0
 	 */
 	public CloudFoundryVcapEnvironmentPostProcessor(DeferredLogFactory logFactory) {
 		this.logger = logFactory.getLog(CloudFoundryVcapEnvironmentPostProcessor.class);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLocationRuntimeHintsRegistrar.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLocationRuntimeHintsRegistrar.java
@@ -34,7 +34,7 @@ import org.springframework.util.ResourceUtils;
  * {@link RuntimeHintsRegistrar} implementation for application configuration.
  *
  * @author Stephane Nicoll
- * @since 3.0
+ * @since 3.0.0
  * @see FilePatternResourceHintsRegistrar
  */
 public class ConfigDataLocationRuntimeHintsRegistrar implements RuntimeHintsRegistrar {


### PR DESCRIPTION
This PR changes to use `3.0.0` for Javadoc `@since` tags for consistency in the codebase.