### PR TITLE
Allow different log level for FILE and CONSOLE appender

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/logging.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/logging.adoc
@@ -336,6 +336,10 @@ To help with the customization, some other properties are transferred from the S
 | `CONSOLE_LOG_CHARSET`
 | The charset to use for console logging.
 
+| configprop:logging.threshold.console[]
+| `CONSOLE_LOG_THRESHOLD`
+| The log level threshold to use for console logging.
+
 | configprop:logging.pattern.file[]
 | `FILE_LOG_PATTERN`
 | The log pattern to use in a file (if `LOG_FILE` is enabled).
@@ -343,6 +347,10 @@ To help with the customization, some other properties are transferred from the S
 | configprop:logging.charset.file[]
 | `FILE_LOG_CHARSET`
 | The charset to use for file logging (if `LOG_FILE` is enabled).
+
+| configprop:logging.threshold.file[]
+| `FILE_LOG_THRESHOLD`
+| The log level threshold to use for file logging.
 
 | configprop:logging.pattern.level[]
 | `LOG_LEVEL_PATTERN`

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
@@ -71,6 +71,11 @@ public class LoggingSystemProperties {
 	public static final String CONSOLE_LOG_CHARSET = "CONSOLE_LOG_CHARSET";
 
 	/**
+	 * The log level threshold for console log.
+	 */
+	public static final String CONSOLE_LOG_THRESHOLD = "CONSOLE_LOG_THRESHOLD";
+
+	/**
 	 * The name of the System property that contains the file log pattern.
 	 */
 	public static final String FILE_LOG_PATTERN = "FILE_LOG_PATTERN";
@@ -79,6 +84,11 @@ public class LoggingSystemProperties {
 	 * The name of the System property that contains the file log charset.
 	 */
 	public static final String FILE_LOG_CHARSET = "FILE_LOG_CHARSET";
+
+	/**
+	 * The log level threshold for file log.
+	 */
+	public static final String FILE_LOG_THRESHOLD = "FILE_LOG_THRESHOLD";
 
 	/**
 	 * The name of the System property that contains the log level pattern.
@@ -139,9 +149,11 @@ public class LoggingSystemProperties {
 		setSystemProperty(PID_KEY, new ApplicationPid().toString());
 		setSystemProperty(resolver, CONSOLE_LOG_PATTERN, "logging.pattern.console");
 		setSystemProperty(resolver, CONSOLE_LOG_CHARSET, "logging.charset.console", getDefaultCharset().name());
+		setSystemProperty(resolver, CONSOLE_LOG_THRESHOLD, "logging.threshold.console");
 		setSystemProperty(resolver, LOG_DATEFORMAT_PATTERN, "logging.pattern.dateformat");
 		setSystemProperty(resolver, FILE_LOG_PATTERN, "logging.pattern.file");
 		setSystemProperty(resolver, FILE_LOG_CHARSET, "logging.charset.file", getDefaultCharset().name());
+		setSystemProperty(resolver, FILE_LOG_THRESHOLD, "logging.threshold.file");
 		setSystemProperty(resolver, LOG_LEVEL_PATTERN, "logging.pattern.level");
 		if (logFile != null) {
 			logFile.applyToSystemProperties();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
@@ -20,6 +20,7 @@ import java.nio.charset.Charset;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.filter.ThresholdFilter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
@@ -75,11 +76,13 @@ class DefaultLogbackConfiguration {
 		String defaultCharset = Charset.defaultCharset().name();
 		config.getContext().putProperty("CONSOLE_LOG_CHARSET",
 				resolve(config, "${CONSOLE_LOG_CHARSET:-" + defaultCharset + "}"));
+		config.getContext().putProperty("CONSOLE_LOG_THRESHOLD", resolve(config, "${CONSOLE_LOG_THRESHOLD:-TRACE}"));
 		config.getContext().putProperty("FILE_LOG_PATTERN", resolve(config, "${FILE_LOG_PATTERN:-"
 				+ "%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd'T'HH:mm:ss.SSSXXX}} ${LOG_LEVEL_PATTERN:-%5p} ${PID:- } --- [%t] "
 				+ "%-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"));
 		config.getContext().putProperty("FILE_LOG_CHARSET",
 				resolve(config, "${FILE_LOG_CHARSET:-" + defaultCharset + "}"));
+		config.getContext().putProperty("FILE_LOG_THRESHOLD", resolve(config, "${FILE_LOG_THRESHOLD:-TRACE}"));
 		config.logger("org.apache.catalina.startup.DigesterFactory", Level.ERROR);
 		config.logger("org.apache.catalina.util.LifecycleBase", Level.ERROR);
 		config.logger("org.apache.coyote.http11.Http11NioProtocol", Level.WARN);
@@ -92,6 +95,9 @@ class DefaultLogbackConfiguration {
 
 	private Appender<ILoggingEvent> consoleAppender(LogbackConfigurator config) {
 		ConsoleAppender<ILoggingEvent> appender = new ConsoleAppender<>();
+		ThresholdFilter filter = new ThresholdFilter();
+		filter.setLevel(resolve(config, "${CONSOLE_LOG_THRESHOLD}"));
+		appender.addFilter(filter);
 		PatternLayoutEncoder encoder = new PatternLayoutEncoder();
 		encoder.setPattern(resolve(config, "${CONSOLE_LOG_PATTERN}"));
 		encoder.setCharset(resolveCharset(config, "${CONSOLE_LOG_CHARSET}"));
@@ -103,6 +109,9 @@ class DefaultLogbackConfiguration {
 
 	private Appender<ILoggingEvent> fileAppender(LogbackConfigurator config, String logFile) {
 		RollingFileAppender<ILoggingEvent> appender = new RollingFileAppender<>();
+		ThresholdFilter filter = new ThresholdFilter();
+		filter.setLevel(resolve(config, "${FILE_LOG_THRESHOLD}"));
+		appender.addFilter(filter);
 		PatternLayoutEncoder encoder = new PatternLayoutEncoder();
 		encoder.setPattern(resolve(config, "${FILE_LOG_PATTERN}"));
 		encoder.setCharset(resolveCharset(config, "${FILE_LOG_CHARSET}"));

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -204,6 +204,18 @@
       "defaultValue": true
     },
     {
+      "name": "logging.threshold.console",
+      "type": "java.lang.String",
+      "description": "Log level threshold for console output.",
+      "defaultValue": "TRACE"
+    },
+    {
+      "name": "logging.threshold.file",
+      "type": "java.lang.String",
+      "description": "Log level threshold for file output.",
+      "defaultValue": "TRACE"
+    },
+    {
       "name": "spring.application.index",
       "type": "java.lang.Integer",
       "description": "Application index.",

--- a/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2-file.xml
+++ b/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2-file.xml
@@ -10,9 +10,15 @@
 	<Appenders>
 		<Console name="Console" target="SYSTEM_OUT" follow="true">
 			<PatternLayout pattern="${sys:CONSOLE_LOG_PATTERN}" charset="${sys:CONSOLE_LOG_CHARSET}" />
+			<Filters>
+				<ThresholdFilter level="${sys:CONSOLE_LOG_THRESHOLD:-TRACE}"/>
+			</Filters>
 		</Console>
 		<RollingFile name="File" fileName="${sys:LOG_FILE}" filePattern="${sys:LOG_PATH}/$${date:yyyy-MM}/app-%d{yyyy-MM-dd-HH}-%i.log.gz">
 			<PatternLayout pattern="${sys:FILE_LOG_PATTERN}" charset="${sys:FILE_LOG_CHARSET}"/>
+			<Filters>
+				<ThresholdFilter level="${sys:FILE_LOG_THRESHOLD:-TRACE}"/>
+			</Filters>
 			<Policies>
 				<SizeBasedTriggeringPolicy size="10 MB" />
 			</Policies>

--- a/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2.xml
+++ b/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2.xml
@@ -10,6 +10,9 @@
 	<Appenders>
 		<Console name="Console" target="SYSTEM_OUT" follow="true">
 			<PatternLayout pattern="${sys:CONSOLE_LOG_PATTERN}" charset="${sys:CONSOLE_LOG_CHARSET}"/>
+			<filters>
+				<ThresholdFilter level="${sys:CONSOLE_LOG_THRESHOLD:-TRACE}"/>
+			</filters>
 		</Console>
 	</Appenders>
 	<Loggers>

--- a/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/console-appender.xml
+++ b/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/console-appender.xml
@@ -7,6 +7,9 @@ initialization performed by Boot
 
 <included>
 	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+			<level>${CONSOLE_LOG_THRESHOLD}</level>
+		</filter>
 		<encoder>
 			<pattern>${CONSOLE_LOG_PATTERN}</pattern>
 			<charset>${CONSOLE_LOG_CHARSET}</charset>

--- a/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/defaults.xml
+++ b/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/defaults.xml
@@ -11,8 +11,10 @@ Default logback configuration provided for import
 
 	<property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd'T'HH:mm:ss.SSSXXX}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
 	<property name="CONSOLE_LOG_CHARSET" value="${CONSOLE_LOG_CHARSET:-${file.encoding:-UTF-8}}"/>
+	<property name="CONSOLE_LOG_THRESHOLD" value="${CONSOLE_LOG_THRESHOLD:-TRACE}"/>
 	<property name="FILE_LOG_PATTERN" value="${FILE_LOG_PATTERN:-%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd'T'HH:mm:ss.SSSXXX}} ${LOG_LEVEL_PATTERN:-%5p} ${PID:- } --- [%t] %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
 	<property name="FILE_LOG_CHARSET" value="${FILE_LOG_CHARSET:-${file.encoding:-UTF-8}}"/>
+	<property name="FILE_LOG_THRESHOLD" value="${FILE_LOG_THRESHOLD:-TRACE}"/>
 
 	<logger name="org.apache.catalina.startup.DigesterFactory" level="ERROR"/>
 	<logger name="org.apache.catalina.util.LifecycleBase" level="ERROR"/>

--- a/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/file-appender.xml
+++ b/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/file-appender.xml
@@ -7,6 +7,9 @@ initialization performed by Boot
 
 <included>
 	<appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+			<level>${FILE_LOG_THRESHOLD}</level>
+		</filter>
 		<encoder>
 			<pattern>${FILE_LOG_PATTERN}</pattern>
 			<charset>${FILE_LOG_CHARSET}</charset>


### PR DESCRIPTION
Fix gh-32075.

Notice jul isn't supported yet.

With this patch,  we can set different log level for console and file appenders without falling back to customized log4j.xml or logback-spring.xml.

Related questions on stackoverflow:

* https://stackoverflow.com/questions/51349261/how-to-set-different-logging-levels-for-console-writing-and-file-writing-in-java
* https://stackoverflow.com/questions/51277445/how-to-specify-specific-logger-level-for-each-of-file-writing-and-console-writin