### PR TITLE
Fix links in documentations

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/attributes.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/attributes.adoc
@@ -90,7 +90,6 @@
 :spring-security: https://spring.io/projects/spring-security
 :spring-security-docs: https://docs.spring.io/spring-security/reference/{spring-security-version}
 :spring-security-oauth2: https://spring.io/projects/spring-security-oauth
-:spring-security-oauth2-docs: https://projects.spring.io/spring-security-oauth/docs/oauth2.html
 :spring-session: https://spring.io/projects/spring-session
 :spring-webservices-docs: https://docs.spring.io/spring-ws/docs/{spring-webservices-version}/reference/html/
 :ant-docs: https://ant.apache.org/manual

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/sql.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/sql.adoc
@@ -22,7 +22,7 @@ You need to populate your database when your application starts and be prepared 
 
 TIP: The "`How-to`" section includes a <<howto#howto.data-initialization, section on how to initialize a database>>.
 
-Spring Boot can auto-configure embedded https://www.h2database.com[H2], http://hsqldb.org/[HSQL], and https://db.apache.org/derby/[Derby] databases.
+Spring Boot can auto-configure embedded https://www.h2database.com[H2], https://hsqldb.org/[HSQL], and https://db.apache.org/derby/[Derby] databases.
 You need not provide any connection URLs.
 You need only include a build dependency to the embedded database that you want to use.
 If there are multiple embedded databases on the classpath, set the configprop:spring.datasource.embedded-database-connection[] configuration property to control which one is used.

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
@@ -565,7 +565,7 @@ If you need a secure way to store credentials and passwords, the https://cloud.s
 [[features.external-config.yaml]]
 === Working with YAML
 https://yaml.org[YAML] is a superset of JSON and, as such, is a convenient format for specifying hierarchical configuration data.
-The `SpringApplication` class automatically supports YAML as an alternative to properties whenever you have the https://bitbucket.org/asomov/snakeyaml[SnakeYAML] library on your classpath.
+The `SpringApplication` class automatically supports YAML as an alternative to properties whenever you have the https://github.com/snakeyaml/snakeyaml[SnakeYAML] library on your classpath.
 
 NOTE: If you use "`Starters`", SnakeYAML is automatically provided by `spring-boot-starter`.
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/logging.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/logging.adoc
@@ -266,7 +266,7 @@ In order to release logging resources when your application terminates, a shutdo
 This shutdown hook is registered automatically unless your application is deployed as a war file.
 If your application has complex context hierarchies the shutdown hook may not meet your needs.
 If it does not, disable the shutdown hook and investigate the options provided directly by the underlying logging system.
-For example, Logback offers http://logback.qos.ch/manual/loggingSeparation.html[context selectors] which allow each Logger to be created in its own context.
+For example, Logback offers https://logback.qos.ch/manual/loggingSeparation.html[context selectors] which allow each Logger to be created in its own context.
 You can use the configprop:logging.register-shutdown-hook[] property to disable the shutdown hook.
 Setting it to `false` will disable the registration.
 You can set the property in your `application.properties` or `application.yaml` file:

--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -34,9 +34,6 @@ do as they were designed before this was clarified.
 | https://qpid.apache.org/components/jms/[Apache Qpid]
 | https://github.com/amqphub/amqp-10-jms-spring-boot
 
-| https://rocketmq.apache.org/[Apache RocketMQ]
-| https://github.com/ThierrySquirrel/rocketmq-spring-boot-starter
-
 | https://wicket.apache.org/[Apache Wicket]
 | https://github.com/MarcGiffing/wicket-spring-boot
 
@@ -161,7 +158,7 @@ do as they were designed before this was clarified.
 | https://github.com/liquigraph/liquigraph
 
 | https://logback.qos.ch/access.html[Logback-access]
-| https://github.com/akihyro/logback-access-spring-boot-starter
+| https://github.com/akkinoc/logback-access-spring-boot-starter
 
 | https://github.com/mulesoft/mule[Mule 4]
 | https://github.com/hawkore/mule4-spring-boot-starter
@@ -230,7 +227,7 @@ do as they were designed before this was clarified.
 | https://github.com/fonimus/ssh-shell-spring-boot
 
 | https://github.com/savantly-net/sprout-platform[Sprout Platform]
-| https://github.com/savantly-net/sprout-platform/tree/master/spring/sprout-spring-boot-starter
+| https://github.com/savantly-net/sprout-platform/tree/master/backend/starters/sprout-spring-boot-starter
 
 | SSH Daemon
 | https://github.com/anand1st/sshd-shell-spring-boot

--- a/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/env/test-yaml.yml
+++ b/spring-boot-project/spring-boot/src/test/resources/org/springframework/boot/env/test-yaml.yml
@@ -1,4 +1,4 @@
-# https://docs.ansible.com/ansible/YAMLSyntax.html
+# https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html
 
 name: Martin D'vloper
 job: Developer

--- a/src/nohttp/allowlist.lines
+++ b/src/nohttp/allowlist.lines
@@ -1,8 +1,5 @@
-^http://exslt.org/common.*
 ^http://ganglia.sourceforge.net.*
-^http://hsqldb.org.*
 ^http://livereload.com/.*
-^http://logback.qos.ch/manual/loggingSeparation.html
 ^http://schemas.xmlsoap.org/.*
 ^http://www.jdotsoft.com.*
 ^http://www.liquibase.org/xml/ns/dbchangelog/.*


### PR DESCRIPTION
- fix broken links (using their new URL, an alternative URL or a Wayback Machine link),
- use HTTPS where possible,
- remove spring-security-oauth2-docs : this link is not used anymore,
- remove https://github.com/ThierrySquirrel/rocketmq-spring-boot-starter, this starter is 404 and https://github.com/rocketmq/rocketmq-spring-boot-starter hasn't been updated for 4 years,
- cleanup nohttp allowlist.lines.
