### PR TITLE
Fix deprecation warnings in Spring Session auto-configuration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HazelcastSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/HazelcastSessionConfiguration.java
@@ -55,7 +55,7 @@ class HazelcastSessionConfiguration {
 		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		return (sessionRepository) -> {
 			map.from(sessionProperties.determineTimeout(() -> serverProperties.getServlet().getSession().getTimeout()))
-					.to((timeout) -> sessionRepository.setDefaultMaxInactiveInterval((int) timeout.getSeconds()));
+					.to(sessionRepository::setDefaultMaxInactiveInterval);
 			map.from(hazelcastSessionProperties::getMapName).to(sessionRepository::setSessionMapName);
 			map.from(hazelcastSessionProperties::getFlushMode).to(sessionRepository::setFlushMode);
 			map.from(hazelcastSessionProperties::getSaveMode).to(sessionRepository::setSaveMode);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java
@@ -70,7 +70,7 @@ class JdbcSessionConfiguration {
 		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		return (sessionRepository) -> {
 			map.from(sessionProperties.determineTimeout(() -> serverProperties.getServlet().getSession().getTimeout()))
-					.to((timeout) -> sessionRepository.setDefaultMaxInactiveInterval((int) timeout.getSeconds()));
+					.to(sessionRepository::setDefaultMaxInactiveInterval);
 			map.from(jdbcSessionProperties::getTableName).to(sessionRepository::setTableName);
 			map.from(jdbcSessionProperties::getFlushMode).to(sessionRepository::setFlushMode);
 			map.from(jdbcSessionProperties::getSaveMode).to(sessionRepository::setSaveMode);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/MongoReactiveSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/MongoReactiveSessionConfiguration.java
@@ -53,7 +53,7 @@ class MongoReactiveSessionConfiguration {
 		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		return (sessionRepository) -> {
 			map.from(sessionProperties.determineTimeout(() -> serverProperties.getReactive().getSession().getTimeout()))
-					.to((timeout) -> sessionRepository.setMaxInactiveIntervalInSeconds((int) timeout.getSeconds()));
+					.to(sessionRepository::setDefaultMaxInactiveInterval);
 			map.from(mongoSessionProperties::getCollectionName).to(sessionRepository::setCollectionName);
 		};
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/MongoSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/MongoSessionConfiguration.java
@@ -53,7 +53,7 @@ class MongoSessionConfiguration {
 		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		return (sessionRepository) -> {
 			map.from(sessionProperties.determineTimeout(() -> serverProperties.getServlet().getSession().getTimeout()))
-					.to((timeout) -> sessionRepository.setMaxInactiveIntervalInSeconds((int) timeout.getSeconds()));
+					.to(sessionRepository::setDefaultMaxInactiveInterval);
 			map.from(mongoSessionProperties::getCollectionName).to(sessionRepository::setCollectionName);
 		};
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisReactiveSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisReactiveSessionConfiguration.java
@@ -53,7 +53,7 @@ class RedisReactiveSessionConfiguration {
 		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		return (sessionRepository) -> {
 			map.from(sessionProperties.determineTimeout(() -> serverProperties.getReactive().getSession().getTimeout()))
-					.to((timeout) -> sessionRepository.setDefaultMaxInactiveInterval((int) timeout.getSeconds()));
+					.to(sessionRepository::setDefaultMaxInactiveInterval);
 			map.from(redisSessionProperties::getNamespace).to(sessionRepository::setRedisKeyNamespace);
 			map.from(redisSessionProperties::getSaveMode).to(sessionRepository::setSaveMode);
 		};

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/RedisSessionConfiguration.java
@@ -105,7 +105,7 @@ class RedisSessionConfiguration {
 			return (sessionRepository) -> {
 				map.from(sessionProperties
 						.determineTimeout(() -> serverProperties.getServlet().getSession().getTimeout()))
-						.to((timeout) -> sessionRepository.setDefaultMaxInactiveInterval((int) timeout.getSeconds()));
+						.to(sessionRepository::setDefaultMaxInactiveInterval);
 				map.from(redisSessionProperties::getNamespace).to(sessionRepository::setRedisKeyNamespace);
 				map.from(redisSessionProperties::getFlushMode).to(sessionRepository::setFlushMode);
 				map.from(redisSessionProperties::getSaveMode).to(sessionRepository::setSaveMode);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/ReactiveSessionAutoConfigurationMongoTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/ReactiveSessionAutoConfigurationMongoTests.java
@@ -36,6 +36,7 @@ import org.springframework.boot.test.context.runner.ContextConsumer;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
 import org.springframework.boot.testsupport.testcontainers.DockerImageNames;
 import org.springframework.http.ResponseCookie;
+import org.springframework.session.MapSession;
 import org.springframework.session.data.mongo.ReactiveMongoSessionRepository;
 import org.springframework.session.data.redis.ReactiveRedisSessionRepository;
 
@@ -72,7 +73,8 @@ class ReactiveSessionAutoConfigurationMongoTests extends AbstractSessionAutoConf
 				"spring.data.mongodb.uri=" + mongoDb.getReplicaSetUrl()).run((context) -> {
 					ReactiveMongoSessionRepository repository = validateSessionRepository(context,
 							ReactiveMongoSessionRepository.class);
-					assertThat(repository).hasFieldOrPropertyWithValue("maxInactiveIntervalInSeconds", 60);
+					assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval",
+							Duration.ofMinutes(1));
 				});
 	}
 
@@ -82,7 +84,8 @@ class ReactiveSessionAutoConfigurationMongoTests extends AbstractSessionAutoConf
 				"spring.data.mongodb.uri=" + mongoDb.getReplicaSetUrl()).run((context) -> {
 					ReactiveMongoSessionRepository repository = validateSessionRepository(context,
 							ReactiveMongoSessionRepository.class);
-					assertThat(repository).hasFieldOrPropertyWithValue("maxInactiveIntervalInSeconds", 60);
+					assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval",
+							Duration.ofMinutes(1));
 				});
 	}
 
@@ -126,8 +129,8 @@ class ReactiveSessionAutoConfigurationMongoTests extends AbstractSessionAutoConf
 			ReactiveMongoSessionRepository repository = validateSessionRepository(context,
 					ReactiveMongoSessionRepository.class);
 			assertThat(repository.getCollectionName()).isEqualTo(collectionName);
-			assertThat(repository).hasFieldOrPropertyWithValue("maxInactiveIntervalInSeconds",
-					ReactiveMongoSessionRepository.DEFAULT_INACTIVE_INTERVAL);
+			assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval",
+					MapSession.DEFAULT_MAX_INACTIVE_INTERVAL);
 		};
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/ReactiveSessionAutoConfigurationRedisTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/ReactiveSessionAutoConfigurationRedisTests.java
@@ -78,7 +78,7 @@ class ReactiveSessionAutoConfigurationRedisTests extends AbstractSessionAutoConf
 		this.contextRunner.withPropertyValues("spring.session.timeout=1m").run((context) -> {
 			ReactiveRedisSessionRepository repository = validateSessionRepository(context,
 					ReactiveRedisSessionRepository.class);
-			assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval", 60);
+			assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval", Duration.ofMinutes(1));
 		});
 	}
 
@@ -87,7 +87,7 @@ class ReactiveSessionAutoConfigurationRedisTests extends AbstractSessionAutoConf
 		this.contextRunner.withPropertyValues("server.reactive.session.timeout=1m").run((context) -> {
 			ReactiveRedisSessionRepository repository = validateSessionRepository(context,
 					ReactiveRedisSessionRepository.class);
-			assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval", 60);
+			assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval", Duration.ofMinutes(1));
 		});
 	}
 
@@ -124,7 +124,7 @@ class ReactiveSessionAutoConfigurationRedisTests extends AbstractSessionAutoConf
 			ReactiveRedisSessionRepository repository = validateSessionRepository(context,
 					ReactiveRedisSessionRepository.class);
 			assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval",
-					MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS);
+					MapSession.DEFAULT_MAX_INACTIVE_INTERVAL);
 			assertThat(repository).hasFieldOrPropertyWithValue("namespace", namespace);
 			assertThat(repository).hasFieldOrPropertyWithValue("saveMode", saveMode);
 		};

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationHazelcastTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationHazelcastTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.autoconfigure.session;
 
+import java.time.Duration;
+
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import org.junit.jupiter.api.Test;
@@ -69,7 +71,7 @@ class SessionAutoConfigurationHazelcastTests extends AbstractSessionAutoConfigur
 		this.contextRunner.withPropertyValues("spring.session.timeout=1m").run((context) -> {
 			HazelcastIndexedSessionRepository repository = validateSessionRepository(context,
 					HazelcastIndexedSessionRepository.class);
-			assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval", 60);
+			assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval", Duration.ofMinutes(1));
 		});
 	}
 
@@ -77,7 +79,7 @@ class SessionAutoConfigurationHazelcastTests extends AbstractSessionAutoConfigur
 		HazelcastIndexedSessionRepository repository = validateSessionRepository(context,
 				HazelcastIndexedSessionRepository.class);
 		assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval",
-				(int) new ServerProperties().getServlet().getSession().getTimeout().getSeconds());
+				new ServerProperties().getServlet().getSession().getTimeout());
 		HazelcastInstance hazelcastInstance = context.getBean(HazelcastInstance.class);
 		then(hazelcastInstance).should().getMap("spring:session:sessions");
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationJdbcTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationJdbcTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.autoconfigure.session;
 
+import java.time.Duration;
+
 import javax.sql.DataSource;
 
 import org.apache.commons.dbcp2.BasicDataSource;
@@ -83,7 +85,7 @@ class SessionAutoConfigurationJdbcTests extends AbstractSessionAutoConfiguration
 		JdbcIndexedSessionRepository repository = validateSessionRepository(context,
 				JdbcIndexedSessionRepository.class);
 		assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval",
-				(int) new ServerProperties().getServlet().getSession().getTimeout().getSeconds());
+				new ServerProperties().getServlet().getSession().getTimeout());
 		assertThat(repository).hasFieldOrPropertyWithValue("tableName", "SPRING_SESSION");
 		assertThat(repository).hasFieldOrPropertyWithValue("cleanupCron", "0 * * * * *");
 		assertThat(context.getBean(JdbcSessionProperties.class).getInitializeSchema())
@@ -118,7 +120,7 @@ class SessionAutoConfigurationJdbcTests extends AbstractSessionAutoConfiguration
 		this.contextRunner.withPropertyValues("spring.session.timeout=1m").run((context) -> {
 			JdbcIndexedSessionRepository repository = validateSessionRepository(context,
 					JdbcIndexedSessionRepository.class);
-			assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval", 60);
+			assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval", Duration.ofMinutes(1));
 		});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationMongoTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationMongoTests.java
@@ -86,8 +86,7 @@ class SessionAutoConfigurationMongoTests extends AbstractSessionAutoConfiguratio
 			MongoIndexedSessionRepository repository = validateSessionRepository(context,
 					MongoIndexedSessionRepository.class);
 			assertThat(repository).hasFieldOrPropertyWithValue("collectionName", collectionName);
-			assertThat(repository).hasFieldOrPropertyWithValue("maxInactiveIntervalInSeconds",
-					(int) timeout.getSeconds());
+			assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval", timeout);
 		};
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationRedisTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationRedisTests.java
@@ -186,7 +186,7 @@ class SessionAutoConfigurationRedisTests extends AbstractSessionAutoConfiguratio
 			RedisIndexedSessionRepository repository = validateSessionRepository(context,
 					RedisIndexedSessionRepository.class);
 			assertThat(repository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval",
-					(int) new ServerProperties().getServlet().getSession().getTimeout().getSeconds());
+					new ServerProperties().getServlet().getSession().getTimeout());
 			assertThat(repository).hasFieldOrPropertyWithValue("namespace", keyNamespace);
 			assertThat(repository).hasFieldOrPropertyWithValue("flushMode", flushMode);
 			assertThat(repository).hasFieldOrPropertyWithValue("saveMode", saveMode);


### PR DESCRIPTION
This PR updates Spring Session auto-configuration to avoid usage of deprecated methods, and moves to newly introduced `Duration` based `defaultMaxInactiveInterval` setters across all session repository implementations.

Additionally, this fixes several tests that are broken due to session repository implementations now using `Duration` type for their `defaultMaxInactiveInterval` fields.