### PR TITLE
Normalize DataSize inputs via removing all whitespaces

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/StringToDataSizeConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/StringToDataSizeConverter.java
@@ -23,6 +23,7 @@ import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.util.unit.DataSize;
 import org.springframework.util.unit.DataUnit;
 
@@ -54,7 +55,7 @@ final class StringToDataSizeConverter implements GenericConverter {
 	}
 
 	private DataSize convert(String source, DataUnit unit) {
-		return DataSize.parse(source, unit);
+		return DataSize.parse(StringUtils.trimAllWhitespace(source), unit);
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/StringToDataSizeConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/StringToDataSizeConverterTests.java
@@ -86,6 +86,14 @@ class StringToDataSizeConverterTests {
 	}
 
 	@ConversionServiceTest
+	void convertWithSpacesInValidUnitShouldWork(ConversionService conversionService) {
+		assertThat(convert(conversionService, " 1 0 ", DataUnit.KILOBYTES)).isEqualTo(DataSize.ofKilobytes(10));
+		assertThat(convert(conversionService, " +10 ", DataUnit.KILOBYTES)).isEqualTo(DataSize.ofKilobytes(10));
+		assertThat(convert(conversionService, " - 1 0", DataUnit.KILOBYTES)).isEqualTo(DataSize.ofKilobytes(-10));
+		assertThat(convert(conversionService, " 10", DataUnit.KILOBYTES)).isEqualTo(DataSize.ofKilobytes(10));
+	}
+
+	@ConversionServiceTest
 	void convertWhenBadFormatShouldThrowException(ConversionService conversionService) {
 		assertThatExceptionOfType(ConversionFailedException.class).isThrownBy(() -> convert(conversionService, "10WB"))
 				.havingCause().isInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
Trim all whitespaces before parsing a given DataSize string so that the parsing is more robust

This relates to the following issue in Spring Framework: https://github.com/spring-projects/spring-framework/issues/28643 since one of the maintainers recommended a fix in StringToDataSizeConverter in SpringBoot.

Closes gh-28357
