### PR TITLE
Upgrade CI image update detection to Ubuntu Jammy

### DIFF
--- a/ci/scripts/detect-ubuntu-image-updates.sh
+++ b/ci/scripts/detect-ubuntu-image-updates.sh
@@ -2,7 +2,7 @@
 
 ISSUE_TITLE="Upgrade Ubuntu version in CI images"
 
-ubuntu="focal"
+ubuntu="jammy"
 latest=$( curl -s "https://hub.docker.com/v2/repositories/library/ubuntu/tags/?page_size=1&page=1&name=$ubuntu" | jq -c -r '.results[0].name' | awk '{split($0, parts, "-"); print parts[2]}' )
 current=$( grep "ubuntu:$ubuntu" git-repo/ci/images/ci-image/Dockerfile | awk '{split($0, parts, "-"); print parts[2]}' )
 


### PR DESCRIPTION
Hi,

this PR updates the `detect-ubuntu-image-updates.sh` script to check for updates on `Jammy` rather than `Focal`. The former is the LTS version since April 2022.

I didn't update the CI images on purpose since the script should pick this up, but let me know if I should directly do this.

Cheers,
Christoph