### PR TITLE
Use NBT plugin version from gradle.properties in image tests

### DIFF
--- a/spring-boot-system-tests/spring-boot-image-tests/src/systemTest/java/org/springframework/boot/image/paketo/PaketoBuilderTests.java
+++ b/spring-boot-system-tests/spring-boot-image-tests/src/systemTest/java/org/springframework/boot/image/paketo/PaketoBuilderTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.image.paketo;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -24,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.jar.Attributes;
@@ -68,11 +70,20 @@ class PaketoBuilderTests {
 	GradleBuild gradleBuild;
 
 	@BeforeEach
-	void configureGradleBuild() {
+	void configureGradleBuild() throws IOException {
 		this.gradleBuild.scriptProperty("systemTestMavenRepository",
 				new File("build/system-test-maven-repository").getAbsoluteFile().toURI().toASCIIString());
+		this.gradleBuild.scriptProperty("nativeBuildToolsVersion", getNativeBuildToolsVersion());
 		this.gradleBuild.expectDeprecationMessages("BPL_SPRING_CLOUD_BINDINGS_ENABLED.*true.*Deprecated");
 		this.gradleBuild.expectDeprecationMessages("BOM table is deprecated");
+	}
+
+	private String getNativeBuildToolsVersion() throws IOException {
+		Properties gradleProperties = new Properties();
+		try (FileInputStream input = new FileInputStream("../../gradle.properties")) {
+			gradleProperties.load(input);
+			return gradleProperties.getProperty("nativeBuildToolsVersion");
+		}
 	}
 
 	@Test

--- a/spring-boot-system-tests/spring-boot-image-tests/src/systemTest/resources/org/springframework/boot/image/paketo/PaketoBuilderTests-nativeApp.gradle
+++ b/spring-boot-system-tests/spring-boot-image-tests/src/systemTest/resources/org/springframework/boot/image/paketo/PaketoBuilderTests-nativeApp.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '{bootVersion}'
 	id 'org.springframework.boot.aot' version '{bootVersion}'
 	id 'io.spring.dependency-management' version '{dependencyManagementPluginVersion}'
-	id 'org.graalvm.buildtools.native' version '0.9.14'
+	id 'org.graalvm.buildtools.native' version '{nativeBuildToolsVersion}'
 	id 'java'
 }
 


### PR DESCRIPTION
This PR changes to use NBT plugin version from `gradle.properties` in image tests to try to resolve #32474.

Closes gh-32474