### PR TITLE
OTel W3C doesn't propagate remote fields

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java
@@ -195,9 +195,11 @@ public class OpenTelemetryAutoConfiguration {
 		@Bean
 		@ConditionalOnProperty(prefix = "management.tracing.propagation", name = "type", havingValue = "W3C",
 				matchIfMissing = true)
-		TextMapPropagator w3cTextMapPropagatorWithBaggage() {
+		TextMapPropagator w3cTextMapPropagatorWithBaggage(OtelCurrentTraceContext otelCurrentTraceContext) {
+			List<String> remoteFields = this.tracingProperties.getBaggage().getRemoteFields();
 			return TextMapPropagator.composite(W3CTraceContextPropagator.getInstance(),
-					W3CBaggagePropagator.getInstance());
+					W3CBaggagePropagator.getInstance(), new BaggageTextMapPropagator(remoteFields,
+							new OtelBaggageManager(otelCurrentTraceContext, remoteFields, Collections.emptyList())));
 		}
 
 		@Bean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfigurationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.tracing;
 
+import java.util.Collection;
 import java.util.List;
 
 import io.micrometer.tracing.otel.bridge.OtelCurrentTraceContext;
@@ -182,7 +183,17 @@ class OpenTelemetryAutoConfigurationTests {
 
 	@Test
 	void shouldSupplyW3CPropagationWithBaggageByDefault() {
-		this.contextRunner.run((context) -> assertThat(context).hasBean("w3cTextMapPropagatorWithBaggage"));
+		this.contextRunner.withPropertyValues("management.tracing.baggage.remote-fields=foo").run((context) -> {
+			assertThat(context).hasBean("w3cTextMapPropagatorWithBaggage");
+			Collection<String> allFields = context.getBean("w3cTextMapPropagatorWithBaggage", TextMapPropagator.class)
+					.fields();
+			assertThat(allFields).containsExactly("traceparent", "tracestate", "baggage", "foo"); // order
+																									// matters,
+																									// foo
+																									// must
+																									// be
+																									// last!
+		});
 	}
 
 	@Test


### PR DESCRIPTION
without this change we're missing the BaggageTextMapPropagator for OTel. This means that we're not propagating remote-fields (only baggage via the 'baggage' field).

with this change we're adding the missing propagator as THE LAST entry in the composite TextMapPropagator. It has to be last cause with the latest Snapshots of Micrometer Tracing it will append the remote field baggage to existing baggage in the Context extracted via the W3CBaggagePropagator.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
