### PR TITLE
Remove unused code in GitInfoContributor

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/GitInfoContributor.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/GitInfoContributor.java
@@ -71,7 +71,6 @@ public class GitInfoContributor extends InfoPropertiesInfoContributor<GitPropert
 	@Override
 	protected void postProcessContent(Map<String, Object> content) {
 		replaceValue(getNestedMap(content, "commit"), "time", getProperties().getCommitTime());
-		replaceValue(getNestedMap(content, "build"), "time", getProperties().getInstant("build.time"));
 	}
 
 	static class GitInfoContributorRuntimeHints implements RuntimeHintsRegistrar {


### PR DESCRIPTION
As stated in the documentation at https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#info.retrieving.response-structure.git, the `info` Actuator endpoint doesn't include a `build.time` in the response.
Yet, in `GitInfoContributor::postProcessContent()`, the method looks for a `build.time` property that thus never exists, because it's not retained in the `toSimplePropertySource()` method above.
The line of code in question doesn't break anything but it has no effect either.
That's why I suggest removing it altogether for clarity.