### PR TITLE
Don't warn about missing Freemarker templates if disabled

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/freemarker/FreeMarkerAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/freemarker/FreeMarkerAutoConfiguration.java
@@ -61,7 +61,7 @@ public class FreeMarkerAutoConfiguration {
 	}
 
 	public void checkTemplateLocationExists() {
-		if (logger.isWarnEnabled() && this.properties.isCheckTemplateLocation()) {
+		if (logger.isWarnEnabled() && this.properties.isEnabled() && this.properties.isCheckTemplateLocation()) {
 			List<TemplateLocation> locations = getLocations();
 			if (locations.stream().noneMatch(this::locationExists)) {
 				logger.warn("Cannot find template location(s): " + locations + " (please add some templates, "

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/freemarker/FreeMarkerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/freemarker/FreeMarkerAutoConfigurationTests.java
@@ -55,6 +55,13 @@ class FreeMarkerAutoConfigurationTests {
 	}
 
 	@Test
+	void templateResolverDisabled(CapturedOutput output) {
+		this.contextRunner
+				.withPropertyValues("spring.freemarker.enabled:false")
+				.run((context) -> assertThat(output).doesNotContain("Cannot find template location"));
+    }
+
+	@Test
 	void nonExistentTemplateLocation(CapturedOutput output) {
 		this.contextRunner
 				.withPropertyValues("spring.freemarker.templateLoaderPath:"


### PR DESCRIPTION
The `FreeMarkerAutoConfiguration` logs a warning about missing templates even if the entire auto-configuration class is disabled via properties. I am using FreeMarker internally for non-Web reasons, but its presence triggers spurious warnings from the auto-configuration even after adding `spring.freemarker.enabled: false`.