### PR TITLE
Use java.util.HexFormat where appropriate

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/payload/HttpTunnelPayload.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/tunnel/payload/HttpTunnelPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.util.HexFormat;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -45,7 +46,7 @@ public class HttpTunnelPayload {
 
 	private static final int BUFFER_SIZE = 1024 * 100;
 
-	protected static final char[] HEX_CHARS = "0123456789ABCDEF".toCharArray();
+	private static final HexFormat HEX_FORMAT = HexFormat.of().withUpperCase();
 
 	private static final Log logger = LogFactory.getLog(HttpTunnelPayload.class);
 
@@ -173,13 +174,7 @@ public class HttpTunnelPayload {
 	 */
 	public String toHexString() {
 		byte[] bytes = this.data.array();
-		char[] hex = new char[this.data.remaining() * 2];
-		for (int i = this.data.position(); i < this.data.remaining(); i++) {
-			int b = bytes[i] & 0xFF;
-			hex[i * 2] = HEX_CHARS[b >>> 4];
-			hex[i * 2 + 1] = HEX_CHARS[b & 0x0F];
-		}
-		return new String(hex);
+		return HEX_FORMAT.formatHex(bytes);
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/VolumeName.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/VolumeName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package org.springframework.boot.buildpack.platform.docker.type;
 
-import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 import java.util.function.Function;
 
 import org.springframework.util.Assert;
@@ -126,9 +126,7 @@ public final class VolumeName {
 	private static String asHexString(byte[] digest, int digestLength) {
 		Assert.isTrue(digestLength <= digest.length,
 				() -> "DigestLength must be less than or equal to " + digest.length);
-		byte[] shortDigest = new byte[6];
-		System.arraycopy(digest, 0, shortDigest, 0, shortDigest.length);
-		return String.format("%0" + digestLength + "x", new BigInteger(1, shortDigest));
+		return HexFormat.of().formatHex(digest, 0, digestLength);
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Digest.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Digest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 
 /**
  * Utility class used to calculate digests.
@@ -41,24 +42,13 @@ final class Digest {
 		try {
 			try (DigestInputStream inputStream = new DigestInputStream(supplier.openStream(),
 					MessageDigest.getInstance("SHA-1"))) {
-				byte[] buffer = new byte[4098];
-				while (inputStream.read(buffer) != -1) {
-					// Read the entire stream
-				}
-				return bytesToHex(inputStream.getMessageDigest().digest());
+				inputStream.readAllBytes();
+				return HexFormat.of().formatHex(inputStream.getMessageDigest().digest());
 			}
 		}
 		catch (NoSuchAlgorithmException ex) {
 			throw new IllegalStateException(ex);
 		}
-	}
-
-	private static String bytesToHex(byte[] bytes) {
-		StringBuilder hex = new StringBuilder();
-		for (byte b : bytes) {
-			hex.append(String.format("%02x", b));
-		}
-		return hex.toString();
 	}
 
 }


### PR DESCRIPTION
Hi,

this PR closes #28154 by using `java.util.HexFormat` where possible.

Cheers,
Christoph
