### PR TITLE
Remove ANTLR 2 dependency management

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -14,16 +14,6 @@ bom {
 			issueLabels = ["type: dependency-upgrade"]
 		}
 	}
-	library("ANTLR2", "2.7.7") {
-		prohibit("20030911") {
-			because "it is old version that used a different versioning scheme"
-		}
-		group("antlr") {
-			modules = [
-				"antlr"
-			]
-		}
-	}
 	library("Artemis", "2.23.1") {
 		group("org.apache.activemq") {
 			modules = [


### PR DESCRIPTION
Dependency management for ANTLR 2 is introduced in #2814 to solve conflicts of Hibernate and Velocity.
However, it is unnecessary in Spring Boot 3.0 because of following reasons:

- Velocity is not supported since Spring Boot 1.5.
- Hibernate 6.1.1.Final use ANTLR 4.