### PR TITLE
Avoid using JUnit 4 assertions

### DIFF
--- a/spring-boot-project/spring-boot-test/src/test/kotlin/org/springframework/boot/test/web/client/TestRestTemplateExtensionsTests.kt
+++ b/spring-boot-project/spring-boot-test/src/test/kotlin/org/springframework/boot/test/web/client/TestRestTemplateExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.boot.test.web.client
 
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.Assert
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpEntity
@@ -251,9 +251,9 @@ class TestRestTemplateExtensionsTests {
 							.apply { addAll(method.parameterTypes.filter { it != kClass.java }) }
 					val f = extensions.getDeclaredMethod(method.name,
 							*parameters.toTypedArray()).kotlinFunction!!
-					Assert.assertEquals(1, f.typeParameters.size)
-					Assert.assertEquals(listOf(Any::class.createType()),
-							f.typeParameters[0].upperBounds)
+					assertThat(f.typeParameters.size).isEqualTo(1)
+					assertThat(listOf(Any::class.createType()))
+						.isEqualTo(f.typeParameters[0].upperBounds)
 				}
 			}
 		}

--- a/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/SpringApplicationExtensionsTests.kt
+++ b/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/SpringApplicationExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  */
 package org.springframework.boot
 
-import org.junit.Assert.assertArrayEquals
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 import org.springframework.beans.factory.getBean
@@ -37,7 +34,7 @@ class SpringApplicationExtensionsTests {
 	@Test
 	fun `Kotlin runApplication() top level function`() {
 		val context = runApplication<ExampleWebConfig>()
-		assertNotNull(context)
+		assertThat(context).isNotNull
 	}
 
 	@Test
@@ -46,16 +43,16 @@ class SpringApplicationExtensionsTests {
 		val context = runApplication<ExampleWebConfig> {
 			setEnvironment(environment)
 		}
-		assertNotNull(context)
-		assertEquals(environment, context.environment)
+		assertThat(context).isNotNull
+		assertThat(environment).isEqualTo(context.environment)
 	}
 
 	@Test
 	fun `Kotlin runApplication(arg1, arg2) top level function`() {
 		val context = runApplication<ExampleWebConfig>("--debug", "spring", "boot")
 		val args = context.getBean<ApplicationArguments>()
-		assertArrayEquals(arrayOf("spring", "boot"), args.nonOptionArgs.toTypedArray())
-		assertTrue(args.containsOption("debug"))
+		assertThat(args.nonOptionArgs.toTypedArray()).containsExactly("spring", "boot")
+		assertThat(args.containsOption("debug")).isTrue
 	}
 
 	@Test
@@ -65,9 +62,9 @@ class SpringApplicationExtensionsTests {
 			setEnvironment(environment)
 		}
 		val args = context.getBean<ApplicationArguments>()
-		assertArrayEquals(arrayOf("spring", "boot"), args.nonOptionArgs.toTypedArray())
-		assertTrue(args.containsOption("debug"))
-		assertEquals(environment, context.environment)
+		assertThat(args.nonOptionArgs.toTypedArray()).containsExactly("spring", "boot")
+		assertThat(args.containsOption("debug")).isTrue
+		assertThat(environment).isEqualTo(context.environment)
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
Hi,

this PR removes usages of the old JUnit 4 assertions in two Kotlin tests. I guess the checkstyle rule to prevent that doesn't work on the Kotlin files.

Cheers,
Christoph