### PR TITLE
Misleading error message when using JarMode Layertools and the source is not an archive

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/main/java/org/springframework/boot/jarmode/layertools/Context.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/main/java/org/springframework/boot/jarmode/layertools/Context.java
@@ -55,7 +55,8 @@ class Context {
 	 * @param workingDir the working directory
 	 */
 	Context(File archiveFile, File workingDir) {
-		Assert.state(isExistingFile(archiveFile) && isJarOrWar(archiveFile), "Unable to find source archive");
+		Assert.state(isExistingFile(archiveFile), "Unable to find source archive");
+		Assert.state(isJarOrWar(archiveFile), "Source archive doesn't end with .jar or .war");
 		this.archiveFile = archiveFile;
 		this.workingDir = workingDir;
 		this.relativeDir = deduceRelativeDir(archiveFile.getParentFile(), this.workingDir);


### PR DESCRIPTION
If the source file given to the layertools is not an archive file, the error message says that the file cannot be found. That might be confusing, if the file actually exists but "only" has the wrong suffix.
I think splitting the assertion into two separate ones gives more precise error messages.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
