### PR TITLE
Detection of DurationStyle.ISO8601 does not support lower-case input

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DurationStyle.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DurationStyle.java
@@ -62,7 +62,7 @@ public enum DurationStyle {
 	/**
 	 * ISO-8601 formatting.
 	 */
-	ISO8601("^[+-]?P.*$") {
+	ISO8601("^[+-]?[pP].*$") {
 
 		@Override
 		public Duration parse(String value, ChronoUnit unit) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/DurationStyleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/DurationStyleTests.java
@@ -39,6 +39,7 @@ class DurationStyleTests {
 
 	@Test
 	void detectAndParseWhenIso8601ShouldReturnDuration() {
+		assertThat(DurationStyle.detectAndParse("pt20.345s")).isEqualTo(Duration.parse("pt20.345s"));
 		assertThat(DurationStyle.detectAndParse("PT20.345S")).isEqualTo(Duration.parse("PT20.345S"));
 		assertThat(DurationStyle.detectAndParse("PT15M")).isEqualTo(Duration.parse("PT15M"));
 		assertThat(DurationStyle.detectAndParse("+PT15M")).isEqualTo(Duration.parse("PT15M"));
@@ -143,6 +144,7 @@ class DurationStyleTests {
 
 	@Test
 	void detectWhenIso8601ShouldReturnIso8601() {
+		assertThat(DurationStyle.detect("pt20.345s")).isEqualTo(DurationStyle.ISO8601);
 		assertThat(DurationStyle.detect("PT20.345S")).isEqualTo(DurationStyle.ISO8601);
 		assertThat(DurationStyle.detect("PT15M")).isEqualTo(DurationStyle.ISO8601);
 		assertThat(DurationStyle.detect("+PT15M")).isEqualTo(DurationStyle.ISO8601);
@@ -161,6 +163,7 @@ class DurationStyleTests {
 
 	@Test
 	void parseIso8601ShouldParse() {
+		assertThat(DurationStyle.ISO8601.parse("pt20.345s")).isEqualTo(Duration.parse("pt20.345s"));
 		assertThat(DurationStyle.ISO8601.parse("PT20.345S")).isEqualTo(Duration.parse("PT20.345S"));
 		assertThat(DurationStyle.ISO8601.parse("PT15M")).isEqualTo(Duration.parse("PT15M"));
 		assertThat(DurationStyle.ISO8601.parse("+PT15M")).isEqualTo(Duration.parse("PT15M"));
@@ -173,6 +176,7 @@ class DurationStyleTests {
 
 	@Test
 	void parseIso8601WithUnitShouldIgnoreUnit() {
+		assertThat(DurationStyle.ISO8601.parse("pt20.345s", ChronoUnit.SECONDS)).isEqualTo(Duration.parse("pt20.345s"));
 		assertThat(DurationStyle.ISO8601.parse("PT20.345S", ChronoUnit.SECONDS)).isEqualTo(Duration.parse("PT20.345S"));
 		assertThat(DurationStyle.ISO8601.parse("PT15M", ChronoUnit.SECONDS)).isEqualTo(Duration.parse("PT15M"));
 		assertThat(DurationStyle.ISO8601.parse("+PT15M", ChronoUnit.SECONDS)).isEqualTo(Duration.parse("PT15M"));

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/StringToDurationConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/StringToDurationConverterTests.java
@@ -38,6 +38,7 @@ class StringToDurationConverterTests {
 
 	@ConversionServiceTest
 	void convertWhenIso8601ShouldReturnDuration(ConversionService conversionService) {
+		assertThat(convert(conversionService, "pt20.345s")).isEqualTo(Duration.parse("pt20.345s"));
 		assertThat(convert(conversionService, "PT20.345S")).isEqualTo(Duration.parse("PT20.345S"));
 		assertThat(convert(conversionService, "PT15M")).isEqualTo(Duration.parse("PT15M"));
 		assertThat(convert(conversionService, "+PT15M")).isEqualTo(Duration.parse("PT15M"));


### PR DESCRIPTION
Fix bug related to issue #32218 by adding lower-case P in the pattern string of DurationStyle.ISO8601.
Test cases also updated.
