### PR TITLE
Disable auto-detection in tests that start Hazelcast

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/resources/hazelcast.xml
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/resources/hazelcast.xml
@@ -5,6 +5,7 @@
 	<map name="defaultCache" />
 	<network>
 		<join>
+			<auto-detection enabled="false"/>
 			<tcp-ip enabled="false"/>
 			<multicast enabled="false"/>
 		</join>

--- a/spring-boot-project/spring-boot-actuator/src/test/resources/hazelcast.xml
+++ b/spring-boot-project/spring-boot-actuator/src/test/resources/hazelcast.xml
@@ -6,6 +6,7 @@
 	<map name="defaultCache" />
 	<network>
 		<join>
+			<auto-detection enabled="false" />
 			<tcp-ip enabled="false"/>
 			<multicast enabled="false"/>
 		</join>

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationServerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationServerTests.java
@@ -139,6 +139,7 @@ class HazelcastAutoConfigurationServerTests {
 	@Test
 	void configInstanceWithName() {
 		Config config = new Config("my-test-instance");
+		config.getNetworkConfig().getJoin().getAutoDetectionConfig().setEnabled(false);
 		HazelcastInstance existing = Hazelcast.newHazelcastInstance(config);
 		try {
 			this.contextRunner.withUserConfiguration(HazelcastConfigWithName.class)
@@ -221,6 +222,7 @@ class HazelcastAutoConfigurationServerTests {
 		@Bean
 		Config anotherHazelcastConfig() {
 			Config config = new Config();
+			config.getNetworkConfig().getJoin().getAutoDetectionConfig().setEnabled(false);
 			config.addQueueConfig(new QueueConfig("another-queue"));
 			return config;
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/hazelcast.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/hazelcast.xml
@@ -5,6 +5,7 @@
 	<map name="defaultCache" />
 	<network>
 		<join>
+			<auto-detection enabled="false" />
 			<tcp-ip enabled="false" />
 			<multicast enabled="false" />
 		</join>

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/hazelcast.yaml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/hazelcast.yaml
@@ -1,5 +1,7 @@
 hazelcast:
   network:
     join:
+      auto-detection:
+        enabled: false
       multicast:
         enabled: false

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.xml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.xml
@@ -11,6 +11,7 @@
 
 	<network>
 		<join>
+			<auto-detection enabled="false" />
 			<tcp-ip enabled="false"/>
 			<multicast enabled="false"/>
 		</join>

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.yaml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.yaml
@@ -1,6 +1,8 @@
 hazelcast:
   network:
     join:
+      auto-detection:
+        enabled: false
       multicast:
         enabled: false
 


### PR DESCRIPTION
Updated test configs to disable auto-detection for Hazelcast instances

Closes #31715


