### PR TITLE
Use switch expressions where appropriate

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/health/AutoConfiguredHealthEndpointGroup.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/health/AutoConfiguredHealthEndpointGroup.java
@@ -95,15 +95,11 @@ class AutoConfiguredHealthEndpointGroup implements HealthEndpointGroup {
 	}
 
 	private boolean getShowResult(SecurityContext securityContext, Show show) {
-		switch (show) {
-			case NEVER:
-				return false;
-			case ALWAYS:
-				return true;
-			case WHEN_AUTHORIZED:
-				return isAuthorized(securityContext);
-		}
-		throw new IllegalStateException("Unsupported 'show' value " + show);
+		return switch (show) {
+			case NEVER -> false;
+			case ALWAYS -> true;
+			case WHEN_AUTHORIZED -> isAuthorized(securityContext);
+		};
 	}
 
 	private boolean isAuthorized(SecurityContext securityContext) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/servlet/ManagementErrorEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/servlet/ManagementErrorEndpoint.java
@@ -76,36 +76,27 @@ public class ManagementErrorEndpoint {
 	}
 
 	private boolean includeStackTrace(ServletWebRequest request) {
-		switch (this.errorProperties.getIncludeStacktrace()) {
-			case ALWAYS:
-				return true;
-			case ON_PARAM:
-				return getBooleanParameter(request, "trace");
-			default:
-				return false;
-		}
+		return switch (this.errorProperties.getIncludeStacktrace()) {
+			case ALWAYS -> true;
+			case ON_PARAM -> getBooleanParameter(request, "trace");
+			default -> false;
+		};
 	}
 
 	private boolean includeMessage(ServletWebRequest request) {
-		switch (this.errorProperties.getIncludeMessage()) {
-			case ALWAYS:
-				return true;
-			case ON_PARAM:
-				return getBooleanParameter(request, "message");
-			default:
-				return false;
-		}
+		return switch (this.errorProperties.getIncludeMessage()) {
+			case ALWAYS -> true;
+			case ON_PARAM -> getBooleanParameter(request, "message");
+			default -> false;
+		};
 	}
 
 	private boolean includeBindingErrors(ServletWebRequest request) {
-		switch (this.errorProperties.getIncludeBindingErrors()) {
-			case ALWAYS:
-				return true;
-			case ON_PARAM:
-				return getBooleanParameter(request, "errors");
-			default:
-				return false;
-		}
+		return switch (this.errorProperties.getIncludeBindingErrors()) {
+			case ALWAYS -> true;
+			case ON_PARAM -> getBooleanParameter(request, "errors");
+			default -> false;
+		};
 	}
 
 	protected boolean getBooleanParameter(ServletWebRequest request, String parameterName) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/dynatrace/DynatraceMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/dynatrace/DynatraceMetricsExportAutoConfigurationTests.java
@@ -135,17 +135,11 @@ class DynatraceMetricsExportAutoConfigurationTests {
 
 		@Bean
 		DynatraceConfig customConfig() {
-			return (key) -> {
-				switch (key) {
-					case "dynatrace.uri":
-						return "https://dynatrace.example.com";
-					case "dynatrace.apiToken":
-						return "abcde";
-					case "dynatrace.deviceId":
-						return "test";
-					default:
-						return null;
-				}
+			return (key) -> switch (key) {
+				case "dynatrace.uri" -> "https://dynatrace.example.com";
+				case "dynatrace.apiToken" -> "abcde";
+				case "dynatrace.deviceId" -> "test";
+				default -> null;
 			};
 		}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusPushGatewayManager.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusPushGatewayManager.java
@@ -141,16 +141,9 @@ public class PrometheusPushGatewayManager {
 		}
 		this.scheduled.cancel(false);
 		switch (shutdownOperation) {
-			case PUSH:
-			case POST:
-				post();
-				break;
-			case PUT:
-				put();
-				break;
-			case DELETE:
-				delete();
-				break;
+			case PUSH, POST -> post();
+			case PUT -> put();
+			case DELETE -> delete();
 		}
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/quartz/QuartzEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/quartz/QuartzEndpoint.java
@@ -265,26 +265,16 @@ public class QuartzEndpoint {
 	}
 
 	private static TemporalUnit temporalUnit(IntervalUnit unit) {
-		switch (unit) {
-			case DAY:
-				return ChronoUnit.DAYS;
-			case HOUR:
-				return ChronoUnit.HOURS;
-			case MINUTE:
-				return ChronoUnit.MINUTES;
-			case MONTH:
-				return ChronoUnit.MONTHS;
-			case SECOND:
-				return ChronoUnit.SECONDS;
-			case MILLISECOND:
-				return ChronoUnit.MILLIS;
-			case WEEK:
-				return ChronoUnit.WEEKS;
-			case YEAR:
-				return ChronoUnit.YEARS;
-			default:
-				throw new IllegalArgumentException("Unknown IntervalUnit");
-		}
+		return switch (unit) {
+			case DAY -> ChronoUnit.DAYS;
+			case HOUR -> ChronoUnit.HOURS;
+			case MINUTE -> ChronoUnit.MINUTES;
+			case MONTH -> ChronoUnit.MONTHS;
+			case SECOND -> ChronoUnit.SECONDS;
+			case MILLISECOND -> ChronoUnit.MILLIS;
+			case WEEK -> ChronoUnit.WEEKS;
+			case YEAR -> ChronoUnit.YEARS;
+		};
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnWebApplicationCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnWebApplicationCondition.java
@@ -99,14 +99,11 @@ class OnWebApplicationCondition extends FilteringSpringBootCondition {
 
 	private ConditionOutcome isWebApplication(ConditionContext context, AnnotatedTypeMetadata metadata,
 			boolean required) {
-		switch (deduceType(metadata)) {
-			case SERVLET:
-				return isServletWebApplication(context);
-			case REACTIVE:
-				return isReactiveWebApplication(context);
-			default:
-				return isAnyWebApplication(context, required);
-		}
+		return switch (deduceType(metadata)) {
+			case SERVLET -> isServletWebApplication(context);
+			case REACTIVE -> isReactiveWebApplication(context);
+			default -> isAnyWebApplication(context, required);
+		};
 	}
 
 	private ConditionOutcome isAnyWebApplication(ConditionContext context, boolean required) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
@@ -315,17 +315,13 @@ public class JacksonAutoConfiguration {
 				if (strategy != null) {
 					builder.postConfigurer((objectMapper) -> {
 						switch (strategy) {
-							case USE_PROPERTIES_BASED:
+							case USE_PROPERTIES_BASED ->
 								objectMapper.setConstructorDetector(ConstructorDetector.USE_PROPERTIES_BASED);
-								break;
-							case USE_DELEGATING:
+							case USE_DELEGATING ->
 								objectMapper.setConstructorDetector(ConstructorDetector.USE_DELEGATING);
-								break;
-							case EXPLICIT_ONLY:
+							case EXPLICIT_ONLY ->
 								objectMapper.setConstructorDetector(ConstructorDetector.EXPLICIT_ONLY);
-								break;
-							default:
-								objectMapper.setConstructorDetector(ConstructorDetector.DEFAULT);
+							default -> objectMapper.setConstructorDetector(ConstructorDetector.DEFAULT);
 						}
 					});
 				}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionConfiguration.java
@@ -53,14 +53,10 @@ class RedisSessionConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	ConfigureRedisAction configureRedisAction(RedisSessionProperties redisSessionProperties) {
-		switch (redisSessionProperties.getConfigureAction()) {
-			case NOTIFY_KEYSPACE_EVENTS:
-				return new ConfigureNotifyKeyspaceEventsAction();
-			case NONE:
-				return ConfigureRedisAction.NO_OP;
-		}
-		throw new IllegalStateException(
-				"Unsupported redis configure action '" + redisSessionProperties.getConfigureAction() + "'.");
+		return switch (redisSessionProperties.getConfigureAction()) {
+			case NOTIFY_KEYSPACE_EVENTS -> new ConfigureNotifyKeyspaceEventsAction();
+			case NONE -> ConfigureRedisAction.NO_OP;
+		};
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandler.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandler.java
@@ -173,14 +173,11 @@ public class DefaultErrorWebExceptionHandler extends AbstractErrorWebExceptionHa
 	 * @return if the stacktrace attribute should be included
 	 */
 	protected boolean isIncludeStackTrace(ServerRequest request, MediaType produces) {
-		switch (this.errorProperties.getIncludeStacktrace()) {
-			case ALWAYS:
-				return true;
-			case ON_PARAM:
-				return isTraceEnabled(request);
-			default:
-				return false;
-		}
+		return switch (this.errorProperties.getIncludeStacktrace()) {
+			case ALWAYS -> true;
+			case ON_PARAM -> isTraceEnabled(request);
+			default -> false;
+		};
 	}
 
 	/**
@@ -190,14 +187,11 @@ public class DefaultErrorWebExceptionHandler extends AbstractErrorWebExceptionHa
 	 * @return if the message attribute should be included
 	 */
 	protected boolean isIncludeMessage(ServerRequest request, MediaType produces) {
-		switch (this.errorProperties.getIncludeMessage()) {
-			case ALWAYS:
-				return true;
-			case ON_PARAM:
-				return isMessageEnabled(request);
-			default:
-				return false;
-		}
+		return switch (this.errorProperties.getIncludeMessage()) {
+			case ALWAYS -> true;
+			case ON_PARAM -> isMessageEnabled(request);
+			default -> false;
+		};
 	}
 
 	/**
@@ -207,14 +201,11 @@ public class DefaultErrorWebExceptionHandler extends AbstractErrorWebExceptionHa
 	 * @return if the errors attribute should be included
 	 */
 	protected boolean isIncludeBindingErrors(ServerRequest request, MediaType produces) {
-		switch (this.errorProperties.getIncludeBindingErrors()) {
-			case ALWAYS:
-				return true;
-			case ON_PARAM:
-				return isBindingErrorsEnabled(request);
-			default:
-				return false;
-		}
+		return switch (this.errorProperties.getIncludeBindingErrors()) {
+			case ALWAYS -> true;
+			case ON_PARAM -> isBindingErrorsEnabled(request);
+			default -> false;
+		};
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/BasicErrorController.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/BasicErrorController.java
@@ -131,14 +131,11 @@ public class BasicErrorController extends AbstractErrorController {
 	 * @return if the stacktrace attribute should be included
 	 */
 	protected boolean isIncludeStackTrace(HttpServletRequest request, MediaType produces) {
-		switch (getErrorProperties().getIncludeStacktrace()) {
-			case ALWAYS:
-				return true;
-			case ON_PARAM:
-				return getTraceParameter(request);
-			default:
-				return false;
-		}
+		return switch (getErrorProperties().getIncludeStacktrace()) {
+			case ALWAYS -> true;
+			case ON_PARAM -> getTraceParameter(request);
+			default -> false;
+		};
 	}
 
 	/**
@@ -148,14 +145,11 @@ public class BasicErrorController extends AbstractErrorController {
 	 * @return if the message attribute should be included
 	 */
 	protected boolean isIncludeMessage(HttpServletRequest request, MediaType produces) {
-		switch (getErrorProperties().getIncludeMessage()) {
-			case ALWAYS:
-				return true;
-			case ON_PARAM:
-				return getMessageParameter(request);
-			default:
-				return false;
-		}
+		return switch (getErrorProperties().getIncludeMessage()) {
+			case ALWAYS -> true;
+			case ON_PARAM -> getMessageParameter(request);
+			default -> false;
+		};
 	}
 
 	/**
@@ -165,14 +159,11 @@ public class BasicErrorController extends AbstractErrorController {
 	 * @return if the errors attribute should be included
 	 */
 	protected boolean isIncludeBindingErrors(HttpServletRequest request, MediaType produces) {
-		switch (getErrorProperties().getIncludeBindingErrors()) {
-			case ALWAYS:
-				return true;
-			case ON_PARAM:
-				return getErrorsParameter(request);
-			default:
-				return false;
-		}
+		return switch (getErrorProperties().getIncludeBindingErrors()) {
+			case ALWAYS -> true;
+			case ON_PARAM -> getErrorsParameter(request);
+			default -> false;
+		};
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/filter/FilterAnnotations.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/filter/FilterAnnotations.java
@@ -85,13 +85,12 @@ public class FilterAnnotations implements Iterable<TypeFilter> {
 	}
 
 	private TypeFilter createTypeFilter(FilterType filterType, String pattern) {
-		switch (filterType) {
-			case ASPECTJ:
-				return new AspectJTypeFilter(pattern, this.classLoader);
-			case REGEX:
-				return new RegexPatternTypeFilter(Pattern.compile(pattern));
-		}
-		throw new IllegalArgumentException("Filter type not supported with String pattern: " + filterType);
+		return switch (filterType) {
+			case ASPECTJ -> new AspectJTypeFilter(pattern, this.classLoader);
+			case REGEX -> new RegexPatternTypeFilter(Pattern.compile(pattern));
+			default ->
+				throw new IllegalArgumentException("Filter type not supported with String pattern: " + filterType);
+		};
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/LogUpdateEvent.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/LogUpdateEvent.java
@@ -54,12 +54,8 @@ public class LogUpdateEvent extends UpdateEvent {
 
 	public void print() {
 		switch (this.streamType) {
-			case STD_OUT:
-				System.out.println(this);
-				return;
-			case STD_ERR:
-				System.err.println(this);
-				return;
+			case STD_OUT -> System.out.println(this);
+			case STD_ERR -> System.err.println(this);
 		}
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/AotProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/AotProcessor.java
@@ -167,15 +167,11 @@ public class AotProcessor {
 	}
 
 	private Path getRoot(Kind kind) {
-		switch (kind) {
-			case SOURCE:
-				return this.sourceOutput;
-			case RESOURCE:
-				return this.resourceOutput;
-			case CLASS:
-				return this.classOutput;
-		}
-		throw new IllegalStateException("Unsupported kind " + kind);
+		return switch (kind) {
+			case SOURCE -> this.sourceOutput;
+			case RESOURCE -> this.resourceOutput;
+			case CLASS -> this.classOutput;
+		};
 	}
 
 	private void writeHints(RuntimeHints hints) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -362,14 +362,11 @@ public class SpringApplication {
 	}
 
 	private Class<? extends StandardEnvironment> deduceEnvironmentClass() {
-		switch (this.webApplicationType) {
-			case SERVLET:
-				return ApplicationServletEnvironment.class;
-			case REACTIVE:
-				return ApplicationReactiveWebEnvironment.class;
-			default:
-				return ApplicationEnvironment.class;
-		}
+		return switch (this.webApplicationType) {
+			case SERVLET -> ApplicationServletEnvironment.class;
+			case REACTIVE -> ApplicationReactiveWebEnvironment.class;
+			default -> ApplicationEnvironment.class;
+		};
 	}
 
 	private void prepareContext(DefaultBootstrapContext bootstrapContext, ConfigurableApplicationContext context,
@@ -457,14 +454,11 @@ public class SpringApplication {
 		if (this.environment != null) {
 			return this.environment;
 		}
-		switch (this.webApplicationType) {
-			case SERVLET:
-				return new ApplicationServletEnvironment();
-			case REACTIVE:
-				return new ApplicationReactiveWebEnvironment();
-			default:
-				return new ApplicationEnvironment();
-		}
+		return switch (this.webApplicationType) {
+			case SERVLET -> new ApplicationServletEnvironment();
+			case REACTIVE -> new ApplicationReactiveWebEnvironment();
+			default -> new ApplicationEnvironment();
+		};
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/DeferredLog.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/DeferredLog.java
@@ -245,23 +245,12 @@ public class DeferredLog implements Log {
 
 	static void logTo(Log log, LogLevel level, Object message, Throwable throwable) {
 		switch (level) {
-			case TRACE:
-				log.trace(message, throwable);
-				return;
-			case DEBUG:
-				log.debug(message, throwable);
-				return;
-			case INFO:
-				log.info(message, throwable);
-				return;
-			case WARN:
-				log.warn(message, throwable);
-				return;
-			case ERROR:
-				log.error(message, throwable);
-				return;
-			case FATAL:
-				log.fatal(message, throwable);
+			case TRACE -> log.trace(message, throwable);
+			case DEBUG -> log.debug(message, throwable);
+			case INFO -> log.info(message, throwable);
+			case WARN -> log.warn(message, throwable);
+			case ERROR -> log.error(message, throwable);
+			case FATAL -> log.fatal(message, throwable);
 		}
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyServletWebServerFactory.java
@@ -704,15 +704,11 @@ public class JettyServletWebServerFactory extends AbstractServletWebServerFactor
 			}
 
 			private String getSameSiteComment(SameSite sameSite) {
-				switch (sameSite) {
-					case NONE:
-						return HttpCookie.SAME_SITE_NONE_COMMENT;
-					case LAX:
-						return HttpCookie.SAME_SITE_LAX_COMMENT;
-					case STRICT:
-						return HttpCookie.SAME_SITE_STRICT_COMMENT;
-				}
-				throw new IllegalStateException("Unsupported SameSite value " + sameSite);
+				return switch (sameSite) {
+					case NONE -> HttpCookie.SAME_SITE_NONE_COMMENT;
+					case LAX -> HttpCookie.SAME_SITE_LAX_COMMENT;
+					case STRICT -> HttpCookie.SAME_SITE_STRICT_COMMENT;
+				};
 			}
 
 			private SameSite getSameSite(Cookie cookie) {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/main/java/smoketest/websocket/jetty/snake/Location.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/main/java/smoketest/websocket/jetty/snake/Location.java
@@ -34,20 +34,13 @@ public class Location {
 	}
 
 	public Location getAdjacentLocation(Direction direction) {
-		switch (direction) {
-			case NORTH:
-				return new Location(this.x, this.y - SnakeUtils.GRID_SIZE);
-			case SOUTH:
-				return new Location(this.x, this.y + SnakeUtils.GRID_SIZE);
-			case EAST:
-				return new Location(this.x + SnakeUtils.GRID_SIZE, this.y);
-			case WEST:
-				return new Location(this.x - SnakeUtils.GRID_SIZE, this.y);
-			case NONE:
-				// fall through
-			default:
-				return this;
-		}
+		return switch (direction) {
+			case NORTH -> new Location(this.x, this.y - SnakeUtils.GRID_SIZE);
+			case SOUTH -> new Location(this.x, this.y + SnakeUtils.GRID_SIZE);
+			case EAST -> new Location(this.x + SnakeUtils.GRID_SIZE, this.y);
+			case WEST -> new Location(this.x - SnakeUtils.GRID_SIZE, this.y);
+			case NONE -> this;
+		};
 	}
 
 	@Override

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/main/java/smoketest/websocket/tomcat/snake/Location.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/main/java/smoketest/websocket/tomcat/snake/Location.java
@@ -34,20 +34,13 @@ public class Location {
 	}
 
 	public Location getAdjacentLocation(Direction direction) {
-		switch (direction) {
-			case NORTH:
-				return new Location(this.x, this.y - SnakeUtils.GRID_SIZE);
-			case SOUTH:
-				return new Location(this.x, this.y + SnakeUtils.GRID_SIZE);
-			case EAST:
-				return new Location(this.x + SnakeUtils.GRID_SIZE, this.y);
-			case WEST:
-				return new Location(this.x - SnakeUtils.GRID_SIZE, this.y);
-			case NONE:
-				// fall through
-			default:
-				return this;
-		}
+		return switch (direction) {
+			case NORTH -> new Location(this.x, this.y - SnakeUtils.GRID_SIZE);
+			case SOUTH -> new Location(this.x, this.y + SnakeUtils.GRID_SIZE);
+			case EAST -> new Location(this.x + SnakeUtils.GRID_SIZE, this.y);
+			case WEST -> new Location(this.x - SnakeUtils.GRID_SIZE, this.y);
+			case NONE -> this;
+		};
 	}
 
 	@Override

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/main/java/smoketest/websocket/undertow/snake/Location.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/main/java/smoketest/websocket/undertow/snake/Location.java
@@ -34,20 +34,13 @@ public class Location {
 	}
 
 	public Location getAdjacentLocation(Direction direction) {
-		switch (direction) {
-			case NORTH:
-				return new Location(this.x, this.y - SnakeUtils.GRID_SIZE);
-			case SOUTH:
-				return new Location(this.x, this.y + SnakeUtils.GRID_SIZE);
-			case EAST:
-				return new Location(this.x + SnakeUtils.GRID_SIZE, this.y);
-			case WEST:
-				return new Location(this.x - SnakeUtils.GRID_SIZE, this.y);
-			case NONE:
-				// fall through
-			default:
-				return this;
-		}
+		return switch (direction) {
+			case NORTH -> new Location(this.x, this.y - SnakeUtils.GRID_SIZE);
+			case SOUTH -> new Location(this.x, this.y + SnakeUtils.GRID_SIZE);
+			case EAST -> new Location(this.x + SnakeUtils.GRID_SIZE, this.y);
+			case WEST -> new Location(this.x - SnakeUtils.GRID_SIZE, this.y);
+			case NONE -> this;
+		};
 	}
 
 	@Override


### PR DESCRIPTION
Hi,

this PR fixes #28180 by applying switch expressions where appropriate (there are a couple of places where they didn't make things more concise imho).

The nice side-benefit is that with switch expressions we get a compilation failure now if a new enum case is added instead of needing to rely on throwing exceptions during runtime.

Cheers,
Christoph