### PR TITLE
Auto-configure a TracingAwareMeterObservationHandler to make tracing interoperable with metrics

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/MetricsAndTracingObservationHandlerGrouping.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/MetricsAndTracingObservationHandlerGrouping.java
@@ -27,8 +27,8 @@ import io.micrometer.observation.ObservationRegistry.ObservationConfig;
 import io.micrometer.tracing.handler.TracingObservationHandler;
 
 /**
- * {@link ObservationHandlerGrouping} used by {@link ObservationAutoConfiguration} if
- * micrometer-tracing is on the classpath.
+ * {@link ObservationHandlerGrouping} used by {@link ObservationAutoConfiguration} if both
+ * micrometer-core and micrometer-tracing are on the classpath.
  *
  * Groups all {@link TracingObservationHandler} into a
  * {@link FirstMatchingCompositeObservationHandler}, and {@link MeterObservationHandler}
@@ -37,7 +37,7 @@ import io.micrometer.tracing.handler.TracingObservationHandler;
  *
  * @author Moritz Halbritter
  */
-class TracingObservationHandlerGrouping implements ObservationHandlerGrouping {
+class MetricsAndTracingObservationHandlerGrouping implements ObservationHandlerGrouping {
 
 	@Override
 	public void apply(Collection<ObservationHandler<?>> handlers, ObservationConfig config) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationAutoConfiguration.java
@@ -20,19 +20,21 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.core.instrument.observation.MeterObservationHandler;
 import io.micrometer.observation.GlobalObservationConvention;
+import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationPredicate;
 import io.micrometer.observation.ObservationRegistry;
-import io.micrometer.tracing.handler.TracingObservationHandler;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.TracingAwareMeterObservationHandler;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.tracing.MicrometerTracingAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,9 +44,10 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Moritz Halbritter
  * @author Brian Clozel
+ * @author Jonatan Ivanov
  * @since 3.0.0
  */
-@AutoConfiguration(after = CompositeMeterRegistryAutoConfiguration.class)
+@AutoConfiguration(after = { CompositeMeterRegistryAutoConfiguration.class, MicrometerTracingAutoConfiguration.class })
 @ConditionalOnClass(ObservationRegistry.class)
 @EnableConfigurationProperties(ObservationProperties.class)
 public class ObservationAutoConfiguration {
@@ -67,20 +70,15 @@ public class ObservationAutoConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnBean(MeterRegistry.class)
-	static class MetricsConfiguration {
+	@ConditionalOnMissingBean(type = "io.micrometer.tracing.Tracer")
+	static class OnlyMetricsConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(MeterObservationHandler.class)
+		@ConditionalOnBean(MeterRegistry.class)
 		DefaultMeterObservationHandler defaultMeterObservationHandler(MeterRegistry meterRegistry) {
 			return new DefaultMeterObservationHandler(meterRegistry);
 		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnMissingClass("io.micrometer.tracing.handler.TracingObservationHandler")
-	static class OnlyMetricsConfiguration {
 
 		@Bean
 		OnlyMetricsObservationHandlerGrouping onlyMetricsObservationHandlerGrouping() {
@@ -90,8 +88,16 @@ public class ObservationAutoConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(TracingObservationHandler.class)
-	static class TracingConfiguration {
+	@ConditionalOnBean(Tracer.class)
+	static class MetricsWithTracingConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean(MeterObservationHandler.class)
+		@ConditionalOnBean(MeterRegistry.class)
+		TracingAwareMeterObservationHandler<Observation.Context> tracingAwareMeterObservationHandler(
+				MeterRegistry meterRegistry, Tracer tracer) {
+			return new TracingAwareMeterObservationHandler<>(new DefaultMeterObservationHandler(meterRegistry), tracer);
+		}
 
 		@Bean
 		TracingObservationHandlerGrouping tracingObservationHandlerGrouping() {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationRegistryConfigurer.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationRegistryConfigurer.java
@@ -68,8 +68,8 @@ class ObservationRegistryConfigurer {
 	}
 
 	private void registerHandlers(ObservationRegistry registry) {
-		this.observationHandlerGrouping.getObject().apply(asOrderedList(this.observationHandlers),
-				registry.observationConfig());
+		this.observationHandlerGrouping.ifAvailable(
+				(grouping) -> grouping.apply(asOrderedList(this.observationHandlers), registry.observationConfig()));
 	}
 
 	private void registerObservationPredicates(ObservationRegistry registry) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/OnlyTracingObservationHandlerGrouping.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/OnlyTracingObservationHandlerGrouping.java
@@ -20,36 +20,36 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import io.micrometer.core.instrument.observation.MeterObservationHandler;
 import io.micrometer.observation.ObservationHandler;
-import io.micrometer.observation.ObservationHandler.FirstMatchingCompositeObservationHandler;
-import io.micrometer.observation.ObservationRegistry.ObservationConfig;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.tracing.handler.TracingObservationHandler;
 
 /**
  * {@link ObservationHandlerGrouping} used by {@link ObservationAutoConfiguration} if
- * micrometer-tracing is not on the classpath but micrometer-core is.
+ * micrometer-core is not on the classpath but micrometer-tracing is.
  *
- * Groups all {@link MeterObservationHandler} into a
- * {@link FirstMatchingCompositeObservationHandler}. All other handlers are added to the
- * {@link ObservationConfig} directly.
+ * Groups all {@link TracingObservationHandler} into a
+ * {@link ObservationHandler.FirstMatchingCompositeObservationHandler}. All other handlers
+ * are added to the {@link ObservationRegistry.ObservationConfig} directly.
  *
- * @author Moritz Halbritter
+ * @author Jonatan Ivanov
  */
-class OnlyMetricsObservationHandlerGrouping implements ObservationHandlerGrouping {
+class OnlyTracingObservationHandlerGrouping implements ObservationHandlerGrouping {
 
 	@Override
-	public void apply(Collection<ObservationHandler<?>> handlers, ObservationConfig config) {
-		List<ObservationHandler<?>> meterObservationHandlers = new ArrayList<>();
+	public void apply(Collection<ObservationHandler<?>> handlers, ObservationRegistry.ObservationConfig config) {
+		List<ObservationHandler<?>> tracingObservationHandlers = new ArrayList<>();
 		for (ObservationHandler<?> handler : handlers) {
-			if (handler instanceof MeterObservationHandler<?>) {
-				meterObservationHandlers.add(handler);
+			if (handler instanceof TracingObservationHandler<?>) {
+				tracingObservationHandlers.add(handler);
 			}
 			else {
 				config.observationHandler(handler);
 			}
 		}
-		if (!meterObservationHandlers.isEmpty()) {
-			config.observationHandler(new FirstMatchingCompositeObservationHandler(meterObservationHandlers));
+		if (!tracingObservationHandlers.isEmpty()) {
+			config.observationHandler(
+					new ObservationHandler.FirstMatchingCompositeObservationHandler(tracingObservationHandlers));
 		}
 	}
 


### PR DESCRIPTION
This PR is trying to address a potential issue with the `ObservationAutoConfiguration`: if tracing is configured `DefaultMeterObservationHandler` should be wrapped to `TracingAwareMeterObservationHandler` so that tracing will be interoperable with metrics.

~This PR depends on `TracingAwareMeterObservationHandler` which is only available in a SNAPSHOT release of Micrometer Tracing so either we wait till the RC release of it or we can do an off-cycle milestone release.~