### PR TITLE
Favor `xmlunit-assertj3` instead of `xmlunit-assertj`

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1620,7 +1620,7 @@ bom {
 	library("XmlUnit2", "2.9.0") {
 		group("org.xmlunit") {
 			modules = [
-				"xmlunit-assertj",
+				"xmlunit-assertj3",
 				"xmlunit-core",
 				"xmlunit-legacy",
 				"xmlunit-matchers",


### PR DESCRIPTION
As an outcome of xmlunit/xmlunit#203, [`xmlunit-assertj3`](https://github.com/xmlunit/xmlunit/tree/main/xmlunit-assertj3) was created to better integrate with the AssertJ 3.x API (Java 8 based), while the existing [`xmlunit-assertj`](https://github.com/xmlunit/xmlunit/tree/main/xmlunit-assertj) remains compatible with AssertJ 2.x (Java 7 based and on maintenance mode).

Knowing that Spring Boot 2 was already requiring Java 8 as the minimum requirement, I think it would be a more sensible choice to include `xmlunit-assertj3`.