### PR TITLE
@RestControllerAdvice @ExceptionHandler Inconsistent behavior with @RestControllerEndpoint

### DIFF
--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/main/java/smoketest/actuator/SampleRestControllerEndpointWithException.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/main/java/smoketest/actuator/SampleRestControllerEndpointWithException.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.actuator;
+
+import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * The Sample rest controller endpoint with exception.
+ *
+ * @author Guirong Hu
+ */
+@Component
+@RestControllerEndpoint(id = "exception")
+public class SampleRestControllerEndpointWithException {
+
+	@GetMapping("/")
+	public String exception() {
+		throw new CustomException();
+	}
+
+	@RestControllerAdvice
+	static class CustomExceptionHandler {
+
+		@ExceptionHandler(CustomException.class)
+		ResponseEntity<String> handleCustomException(CustomException e) {
+			return new ResponseEntity<>("this is a custom exception body", HttpStatus.I_AM_A_TEAPOT);
+		}
+
+	}
+
+	static class CustomException extends RuntimeException {
+
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/ManagementDifferentPortAndEndpointWithExceptionHandlerSampleActuatorApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/ManagementDifferentPortAndEndpointWithExceptionHandlerSampleActuatorApplicationTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.actuator;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.web.server.LocalManagementPort;
+import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for separate management and main service ports with Actuator's MVC
+ * {@link RestControllerEndpoint rest controller endpoints} and {@link ExceptionHandler
+ * exception handler}.
+ *
+ * @author Guirong Hu
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		properties = { "management.endpoints.web.exposure.include=*", "management.server.port=0" })
+class ManagementDifferentPortAndEndpointWithExceptionHandlerSampleActuatorApplicationTests {
+
+	@LocalManagementPort
+	private int managementPort;
+
+	@Test
+	void testExceptionHandlerRestControllerEndpoint() {
+		ResponseEntity<String> entity = new TestRestTemplate("user", "password")
+				.getForEntity("http://localhost:" + this.managementPort + "/actuator/exception", String.class);
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.I_AM_A_TEAPOT);
+		assertThat(entity.getBody()).isEqualTo("this is a custom exception body");
+	}
+
+}


### PR DESCRIPTION
Hi, I submitted this PR to solve #30899 based on @wilkinsona ’s [comment](https://github.com/spring-projects/spring-boot/issues/30899#issuecomment-1121193114). 

When I switched to `BeanFactoryUtils.beansOfTypeIncludingAncestors`, I found that still can't solve the problem, this is because the bean names of `org.springframework.boot.actuate.autoconfigure.web.servlet.CompositeHandlerExceptionResolver` and `org.springframework.web.servlet.handler.HandlerExceptionResolverComposite` are the same.


* > See `WebMvcEndpointChildContextConfiguration.java#L100-L101`

https://github.com/spring-projects/spring-boot/blob/837e2ac277bf9496e07238431710251c083c7a0b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/servlet/WebMvcEndpointChildContextConfiguration.java#L100-L101

* > See [WebMvcConfigurationSupport.java#L1029-L1030](https://github.com/spring-projects/spring-framework/blob/a57dead4be7e19c423df867852380b38c1f5ddbc/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java#L1029-L1030)

---
So when using `BeanFactoryUtils.beansOfTypeIncludingAncestors`, `HandlerExceptionResolverComposite` will be overwritten by `CompositeHandlerExceptionResolver`.

* > See [BeanFactoryUtils.java#L326-L328](https://github.com/spring-projects/spring-framework/blob/0783f0762d72df70572aaceeee099c3ec4b7e019/spring-beans/src/main/java/org/springframework/beans/factory/BeanFactoryUtils.java#L326-L328)

---
Maybe we need a variant of `BeanFactoryUtils.beansOfTypeIncludingAncestors`, use collection to collect `HandlerExceptionResolver` instead of map, or modify the bean name of `CompositeHandlerExceptionResolver`, I chose the former for now.



Closes gh-30899

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
