### PR TITLE
WebClient- and RestTemplate-based Zipkin senders can cause a bean dependency cycle

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateBuilderCustomizer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize the
+ * {@link RestTemplateBuilder} used to send spans to Zipkin.
+ *
+ * @author Marcin Grzejszczak
+ * @since 3.0.0
+ */
+@FunctionalInterface
+public interface ZipkinRestTemplateBuilderCustomizer {
+
+	/**
+	 * Customize the rest template builder.
+	 * @param restTemplateBuilder the {@code RestTemplateBuilder} to customize
+	 */
+	void customize(RestTemplateBuilder restTemplateBuilder);
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinWebClientBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinWebClientBuilderCustomizer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
+
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize the
+ * {@link WebClient.Builder} used to send spans to Zipkin.
+ *
+ * @author Marcin Grzejszczak
+ * @since 3.0.0
+ */
+@FunctionalInterface
+public interface ZipkinWebClientBuilderCustomizer {
+
+	/**
+	 * Customize the web client builder.
+	 * @param webClientBuilder the {@code WebClient.Builder} to customize
+	 */
+	void customize(WebClient.Builder webClientBuilder);
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
 
@@ -25,12 +26,11 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -62,6 +62,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 					assertThat(context).doesNotHaveBean(URLConnectionSender.class);
 					assertThat(context).hasSingleBean(Sender.class);
 					assertThat(context).hasSingleBean(ZipkinWebClientSender.class);
+					then(context.getBean(ZipkinWebClientBuilderCustomizer.class)).should().customize(Mockito.any());
 				});
 	}
 
@@ -81,6 +82,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 					assertThat(context).doesNotHaveBean(URLConnectionSender.class);
 					assertThat(context).hasSingleBean(Sender.class);
 					assertThat(context).hasSingleBean(ZipkinRestTemplateSender.class);
+					then(context.getBean(ZipkinRestTemplateBuilderCustomizer.class)).should().customize(Mockito.any());
 				});
 	}
 
@@ -96,8 +98,8 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	private static class RestTemplateConfiguration {
 
 		@Bean
-		RestTemplateBuilder restTemplateBuilder() {
-			return new RestTemplateBuilder();
+		ZipkinRestTemplateBuilderCustomizer restTemplateBuilder() {
+			return mock(ZipkinRestTemplateBuilderCustomizer.class);
 		}
 
 	}
@@ -106,8 +108,8 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	private static class WebClientConfiguration {
 
 		@Bean
-		WebClient.Builder webClientBuilder() {
-			return WebClient.builder();
+		ZipkinWebClientBuilderCustomizer webClientBuilder() {
+			return mock(ZipkinWebClientBuilderCustomizer.class);
 		}
 
 	}


### PR DESCRIPTION
without this change we're using a RestTemplate and WebClient beans for sending out spans. The same beans require Zipkin senders to be pre-configured through the tracing handlers. That's a cycle. 

with this change we're breaking the cycle by not creating RT and WC as beans but we're creating them via new and we're providing customizers to allow RT and WC customization