### PR TITLE
Remove redundant @ExtendWith(SpringExtension.class) from MyJmxTests example

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/testing/springbootapplications/jmx/MyJmxTests.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/testing/springbootapplications/jmx/MyJmxTests.java
@@ -19,16 +19,13 @@ package org.springframework.boot.docs.features.testing.springbootapplications.jm
 import javax.management.MBeanServer;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = "spring.jmx.enabled=true")
 @DirtiesContext
 class MyJmxTests {

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/jmx/MyJmxTests.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/jmx/MyJmxTests.kt
@@ -20,13 +20,10 @@ import javax.management.MBeanServer
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.annotation.DirtiesContext
-import org.springframework.test.context.junit.jupiter.SpringExtension
 
-@ExtendWith(SpringExtension::class)
 @SpringBootTest(properties = ["spring.jmx.enabled=true"])
 @DirtiesContext
 class MyJmxTests(@Autowired val mBeanServer: MBeanServer) {


### PR DESCRIPTION
`@SpringBootTest` already contains `@ExtendWith(SpringExtension.class)`.
