### PR TITLE
Provide a configuration property for the observation patterns of Spring Integration components

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfiguration.java
@@ -209,7 +209,8 @@ public class IntegrationAutoConfiguration {
 
 		@Configuration(proxyBeanMethods = false)
 		@EnableIntegrationManagement(
-				defaultLoggingEnabled = "${spring.integration.management.default-logging-enabled:true}")
+				defaultLoggingEnabled = "${spring.integration.management.default-logging-enabled:true}",
+				observationPatterns = "${spring.integration.management.observation-patterns:}")
 		protected static class EnableIntegrationManagementConfiguration {
 
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/integration/IntegrationProperties.java
@@ -416,12 +416,26 @@ public class IntegrationProperties {
 		 */
 		private boolean defaultLoggingEnabled = true;
 
+		/**
+		 * Comma-separated simple patterns to match integration components for observation
+		 * instrumentation.
+		 */
+		private List<String> observationPatterns = new ArrayList<>();
+
 		public boolean isDefaultLoggingEnabled() {
 			return this.defaultLoggingEnabled;
 		}
 
 		public void setDefaultLoggingEnabled(boolean defaultLoggingEnabled) {
 			this.defaultLoggingEnabled = defaultLoggingEnabled;
+		}
+
+		public List<String> getObservationPatterns() {
+			return this.observationPatterns;
+		}
+
+		public void setObservationPatterns(List<String> observationPatterns) {
+			this.observationPatterns = observationPatterns;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1379,7 +1379,7 @@ bom {
 			]
 		}
 	}
-	library("Spring Integration", "6.0.0-RC2") {
+	library("Spring Integration", "6.0.0-SNAPSHOT") {
 		group("org.springframework.integration") {
 			imports = [
 				"spring-integration-bom"


### PR DESCRIPTION
Spring Integration can instrument its component with an `Observation` according to the `@EnableIntegrationManagement.observationPatterns` value

* Expose `spring.integration.management.observation-patterns` configuration property
* Propagate this property into an `@EnableIntegrationManagement` in the `IntegrationAutoConfiguration.IntegrationManagementConfiguration`
* Verify that property has an effect via `IntegrationAutoConfigurationTests.integrationManagementInstrumentedWithObservation()`

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
