### PR TITLE
HTTP Server and Data repositories metrics record null for the description

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/data/MetricsRepositoryMethodInvocationListener.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/data/MetricsRepositoryMethodInvocationListener.java
@@ -68,8 +68,9 @@ public class MetricsRepositoryMethodInvocationListener implements RepositoryMeth
 		Set<Timed> annotations = TimedAnnotations.get(invocation.getMethod(), invocation.getRepositoryInterface());
 		Iterable<Tag> tags = this.tagsProvider.repositoryTags(invocation);
 		long duration = invocation.getDuration(TimeUnit.NANOSECONDS);
-		AutoTimer.apply(this.autoTimer, this.metricName, annotations, (builder) -> builder.tags(tags)
-				.register(this.registrySupplier.get()).record(duration, TimeUnit.NANOSECONDS));
+		AutoTimer.apply(this.autoTimer, this.metricName, annotations,
+				(builder) -> builder.description("Duration of repository invocations").tags(tags)
+						.register(this.registrySupplier.get()).record(duration, TimeUnit.NANOSECONDS));
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/MetricsWebFilter.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/MetricsWebFilter.java
@@ -109,7 +109,8 @@ public class MetricsWebFilter implements WebFilter {
 			Iterable<Tag> tags = this.tagsProvider.httpRequestTags(exchange, cause);
 			long duration = System.nanoTime() - start;
 			AutoTimer.apply(this.autoTimer, this.metricName, annotations,
-					(builder) -> builder.tags(tags).register(this.registry).record(duration, TimeUnit.NANOSECONDS));
+					(builder) -> builder.description("Duration of requests made to HTTP Server").tags(tags)
+							.register(this.registry).record(duration, TimeUnit.NANOSECONDS));
 		}
 		catch (Exception ex) {
 			logger.warn("Failed to record timer metrics", ex);

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/MetricsWebFilter.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/server/MetricsWebFilter.java
@@ -109,7 +109,7 @@ public class MetricsWebFilter implements WebFilter {
 			Iterable<Tag> tags = this.tagsProvider.httpRequestTags(exchange, cause);
 			long duration = System.nanoTime() - start;
 			AutoTimer.apply(this.autoTimer, this.metricName, annotations,
-					(builder) -> builder.description("Duration of requests made to HTTP Server").tags(tags)
+					(builder) -> builder.description("Duration of HTTP server request handling").tags(tags)
 							.register(this.registry).record(duration, TimeUnit.NANOSECONDS));
 		}
 		catch (Exception ex) {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilter.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilter.java
@@ -155,7 +155,7 @@ public class WebMvcMetricsFilter extends OncePerRequestFilter {
 
 	private Timer.Builder getTimer(Builder builder, Object handler, HttpServletRequest request,
 			HttpServletResponse response, Throwable exception) {
-		return builder.description("Duration of requests made to HTTP Server")
+		return builder.description("Duration of HTTP server request handling")
 				.tags(this.tagsProvider.getTags(request, response, handler, exception));
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilter.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/servlet/WebMvcMetricsFilter.java
@@ -155,7 +155,8 @@ public class WebMvcMetricsFilter extends OncePerRequestFilter {
 
 	private Timer.Builder getTimer(Builder builder, Object handler, HttpServletRequest request,
 			HttpServletResponse response, Throwable exception) {
-		return builder.tags(this.tagsProvider.getTags(request, response, handler, exception));
+		return builder.description("Duration of requests made to HTTP Server")
+				.tags(this.tagsProvider.getTags(request, response, handler, exception));
 	}
 
 	/**


### PR DESCRIPTION
Hi, 
Recently, during creation of some dashboards with service metrics I found that some of them have missing descriptions.
Decided that maybe It would be good idea to fill them.

This is my first contribution so sorry for any mistakes.
If that missing descriptions are by design(for any reason), this PR can be closed.
If you have any concerns about descriptions - I am open to suggestions.

Before:
`{"name":"http.server.requests","description":null," ...`

After:
`{"name":"http.server.requests","description":"Duration of requests made to HTTP Server", ...`

And same for Data repositories invocations.

Build, Checkstyle and formatter 🟢 

