### PR TITLE
Actuator configprops endpoint does not display DataSize properties correctly

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpoint.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
@@ -48,6 +49,7 @@ import com.fasterxml.jackson.databind.ser.PropertyWriter;
 import com.fasterxml.jackson.databind.ser.SerializerFactory;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -80,6 +82,7 @@ import org.springframework.core.annotation.MergedAnnotations.SearchStrategy;
 import org.springframework.core.env.PropertySource;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.util.unit.DataSize;
 
 /**
  * {@link Endpoint @Endpoint} to expose application properties from
@@ -188,12 +191,12 @@ public class ConfigurationPropertiesReportEndpoint implements ApplicationContext
 		builder.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 		builder.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 		builder.configure(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false);
-		JsonMapper.builder();
 		builder.configure(MapperFeature.USE_STD_BEAN_NAMING, true);
 		builder.serializationInclusion(Include.NON_NULL);
 		applyConfigurationPropertiesFilter(builder);
 		applySerializationModifier(builder);
 		builder.addModule(new JavaTimeModule());
+		builder.addModule(new ConfigurationPropertiesModule());
 	}
 
 	private void applyConfigurationPropertiesFilter(JsonMapper.Builder builder) {
@@ -470,6 +473,18 @@ public class ConfigurationPropertiesReportEndpoint implements ApplicationContext
 				}
 			}
 			super.serializeAsField(pojo, jgen, provider, writer);
+		}
+
+	}
+
+	/**
+	 * {@link SimpleModule} for configure the serializer.
+	 */
+	private static final class ConfigurationPropertiesModule extends SimpleModule {
+
+		private ConfigurationPropertiesModule() {
+			super();
+			addSerializer(DataSize.class, ToStringSerializer.instance);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointTests.java
@@ -46,6 +46,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.mock.env.MockPropertySource;
+import org.springframework.util.unit.DataSize;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
@@ -166,6 +167,19 @@ class ConfigurationPropertiesReportEndpointTests {
 	void descriptorWithMixedBooleanProperty() {
 		this.contextRunner.withUserConfiguration(BooleanPropertiesConfiguration.class).run(assertProperties("boolean",
 				(properties) -> assertThat(properties.get("mixedBoolean")).isEqualTo(true)));
+	}
+
+	@Test
+	void descriptorWithDataSizeProperty() {
+		String configSize = "1MB";
+		String stringifySize = DataSize.parse(configSize).toString();
+		this.contextRunner.withUserConfiguration(DataSizePropertiesConfiguration.class)
+				.withPropertyValues(String.format("data.size=%s", configSize)).run(assertProperties("data",
+						(properties) -> assertThat(properties.get("size")).isEqualTo(stringifySize), (inputs) -> {
+							Map<String, Object> size = (Map<String, Object>) inputs.get("size");
+							assertThat(size.get("value")).isEqualTo(configSize);
+							assertThat(size.get("origin")).isEqualTo("\"data.size\" from property source \"test\"");
+						}));
 	}
 
 	@Test
@@ -686,6 +700,27 @@ class ConfigurationPropertiesReportEndpointTests {
 
 		public void setMixedBoolean(Boolean mixedBoolean) {
 			this.mixedBoolean = mixedBoolean;
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableConfigurationProperties(DataSizeProperties.class)
+	static class DataSizePropertiesConfiguration {
+
+	}
+
+	@ConfigurationProperties("data")
+	public static class DataSizeProperties {
+
+		private DataSize size;
+
+		public DataSize getSize() {
+			return this.size;
+		}
+
+		public void setSize(DataSize size) {
+			this.size = size;
 		}
 
 	}


### PR DESCRIPTION
Add `DataSize` serializer to `objectMapper` of `ConfigurationPropertiesReportEndpoint`.

This line of code seems to have been added by accident, I removed it:

https://github.com/spring-projects/spring-boot/blob/263433cd8136c6cd48375eb747a970e3bb344a9d/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpoint.java#L178

Closes gh-32613

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
