### PR TITLE
HealthContributor beans managed by a CompositeHealthContributor are recreated on each call

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/NamedContributorsMapAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/NamedContributorsMapAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
@@ -93,6 +94,22 @@ class NamedContributorsMapAdapterTests {
 	}
 
 	@Test
+	void eachValueAdapterShouldBeCalledOnlyOnce() {
+		Map<String, String> map = new LinkedHashMap<>();
+		map.put("one", "one");
+		map.put("two", "two");
+		int callCount = map.size();
+
+		AtomicInteger counter = new AtomicInteger(0);
+		TestNamedContributorsMapAdapter<String> adapter = new TestNamedContributorsMapAdapter<>(map,
+				(name) -> count(name, counter));
+		assertThat(adapter.getContributor("one")).isEqualTo("eno");
+		assertThat(counter.get()).isEqualTo(callCount);
+		assertThat(adapter.getContributor("two")).isEqualTo("owt");
+		assertThat(counter.get()).isEqualTo(callCount);
+	}
+
+	@Test
 	void getContributorWhenNotInMapReturnsNull() {
 		TestNamedContributorsMapAdapter<String> adapter = createAdapter();
 		assertThat(adapter.getContributor("missing")).isNull();
@@ -104,6 +121,11 @@ class NamedContributorsMapAdapterTests {
 		map.put("two", "two");
 		TestNamedContributorsMapAdapter<String> adapter = new TestNamedContributorsMapAdapter<>(map, this::reverse);
 		return adapter;
+	}
+
+	private String count(CharSequence charSequence, AtomicInteger counter) {
+		counter.incrementAndGet();
+		return reverse(charSequence);
 	}
 
 	private String reverse(CharSequence charSequence) {


### PR DESCRIPTION
During the construction of the `NamedContributorsMapAdapter`, each value adapter is called only once.

Closes gh-29640

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
