### PR TITLE
 Add checkstyle rules for List.of() / Set.of() / Map.of()

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.tracing;
 
+import java.util.Collections;
 import java.util.List;
 
 import brave.Tracer;
@@ -184,7 +185,7 @@ public class BraveAutoConfiguration {
 			return switch (tracing.getPropagation().getType()) {
 				case B3 ->
 					B3Propagation.newFactoryBuilder().injectFormat(B3Propagation.Format.SINGLE_NO_PARENT).build();
-				case W3C -> new W3CPropagation(BRAVE_BAGGAGE_MANAGER, List.of());
+				case W3C -> new W3CPropagation(BRAVE_BAGGAGE_MANAGER, Collections.emptyList());
 			};
 		}
 
@@ -207,7 +208,7 @@ public class BraveAutoConfiguration {
 			Factory delegate = switch (this.tracingProperties.getPropagation().getType()) {
 				case B3 ->
 					B3Propagation.newFactoryBuilder().injectFormat(B3Propagation.Format.SINGLE_NO_PARENT).build();
-				case W3C -> new W3CPropagation(BRAVE_BAGGAGE_MANAGER, List.of());
+				case W3C -> new W3CPropagation(BRAVE_BAGGAGE_MANAGER, Collections.emptyList());
 			};
 			FactoryBuilder builder = BaggagePropagation.newFactoryBuilder(delegate);
 			baggagePropagationCustomizers.orderedStream().forEach((customizer) -> customizer.customize(builder));

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.tracing;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -137,8 +138,9 @@ public class OpenTelemetryAutoConfiguration {
 	@ConditionalOnMissingBean
 	OtelTracer micrometerOtelTracer(Tracer tracer, EventPublisher eventPublisher,
 			OtelCurrentTraceContext otelCurrentTraceContext) {
-		return new OtelTracer(tracer, otelCurrentTraceContext, eventPublisher, new OtelBaggageManager(
-				otelCurrentTraceContext, this.tracingProperties.getBaggage().getRemoteFields(), List.of()));
+		return new OtelTracer(tracer, otelCurrentTraceContext, eventPublisher,
+				new OtelBaggageManager(otelCurrentTraceContext, this.tracingProperties.getBaggage().getRemoteFields(),
+						Collections.emptyList()));
 	}
 
 	@Bean
@@ -202,8 +204,9 @@ public class OpenTelemetryAutoConfiguration {
 		@ConditionalOnProperty(prefix = "management.tracing.propagation", name = "type", havingValue = "B3")
 		TextMapPropagator b3BaggageTextMapPropagator(OtelCurrentTraceContext otelCurrentTraceContext) {
 			List<String> remoteFields = this.tracingProperties.getBaggage().getRemoteFields();
-			return TextMapPropagator.composite(B3Propagator.injectingSingleHeader(), new BaggageTextMapPropagator(
-					remoteFields, new OtelBaggageManager(otelCurrentTraceContext, remoteFields, List.of())));
+			return TextMapPropagator.composite(B3Propagator.injectingSingleHeader(),
+					new BaggageTextMapPropagator(remoteFields,
+							new OtelBaggageManager(otelCurrentTraceContext, remoteFields, Collections.emptyList())));
 		}
 
 		@Bean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/wavefront/WavefrontTracingAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/wavefront/WavefrontTracingAutoConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.tracing.wavefront;
 
-import java.util.Set;
+import java.util.Collections;
 
 import brave.handler.SpanHandler;
 import com.wavefront.sdk.common.WavefrontSender;
@@ -84,7 +84,7 @@ public class WavefrontTracingAutoConfiguration {
 		WavefrontSpanHandler wavefrontSpanHandler(WavefrontProperties properties, WavefrontSender wavefrontSender,
 				SpanMetrics spanMetrics, ApplicationTags applicationTags) {
 			return new WavefrontSpanHandler(properties.getSender().getMaxQueueSize(), wavefrontSender, spanMetrics,
-					properties.getSourceOrDefault(), applicationTags, Set.of());
+					properties.getSourceOrDefault(), applicationTags, Collections.emptySet());
 		}
 
 		@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/HttpSender.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/HttpSender.java
@@ -19,6 +19,7 @@ package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
@@ -68,7 +69,7 @@ abstract class HttpSender extends Sender {
 	@Override
 	public CheckResult check() {
 		try {
-			sendSpans(List.of()).execute();
+			sendSpans(Collections.emptyList()).execute();
 			return CheckResult.OK;
 		}
 		catch (IOException | RuntimeException ex) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinHttpSenderTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinHttpSenderTests.java
@@ -19,6 +19,7 @@ package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
@@ -53,7 +54,7 @@ abstract class ZipkinHttpSenderTests {
 	@Test
 	void sendSpansShouldThrowIfCloseWasCalled() throws IOException {
 		this.sut.close();
-		assertThatThrownBy(() -> this.sut.sendSpans(List.of())).isInstanceOf(ClosedSenderException.class);
+		assertThatThrownBy(() -> this.sut.sendSpans(Collections.emptyList())).isInstanceOf(ClosedSenderException.class);
 	}
 
 	protected void makeRequest(List<byte[]> encodedSpans, boolean async) throws IOException {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateSenderTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinRestTemplateSenderTests.java
@@ -18,6 +18,7 @@ package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
 
 import java.io.IOException;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -95,12 +96,13 @@ class ZipkinRestTemplateSenderTests extends ZipkinHttpSenderTests {
 		this.mockServer.expect(requestTo(ZIPKIN_URL)).andExpect(method(HttpMethod.POST))
 				.andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
 		if (async) {
-			CallbackResult callbackResult = makeAsyncRequest(List.of());
+			CallbackResult callbackResult = makeAsyncRequest(Collections.emptyList());
 			assertThat(callbackResult.success()).isFalse();
 			assertThat(callbackResult.error()).isNotNull().hasMessageContaining("500 Internal Server Error");
 		}
 		else {
-			assertThatThrownBy(() -> makeSyncRequest(List.of())).hasMessageContaining("500 Internal Server Error");
+			assertThatThrownBy(() -> makeSyncRequest(Collections.emptyList()))
+					.hasMessageContaining("500 Internal Server Error");
 		}
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinWebClientSenderTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinWebClientSenderTests.java
@@ -18,6 +18,7 @@ package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
 
 import java.io.IOException;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -106,12 +107,13 @@ class ZipkinWebClientSenderTests extends ZipkinHttpSenderTests {
 	void sendSpansShouldHandleHttpFailures(boolean async) throws InterruptedException {
 		mockBackEnd.enqueue(new MockResponse().setResponseCode(500));
 		if (async) {
-			CallbackResult callbackResult = makeAsyncRequest(List.of());
+			CallbackResult callbackResult = makeAsyncRequest(Collections.emptyList());
 			assertThat(callbackResult.success()).isFalse();
 			assertThat(callbackResult.error()).isNotNull().hasMessageContaining("500 Internal Server Error");
 		}
 		else {
-			assertThatThrownBy(() -> makeSyncRequest(List.of())).hasMessageContaining("500 Internal Server Error");
+			assertThatThrownBy(() -> makeSyncRequest(Collections.emptyList()))
+					.hasMessageContaining("500 Internal Server Error");
 		}
 
 		requestAssertions((request) -> assertThat(request.getMethod()).isEqualTo("POST"));

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaPropertiesTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.autoconfigure.kafka;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.kafka.common.config.SslConfigs;
@@ -55,7 +56,7 @@ class KafkaPropertiesTests {
 
 	@Test
 	void adminDefaultValuesAreConsistent() {
-		KafkaAdmin admin = new KafkaAdmin(Map.of());
+		KafkaAdmin admin = new KafkaAdmin(Collections.emptyMap());
 		Admin adminProperties = new KafkaProperties().getAdmin();
 		assertThat(admin).hasFieldOrPropertyWithValue("fatalIfBrokerNotAvailable", adminProperties.isFailFast());
 		assertThat(admin).hasFieldOrPropertyWithValue("modifyTopicConfigs", adminProperties.isModifyTopicConfigs());

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/WebResourcesRuntimeHintsTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/WebResourcesRuntimeHintsTests.java
@@ -18,6 +18,7 @@ package org.springframework.boot.autoconfigure.web;
 
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -52,7 +53,7 @@ class WebResourcesRuntimeHintsTests {
 
 	@Test
 	void registerHintsWithNoLocation() {
-		RuntimeHints hints = register(new TestClassLoader(List.of()));
+		RuntimeHints hints = register(new TestClassLoader(Collections.emptyList()));
 		assertThat(hints.resources().resourcePatternHints()).isEmpty();
 	}
 

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -54,6 +54,13 @@
 				value="Please use BDD-style (given, when, then) using BDDMockito imports." />
 			<property name="ignoreComments" value="true" />
 		</module>
+		<module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck">
+			<property name="maximum" value="0"/>
+			<property name="format" value="(List|Map|Set)\.of\(\)" />
+			<property name="message"
+					  value="Please use Collections.emptyList()/emptyMap()/emptySet() for creating empty lists/maps/sets." />
+			<property name="ignoreComments" value="true" />
+		</module>
 		<module name="io.spring.javaformat.checkstyle.check.SpringJavadocCheck">
 			<property name="publicOnlySinceTags" value="true" />
 			<property name="requireSinceTag" value="true" />


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Add checkstyle rule for List.of() / Set.of() / Map.of()

This commits adds a checkstyle rule to not use List.of(), Set.of() and Map.of(), preferring Collections.emptyList() / emptySet() / emptyMap().

It replaces usages of these methods across the code base.

closes gh-31973
