### PR TITLE
Use batch.jdbc.platform to databaseType in JobRepositoryFactoryBean

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BasicBatchConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BasicBatchConfigurer.java
@@ -131,6 +131,7 @@ public class BasicBatchConfigurer implements BatchConfigurer, InitializingBean {
 		map.from(this::determineIsolationLevel).whenNonNull().to(factory::setIsolationLevelForCreate);
 		map.from(this.properties.getJdbc()::getTablePrefix).whenHasText().to(factory::setTablePrefix);
 		map.from(this::getTransactionManager).to(factory::setTransactionManager);
+		map.from(this.properties.getJdbc()::getPlatform).whenHasText().to(factory::setDatabaseType);
 		factory.afterPropertiesSet();
 		return factory.getObject();
 	}


### PR DESCRIPTION
I am using `@BatchDataSource` with reference to https://github.com/spring-projects/spring-boot/issues/9114 and https://github.com/spring-projects/spring-boot/issues/28932.

However, if `@BatchDataSource` is not accessible, the application does not run even if job.enabled is false.

Can skip errors with this PR.


This is my setup.

```
spring:
  datasource:
    url: jdbc:mysql://{{accessible database}}/db
  datasource-batch: #custom
    url: jdbc:mysql://{{unreachable database}}/db
  jpa:
    database: mysql
  batch:
    jdbc:
      platform: mysql
    job:
      enabled: false
```

This is error content.

```
Caused by: java.lang.IllegalStateException: Unable to initialize Spring Batch
	at org.springframework.boot.autoconfigure.batch.BasicBatchConfigurer.initialize(BasicBatchConfigurer.java:106)
	at org.springframework.boot.autoconfigure.batch.BasicBatchConfigurer.afterPropertiesSet(BasicBatchConfigurer.java:95)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1863)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1800)
	... 33 common frames omitted
Caused by: org.springframework.jdbc.support.MetaDataAccessException: Could not get Connection for extracting meta-data; nested exception is org.springframework.jdbc.CannotGetJdbcConnectionException: Failed to obtain JDBC Connection; nested exception is java.sql.SQLNonTransientConnectionException: Could not create connection to database server. Attempted reconnect 3 times. Giving up.
	at org.springframework.jdbc.support.JdbcUtils.extractDatabaseMetaData(JdbcUtils.java:363)
	at org.springframework.jdbc.support.JdbcUtils.extractDatabaseMetaData(JdbcUtils.java:395)
	at org.springframework.batch.support.DatabaseType.fromMetaData(DatabaseType.java:102)
	at org.springframework.batch.core.repository.support.JobRepositoryFactoryBean.afterPropertiesSet(JobRepositoryFactoryBean.java:183)
	at org.springframework.boot.autoconfigure.batch.BasicBatchConfigurer.createJobRepository(BasicBatchConfigurer.java:133)
	at org.springframework.boot.autoconfigure.batch.BasicBatchConfigurer.initialize(BasicBatchConfigurer.java:101)
	... 36 common frames omitted
```