### PR TITLE
Enable LoaderIntegrationTests with Java 19

### DIFF
--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-loader-tests/src/intTest/java/org/springframework/boot/loader/LoaderIntegrationTests.java
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-loader-tests/src/intTest/java/org/springframework/boot/loader/LoaderIntegrationTests.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.GenericContainer;
@@ -46,7 +44,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Phillip Webb
  */
 @DisabledIfDockerUnavailable
-@EnabledForJreRange(max = JRE.JAVA_18)
 class LoaderIntegrationTests {
 
 	private final ToStringConsumer output = new ToStringConsumer();
@@ -81,7 +78,7 @@ class LoaderIntegrationTests {
 		javaRuntimes.add(JavaRuntime.openJdk(JavaVersion.EIGHT));
 		javaRuntimes.add(JavaRuntime.openJdk(JavaVersion.ELEVEN));
 		javaRuntimes.add(JavaRuntime.openJdk(JavaVersion.SEVENTEEN));
-		javaRuntimes.add(JavaRuntime.openJdk(JavaVersion.EIGHTEEN));
+		javaRuntimes.add(JavaRuntime.openJdk(JavaVersion.NINETEEN));
 		javaRuntimes.add(JavaRuntime.oracleJdk17());
 		return javaRuntimes.stream().filter(JavaRuntime::isCompatible);
 	}


### PR DESCRIPTION
This PR enables `LoaderIntegrationTests` with Java 19.

Closes gh-32295