### PR TITLE
Fix Log4J2LoggingSystemTests.configLocationsWithConfigurationFileSystemProperty()

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
@@ -314,8 +314,8 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 	void configLocationsWithConfigurationFileSystemProperty() {
 		System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "custom-log4j2.properties");
 		try {
-			assertThat(this.loggingSystem.getStandardConfigLocations()).contains("log4j2-test.properties",
-					"log4j2-test.xml", "log4j2.properties", "log4j2.xml");
+			assertThat(this.loggingSystem.getStandardConfigLocations()).containsExactly("log4j2-test.properties",
+					"log4j2-test.xml", "log4j2.properties", "log4j2.xml", "custom-log4j2.properties");
 		}
 		finally {
 			System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);


### PR DESCRIPTION
This PR fixes `Log4J2LoggingSystemTests.configLocationsWithConfigurationFileSystemProperty()` as one of its assertion targets seems to be missing.

See gh-32730