### PR TITLE
Remove use of reflection in MustacheViewResolver

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/result/view/MustacheViewResolver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/result/view/MustacheViewResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.web.reactive.result.view.ViewResolver;
  * Spring WebFlux {@link ViewResolver} for Mustache.
  *
  * @author Brian Clozel
+ * @author Marten Deinum
  * @since 2.0.0
  */
 public class MustacheViewResolver extends UrlBasedViewResolver {
@@ -73,6 +74,11 @@ public class MustacheViewResolver extends UrlBasedViewResolver {
 		view.setCompiler(this.compiler);
 		view.setCharset(this.charset);
 		return view;
+	}
+
+	@Override
+	protected AbstractUrlBasedView instantiateView() {
+		return (getViewClass() == MustacheView.class) ? new MustacheView() : super.instantiateView();
 	}
 
 }


### PR DESCRIPTION
Prior to this commit the MustacheViewResolver used reflection
to instantiate a MustacheView class, which fails when using AOT.
Creating the view without reflection (analogous to the
FreemarkerViewResolver) will fix this without the need for additional
constructor hints.

Fixes: #32028

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
