### PR TITLE
Add socketKeepAlive configuration property for Elasticsearch

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchProperties.java
@@ -63,9 +63,9 @@ public class ElasticsearchProperties {
 	private String pathPrefix;
 
 	/**
-	 * Whether to enable keepalive between client and Elasticsearch.
+	 * Whether to enable socket keep alive between client and Elasticsearch.
 	 */
-	private boolean keepalive = true;
+	private boolean socketKeepAlive = false;
 
 	private final Restclient restclient = new Restclient();
 
@@ -117,12 +117,12 @@ public class ElasticsearchProperties {
 		this.pathPrefix = pathPrefix;
 	}
 
-	public boolean isKeepalive() {
-		return this.keepalive;
+	public boolean isSocketKeepAlive() {
+		return this.socketKeepAlive;
 	}
 
-	public void setKeepalive(boolean keepalive) {
-		this.keepalive = keepalive;
+	public void setSocketKeepAlive(boolean socketKeepAlive) {
+		this.socketKeepAlive = socketKeepAlive;
 	}
 
 	public Restclient getRestclient() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchProperties.java
@@ -62,6 +62,11 @@ public class ElasticsearchProperties {
 	 */
 	private String pathPrefix;
 
+	/**
+	 * Whether to enable keepalive between client and Elasticsearch.
+	 */
+	private boolean keepalive = true;
+
 	private final Restclient restclient = new Restclient();
 
 	public List<String> getUris() {
@@ -110,6 +115,14 @@ public class ElasticsearchProperties {
 
 	public void setPathPrefix(String pathPrefix) {
 		this.pathPrefix = pathPrefix;
+	}
+
+	public boolean isKeepalive() {
+		return this.keepalive;
+	}
+
+	public void setKeepalive(boolean keepalive) {
+		this.keepalive = keepalive;
 	}
 
 	public Restclient getRestclient() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java
@@ -27,6 +27,7 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.reactor.IOReactorConfig;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.sniff.Sniffer;
@@ -155,6 +156,8 @@ class ElasticsearchRestClientConfigurations {
 		@Override
 		public void customize(HttpAsyncClientBuilder builder) {
 			builder.setDefaultCredentialsProvider(new PropertiesCredentialsProvider(this.properties));
+			map.from(this.properties::isKeepalive).whenTrue()
+					.to(keepalive -> builder.setDefaultIOReactorConfig(IOReactorConfig.custom().setSoKeepAlive(keepalive).build()));
 		}
 
 		@Override

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java
@@ -156,7 +156,7 @@ class ElasticsearchRestClientConfigurations {
 		@Override
 		public void customize(HttpAsyncClientBuilder builder) {
 			builder.setDefaultCredentialsProvider(new PropertiesCredentialsProvider(this.properties));
-			map.from(this.properties::isKeepalive).whenTrue()
+			map.from(this.properties::isSocketKeepAlive).whenTrue()
 					.to(keepalive -> builder.setDefaultIOReactorConfig(IOReactorConfig.custom().setSoKeepAlive(keepalive).build()));
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfigurationTests.java
@@ -184,20 +184,16 @@ class ElasticsearchRestClientAutoConfigurationTests {
 	}
 
 	@Test
-	void configureWithNoSocketKeepAliveApplyDefaults() {
-		this.contextRunner.run(
-				context -> {
-					assertThat(context).hasSingleBean(RestClient.class);
-					RestClient client = context.getBean(RestClient.class);
-					assertThat(client.getHttpClient()).extracting("connmgr.ioReactor.config.soKeepAlive").isEqualTo(Boolean.FALSE);
-				}
-		);
+	void socketKeepAliveDefaults() {
+		RestClient client = RestClient.builder(new HttpHost("localhost", 9201, "http")).build();
+		assertThat(client.getHttpClient()).extracting("connmgr.ioReactor.config.soKeepAlive").isEqualTo(Boolean.FALSE);
 	}
 
 	@Test
 	void configureWithCustomSocketKeepAlive() {
 		this.contextRunner.withPropertyValues("spring.elasticsearch.socket-keep-alive=true").run(
 				context -> {
+					assertThat(context).hasSingleBean(RestClient.class);
 					RestClient client = context.getBean(RestClient.class);
 					assertThat(client.getHttpClient()).extracting("connmgr.ioReactor.config.soKeepAlive").isEqualTo(Boolean.TRUE);
 				}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfigurationTests.java
@@ -184,8 +184,19 @@ class ElasticsearchRestClientAutoConfigurationTests {
 	}
 
 	@Test
-	void configureWithKeepalive() {
-		this.contextRunner.withPropertyValues("spring.elasticsearch.keepalive=true").run(
+	void configureWithNoSocketKeepAliveApplyDefaults() {
+		this.contextRunner.run(
+				context -> {
+					assertThat(context).hasSingleBean(RestClient.class);
+					RestClient client = context.getBean(RestClient.class);
+					assertThat(client.getHttpClient()).extracting("connmgr.ioReactor.config.soKeepAlive").isEqualTo(Boolean.FALSE);
+				}
+		);
+	}
+
+	@Test
+	void configureWithCustomSocketKeepAlive() {
+		this.contextRunner.withPropertyValues("spring.elasticsearch.socket-keep-alive=true").run(
 				context -> {
 					RestClient client = context.getBean(RestClient.class);
 					assertThat(client.getHttpClient()).extracting("connmgr.ioReactor.config.soKeepAlive").isEqualTo(Boolean.TRUE);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfigurationTests.java
@@ -184,6 +184,16 @@ class ElasticsearchRestClientAutoConfigurationTests {
 	}
 
 	@Test
+	void configureWithKeepalive() {
+		this.contextRunner.withPropertyValues("spring.elasticsearch.keepalive=true").run(
+				context -> {
+					RestClient client = context.getBean(RestClient.class);
+					assertThat(client.getHttpClient()).extracting("connmgr.ioReactor.config.soKeepAlive").isEqualTo(Boolean.TRUE);
+				}
+		);
+	}
+
+	@Test
 	void configureWithoutSnifferLibraryShouldNotCreateSniffer() {
 		this.contextRunner.withClassLoader(new FilteredClassLoader("org.elasticsearch.client.sniff"))
 				.run((context) -> assertThat(context).hasSingleBean(RestClient.class).doesNotHaveBean(Sniffer.class));


### PR DESCRIPTION
Keepalive property for the connection between client and elasticsearch should be considered as configurable. Futher more, i do think it's good to keep it alive by default.

Here is the issue:

When read/write elasticsearch in high concurrency, threads have chances to stuck on obsolete connection between client and elasticsearch. The more threads involves, the quicker stucking on connection happens. The reason is described [here](https://github.com/elastic/elasticsearch/issues/65213#issue-745760090):
> Worse, if the connection is dropped silently while a request is in flight then the client may block indefinitely since it will send no more data on this connection and will therefore never find out that it's been closed.

And here is the situation i run into. Logs can also be found here:
- https://stackoverflow.com/questions/73217318/elasticsearch-java-response-stuck

similar issue:
- https://github.com/elastic/elasticsearch/issues/65909

However, spring boot can't config keepalive through current properties. We have to write some config codes like:
```
    @Bean
    public RestClientBuilderCustomizer keepalive() {
        return new RestClientBuilderCustomizer() {
            @Override
            public void customize(RestClientBuilder builder) {

            }

            @Override
            public void customize(HttpAsyncClientBuilder builder) {
                builder.setDefaultIOReactorConfig(IOReactorConfig.custom().setSoKeepAlive(true).build());
                log.info("es tcp keep-alive must be enabled!");
            }
        };
    }
```

So i add some support for `spring.elasticsearch.keepalive=true` to make it easier to config.