### PR TITLE
Disable incompatible tests on macOS AArch64

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/junit/DisabledOnOs.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/junit/DisabledOnOs.java
@@ -40,7 +40,7 @@ public @interface DisabledOnOs {
 	 * See {@link org.junit.jupiter.api.condition.DisabledOnOs#value()}.
 	 * @return os
 	 */
-	OS os();
+	OS[] os();
 
 	/**
 	 * Architecture of the operating system.

--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/junit/DisabledOnOsCondition.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/junit/DisabledOnOsCondition.java
@@ -18,6 +18,7 @@ package org.springframework.boot.testsupport.junit;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -42,11 +43,15 @@ class DisabledOnOsCondition implements ExecutionCondition {
 	private ConditionEvaluationResult evaluate(DisabledOnOs annotation) {
 		String architecture = System.getProperty("os.arch");
 		String os = System.getProperty("os.name");
-		if (annotation.os().isCurrentOs() && annotation.architecture().equals(architecture)) {
-			String reason = annotation.disabledReason().isEmpty()
-					? String.format("Disabled on OS = %s, architecture = %s", os, architecture)
-					: annotation.disabledReason();
-			return ConditionEvaluationResult.disabled(reason);
+		if (annotation.architecture().equals(architecture)) {
+			for (OS targetOs : annotation.os()) {
+				if (targetOs.isCurrentOs()) {
+					String reason = annotation.disabledReason().isEmpty()
+							? String.format("Disabled on OS = %s, architecture = %s", os, architecture)
+							: annotation.disabledReason();
+					return ConditionEvaluationResult.disabled(reason);
+				}
+			}
 		}
 		return ConditionEvaluationResult
 				.enabled(String.format("Enabled on OS = %s, architecture = %s", os, architecture));

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/jetty/SslServerCustomizerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/jetty/SslServerCustomizerTests.java
@@ -57,8 +57,8 @@ class SslServerCustomizerTests {
 
 	@Test
 	@SuppressWarnings("rawtypes")
-	@DisabledOnOs(os = OS.LINUX, architecture = "aarch64",
-			disabledReason = "conscrypt doesn't support Linux aarch64, see https://github.com/google/conscrypt/issues/1051")
+	@DisabledOnOs(os = { OS.LINUX, OS.MAC }, architecture = "aarch64",
+			disabledReason = "conscrypt doesn't support Linux/macOS aarch64, see https://github.com/google/conscrypt/issues/1051")
 	void whenHttp2IsEnabledServerConnectorsHasSslAlpnH2AndHttpConnectionFactories() {
 		Http2 http2 = new Http2();
 		http2.setEnabled(true);
@@ -71,8 +71,8 @@ class SslServerCustomizerTests {
 	}
 
 	@Test
-	@DisabledOnOs(os = OS.LINUX, architecture = "aarch64",
-			disabledReason = "conscrypt doesn't support Linux aarch64, see https://github.com/google/conscrypt/issues/1051")
+	@DisabledOnOs(os = { OS.LINUX, OS.MAC }, architecture = "aarch64",
+			disabledReason = "conscrypt doesn't support Linux/macOS aarch64, see https://github.com/google/conscrypt/issues/1051")
 	void alpnConnectionFactoryHasNullDefaultProtocolToAllowNegotiationToHttp11() {
 		Http2 http2 = new Http2();
 		http2.setEnabled(true);


### PR DESCRIPTION
This PR disables incompatible tests on macOS AArch64 as they are failing as follows:

```
java.lang.IllegalStateException: An 'org.eclipse.jetty:jetty-alpn-*-server' dependency is required for HTTP/2 support.
	at org.springframework.boot.web.embedded.jetty.SslServerCustomizer.createAlpnServerConnectionFactory(SslServerCustomizer.java:156)
	at org.springframework.boot.web.embedded.jetty.SslServerCustomizer.createHttp2ServerConnector(SslServerCustomizer.java:142)
	at org.springframework.boot.web.embedded.jetty.SslServerCustomizer.createServerConnector(SslServerCustomizer.java:103)
	at org.springframework.boot.web.embedded.jetty.SslServerCustomizer.createConnector(SslServerCustomizer.java:88)
	at org.springframework.boot.web.embedded.jetty.SslServerCustomizer.customize(SslServerCustomizer.java:77)
	at org.springframework.boot.web.embedded.jetty.SslServerCustomizerTests.createCustomizedServer(SslServerCustomizerTests.java:109)
	at org.springframework.boot.web.embedded.jetty.SslServerCustomizerTests.createCustomizedServer(SslServerCustomizerTests.java:104)
	at org.springframework.boot.web.embedded.jetty.SslServerCustomizerTests.whenHttp2IsEnabledServerConnectorsHasSslAlpnH2AndHttpConnectionFactories(SslServerCustomizerTests.java:65)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:214)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:210)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:135)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:66)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:53)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:99)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:79)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:75)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:61)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at jdk.proxy1/jdk.proxy1.$Proxy2.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:133)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: java.lang.IllegalStateException: No Server ALPNProcessors!
	at org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory.<init>(ALPNServerConnectionFactory.java:47)
	at org.springframework.boot.web.embedded.jetty.SslServerCustomizer.createAlpnServerConnectionFactory(SslServerCustomizer.java:153)
	... 92 more
	Suppressed: java.lang.UnsatisfiedLinkError: no conscrypt_openjdk_jni-osx-aarch_64 in java.library.path: /Users/user/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:.
		at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2429)
		at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:818)
		at java.base/java.lang.System.loadLibrary(System.java:1989)
		at org.conscrypt.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:54)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:568)
		at org.conscrypt.NativeLibraryLoader$1.run(NativeLibraryLoader.java:297)
		at org.conscrypt.NativeLibraryLoader$1.run(NativeLibraryLoader.java:289)
		at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
		at org.conscrypt.NativeLibraryLoader.loadLibraryFromHelperClassloader(NativeLibraryLoader.java:289)
		at org.conscrypt.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:262)
		at org.conscrypt.NativeLibraryLoader.load(NativeLibraryLoader.java:162)
		at org.conscrypt.NativeLibraryLoader.loadFirstAvailable(NativeLibraryLoader.java:106)
		at org.conscrypt.NativeCryptoJni.init(NativeCryptoJni.java:50)
		at org.conscrypt.NativeCrypto.<clinit>(NativeCrypto.java:64)
		at org.conscrypt.OpenSSLProvider.<init>(OpenSSLProvider.java:58)
		at org.conscrypt.OpenSSLProvider.<init>(OpenSSLProvider.java:51)
		at org.conscrypt.OpenSSLProvider.<init>(OpenSSLProvider.java:47)
		at org.eclipse.jetty.alpn.conscrypt.server.ConscryptServerALPNProcessor.init(ConscryptServerALPNProcessor.java:41)
		at org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory.lambda$new$0(ALPNServerConnectionFactory.java:67)
		at org.eclipse.jetty.util.ServiceLoaderSpliterator.tryAdvance(ServiceLoaderSpliterator.java:46)
		at java.base/java.util.Spliterator.forEachRemaining(Spliterator.java:332)
		at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
		at org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory.<init>(ALPNServerConnectionFactory.java:49)
		... 93 more
		Suppressed: java.lang.UnsatisfiedLinkError: no conscrypt_openjdk_jni-osx-aarch_64 in java.library.path: /Users/user/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:.
			at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2429)
			at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:818)
			at java.base/java.lang.System.loadLibrary(System.java:1989)
			at org.conscrypt.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:54)
			at org.conscrypt.NativeLibraryLoader.loadLibraryFromCurrentClassloader(NativeLibraryLoader.java:318)
			at org.conscrypt.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:273)
			... 106 more
		Suppressed: java.lang.UnsatisfiedLinkError: no conscrypt_openjdk_jni in java.library.path: /Users/user/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:.
			... 119 more
		Suppressed: java.lang.UnsatisfiedLinkError: no conscrypt_openjdk_jni in java.library.path: /Users/user/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:.
			at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2429)
			at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:818)
			at java.base/java.lang.System.loadLibrary(System.java:1989)
			at org.conscrypt.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:54)
			at org.conscrypt.NativeLibraryLoader.loadLibraryFromCurrentClassloader(NativeLibraryLoader.java:318)
			at org.conscrypt.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:273)
			... 106 more
		Suppressed: java.lang.UnsatisfiedLinkError: no conscrypt in java.library.path: /Users/user/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:.
			... 119 more
		Suppressed: java.lang.UnsatisfiedLinkError: no conscrypt in java.library.path: /Users/user/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:.
			at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2429)
			at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:818)
			at java.base/java.lang.System.loadLibrary(System.java:1989)
			at org.conscrypt.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:54)
			at org.conscrypt.NativeLibraryLoader.loadLibraryFromCurrentClassloader(NativeLibraryLoader.java:318)
			at org.conscrypt.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:273)
			... 106 more
```

This PR also updates related test support classes.

See gh-30082