### PR TITLE
Add auto-configuration for Prometheus Exemplars

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/MetricsAndTracingObservationHandlerGrouping.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/MetricsAndTracingObservationHandlerGrouping.java
@@ -27,8 +27,8 @@ import io.micrometer.observation.ObservationRegistry.ObservationConfig;
 import io.micrometer.tracing.handler.TracingObservationHandler;
 
 /**
- * {@link ObservationHandlerGrouping} used by {@link ObservationAutoConfiguration} if
- * micrometer-tracing is on the classpath.
+ * {@link ObservationHandlerGrouping} used by {@link ObservationAutoConfiguration} if both
+ * micrometer-core and micrometer-tracing are on the classpath.
  *
  * Groups all {@link TracingObservationHandler} into a
  * {@link FirstMatchingCompositeObservationHandler}, and {@link MeterObservationHandler}
@@ -37,7 +37,7 @@ import io.micrometer.tracing.handler.TracingObservationHandler;
  *
  * @author Moritz Halbritter
  */
-class TracingObservationHandlerGrouping implements ObservationHandlerGrouping {
+class MetricsAndTracingObservationHandlerGrouping implements ObservationHandlerGrouping {
 
 	@Override
 	public void apply(Collection<ObservationHandler<?>> handlers, ObservationConfig config) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationAutoConfiguration.java
@@ -20,19 +20,21 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.core.instrument.observation.MeterObservationHandler;
 import io.micrometer.observation.GlobalObservationConvention;
+import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationPredicate;
 import io.micrometer.observation.ObservationRegistry;
-import io.micrometer.tracing.handler.TracingObservationHandler;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.TracingAwareMeterObservationHandler;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.tracing.MicrometerTracingAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,9 +44,10 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Moritz Halbritter
  * @author Brian Clozel
+ * @author Jonatan Ivanov
  * @since 3.0.0
  */
-@AutoConfiguration(after = CompositeMeterRegistryAutoConfiguration.class)
+@AutoConfiguration(after = { CompositeMeterRegistryAutoConfiguration.class, MicrometerTracingAutoConfiguration.class })
 @ConditionalOnClass(ObservationRegistry.class)
 @EnableConfigurationProperties(ObservationProperties.class)
 public class ObservationAutoConfiguration {
@@ -67,20 +70,15 @@ public class ObservationAutoConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnBean(MeterRegistry.class)
-	static class MetricsConfiguration {
+	@ConditionalOnMissingBean(type = "io.micrometer.tracing.Tracer")
+	static class OnlyMetricsConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(MeterObservationHandler.class)
+		@ConditionalOnBean(MeterRegistry.class)
 		DefaultMeterObservationHandler defaultMeterObservationHandler(MeterRegistry meterRegistry) {
 			return new DefaultMeterObservationHandler(meterRegistry);
 		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnMissingClass("io.micrometer.tracing.handler.TracingObservationHandler")
-	static class OnlyMetricsConfiguration {
 
 		@Bean
 		OnlyMetricsObservationHandlerGrouping onlyMetricsObservationHandlerGrouping() {
@@ -90,8 +88,16 @@ public class ObservationAutoConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(TracingObservationHandler.class)
-	static class TracingConfiguration {
+	@ConditionalOnBean(Tracer.class)
+	static class MetricsWithTracingConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean(MeterObservationHandler.class)
+		@ConditionalOnBean(MeterRegistry.class)
+		TracingAwareMeterObservationHandler<Observation.Context> tracingAwareMeterObservationHandler(
+				MeterRegistry meterRegistry, Tracer tracer) {
+			return new TracingAwareMeterObservationHandler<>(new DefaultMeterObservationHandler(meterRegistry), tracer);
+		}
 
 		@Bean
 		TracingObservationHandlerGrouping tracingObservationHandlerGrouping() {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationRegistryConfigurer.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationRegistryConfigurer.java
@@ -68,8 +68,8 @@ class ObservationRegistryConfigurer {
 	}
 
 	private void registerHandlers(ObservationRegistry registry) {
-		this.observationHandlerGrouping.getObject().apply(asOrderedList(this.observationHandlers),
-				registry.observationConfig());
+		this.observationHandlerGrouping.ifAvailable(
+				(grouping) -> grouping.apply(asOrderedList(this.observationHandlers), registry.observationConfig()));
 	}
 
 	private void registerObservationPredicates(ObservationRegistry registry) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/OnlyTracingObservationHandlerGrouping.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/OnlyTracingObservationHandlerGrouping.java
@@ -20,36 +20,36 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import io.micrometer.core.instrument.observation.MeterObservationHandler;
 import io.micrometer.observation.ObservationHandler;
-import io.micrometer.observation.ObservationHandler.FirstMatchingCompositeObservationHandler;
-import io.micrometer.observation.ObservationRegistry.ObservationConfig;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.tracing.handler.TracingObservationHandler;
 
 /**
  * {@link ObservationHandlerGrouping} used by {@link ObservationAutoConfiguration} if
- * micrometer-tracing is not on the classpath but micrometer-core is.
+ * micrometer-core is not on the classpath but micrometer-tracing is.
  *
- * Groups all {@link MeterObservationHandler} into a
- * {@link FirstMatchingCompositeObservationHandler}. All other handlers are added to the
- * {@link ObservationConfig} directly.
+ * Groups all {@link TracingObservationHandler} into a
+ * {@link ObservationHandler.FirstMatchingCompositeObservationHandler}. All other handlers
+ * are added to the {@link ObservationRegistry.ObservationConfig} directly.
  *
- * @author Moritz Halbritter
+ * @author Jonatan Ivanov
  */
-class OnlyMetricsObservationHandlerGrouping implements ObservationHandlerGrouping {
+class OnlyTracingObservationHandlerGrouping implements ObservationHandlerGrouping {
 
 	@Override
-	public void apply(Collection<ObservationHandler<?>> handlers, ObservationConfig config) {
-		List<ObservationHandler<?>> meterObservationHandlers = new ArrayList<>();
+	public void apply(Collection<ObservationHandler<?>> handlers, ObservationRegistry.ObservationConfig config) {
+		List<ObservationHandler<?>> tracingObservationHandlers = new ArrayList<>();
 		for (ObservationHandler<?> handler : handlers) {
-			if (handler instanceof MeterObservationHandler<?>) {
-				meterObservationHandlers.add(handler);
+			if (handler instanceof TracingObservationHandler<?>) {
+				tracingObservationHandlers.add(handler);
 			}
 			else {
 				config.observationHandler(handler);
 			}
 		}
-		if (!meterObservationHandlers.isEmpty()) {
-			config.observationHandler(new FirstMatchingCompositeObservationHandler(meterObservationHandlers));
+		if (!tracingObservationHandlers.isEmpty()) {
+			config.observationHandler(
+					new ObservationHandler.FirstMatchingCompositeObservationHandler(tracingObservationHandlers));
 		}
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/exemplars/ExemplarsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/exemplars/ExemplarsAutoConfiguration.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.tracing.exemplars;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.prometheus.client.exemplars.tracer.common.SpanContextSupplier;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusMetricsExportAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.tracing.ConditionalOnEnabledTracing;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Prometheus Exemplars with
+ * Micrometer Tracing.
+ *
+ * @author Jonatan Ivanov
+ * @since 3.0.0
+ */
+@AutoConfiguration(before = PrometheusMetricsExportAutoConfiguration.class)
+@ConditionalOnClass({ Tracer.class, SpanContextSupplier.class })
+@ConditionalOnEnabledTracing
+public class ExemplarsAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	SpanContextSupplier spanContextSupplier(ObjectProvider<Tracer> tracerProvider) {
+		return new LazyTracingSpanContextSupplier(tracerProvider);
+	}
+
+	/**
+	 * Since the MeterRegistry can depend on the {@link Tracer} (Exemplars) and the
+	 * {@link Tracer} can depend on the MeterRegistry (recording metrics), this
+	 * {@link SpanContextSupplier} breaks the circle by lazily loading the {@link Tracer}.
+	 */
+	static class LazyTracingSpanContextSupplier implements SpanContextSupplier, SmartInitializingSingleton {
+
+		private final ObjectProvider<Tracer> tracerProvider;
+
+		private Tracer tracer;
+
+		LazyTracingSpanContextSupplier(ObjectProvider<Tracer> tracerProvider) {
+			this.tracerProvider = tracerProvider;
+		}
+
+		@Override
+		public String getTraceId() {
+			return this.tracer.currentSpan().context().traceId();
+		}
+
+		@Override
+		public String getSpanId() {
+			return this.tracer.currentSpan().context().spanId();
+		}
+
+		@Override
+		public boolean isSampled() {
+			return this.tracer != null && isSampled(this.tracer);
+		}
+
+		private boolean isSampled(Tracer tracer) {
+			Span currentSpan = tracer.currentSpan();
+			return currentSpan != null && currentSpan.context().sampled();
+		}
+
+		@Override
+		public void afterSingletonsInstantiated() {
+			this.tracer = this.tracerProvider.getIfAvailable();
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/exemplars/package-info.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/exemplars/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Prometheus Exemplars with Micrometer Tracing.
+ */
+package org.springframework.boot.actuate.autoconfigure.tracing.exemplars;

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -101,6 +101,7 @@ org.springframework.boot.actuate.autoconfigure.trace.http.HttpTraceEndpointAutoC
 org.springframework.boot.actuate.autoconfigure.tracing.BraveAutoConfiguration
 org.springframework.boot.actuate.autoconfigure.tracing.MicrometerTracingAutoConfiguration
 org.springframework.boot.actuate.autoconfigure.tracing.OpenTelemetryAutoConfiguration
+org.springframework.boot.actuate.autoconfigure.tracing.exemplars.ExemplarsAutoConfiguration
 org.springframework.boot.actuate.autoconfigure.tracing.wavefront.WavefrontTracingAutoConfiguration
 org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration
 org.springframework.boot.actuate.autoconfigure.web.mappings.MappingsEndpointAutoConfiguration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/exemplars/ExemplarsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/exemplars/ExemplarsAutoConfigurationTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.tracing.exemplars;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.exemplars.tracer.common.SpanContextSupplier;
+import io.prometheus.client.exporter.common.TextFormat;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusMetricsExportAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.test.MetricsRun;
+import org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.tracing.BraveAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.tracing.MicrometerTracingAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link ExemplarsAutoConfiguration}.
+ *
+ * * @author Jonatan Ivanov
+ */
+class ExemplarsAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withPropertyValues("management.tracing.sampling.probability=1.0",
+					"management.metrics.distribution.percentiles-histogram.all=true")
+			.with(MetricsRun.limitedTo(PrometheusMetricsExportAutoConfiguration.class)).withConfiguration(
+					AutoConfigurations.of(ExemplarsAutoConfiguration.class, ObservationAutoConfiguration.class,
+							BraveAutoConfiguration.class, MicrometerTracingAutoConfiguration.class));
+
+	@Test
+	void shouldNotSupplyBeansIfTracingIsDisabled() {
+		this.contextRunner.withPropertyValues("management.tracing.enabled=false")
+				.run((context) -> assertThat(context).doesNotHaveBean(SpanContextSupplier.class));
+	}
+
+	@Test
+	void shouldNotSupplyBeansIfPrometheusSupportIsMissing() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader("io.prometheus.client.exemplars"))
+				.run((context) -> assertThat(context).doesNotHaveBean(SpanContextSupplier.class));
+	}
+
+	@Test
+	void shouldNotSupplyBeansIfMicrometerTracingIsMissing() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader("io.micrometer.tracing"))
+				.run((context) -> assertThat(context).doesNotHaveBean(SpanContextSupplier.class));
+	}
+
+	@Test
+	void shouldSupplyCustomBeans() {
+		this.contextRunner.withUserConfiguration(CustomConfiguration.class)
+				.run((context) -> assertThat(context).hasSingleBean(SpanContextSupplier.class)
+						.getBean(SpanContextSupplier.class).isSameAs(CustomConfiguration.SUPPLIER));
+	}
+
+	@Test
+	void prometheusOpenMetricsOutputShouldContainExemplars() {
+		this.contextRunner.run((context) -> {
+			assertThat(context).hasSingleBean(SpanContextSupplier.class);
+			ObservationRegistry observationRegistry = context.getBean(ObservationRegistry.class);
+			Observation.start("test.observation", observationRegistry).stop();
+
+			PrometheusMeterRegistry prometheusMeterRegistry = context.getBean(PrometheusMeterRegistry.class);
+			String openMetricsOutput = prometheusMeterRegistry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100);
+			assertThat(openMetricsOutput).contains("test_observation_seconds_bucket").containsOnlyOnce("trace_id=")
+					.containsOnlyOnce("span_id=");
+		});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	private static class CustomConfiguration {
+
+		static final SpanContextSupplier SUPPLIER = mock(SpanContextSupplier.class);
+
+		@Bean
+		SpanContextSupplier customSpanContextSupplier() {
+			return SUPPLIER;
+		}
+
+	}
+
+}


### PR DESCRIPTION
This PR adds Exemplars support for Micrometer Tracing.
Please notice that this PR depends on https://github.com/spring-projects/spring-boot/pull/32399 because it needs all of those issues fixed first so the only real change in this PR is adding `ExemplarsAutoConfiguration` and `ExemplarsAutoConfigurationTests`.
