### PR TITLE
Make auto-configured Brave Tracer more compliant with OTel tracer

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java
@@ -92,8 +92,9 @@ public class BraveAutoConfiguration {
 			List<TracingCustomizer> tracingCustomizers, CurrentTraceContext currentTraceContext,
 			Factory propagationFactory, Sampler sampler) {
 		String applicationName = environment.getProperty("spring.application.name", DEFAULT_APPLICATION_NAME);
-		Builder builder = Tracing.newBuilder().currentTraceContext(currentTraceContext)
-				.propagationFactory(propagationFactory).sampler(sampler).localServiceName(applicationName);
+		Builder builder = Tracing.newBuilder().currentTraceContext(currentTraceContext).traceId128Bit(true)
+				.supportsJoin(false).propagationFactory(propagationFactory).sampler(sampler)
+				.localServiceName(applicationName);
 		for (SpanHandler spanHandler : spanHandlers) {
 			builder.addSpanHandler(spanHandler);
 		}


### PR DESCRIPTION
by default we will not support joined spans and the trace id will be 128 bit