### PR TITLE
Make SpringApplication Kotlin samples idiomatic

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/springapplication/MyApplication.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/springapplication/MyApplication.kt
@@ -16,13 +16,13 @@
 
 package org.springframework.boot.docs.features.springapplication
 
-import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
 
 
 @SpringBootApplication
 class MyApplication
 
 fun main(args: Array<String>) {
-	SpringApplication.run(MyApplication::class.java, *args)
+	runApplication<MyApplication>(*args)
 }

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/springapplication/applicationexit/MyApplication.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/springapplication/applicationexit/MyApplication.kt
@@ -19,6 +19,7 @@ package org.springframework.boot.docs.features.springapplication.applicationexit
 import org.springframework.boot.ExitCodeGenerator
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
 
 import kotlin.system.exitProcess
@@ -27,13 +28,11 @@ import kotlin.system.exitProcess
 class MyApplication {
 
 	@Bean
-	fun exitCodeGenerator(): ExitCodeGenerator? {
-		return ExitCodeGenerator { 42 }
-	}
+	fun exitCodeGenerator() = ExitCodeGenerator { 42 }
 
 }
 
 fun main(args: Array<String>) {
 	exitProcess(SpringApplication.exit(
-		SpringApplication.run(MyApplication::class.java, *args)))
+		runApplication<MyApplication>(*args)))
 }

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/springapplication/customizingspringapplication/MyApplication.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/springapplication/customizingspringapplication/MyApplication.kt
@@ -17,14 +17,14 @@
 package org.springframework.boot.docs.features.springapplication.customizingspringapplication
 
 import org.springframework.boot.Banner
-import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
 
 @SpringBootApplication
 class MyApplication
 
 fun main(args: Array<String>) {
-	val application = SpringApplication(MyApplication::class.java)
-	application.setBannerMode(Banner.Mode.OFF)
-	application.run(*args)
+	runApplication<MyApplication>(*args) {
+		setBannerMode(Banner.Mode.OFF)
+	}
 }

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/springapplication/startuptracking/MyApplication.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/springapplication/startuptracking/MyApplication.kt
@@ -16,15 +16,15 @@
 
 package org.springframework.boot.docs.features.springapplication.startuptracking
 
-import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.metrics.buffering.BufferingApplicationStartup
+import org.springframework.boot.runApplication
 
 @SpringBootApplication
 class MyApplication
 
 fun main(args: Array<String>) {
-	val application = SpringApplication(MyApplication::class.java)
-	application.applicationStartup = BufferingApplicationStartup(2048)
-	application.run(*args)
+	runApplication<MyApplication>(*args) {
+		applicationStartup = BufferingApplicationStartup(2048)
+	}
 }


### PR DESCRIPTION
Use `runApplication<MyApplication>(*args)` instead of `SpringApplication.run(MyApplication::class.java, *args)` as recommended.