### PR TITLE
Align Kotlin API and language versions

### DIFF
--- a/spring-boot-project/spring-boot-docs/build.gradle
+++ b/spring-boot-project/spring-boot-docs/build.gradle
@@ -40,11 +40,6 @@ plugins.withType(EclipsePlugin) {
 	}
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) { 
-	kotlinOptions.apiVersion = '1.6'
-	kotlinOptions.languageVersion = '1.6'
-}
-
 dependencies {
 	actuatorApiDocumentation(project(path: ":spring-boot-project:spring-boot-actuator-autoconfigure", configuration: "documentation"))
 


### PR DESCRIPTION
Hi,

this PR aligns the version handling of Kotlin API and language level by removing the pinning on 1.6 inside the docs project, which got introduced in #29654 to allow for more modern docs while still maintaining a 1.3 baseline overall.

Now that 1.7 is the baseline (see #31391) this imho doesn't serve a purpose anymore and would hold back any modernization of documentation snippets at the moment.

Let me know what you think.

Cheers,
Christoph