### PR TITLE
add example for conditions report

### DIFF
--- a/spring-boot-project/spring-boot-docs/build.gradle
+++ b/spring-boot-project/spring-boot-docs/build.gradle
@@ -285,11 +285,21 @@ task runLoggingFormatExample(type: org.springframework.boot.build.docs.Applicati
 	normalizeTomcatPort()
 }
 
+task runConditionsReportExample(type: org.springframework.boot.build.docs.ApplicationRunner) {
+	classpath = configurations.springApplicationExample + sourceSets.main.output
+	mainClass = "org.springframework.boot.docs.features.springapplication.MyApplication"
+	args = ["--spring.main.banner-mode=off", "--server.port=0","--debug"]
+	output = file("$buildDir/example-output/conditions-report.txt")
+	expectedLogging = "Started MyApplication in "
+	normalizeTomcatPort()
+}
+
 tasks.withType(org.asciidoctor.gradle.jvm.AbstractAsciidoctorTask) {
 	dependsOn dependencyVersions
 	inputs.files(runRemoteSpringApplicationExample).withPathSensitivity(PathSensitivity.RELATIVE)
 	inputs.files(runSpringApplicationExample).withPathSensitivity(PathSensitivity.RELATIVE)
 	inputs.files(runLoggingFormatExample).withPathSensitivity(PathSensitivity.RELATIVE)
+	inputs.files(runConditionsReportExample).withPathSensitivity(PathSensitivity.RELATIVE)
 	asciidoctorj {
 		fatalWarnings = ['^((?!successfully validated).)*$']
 	}
@@ -322,7 +332,8 @@ tasks.withType(org.asciidoctor.gradle.jvm.AbstractAsciidoctorTask) {
 					"spring-webservices-version": versionConstraints["org.springframework.ws:spring-ws-core"],
 					"remote-spring-application-output": runRemoteSpringApplicationExample.outputs.files.singleFile,
 					"spring-application-output": runSpringApplicationExample.outputs.files.singleFile,
-					"logging-format-output": runLoggingFormatExample.outputs.files.singleFile
+					"logging-format-output": runLoggingFormatExample.outputs.files.singleFile,
+					"conditions-report-output":runConditionsReportExample.outputs.files.singleFile
 	}
 }
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/using/auto-configuration.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/using/auto-configuration.adoc
@@ -19,7 +19,14 @@ For example, if you add your own `DataSource` bean, the default embedded databas
 If you need to find out what auto-configuration is currently being applied, and why, start your application with the `--debug` switch.
 Doing so enables debug logs for a selection of core loggers and logs a conditions report to the console.
 
-
+.Sample log with Conditions Report
+[%collapsible]
+====
+[indent=0,subs="verbatim,attributes"]
+----
+include::{conditions-report-output}[]
+----
+====
 
 [[using.auto-configuration.disabling-specific]]
 === Disabling Specific Auto-configuration Classes


### PR DESCRIPTION
So far, the docs do not have an example for Conditions Report. This change generates the conditions report during the docs build and adds it to the generated docs.

Please refer #32196