### PR TITLE
Add log level guards in org.springframework.boot.autoconfigure.graphql

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/GraphQlAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/GraphQlAutoConfiguration.java
@@ -111,7 +111,9 @@ public class GraphQlAutoConfiguration {
 			return Arrays.asList(resolver.getResources(pattern));
 		}
 		catch (IOException ex) {
-			logger.debug("Could not resolve schema location: '" + pattern + "'", ex);
+			if (logger.isDebugEnabled()) {
+				logger.debug("Could not resolve schema location: '" + pattern + "'", ex);
+			}
 			return Collections.emptyList();
 		}
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/reactive/GraphQlWebFluxAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/reactive/GraphQlWebFluxAutoConfiguration.java
@@ -106,7 +106,9 @@ public class GraphQlWebFluxAutoConfiguration {
 	public RouterFunction<ServerResponse> graphQlRouterFunction(GraphQlHttpHandler httpHandler,
 			GraphQlSource graphQlSource, GraphQlProperties properties) {
 		String path = properties.getPath();
-		logger.info(LogMessage.format("GraphQL endpoint HTTP POST %s", path));
+		if (logger.isInfoEnabled()) {
+			logger.info(LogMessage.format("GraphQL endpoint HTTP POST %s", path));
+		}
 		RouterFunctions.Builder builder = RouterFunctions.route();
 		builder = builder.GET(path, this::onlyAllowPost);
 		builder = builder.POST(path, SUPPORTS_MEDIATYPES, httpHandler::handleRequest);
@@ -167,7 +169,9 @@ public class GraphQlWebFluxAutoConfiguration {
 		public HandlerMapping graphQlWebSocketEndpoint(GraphQlWebSocketHandler graphQlWebSocketHandler,
 				GraphQlProperties properties) {
 			String path = properties.getWebsocket().getPath();
-			logger.info(LogMessage.format("GraphQL endpoint WebSocket %s", path));
+			if (logger.isInfoEnabled()) {
+				logger.info(LogMessage.format("GraphQL endpoint WebSocket %s", path));
+			}
 			SimpleUrlHandlerMapping mapping = new SimpleUrlHandlerMapping();
 			mapping.setHandlerPredicate(new WebSocketUpgradeHandlerPredicate());
 			mapping.setUrlMap(Collections.singletonMap(path, graphQlWebSocketHandler));

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/servlet/GraphQlWebMvcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/servlet/GraphQlWebMvcAutoConfiguration.java
@@ -111,7 +111,9 @@ public class GraphQlWebMvcAutoConfiguration {
 	public RouterFunction<ServerResponse> graphQlRouterFunction(GraphQlHttpHandler httpHandler,
 			GraphQlSource graphQlSource, GraphQlProperties properties) {
 		String path = properties.getPath();
-		logger.info(LogMessage.format("GraphQL endpoint HTTP POST %s", path));
+		if (logger.isInfoEnabled()) {
+			logger.info(LogMessage.format("GraphQL endpoint HTTP POST %s", path));
+		}
 		RouterFunctions.Builder builder = RouterFunctions.route();
 		builder = builder.GET(path, this::onlyAllowPost);
 		builder = builder.POST(path, RequestPredicates.contentType(SUPPORTED_MEDIA_TYPES)
@@ -188,7 +190,9 @@ public class GraphQlWebMvcAutoConfiguration {
 		@Bean
 		public HandlerMapping graphQlWebSocketMapping(GraphQlWebSocketHandler handler, GraphQlProperties properties) {
 			String path = properties.getWebsocket().getPath();
-			logger.info(LogMessage.format("GraphQL endpoint WebSocket %s", path));
+			if (logger.isInfoEnabled()) {
+				logger.info(LogMessage.format("GraphQL endpoint WebSocket %s", path));
+			}
 			WebSocketHandlerMapping mapping = new WebSocketHandlerMapping();
 			mapping.setWebSocketUpgradeMatch(true);
 			mapping.setUrlMap(Collections.singletonMap(path,


### PR DESCRIPTION
This PR adds log level guards in `org.springframework.boot.autoconfigure.graphql` package.