### PR TITLE
Wavefront application tags differ from those used in a Spring Boot 2.x application

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfiguration.java
@@ -77,7 +77,6 @@ public class WavefrontMetricsExportAutoConfiguration {
 
 	@Bean
 	@ConditionalOnBean(ApplicationTags.class)
-	@ConditionalOnClass(MeterRegistryCustomizer.class)
 	MeterRegistryCustomizer<WavefrontMeterRegistry> applicationTagsCustomizer(ApplicationTags applicationTags) {
 		Tags commonTags = Tags.of(applicationTags.toPointTags().entrySet().stream()
 				.map(WavefrontMetricsExportAutoConfiguration::asTag).toList());

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfiguration.java
@@ -16,12 +16,18 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.wavefront;
 
+import java.util.Map;
+
 import com.wavefront.sdk.common.WavefrontSender;
+import com.wavefront.sdk.common.application.ApplicationTags;
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.wavefront.WavefrontConfig;
 import io.micrometer.wavefront.WavefrontMeterRegistry;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.ConditionalOnEnabledMetricsExport;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
@@ -42,6 +48,7 @@ import org.springframework.context.annotation.Import;
  * @author Jon Schneider
  * @author Artsiom Yudovin
  * @author Stephane Nicoll
+ * @author Glenn Oppegard
  * @since 2.0.0
  */
 @AutoConfiguration(
@@ -66,6 +73,19 @@ public class WavefrontMetricsExportAutoConfiguration {
 	public WavefrontMeterRegistry wavefrontMeterRegistry(WavefrontConfig wavefrontConfig, Clock clock,
 			WavefrontSender wavefrontSender) {
 		return WavefrontMeterRegistry.builder(wavefrontConfig).clock(clock).wavefrontSender(wavefrontSender).build();
+	}
+
+	@Bean
+	@ConditionalOnBean(ApplicationTags.class)
+	@ConditionalOnClass(MeterRegistryCustomizer.class)
+	MeterRegistryCustomizer<WavefrontMeterRegistry> applicationTagsCustomizer(ApplicationTags applicationTags) {
+		Tags commonTags = Tags.of(applicationTags.toPointTags().entrySet().stream()
+				.map(WavefrontMetricsExportAutoConfiguration::asTag).toList());
+		return (registry) -> registry.config().commonTags(commonTags);
+	}
+
+	private static Tag asTag(Map.Entry<String, String> entry) {
+		return Tag.of(entry.getKey(), entry.getValue());
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/wavefront/WavefrontTracingAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/wavefront/WavefrontTracingAutoConfiguration.java
@@ -61,22 +61,29 @@ public class WavefrontTracingAutoConfiguration {
 
 	/**
 	 * Default value for the Wavefront Application name.
-	 * @see <a href="https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront Application Tags</a>
+	 * @see <a href=
+	 * "https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront
+	 * Application Tags</a>
 	 */
 	private static final String DEFAULT_WAVEFRONT_APPLICATION_NAME = "unnamed_application";
 
 	/**
-	 * Default value for the Wavefront Service name if {@code spring.application.name} is not set.
-	 * @see <a href="https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront Application Tags</a>
+	 * Default value for the Wavefront Service name if {@code spring.application.name} is
+	 * not set.
+	 * @see <a href=
+	 * "https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront
+	 * Application Tags</a>
 	 */
 	private static final String DEFAULT_WAVEFRONT_SERVICE_NAME = "unnamed_service";
 
 	@Bean
 	@ConditionalOnMissingBean
 	public ApplicationTags applicationTags(Environment environment, WavefrontProperties properties) {
-		String fallbackWavefrontServiceName = environment.getProperty("spring.application.name", DEFAULT_WAVEFRONT_SERVICE_NAME);
+		String fallbackWavefrontServiceName = environment.getProperty("spring.application.name",
+				DEFAULT_WAVEFRONT_SERVICE_NAME);
 		Tracing tracing = properties.getTracing();
-		String wavefrontServiceName = (tracing.getServiceName() != null) ? tracing.getServiceName() : fallbackWavefrontServiceName;
+		String wavefrontServiceName = (tracing.getServiceName() != null) ? tracing.getServiceName()
+				: fallbackWavefrontServiceName;
 		String wavefrontApplicationName = (tracing.getApplicationName() != null) ? tracing.getApplicationName()
 				: DEFAULT_WAVEFRONT_APPLICATION_NAME;
 		ApplicationTags.Builder builder = new ApplicationTags.Builder(wavefrontApplicationName, wavefrontServiceName);

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/wavefront/WavefrontTracingAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/wavefront/WavefrontTracingAutoConfiguration.java
@@ -59,22 +59,27 @@ import org.springframework.core.env.Environment;
 @ConditionalOnEnabledTracing
 public class WavefrontTracingAutoConfiguration {
 
-	private static final String DEFAULT_APPLICATION_NAME = "unnamed_application";
+	/**
+	 * Default value for the Wavefront Application name.
+	 * @see <a href="https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront Application Tags</a>
+	 */
+	private static final String DEFAULT_WAVEFRONT_APPLICATION_NAME = "unnamed_application";
 
 	/**
-	 * Default value for service name if {@code spring.application.name} is not set.
+	 * Default value for the Wavefront Service name if {@code spring.application.name} is not set.
+	 * @see <a href="https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront Application Tags</a>
 	 */
-	private static final String DEFAULT_SERVICE_NAME = "unnamed_service";
+	private static final String DEFAULT_WAVEFRONT_SERVICE_NAME = "unnamed_service";
 
 	@Bean
 	@ConditionalOnMissingBean
 	public ApplicationTags applicationTags(Environment environment, WavefrontProperties properties) {
-		String fallbackServiceName = environment.getProperty("spring.application.name", DEFAULT_SERVICE_NAME);
+		String fallbackWavefrontServiceName = environment.getProperty("spring.application.name", DEFAULT_WAVEFRONT_SERVICE_NAME);
 		Tracing tracing = properties.getTracing();
-		String serviceName = (tracing.getServiceName() != null) ? tracing.getServiceName() : fallbackServiceName;
-		String applicationName = (tracing.getApplicationName() != null) ? tracing.getApplicationName()
-				: DEFAULT_APPLICATION_NAME;
-		ApplicationTags.Builder builder = new ApplicationTags.Builder(applicationName, serviceName);
+		String wavefrontServiceName = (tracing.getServiceName() != null) ? tracing.getServiceName() : fallbackWavefrontServiceName;
+		String wavefrontApplicationName = (tracing.getApplicationName() != null) ? tracing.getApplicationName()
+				: DEFAULT_WAVEFRONT_APPLICATION_NAME;
+		ApplicationTags.Builder builder = new ApplicationTags.Builder(wavefrontApplicationName, wavefrontServiceName);
 		if (tracing.getClusterName() != null) {
 			builder.cluster(tracing.getClusterName());
 		}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/wavefront/WavefrontProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/wavefront/WavefrontProperties.java
@@ -21,6 +21,8 @@ import java.net.URI;
 import java.net.UnknownHostException;
 import java.time.Duration;
 
+import com.wavefront.sdk.common.application.ApplicationTags;
+
 import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.PushRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
@@ -30,6 +32,7 @@ import org.springframework.util.unit.DataSize;
  * Configuration properties to configure Wavefront.
  *
  * @author Moritz Halbritter
+ * @author Glenn Oppegard
  * @since 3.0.0
  */
 @ConfigurationProperties(prefix = "management.wavefront")
@@ -261,14 +264,27 @@ public class WavefrontProperties {
 	public static class Tracing {
 
 		/**
-		 * Application name. Defaults to 'spring.application.name'.
+		 * Application name used in {@link ApplicationTags}. Defaults to
+		 * 'unnamed_application'.
 		 */
 		private String applicationName;
 
 		/**
-		 * Service name. Defaults to 'spring.application.name'.
+		 * Service name used in {@link ApplicationTags}, falling back to
+		 * {@code spring.application.name}. If both are unset it defaults to
+		 * 'unnamed_service'.
 		 */
 		private String serviceName;
+
+		/**
+		 * Optional cluster name used in {@link ApplicationTags}.
+		 */
+		private String clusterName;
+
+		/**
+		 * Optional shard name used in {@link ApplicationTags}.
+		 */
+		private String shardName;
 
 		public String getServiceName() {
 			return this.serviceName;
@@ -284,6 +300,22 @@ public class WavefrontProperties {
 
 		public void setApplicationName(String applicationName) {
 			this.applicationName = applicationName;
+		}
+
+		public String getClusterName() {
+			return this.clusterName;
+		}
+
+		public void setClusterName(String clusterName) {
+			this.clusterName = clusterName;
+		}
+
+		public String getShardName() {
+			return this.shardName;
+		}
+
+		public void setShardName(String shardName) {
+			this.shardName = shardName;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/wavefront/WavefrontProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/wavefront/WavefrontProperties.java
@@ -264,25 +264,29 @@ public class WavefrontProperties {
 	public static class Tracing {
 
 		/**
-		 * Application name used in {@link ApplicationTags}. Defaults to
+		 * Wavefront Application name used in {@link ApplicationTags}. Defaults to
 		 * 'unnamed_application'.
+		 * @see <a href="https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront Application Tags</a>
 		 */
 		private String applicationName;
 
 		/**
-		 * Service name used in {@link ApplicationTags}, falling back to
+		 * Wavefront Service name used in {@link ApplicationTags}, falling back to
 		 * {@code spring.application.name}. If both are unset it defaults to
 		 * 'unnamed_service'.
+		 * @see <a href="https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront Application Tags</a>
 		 */
 		private String serviceName;
 
 		/**
-		 * Optional cluster name used in {@link ApplicationTags}.
+		 * Optional Wavefront Cluster name used in {@link ApplicationTags}.
+		 * @see <a href="https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront Application Tags</a>
 		 */
 		private String clusterName;
 
 		/**
-		 * Optional shard name used in {@link ApplicationTags}.
+		 * Optional Wavefront Shard name used in {@link ApplicationTags}.
+		 * @see <a href="https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront Application Tags</a>
 		 */
 		private String shardName;
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/wavefront/WavefrontProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/wavefront/WavefrontProperties.java
@@ -266,7 +266,9 @@ public class WavefrontProperties {
 		/**
 		 * Wavefront Application name used in {@link ApplicationTags}. Defaults to
 		 * 'unnamed_application'.
-		 * @see <a href="https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront Application Tags</a>
+		 * @see <a href=
+		 * "https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront
+		 * Application Tags</a>
 		 */
 		private String applicationName;
 
@@ -274,19 +276,25 @@ public class WavefrontProperties {
 		 * Wavefront Service name used in {@link ApplicationTags}, falling back to
 		 * {@code spring.application.name}. If both are unset it defaults to
 		 * 'unnamed_service'.
-		 * @see <a href="https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront Application Tags</a>
+		 * @see <a href=
+		 * "https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront
+		 * Application Tags</a>
 		 */
 		private String serviceName;
 
 		/**
 		 * Optional Wavefront Cluster name used in {@link ApplicationTags}.
-		 * @see <a href="https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront Application Tags</a>
+		 * @see <a href=
+		 * "https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront
+		 * Application Tags</a>
 		 */
 		private String clusterName;
 
 		/**
 		 * Optional Wavefront Shard name used in {@link ApplicationTags}.
-		 * @see <a href="https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront Application Tags</a>
+		 * @see <a href=
+		 * "https://docs.wavefront.com/trace_data_details.html#application-tags">Wavefront
+		 * Application Tags</a>
 		 */
 		private String shardName;
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfigurationTests.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import com.wavefront.sdk.common.WavefrontSender;
 import com.wavefront.sdk.common.application.ApplicationTags;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.wavefront.WavefrontConfig;
 import io.micrometer.wavefront.WavefrontMeterRegistry;

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/wavefront/WavefrontMetricsExportAutoConfigurationTests.java
@@ -16,12 +16,17 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.wavefront;
 
+import java.util.Map;
+
 import com.wavefront.sdk.common.WavefrontSender;
+import com.wavefront.sdk.common.application.ApplicationTags;
+
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.wavefront.WavefrontConfig;
 import io.micrometer.wavefront.WavefrontMeterRegistry;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -36,6 +41,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Jon Schneider
  * @author Stephane Nicoll
+ * @author Glenn Oppegard
  */
 class WavefrontMetricsExportAutoConfigurationTests {
 
@@ -79,6 +85,24 @@ class WavefrontMetricsExportAutoConfigurationTests {
 				.withPropertyValues("management.wavefront.api-token=abcde")
 				.run((context) -> assertThat(context).hasSingleBean(Clock.class).hasSingleBean(WavefrontConfig.class)
 						.hasSingleBean(WavefrontMeterRegistry.class).hasBean("customRegistry"));
+	}
+
+	@Test
+	void exportsApplicationTagsInWavefrontRegistry() {
+		ApplicationTags.Builder appTagsBuilder = new ApplicationTags.Builder("super-application", "super-service");
+		appTagsBuilder.cluster("super-cluster");
+		appTagsBuilder.shard("super-shard");
+		appTagsBuilder.customTags(Map.of("custom-key", "custom-val"));
+
+		this.contextRunner.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class))
+				.withUserConfiguration(BaseConfiguration.class).withBean(ApplicationTags.class, appTagsBuilder::build)
+				.run((context) -> {
+					WavefrontMeterRegistry registry = context.getBean(WavefrontMeterRegistry.class);
+					registry.counter("my.counter", "env", "qa");
+					assertThat(registry.find("my.counter").tags("env", "qa").tags("application", "super-application")
+							.tags("service", "super-service").tags("cluster", "super-cluster")
+							.tags("shard", "super-shard").tags("custom-key", "custom-val").counter()).isNotNull();
+				});
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/wavefront/WavefrontTracingAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/wavefront/WavefrontTracingAutoConfigurationTests.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link WavefrontTracingAutoConfiguration}.
  *
  * @author Moritz Halbritter
+ * @author Glenn Oppegard
  */
 class WavefrontTracingAutoConfigurationTests {
 
@@ -114,22 +115,40 @@ class WavefrontTracingAutoConfigurationTests {
 	}
 
 	@Test
-	void shouldHaveADefaultApplicationName() {
+	void shouldHaveADefaultApplicationNameAndServiceName() {
 		this.contextRunner.withUserConfiguration(WavefrontSenderConfiguration.class).run((context) -> {
 			ApplicationTags applicationTags = context.getBean(ApplicationTags.class);
-			assertThat(applicationTags.getApplication()).isEqualTo("application");
+			assertThat(applicationTags.getApplication()).isEqualTo("unnamed_application");
+			assertThat(applicationTags.getService()).isEqualTo("unnamed_service");
+			assertThat(applicationTags.getCluster()).isNull();
+			assertThat(applicationTags.getShard()).isNull();
 		});
+	}
+
+	@Test
+	void shouldUseSpringApplicationNameForServiceName() {
+		this.contextRunner.withUserConfiguration(WavefrontSenderConfiguration.class)
+				.withPropertyValues("spring.application.name=super-service").run((context) -> {
+					ApplicationTags applicationTags = context.getBean(ApplicationTags.class);
+					assertThat(applicationTags.getApplication()).isEqualTo("unnamed_application");
+					assertThat(applicationTags.getService()).isEqualTo("super-service");
+				});
 	}
 
 	@Test
 	void shouldHonorConfigProperties() {
 		this.contextRunner.withUserConfiguration(WavefrontSenderConfiguration.class)
-				.withPropertyValues("spring.application.name=super-application",
-						"management.wavefront.tracing.service-name=super-service")
+				.withPropertyValues("spring.application.name=ignored",
+						"management.wavefront.tracing.application-name=super-application",
+						"management.wavefront.tracing.service-name=super-service",
+						"management.wavefront.tracing.cluster-name=super-cluster",
+						"management.wavefront.tracing.shard-name=super-shard")
 				.run((context) -> {
 					ApplicationTags applicationTags = context.getBean(ApplicationTags.class);
 					assertThat(applicationTags.getApplication()).isEqualTo("super-application");
 					assertThat(applicationTags.getService()).isEqualTo("super-service");
+					assertThat(applicationTags.getCluster()).isEqualTo("super-cluster");
+					assertThat(applicationTags.getShard()).isEqualTo("super-shard");
 				});
 	}
 


### PR DESCRIPTION
This PR fleshes out the use of Wavefront [Application Tags](https://docs.wavefront.com/trace_data_details.html#application-tags), used in Wavefront to organize a service within a larger distributed application.

- **application** (required): this is the name of a distributed application comprised of multiple microservices (not to be confused with an individual service, below).
- **service** (required): this is the name of the current service that is part of the larger application. It will use `spring.application.name` if available.
- **cluster** (optional)
- **shard** (optional)

This PR add two new properties: 
- `management.wavefront.tracing.cluster-name`
- `management.wavefront.tracing.shard-name`

In wavefront-spring-boot [these properties](https://github.com/wavefrontHQ/wavefront-spring-boot/blob/master/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/ApplicationTagsFactory.java#L22) were `wavefront.application.cluster` and `wavefront.application.shard`. I'm not sure if there's a way to migrate users of the old properties (same goes for `wavefront.application.name` and `wavefront.application.service`).

This PR also adds Application Tags to metrics exported by instances of `WavefrontMeterRegistry`, replacing [functionality](https://github.com/wavefrontHQ/wavefront-spring-boot/blob/master/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontMetricsConfiguration.java#L51-L56) from wavefront-spring-boot.