### PR TITLE
Adapt deprecated getIpAddress call with getHost in Redis Tests

### DIFF
--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-cache/src/redisTest/java/smoketest/cache/SampleCacheApplicationRedisTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-cache/src/redisTest/java/smoketest/cache/SampleCacheApplicationRedisTests.java
@@ -45,8 +45,7 @@ class SampleCacheApplicationRedisTests {
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry properties) {
-		properties.add("spring.data.redis.url",
-				() -> "redis://" + redis.getHost() + ":" + redis.getFirstMappedPort());
+		properties.add("spring.data.redis.url", () -> "redis://" + redis.getHost() + ":" + redis.getFirstMappedPort());
 	}
 
 	@Test

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-cache/src/redisTest/java/smoketest/cache/SampleCacheApplicationRedisTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-cache/src/redisTest/java/smoketest/cache/SampleCacheApplicationRedisTests.java
@@ -46,7 +46,7 @@ class SampleCacheApplicationRedisTests {
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry properties) {
 		properties.add("spring.data.redis.url",
-				() -> "redis://" + redis.getContainerIpAddress() + ":" + redis.getFirstMappedPort());
+				() -> "redis://" + redis.getHost() + ":" + redis.getFirstMappedPort());
 	}
 
 	@Test


### PR DESCRIPTION
A deprecated method call for getIpAddress() is replaced in this commit with a new method getHost().

This closes #32130

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
