### PR TITLE
Hazelcast shutdown logs are not available out-of-the-box

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastServerConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastServerConfiguration.java
@@ -51,6 +51,7 @@ import org.springframework.util.StringUtils;
 class HazelcastServerConfiguration {
 
 	static final String CONFIG_SYSTEM_PROPERTY = "hazelcast.config";
+	static final String HAZELCAST_LOGGING_TYPE = "hazelcast.logging.type";
 
 	private static HazelcastInstance getHazelcastInstance(Config config) {
 		if (StringUtils.hasText(config.getInstanceName())) {
@@ -118,6 +119,22 @@ class HazelcastServerConfiguration {
 				SpringManagedContext managementContext = new SpringManagedContext();
 				managementContext.setApplicationContext(applicationContext);
 				config.setManagedContext(managementContext);
+			};
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(org.slf4j.Logger.class)
+	static class LoggingHazelcastConfigCustomizerConfiguration {
+
+		@Bean
+		@Order(0)
+		HazelcastConfigCustomizer loggingHazelcastConfigCustomizer() {
+			return (config) -> {
+				if (!config.getProperties().containsKey(HAZELCAST_LOGGING_TYPE)) {
+					config.setProperty(HAZELCAST_LOGGING_TYPE, "slf4j");
+				}
 			};
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationServerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationServerTests.java
@@ -264,7 +264,6 @@ class HazelcastAutoConfigurationServerTests {
 
 	}
 
-
 	@SpringAware
 	static class SpringAwareEntryProcessor<V> implements EntryProcessor<String, V, String> {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationServerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hazelcast/HazelcastAutoConfigurationServerTests.java
@@ -206,6 +206,22 @@ class HazelcastAutoConfigurationServerTests {
 		});
 	}
 
+	@Test
+	void configWithDefaultLoggingTypeSlf4j() {
+		this.contextRunner.run((context) -> {
+			Config config = context.getBean(HazelcastInstance.class).getConfig();
+			assertThat(config.getProperty(HazelcastServerConfiguration.HAZELCAST_LOGGING_TYPE)).isEqualTo("slf4j");
+		});
+	}
+
+	@Test
+	void configWithExplicitLoggingType() {
+		this.contextRunner.withUserConfiguration(HazelcastConfigWithJDKLogging.class).run((context) -> {
+			Config config = context.getBean(HazelcastInstance.class).getConfig();
+			assertThat(config.getProperty(HazelcastServerConfiguration.HAZELCAST_LOGGING_TYPE)).isEqualTo("jdk");
+		});
+	}
+
 	private static Config createTestConfig(String instanceName) {
 		Config config = new Config(instanceName);
 		JoinConfig join = config.getNetworkConfig().getJoin();
@@ -235,6 +251,19 @@ class HazelcastAutoConfigurationServerTests {
 		}
 
 	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class HazelcastConfigWithJDKLogging {
+
+		@Bean
+		Config anotherHazelcastConfig() {
+			Config config = new Config();
+			config.setProperty(HazelcastServerConfiguration.HAZELCAST_LOGGING_TYPE, "jdk");
+			return config;
+		}
+
+	}
+
 
 	@SpringAware
 	static class SpringAwareEntryProcessor<V> implements EntryProcessor<String, V, String> {


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/19668

Hazelcast will use `slf4j` as a default logging type when SLF4J is detected on the classpath.

Otherwise, Hazelcast shutdown logs are missing. It seems it's caused by a bug in JDK - jul's LogManager resets the loggers on shutdown, running concurrently with other shutdown hooks it is not deterministic what runs first and we may or may not see the logs in the configuration using jul see [JDK-8161253](https://bugs.openjdk.java.net/browse/JDK-8161253) and [JDK-8029834](https://bugs.openjdk.java.net/browse/JDK-8029834).


Before:
```
2022-08-29T12:47:34.822+02:00  INFO 2312 --- [.ShutdownThread] com.hazelcast.instance.impl.Node         : [192.168.0.42]:5701 [dev] [5.1.2] Running shutdown hook... Current state: ACTIVE

```

After:
```
2022-08-29T12:49:21.111+02:00  INFO 2378 --- [.ShutdownThread] com.hazelcast.instance.impl.Node         : [192.168.0.42]:5701 [dev] [5.1.2] Running shutdown hook... Current state: ACTIVE
2022-08-29T12:49:21.111+02:00  INFO 2378 --- [.ShutdownThread] com.hazelcast.core.LifecycleService      : [192.168.0.42]:5701 [dev] [5.1.2] [192.168.0.42]:5701 is SHUTTING_DOWN
2022-08-29T12:49:21.115+02:00  WARN 2378 --- [.ShutdownThread] com.hazelcast.instance.impl.Node         : [192.168.0.42]:5701 [dev] [5.1.2] Terminating forcefully...
2022-08-29T12:49:21.116+02:00  INFO 2378 --- [.ShutdownThread] com.hazelcast.instance.impl.Node         : [192.168.0.42]:5701 [dev] [5.1.2] Shutting down connection manager...
2022-08-29T12:49:21.119+02:00  INFO 2378 --- [.ShutdownThread] com.hazelcast.instance.impl.Node         : [192.168.0.42]:5701 [dev] [5.1.2] Shutting down node engine...
2022-08-29T12:49:21.139+02:00  INFO 2378 --- [.ShutdownThread] c.hazelcast.instance.impl.NodeExtension  : [192.168.0.42]:5701 [dev] [5.1.2] Destroying node NodeExtension.
2022-08-29T12:49:21.140+02:00  INFO 2378 --- [.ShutdownThread] com.hazelcast.instance.impl.Node         : [192.168.0.42]:5701 [dev] [5.1.2] Hazelcast Shutdown is completed in 25 ms.
2022-08-29T12:49:21.140+02:00  INFO 2378 --- [.ShutdownThread] com.hazelcast.core.LifecycleService      : [192.168.0.42]:5701 [dev] [5.1.2] [192.168.0.42]:5701 is SHUTDOWN
```

Reference documentation: https://docs.hazelcast.com/hazelcast/5.1/maintain-cluster/logging