### PR TITLE
Spring Boot's Lettuce metrics enable histrograms by default and it's hard to switch them off

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsProperties.java
@@ -67,6 +67,8 @@ public class MetricsProperties {
 
 	private final Distribution distribution = new Distribution();
 
+	private final Lettuce lettuce = new Lettuce();
+
 	public boolean isUseGlobalRegistry() {
 		return this.useGlobalRegistry;
 	}
@@ -97,6 +99,10 @@ public class MetricsProperties {
 
 	public Distribution getDistribution() {
 		return this.distribution;
+	}
+
+	public Lettuce getLettuce() {
+		return this.lettuce;
 	}
 
 	public static class Web {
@@ -351,6 +357,23 @@ public class MetricsProperties {
 
 		public Map<String, Integer> getBufferLength() {
 			return this.bufferLength;
+		}
+
+	}
+
+	public static class Lettuce {
+
+		/**
+		 * Whether histogram buckets should be recorded.
+		 */
+		private boolean histogram;
+
+		public boolean isHistogram() {
+			return this.histogram;
+		}
+
+		public void setHistogram(boolean histogram) {
+			this.histogram = histogram;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/redis/LettuceMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/redis/LettuceMetricsAutoConfiguration.java
@@ -23,11 +23,13 @@ import io.micrometer.core.instrument.MeterRegistry;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.data.redis.ClientResourcesBuilderCustomizer;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
 /**
@@ -41,11 +43,19 @@ import org.springframework.context.annotation.Bean;
 		after = { MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class })
 @ConditionalOnClass({ RedisClient.class, MicrometerCommandLatencyRecorder.class })
 @ConditionalOnBean(MeterRegistry.class)
+@EnableConfigurationProperties(MetricsProperties.class)
 public class LettuceMetricsAutoConfiguration {
+
+	private final MetricsProperties properties;
+
+	public LettuceMetricsAutoConfiguration(MetricsProperties properties) {
+		this.properties = properties;
+	}
 
 	@Bean
 	public ClientResourcesBuilderCustomizer lettuceMetrics(MeterRegistry meterRegistry) {
-		MicrometerOptions options = MicrometerOptions.builder().histogram(true).build();
+		MicrometerOptions options = MicrometerOptions.builder().histogram(this.properties.getLettuce().isHistogram())
+				.build();
 		return (client) -> client.commandLatencyRecorder(new MicrometerCommandLatencyRecorder(meterRegistry, options));
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
@@ -1168,6 +1168,15 @@ Long task timers require a separate metric name and can be stacked with a short 
 ==== Redis Metrics
 Auto-configuration registers a `MicrometerCommandLatencyRecorder` for the auto-configured `LettuceConnectionFactory`.
 For more detail, see the {lettuce-docs}#command.latency.metrics.micrometer[Micrometer Metrics section] of the Lettuce documentation.
+By default, the `MicrometerCommandLatencyRecorder` records no histogram data, but you can enable this via:
+
+[source,yaml,indent=0,subs="verbatim",configprops,configblocks]
+----
+	management:
+	  metrics:
+	    lettuce:
+	      histogram: true
+----
 
 
 


### PR DESCRIPTION
Hi,

I recently noticed that our Spring based applications publish a lot of metrics and traced this back to the `lettuce` metrics taking a large portion of up to 50-60%. (E.g ~7800 of ~14800 metrics on a single app server that go over the wire are just generated by this within 60 seconds)

```
prefix.lettuce.command.completion.percentile.command.CLIENT.local.local:any.phi.0.5.remote....
prefix.lettuce.command.completion.percentile.command.CLIENT.local.local:any.phi.0.5.remote....
prefix.lettuce.command.completion.percentile.command.CLIENT.local.local:any.phi.0.5.remote....
prefix.lettuce.command.completion.percentile.command.CLIENT.local.local:any.phi.0.5.remote....
prefix.lettuce.command.completion.percentile.command.CLIENT.local.local:any.phi.0.5.remote....
prefix.lettuce.command.completion.percentile.command.CLIENT.local.local:any.phi.0.5.remote.... 
```
The list goes on and on with the different percentiles and their respective histogram data for the various commands. (I've stripped the IPs and actual values btw. but I hope it's clear nonetheless)

#27865 added the metrics autoconfiguration for Lettuce. Unfortunately, with the `histogram` option being set to `true` which is not in line with the default from [Lettuce](https://lettuce.io/core/release/reference/#command.latency.metrics.micrometer-options).

This PR adds the option to enable the `histogram` on demand and aligns the default value to `false`. Given that this breaks behaviour it's probably something for 3.x, but I could imagine seeing a backport to 2.7.x where the default is simply set to `true` in the new `MetricsProperties$Lettuce` class. A backport would be at least highly appreciated.

Let me know what you think.
Cheers,
Christoph
