### PR TITLE
Context Propagation via W3C and B3 for OTel and Brave 

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurations.java
@@ -23,17 +23,23 @@ import java.util.stream.Collectors;
 import io.micrometer.tracing.SamplerFunction;
 import io.micrometer.tracing.otel.bridge.DefaultHttpClientAttributesGetter;
 import io.micrometer.tracing.otel.bridge.DefaultHttpServerAttributesExtractor;
+import io.micrometer.tracing.otel.bridge.EventListener;
+import io.micrometer.tracing.otel.bridge.EventPublishingContextWrapper;
 import io.micrometer.tracing.otel.bridge.OtelBaggageManager;
 import io.micrometer.tracing.otel.bridge.OtelCurrentTraceContext;
 import io.micrometer.tracing.otel.bridge.OtelHttpClientHandler;
 import io.micrometer.tracing.otel.bridge.OtelHttpServerHandler;
+import io.micrometer.tracing.otel.bridge.OtelPropagator;
 import io.micrometer.tracing.otel.bridge.OtelTracer;
 import io.micrometer.tracing.otel.bridge.OtelTracer.EventPublisher;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.ContextStorage;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -48,6 +54,7 @@ import org.springframework.boot.SpringBootVersion;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -58,6 +65,7 @@ import org.springframework.core.env.Environment;
  * {@link OpenTelemetryAutoConfiguration}.
  *
  * @author Moritz Halbritter
+ * @author Marcin Grzejszczak
  */
 class OpenTelemetryConfigurations {
 
@@ -105,10 +113,41 @@ class OpenTelemetryConfigurations {
 		}
 
 		@Bean
-		@ConditionalOnMissingBean
 		SpanProcessor otelSpanProcessor(List<SpanExporter> spanExporter) {
 			return SpanProcessor.composite(spanExporter.stream()
 					.map((exporter) -> BatchSpanProcessor.builder(exporter).build()).collect(Collectors.toList()));
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		static class PropagationConfiguration {
+
+			@Configuration(proxyBeanMethods = false)
+			@ConditionalOnClass(B3Propagator.class)
+			static class B3NoBaggagePropagatorConfiguration {
+
+				@Bean
+				@ConditionalOnMissingBean
+				@ConditionalOnProperty(value = "management.tracing.propagation.type", havingValue = "B3")
+				B3Propagator b3TextMapPropagator() {
+					return B3Propagator.injectingSingleHeader();
+				}
+
+			}
+
+			@Configuration(proxyBeanMethods = false)
+			@ConditionalOnClass(W3CTraceContextPropagator.class)
+			static class W3CNoBaggagePropagatorConfiguration {
+
+				@Bean
+				@ConditionalOnMissingBean
+				@ConditionalOnProperty(value = "management.tracing.propagation.type", havingValue = "W3C",
+						matchIfMissing = true)
+				W3CTraceContextPropagator w3cTextMapPropagatorWithoutBaggage() {
+					return W3CTraceContextPropagator.getInstance();
+				}
+
+			}
+
 		}
 
 	}
@@ -128,6 +167,7 @@ class OpenTelemetryConfigurations {
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(OtelTracer.class)
+	@EnableConfigurationProperties(TracingProperties.class)
 	static class MicrometerConfiguration {
 
 		@Bean
@@ -141,14 +181,21 @@ class OpenTelemetryConfigurations {
 
 		@Bean
 		@ConditionalOnMissingBean
-		EventPublisher otelTracerEventPublisher() {
-			return (event) -> {
-			};
+		@ConditionalOnBean({ Tracer.class, ContextPropagators.class })
+		OtelPropagator otelPropagator(ContextPropagators contextPropagators, Tracer tracer) {
+			return new OtelPropagator(contextPropagators, tracer);
 		}
 
 		@Bean
 		@ConditionalOnMissingBean
-		OtelCurrentTraceContext otelCurrentTraceContext() {
+		EventPublisher otelTracerEventPublisher(List<EventListener> eventListeners) {
+			return new OTelEventPublisher(eventListeners);
+		}
+
+		@Bean
+		@ConditionalOnMissingBean
+		OtelCurrentTraceContext otelCurrentTraceContext(EventPublisher publisher) {
+			ContextStorage.addWrapper(new EventPublishingContextWrapper(publisher));
 			return new OtelCurrentTraceContext();
 		}
 
@@ -166,6 +213,23 @@ class OpenTelemetryConfigurations {
 		OtelHttpServerHandler otelHttpServerHandler(OpenTelemetry openTelemetry) {
 			return new OtelHttpServerHandler(openTelemetry, null, null, Pattern.compile(""),
 					new DefaultHttpServerAttributesExtractor());
+		}
+
+		static class OTelEventPublisher implements EventPublisher {
+
+			private final List<EventListener> listeners;
+
+			OTelEventPublisher(List<EventListener> listeners) {
+				this.listeners = listeners;
+			}
+
+			@Override
+			public void publishEvent(Object event) {
+				for (EventListener listener : this.listeners) {
+					listener.onEvent(event);
+				}
+			}
+
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/TracingProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/TracingProperties.java
@@ -32,8 +32,17 @@ public class TracingProperties {
 	 */
 	private final Sampling sampling = new Sampling();
 
+	/**
+	 * Propagation configuration.
+	 */
+	private final Propagation propagation = new Propagation();
+
 	public Sampling getSampling() {
 		return this.sampling;
+	}
+
+	public Propagation getPropagation() {
+		return this.propagation;
 	}
 
 	public static class Sampling {
@@ -49,6 +58,37 @@ public class TracingProperties {
 
 		public void setProbability(float probability) {
 			this.probability = probability;
+		}
+
+	}
+
+	public static class Propagation {
+
+		/**
+		 * Tracing context propagation types.
+		 */
+		private PropagationType type = PropagationType.W3C;
+
+		public PropagationType getType() {
+			return this.type;
+		}
+
+		public void setType(PropagationType type) {
+			this.type = type;
+		}
+
+		enum PropagationType {
+
+			/**
+			 * B3 propagation type.
+			 */
+			B3,
+
+			/**
+			 * W3C propagation type.
+			 */
+			W3C
+
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2086,6 +2086,14 @@
         "replacement": "management.trace.http.include",
         "level": "error"
       }
+    },
+    {
+      "name": "management.tracing.propagation.type",
+      "defaultValue": "W3C"
+    },
+    {
+      "name": "management.tracing.sampling.probability",
+      "defaultValue": "0.10"
     }
   ],
   "hints": [

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurationsMicrometerConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurationsMicrometerConfigurationTests.java
@@ -19,10 +19,13 @@ package org.springframework.boot.actuate.autoconfigure.tracing;
 import io.micrometer.tracing.otel.bridge.OtelCurrentTraceContext;
 import io.micrometer.tracing.otel.bridge.OtelHttpClientHandler;
 import io.micrometer.tracing.otel.bridge.OtelHttpServerHandler;
+import io.micrometer.tracing.otel.bridge.OtelPropagator;
 import io.micrometer.tracing.otel.bridge.OtelTracer;
 import io.micrometer.tracing.otel.bridge.OtelTracer.EventPublisher;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapPropagator;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
@@ -48,13 +51,14 @@ class OpenTelemetryConfigurationsMicrometerConfigurationTests {
 
 	@Test
 	void shouldSupplyBeans() {
-		this.contextRunner.withUserConfiguration(TracerConfiguration.class, OpenTelemetryConfiguration.class)
-				.run((context) -> {
+		this.contextRunner.withUserConfiguration(TracerConfiguration.class, OpenTelemetryConfiguration.class,
+				ContextPropagatorsConfiguration.class).run((context) -> {
 					assertThat(context).hasSingleBean(OtelTracer.class);
 					assertThat(context).hasSingleBean(EventPublisher.class);
 					assertThat(context).hasSingleBean(OtelCurrentTraceContext.class);
 					assertThat(context).hasSingleBean(OtelHttpClientHandler.class);
 					assertThat(context).hasSingleBean(OtelHttpServerHandler.class);
+					assertThat(context).hasSingleBean(OtelPropagator.class);
 				});
 	}
 
@@ -67,6 +71,7 @@ class OpenTelemetryConfigurationsMicrometerConfigurationTests {
 					assertThat(context).doesNotHaveBean(OtelCurrentTraceContext.class);
 					assertThat(context).doesNotHaveBean(OtelHttpClientHandler.class);
 					assertThat(context).doesNotHaveBean(OtelHttpServerHandler.class);
+					assertThat(context).doesNotHaveBean(OtelPropagator.class);
 				});
 	}
 
@@ -96,6 +101,8 @@ class OpenTelemetryConfigurationsMicrometerConfigurationTests {
 			assertThat(context).hasSingleBean(OtelHttpClientHandler.class);
 			assertThat(context).hasBean("customOtelHttpServerHandler");
 			assertThat(context).hasSingleBean(OtelHttpServerHandler.class);
+			assertThat(context).hasBean("customOtelPropagator");
+			assertThat(context).hasSingleBean(OtelPropagator.class);
 		});
 	}
 
@@ -127,6 +134,11 @@ class OpenTelemetryConfigurationsMicrometerConfigurationTests {
 			return mock(OtelHttpServerHandler.class);
 		}
 
+		@Bean
+		OtelPropagator customOtelPropagator() {
+			return mock(OtelPropagator.class);
+		}
+
 	}
 
 	@Configuration(proxyBeanMethods = false)
@@ -145,6 +157,26 @@ class OpenTelemetryConfigurationsMicrometerConfigurationTests {
 		@Bean
 		OpenTelemetry openTelemetry() {
 			return mock(OpenTelemetry.class, Answers.RETURNS_MOCKS);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	private static class ContextPropagatorsConfiguration {
+
+		@Bean
+		ContextPropagators contextPropagators() {
+			return mock(ContextPropagators.class, Answers.RETURNS_MOCKS);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	private static class CustomFactoryConfiguration {
+
+		@Bean
+		TextMapPropagator customPropagationFactory() {
+			return mock(TextMapPropagator.class);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurationsSdkConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryConfigurationsSdkConfigurationTests.java
@@ -17,7 +17,9 @@
 package org.springframework.boot.actuate.autoconfigure.tracing;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
@@ -65,7 +67,6 @@ class OpenTelemetryConfigurationsSdkConfigurationTests {
 			assertThat(context).hasBean("customSampler");
 			assertThat(context).hasSingleBean(Sampler.class);
 			assertThat(context).hasBean("customSpanProcessor");
-			assertThat(context).hasSingleBean(SpanProcessor.class);
 		});
 	}
 
@@ -77,6 +78,15 @@ class OpenTelemetryConfigurationsSdkConfigurationTests {
 			assertThat(context).doesNotHaveBean(ContextPropagators.class);
 			assertThat(context).doesNotHaveBean(Sampler.class);
 			assertThat(context).doesNotHaveBean(SpanProcessor.class);
+		});
+	}
+
+	@Test
+	void shouldSupplyB3PropagationIfPropagationPropertySet() {
+		this.contextRunner.withPropertyValues("management.tracing.propagation.type=B3").run((context) -> {
+			assertThat(context).hasSingleBean(B3Propagator.class);
+			assertThat(context).hasBean("b3TextMapPropagator");
+			assertThat(context).doesNotHaveBean(W3CTraceContextPropagator.class);
 		});
 	}
 


### PR DESCRIPTION
# Rationale

In order to provide the users with the basic tracing observability story we need the following, additional features

* [W3C](https://www.w3.org/TR/trace-context/) propagation type as the default propagation option (there would be 2 options, W3C and B3)

## Conditionals

* If Micrometer Tracing IS NOT on the classpath
  * For Brave 
    * [Context-Propagation] We will setup Brave B3 Propagation as default (there's no W3C support out of the box in Brave)
  * For OTel
    * [Context-Propagation] We will setup W3C Propagation without Baggage
    * [Context-Propagation] We will setup B3 Propagation without Baggage when B3 propagation property turned on
* If Micrometer Tracing IS on the classpath
  * For Brave
      * [Context-Propagation] By default we setup W3C context propagation without Baggage (that will be possible with Tracing snapshots - https://github.com/micrometer-metrics/tracing/pull/72)
      * [Context-Propagation] We can switch to B3 context propagation (via a property) 
  * For OTel:
    * [Context-Propagation] We will setup W3C Propagation without Baggage
    * [Context-Propagation] We will setup B3 Propagation without Baggage when B3 propagation property turned on
  

superseeds https://github.com/spring-projects/spring-boot/pull/32214
split from https://github.com/spring-projects/spring-boot/pull/32480