### PR TITLE
Prefer WebClient to RestTemplate when creating the Zipkin Sender

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
@@ -28,7 +28,6 @@ import zipkin2.reporter.urlconnection.URLConnectionSender;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
@@ -46,8 +45,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 class ZipkinConfigurations {
 
 	@Configuration(proxyBeanMethods = false)
-	@Import({ UrlConnectionSenderConfiguration.class, RestTemplateSenderConfiguration.class,
-			WebClientSenderConfiguration.class })
+	@Import({ UrlConnectionSenderConfiguration.class, WebClientSenderConfiguration.class,
+			RestTemplateSenderConfiguration.class })
 	static class SenderConfiguration {
 
 	}
@@ -85,7 +84,7 @@ class ZipkinConfigurations {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
+	@ConditionalOnClass(WebClient.class)
 	@EnableConfigurationProperties(ZipkinProperties.class)
 	static class WebClientSenderConfiguration {
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
@@ -77,7 +77,9 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	@Test
 	void shouldUseRestTemplateSenderIfUrlConnectionSenderIsNotAvailableAndWebAppIsNotReactive() {
 		this.contextRunner.withUserConfiguration(RestTemplateConfiguration.class)
-				.withClassLoader(new FilteredClassLoader("zipkin2.reporter.urlconnection")).run((context) -> {
+				.withClassLoader(
+						new FilteredClassLoader("zipkin2.reporter.urlconnection", "org.springframework.web.reactive"))
+				.run((context) -> {
 					assertThat(context).doesNotHaveBean(URLConnectionSender.class);
 					assertThat(context).hasSingleBean(Sender.class);
 					assertThat(context).hasSingleBean(ZipkinRestTemplateSender.class);


### PR DESCRIPTION
without this change we're registering WebClient sender only for webflux applications and we fallback to a RestTemplate sender in all the other cases

with this change we're always trying to register a WebClient sender and fallback to RestTemplate only when WebClient is not on the classpath