### PR TITLE
Fix possible type pollution in ConditionEvaluationReport

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionEvaluationReport.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionEvaluationReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import java.util.TreeMap;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
@@ -65,7 +64,7 @@ public final class ConditionEvaluationReport {
 
 	/**
 	 * Private constructor.
-	 * @see #get(ConfigurableListableBeanFactory)
+	 * @see #get(ConfigurableBeanFactory)
 	 */
 	private ConditionEvaluationReport() {
 	}
@@ -168,7 +167,7 @@ public final class ConditionEvaluationReport {
 	 */
 	public static ConditionEvaluationReport find(BeanFactory beanFactory) {
 		if (beanFactory != null && beanFactory instanceof ConfigurableBeanFactory) {
-			return ConditionEvaluationReport.get((ConfigurableListableBeanFactory) beanFactory);
+			return ConditionEvaluationReport.get((ConfigurableBeanFactory) beanFactory);
 		}
 		return null;
 	}
@@ -178,7 +177,7 @@ public final class ConditionEvaluationReport {
 	 * @param beanFactory the bean factory
 	 * @return an existing or new {@link ConditionEvaluationReport}
 	 */
-	public static ConditionEvaluationReport get(ConfigurableListableBeanFactory beanFactory) {
+	public static ConditionEvaluationReport get(ConfigurableBeanFactory beanFactory) {
 		synchronized (beanFactory) {
 			ConditionEvaluationReport report;
 			if (beanFactory.containsSingleton(BEAN_NAME)) {


### PR DESCRIPTION
Hi,

I've been playing around with the https://github.com/RedHatPerf/type-pollution-agent from @franz1981 and found one case in Spring-Boot that caught my eye. On a vanilla app startup the output shows the following:

```
--------------------------
Type Pollution Statistics:
--------------------------
1:	org.springframework.beans.factory.support.DefaultListableBeanFactory
Count:	350
Types:
	org.springframework.beans.factory.config.ConfigurableListableBeanFactory
	org.springframework.beans.factory.config.ConfigurableBeanFactory
	org.springframework.beans.factory.BeanFactory
	org.springframework.beans.factory.HierarchicalBeanFactory
	org.springframework.beans.factory.ListableBeanFactory
	org.springframework.beans.factory.support.BeanDefinitionRegistry
	org.springframework.beans.factory.config.SingletonBeanRegistry
Traces:
	org.springframework.boot.autoconfigure.condition.ConditionEvaluationReport.find(ConditionEvaluationReport.java:171)
		class: org.springframework.beans.factory.config.ConfigurableListableBeanFactory
		count: 156
	org.springframework.boot.autoconfigure.condition.ConditionEvaluationReport.find(ConditionEvaluationReport.java:170)
		class: org.springframework.beans.factory.config.ConfigurableBeanFactory
		count: 150
```

On another much much bigger app of mine it's still TOP 13:
```
13:     org.springframework.beans.factory.support.DefaultListableBeanFactory
Count:  3795
Types:
        org.springframework.beans.factory.config.ConfigurableBeanFactory
        org.springframework.beans.factory.config.ConfigurableListableBeanFactory
        org.springframework.beans.factory.HierarchicalBeanFactory
        org.springframework.beans.factory.ListableBeanFactory
        org.springframework.beans.factory.BeanFactory
        org.springframework.beans.factory.support.BeanDefinitionRegistry
        org.springframework.beans.factory.config.AutowireCapableBeanFactory
        org.springframework.beans.factory.config.SingletonBeanRegistry
Traces:
        org.springframework.boot.autoconfigure.condition.ConditionEvaluationReport.find(ConditionEvaluationReport.java:171)
                class: org.springframework.beans.factory.config.ConfigurableListableBeanFactory
                count: 1635
        org.springframework.boot.autoconfigure.condition.ConditionEvaluationReport.find(ConditionEvaluationReport.java:170)
                class: org.springframework.beans.factory.config.ConfigurableBeanFactory
                count: 1566
```

Imho, the possible pollution here doesn't really matter in terms of performance and is neglectable. (At least I didn't see an improvement or regression in some measurements) What's weird about this is that `ConditionEvaluationReport.find` does an `instanceof` check on `ConfigurableBeanFactory` but casts to `ConfigurableListableBeanFactory`. The PR simply aligns the cast to `ConfigurableBeanFactory`. Everything that `ConditionEvaluationReport.get` internally needs seems to be satisfied with  `ConfigurableBeanFactory` at least, but since this changes a public method, we might want to go for the `instanceof` check on `ConfigurableListableBeanFactory` instead.

Let me know what you think.
Cheers,
Christoph