### PR TITLE
Remove obsolete Java compatibility code

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/run/BootRun.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/run/BootRun.java
@@ -17,16 +17,13 @@
 package org.springframework.boot.gradle.tasks.run;
 
 import java.io.File;
-import java.lang.reflect.Method;
 import java.util.Set;
 
 import org.gradle.api.file.SourceDirectorySet;
-import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetOutput;
-import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.work.DisableCachingByDefault;
 
 /**
@@ -78,9 +75,6 @@ public class BootRun extends JavaExec {
 	public void exec() {
 		if (this.optimizedLaunch) {
 			setJvmArgs(getJvmArgs());
-			if (!isJava13OrLater()) {
-				jvmArgs("-Xverify:none");
-			}
 			jvmArgs("-XX:TieredStopAtLevel=1");
 		}
 		if (System.console() != null) {
@@ -88,19 +82,6 @@ public class BootRun extends JavaExec {
 			getEnvironment().put("spring.output.ansi.console-available", true);
 		}
 		super.exec();
-	}
-
-	private boolean isJava13OrLater() {
-		Property<JavaLauncher> javaLauncher = this.getJavaLauncher();
-		if (javaLauncher.isPresent()) {
-			return javaLauncher.get().getMetadata().getLanguageVersion().asInt() >= 13;
-		}
-		for (Method method : String.class.getMethods()) {
-			if (method.getName().equals("stripIndent")) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/run/BootRunIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/run/BootRunIntegrationTests.java
@@ -24,7 +24,6 @@ import java.util.jar.Attributes;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 
-import org.gradle.api.JavaVersion;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.TestTemplate;
@@ -96,12 +95,7 @@ class BootRunIntegrationTests {
 		copyJvmArgsApplication();
 		BuildResult result = this.gradleBuild.build("bootRun");
 		assertThat(result.task(":bootRun").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
-		if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_13)) {
-			assertThat(result.getOutput()).contains("-XX:TieredStopAtLevel=1");
-		}
-		else {
-			assertThat(result.getOutput()).contains("-Xverify:none").contains("-XX:TieredStopAtLevel=1");
-		}
+		assertThat(result.getOutput()).contains("-XX:TieredStopAtLevel=1");
 	}
 
 	@TestTemplate
@@ -117,14 +111,8 @@ class BootRunIntegrationTests {
 		copyJvmArgsApplication();
 		BuildResult result = this.gradleBuild.build("bootRun");
 		assertThat(result.task(":bootRun").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
-		if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_13)) {
-			assertThat(result.getOutput()).contains("-Dcom.bar=baz").contains("-Dcom.foo=bar")
-					.contains("-XX:TieredStopAtLevel=1");
-		}
-		else {
-			assertThat(result.getOutput()).contains("-Dcom.bar=baz").contains("-Dcom.foo=bar").contains("-Xverify:none")
-					.contains("-XX:TieredStopAtLevel=1");
-		}
+		assertThat(result.getOutput()).contains("-Dcom.bar=baz").contains("-Dcom.foo=bar")
+				.contains("-XX:TieredStopAtLevel=1");
 	}
 
 	@TestTemplate

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/RunIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/RunIntegrationTests.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.maven;
 
 import java.io.File;
-import java.lang.reflect.Method;
 
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -38,8 +37,7 @@ class RunIntegrationTests {
 	@TestTemplate
 	void whenTheRunGoalIsExecutedTheApplicationIsForkedWithOptimizedJvmArguments(MavenBuild mavenBuild) {
 		mavenBuild.project("run").goals("spring-boot:run", "-X").execute((project) -> {
-			String jvmArguments = isJava13OrLater() ? "JVM argument(s): -XX:TieredStopAtLevel=1"
-					: "JVM argument(s): -Xverify:none -XX:TieredStopAtLevel=1";
+			String jvmArguments = "JVM argument(s): -XX:TieredStopAtLevel=1";
 			assertThat(buildLog(project)).contains("I haz been run").contains(jvmArguments);
 		});
 	}
@@ -134,15 +132,6 @@ class RunIntegrationTests {
 
 	private String buildLog(File project) {
 		return contentOf(new File(project, "target/build.log"));
-	}
-
-	private boolean isJava13OrLater() {
-		for (Method method : String.class.getMethods()) {
-			if (method.getName().equals("stripIndent")) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunMojo.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.maven;
 
 import java.io.File;
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 
@@ -56,20 +55,8 @@ public class RunMojo extends AbstractApplicationRunMojo {
 		RunArguments jvmArguments = super.resolveJvmArguments();
 		if (this.optimizedLaunch) {
 			jvmArguments.getArgs().addFirst("-XX:TieredStopAtLevel=1");
-			if (!isJava13OrLater()) {
-				jvmArguments.getArgs().addFirst("-Xverify:none");
-			}
 		}
 		return jvmArguments;
-	}
-
-	private boolean isJava13OrLater() {
-		for (Method method : String.class.getMethods()) {
-			if (method.getName().equals("stripIndent")) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 	@Override

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webservices/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webservices/build.gradle
@@ -11,10 +11,8 @@ dependencies {
 
 	runtimeOnly("jaxen:jaxen")
 	runtimeOnly("wsdl4j:wsdl4j")
-	if (JavaVersion.current().java11Compatible) {
-		runtimeOnly("jakarta.activation:jakarta.activation-api")
-		runtimeOnly("org.glassfish.jaxb:jaxb-runtime")
-	}
+	runtimeOnly("jakarta.activation:jakarta.activation-api")
+	runtimeOnly("org.glassfish.jaxb:jaxb-runtime")
 
 	testImplementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-test"))
 	testImplementation("org.springframework.ws:spring-ws-test")


### PR DESCRIPTION
Hi,

the new Java 17 baseline makes some compatibility checks obsolete.

Cheers,
Christoph