### PR TITLE
Upgrade to Flyway 9.0.1

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/FlywayEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/FlywayEndpointDocumentationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import java.util.List;
 import javax.sql.DataSource;
 
 import org.flywaydb.core.api.MigrationState;
-import org.flywaydb.core.api.MigrationType;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.actuate.flyway.FlywayEndpoint;
@@ -77,10 +76,8 @@ class FlywayEndpointDocumentationTests extends MockMvcEndpointDocumentationTests
 						.optional(),
 				fieldWithPath("state")
 						.description("State of the migration. (" + describeEnumValues(MigrationState.class) + ")"),
-				fieldWithPath("type")
-						.description("Type of the migration. (" + describeEnumValues(MigrationType.class) + ")"),
-				fieldWithPath("version").description("Version of the database after applying the migration, if any.")
-						.optional());
+				fieldWithPath("type").description("Type of the migration."), fieldWithPath("version")
+						.description("Version of the database after applying the migration, if any.").optional());
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/flyway/FlywayEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/flyway/FlywayEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import java.util.stream.Stream;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationInfo;
 import org.flywaydb.core.api.MigrationState;
-import org.flywaydb.core.api.MigrationType;
 
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
@@ -136,7 +135,7 @@ public class FlywayEndpoint {
 	 */
 	public static final class FlywayMigration {
 
-		private final MigrationType type;
+		private final String type;
 
 		private final Integer checksum;
 
@@ -157,7 +156,7 @@ public class FlywayEndpoint {
 		private final Integer executionTime;
 
 		private FlywayMigration(MigrationInfo info) {
-			this.type = info.getType();
+			this.type = info.getType().name();
 			this.checksum = info.getChecksum();
 			this.version = nullSafeToString(info.getVersion());
 			this.description = info.getDescription();
@@ -177,7 +176,7 @@ public class FlywayEndpoint {
 			return (date != null) ? Instant.ofEpochMilli(date.getTime()) : null;
 		}
 
-		public MigrationType getType() {
+		public String getType() {
 			return this.type;
 		}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/flyway/FlywayEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/flyway/FlywayEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ class FlywayEndpointTests {
 					Map<String, FlywayDescriptor> flywayBeans = context.getBean(FlywayEndpoint.class).flywayBeans()
 							.getContexts().get(context.getId()).getFlywayBeans();
 					assertThat(flywayBeans).hasSize(1);
-					assertThat(flywayBeans.values().iterator().next().getMigrations()).hasSize(3);
+					assertThat(flywayBeans.values().iterator().next().getMigrations()).hasSize(4);
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.convert.DurationUnit;
 
 /**
@@ -209,7 +208,7 @@ public class FlywayProperties {
 	/**
 	 * Whether to disable cleaning of the database.
 	 */
-	private boolean cleanDisabled;
+	private boolean cleanDisabled = true;
 
 	/**
 	 * Whether to automatically call clean when a validation error occurs.
@@ -221,30 +220,6 @@ public class FlywayProperties {
 	 * applying them.
 	 */
 	private boolean group;
-
-	/**
-	 * Whether to ignore missing migrations when reading the schema history table.
-	 */
-	@Deprecated
-	private boolean ignoreMissingMigrations;
-
-	/**
-	 * Whether to ignore ignored migrations when reading the schema history table.
-	 */
-	@Deprecated
-	private boolean ignoreIgnoredMigrations;
-
-	/**
-	 * Whether to ignore pending migrations when reading the schema history table.
-	 */
-	@Deprecated
-	private boolean ignorePendingMigrations;
-
-	/**
-	 * Whether to ignore future migrations when reading the schema history table.
-	 */
-	@Deprecated
-	private boolean ignoreFutureMigrations = true;
 
 	/**
 	 * Whether to allow mixing transactional and non-transactional statements within the
@@ -376,11 +351,6 @@ public class FlywayProperties {
 	 * Flyway Teams.
 	 */
 	private Boolean detectEncoding;
-
-	/**
-	 * Filename prefix for baseline migrations. Requires Flyway Teams.
-	 */
-	private String baselineMigrationPrefix;
 
 	/**
 	 * Prefix of placeholders in migration scripts.
@@ -664,50 +634,6 @@ public class FlywayProperties {
 		this.group = group;
 	}
 
-	@Deprecated
-	@DeprecatedConfigurationProperty(replacement = "spring.flyway.ignore-migration-patterns")
-	public boolean isIgnoreMissingMigrations() {
-		return this.ignoreMissingMigrations;
-	}
-
-	@Deprecated
-	public void setIgnoreMissingMigrations(boolean ignoreMissingMigrations) {
-		this.ignoreMissingMigrations = ignoreMissingMigrations;
-	}
-
-	@Deprecated
-	@DeprecatedConfigurationProperty(replacement = "spring.flyway.ignore-migration-patterns")
-	public boolean isIgnoreIgnoredMigrations() {
-		return this.ignoreIgnoredMigrations;
-	}
-
-	@Deprecated
-	public void setIgnoreIgnoredMigrations(boolean ignoreIgnoredMigrations) {
-		this.ignoreIgnoredMigrations = ignoreIgnoredMigrations;
-	}
-
-	@Deprecated
-	@DeprecatedConfigurationProperty(replacement = "spring.flyway.ignore-migration-patterns")
-	public boolean isIgnorePendingMigrations() {
-		return this.ignorePendingMigrations;
-	}
-
-	@Deprecated
-	public void setIgnorePendingMigrations(boolean ignorePendingMigrations) {
-		this.ignorePendingMigrations = ignorePendingMigrations;
-	}
-
-	@Deprecated
-	@DeprecatedConfigurationProperty(replacement = "spring.flyway.ignore-migration-patterns")
-	public boolean isIgnoreFutureMigrations() {
-		return this.ignoreFutureMigrations;
-	}
-
-	@Deprecated
-	public void setIgnoreFutureMigrations(boolean ignoreFutureMigrations) {
-		this.ignoreFutureMigrations = ignoreFutureMigrations;
-	}
-
 	public boolean isMixed() {
 		return this.mixed;
 	}
@@ -860,17 +786,6 @@ public class FlywayProperties {
 		this.oracleKerberosCacheFile = oracleKerberosCacheFile;
 	}
 
-	@DeprecatedConfigurationProperty(replacement = "spring.flyway.kerberos-config-file")
-	@Deprecated
-	public String getOracleKerberosConfigFile() {
-		return getKerberosConfigFile();
-	}
-
-	@Deprecated
-	public void setOracleKerberosConfigFile(String oracleKerberosConfigFile) {
-		setKerberosConfigFile(oracleKerberosConfigFile);
-	}
-
 	public Boolean getOutputQueryResults() {
 		return this.outputQueryResults;
 	}
@@ -909,14 +824,6 @@ public class FlywayProperties {
 
 	public void setDetectEncoding(final Boolean detectEncoding) {
 		this.detectEncoding = detectEncoding;
-	}
-
-	public String getBaselineMigrationPrefix() {
-		return this.baselineMigrationPrefix;
-	}
-
-	public void setBaselineMigrationPrefix(String baselineMigrationPrefix) {
-		this.baselineMigrationPrefix = baselineMigrationPrefix;
 	}
 
 	public String getScriptPlaceholderPrefix() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/Flyway5xAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/Flyway5xAutoConfigurationTests.java
@@ -104,11 +104,6 @@ class Flyway5xAutoConfigurationTests {
 		}
 
 		@Override
-		public boolean isUndo() {
-			return false;
-		}
-
-		@Override
 		public boolean canExecuteInTransaction() {
 			return true;
 		}
@@ -116,11 +111,6 @@ class Flyway5xAutoConfigurationTests {
 		@Override
 		public void migrate(org.flywaydb.core.api.migration.Context context) {
 
-		}
-
-		@Override
-		public boolean isBaselineMigration() {
-			return false;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
@@ -33,8 +33,6 @@ import org.flywaydb.core.api.callback.Context;
 import org.flywaydb.core.api.callback.Event;
 import org.flywaydb.core.api.migration.JavaMigration;
 import org.flywaydb.core.internal.license.FlywayTeamsUpgradeRequiredException;
-import org.flywaydb.core.internal.plugin.PluginRegister;
-import org.flywaydb.database.sqlserver.SQLServerConfigurationExtension;
 import org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
@@ -493,8 +491,8 @@ class FlywayAutoConfigurationTests {
 	void licenseKeyIsCorrectlyMapped(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
 				.withPropertyValues("spring.flyway.license-key=<<secret>>")
-				.run((context) -> assertThat(output).contains(
-						"Flyway Teams Edition upgrade required: licenseKey is not supported by Flyway Community Edition."));
+				.run((context) -> assertThat(output).contains("License key detected - in order to use Teams or "
+						+ "Enterprise features, download Flyway Teams Edition & Flyway Enterprise Edition"));
 	}
 
 	@Test
@@ -574,14 +572,6 @@ class FlywayAutoConfigurationTests {
 	}
 
 	@Test
-	@Deprecated
-	void oracleKerberosConfigFileIsCorrectlyMappedToReplacementProperty() {
-		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
-				.withPropertyValues("spring.flyway.oracle-kerberos-config-file=/tmp/config")
-				.run(validateFlywayTeamsPropertyOnly("kerberosConfigFile"));
-	}
-
-	@Test
 	void oracleKerberosCacheFileIsCorrectlyMapped() {
 		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
 				.withPropertyValues("spring.flyway.oracle-kerberos-cache-file=/tmp/cache")
@@ -597,15 +587,9 @@ class FlywayAutoConfigurationTests {
 
 	@Test
 	void sqlServerKerberosLoginFileIsCorrectlyMapped() {
-		try {
-			this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
-					.withPropertyValues("spring.flyway.sql-server-kerberos-login-file=/tmp/config")
-					.run(validateFlywayTeamsPropertyOnly("sqlserver.kerberos.login.file"));
-		}
-		finally {
-			// Reset to default value
-			PluginRegister.getPlugin(SQLServerConfigurationExtension.class).setKerberosLoginFile(null);
-		}
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+				.withPropertyValues("spring.flyway.sql-server-kerberos-login-file=/tmp/config")
+				.run(validateFlywayTeamsPropertyOnly("sqlserver.kerberos.login.file"));
 	}
 
 	@Test
@@ -641,13 +625,6 @@ class FlywayAutoConfigurationTests {
 					BeanDefinition beanDefinition = context.getBeanFactory().getBeanDefinition("dslContext");
 					assertThat(beanDefinition.getDependsOn()).containsExactlyInAnyOrder("customFlyway");
 				});
-	}
-
-	@Test
-	void baselineMigrationPrefixIsCorrectlyMapped() {
-		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
-				.withPropertyValues("spring.flyway.baseline-migration-prefix=BL")
-				.run(validateFlywayTeamsPropertyOnly("baselineMigrationPrefix"));
 	}
 
 	@Test
@@ -1004,11 +981,6 @@ class FlywayAutoConfigurationTests {
 		}
 
 		@Override
-		public boolean isUndo() {
-			return false;
-		}
-
-		@Override
 		public boolean canExecuteInTransaction() {
 			return true;
 		}
@@ -1016,11 +988,6 @@ class FlywayAutoConfigurationTests {
 		@Override
 		public void migrate(org.flywaydb.core.api.migration.Context context) {
 
-		}
-
-		@Override
-		public boolean isBaselineMigration() {
-			return false;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayPropertiesTests.java
@@ -44,7 +44,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class FlywayPropertiesTests {
 
-	@SuppressWarnings("deprecation")
 	@Test
 	void defaultValuesAreConsistent() {
 		FlywayProperties properties = new FlywayProperties();
@@ -86,10 +85,6 @@ class FlywayPropertiesTests {
 		assertThat(configuration.isCleanDisabled()).isEqualTo(properties.isCleanDisabled());
 		assertThat(configuration.isCleanOnValidationError()).isEqualTo(properties.isCleanOnValidationError());
 		assertThat(configuration.isGroup()).isEqualTo(properties.isGroup());
-		assertThat(configuration.isIgnoreMissingMigrations()).isEqualTo(properties.isIgnoreMissingMigrations());
-		assertThat(configuration.isIgnoreIgnoredMigrations()).isEqualTo(properties.isIgnoreIgnoredMigrations());
-		assertThat(configuration.isIgnorePendingMigrations()).isEqualTo(properties.isIgnorePendingMigrations());
-		assertThat(configuration.isIgnoreFutureMigrations()).isEqualTo(properties.isIgnoreFutureMigrations());
 		assertThat(configuration.isMixed()).isEqualTo(properties.isMixed());
 		assertThat(configuration.isOutOfOrder()).isEqualTo(properties.isOutOfOrder());
 		assertThat(configuration.isSkipDefaultCallbacks()).isEqualTo(properties.isSkipDefaultCallbacks());
@@ -113,7 +108,7 @@ class FlywayPropertiesTests {
 		ignoreProperties(properties, "sqlServerKerberosLoginFile");
 		// High level object we can't set with properties
 		ignoreProperties(configuration, "callbacks", "classLoader", "dataSource", "javaMigrations",
-				"javaMigrationClassProvider", "resourceProvider", "resolvers");
+				"javaMigrationClassProvider", "pluginRegister", "resourceProvider", "resolvers");
 		// Properties we don't want to expose
 		ignoreProperties(configuration, "resolversAsClassNames", "callbacksAsClassNames", "loggers", "driver");
 		// Handled by the conversion service

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -243,7 +243,7 @@ bom {
 			]
 		}
 	}
-	library("Flyway", "8.5.13") {
+	library("Flyway", "9.0.1") {
 		group("org.flywaydb") {
 			modules = [
 				"flyway-core",


### PR DESCRIPTION
This PR upgrades Flyway dependency to [recently released `9.0.1`](https://flywaydb.org/documentation/learnmore/releaseNotes#9.0.1) and adjusts to various breaking changes:

- removal of previously deprecated properties (`ignore*Migrations`, `oracleKerberosConfigFile`)
- removal of properties that have moved out of Flyway OSS (`baselineMigrationPrefix`)
- change of default values for properties (`cleanDisabled`)
- `PluginRegister#getPlugin` not being `static` anymore
- `MigrationType` changed from being an `enum` to `interface`
- license key detection log entry