### PR TITLE
Document additional configuration that is required for spring.mvc.throw-exception-if-no-handler-found=true to be effective

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/web/servlet.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/web/servlet.adoc
@@ -109,6 +109,8 @@ Any resources with a path in `+/webjars/**+` are served from jar files if they a
 TIP: Do not use the `src/main/webapp` directory if your application is packaged as a jar.
 Although this directory is a common standard, it works *only* with war packaging, and it is silently ignored by most build tools if you generate a jar.
 
+TIP: If you configure `spring.mvc.throw-exception-if-no-handler-found=true`, it will not work with default `+spring.mvc.static-path-pattern=/**+`, because each url matches `+/**+`. Url without handler must be excluded from _static-path-pattern_ to `NoHandlerFoundException` be thrown. Quite effective exclusion is  `spring.mvc.static-path-pattern=`
+
 Spring Boot also supports the advanced resource handling features provided by Spring MVC, allowing use cases such as cache-busting static resources or using version agnostic URLs for Webjars.
 
 To use version agnostic URLs for Webjars, add the `webjars-locator-core` dependency.


### PR DESCRIPTION
`spring.mvc.throw-exception-if-no-handler-found=true` requires additional configuration to be effective because default `+spring.mvc.static-path-pattern=/**+` collides it.
This PR explains correlation, which is confusing.
The confusion was reported in https://github.com/spring-projects/spring-boot/issues/9263 and others

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
