### PR TITLE
@Bean methods in KafkaAutoConfiguration provide less type information than they could

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfiguration.java
@@ -74,14 +74,14 @@ public class KafkaAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(ProducerListener.class)
-	public ProducerListener<Object, Object> kafkaProducerListener() {
+	@ConditionalOnMissingBean(LoggingProducerListener.class)
+	public LoggingProducerListener<Object, Object> kafkaProducerListener() {
 		return new LoggingProducerListener<>();
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(ConsumerFactory.class)
-	public ConsumerFactory<?, ?> kafkaConsumerFactory(
+	@ConditionalOnMissingBean(DefaultKafkaConsumerFactory.class)
+	public DefaultKafkaConsumerFactory<?, ?> kafkaConsumerFactory(
 			ObjectProvider<DefaultKafkaConsumerFactoryCustomizer> customizers) {
 		DefaultKafkaConsumerFactory<Object, Object> factory = new DefaultKafkaConsumerFactory<>(
 				this.properties.buildConsumerProperties());
@@ -90,8 +90,8 @@ public class KafkaAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(ProducerFactory.class)
-	public ProducerFactory<?, ?> kafkaProducerFactory(
+	@ConditionalOnMissingBean(DefaultKafkaProducerFactory.class)
+	public DefaultKafkaProducerFactory<?, ?> kafkaProducerFactory(
 			ObjectProvider<DefaultKafkaProducerFactoryCustomizer> customizers) {
 		DefaultKafkaProducerFactory<?, ?> factory = new DefaultKafkaProducerFactory<>(
 				this.properties.buildProducerProperties());


### PR DESCRIPTION
As pointed out by @maciejwalkowiak in #32763, there are a number of `@Bean` methods in `KafkaAutoConfiguration` where the return type isn't as specific as it could be. For example, `kafkaConsumerFactory` always returns a `DefaultKafkaConsumerFactory` but its return type is only `ConsumerFactory`.

See #32766