### PR TITLE
Add support for configuring Spring Session Redis repository

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2758,6 +2758,20 @@
       "defaultValue": "on-save"
     },
     {
+      "name": "spring.session.redis.repository",
+      "description": "Redis session repository implementation to use.",
+      "values": [
+        {
+          "value": "default",
+          "description": "Use default Redis session repository."
+        },
+        {
+          "value": "indexed",
+          "description": "Use indexed Redis session repository."
+        }
+      ]
+    },
+    {
       "name": "spring.session.redis.save-mode",
       "defaultValue": "on-set-attribute"
     },

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-session-redis/src/main/resources/application.properties
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-session-redis/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 management.endpoints.web.exposure.include=*
 spring.security.user.name=user
 spring.security.user.password=password
+spring.session.redis.repository=indexed


### PR DESCRIPTION
With Spring Session moving to `RedisSessionRepository` as the preferred session repository, Spring Boot auto-configuration should make it possible to easily switch back to the previous default (`RedisIndexedSessionRepository`).

This commit introduces `spring.session.redis.repository` configuration property that allow selecting the desired Redis-backed session repository implementation.

Closes #30673