### PR TITLE
Handle null currentSpan() in LazyTracingSpanContextSupplier consistently

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/exemplars/ExemplarsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/exemplars/ExemplarsAutoConfiguration.java
@@ -67,12 +67,14 @@ public class ExemplarsAutoConfiguration {
 
 		@Override
 		public String getTraceId() {
-			return currentSpan().context().traceId();
+			Span currentSpan = currentSpan();
+			return (currentSpan != null) ? currentSpan.context().traceId() : null;
 		}
 
 		@Override
 		public String getSpanId() {
-			return currentSpan().context().spanId();
+			Span currentSpan = currentSpan();
+			return (currentSpan != null) ? currentSpan.context().spanId() : null;
 		}
 
 		@Override


### PR DESCRIPTION
This PR changes to handle `null` `currentSpan()` in the `LazyTracingSpanContextSupplier` consistently.