### PR TITLE
Allow JMX Registration Policy to be set

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfiguration.java
@@ -34,7 +34,6 @@ import org.springframework.jmx.export.annotation.AnnotationJmxAttributeSource;
 import org.springframework.jmx.export.annotation.AnnotationMBeanExporter;
 import org.springframework.jmx.export.naming.ObjectNamingStrategy;
 import org.springframework.jmx.support.MBeanServerFactoryBean;
-import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.util.StringUtils;
 
 /**
@@ -67,7 +66,7 @@ public class JmxAutoConfiguration {
 	@ConditionalOnMissingBean(value = MBeanExporter.class, search = SearchStrategy.CURRENT)
 	public AnnotationMBeanExporter mbeanExporter(ObjectNamingStrategy namingStrategy, BeanFactory beanFactory) {
 		AnnotationMBeanExporter exporter = new AnnotationMBeanExporter();
-		exporter.setRegistrationPolicy(RegistrationPolicy.FAIL_ON_EXISTING);
+		exporter.setRegistrationPolicy(this.properties.getRegistrationPolicy());
 		exporter.setNamingStrategy(namingStrategy);
 		String serverBean = this.properties.getServer();
 		if (StringUtils.hasLength(serverBean)) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jmx/JmxProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jmx/JmxProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.jmx;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.jmx.support.RegistrationPolicy;
 
 /**
  * Configuration properties for JMX.
@@ -46,6 +47,11 @@ public class JmxProperties {
 	 * JMX domain name.
 	 */
 	private String defaultDomain;
+
+	/**
+	 * JMX Registration policy.
+	 */
+	private RegistrationPolicy registrationPolicy = RegistrationPolicy.FAIL_ON_EXISTING;
 
 	public boolean getEnabled() {
 		return this.enabled;
@@ -77,6 +83,14 @@ public class JmxProperties {
 
 	public void setDefaultDomain(String defaultDomain) {
 		this.defaultDomain = defaultDomain;
+	}
+
+	public RegistrationPolicy getRegistrationPolicy() {
+		return this.registrationPolicy;
+	}
+
+	public void setRegistrationPolicy(RegistrationPolicy registrationPolicy) {
+		this.registrationPolicy = registrationPolicy;
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jmx/JmxAutoConfigurationTests.java
@@ -33,6 +33,7 @@ import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.jmx.export.naming.MetadataNamingStrategy;
 import org.springframework.jmx.export.naming.ObjectNamingStrategy;
+import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,6 +73,8 @@ class JmxAutoConfigurationTests {
 			assertThat(context).hasSingleBean(ParentAwareNamingStrategy.class);
 			MBeanExporter exporter = context.getBean(MBeanExporter.class);
 			assertThat(exporter).hasFieldOrPropertyWithValue("ensureUniqueRuntimeObjectNames", false);
+			assertThat(exporter).hasFieldOrPropertyWithValue("registrationPolicy", RegistrationPolicy.FAIL_ON_EXISTING);
+
 			MetadataNamingStrategy naming = (MetadataNamingStrategy) ReflectionTestUtils.getField(exporter,
 					"namingStrategy");
 			assertThat(naming).hasFieldOrPropertyWithValue("ensureUniqueRuntimeObjectNames", false);
@@ -80,15 +83,21 @@ class JmxAutoConfigurationTests {
 
 	@Test
 	void testDefaultDomainConfiguredOnMBeanExport() {
-		this.contextRunner.withPropertyValues("spring.jmx.enabled=true", "spring.jmx.default-domain=my-test-domain",
-				"spring.jmx.unique-names=true").run((context) -> {
+		this.contextRunner
+				.withPropertyValues("spring.jmx.enabled=true", "spring.jmx.default-domain=my-test-domain",
+						"spring.jmx.unique-names=true", "spring.jmx.registration-policy=IGNORE_EXISTING")
+				.run((context) -> {
 					assertThat(context).hasSingleBean(MBeanExporter.class);
 					MBeanExporter exporter = context.getBean(MBeanExporter.class);
 					assertThat(exporter).hasFieldOrPropertyWithValue("ensureUniqueRuntimeObjectNames", true);
+					assertThat(exporter).hasFieldOrPropertyWithValue("registrationPolicy",
+							RegistrationPolicy.IGNORE_EXISTING);
+
 					MetadataNamingStrategy naming = (MetadataNamingStrategy) ReflectionTestUtils.getField(exporter,
 							"namingStrategy");
 					assertThat(naming).hasFieldOrPropertyWithValue("defaultDomain", "my-test-domain");
 					assertThat(naming).hasFieldOrPropertyWithValue("ensureUniqueRuntimeObjectNames", true);
+
 				});
 	}
 


### PR DESCRIPTION
Currently the `JmxAutoconfiguration` sets the `RegistrationPolicy` to `FAIL_ON_EXISTING`. However there can be situations where it might be useful to set it to something else like `IGNORE_EXISTING`. 

This could help to workaround the issue with both HikariCP and Spring Boot registering JMX beans. 

See https://stackoverflow.com/questions/73896176/spring-boot-hikari-config-not-loaded/73896695#73896695 (for my recommended solution). 

And [the issue from HikariCP](https://github.com/brettwooldridge/HikariCP/issues/342) with several other proposed solutions/workaround. 

The drawback of those solutions, imho, is that the disable (or at least partially) the auto-configuration from Spring Boot. 