### PR TITLE
Use ByteArrayOutputStream.toString where possible

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/HttpClientTransportTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/HttpClientTransportTests.java
@@ -316,7 +316,7 @@ class HttpClientTransportTests {
 	private String writeToString(HttpEntity entity) throws IOException {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		entity.writeTo(out);
-		return new String(out.toByteArray(), StandardCharsets.UTF_8);
+		return out.toString(StandardCharsets.UTF_8);
 	}
 
 	private void givenClientWillReturnResponse() throws IOException {

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/ContainerConfigTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/ContainerConfigTests.java
@@ -65,7 +65,7 @@ class ContainerConfigTests extends AbstractJsonTests {
 		});
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 		containerConfig.writeTo(outputStream);
-		String actualJson = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+		String actualJson = outputStream.toString(StandardCharsets.UTF_8);
 		String expectedJson = StreamUtils.copyToString(getContent("container-config.json"), StandardCharsets.UTF_8);
 		JSONAssert.assertEquals(expectedJson, actualJson, true);
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/DefaultLaunchScript.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/DefaultLaunchScript.java
@@ -71,7 +71,7 @@ public class DefaultLaunchScript implements LaunchScript {
 		try {
 			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 			copy(inputStream, outputStream);
-			return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+			return outputStream.toString(StandardCharsets.UTF_8);
 		}
 		finally {
 			inputStream.close();

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/LayersIndexTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/LayersIndexTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,7 +144,7 @@ class LayersIndexTests {
 		private String getContent() throws IOException {
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
 			this.actual.writeTo(out);
-			return new String(out.toByteArray(), StandardCharsets.UTF_8);
+			return out.toString(StandardCharsets.UTF_8);
 		}
 
 	}


### PR DESCRIPTION
Hi,

the method was introduced in Java 10 and is slightly faster (because it avoids unnecessary array copies), but more importantly it is a little more concise ;-)

Cheers,
Christoph