### PR TITLE
Detection of PeriodStyle.ISO8601 does not support lower-case input

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/PeriodStyle.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/PeriodStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
  *
  * @author Eddú Meléndez
  * @author Edson Chávez
+ * @author Valentine Wu
  * @since 2.3.0
  * @see Period
  */
@@ -102,7 +103,7 @@ public enum PeriodStyle {
 	/**
 	 * ISO-8601 formatting.
 	 */
-	ISO8601("^[+-]?P.*$", 0) {
+	ISO8601("^[+-]?P.*$", Pattern.CASE_INSENSITIVE) {
 
 		@Override
 		public Period parse(String value, ChronoUnit unit) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/PeriodStyleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/PeriodStyleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  *
  * @author Eddú Meléndez
  * @author Edson Chávez
+ * @author Valentine Wu
  */
 class PeriodStyleTests {
 
@@ -40,6 +41,7 @@ class PeriodStyleTests {
 
 	@Test
 	void detectAndParseWhenIso8601ShouldReturnPeriod() {
+		assertThat(PeriodStyle.detectAndParse("p15m")).isEqualTo(Period.parse("p15m"));
 		assertThat(PeriodStyle.detectAndParse("P15M")).isEqualTo(Period.parse("P15M"));
 		assertThat(PeriodStyle.detectAndParse("-P15M")).isEqualTo(Period.parse("P-15M"));
 		assertThat(PeriodStyle.detectAndParse("+P15M")).isEqualTo(Period.parse("P15M"));
@@ -123,6 +125,7 @@ class PeriodStyleTests {
 
 	@Test
 	void detectWhenIso8601ShouldReturnIso8601() {
+		assertThat(PeriodStyle.detect("p20")).isEqualTo(PeriodStyle.ISO8601);
 		assertThat(PeriodStyle.detect("P20")).isEqualTo(PeriodStyle.ISO8601);
 		assertThat(PeriodStyle.detect("-P15M")).isEqualTo(PeriodStyle.ISO8601);
 		assertThat(PeriodStyle.detect("+P15M")).isEqualTo(PeriodStyle.ISO8601);
@@ -140,6 +143,7 @@ class PeriodStyleTests {
 
 	@Test
 	void parseIso8601ShouldParse() {
+		assertThat(PeriodStyle.ISO8601.parse("p20d")).isEqualTo(Period.parse("p20d"));
 		assertThat(PeriodStyle.ISO8601.parse("P20D")).isEqualTo(Period.parse("P20D"));
 		assertThat(PeriodStyle.ISO8601.parse("P15M")).isEqualTo(Period.parse("P15M"));
 		assertThat(PeriodStyle.ISO8601.parse("+P15M")).isEqualTo(Period.parse("P15M"));
@@ -151,6 +155,7 @@ class PeriodStyleTests {
 
 	@Test
 	void parseIso8601WithUnitShouldIgnoreUnit() {
+		assertThat(PeriodStyle.ISO8601.parse("p20d", ChronoUnit.SECONDS)).isEqualTo(Period.parse("p20d"));
 		assertThat(PeriodStyle.ISO8601.parse("P20D", ChronoUnit.SECONDS)).isEqualTo(Period.parse("P20D"));
 		assertThat(PeriodStyle.ISO8601.parse("P15M", ChronoUnit.SECONDS)).isEqualTo(Period.parse("P15M"));
 		assertThat(PeriodStyle.ISO8601.parse("+P15M", ChronoUnit.SECONDS)).isEqualTo(Period.parse("P15M"));

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/StringToPeriodConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/StringToPeriodConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ class StringToPeriodConverterTests {
 
 	@ConversionServiceTest
 	void convertWhenIso8601ShouldReturnPeriod(ConversionService conversionService) {
+		assertThat(convert(conversionService, "p2y")).isEqualTo(Period.parse("p2y"));
 		assertThat(convert(conversionService, "P2Y")).isEqualTo(Period.parse("P2Y"));
 		assertThat(convert(conversionService, "P3M")).isEqualTo(Period.parse("P3M"));
 		assertThat(convert(conversionService, "P4W")).isEqualTo(Period.parse("P4W"));


### PR DESCRIPTION
Support lower-case input in PeriodStyle  for ISO-8601 format used by java.time.Period.

This is a pull request similar to pull request #32223.

It will fix a bug similar to the one reported as #32218, found in Spring Boot version 2.7.3 with JDK 11.

The bug is demonstrated in the example application at https://github.com/valentine-dev/spring-boot-period-style-iso8601.

