### PR TITLE
Use InputStream.transferTo() when possible

### DIFF
--- a/spring-boot-project/spring-boot-cli/src/intTest/java/org/springframework/boot/cli/infrastructure/CommandLineInvoker.java
+++ b/spring-boot-project/spring-boot-cli/src/intTest/java/org/springframework/boot/cli/infrastructure/CommandLineInvoker.java
@@ -95,6 +95,7 @@ public final class CommandLineInvoker {
 						file.getParentFile().mkdirs();
 						try (FileOutputStream output = new FileOutputStream(file)) {
 							input.transferTo(output);
+							output.flush();
 							if (entry.getName().endsWith("/bin/spring")) {
 								file.setExecutable(true);
 							}

--- a/spring-boot-project/spring-boot-cli/src/intTest/java/org/springframework/boot/cli/infrastructure/CommandLineInvoker.java
+++ b/spring-boot-project/spring-boot-cli/src/intTest/java/org/springframework/boot/cli/infrastructure/CommandLineInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,6 @@ import java.util.zip.ZipInputStream;
 
 import org.springframework.boot.testsupport.BuildOutput;
 import org.springframework.util.Assert;
-import org.springframework.util.StreamUtils;
 
 /**
  * Utility to invoke the command line in the same way as a user would, i.e. via the shell
@@ -95,7 +94,7 @@ public final class CommandLineInvoker {
 					else {
 						file.getParentFile().mkdirs();
 						try (FileOutputStream output = new FileOutputStream(file)) {
-							StreamUtils.copy(input, output);
+							input.transferTo(output);
 							if (entry.getName().endsWith("/bin/spring")) {
 								file.setExecutable(true);
 							}

--- a/spring-boot-project/spring-boot-devtools/src/intTest/java/org/springframework/boot/devtools/tests/JarFileRemoteApplicationLauncher.java
+++ b/spring-boot-project/spring-boot-devtools/src/intTest/java/org/springframework/boot/devtools/tests/JarFileRemoteApplicationLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 
-import org.springframework.util.StreamUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -69,7 +68,8 @@ public class JarFileRemoteApplicationLauncher extends RemoteApplicationLauncher 
 							+ (file.isDirectory() ? "/" : "")));
 			if (file.isFile()) {
 				try (FileInputStream input = new FileInputStream(file)) {
-					StreamUtils.copy(input, output);
+					input.transferTo(output);
+					output.flush();
 				}
 			}
 			output.closeEntry();

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/classloader/RestartClassLoaderTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/classloader/RestartClassLoaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,9 @@ class RestartClassLoaderTests {
 		File file = new File(tempDir, "sample.jar");
 		JarOutputStream jarOutputStream = new JarOutputStream(new FileOutputStream(file));
 		jarOutputStream.putNextEntry(new ZipEntry(PACKAGE_PATH + "/Sample.class"));
-		StreamUtils.copy(getClass().getResourceAsStream("Sample.class"), jarOutputStream);
+		InputStream inputStream = getClass().getResourceAsStream("Sample.class");
+		inputStream.transferTo(jarOutputStream);
+		jarOutputStream.flush();
 		jarOutputStream.closeEntry();
 		jarOutputStream.putNextEntry(new ZipEntry(PACKAGE_PATH + "/Sample.txt"));
 		StreamUtils.copy("fromchild", StandardCharsets.UTF_8, jarOutputStream);

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/ImageBuildpack.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/ImageBuildpack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ import org.springframework.boot.buildpack.platform.docker.type.ImageReference;
 import org.springframework.boot.buildpack.platform.docker.type.Layer;
 import org.springframework.boot.buildpack.platform.io.IOConsumer;
 import org.springframework.boot.buildpack.platform.io.TarArchive;
-import org.springframework.util.StreamUtils;
 
 /**
  * A {@link Buildpack} that references a buildpack contained in an OCI image.
@@ -129,7 +128,8 @@ final class ImageBuildpack implements Buildpack {
 				TarArchiveEntry entry = tarIn.getNextTarEntry();
 				while (entry != null) {
 					tarOut.putArchiveEntry(entry);
-					StreamUtils.copy(tarIn, tarOut);
+					tarIn.transferTo(tarOut);
+					tarOut.flush();
 					tarOut.closeArchiveEntry();
 					entry = tarIn.getNextTarEntry();
 				}

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/TarGzipBuildpack.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/TarGzipBuildpack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 
 import org.springframework.boot.buildpack.platform.docker.type.Layer;
 import org.springframework.boot.buildpack.platform.io.IOConsumer;
-import org.springframework.util.StreamUtils;
 
 /**
  * A {@link Buildpack} that references a buildpack contained in a local gzipped tar
@@ -94,7 +93,8 @@ final class TarGzipBuildpack implements Buildpack {
 			while (entry != null) {
 				entry.setName(basePath + "/" + entry.getName());
 				output.putArchiveEntry(entry);
-				StreamUtils.copy(tar, output);
+				tar.transferTo(output);
+				output.flush();
 				output.closeArchiveEntry();
 				entry = tar.getNextTarEntry();
 			}

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/DockerApi.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/DockerApi.java
@@ -44,7 +44,6 @@ import org.springframework.boot.buildpack.platform.io.TarArchive;
 import org.springframework.boot.buildpack.platform.json.JsonStream;
 import org.springframework.boot.buildpack.platform.json.SharedObjectMapper;
 import org.springframework.util.Assert;
-import org.springframework.util.StreamUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -266,7 +265,10 @@ public class DockerApi {
 				TarArchiveEntry entry = tar.getNextTarEntry();
 				while (entry != null) {
 					if (entry.getName().endsWith("/layer.tar")) {
-						TarArchive archive = (out) -> StreamUtils.copy(tar, out);
+						TarArchive archive = (out) -> {
+							tar.transferTo(out);
+							out.flush();
+						};
 						exports.accept(entry.getName(), archive);
 					}
 					entry = tar.getNextTarEntry();

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootZipCopyAction.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootZipCopyAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,6 @@ import org.springframework.boot.loader.tools.JarModeLibrary;
 import org.springframework.boot.loader.tools.Layer;
 import org.springframework.boot.loader.tools.LayersIndex;
 import org.springframework.util.Assert;
-import org.springframework.util.StreamUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -433,7 +432,8 @@ class BootZipCopyAction implements CopyAction {
 		 */
 		static ZipEntryContentWriter fromInputStream(InputStream in) {
 			return (out) -> {
-				StreamUtils.copy(in, out);
+				in.transferTo(out);
+				out.flush();
 				in.close();
 			};
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/LoaderZipEntries.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/LoaderZipEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@
 package org.springframework.boot.gradle.tasks.bundling;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.zip.ZipEntry;
@@ -28,8 +26,6 @@ import org.apache.commons.compress.archivers.zip.UnixStat;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.gradle.api.file.FileTreeElement;
-
-import org.springframework.util.StreamUtils;
 
 /**
  * Internal utility used to copy entries from the {@code spring-boot-loader.jar}.
@@ -75,7 +71,8 @@ class LoaderZipEntries {
 	private void writeClass(ZipArchiveEntry entry, ZipInputStream in, ZipArchiveOutputStream out) throws IOException {
 		prepareEntry(entry, UnixStat.FILE_FLAG | UnixStat.DEFAULT_FILE_PERM);
 		out.putArchiveEntry(entry);
-		copy(in, out);
+		in.transferTo(out);
+		out.flush();
 		out.closeArchiveEntry();
 	}
 
@@ -84,10 +81,6 @@ class LoaderZipEntries {
 			entry.setTime(this.entryTime);
 		}
 		entry.setUnixMode(unixMode);
-	}
-
-	private void copy(InputStream in, OutputStream out) throws IOException {
-		StreamUtils.copy(in, out);
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/main/java/org/springframework/boot/jarmode/layertools/ExtractCommand.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/main/java/org/springframework/boot/jarmode/layertools/ExtractCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import org.springframework.util.Assert;
-import org.springframework.util.StreamUtils;
 
 /**
  * The {@code 'extract'} tools command.
@@ -95,7 +94,8 @@ class ExtractCommand extends Command {
 						+ "'. Verify the contents of your archive.");
 		mkParentDirs(file);
 		try (OutputStream out = new FileOutputStream(file)) {
-			StreamUtils.copy(zip, out);
+			zip.transferTo(out);
+			out.flush();
 		}
 		try {
 			Files.getFileAttributeView(file.toPath(), BasicFileAttributeView.class)

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/SizeCalculatingEntryWriter.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/SizeCalculatingEntryWriter.java
@@ -55,8 +55,10 @@ final class SizeCalculatingEntryWriter implements EntryWriter {
 
 	@Override
 	public void write(OutputStream outputStream) throws IOException {
-		InputStream inputStream = getContentInputStream();
-		copy(inputStream, outputStream);
+		try (InputStream inputStream = getContentInputStream()) {
+			inputStream.transferTo(outputStream);
+			outputStream.flush();
+		}
 	}
 
 	private InputStream getContentInputStream() throws FileNotFoundException {
@@ -64,15 +66,6 @@ final class SizeCalculatingEntryWriter implements EntryWriter {
 			return new FileInputStream(file);
 		}
 		return new ByteArrayInputStream((byte[]) this.content);
-	}
-
-	private void copy(InputStream inputStream, OutputStream outputStream) throws IOException {
-		try {
-			StreamUtils.copy(inputStream, outputStream);
-		}
-		finally {
-			inputStream.close();
-		}
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
@@ -602,7 +602,8 @@ class JarFileTests {
 				storedEntry.setMethod(ZipEntry.STORED);
 				jarOutput.putNextEntry(storedEntry);
 				try (FileInputStream entryIn = new FileInputStream(entry)) {
-					StreamUtils.copy(entryIn, jarOutput);
+					entryIn.transferTo(jarOutput);
+					jarOutput.flush();
 				}
 				jarOutput.closeEntry();
 			}

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/intTest/java/org/springframework/boot/context/embedded/AbstractApplicationLauncher.java
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/intTest/java/org/springframework/boot/context/embedded/AbstractApplicationLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.FileSystemUtils;
-import org.springframework.util.StreamUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -129,7 +128,8 @@ abstract class AbstractApplicationLauncher implements BeforeEachCallback {
 		@Override
 		public void run() {
 			try {
-				StreamUtils.copy(this.input, this.output);
+				this.input.transferTo(this.output);
+				this.output.flush();
 			}
 			catch (IOException ex) {
 			}

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/intTest/java/org/springframework/boot/context/embedded/BootRunApplicationLauncher.java
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/intTest/java/org/springframework/boot/context/embedded/BootRunApplicationLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import java.util.jar.JarFile;
 
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.FileSystemUtils;
-import org.springframework.util.StreamUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -126,7 +125,8 @@ class BootRunApplicationLauncher extends AbstractApplicationLauncher {
 			}
 			else {
 				FileOutputStream extractedOutputStream = new FileOutputStream(extracted);
-				StreamUtils.copy(jarFile.getInputStream(jarEntry), extractedOutputStream);
+				jarFile.getInputStream(jarEntry).transferTo(extractedOutputStream);
+				extractedOutputStream.flush();
 				extractedOutputStream.close();
 			}
 		}

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/intTest/java/org/springframework/boot/context/embedded/ExplodedApplicationLauncher.java
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/intTest/java/org/springframework/boot/context/embedded/ExplodedApplicationLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 import org.springframework.util.FileSystemUtils;
-import org.springframework.util.StreamUtils;
 
 /**
  * {@link AbstractApplicationLauncher} that launches a Spring Boot application using
@@ -79,7 +78,8 @@ class ExplodedApplicationLauncher extends AbstractApplicationLauncher {
 			else {
 				extracted.getParentFile().mkdirs();
 				FileOutputStream extractedOutputStream = new FileOutputStream(extracted);
-				StreamUtils.copy(jarFile.getInputStream(jarEntry), extractedOutputStream);
+				jarFile.getInputStream(jarEntry).transferTo(extractedOutputStream);
+				extractedOutputStream.flush();
 				extractedOutputStream.close();
 			}
 		}

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/intTest/java/org/springframework/boot/context/embedded/IdeApplicationLauncher.java
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/intTest/java/org/springframework/boot/context/embedded/IdeApplicationLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import java.util.jar.JarFile;
 
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.FileSystemUtils;
-import org.springframework.util.StreamUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -146,7 +145,8 @@ class IdeApplicationLauncher extends AbstractApplicationLauncher {
 			}
 			else {
 				FileOutputStream extractedOutputStream = new FileOutputStream(extracted);
-				StreamUtils.copy(jarFile.getInputStream(jarEntry), extractedOutputStream);
+				jarFile.getInputStream(jarEntry).transferTo(extractedOutputStream);
+				extractedOutputStream.flush();
 				extractedOutputStream.close();
 			}
 		}


### PR DESCRIPTION
Hi,

this PR closes #28221 by using `InputStream.transferTo` where possible.

I'm not super convinced of that PR to be honest because for consistency reasons and to make sure it works as before, we need to call `flush` on the `OutputStream`. While this wouldn't be necessary for `FileOutputStream` strictly speaking, because its implementation does nothing, I added it everywhere.

Let me know what you think.
Cheers,
Christoph
