### PR TITLE
CouchbaseReactiveHealthIndicator uses blocking API to relieve the cluster diagnostics

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/couchbase/CouchbaseReactiveHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/couchbase/CouchbaseReactiveHealthIndicator.java
@@ -46,9 +46,12 @@ public class CouchbaseReactiveHealthIndicator extends AbstractReactiveHealthIndi
 
 	@Override
 	protected Mono<Health> doHealthCheck(Health.Builder builder) {
-		DiagnosticsResult diagnostics = this.cluster.diagnostics();
-		new CouchbaseHealth(diagnostics).applyTo(builder);
-		return Mono.just(builder.build());
+		return this.cluster.reactive()
+				.diagnostics()
+				.map(diagnostics -> {
+					new CouchbaseHealth(diagnostics).applyTo(builder);
+					return builder.build();
+				});
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/couchbase/CouchbaseReactiveHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/couchbase/CouchbaseReactiveHealthIndicator.java
@@ -46,12 +46,10 @@ public class CouchbaseReactiveHealthIndicator extends AbstractReactiveHealthIndi
 
 	@Override
 	protected Mono<Health> doHealthCheck(Health.Builder builder) {
-		return this.cluster.reactive()
-				.diagnostics()
-				.map(diagnostics -> {
-					new CouchbaseHealth(diagnostics).applyTo(builder);
-					return builder.build();
-				});
+		return this.cluster.reactive().diagnostics().map(diagnostics -> {
+			new CouchbaseHealth(diagnostics).applyTo(builder);
+			return builder.build();
+		});
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/couchbase/CouchbaseReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/couchbase/CouchbaseReactiveHealthIndicatorTests.java
@@ -28,10 +28,12 @@ import com.couchbase.client.core.diagnostics.EndpointDiagnostics;
 import com.couchbase.client.core.endpoint.EndpointState;
 import com.couchbase.client.core.service.ServiceType;
 import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.ReactiveCluster;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
+import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -53,13 +55,15 @@ class CouchbaseReactiveHealthIndicatorTests {
 						new EndpointDiagnostics(ServiceType.KV, EndpointState.CONNECTED, "127.0.0.1", "127.0.0.1",
 								Optional.empty(), Optional.of(1234L), Optional.of("endpoint-1"), Optional.empty())));
 		DiagnosticsResult diagnostics = new DiagnosticsResult(endpoints, "test-sdk", "test-id");
-		given(cluster.diagnostics()).willReturn(diagnostics);
+		ReactiveCluster reactiveCluster = mock(ReactiveCluster.class);
+		given(reactiveCluster.diagnostics()).willReturn(Mono.just(diagnostics));
+		given(cluster.reactive()).willReturn(reactiveCluster);
 		Health health = healthIndicator.health().block(Duration.ofSeconds(30));
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
 		assertThat(health.getDetails()).containsEntry("sdk", "test-sdk");
 		assertThat(health.getDetails()).containsKey("endpoints");
 		assertThat((List<Map<String, Object>>) health.getDetails().get("endpoints")).hasSize(1);
-		then(cluster).should().diagnostics();
+		then(reactiveCluster).should().diagnostics();
 	}
 
 	@Test
@@ -74,13 +78,15 @@ class CouchbaseReactiveHealthIndicatorTests {
 						new EndpointDiagnostics(ServiceType.KV, EndpointState.CONNECTING, "127.0.0.1", "127.0.0.1",
 								Optional.empty(), Optional.of(1234L), Optional.of("endpoint-2"), Optional.empty())));
 		DiagnosticsResult diagnostics = new DiagnosticsResult(endpoints, "test-sdk", "test-id");
-		given(cluster.diagnostics()).willReturn(diagnostics);
+		ReactiveCluster reactiveCluster = mock(ReactiveCluster.class);
+		given(reactiveCluster.diagnostics()).willReturn(Mono.just(diagnostics));
+		given(cluster.reactive()).willReturn(reactiveCluster);
 		Health health = healthIndicator.health().block(Duration.ofSeconds(30));
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
 		assertThat(health.getDetails()).containsEntry("sdk", "test-sdk");
 		assertThat(health.getDetails()).containsKey("endpoints");
 		assertThat((List<Map<String, Object>>) health.getDetails().get("endpoints")).hasSize(2);
-		then(cluster).should().diagnostics();
+		then(reactiveCluster).should().diagnostics();
 	}
 
 }


### PR DESCRIPTION
Title pretty much says it all, but 
use non-blocking `cluster.reactive().diagnostics()`
instead of blocking `cluster.diagnostics()` call