### PR TITLE
Fix typo in "HTTP and WebSocket" section of GraphQL documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/web/spring-graphql.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/web/spring-graphql.adoc
@@ -86,7 +86,7 @@ are detected by Spring Boot and considered as candidates for `DataFetcher` for m
 The GraphQL HTTP endpoint is at HTTP POST "/graphql" by default.
 The path can be customized with configprop:spring.graphql.path[].
 
-TIP: The HTTP endpoint for both Spring MVC and Spring WebFlux is provided by a `RouterFunction` bean with an `@Order` or `0`.
+TIP: The HTTP endpoint for both Spring MVC and Spring WebFlux is provided by a `RouterFunction` bean with an `@Order` of `0`.
 If you define your own `RouterFunction` beans, you may want to add appropriate `@Order` annotations to ensure that they are sorted correctly.
 
 The GraphQL WebSocket endpoint is off by default. To enable it:


### PR DESCRIPTION
Fixes typo introduced in https://github.com/spring-projects/spring-boot/commit/378e56f1d30f1a10d50de7f340236fb0af842b1c