### PR TITLE
Hazelcast auto-configuration recognizes hazelcast.xml and hazelcast.yaml files but not hazelcast.yml

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientConfigAvailableCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientConfigAvailableCondition.java
@@ -39,7 +39,8 @@ class HazelcastClientConfigAvailableCondition extends HazelcastConfigResourceCon
 
 	HazelcastClientConfigAvailableCondition() {
 		super(HazelcastClientConfiguration.CONFIG_SYSTEM_PROPERTY, "file:./hazelcast-client.xml",
-				"classpath:/hazelcast-client.xml", "file:./hazelcast-client.yaml", "classpath:/hazelcast-client.yaml");
+				"classpath:/hazelcast-client.xml", "file:./hazelcast-client.yaml", "classpath:/hazelcast-client.yaml",
+				"file:./hazelcast-client.yml", "classpath:/hazelcast-client.yml");
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientConfiguration.java
@@ -72,7 +72,7 @@ class HazelcastClientConfiguration {
 		private ClientConfig loadClientConfig(Resource configLocation) throws IOException {
 			URL configUrl = configLocation.getURL();
 			String configFileName = configUrl.getPath();
-			if (configFileName.endsWith(".yaml")) {
+			if (configFileName.endsWith(".yaml") || configFileName.endsWith(".yml")) {
 				return new YamlClientConfigBuilder(configUrl).build();
 			}
 			return new XmlClientConfigBuilder(configUrl).build();

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastServerConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastServerConfiguration.java
@@ -88,7 +88,7 @@ class HazelcastServerConfiguration {
 
 		private static Config loadConfig(URL configUrl) throws IOException {
 			String configFileName = configUrl.getPath();
-			if (configFileName.endsWith(".yaml")) {
+			if (configFileName.endsWith(".yaml") || configFileName.endsWith(".yml")) {
 				return new YamlConfigBuilder(configUrl).build();
 			}
 			return new XmlConfigBuilder(configUrl).build();
@@ -131,7 +131,7 @@ class HazelcastServerConfiguration {
 
 		ConfigAvailableCondition() {
 			super(CONFIG_SYSTEM_PROPERTY, "file:./hazelcast.xml", "classpath:/hazelcast.xml", "file:./hazelcast.yaml",
-					"classpath:/hazelcast.yaml");
+					"classpath:/hazelcast.yaml", "file:./hazelcast.yml", "classpath:/hazelcast.yml");
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationClientTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationClientTests.java
@@ -82,6 +82,14 @@ class HazelcastAutoConfigurationClientTests {
 	}
 
 	@Test
+	void systemPropertyWithYml() {
+		this.contextRunner
+				.withSystemProperties(HazelcastClientConfiguration.CONFIG_SYSTEM_PROPERTY
+						+ "=classpath:org/springframework/boot/autoconfigure/hazelcast/hazelcast-client-specific.yml")
+				.run(assertSpecificHazelcastClient("explicit-yml"));
+	}
+
+	@Test
 	void explicitConfigFileWithXml() {
 		this.contextRunner.withPropertyValues("spring.hazelcast.config=org/springframework/boot/autoconfigure/"
 				+ "hazelcast/hazelcast-client-specific.xml").run(assertSpecificHazelcastClient("explicit-xml"));
@@ -93,6 +101,14 @@ class HazelcastAutoConfigurationClientTests {
 				.withPropertyValues("spring.hazelcast.config=org/springframework/boot/autoconfigure/"
 						+ "hazelcast/hazelcast-client-specific.yaml")
 				.run(assertSpecificHazelcastClient("explicit-yaml"));
+	}
+
+	@Test
+	void explicitConfigFileWithYml() {
+		this.contextRunner
+				.withPropertyValues("spring.hazelcast.config=org/springframework/boot/autoconfigure/"
+						+ "hazelcast/hazelcast-client-specific.yml")
+				.run(assertSpecificHazelcastClient("explicit-yml"));
 	}
 
 	@Test
@@ -109,6 +125,14 @@ class HazelcastAutoConfigurationClientTests {
 				.withPropertyValues("spring.hazelcast.config=classpath:org/springframework/"
 						+ "boot/autoconfigure/hazelcast/hazelcast-client-specific.yaml")
 				.run(assertSpecificHazelcastClient("explicit-yaml"));
+	}
+
+	@Test
+	void explicitConfigUrlWithYml() {
+		this.contextRunner
+				.withPropertyValues("spring.hazelcast.config=classpath:org/springframework/"
+						+ "boot/autoconfigure/hazelcast/hazelcast-client-specific.yml")
+				.run(assertSpecificHazelcastClient("explicit-yml"));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationServerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationServerTests.java
@@ -88,6 +88,17 @@ class HazelcastAutoConfigurationServerTests {
 	}
 
 	@Test
+	void systemPropertyWithYml() {
+		this.contextRunner
+				.withSystemProperties(HazelcastServerConfiguration.CONFIG_SYSTEM_PROPERTY
+						+ "=classpath:org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.yml")
+				.run((context) -> {
+					Config config = context.getBean(HazelcastInstance.class).getConfig();
+					assertThat(config.getMapConfigs().keySet()).containsOnly("foobar");
+				});
+	}
+
+	@Test
 	void explicitConfigFileWithXml() {
 		this.contextRunner
 				.withPropertyValues("spring.hazelcast.config=org/springframework/boot/autoconfigure/hazelcast/"
@@ -106,6 +117,15 @@ class HazelcastAutoConfigurationServerTests {
 	}
 
 	@Test
+	void explicitConfigFileWithYml() {
+		this.contextRunner
+				.withPropertyValues("spring.hazelcast.config=org/springframework/boot/autoconfigure/hazelcast/"
+						+ "hazelcast-specific.yml")
+				.run(assertSpecificHazelcastServer(
+						"org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.yml"));
+	}
+
+	@Test
 	void explicitConfigUrlWithXml() {
 		this.contextRunner
 				.withPropertyValues("spring.hazelcast.config=classpath:org/springframework/"
@@ -121,6 +141,15 @@ class HazelcastAutoConfigurationServerTests {
 						+ "boot/autoconfigure/hazelcast/hazelcast-specific.yaml")
 				.run(assertSpecificHazelcastServer(
 						"org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.yaml"));
+	}
+
+	@Test
+	void explicitConfigUrlWithYml() {
+		this.contextRunner
+				.withPropertyValues("spring.hazelcast.config=classpath:org/springframework/"
+						+ "boot/autoconfigure/hazelcast/hazelcast-specific.yml")
+				.run(assertSpecificHazelcastServer(
+						"org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.yml"));
 	}
 
 	private ContextConsumer<AssertableApplicationContext> assertSpecificHazelcastServer(String location) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationTests.java
@@ -40,7 +40,7 @@ class HazelcastAutoConfigurationTests {
 	void defaultConfigFile() {
 		// no hazelcast-client.xml and hazelcast.xml is present in root classpath
 		// this also asserts that XML has priority over YAML
-		// as both hazelcast.yaml and hazelcast.xml in test classpath.
+		// as both hazelcast.yaml, hazelcast.yml and hazelcast.xml in test classpath.
 		this.contextRunner.run((context) -> {
 			Config config = context.getBean(HazelcastInstance.class).getConfig();
 			assertThat(config.getConfigurationUrl()).isEqualTo(new ClassPathResource("hazelcast.xml").getURL());

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/hazelcast.yml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/hazelcast.yml
@@ -1,0 +1,7 @@
+hazelcast:
+  network:
+    join:
+      auto-detection:
+        enabled: false
+      multicast:
+        enabled: false

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-client-specific.yml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-client-specific.yml
@@ -1,0 +1,3 @@
+hazelcast-client:
+  client-labels:
+    - explicit-yml

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.yml
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/resources/org/springframework/boot/autoconfigure/hazelcast/hazelcast-specific.yml
@@ -1,0 +1,12 @@
+hazelcast:
+  network:
+    join:
+      auto-detection:
+        enabled: false
+      multicast:
+        enabled: false
+
+  map:
+    foobar:
+      time-to-live-seconds: 3600
+      max-idle-seconds: 600


### PR DESCRIPTION
Fixes issue #32141

Adds support for "yml" suffix config files. "yaml" already supported