### PR TITLE
management.observations.http.server.requests.name is ignored when auto-configuring meter filters for maximum allowable uri tags

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfiguration.java
@@ -108,12 +108,15 @@ public class WebFluxObservationAutoConfiguration {
 
 		@Bean
 		@Order(0)
-		MeterFilter metricsHttpServerUriTagFilter(MetricsProperties properties) {
-			Server serverProperties = properties.getWeb().getServer();
-			String metricName = serverProperties.getRequest().getMetricName();
+		MeterFilter metricsHttpServerUriTagFilter(MetricsProperties metricsProperties,
+				ObservationProperties observationProperties) {
+			String observationName = observationProperties.getHttp().getServer().getRequests().getName();
+			Server metricsServerProperties = metricsProperties.getWeb().getServer();
+			String metricName = metricsServerProperties.getRequest().getMetricName();
+			String name = (observationName != null) ? observationName : metricName;
 			MeterFilter filter = new OnlyOnceLoggingDenyMeterFilter(
-					() -> "Reached the maximum number of URI tags for '%s'.".formatted(metricName));
-			return MeterFilter.maximumAllowableTags(metricName, "uri", serverProperties.getMaxUriTags(), filter);
+					() -> "Reached the maximum number of URI tags for '%s'.".formatted(name));
+			return MeterFilter.maximumAllowableTags(name, "uri", metricsServerProperties.getMaxUriTags(), filter);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfiguration.java
@@ -108,11 +108,14 @@ public class WebMvcObservationAutoConfiguration {
 
 		@Bean
 		@Order(0)
-		MeterFilter metricsHttpServerUriTagFilter(MetricsProperties properties) {
-			String metricName = properties.getWeb().getServer().getRequest().getMetricName();
+		MeterFilter metricsHttpServerUriTagFilter(MetricsProperties metricsProperties,
+				ObservationProperties observationProperties) {
+			String observationName = observationProperties.getHttp().getServer().getRequests().getName();
+			String metricName = metricsProperties.getWeb().getServer().getRequest().getMetricName();
+			String name = (observationName != null) ? observationName : metricName;
 			MeterFilter filter = new OnlyOnceLoggingDenyMeterFilter(
-					() -> String.format("Reached the maximum number of URI tags for '%s'.", metricName));
-			return MeterFilter.maximumAllowableTags(metricName, "uri", properties.getWeb().getServer().getMaxUriTags(),
+					() -> String.format("Reached the maximum number of URI tags for '%s'.", name));
+			return MeterFilter.maximumAllowableTags(name, "uri", metricsProperties.getWeb().getServer().getMaxUriTags(),
 					filter);
 		}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfigurationTests.java
@@ -149,6 +149,34 @@ class WebMvcObservationAutoConfigurationTests {
 	}
 
 	@Test
+	void afterMaxUrisReachedFurtherUrisAreDeniedWhenUsingCustomMetricName(CapturedOutput output) {
+		this.contextRunner.withUserConfiguration(TestController.class)
+				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class,
+						ObservationAutoConfiguration.class, WebMvcAutoConfiguration.class))
+				.withPropertyValues("management.metrics.web.server.max-uri-tags=2",
+						"management.metrics.web.server.request.metric-name=my.http.server.requests")
+				.run((context) -> {
+					MeterRegistry registry = getInitializedMeterRegistry(context);
+					assertThat(registry.get("my.http.server.requests").meters().size()).isLessThanOrEqualTo(2);
+					assertThat(output).contains("Reached the maximum number of URI tags for 'my.http.server.requests'");
+				});
+	}
+
+	@Test
+	void afterMaxUrisReachedFurtherUrisAreDeniedWhenUsingCustomObservationName(CapturedOutput output) {
+		this.contextRunner.withUserConfiguration(TestController.class)
+				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class,
+						ObservationAutoConfiguration.class, WebMvcAutoConfiguration.class))
+				.withPropertyValues("management.metrics.web.server.max-uri-tags=2",
+						"management.observations.http.server.requests.name=my.http.server.requests")
+				.run((context) -> {
+					MeterRegistry registry = getInitializedMeterRegistry(context);
+					assertThat(registry.get("my.http.server.requests").meters().size()).isLessThanOrEqualTo(2);
+					assertThat(output).contains("Reached the maximum number of URI tags for 'my.http.server.requests'");
+				});
+	}
+
+	@Test
 	void shouldNotDenyNorLogIfMaxUrisIsNotReached(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestController.class)
 				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class,


### PR DESCRIPTION
This PR changes to handle custom observation name for HTTP server requests in max URI tag filters.