### PR TITLE
Allow to disable JacksonFeature in JerseyAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfiguration.java
@@ -74,6 +74,7 @@ import org.springframework.web.filter.RequestContextFilter;
  * @author Andy Wilkinson
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @author Sascha Woo
  * @since 1.2.0
  */
 @AutoConfiguration(before = DispatcherServletAutoConfiguration.class, after = JacksonAutoConfiguration.class)
@@ -182,6 +183,7 @@ public class JerseyAutoConfiguration implements ServletContextAware {
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(JacksonFeature.class)
 	@ConditionalOnSingleCandidate(ObjectMapper.class)
+	@ConditionalOnProperty(prefix = "spring.jersey", name = "feature", havingValue = "jackson", matchIfMissing = true)
 	static class JacksonResourceConfigCustomizer {
 
 		@Bean

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jersey/JerseyProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jersey/JerseyProperties.java
@@ -27,6 +27,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Dave Syer
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @author Sascha Woo
  * @since 1.2.0
  */
 @ConfigurationProperties(prefix = "spring.jersey")
@@ -36,6 +37,11 @@ public class JerseyProperties {
 	 * Jersey integration type.
 	 */
 	private Type type = Type.SERVLET;
+
+	/**
+	 * Jersey feature. By default {@code JacksonFeature} is enabled.
+	 */
+	private Feature feature = Feature.JACKSON;
 
 	/**
 	 * Init parameters to pass to Jersey through the servlet or filter.
@@ -83,10 +89,24 @@ public class JerseyProperties {
 	public void setApplicationPath(String applicationPath) {
 		this.applicationPath = applicationPath;
 	}
+	
+	public Feature getFeature() {
+		return feature;
+	}
+	
+	public void setFeature(Feature feature) {
+		this.feature = feature;
+	}
 
 	public enum Type {
 
 		SERVLET, FILTER
+
+	}
+
+	public enum Feature {
+
+		NONE, JACKSON
 
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfigurationTests.java
@@ -18,6 +18,8 @@ package org.springframework.boot.autoconfigure.jersey;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
+
+import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Test;
 
@@ -94,6 +96,25 @@ class JerseyAutoConfigurationTests {
 					ObjectMapper objectMapper = context.getBean(ObjectMapper.class);
 					assertThat(objectMapper.getSerializationConfig().getAnnotationIntrospector().allIntrospectors()
 							.stream().filter(JakartaXmlBindAnnotationIntrospector.class::isInstance)).isEmpty();
+				});
+	}
+
+	@Test
+	void whenFeatureIsJacksonTheJacksonFeatureIsRegistered() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(JacksonAutoConfiguration.class)).run((context) -> {
+			assertThat(context).hasSingleBean(ResourceConfig.class);
+			ResourceConfig config = context.getBean(ResourceConfig.class);
+			assertThat(config.isRegistered(JacksonFeature.class)).isTrue();
+		});
+	}
+
+	@Test
+	void whenFeatureIsNoneTheJacksonFeatureIsNotRegistered() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(JacksonAutoConfiguration.class))
+				.withPropertyValues("spring.jersey.feature=none").run((context) -> {
+					assertThat(context).hasSingleBean(ResourceConfig.class);
+					ResourceConfig config = context.getBean(ResourceConfig.class);
+					assertThat(config.isRegistered(JacksonFeature.class)).isFalse();
 				});
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

The Spring Boot auto-configuration for Jersey registers the `JacksonFeature` by default if an `ObjectMapper` bean is present. This is always the case if Jackson is on the classpath, because `JacksonAutoConfiguration` kicks in. In some cases, however, you may want to use Jersey without preconfigured Jackson, e.g. if you use MOXy instead. Having both configured in `ResourceConfig` leads to problems with XML serialization.
