### PR TITLE
Able to provide tags base on data fetcher result

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/graphql/DefaultGraphQlTagsProvider.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/graphql/DefaultGraphQlTagsProvider.java
@@ -74,4 +74,14 @@ public class DefaultGraphQlTagsProvider implements GraphQlTagsProvider {
 		return tags;
 	}
 
+	@Override
+	public Iterable<Tag> getDataFetchingTags(DataFetcher<?> dataFetcher, Object dataFetcherResult,
+			InstrumentationFieldFetchParameters parameters, Throwable exception) {
+		Tags tags = Tags.empty();
+		for (GraphQlTagsContributor contributor : this.contributors) {
+			tags = tags.and(contributor.getDataFetchingTags(dataFetcher, dataFetcherResult, parameters, exception));
+		}
+		return tags;
+	}
+
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/graphql/GraphQlTagsContributor.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/graphql/GraphQlTagsContributor.java
@@ -22,6 +22,7 @@ import graphql.execution.instrumentation.parameters.InstrumentationExecutionPara
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.schema.DataFetcher;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 
 /**
  * A contributor of {@link Tag Tags} for Spring GraphQL-based request handling. Typically,
@@ -39,5 +40,10 @@ public interface GraphQlTagsContributor {
 
 	Iterable<Tag> getDataFetchingTags(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters,
 			Throwable exception);
+
+	default Iterable<Tag> getDataFetchingTags(DataFetcher<?> dataFetcher, Object dataFetcherResult,
+			InstrumentationFieldFetchParameters parameters, Throwable exception) {
+		return Tags.empty();
+	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/graphql/GraphQlTagsProvider.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/graphql/GraphQlTagsProvider.java
@@ -22,6 +22,7 @@ import graphql.execution.instrumentation.parameters.InstrumentationExecutionPara
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.schema.DataFetcher;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 
 /**
  * Provides {@link Tag Tags} for Spring GraphQL-based request handling.
@@ -38,5 +39,10 @@ public interface GraphQlTagsProvider {
 
 	Iterable<Tag> getDataFetchingTags(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters,
 			Throwable exception);
+
+	default Iterable<Tag> getDataFetchingTags(DataFetcher<?> dataFetcher, Object dataFetcherResult,
+			InstrumentationFieldFetchParameters parameters, Throwable exception) {
+		return Tags.empty();
+	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/graphql/DefaultGraphQlTagsProviderTest.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/graphql/DefaultGraphQlTagsProviderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.metrics.graphql;
+
+import java.util.List;
+
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.schema.DataFetcher;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link DefaultGraphQlTagsProvider}.
+ *
+ * @author Grzegorz Zgudka
+ */
+class DefaultGraphQlTagsProviderTest {
+
+	private GraphQlTagsContributor firstContributor;
+
+	private GraphQlTagsContributor secondContributor;
+
+	private DataFetcher<?> dataFetcher;
+
+	private InstrumentationFieldFetchParameters fieldFetchParameters;
+
+	private DefaultGraphQlTagsProvider sut;
+
+	@BeforeEach
+	void setup() {
+		this.firstContributor = mock(GraphQlTagsContributor.class);
+		this.secondContributor = mock(GraphQlTagsContributor.class);
+		this.dataFetcher = mock(DataFetcher.class);
+		this.fieldFetchParameters = mock(InstrumentationFieldFetchParameters.class);
+		this.sut = new DefaultGraphQlTagsProvider(List.of(this.firstContributor, this.secondContributor));
+	}
+
+	@Test
+	void shouldCallContributorsWithDataFetcherResultAndConcatTheirTags() {
+		String dataFetcherResult = "value";
+		given(this.firstContributor.getDataFetchingTags(this.dataFetcher, dataFetcherResult, this.fieldFetchParameters,
+				null)).willReturn(Tags.of("tag1", "val1"));
+		given(this.secondContributor.getDataFetchingTags(this.dataFetcher, dataFetcherResult, this.fieldFetchParameters,
+				null)).willReturn(Tags.of("tag2", "val2"));
+
+		Iterable<Tag> tags = this.sut.getDataFetchingTags(this.dataFetcher, dataFetcherResult,
+				this.fieldFetchParameters, null);
+
+		assertThat(tags).containsExactly(Tag.of("tag1", "val1"), Tag.of("tag2", "val2"));
+	}
+
+	@Test
+	void shouldCallContributorsWithDataFetcherResultAndDedupTheirTags() {
+		String dataFetcherResult = "value";
+		given(this.firstContributor.getDataFetchingTags(this.dataFetcher, dataFetcherResult, this.fieldFetchParameters,
+				null)).willReturn(Tags.of("tag1", "val1"));
+		given(this.secondContributor.getDataFetchingTags(this.dataFetcher, dataFetcherResult, this.fieldFetchParameters,
+				null)).willReturn(Tags.of("tag1", "val2"));
+
+		Iterable<Tag> tags = this.sut.getDataFetchingTags(this.dataFetcher, dataFetcherResult,
+				this.fieldFetchParameters, null);
+
+		assertThat(tags).containsExactly(Tag.of("tag1", "val2"));
+	}
+
+}


### PR DESCRIPTION
Previously, GraphQlTagsContributor was unable to produce tags base on GQL data fetcher result as DataFetcher<?> does not really allow to access its result. Sometimes accessing the result (POJO) is necessary as the requester may opt out from returning errors in their GQL query, but you still want to record that operation as a failure.

For example, assume your mutations can return a standardised type of a response:

```
interface Payload {
   success: Boolean!
   errors: [Error!]
}
type Error {
  code: Int!
}
```

Each data fetcher call  can return 0* errors. A requester can opt out from returning them in the request response, hence it's impossible to add tags based on those errors to the metric `graphql.datafetcher`, unless I am missing something.

With this change a developer can do something like that:
```java
class MyGraphQlTagsContributor implements GraphQlTagsContributor {
	(...)
	@Override
	public Iterable<Tag> getDataFetchingTags(
		DataFetcher<?> dataFetcher,
		Object dataFetcherResult,
		InstrumentationFieldFetchParameters parameters,
		Throwable exception
	) {
		return Optional.ofNullable(dataFetcherResult)
			.filter(Payload.class::isInstance)
			.map(Payload.class::cast)
			.map(Payload::errors)
			.map(errors -> errors.stream()
				.map(Error::code)
				.reduce(0, Integer::max))
			.map(code -> Tags.of("code", String.valueOf(code)))
			.orElseGet(Tags::empty);			
	}
}

interface Payload {
	boolean success();
	List<Error> errors();
}

interface Error {
	int code();
}
```

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
