### PR TITLE
Provide a workaround to allow multiple @ImportRuntimeHints

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/reactive/WebFluxEndpointHandlerMapping.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/reactive/WebFluxEndpointHandlerMapping.java
@@ -39,6 +39,8 @@ import org.springframework.web.reactive.HandlerMapping;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import static org.springframework.boot.actuate.endpoint.web.reactive.AbstractWebFluxEndpointHandlerMapping.*;
+
 /**
  * A custom {@link HandlerMapping} that makes web endpoints available over HTTP using
  * Spring WebFlux.
@@ -48,7 +50,8 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @author Brian Clozel
  * @since 2.0.0
  */
-@ImportRuntimeHints(WebFluxEndpointHandlerMappingRuntimeHints.class)
+@ImportRuntimeHints({ WebFluxEndpointHandlerMappingRuntimeHints.class,
+		AbstractWebFluxEndpointHandlerMappingRuntimeHints.class })
 public class WebFluxEndpointHandlerMapping extends AbstractWebFluxEndpointHandlerMapping implements InitializingBean {
 
 	private final EndpointLinksResolver linksResolver;

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcEndpointHandlerMapping.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/servlet/WebMvcEndpointHandlerMapping.java
@@ -39,6 +39,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.servlet.HandlerMapping;
 
+import static org.springframework.boot.actuate.endpoint.web.servlet.AbstractWebMvcEndpointHandlerMapping.*;
+
 /**
  * A custom {@link HandlerMapping} that makes web endpoints available over HTTP using
  * Spring MVC.
@@ -47,7 +49,8 @@ import org.springframework.web.servlet.HandlerMapping;
  * @author Phillip Webb
  * @since 2.0.0
  */
-@ImportRuntimeHints(WebMvcEndpointHandlerMappingRuntimeHints.class)
+@ImportRuntimeHints({ WebMvcEndpointHandlerMappingRuntimeHints.class,
+		AbstractWebMvcEndpointHandlerMappingRuntimeHints.class })
 public class WebMvcEndpointHandlerMapping extends AbstractWebMvcEndpointHandlerMapping {
 
 	private final EndpointLinksResolver linksResolver;


### PR DESCRIPTION
This commit provides a workaround for spring-projects/spring-framework#29361 that should cover Actuator web end point use cases (exception Cloud Foundry one not possible due to package access issue).