### PR TITLE
Add missing @Test to ConfigurationPropertiesReportEndpointTests.sanitizeLists()

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointTests.java
@@ -189,6 +189,7 @@ class ConfigurationPropertiesReportEndpointTests {
 						}));
 	}
 
+	@Test
 	void sanitizeLists() {
 		new ApplicationContextRunner()
 				.withUserConfiguration(EndpointConfigWithShowNever.class, SensiblePropertiesConfiguration.class)


### PR DESCRIPTION
This PR adds a missing `@Test` to the `ConfigurationPropertiesReportEndpointTests.sanitizeLists()`.