### PR TITLE
Add Nomad to cloud platforms

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
@@ -86,6 +86,18 @@ public enum CloudPlatform {
 	},
 
 	/**
+	 * Nomad platform.
+	 */
+	NOMAD {
+
+		@Override
+		public boolean isDetected(Environment environment) {
+			return environment.containsProperty("NOMAD_ALLOC_ID");
+		}
+
+	},
+
+	/**
 	 * Kubernetes platform.
 	 */
 	KUBERNETES {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
@@ -87,6 +87,14 @@ class CloudPlatformTests {
 	}
 
 	@Test
+	void getActiveWhenHasNomadAllocIdShouldReturnNomad() {
+		Environment environment = new MockEnvironment().withProperty("NOMAD_ALLOC_ID", "---");
+		CloudPlatform platform = CloudPlatform.getActive(environment);
+		assertThat(platform).isEqualTo(CloudPlatform.NOMAD);
+		assertThat(platform.isActive(environment)).isTrue();
+	}
+
+	@Test
 	void getActiveWhenHasKubernetesServiceHostAndPortShouldReturnKubernetes() {
 		Map<String, Object> envVars = new HashMap<>();
 		envVars.put("KUBERNETES_SERVICE_HOST", "---");


### PR DESCRIPTION
This PR adds support for detecting Nomad as cloud platform. I added this so I can add Nomad-specific configuration with:

```
spring.config.activate.on-cloud-platform=nomad
```