### PR TITLE
[Bug][Document] Fix a minor bug in an example in oauth2 doc

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/web/spring-security.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/web/spring-security.adoc
@@ -95,7 +95,7 @@ You can register multiple OAuth2 clients and providers under the `spring.securit
 	            scope: "user"
 	            redirect-uri: "https://my-redirect-uri.com"
 	            client-authentication-method: "basic"
-	            authorization-grant-type: "authorization-code"
+	            authorization-grant-type: "authorization_code"
 
 	          my-client-2:
 	            client-id: "abcd"


### PR DESCRIPTION
* Fix a minor bug in a code example in `OAuth2` doc. There is a typo in the code snippet shown in the screenshot below, `authorization-code` should be `authorization_code`. This minor bug may cause a developer to spend quite some time wondering why his / her `OAuth2` configuration does not work. 

![image](https://user-images.githubusercontent.com/34905992/199057163-101ae351-6c97-41b7-ad2d-92fd3a3c8d45.png)
