### PR TITLE
Optimize the conversion of AnsiColor

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiColorWrapper.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiColorWrapper.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.ansi;
+
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+import java.util.Objects;
+
+/**
+ * ANSI Color Wrapper
+ *
+ * @author TomXin
+ * @since 3.0.0
+ */
+public class AnsiColorWrapper {
+
+	private final int code;
+
+	private final AnsiColors.BitDepth bitDepth;
+
+	/**
+	 * Create a new {@link AnsiColorWrapper} instance with the specified bit depth.
+	 * @param bitDepth the required bit depth
+	 * @param code Color code, when the bit depth is 4bit, the value range of code is
+	 * [30~37], [90~97]. When the bit depth is 8bit, the code value range is [0~255]
+	 */
+	public AnsiColorWrapper(int code, AnsiColors.BitDepth bitDepth) {
+		if (bitDepth == AnsiColors.BitDepth.FOUR) {
+			Assert.isTrue((30 <= code && code <= 37) || (90 <= code && code <= 97),
+					"The value of 4 bit color only supported [30~37],[90~97].");
+		}
+		Assert.isTrue((0 <= code && code <= 255), "The value of 8 bit color only supported [0~255].");
+		this.code = code;
+		this.bitDepth = bitDepth;
+	}
+
+	/**
+	 * Convert to {@link AnsiElement} instance
+	 * @param foreOrBack foreground or background
+	 * @return {@link AnsiElement} instance
+	 */
+	public AnsiElement toAnsiElement(ForeOrBack foreOrBack) {
+		if (bitDepth == AnsiColors.BitDepth.FOUR) {
+			if (foreOrBack == ForeOrBack.FORE) {
+				for (AnsiColor item : AnsiColor.values()) {
+					if (ObjectUtils.nullSafeEquals(item.toString(), String.valueOf(this.code))) {
+						return item;
+					}
+				}
+				throw new IllegalArgumentException(String.format("No matched AnsiColor instance,code= %d", this.code));
+			}
+			for (AnsiBackground item : AnsiBackground.values()) {
+				if (ObjectUtils.nullSafeEquals(item.toString(), String.valueOf(this.code + 10))) {
+					return item;
+				}
+			}
+			throw new IllegalArgumentException(String.format("No matched Background instance,code= %d", this.code));
+		}
+		if (foreOrBack == ForeOrBack.FORE) {
+			return Ansi8BitColor.foreground(this.code);
+		}
+		return Ansi8BitColor.background(this.code);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		AnsiColorWrapper that = (AnsiColorWrapper) o;
+		return this.code == that.code && this.bitDepth == that.bitDepth;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.code, this.bitDepth);
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiColors.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiColors.java
@@ -38,24 +38,109 @@ public final class AnsiColors {
 
 	private static final Map<AnsiColorWrapper, LabColor> ANSI_COLOR_MAP;
 
+	/**
+	 * @see AnsiColor#BLACK
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_BLACK = 30;
+
+	/**
+	 * @see AnsiColor#RED
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_RED = 31;
+
+	/**
+	 * @see AnsiColor#GREEN
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_GREEN = 32;
+
+	/**
+	 * @see AnsiColor#YELLOW
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_YELLOW = 33;
+
+	/**
+	 * @see AnsiColor#BLUE
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_BLUE = 34;
+
+	/**
+	 * @see AnsiColor#MAGENTA
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_MAGENTA = 35;
+
+	/**
+	 * @see AnsiColor#CYAN
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_CYAN = 36;
+
+	/**
+	 * @see AnsiColor#WHITE
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_WHITE = 37;
+
+	/**
+	 * @see AnsiColor#BRIGHT_BLACK
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_BLACK = 90;
+
+	/**
+	 * @see AnsiColor#BRIGHT_RED
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_RED = 91;
+
+	/**
+	 * @see AnsiColor#BRIGHT_GREEN
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_GREEN = 92;
+
+	/**
+	 * @see AnsiColor#BRIGHT_YELLOW
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_YELLOW = 93;
+
+	/**
+	 * @see AnsiColor#BRIGHT_BLUE
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_BLUE = 94;
+
+	/**
+	 * @see AnsiColor#BRIGHT_MAGENTA
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_MAGENTA = 95;
+
+	/**
+	 * @see AnsiColor#BRIGHT_CYAN
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_CYAN = 96;
+
+	/**
+	 * @see AnsiColor#BRIGHT_WHITE
+	 */
+	private static final int CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_WHITE = 97;
+
 	static {
 		Map<AnsiColorWrapper, LabColor> colorMap = new LinkedHashMap<>(16);
-		colorMap.put(new AnsiColorWrapper(30, BitDepth.FOUR), new LabColor(0x000000));
-		colorMap.put(new AnsiColorWrapper(31, BitDepth.FOUR), new LabColor(0xAA0000));
-		colorMap.put(new AnsiColorWrapper(32, BitDepth.FOUR), new LabColor(0x00AA00));
-		colorMap.put(new AnsiColorWrapper(33, BitDepth.FOUR), new LabColor(0xAA5500));
-		colorMap.put(new AnsiColorWrapper(34, BitDepth.FOUR), new LabColor(0x0000AA));
-		colorMap.put(new AnsiColorWrapper(35, BitDepth.FOUR), new LabColor(0xAA00AA));
-		colorMap.put(new AnsiColorWrapper(36, BitDepth.FOUR), new LabColor(0x00AAAA));
-		colorMap.put(new AnsiColorWrapper(37, BitDepth.FOUR), new LabColor(0xAAAAAA));
-		colorMap.put(new AnsiColorWrapper(90, BitDepth.FOUR), new LabColor(0x555555));
-		colorMap.put(new AnsiColorWrapper(91, BitDepth.FOUR), new LabColor(0xFF5555));
-		colorMap.put(new AnsiColorWrapper(92, BitDepth.FOUR), new LabColor(0x55FF00));
-		colorMap.put(new AnsiColorWrapper(93, BitDepth.FOUR), new LabColor(0xFFFF55));
-		colorMap.put(new AnsiColorWrapper(94, BitDepth.FOUR), new LabColor(0x5555FF));
-		colorMap.put(new AnsiColorWrapper(95, BitDepth.FOUR), new LabColor(0xFF55FF));
-		colorMap.put(new AnsiColorWrapper(96, BitDepth.FOUR), new LabColor(0x55FFFF));
-		colorMap.put(new AnsiColorWrapper(97, BitDepth.FOUR), new LabColor(0xFFFFFF));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BLACK, BitDepth.FOUR), new LabColor(0x000000));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_RED, BitDepth.FOUR), new LabColor(0xAA0000));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_GREEN, BitDepth.FOUR), new LabColor(0x00AA00));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_YELLOW, BitDepth.FOUR), new LabColor(0xAA5500));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BLUE, BitDepth.FOUR), new LabColor(0x0000AA));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_MAGENTA, BitDepth.FOUR), new LabColor(0xAA00AA));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_CYAN, BitDepth.FOUR), new LabColor(0x00AAAA));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_WHITE, BitDepth.FOUR), new LabColor(0xAAAAAA));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_BLACK, BitDepth.FOUR),
+				new LabColor(0x555555));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_RED, BitDepth.FOUR), new LabColor(0xFF5555));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_GREEN, BitDepth.FOUR),
+				new LabColor(0x55FF00));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_YELLOW, BitDepth.FOUR),
+				new LabColor(0xFFFF55));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_BLUE, BitDepth.FOUR), new LabColor(0x5555FF));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_MAGENTA, BitDepth.FOUR),
+				new LabColor(0xFF55FF));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_CYAN, BitDepth.FOUR), new LabColor(0x55FFFF));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_WHITE, BitDepth.FOUR),
+				new LabColor(0xFFFFFF));
 		ANSI_COLOR_MAP = Collections.unmodifiableMap(colorMap);
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiColors.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiColors.java
@@ -118,6 +118,7 @@ public final class AnsiColors {
 	 */
 	private static final int CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_WHITE = 97;
 
+	// @formatter:off
 	static {
 		Map<AnsiColorWrapper, LabColor> colorMap = new LinkedHashMap<>(16);
 		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BLACK, BitDepth.FOUR), new LabColor(0x000000));
@@ -128,22 +129,17 @@ public final class AnsiColors {
 		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_MAGENTA, BitDepth.FOUR), new LabColor(0xAA00AA));
 		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_CYAN, BitDepth.FOUR), new LabColor(0x00AAAA));
 		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_WHITE, BitDepth.FOUR), new LabColor(0xAAAAAA));
-		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_BLACK, BitDepth.FOUR),
-				new LabColor(0x555555));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_BLACK, BitDepth.FOUR), new LabColor(0x555555));
 		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_RED, BitDepth.FOUR), new LabColor(0xFF5555));
-		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_GREEN, BitDepth.FOUR),
-				new LabColor(0x55FF00));
-		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_YELLOW, BitDepth.FOUR),
-				new LabColor(0xFFFF55));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_GREEN, BitDepth.FOUR), new LabColor(0x55FF00));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_YELLOW, BitDepth.FOUR), new LabColor(0xFFFF55));
 		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_BLUE, BitDepth.FOUR), new LabColor(0x5555FF));
-		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_MAGENTA, BitDepth.FOUR),
-				new LabColor(0xFF55FF));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_MAGENTA, BitDepth.FOUR), new LabColor(0xFF55FF));
 		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_CYAN, BitDepth.FOUR), new LabColor(0x55FFFF));
-		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_WHITE, BitDepth.FOUR),
-				new LabColor(0xFFFFFF));
+		colorMap.put(new AnsiColorWrapper(CODE_OF_4_BIT_ANSI_COLOR_BRIGHT_WHITE, BitDepth.FOUR), new LabColor(0xFFFFFF));
 		ANSI_COLOR_MAP = Collections.unmodifiableMap(colorMap);
 	}
-
+	// @formatter:on
 	private static final int[] ANSI_8BIT_COLOR_CODE_LOOKUP = new int[] { 0x000000, 0x800000, 0x008000, 0x808000,
 			0x000080, 0x800080, 0x008080, 0xc0c0c0, 0x808080, 0xff0000, 0x00ff00, 0xffff00, 0x0000ff, 0xff00ff,
 			0x00ffff, 0xffffff, 0x000000, 0x00005f, 0x000087, 0x0000af, 0x0000d7, 0x0000ff, 0x005f00, 0x005f5f,

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/ForeOrBack.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/ForeOrBack.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.ansi;
+
+/**
+ * Foreground or Background
+ *
+ * @author TomXin
+ * @since 3.0.0
+ */
+public enum ForeOrBack {
+
+	/**
+	 * Foreground
+	 */
+	FORE,
+	/**
+	 * Background
+	 */
+	BACK,
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/ansi/AnsiColorsTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/ansi/AnsiColorsTests.java
@@ -33,71 +33,129 @@ class AnsiColorsTests {
 
 	@Test
 	void findClosest4BitWhenExactMatchShouldReturnAnsiColor() {
-		assertThat(findClosest4Bit(0x000000)).isEqualTo(AnsiColor.BLACK);
-		assertThat(findClosest4Bit(0xAA0000)).isEqualTo(AnsiColor.RED);
-		assertThat(findClosest4Bit(0x00AA00)).isEqualTo(AnsiColor.GREEN);
-		assertThat(findClosest4Bit(0xAA5500)).isEqualTo(AnsiColor.YELLOW);
-		assertThat(findClosest4Bit(0x0000AA)).isEqualTo(AnsiColor.BLUE);
-		assertThat(findClosest4Bit(0xAA00AA)).isEqualTo(AnsiColor.MAGENTA);
-		assertThat(findClosest4Bit(0x00AAAA)).isEqualTo(AnsiColor.CYAN);
-		assertThat(findClosest4Bit(0xAAAAAA)).isEqualTo(AnsiColor.WHITE);
-		assertThat(findClosest4Bit(0x555555)).isEqualTo(AnsiColor.BRIGHT_BLACK);
-		assertThat(findClosest4Bit(0xFF5555)).isEqualTo(AnsiColor.BRIGHT_RED);
-		assertThat(findClosest4Bit(0x55FF00)).isEqualTo(AnsiColor.BRIGHT_GREEN);
-		assertThat(findClosest4Bit(0xFFFF55)).isEqualTo(AnsiColor.BRIGHT_YELLOW);
-		assertThat(findClosest4Bit(0x5555FF)).isEqualTo(AnsiColor.BRIGHT_BLUE);
-		assertThat(findClosest4Bit(0xFF55FF)).isEqualTo(AnsiColor.BRIGHT_MAGENTA);
-		assertThat(findClosest4Bit(0x55FFFF)).isEqualTo(AnsiColor.BRIGHT_CYAN);
-		assertThat(findClosest4Bit(0xFFFFFF)).isEqualTo(AnsiColor.BRIGHT_WHITE);
+		assertThat(findClosest4Bit(0x000000).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BLACK);
+		assertThat(findClosest4Bit(0xAA0000).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.RED);
+		assertThat(findClosest4Bit(0x00AA00).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.GREEN);
+		assertThat(findClosest4Bit(0xAA5500).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.YELLOW);
+		assertThat(findClosest4Bit(0x0000AA).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BLUE);
+		assertThat(findClosest4Bit(0xAA00AA).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.MAGENTA);
+		assertThat(findClosest4Bit(0x00AAAA).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.CYAN);
+		assertThat(findClosest4Bit(0xAAAAAA).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.WHITE);
+		assertThat(findClosest4Bit(0x555555).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_BLACK);
+		assertThat(findClosest4Bit(0xFF5555).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_RED);
+		assertThat(findClosest4Bit(0x55FF00).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_GREEN);
+		assertThat(findClosest4Bit(0xFFFF55).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_YELLOW);
+		assertThat(findClosest4Bit(0x5555FF).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_BLUE);
+		assertThat(findClosest4Bit(0xFF55FF).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_MAGENTA);
+		assertThat(findClosest4Bit(0x55FFFF).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_CYAN);
+		assertThat(findClosest4Bit(0xFFFFFF).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_WHITE);
+	}
+
+	@Test
+	void findClosest4BitWhenExactMatchShouldReturnAnsiBackground() {
+		assertThat(findClosest4Bit(0x000000).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BLACK);
+		assertThat(findClosest4Bit(0xAA0000).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.RED);
+		assertThat(findClosest4Bit(0x00AA00).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.GREEN);
+		assertThat(findClosest4Bit(0xAA5500).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.YELLOW);
+		assertThat(findClosest4Bit(0x0000AA).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BLUE);
+		assertThat(findClosest4Bit(0xAA00AA).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.MAGENTA);
+		assertThat(findClosest4Bit(0x00AAAA).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.CYAN);
+		assertThat(findClosest4Bit(0xAAAAAA).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.WHITE);
+		assertThat(findClosest4Bit(0x555555).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_BLACK);
+		assertThat(findClosest4Bit(0xFF5555).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_RED);
+		assertThat(findClosest4Bit(0x55FF00).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_GREEN);
+		assertThat(findClosest4Bit(0xFFFF55).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_YELLOW);
+		assertThat(findClosest4Bit(0x5555FF).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_BLUE);
+		assertThat(findClosest4Bit(0xFF55FF).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_MAGENTA);
+		assertThat(findClosest4Bit(0x55FFFF).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_CYAN);
+		assertThat(findClosest4Bit(0xFFFFFF).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_WHITE);
 	}
 
 	@Test
 	void getClosest4BitWhenCloseShouldReturnAnsiColor() {
-		assertThat(findClosest4Bit(0x292424)).isEqualTo(AnsiColor.BLACK);
-		assertThat(findClosest4Bit(0x8C1919)).isEqualTo(AnsiColor.RED);
-		assertThat(findClosest4Bit(0x0BA10B)).isEqualTo(AnsiColor.GREEN);
-		assertThat(findClosest4Bit(0xB55F09)).isEqualTo(AnsiColor.YELLOW);
-		assertThat(findClosest4Bit(0x0B0BA1)).isEqualTo(AnsiColor.BLUE);
-		assertThat(findClosest4Bit(0xA312A3)).isEqualTo(AnsiColor.MAGENTA);
-		assertThat(findClosest4Bit(0x0BB5B5)).isEqualTo(AnsiColor.CYAN);
-		assertThat(findClosest4Bit(0xBAB6B6)).isEqualTo(AnsiColor.WHITE);
-		assertThat(findClosest4Bit(0x615A5A)).isEqualTo(AnsiColor.BRIGHT_BLACK);
-		assertThat(findClosest4Bit(0xF23333)).isEqualTo(AnsiColor.BRIGHT_RED);
-		assertThat(findClosest4Bit(0x55E80C)).isEqualTo(AnsiColor.BRIGHT_GREEN);
-		assertThat(findClosest4Bit(0xF5F54C)).isEqualTo(AnsiColor.BRIGHT_YELLOW);
-		assertThat(findClosest4Bit(0x5656F0)).isEqualTo(AnsiColor.BRIGHT_BLUE);
-		assertThat(findClosest4Bit(0xFA50FA)).isEqualTo(AnsiColor.BRIGHT_MAGENTA);
-		assertThat(findClosest4Bit(0x56F5F5)).isEqualTo(AnsiColor.BRIGHT_CYAN);
-		assertThat(findClosest4Bit(0xEDF5F5)).isEqualTo(AnsiColor.BRIGHT_WHITE);
+		assertThat(findClosest4Bit(0x292424).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BLACK);
+		assertThat(findClosest4Bit(0x8C1919).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.RED);
+		assertThat(findClosest4Bit(0x0BA10B).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.GREEN);
+		assertThat(findClosest4Bit(0xB55F09).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.YELLOW);
+		assertThat(findClosest4Bit(0x0B0BA1).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BLUE);
+		assertThat(findClosest4Bit(0xA312A3).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.MAGENTA);
+		assertThat(findClosest4Bit(0x0BB5B5).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.CYAN);
+		assertThat(findClosest4Bit(0xBAB6B6).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.WHITE);
+		assertThat(findClosest4Bit(0x615A5A).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_BLACK);
+		assertThat(findClosest4Bit(0xF23333).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_RED);
+		assertThat(findClosest4Bit(0x55E80C).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_GREEN);
+		assertThat(findClosest4Bit(0xF5F54C).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_YELLOW);
+		assertThat(findClosest4Bit(0x5656F0).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_BLUE);
+		assertThat(findClosest4Bit(0xFA50FA).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_MAGENTA);
+		assertThat(findClosest4Bit(0x56F5F5).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_CYAN);
+		assertThat(findClosest4Bit(0xEDF5F5).toAnsiElement(ForeOrBack.FORE)).isEqualTo(AnsiColor.BRIGHT_WHITE);
+	}
+
+	@Test
+	void getClosest4BitWhenCloseShouldReturnAnsiBackground() {
+		assertThat(findClosest4Bit(0x292424).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BLACK);
+		assertThat(findClosest4Bit(0x8C1919).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.RED);
+		assertThat(findClosest4Bit(0x0BA10B).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.GREEN);
+		assertThat(findClosest4Bit(0xB55F09).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.YELLOW);
+		assertThat(findClosest4Bit(0x0B0BA1).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BLUE);
+		assertThat(findClosest4Bit(0xA312A3).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.MAGENTA);
+		assertThat(findClosest4Bit(0x0BB5B5).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.CYAN);
+		assertThat(findClosest4Bit(0xBAB6B6).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.WHITE);
+		assertThat(findClosest4Bit(0x615A5A).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_BLACK);
+		assertThat(findClosest4Bit(0xF23333).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_RED);
+		assertThat(findClosest4Bit(0x55E80C).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_GREEN);
+		assertThat(findClosest4Bit(0xF5F54C).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_YELLOW);
+		assertThat(findClosest4Bit(0x5656F0).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_BLUE);
+		assertThat(findClosest4Bit(0xFA50FA).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_MAGENTA);
+		assertThat(findClosest4Bit(0x56F5F5).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_CYAN);
+		assertThat(findClosest4Bit(0xEDF5F5).toAnsiElement(ForeOrBack.BACK)).isEqualTo(AnsiBackground.BRIGHT_WHITE);
 	}
 
 	@Test
 	void findClosest8BitWhenExactMatchShouldReturnAnsiColor() {
-		assertThat(findClosest8Bit(0x000000)).isEqualTo(Ansi8BitColor.foreground(0));
-		assertThat(findClosest8Bit(0xFFFFFF)).isEqualTo(Ansi8BitColor.foreground(15));
-		assertThat(findClosest8Bit(0xFF00FF)).isEqualTo(Ansi8BitColor.foreground(13));
-		assertThat(findClosest8Bit(0x008700)).isEqualTo(Ansi8BitColor.foreground(28));
-		assertThat(findClosest8Bit(0xAF8700)).isEqualTo(Ansi8BitColor.foreground(136));
+		assertThat(findClosest8Bit(0x000000).toAnsiElement(ForeOrBack.FORE)).isEqualTo(Ansi8BitColor.foreground(0));
+		assertThat(findClosest8Bit(0xFFFFFF).toAnsiElement(ForeOrBack.FORE)).isEqualTo(Ansi8BitColor.foreground(15));
+		assertThat(findClosest8Bit(0xFF00FF).toAnsiElement(ForeOrBack.FORE)).isEqualTo(Ansi8BitColor.foreground(13));
+		assertThat(findClosest8Bit(0x008700).toAnsiElement(ForeOrBack.FORE)).isEqualTo(Ansi8BitColor.foreground(28));
+		assertThat(findClosest8Bit(0xAF8700).toAnsiElement(ForeOrBack.FORE)).isEqualTo(Ansi8BitColor.foreground(136));
+	}
+
+	@Test
+	void findClosest8BitWhenExactMatchShouldReturnAnsiBackground() {
+		assertThat(findClosest8Bit(0x000000).toAnsiElement(ForeOrBack.BACK)).isEqualTo(Ansi8BitColor.background(0));
+		assertThat(findClosest8Bit(0xFFFFFF).toAnsiElement(ForeOrBack.BACK)).isEqualTo(Ansi8BitColor.background(15));
+		assertThat(findClosest8Bit(0xFF00FF).toAnsiElement(ForeOrBack.BACK)).isEqualTo(Ansi8BitColor.background(13));
+		assertThat(findClosest8Bit(0x008700).toAnsiElement(ForeOrBack.BACK)).isEqualTo(Ansi8BitColor.background(28));
+		assertThat(findClosest8Bit(0xAF8700).toAnsiElement(ForeOrBack.BACK)).isEqualTo(Ansi8BitColor.background(136));
 	}
 
 	@Test
 	void getClosest8BitWhenCloseShouldReturnAnsiColor() {
-		assertThat(findClosest8Bit(0x000001)).isEqualTo(Ansi8BitColor.foreground(0));
-		assertThat(findClosest8Bit(0xFFFFFE)).isEqualTo(Ansi8BitColor.foreground(15));
-		assertThat(findClosest8Bit(0xFF00FE)).isEqualTo(Ansi8BitColor.foreground(13));
-		assertThat(findClosest8Bit(0x008701)).isEqualTo(Ansi8BitColor.foreground(28));
-		assertThat(findClosest8Bit(0xAF8701)).isEqualTo(Ansi8BitColor.foreground(136));
+		assertThat(findClosest8Bit(0x000001).toAnsiElement(ForeOrBack.FORE)).isEqualTo(Ansi8BitColor.foreground(0));
+		assertThat(findClosest8Bit(0xFFFFFE).toAnsiElement(ForeOrBack.FORE)).isEqualTo(Ansi8BitColor.foreground(15));
+		assertThat(findClosest8Bit(0xFF00FE).toAnsiElement(ForeOrBack.FORE)).isEqualTo(Ansi8BitColor.foreground(13));
+		assertThat(findClosest8Bit(0x008701).toAnsiElement(ForeOrBack.FORE)).isEqualTo(Ansi8BitColor.foreground(28));
+		assertThat(findClosest8Bit(0xAF8701).toAnsiElement(ForeOrBack.FORE)).isEqualTo(Ansi8BitColor.foreground(136));
 	}
 
-	private AnsiElement findClosest4Bit(int rgb) {
+	@Test
+	void getClosest8BitWhenCloseShouldReturnAnsiBackground() {
+		assertThat(findClosest8Bit(0x000001).toAnsiElement(ForeOrBack.BACK)).isEqualTo(Ansi8BitColor.background(0));
+		assertThat(findClosest8Bit(0xFFFFFE).toAnsiElement(ForeOrBack.BACK)).isEqualTo(Ansi8BitColor.background(15));
+		assertThat(findClosest8Bit(0xFF00FE).toAnsiElement(ForeOrBack.BACK)).isEqualTo(Ansi8BitColor.background(13));
+		assertThat(findClosest8Bit(0x008701).toAnsiElement(ForeOrBack.BACK)).isEqualTo(Ansi8BitColor.background(28));
+		assertThat(findClosest8Bit(0xAF8701).toAnsiElement(ForeOrBack.BACK)).isEqualTo(Ansi8BitColor.background(136));
+	}
+
+	private AnsiColorWrapper findClosest4Bit(int rgb) {
 		return findClosest(BitDepth.FOUR, rgb);
 	}
 
-	private AnsiElement findClosest8Bit(int rgb) {
+	private AnsiColorWrapper findClosest8Bit(int rgb) {
 		return findClosest(BitDepth.EIGHT, rgb);
 	}
 
-	private AnsiElement findClosest(BitDepth depth, int rgb) {
+	private AnsiColorWrapper findClosest(BitDepth depth, int rgb) {
 		return new AnsiColors(depth).findClosest(new Color(rgb));
 	}
 


### PR DESCRIPTION
The original AnsiColors class does not contain the processing of AnsiBackground and Ansi8BitColor.background(xxx), this Pr supplements this.