### PR TITLE
Rework Spring Session auto-configuration to use customizers

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HazelcastSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HazelcastSessionConfiguration.java
@@ -16,18 +16,19 @@
 
 package org.springframework.boot.autoconfigure.session;
 
-import java.time.Duration;
-
 import com.hazelcast.core.HazelcastInstance;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.session.SessionRepository;
+import org.springframework.session.config.SessionRepositoryCustomizer;
 import org.springframework.session.hazelcast.HazelcastIndexedSessionRepository;
 import org.springframework.session.hazelcast.config.annotation.web.http.HazelcastHttpSessionConfiguration;
 
@@ -47,19 +48,22 @@ import org.springframework.session.hazelcast.config.annotation.web.http.Hazelcas
 class HazelcastSessionConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
-	public static class SpringBootHazelcastHttpSessionConfiguration extends HazelcastHttpSessionConfiguration {
+	@Import(HazelcastHttpSessionConfiguration.class)
+	static class SpringBootHazelcastHttpSessionConfiguration {
 
-		@Autowired
-		public void customize(SessionProperties sessionProperties,
-				HazelcastSessionProperties hazelcastSessionProperties, ServerProperties serverProperties) {
-			Duration timeout = sessionProperties
-					.determineTimeout(() -> serverProperties.getServlet().getSession().getTimeout());
-			if (timeout != null) {
-				setMaxInactiveIntervalInSeconds((int) timeout.getSeconds());
-			}
-			setSessionMapName(hazelcastSessionProperties.getMapName());
-			setFlushMode(hazelcastSessionProperties.getFlushMode());
-			setSaveMode(hazelcastSessionProperties.getSaveMode());
+		@Bean
+		SessionRepositoryCustomizer<HazelcastIndexedSessionRepository> springBootSessionRepositoryCustomizer(
+				SessionProperties sessionProperties, HazelcastSessionProperties hazelcastSessionProperties,
+				ServerProperties serverProperties) {
+			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
+			return (sessionRepository) -> {
+				map.from(sessionProperties
+						.determineTimeout(() -> serverProperties.getServlet().getSession().getTimeout()))
+						.to((timeout) -> sessionRepository.setDefaultMaxInactiveInterval((int) timeout.getSeconds()));
+				map.from(hazelcastSessionProperties::getMapName).to(sessionRepository::setSessionMapName);
+				map.from(hazelcastSessionProperties::getFlushMode).to(sessionRepository::setFlushMode);
+				map.from(hazelcastSessionProperties::getSaveMode).to(sessionRepository::setSaveMode);
+			};
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java
@@ -16,18 +16,16 @@
 
 package org.springframework.boot.autoconfigure.session;
 
-import java.time.Duration;
-
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.sql.init.OnDatabaseInitializationCondition;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.boot.sql.init.dependency.DatabaseInitializationDependencyConfigurer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -35,6 +33,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.session.SessionRepository;
+import org.springframework.session.config.SessionRepositoryCustomizer;
 import org.springframework.session.jdbc.JdbcIndexedSessionRepository;
 import org.springframework.session.jdbc.config.annotation.SpringSessionDataSource;
 import org.springframework.session.jdbc.config.annotation.web.http.JdbcHttpSessionConfiguration;
@@ -65,20 +64,23 @@ class JdbcSessionConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	static class SpringBootJdbcHttpSessionConfiguration extends JdbcHttpSessionConfiguration {
+	@Import(JdbcHttpSessionConfiguration.class)
+	static class SpringBootJdbcHttpSessionConfiguration {
 
-		@Autowired
-		void customize(SessionProperties sessionProperties, JdbcSessionProperties jdbcSessionProperties,
+		@Bean
+		SessionRepositoryCustomizer<JdbcIndexedSessionRepository> springBootSessionRepositoryCustomizer(
+				SessionProperties sessionProperties, JdbcSessionProperties jdbcSessionProperties,
 				ServerProperties serverProperties) {
-			Duration timeout = sessionProperties
-					.determineTimeout(() -> serverProperties.getServlet().getSession().getTimeout());
-			if (timeout != null) {
-				setMaxInactiveIntervalInSeconds((int) timeout.getSeconds());
-			}
-			setTableName(jdbcSessionProperties.getTableName());
-			setCleanupCron(jdbcSessionProperties.getCleanupCron());
-			setFlushMode(jdbcSessionProperties.getFlushMode());
-			setSaveMode(jdbcSessionProperties.getSaveMode());
+			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
+			return (sessionRepository) -> {
+				map.from(sessionProperties
+						.determineTimeout(() -> serverProperties.getServlet().getSession().getTimeout()))
+						.to((timeout) -> sessionRepository.setDefaultMaxInactiveInterval((int) timeout.getSeconds()));
+				map.from(jdbcSessionProperties::getTableName).to(sessionRepository::setTableName);
+				map.from(jdbcSessionProperties::getFlushMode).to(sessionRepository::setFlushMode);
+				map.from(jdbcSessionProperties::getSaveMode).to(sessionRepository::setSaveMode);
+				map.from(jdbcSessionProperties::getCleanupCron).to(sessionRepository::setCleanupCron);
+			};
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/MongoReactiveSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/MongoReactiveSessionConfiguration.java
@@ -16,17 +16,18 @@
 
 package org.springframework.boot.autoconfigure.session;
 
-import java.time.Duration;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.session.ReactiveSessionRepository;
+import org.springframework.session.config.ReactiveSessionRepositoryCustomizer;
 import org.springframework.session.data.mongo.ReactiveMongoSessionRepository;
 import org.springframework.session.data.mongo.config.annotation.web.reactive.ReactiveMongoWebSessionConfiguration;
 
@@ -35,6 +36,7 @@ import org.springframework.session.data.mongo.config.annotation.web.reactive.Rea
  *
  * @author Andy Wilkinson
  * @author Weix Sun
+ * @author Vedran Pavic
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass({ ReactiveMongoOperations.class, ReactiveMongoSessionRepository.class })
@@ -44,17 +46,20 @@ import org.springframework.session.data.mongo.config.annotation.web.reactive.Rea
 class MongoReactiveSessionConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
-	static class SpringBootReactiveMongoWebSessionConfiguration extends ReactiveMongoWebSessionConfiguration {
+	@Import(ReactiveMongoWebSessionConfiguration.class)
+	static class SpringBootMongoWebSessionConfiguration {
 
-		@Autowired
-		void customize(SessionProperties sessionProperties, MongoSessionProperties mongoSessionProperties,
+		@Bean
+		ReactiveSessionRepositoryCustomizer<ReactiveMongoSessionRepository> springBootSessionRepositoryCustomizer(
+				SessionProperties sessionProperties, MongoSessionProperties mongoSessionProperties,
 				ServerProperties serverProperties) {
-			Duration timeout = sessionProperties
-					.determineTimeout(() -> serverProperties.getReactive().getSession().getTimeout());
-			if (timeout != null) {
-				setMaxInactiveIntervalInSeconds((int) timeout.getSeconds());
-			}
-			setCollectionName(mongoSessionProperties.getCollectionName());
+			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
+			return (sessionRepository) -> {
+				map.from(sessionProperties
+						.determineTimeout(() -> serverProperties.getReactive().getSession().getTimeout()))
+						.to((timeout) -> sessionRepository.setMaxInactiveIntervalInSeconds((int) timeout.getSeconds()));
+				map.from(mongoSessionProperties::getCollectionName).to(sessionRepository::setCollectionName);
+			};
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisReactiveSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisReactiveSessionConfiguration.java
@@ -16,17 +16,18 @@
 
 package org.springframework.boot.autoconfigure.session;
 
-import java.time.Duration;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.session.ReactiveSessionRepository;
+import org.springframework.session.config.ReactiveSessionRepositoryCustomizer;
 import org.springframework.session.data.redis.ReactiveRedisSessionRepository;
 import org.springframework.session.data.redis.config.annotation.web.server.RedisWebSessionConfiguration;
 
@@ -35,6 +36,7 @@ import org.springframework.session.data.redis.config.annotation.web.server.Redis
  *
  * @author Andy Wilkinson
  * @author Weix Sun
+ * @author Vedran Pavic
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass({ ReactiveRedisConnectionFactory.class, ReactiveRedisSessionRepository.class })
@@ -44,18 +46,21 @@ import org.springframework.session.data.redis.config.annotation.web.server.Redis
 class RedisReactiveSessionConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
-	static class SpringBootRedisWebSessionConfiguration extends RedisWebSessionConfiguration {
+	@Import(RedisWebSessionConfiguration.class)
+	static class SpringBootRedisWebSessionConfiguration {
 
-		@Autowired
-		void customize(SessionProperties sessionProperties, RedisSessionProperties redisSessionProperties,
+		@Bean
+		ReactiveSessionRepositoryCustomizer<ReactiveRedisSessionRepository> springBootSessionRepositoryCustomizer(
+				SessionProperties sessionProperties, RedisSessionProperties redisSessionProperties,
 				ServerProperties serverProperties) {
-			Duration timeout = sessionProperties
-					.determineTimeout(() -> serverProperties.getReactive().getSession().getTimeout());
-			if (timeout != null) {
-				setMaxInactiveIntervalInSeconds((int) timeout.getSeconds());
-			}
-			setRedisNamespace(redisSessionProperties.getNamespace());
-			setSaveMode(redisSessionProperties.getSaveMode());
+			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
+			return (sessionRepository) -> {
+				map.from(sessionProperties
+						.determineTimeout(() -> serverProperties.getReactive().getSession().getTimeout()))
+						.to((timeout) -> sessionRepository.setDefaultMaxInactiveInterval((int) timeout.getSeconds()));
+				map.from(redisSessionProperties::getNamespace).to(sessionRepository::setRedisKeyNamespace);
+				map.from(redisSessionProperties::getSaveMode).to(sessionRepository::setSaveMode);
+			};
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationJdbcTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationJdbcTests.java
@@ -28,7 +28,6 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
-import org.springframework.boot.autoconfigure.session.JdbcSessionConfiguration.SpringBootJdbcHttpSessionConfiguration;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.jdbc.init.DataSourceScriptDatabaseInitializer;
 import org.springframework.boot.sql.init.DatabaseInitializationMode;
@@ -86,12 +85,10 @@ class SessionAutoConfigurationJdbcTests extends AbstractSessionAutoConfiguration
 		assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval",
 				(int) new ServerProperties().getServlet().getSession().getTimeout().getSeconds());
 		assertThat(repository).hasFieldOrPropertyWithValue("tableName", "SPRING_SESSION");
+		assertThat(repository).hasFieldOrPropertyWithValue("cleanupCron", "0 * * * * *");
 		assertThat(context.getBean(JdbcSessionProperties.class).getInitializeSchema())
 				.isEqualTo(DatabaseInitializationMode.EMBEDDED);
 		assertThat(context.getBean(JdbcOperations.class).queryForList("select * from SPRING_SESSION")).isEmpty();
-		SpringBootJdbcHttpSessionConfiguration configuration = context
-				.getBean(SpringBootJdbcHttpSessionConfiguration.class);
-		assertThat(configuration).hasFieldOrPropertyWithValue("cleanupCron", "0 * * * * *");
 	}
 
 	@Test
@@ -142,29 +139,27 @@ class SessionAutoConfigurationJdbcTests extends AbstractSessionAutoConfiguration
 	void customCleanupCron() {
 		this.contextRunner.withPropertyValues("spring.session.jdbc.cleanup-cron=0 0 12 * * *").run((context) -> {
 			assertThat(context.getBean(JdbcSessionProperties.class).getCleanupCron()).isEqualTo("0 0 12 * * *");
-			SpringBootJdbcHttpSessionConfiguration configuration = context
-					.getBean(SpringBootJdbcHttpSessionConfiguration.class);
-			assertThat(configuration).hasFieldOrPropertyWithValue("cleanupCron", "0 0 12 * * *");
+			JdbcIndexedSessionRepository repository = validateSessionRepository(context,
+					JdbcIndexedSessionRepository.class);
+			assertThat(repository).hasFieldOrPropertyWithValue("cleanupCron", "0 0 12 * * *");
 		});
 	}
 
 	@Test
 	void customFlushMode() {
 		this.contextRunner.withPropertyValues("spring.session.jdbc.flush-mode=immediate").run((context) -> {
-			assertThat(context.getBean(JdbcSessionProperties.class).getFlushMode()).isEqualTo(FlushMode.IMMEDIATE);
-			SpringBootJdbcHttpSessionConfiguration configuration = context
-					.getBean(SpringBootJdbcHttpSessionConfiguration.class);
-			assertThat(configuration).hasFieldOrPropertyWithValue("flushMode", FlushMode.IMMEDIATE);
+			JdbcIndexedSessionRepository repository = validateSessionRepository(context,
+					JdbcIndexedSessionRepository.class);
+			assertThat(repository).hasFieldOrPropertyWithValue("flushMode", FlushMode.IMMEDIATE);
 		});
 	}
 
 	@Test
 	void customSaveMode() {
 		this.contextRunner.withPropertyValues("spring.session.jdbc.save-mode=on-get-attribute").run((context) -> {
-			assertThat(context.getBean(JdbcSessionProperties.class).getSaveMode()).isEqualTo(SaveMode.ON_GET_ATTRIBUTE);
-			SpringBootJdbcHttpSessionConfiguration configuration = context
-					.getBean(SpringBootJdbcHttpSessionConfiguration.class);
-			assertThat(configuration).hasFieldOrPropertyWithValue("saveMode", SaveMode.ON_GET_ATTRIBUTE);
+			JdbcIndexedSessionRepository repository = validateSessionRepository(context,
+					JdbcIndexedSessionRepository.class);
+			assertThat(repository).hasFieldOrPropertyWithValue("saveMode", SaveMode.ON_GET_ATTRIBUTE);
 		});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationRedisTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationRedisTests.java
@@ -25,7 +25,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
-import org.springframework.boot.autoconfigure.session.RedisSessionConfiguration.IndexedRedisSessionConfiguration.SpringBootRedisIndexedHttpSessionConfiguration;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -191,9 +190,7 @@ class SessionAutoConfigurationRedisTests extends AbstractSessionAutoConfiguratio
 			assertThat(repository).hasFieldOrPropertyWithValue("namespace", keyNamespace);
 			assertThat(repository).hasFieldOrPropertyWithValue("flushMode", flushMode);
 			assertThat(repository).hasFieldOrPropertyWithValue("saveMode", saveMode);
-			SpringBootRedisIndexedHttpSessionConfiguration configuration = context
-					.getBean(SpringBootRedisIndexedHttpSessionConfiguration.class);
-			assertThat(configuration).hasFieldOrPropertyWithValue("cleanupCron", cleanupCron);
+			assertThat(repository).hasFieldOrPropertyWithValue("cleanupCron", cleanupCron);
 		};
 	}
 

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1485,7 +1485,7 @@ bom {
 			]
 		}
 	}
-	library("Spring Session Bom", "2022.0.0-M3") {
+	library("Spring Session Bom", "2022.0.0-SNAPSHOT") {
 		group("org.springframework.session") {
 			imports = [
 				"spring-session-bom"


### PR DESCRIPTION
This PR reworks Spring Session auto-configuration to avoid extending Spring Session's configuration classes. Instead, those configuration classes are now imported and customizations are applied using dedicated `(Reactive)SessionRepositoryCustomizer` beans.