### PR TITLE
Allow multiple hosts to be set in MongoProperties

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
@@ -212,7 +212,7 @@ public class MongoProperties {
 	}
 
 	public String getAdditionalHosts() {
-		return additionalHosts;
+		return this.additionalHosts;
 	}
 
 	public void setAdditionalHosts(String additionalHosts) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.autoconfigure.mongo;
 
+import java.util.List;
+
 import com.mongodb.ConnectionString;
 import org.bson.UuidRepresentation;
 
@@ -106,7 +108,10 @@ public class MongoProperties {
 	 */
 	private Boolean autoIndexCreation;
 
-	private String additionalHosts;
+	/**
+	 * List of additional hosts to connect with different hosts in a replica set.
+	 */
+	private List<String> additionalHosts;
 
 	public String getHost() {
 		return this.host;
@@ -211,11 +216,11 @@ public class MongoProperties {
 		this.autoIndexCreation = autoIndexCreation;
 	}
 
-	public String getAdditionalHosts() {
+	public List<String> getAdditionalHosts() {
 		return this.additionalHosts;
 	}
 
-	public void setAdditionalHosts(String additionalHosts) {
+	public void setAdditionalHosts(List<String> additionalHosts) {
 		this.additionalHosts = additionalHosts;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
@@ -33,6 +33,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Nasko Vasilev
  * @author Mark Paluch
  * @author Artsiom Yudovin
+ * @author Safeer Ansari
  * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "spring.data.mongodb")
@@ -104,6 +105,8 @@ public class MongoProperties {
 	 * Whether to enable auto-index creation.
 	 */
 	private Boolean autoIndexCreation;
+
+	private String additionalHosts;
 
 	public String getHost() {
 		return this.host;
@@ -206,6 +209,14 @@ public class MongoProperties {
 
 	public void setAutoIndexCreation(Boolean autoIndexCreation) {
 		this.autoIndexCreation = autoIndexCreation;
+	}
+
+	public String getAdditionalHosts() {
+		return additionalHosts;
+	}
+
+	public void setAdditionalHosts(String additionalHosts) {
+		this.additionalHosts = additionalHosts;
 	}
 
 	public static class Gridfs {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoPropertiesClientSettingsBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoPropertiesClientSettingsBuilderCustomizer.java
@@ -18,11 +18,9 @@ package org.springframework.boot.autoconfigure.mongo;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
@@ -91,7 +89,7 @@ public class MongoPropertiesClientSettingsBuilderCustomizer implements MongoClie
 			String[] additionalHosts = this.properties.getAdditionalHosts()
 					.substring(1, this.properties.getAdditionalHosts().length() - 1).split(",");
 			Arrays.stream(additionalHosts)
-					.forEach(additionalHost -> serverAddressList.add(new ServerAddress(additionalHost)));
+					.forEach((additionalHost) -> serverAddressList.add(new ServerAddress(additionalHost)));
 		}
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoPropertiesClientSettingsBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoPropertiesClientSettingsBuilderCustomizer.java
@@ -16,7 +16,13 @@
 
 package org.springframework.boot.autoconfigure.mongo;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
@@ -30,11 +36,15 @@ import org.springframework.core.Ordered;
  * {@link MongoProperties} to a {@link MongoClientSettings}.
  *
  * @author Scott Frederick
+ * @author Safeer Ansari
  * @since 2.4.0
  */
 public class MongoPropertiesClientSettingsBuilderCustomizer implements MongoClientSettingsBuilderCustomizer, Ordered {
 
 	private final MongoProperties properties;
+
+	private static final Pattern ADDITIONAL_HOSTS_PATTERN = Pattern
+			.compile("^\\[[0-9a-zA-Z]+(.)*(:)*(,[0-9a-zA-Z]+(.)*(:)*)*]$");
 
 	private int order = 0;
 
@@ -63,10 +73,26 @@ public class MongoPropertiesClientSettingsBuilderCustomizer implements MongoClie
 			String host = getOrDefault(this.properties.getHost(), "localhost");
 			int port = getOrDefault(this.properties.getPort(), MongoProperties.DEFAULT_PORT);
 			ServerAddress serverAddress = new ServerAddress(host, port);
-			settings.applyToClusterSettings((cluster) -> cluster.hosts(Collections.singletonList(serverAddress)));
+			List<ServerAddress> serverAddressList = new ArrayList<>(List.of(serverAddress));
+			applyAdditionalHosts(serverAddressList);
+			settings.applyToClusterSettings((cluster) -> cluster.hosts(serverAddressList));
 			return;
 		}
 		settings.applyConnectionString(new ConnectionString(MongoProperties.DEFAULT_URI));
+	}
+
+	private void applyAdditionalHosts(List<ServerAddress> serverAddressList) {
+		if (this.properties.getAdditionalHosts() != null && !this.properties.getAdditionalHosts().isEmpty()) {
+			Matcher matcher = ADDITIONAL_HOSTS_PATTERN.matcher((this.properties.getAdditionalHosts()));
+			if (!matcher.matches()) {
+				return;
+			}
+
+			String[] additionalHosts = this.properties.getAdditionalHosts()
+					.substring(1, this.properties.getAdditionalHosts().length() - 1).split(",");
+			Arrays.stream(additionalHosts)
+					.forEach(additionalHost -> serverAddressList.add(new ServerAddress(additionalHost)));
+		}
 	}
 
 	private void applyCredentials(MongoClientSettings.Builder builder) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoPropertiesClientSettingsBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoPropertiesClientSettingsBuilderCustomizer.java
@@ -17,10 +17,7 @@
 package org.springframework.boot.autoconfigure.mongo;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
@@ -40,9 +37,6 @@ import org.springframework.core.Ordered;
 public class MongoPropertiesClientSettingsBuilderCustomizer implements MongoClientSettingsBuilderCustomizer, Ordered {
 
 	private final MongoProperties properties;
-
-	private static final Pattern ADDITIONAL_HOSTS_PATTERN = Pattern
-			.compile("^\\[[0-9a-zA-Z]+(.)*(:)*(,[0-9a-zA-Z]+(.)*(:)*)*]$");
 
 	private int order = 0;
 
@@ -81,14 +75,7 @@ public class MongoPropertiesClientSettingsBuilderCustomizer implements MongoClie
 
 	private void applyAdditionalHosts(List<ServerAddress> serverAddressList) {
 		if (this.properties.getAdditionalHosts() != null && !this.properties.getAdditionalHosts().isEmpty()) {
-			Matcher matcher = ADDITIONAL_HOSTS_PATTERN.matcher((this.properties.getAdditionalHosts()));
-			if (!matcher.matches()) {
-				return;
-			}
-
-			String[] additionalHosts = this.properties.getAdditionalHosts()
-					.substring(1, this.properties.getAdditionalHosts().length() - 1).split(",");
-			Arrays.stream(additionalHosts)
+			this.properties.getAdditionalHosts()
 					.forEach((additionalHost) -> serverAddressList.add(new ServerAddress(additionalHost)));
 		}
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -981,12 +981,6 @@
       "defaultValue": true
     },
     {
-      "name": "spring.data.mongodb.additional-hosts",
-      "type": "java.lang.String",
-      "description": "List of additional hosts to connect with different hosts in a replica set.",
-      "defaultValue": ""
-    },
-    {
       "name": "spring.data.mongodb.grid-fs-database",
       "type": "java.lang.String",
       "deprecation": {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -981,6 +981,12 @@
       "defaultValue": true
     },
     {
+      "name": "spring.data.mongodb.additional-hosts",
+      "type": "java.lang.String",
+      "description": "List of additional hosts to connect with different hosts in a replica set.",
+      "defaultValue": ""
+    },
+    {
       "name": "spring.data.mongodb.grid-fs-database",
       "type": "java.lang.String",
       "deprecation": {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoPropertiesClientSettingsBuilderCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoPropertiesClientSettingsBuilderCustomizerTests.java
@@ -54,6 +54,18 @@ class MongoPropertiesClientSettingsBuilderCustomizerTests {
 	}
 
 	@Test
+	void additionalHostCanBeAdded() {
+		this.properties.setHost("mongo.example.com");
+		this.properties.setAdditionalHosts("[mongo.example.com:33, mongo.example2.com]");
+		MongoClientSettings settings = customizeSettings();
+		List<ServerAddress> allAddresses = getAllAddresses(settings);
+		assertThat(allAddresses).hasSize(3);
+		assertServerAddress(allAddresses.get(0), "mongo.example.com", 27017);
+		assertServerAddress(allAddresses.get(1), "mongo.example.com", 33);
+		assertServerAddress(allAddresses.get(2), "mongo.example2.com", 27017);
+	}
+
+	@Test
 	void credentialsCanBeCustomized() {
 		this.properties.setUsername("user");
 		this.properties.setPassword("secret".toCharArray());

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoPropertiesClientSettingsBuilderCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoPropertiesClientSettingsBuilderCustomizerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.autoconfigure.mongo;
 
+import java.util.Arrays;
 import java.util.List;
 
 import com.mongodb.MongoClientSettings;
@@ -56,7 +57,7 @@ class MongoPropertiesClientSettingsBuilderCustomizerTests {
 	@Test
 	void additionalHostCanBeAdded() {
 		this.properties.setHost("mongo.example.com");
-		this.properties.setAdditionalHosts("[mongo.example.com:33, mongo.example2.com]");
+		this.properties.setAdditionalHosts(Arrays.asList("mongo.example.com:33", "mongo.example2.com"));
 		MongoClientSettings settings = customizeSettings();
 		List<ServerAddress> allAddresses = getAllAddresses(settings);
 		assertThat(allAddresses).hasSize(3);


### PR DESCRIPTION
Currently MongoProperties allow only single host to be set in the MongoProperties. 
With this commit a set of 'additional hosts' can be set along with the base host/port.

This closes #32113

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
