### PR TITLE
docfix: kafka streams auto start description typo

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/messaging/kafka.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/messaging/kafka.adoc
@@ -67,7 +67,7 @@ To use the factory bean, wire `StreamsBuilder` into your `@Bean` as shown in the
 
 include::code:MyKafkaStreamsConfiguration[]
 
-By default, the streams managed by the `StreamBuilder` object it creates are started automatically.
+By default, the streams managed by the `StreamBuilder` object are started automatically.
 You can customize this behavior using the configprop:spring.kafka.streams.auto-startup[] property.
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
remove "it creates"  from "By default, the streams managed by the `StreamBuilder` object it creates are started automatically."