### PR TITLE
MDC & Baggage AutoConfiguration for Micrometer Tracing with Brave and OpenTelemetry

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java
@@ -258,11 +258,11 @@ public class BraveAutoConfiguration {
 			@Bean
 			@ConditionalOnMissingBean(CorrelationScopeDecorator.class)
 			@ConditionalOnBean(CorrelationScopeDecorator.Builder.class)
-			@ConditionalOnProperty(value = "management.tracing.baggage.correlation-enabled", matchIfMissing = true)
+			@ConditionalOnProperty(value = "management.tracing.baggage.correlation.enabled", matchIfMissing = true)
 			ScopeDecorator correlationFieldsCorrelationScopeDecorator(TracingProperties properties,
 					ObjectProvider<List<CorrelationScopeCustomizer>> correlationScopeCustomizers,
 					CorrelationScopeDecorator.Builder builder) {
-				List<String> correlationFields = properties.getBaggage().getCorrelationFields();
+				List<String> correlationFields = properties.getBaggage().getCorrelation().getFields();
 				for (String field : correlationFields) {
 					builder.add(CorrelationScopeConfig.SingleCorrelationField.newBuilder(BaggageField.create(field))
 							.flushOnUpdate().build());
@@ -275,7 +275,7 @@ public class BraveAutoConfiguration {
 			@Bean
 			@ConditionalOnMissingBean(CorrelationScopeDecorator.class)
 			@ConditionalOnBean(CorrelationScopeDecorator.Builder.class)
-			@ConditionalOnProperty(value = "management.tracing.baggage.correlation-enabled", havingValue = "false")
+			@ConditionalOnProperty(value = "management.tracing.baggage.correlation.enabled", havingValue = "false")
 			ScopeDecorator noCorrelationFieldsCorrelationScopeDecorator(CorrelationScopeDecorator.Builder builder,
 					ObjectProvider<List<CorrelationScopeCustomizer>> correlationScopeCustomizers) {
 				correlationScopeCustomizers.ifAvailable(

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java
@@ -21,6 +21,14 @@ import java.util.List;
 import brave.Tracing;
 import brave.Tracing.Builder;
 import brave.TracingCustomizer;
+import brave.baggage.BaggageField;
+import brave.baggage.BaggagePropagation;
+import brave.baggage.BaggagePropagationConfig;
+import brave.baggage.BaggagePropagationCustomizer;
+import brave.baggage.CorrelationScopeConfig;
+import brave.baggage.CorrelationScopeCustomizer;
+import brave.baggage.CorrelationScopeDecorator;
+import brave.context.slf4j.MDCScopeDecorator;
 import brave.handler.SpanHandler;
 import brave.http.HttpClientHandler;
 import brave.http.HttpClientRequest;
@@ -33,6 +41,7 @@ import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.ScopeDecorator;
 import brave.propagation.CurrentTraceContextCustomizer;
+import brave.propagation.Propagation;
 import brave.propagation.Propagation.Factory;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
@@ -40,12 +49,19 @@ import io.micrometer.tracing.brave.bridge.BraveBaggageManager;
 import io.micrometer.tracing.brave.bridge.BraveCurrentTraceContext;
 import io.micrometer.tracing.brave.bridge.BraveHttpClientHandler;
 import io.micrometer.tracing.brave.bridge.BraveHttpServerHandler;
+import io.micrometer.tracing.brave.bridge.BravePropagator;
 import io.micrometer.tracing.brave.bridge.BraveTracer;
+import io.micrometer.tracing.brave.bridge.W3CPropagation;
+import org.slf4j.MDC;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -55,6 +71,7 @@ import org.springframework.core.env.Environment;
  * {@link EnableAutoConfiguration Auto-configuration} for Brave.
  *
  * @author Moritz Halbritter
+ * @author Marcin Grzejszczak
  * @since 3.0.0
  */
 @AutoConfiguration(before = MicrometerTracingAutoConfiguration.class)
@@ -107,12 +124,6 @@ public class BraveAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public Factory bravePropagationFactory() {
-		return B3Propagation.newFactoryBuilder().injectFormat(B3Propagation.Format.SINGLE_NO_PARENT).build();
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
 	public Sampler braveSampler(TracingProperties properties) {
 		return Sampler.create(properties.getSampling().getProbability());
 	}
@@ -136,20 +147,34 @@ public class BraveAutoConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(BraveTracer.class)
-	static class BraveMicrometer {
+	@ConditionalOnMissingClass("io.micrometer.tracing.brave.bridge.BraveTracer")
+	static class BraveMicrometerMissing {
 
 		@Bean
 		@ConditionalOnMissingBean
-		BraveTracer braveTracerBridge(brave.Tracer tracer, CurrentTraceContext currentTraceContext,
-				BraveBaggageManager braveBaggageManager) {
-			return new BraveTracer(tracer, new BraveCurrentTraceContext(currentTraceContext), braveBaggageManager);
+		@ConditionalOnProperty(value = "management.tracing.propagation.type", havingValue = "B3", matchIfMissing = true)
+		Factory bravePropagationFactory() {
+			return B3Propagation.newFactoryBuilder().injectFormat(B3Propagation.Format.SINGLE_NO_PARENT).build();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(BraveTracer.class)
+	static class BraveMicrometer {
+
+		private static final BraveBaggageManager BRAVE_BAGGAGE_MANAGER = new BraveBaggageManager();
+
+		@Bean
+		@ConditionalOnMissingBean
+		BraveTracer braveTracerBridge(brave.Tracer tracer, CurrentTraceContext currentTraceContext) {
+			return new BraveTracer(tracer, new BraveCurrentTraceContext(currentTraceContext), BRAVE_BAGGAGE_MANAGER);
 		}
 
 		@Bean
 		@ConditionalOnMissingBean
-		BraveBaggageManager braveBaggageManager() {
-			return new BraveBaggageManager();
+		BravePropagator bravePropagator(Tracing tracing) {
+			return new BravePropagator(tracing);
 		}
 
 		@Bean
@@ -164,6 +189,123 @@ public class BraveAutoConfiguration {
 		BraveHttpClientHandler braveHttpClientHandler(
 				HttpClientHandler<HttpClientRequest, HttpClientResponse> httpClientHandler) {
 			return new BraveHttpClientHandler(httpClientHandler);
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		@ConditionalOnProperty(value = "management.tracing.baggage.enabled", havingValue = "false",
+				matchIfMissing = true)
+		static class BraveNoBaggageConfiguration {
+
+			@Bean
+			@ConditionalOnMissingBean
+			@ConditionalOnProperty(value = "management.tracing.propagation.type", havingValue = "W3C",
+					matchIfMissing = true)
+			Factory w3cPropagationNoBaggageFactory() {
+				return new W3CPropagation(BRAVE_BAGGAGE_MANAGER, List.of()); // TODO: Use
+																				// snapshots
+																				// of
+																				// tracing
+																				// to not
+																				// use
+																				// baggage
+																				// for W3C
+			}
+
+			@Bean
+			@ConditionalOnMissingBean
+			@ConditionalOnProperty(value = "management.tracing.propagation.type", havingValue = "B3")
+			Factory b3PropagationNoBaggageFactory() {
+				return B3Propagation.newFactoryBuilder().injectFormat(B3Propagation.Format.SINGLE_NO_PARENT).build();
+			}
+
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		@ConditionalOnProperty(value = "management.tracing.baggage.enabled", matchIfMissing = true)
+		static class BraveBaggageConfiguration {
+
+			@Bean
+			@ConditionalOnMissingBean
+			@ConditionalOnProperty(value = "management.tracing.propagation.type", havingValue = "W3C",
+					matchIfMissing = true)
+			BaggagePropagation.FactoryBuilder w3cPropagationFactory() {
+				return BaggagePropagation.newFactoryBuilder(new W3CPropagation(BRAVE_BAGGAGE_MANAGER, List.of()));
+			}
+
+			@Bean
+			@ConditionalOnMissingBean
+			@ConditionalOnProperty(value = "management.tracing.propagation.type", havingValue = "B3")
+			BaggagePropagation.FactoryBuilder b3PropagationFactory() {
+				return BaggagePropagation.newFactoryBuilder(
+						B3Propagation.newFactoryBuilder().injectFormat(B3Propagation.Format.SINGLE_NO_PARENT).build());
+			}
+
+			@Bean
+			@ConditionalOnMissingBean
+			Propagation.Factory micrometerTracingPropagationWithBaggage(
+					BaggagePropagation.FactoryBuilder factoryBuilder, TracingProperties tracingProperties,
+					ObjectProvider<List<BaggagePropagationCustomizer>> baggagePropagationCustomizers) {
+				List<String> remoteFields = tracingProperties.getBaggage().getRemoteFields();
+				for (String fieldName : remoteFields) {
+					factoryBuilder
+							.add(BaggagePropagationConfig.SingleBaggageField.remote(BaggageField.create(fieldName)));
+				}
+				baggagePropagationCustomizers.ifAvailable(
+						(customizers) -> customizers.forEach((customizer) -> customizer.customize(factoryBuilder)));
+				return factoryBuilder.build();
+			}
+
+			@Bean
+			@ConditionalOnMissingBean(CorrelationScopeDecorator.class)
+			@ConditionalOnBean(CorrelationScopeDecorator.Builder.class)
+			@ConditionalOnProperty(value = "management.tracing.baggage.correlation-enabled", matchIfMissing = true)
+			ScopeDecorator correlationFieldsCorrelationScopeDecorator(TracingProperties properties,
+					ObjectProvider<List<CorrelationScopeCustomizer>> correlationScopeCustomizers,
+					CorrelationScopeDecorator.Builder builder) {
+				List<String> correlationFields = properties.getBaggage().getCorrelationFields();
+				for (String field : correlationFields) {
+					builder.add(CorrelationScopeConfig.SingleCorrelationField.newBuilder(BaggageField.create(field))
+							.flushOnUpdate().build());
+				}
+				correlationScopeCustomizers.ifAvailable(
+						(customizers) -> customizers.forEach((customizer) -> customizer.customize(builder)));
+				return builder.build();
+			}
+
+			@Bean
+			@ConditionalOnMissingBean(CorrelationScopeDecorator.class)
+			@ConditionalOnBean(CorrelationScopeDecorator.Builder.class)
+			@ConditionalOnProperty(value = "management.tracing.baggage.correlation-enabled", havingValue = "false")
+			ScopeDecorator noCorrelationFieldsCorrelationScopeDecorator(CorrelationScopeDecorator.Builder builder,
+					ObjectProvider<List<CorrelationScopeCustomizer>> correlationScopeCustomizers) {
+				correlationScopeCustomizers.ifAvailable(
+						(customizers) -> customizers.forEach((customizer) -> customizer.customize(builder)));
+				return builder.build();
+			}
+
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CorrelationScopeDecoratorConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean
+		@ConditionalOnClass(MDC.class)
+		CorrelationScopeDecorator.Builder mdcCorrelationScopeDecoratorBuilder() {
+			return MDCScopeDecorator.newBuilder();
+		}
+
+		@Bean
+		@ConditionalOnMissingBean(CorrelationScopeDecorator.class)
+		@ConditionalOnBean(CorrelationScopeDecorator.Builder.class)
+		@ConditionalOnMissingClass("io.micrometer.tracing.brave.bridge.BraveTracer")
+		ScopeDecorator correlationScopeDecorator(CorrelationScopeDecorator.Builder builder,
+				ObjectProvider<List<CorrelationScopeCustomizer>> correlationScopeCustomizers) {
+			correlationScopeCustomizers
+					.ifAvailable((customizers) -> customizers.forEach((customizer) -> customizer.customize(builder)));
+			return builder.build();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurations.java
@@ -274,10 +274,11 @@ class OpenTelemetryConfigurations {
 
 					@Bean
 					@ConditionalOnMissingBean
-					@ConditionalOnProperty(value = "management.tracing.baggage.correlation-enabled",
+					@ConditionalOnProperty(value = "management.tracing.baggage.correlation.enabled",
 							matchIfMissing = true)
 					Slf4JBaggageEventListener otelSlf4JBaggageEventListener(TracingProperties tracingProperties) {
-						return new Slf4JBaggageEventListener(tracingProperties.getBaggage().getCorrelationFields());
+						return new Slf4JBaggageEventListener(
+								tracingProperties.getBaggage().getCorrelation().getFields());
 					}
 
 				}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/TracingProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/TracingProperties.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.actuate.autoconfigure.tracing;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -32,8 +35,26 @@ public class TracingProperties {
 	 */
 	private final Sampling sampling = new Sampling();
 
+	/**
+	 * Baggage configuration.
+	 */
+	private final Baggage baggage = new Baggage();
+
+	/**
+	 * Propagation configuration.
+	 */
+	private final Propagation propagation = new Propagation();
+
 	public Sampling getSampling() {
 		return this.sampling;
+	}
+
+	public Baggage getBaggage() {
+		return this.baggage;
+	}
+
+	public Propagation getPropagation() {
+		return this.propagation;
 	}
 
 	public static class Sampling {
@@ -49,6 +70,83 @@ public class TracingProperties {
 
 		public void setProbability(float probability) {
 			this.probability = probability;
+		}
+
+	}
+
+	public static class Baggage {
+
+		/**
+		 * Whether to enable correlation of the baggage context with logging contexts.
+		 */
+		private boolean correlationEnabled = true;
+
+		/**
+		 * List of fields that should be correlated with the logging context. That means
+		 * that these fields would end up as key-value pairs in e.g. MDC.
+		 */
+		private List<String> correlationFields = new ArrayList<>();
+
+		/**
+		 * List of fields that are referenced the same in-process as it is on the wire.
+		 * For example, the field "x-vcap-request-id" would be set as-is including the
+		 * prefix.
+		 */
+		private List<String> remoteFields = new ArrayList<>();
+
+		public boolean isCorrelationEnabled() {
+			return this.correlationEnabled;
+		}
+
+		public void setCorrelationEnabled(boolean correlationEnabled) {
+			this.correlationEnabled = correlationEnabled;
+		}
+
+		public List<String> getCorrelationFields() {
+			return this.correlationFields;
+		}
+
+		public void setCorrelationFields(List<String> correlationFields) {
+			this.correlationFields = correlationFields;
+		}
+
+		public List<String> getRemoteFields() {
+			return this.remoteFields;
+		}
+
+		public void setRemoteFields(List<String> remoteFields) {
+			this.remoteFields = remoteFields;
+		}
+
+	}
+
+	public static class Propagation {
+
+		/**
+		 * Tracing context propagation types.
+		 */
+		private PropagationType type = PropagationType.W3C;
+
+		public PropagationType getType() {
+			return this.type;
+		}
+
+		public void setType(PropagationType type) {
+			this.type = type;
+		}
+
+		enum PropagationType {
+
+			/**
+			 * B3 propagation type.
+			 */
+			B3,
+
+			/**
+			 * W3C propagation type.
+			 */
+			W3C
+
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/TracingProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/TracingProperties.java
@@ -77,15 +77,14 @@ public class TracingProperties {
 	public static class Baggage {
 
 		/**
-		 * Whether to enable correlation of the baggage context with logging contexts.
+		 * Whether to enable Micrometer Tracing baggage propagation.
 		 */
-		private boolean correlationEnabled = true;
+		private boolean enabled;
 
 		/**
-		 * List of fields that should be correlated with the logging context. That means
-		 * that these fields would end up as key-value pairs in e.g. MDC.
+		 * Correlation configuration.
 		 */
-		private List<String> correlationFields = new ArrayList<>();
+		private Correlation correlation = new Correlation();
 
 		/**
 		 * List of fields that are referenced the same in-process as it is on the wire.
@@ -94,20 +93,20 @@ public class TracingProperties {
 		 */
 		private List<String> remoteFields = new ArrayList<>();
 
-		public boolean isCorrelationEnabled() {
-			return this.correlationEnabled;
+		public boolean isEnabled() {
+			return this.enabled;
 		}
 
-		public void setCorrelationEnabled(boolean correlationEnabled) {
-			this.correlationEnabled = correlationEnabled;
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
 		}
 
-		public List<String> getCorrelationFields() {
-			return this.correlationFields;
+		public Correlation getCorrelation() {
+			return this.correlation;
 		}
 
-		public void setCorrelationFields(List<String> correlationFields) {
-			this.correlationFields = correlationFields;
+		public void setCorrelation(Correlation correlation) {
+			this.correlation = correlation;
 		}
 
 		public List<String> getRemoteFields() {
@@ -116,6 +115,37 @@ public class TracingProperties {
 
 		public void setRemoteFields(List<String> remoteFields) {
 			this.remoteFields = remoteFields;
+		}
+
+		public static class Correlation {
+
+			/**
+			 * Whether to enable correlation of the baggage context with logging contexts.
+			 */
+			private boolean enabled = true;
+
+			/**
+			 * List of fields that should be correlated with the logging context. That
+			 * means that these fields would end up as key-value pairs in e.g. MDC.
+			 */
+			private List<String> fields = new ArrayList<>();
+
+			public boolean isEnabled() {
+				return this.enabled;
+			}
+
+			public void setEnabled(boolean enabled) {
+				this.enabled = enabled;
+			}
+
+			public List<String> getFields() {
+				return this.fields;
+			}
+
+			public void setFields(List<String> fields) {
+				this.fields = fields;
+			}
+
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2086,6 +2086,20 @@
         "replacement": "management.trace.http.include",
         "level": "error"
       }
+    },
+    {
+      "name": "management.tracing.baggage.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable Micrometer Tracing baggage propagation.",
+      "defaultValue": true
+    },
+    {
+      "name": "management.tracing.propagation.type",
+      "defaultValue": "W3C"
+    },
+    {
+      "name": "management.tracing.sampling.probability",
+      "defaultValue": "0.10"
     }
   ],
   "hints": [

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2088,18 +2088,8 @@
       }
     },
     {
-      "name": "management.tracing.baggage.enabled",
-      "type": "java.lang.Boolean",
-      "description": "Whether to enable Micrometer Tracing baggage propagation.",
-      "defaultValue": true
-    },
-    {
       "name": "management.tracing.propagation.type",
       "defaultValue": "W3C"
-    },
-    {
-      "name": "management.tracing.sampling.probability",
-      "defaultValue": "0.10"
     }
   ],
   "hints": [

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BaggageAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BaggageAutoConfigurationTests.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.tracing;
+
+import java.util.function.Supplier;
+
+import io.micrometer.tracing.BaggageInScope;
+import io.micrometer.tracing.BaggageManager;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.opentelemetry.context.Context;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.MDC;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for Baggage configuration.
+ *
+ * @author Marcin Grzejszczak
+ */
+class BaggageAutoConfigurationTests {
+
+	static final String COUNTRY_CODE = "country-code";
+	static final String BUSINESS_PROCESS = "bp";
+
+	@BeforeEach
+	@AfterEach
+	void setup() {
+		MDC.clear();
+	}
+
+	@ParameterizedTest
+	@EnumSource(AutoConfig.class)
+	void shouldSetEntriesToMdcFromSpanWithBaggage(AutoConfig autoConfig) {
+		autoConfig.get().run((context) -> {
+			Tracer tracer = tracer(context);
+			Span span = createSpan(tracer);
+			assertThatTracingContextIsInitialized(autoConfig);
+			try (Tracer.SpanInScope scope = tracer.withSpan(span.start());
+					BaggageInScope fo = context.getBean(BaggageManager.class).createBaggage(COUNTRY_CODE)
+							.set(span.context(), "FO");
+					BaggageInScope bp = context.getBean(BaggageManager.class).createBaggage(BUSINESS_PROCESS)
+							.set(span.context(), "ALM")) {
+				assertThat(MDC.get("traceId")).isEqualTo(span.context().traceId());
+				assertThat(MDC.get(COUNTRY_CODE)).isEqualTo("FO");
+				assertThat(MDC.get(BUSINESS_PROCESS)).isEqualTo("ALM");
+			}
+			finally {
+				span.end();
+			}
+
+			assertThatMdcContainsUnsetTraceId();
+			assertThat(MDC.get(COUNTRY_CODE)).isNull();
+			assertThat(MDC.get(BUSINESS_PROCESS)).isNull();
+		});
+	}
+
+	@ParameterizedTest
+	@EnumSource(AutoConfig.class)
+	void shouldRemoveEntriesFromMdcForNullSpan(AutoConfig autoConfig) {
+		autoConfig.get().run((context) -> {
+			Tracer tracer = tracer(context);
+			Span span = createSpan(tracer);
+			assertThatTracingContextIsInitialized(autoConfig);
+			try (Tracer.SpanInScope scope = tracer.withSpan(span.start());
+					BaggageInScope fo = context.getBean(BaggageManager.class).createBaggage(COUNTRY_CODE)
+							.set(span.context(), "FO")) {
+				assertThat(MDC.get("traceId")).isEqualTo(span.context().traceId());
+				assertThat(MDC.get(COUNTRY_CODE)).isEqualTo("FO");
+
+				try (Tracer.SpanInScope scope2 = tracer.withSpan(null)) {
+					assertThatMdcContainsUnsetTraceId();
+					assertThat(MDC.get(COUNTRY_CODE)).isNullOrEmpty();
+				}
+
+				assertThat(MDC.get("traceId")).isEqualTo(span.context().traceId());
+				assertThat(MDC.get(COUNTRY_CODE)).isEqualTo("FO");
+			}
+			finally {
+				span.end();
+			}
+			assertThatMdcContainsUnsetTraceId();
+			assertThat(MDC.get(COUNTRY_CODE)).isNullOrEmpty();
+		});
+	}
+
+	private Span createSpan(Tracer tracer) {
+		return tracer.nextSpan().name("span");
+	}
+
+	private Tracer tracer(ApplicationContext context) {
+		return context.getBean(Tracer.class);
+	}
+
+	private void assertThatTracingContextIsInitialized(AutoConfig autoConfig) {
+		if (autoConfig == AutoConfig.OTEL_B3) {
+			assertThat(Context.current()).isEqualTo(Context.root());
+		}
+	}
+
+	private void assertThatMdcContainsUnsetTraceId() {
+		assertThat(isInvalidBraveTraceId() || isInvalidOtelTraceId()).isTrue();
+	}
+
+	private boolean isInvalidBraveTraceId() {
+		return MDC.get("traceId") == null;
+	}
+
+	private boolean isInvalidOtelTraceId() {
+		return MDC.get("traceId").equals("00000000000000000000000000000000");
+	}
+
+	enum AutoConfig implements Supplier<ApplicationContextRunner> {
+
+		BRAVE_W3C {
+			@Override
+			public ApplicationContextRunner get() {
+				return new ApplicationContextRunner()
+						.withConfiguration(AutoConfigurations.of(BraveAutoConfiguration.class)).withPropertyValues(
+								"management.tracing.baggage.remote-fields=x-vcap-request-id,country-code,bp",
+								"management.tracing.baggage.correlation-fields=country-code,bp");
+			}
+		},
+
+		OTEL_W3C {
+			@Override
+			public ApplicationContextRunner get() {
+				return new ApplicationContextRunner()
+						.withConfiguration(AutoConfigurations.of(OpenTelemetryAutoConfiguration.class))
+						.withPropertyValues(
+								"management.tracing.baggage.remote-fields=x-vcap-request-id,country-code,bp",
+								"management.tracing.baggage.correlation-fields=country-code,bp");
+			}
+		},
+
+		BRAVE_B3 {
+			@Override
+			public ApplicationContextRunner get() {
+				return new ApplicationContextRunner()
+						.withConfiguration(AutoConfigurations.of(BraveAutoConfiguration.class))
+						.withPropertyValues("management.tracing.propagation.type=B3",
+								"management.tracing.baggage.remote-fields=x-vcap-request-id,country-code,bp",
+								"management.tracing.baggage.correlation-fields=country-code,bp");
+			}
+		},
+
+		OTEL_B3 {
+			@Override
+			public ApplicationContextRunner get() {
+				return new ApplicationContextRunner()
+						.withConfiguration(AutoConfigurations.of(OpenTelemetryAutoConfiguration.class))
+						.withPropertyValues("management.tracing.propagation.type=B3",
+								"management.tracing.baggage.remote-fields=x-vcap-request-id,country-code,bp",
+								"management.tracing.baggage.correlation-fields=country-code,bp");
+			}
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BaggageAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BaggageAutoConfigurationTests.java
@@ -140,7 +140,7 @@ class BaggageAutoConfigurationTests {
 				return new ApplicationContextRunner()
 						.withConfiguration(AutoConfigurations.of(BraveAutoConfiguration.class)).withPropertyValues(
 								"management.tracing.baggage.remote-fields=x-vcap-request-id,country-code,bp",
-								"management.tracing.baggage.correlation-fields=country-code,bp");
+								"management.tracing.baggage.correlation.fields=country-code,bp");
 			}
 		},
 
@@ -151,7 +151,7 @@ class BaggageAutoConfigurationTests {
 						.withConfiguration(AutoConfigurations.of(OpenTelemetryAutoConfiguration.class))
 						.withPropertyValues(
 								"management.tracing.baggage.remote-fields=x-vcap-request-id,country-code,bp",
-								"management.tracing.baggage.correlation-fields=country-code,bp");
+								"management.tracing.baggage.correlation.fields=country-code,bp");
 			}
 		},
 
@@ -162,7 +162,7 @@ class BaggageAutoConfigurationTests {
 						.withConfiguration(AutoConfigurations.of(BraveAutoConfiguration.class))
 						.withPropertyValues("management.tracing.propagation.type=B3",
 								"management.tracing.baggage.remote-fields=x-vcap-request-id,country-code,bp",
-								"management.tracing.baggage.correlation-fields=country-code,bp");
+								"management.tracing.baggage.correlation.fields=country-code,bp");
 			}
 		},
 
@@ -173,7 +173,7 @@ class BaggageAutoConfigurationTests {
 						.withConfiguration(AutoConfigurations.of(OpenTelemetryAutoConfiguration.class))
 						.withPropertyValues("management.tracing.propagation.type=B3",
 								"management.tracing.baggage.remote-fields=x-vcap-request-id,country-code,bp",
-								"management.tracing.baggage.correlation-fields=country-code,bp");
+								"management.tracing.baggage.correlation.fields=country-code,bp");
 			}
 		}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfigurationTests.java
@@ -155,19 +155,11 @@ class BraveAutoConfigurationTests {
 	}
 
 	@Test
-	void shouldSupplyB3PropagationIfMicrometerIsMissing() {
+	void shouldNotSetupTracingIfMicrometerIsMissing() {
 		this.contextRunner.withClassLoader(new FilteredClassLoader("io.micrometer")).run((context) -> {
-			assertThat(context).hasBean("bravePropagationFactory");
-			assertThat(context).hasSingleBean(Propagation.Factory.class);
+			assertThat(context).doesNotHaveBean(Tracing.class);
+			assertThat(context).doesNotHaveBean(BraveTracer.class);
 		});
-	}
-
-	@Test
-	void shouldFailIfMicrometerIsMissingAndW3CPropagationIsPicked() {
-		this.contextRunner.withClassLoader(new FilteredClassLoader("io.micrometer"))
-				.withPropertyValues("management.tracing.propagation.type=W3C")
-				.run((context) -> assertThat(context).getFailure()
-						.hasMessageContaining("No qualifying bean of type 'brave.propagation.Propagation$Factory'"));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfigurationTests.java
@@ -18,6 +18,7 @@ package org.springframework.boot.actuate.autoconfigure.tracing;
 
 import brave.Tracer;
 import brave.Tracing;
+import brave.baggage.BaggagePropagation;
 import brave.http.HttpClientHandler;
 import brave.http.HttpClientRequest;
 import brave.http.HttpClientResponse;
@@ -26,6 +27,7 @@ import brave.http.HttpServerRequest;
 import brave.http.HttpServerResponse;
 import brave.http.HttpTracing;
 import brave.propagation.CurrentTraceContext;
+import brave.propagation.Propagation;
 import brave.propagation.Propagation.Factory;
 import brave.sampler.Sampler;
 import io.micrometer.tracing.brave.bridge.BraveBaggageManager;
@@ -65,6 +67,8 @@ class BraveAutoConfigurationTests {
 			assertThat(context).hasSingleBean(HttpTracing.class);
 			assertThat(context).hasSingleBean(HttpServerHandler.class);
 			assertThat(context).hasSingleBean(HttpClientHandler.class);
+			assertThat(context).hasSingleBean(Propagation.Factory.class);
+			assertThat(context).hasSingleBean(BaggagePropagation.FactoryBuilder.class);
 		});
 	}
 
@@ -94,7 +98,6 @@ class BraveAutoConfigurationTests {
 	void shouldSupplyMicrometerBeans() {
 		this.contextRunner.run((context) -> {
 			assertThat(context).hasSingleBean(BraveTracer.class);
-			assertThat(context).hasSingleBean(BraveBaggageManager.class);
 			assertThat(context).hasSingleBean(BraveHttpServerHandler.class);
 			assertThat(context).hasSingleBean(BraveHttpClientHandler.class);
 		});
@@ -111,6 +114,18 @@ class BraveAutoConfigurationTests {
 			assertThat(context).hasSingleBean(BraveHttpServerHandler.class);
 			assertThat(context).hasBean("customBraveHttpClientHandler");
 			assertThat(context).hasSingleBean(BraveHttpClientHandler.class);
+		});
+	}
+
+	@Test
+	void shouldBackOffOnCustomPropagationBeans() {
+		this.contextRunner.withUserConfiguration(CustomFactoryConfiguration.class).run((context) -> {
+			assertThat(context).hasBean("customPropagationFactory");
+			assertThat(context).hasSingleBean(Propagation.Factory.class);
+			assertThat(context).hasBean("customHttpServerHandler");
+			assertThat(context).hasSingleBean(HttpServerHandler.class);
+			assertThat(context).hasBean("customHttpClientHandler");
+			assertThat(context).hasSingleBean(HttpClientHandler.class);
 		});
 	}
 
@@ -135,6 +150,39 @@ class BraveAutoConfigurationTests {
 			assertThat(context).doesNotHaveBean(BraveBaggageManager.class);
 			assertThat(context).doesNotHaveBean(BraveHttpServerHandler.class);
 			assertThat(context).doesNotHaveBean(BraveHttpClientHandler.class);
+			assertThat(context).doesNotHaveBean(BraveHttpClientHandler.class);
+		});
+	}
+
+	@Test
+	void shouldSupplyB3PropagationIfMicrometerIsMissing() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader("io.micrometer")).run((context) -> {
+			assertThat(context).hasBean("bravePropagationFactory");
+			assertThat(context).hasSingleBean(Propagation.Factory.class);
+		});
+	}
+
+	@Test
+	void shouldFailIfMicrometerIsMissingAndW3CPropagationIsPicked() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader("io.micrometer"))
+				.withPropertyValues("management.tracing.propagation.type=W3C")
+				.run((context) -> assertThat(context).getFailure()
+						.hasMessageContaining("No qualifying bean of type 'brave.propagation.Propagation$Factory'"));
+	}
+
+	@Test
+	void shouldSupplyW3CPropagationFactoryByDefault() {
+		this.contextRunner.run((context) -> {
+			assertThat(context).hasBean("w3cPropagationFactory");
+			assertThat(context).hasSingleBean(BaggagePropagation.FactoryBuilder.class);
+		});
+	}
+
+	@Test
+	void shouldSupplyB3PropagationFactoryViaProperty() {
+		this.contextRunner.withPropertyValues("management.tracing.propagation.type=B3").run((context) -> {
+			assertThat(context).hasBean("b3PropagationFactory");
+			assertThat(context).hasSingleBean(BaggagePropagation.FactoryBuilder.class);
 		});
 	}
 
@@ -150,6 +198,46 @@ class BraveAutoConfigurationTests {
 			assertThat(context).doesNotHaveBean(HttpServerHandler.class);
 			assertThat(context).doesNotHaveBean(HttpClientHandler.class);
 		});
+	}
+
+	@Test
+	void shouldNotSupplyMdcCorrelationScopeWhenMdcNotOnClasspath() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader("org.slf4j")).run((context) -> {
+			assertThat(context).doesNotHaveBean("mdcCorrelationScopeDecoratorBuilder");
+			assertThat(context).doesNotHaveBean("correlationScopeDecorator");
+		});
+	}
+
+	@Test
+	void shouldNotSupplyCorrelationScopeDecoratorIfBaggageDisabled() {
+		this.contextRunner.withPropertyValues("management.tracing.baggage.enabled=false")
+				.run((context) -> assertThat(context).doesNotHaveBean("correlationScopeDecorator"));
+	}
+
+	@Test
+	void shouldSupplyW3CWithoutBaggageByDefaultIfBaggageDisabled() {
+		this.contextRunner.withPropertyValues("management.tracing.baggage.enabled=false")
+				.run((context) -> assertThat(context).hasBean("w3cPropagationNoBaggageFactory"));
+	}
+
+	@Test
+	void shouldSupplyB3WithoutBaggageIfBaggageDisabledAndB3Picked() {
+		this.contextRunner
+				.withPropertyValues("management.tracing.baggage.enabled=false",
+						"management.tracing.propagation.type=B3")
+				.run((context) -> assertThat(context).hasBean("b3PropagationNoBaggageFactory"));
+	}
+
+	@Test
+	void shouldNotSupplyCorrelationScopeDecoratorIfBaggageCorrelationDisabled() {
+		this.contextRunner.withPropertyValues("management.tracing.baggage.correlation-enabled=false")
+				.run((context) -> assertThat(context).doesNotHaveBean("correlationFieldsCorrelationScopeDecorator"));
+	}
+
+	@Test
+	void shouldSupplyMdcCorrelationScopeDecoratorIfBaggageCorrelationDisabled() {
+		this.contextRunner.withPropertyValues("management.tracing.baggage.correlation-enabled=false")
+				.run((context) -> assertThat(context).hasBean("mdcCorrelationScopeDecoratorBuilder"));
 	}
 
 	@Configuration(proxyBeanMethods = false)
@@ -220,6 +308,28 @@ class BraveAutoConfigurationTests {
 		@Bean
 		BraveHttpClientHandler customBraveHttpClientHandler() {
 			return mock(BraveHttpClientHandler.class);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	private static class CustomFactoryConfiguration {
+
+		@Bean
+		Propagation.Factory customPropagationFactory() {
+			return mock(Propagation.Factory.class);
+		}
+
+		@Bean
+		HttpServerHandler<HttpServerRequest, HttpServerResponse> customHttpServerHandler() {
+			HttpTracing httpTracing = mock(HttpTracing.class, Answers.RETURNS_MOCKS);
+			return HttpServerHandler.create(httpTracing);
+		}
+
+		@Bean
+		HttpClientHandler<HttpClientRequest, HttpClientResponse> customHttpClientHandler() {
+			HttpTracing httpTracing = mock(HttpTracing.class, Answers.RETURNS_MOCKS);
+			return HttpClientHandler.create(httpTracing);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfigurationTests.java
@@ -230,13 +230,13 @@ class BraveAutoConfigurationTests {
 
 	@Test
 	void shouldNotSupplyCorrelationScopeDecoratorIfBaggageCorrelationDisabled() {
-		this.contextRunner.withPropertyValues("management.tracing.baggage.correlation-enabled=false")
+		this.contextRunner.withPropertyValues("management.tracing.baggage.correlation.enabled=false")
 				.run((context) -> assertThat(context).doesNotHaveBean("correlationFieldsCorrelationScopeDecorator"));
 	}
 
 	@Test
 	void shouldSupplyMdcCorrelationScopeDecoratorIfBaggageCorrelationDisabled() {
-		this.contextRunner.withPropertyValues("management.tracing.baggage.correlation-enabled=false")
+		this.contextRunner.withPropertyValues("management.tracing.baggage.correlation.enabled=false")
 				.run((context) -> assertThat(context).hasBean("mdcCorrelationScopeDecoratorBuilder"));
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurationsMicrometerConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurationsMicrometerConfigurationTests.java
@@ -119,7 +119,7 @@ class OpenTelemetryConfigurationsMicrometerConfigurationTests {
 	@Test
 	void shouldSupplySlf4jEventListenersWhenMdcOnClasspathAndBaggageCorrelationDisabled() {
 		this.contextRunner.withUserConfiguration(TracerConfiguration.class)
-				.withPropertyValues("management.tracing.baggage.correlation-enabled=false").run((context) -> {
+				.withPropertyValues("management.tracing.baggage.correlation.enabled=false").run((context) -> {
 					assertThat(context).hasSingleBean(Slf4JEventListener.class);
 					assertThat(context).doesNotHaveBean(Slf4JBaggageEventListener.class);
 				});

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurationsSdkConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurationsSdkConfigurationTests.java
@@ -17,7 +17,9 @@
 package org.springframework.boot.actuate.autoconfigure.tracing;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
@@ -65,7 +67,6 @@ class OpenTelemetryConfigurationsSdkConfigurationTests {
 			assertThat(context).hasBean("customSampler");
 			assertThat(context).hasSingleBean(Sampler.class);
 			assertThat(context).hasBean("customSpanProcessor");
-			assertThat(context).hasSingleBean(SpanProcessor.class);
 		});
 	}
 
@@ -78,6 +79,36 @@ class OpenTelemetryConfigurationsSdkConfigurationTests {
 			assertThat(context).doesNotHaveBean(Sampler.class);
 			assertThat(context).doesNotHaveBean(SpanProcessor.class);
 		});
+	}
+
+	@Test
+	void shouldSupplyB3PropagationIfPropagationPropertySet() {
+		this.contextRunner.withPropertyValues("management.tracing.propagation.type=B3").run((context) -> {
+			assertThat(context).hasSingleBean(B3Propagator.class);
+			assertThat(context).hasBean("b3TextMapPropagator");
+			assertThat(context).doesNotHaveBean(W3CTraceContextPropagator.class);
+		});
+	}
+
+	@Test
+	void shouldSupplyW3CPropagationWithBaggageByDefault() {
+		this.contextRunner.run((context) -> assertThat(context).hasBean("w3cTextMapPropagatorWithBaggage"));
+	}
+
+	@Test
+	void shouldSupplyW3CPropagationWithoutBaggageWhenDisabled() {
+		this.contextRunner.withPropertyValues("management.tracing.baggage.enabled=false")
+				.run((context) -> assertThat(context).hasBean("w3cTextMapPropagatorWithoutBaggage"));
+	}
+
+	@Test
+	void shouldSupplyB3PropagationWithoutBaggageWhenBaggageDisabledAndB3PropagationEnabled() {
+		this.contextRunner.withPropertyValues("management.tracing.baggage.enabled=false",
+				"management.tracing.propagation.type=B3").run((context) -> {
+					assertThat(context).hasBean("b3TextMapPropagator");
+					assertThat(context).hasSingleBean(B3Propagator.class);
+					assertThat(context).doesNotHaveBean("w3cTextMapPropagatorWithoutBaggage");
+				});
 	}
 
 	private static class CustomBeans {


### PR DESCRIPTION
# Rationale

In order to provide the users with the basic tracing observability story we need the following, additional features

* [W3C](https://www.w3.org/TR/trace-context/) propagation type as the default propagation option (there would be 2 options, W3C and B3)
* Baggage support (remote fields only (these are passed over the wire) - no local field support, no tagged field support)
  * Correlation fields support (automatically ads to MDC given baggage entries)
* MDC updating for OTel and Brave (we will NOT modify the logging format but we WILL prepare the MDC so that the logging format would pick those entries)

## Conditionals

* If Micrometer Tracing IS NOT on the classpath
  * For Brave 
    * [Context-Propagation] We will setup Brave B3 Propagation as default (there's no W3C support out of the box in Brave)
  * For OTel
    * [Baggage] [Context-Propagation] We will setup W3C Propagation with Baggage as default
    * [Context-Propagation] We will setup W3C Propagation without Baggage when Baggage disabled via property
    * [Context-Propagation] We will setup B3 Propagation without Baggage when B3 propagation property turned on (there's no option to have baggage with B3 without Micrometer Tracing)
* If Micrometer Tracing IS on the classpath
  * For Brave
    * If baggage is not opt-out (management.tracing.baggage.enabled)      
      * [Context-Propagation] [Baggage] By default we setup W3C context propagation with Baggage
      * [Context-Propagation] [Baggage] We can switch to B3 context propagation (via a property) with Baggage
      * [Baggage] If provided up-front via properties, we will set remote baggage entries
      * [Baggage] [MDC] If MDC is on the classpath 
        * We will setup injecting correlated baggage entries to MDC (those need to be provided up-front)
    * If baggage is opt-out      
      * [Context-Propagation] By default we setup W3C context propagation without Baggage (that will be possible with Tracing snapshots - https://github.com/micrometer-metrics/tracing/pull/72)
      * [Context-Propagation] We can switch to B3 context propagation (via a property) 
    * [MDC] If MDC is on the classpath 
      * We will setup injecting spanId / traceId to MDC context 
  * For OTel:
    * [Baggage] [Context-Propagation] We will setup W3C Propagation with Baggage as default
    * [Context-Propagation] We will setup W3C Propagation without Baggage when Baggage disabled via property
    * [Baggage] [Context-Propagation] We will setup B3 Propagation with Baggage when B3 propagation property turned on
    * [Context-Propagation] We will setup B3 Propagation without Baggage when B3 propagation property turned on and baggage option disabled
    * [Baggage] [MDC] If MDC is on the classpath 
        * We will setup injecting correlated baggage entries to MDC (those need to be provided up-front)
    * [MDC] If MDC is on the classpath 
      * We will setup injecting spanId / traceId to MDC context 

prerequisites
- [ ] https://github.com/spring-projects/spring-boot/pull/32487
- [ ] https://github.com/spring-projects/spring-boot/pull/32488

superseeds https://github.com/spring-projects/spring-boot/pull/32214