### PR TITLE
Add Javadoc since for UseMainMethod

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTest.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTest.java
@@ -187,6 +187,7 @@ public @interface SpringBootTest {
 	 * Enumeration of how the main method of the
 	 * {@link SpringBootConfiguration @SpringBootConfiguration}-annotated class is used
 	 * when creating and running the {@link SpringApplication} under test.
+	 * @since 3.0.0
 	 */
 	enum UseMainMethod {
 


### PR DESCRIPTION
This PR adds Javadoc `@since` tag for `SpringBootTest.UseMainMethod`.

See gh-22405