### PR TITLE
Add reflection hints for Tomcat 10.1

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
@@ -17,7 +17,9 @@
 package org.springframework.boot.web.embedded.tomcat;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -37,6 +39,10 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.naming.ContextBindings;
 
+import org.springframework.aot.hint.ExecutableMode;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
 import org.springframework.boot.web.server.GracefulShutdownCallback;
 import org.springframework.boot.web.server.GracefulShutdownResult;
 import org.springframework.boot.web.server.PortInUseException;
@@ -388,6 +394,28 @@ public class TomcatWebServer implements WebServer {
 			return;
 		}
 		this.gracefulShutdown.shutDownGracefully(callback);
+	}
+
+	/**
+	 * {@link RuntimeHintsRegistrar} that allows Tomcat protocol properties accessed
+	 * reflectively to be retrieved at runtime in a native image.
+	 */
+	static class TomcatWebServerRuntimeHints implements RuntimeHintsRegistrar {
+
+		@Override
+		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+			hints.reflection().registerTypeIfPresent(classLoader, "org.apache.coyote.AbstractProtocol",
+					(hint) -> hint.withMethod("setPort", List.of(TypeReference.of(int.class)), ExecutableMode.INVOKE)
+							.withMethod("setPortOffset", List.of(TypeReference.of(int.class)), ExecutableMode.INVOKE)
+							.withMethod("getPort", Collections.emptyList(), ExecutableMode.INVOKE)
+							.withMethod("getPortOffset", Collections.emptyList(), ExecutableMode.INVOKE)
+							.withMethod("getLocalPort", Collections.emptyList(), ExecutableMode.INVOKE))
+					.registerTypeIfPresent(classLoader, "org.apache.coyote.http11.AbstractHttp11Protocol",
+							(hint) -> hint.withMethod("setMaxSavePostSize", List.of(TypeReference.of(int.class)),
+									ExecutableMode.INVOKE).withMethod("setSecure",
+											List.of(TypeReference.of(boolean.class)), ExecutableMode.INVOKE));
+		}
+
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/spring/aot.factories
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/spring/aot.factories
@@ -9,6 +9,7 @@ org.springframework.boot.json.JacksonRuntimeHints,\
 org.springframework.boot.logging.java.JavaLoggingSystemRuntimeHints,\
 org.springframework.boot.logging.logback.LogbackRuntimeHints,\
 org.springframework.boot.web.client.ClientHttpRequestFactoriesRuntimeHints,\
+org.springframework.boot.web.embedded.tomcat.TomcatWebServer.TomcatWebServerRuntimeHints,\
 org.springframework.boot.web.embedded.undertow.UndertowWebServer.UndertowWebServerRuntimeHints,\
 org.springframework.boot.web.server.MimeMappings.MimeMappingsRuntimeHints
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServerRuntimeHintsTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServerRuntimeHintsTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.embedded.tomcat;
+
+import org.apache.coyote.AbstractProtocol;
+import org.apache.coyote.http11.AbstractHttp11Protocol;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link TomcatWebServer.TomcatWebServerRuntimeHints}.
+ *
+ * @author Sebastien Deleuze
+ */
+public class TomcatWebServerRuntimeHintsTests {
+
+	@Test
+	void registersHints() {
+		RuntimeHints runtimeHints = new RuntimeHints();
+		new TomcatWebServer.TomcatWebServerRuntimeHints().registerHints(runtimeHints, getClass().getClassLoader());
+		assertThat(RuntimeHintsPredicates.reflection().onMethod(AbstractProtocol.class, "setPort"))
+				.accepts(runtimeHints);
+		assertThat(RuntimeHintsPredicates.reflection().onMethod(AbstractProtocol.class, "setPortOffset"))
+				.accepts(runtimeHints);
+		assertThat(RuntimeHintsPredicates.reflection().onMethod(AbstractProtocol.class, "getPort"))
+				.accepts(runtimeHints);
+		assertThat(RuntimeHintsPredicates.reflection().onMethod(AbstractProtocol.class, "getPortOffset"))
+				.accepts(runtimeHints);
+		assertThat(RuntimeHintsPredicates.reflection().onMethod(AbstractProtocol.class, "getLocalPort"))
+				.accepts(runtimeHints);
+		assertThat(RuntimeHintsPredicates.reflection().onMethod(AbstractHttp11Protocol.class, "setMaxSavePostSize"))
+				.accepts(runtimeHints);
+		assertThat(RuntimeHintsPredicates.reflection().onMethod(AbstractHttp11Protocol.class, "setSecure"))
+				.accepts(runtimeHints);
+	}
+
+}


### PR DESCRIPTION
In Tomcat 10.0, reflection hints on `Http11AprProtocol` were registering hints on `AbstractProtocol` as a side effect.

Tomcat 10.1 removed this protocol and related hints, breaking `Http11NioProtocol` usage in Spring Boot.

This commit contributes reflection hints for protocol properties accessed reflectively from `org.apache.catalina.connector.Connector`.