### PR TITLE
Use AntPathMatcher at AutoConfigurationImportSelector

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ImportAutoConfigurationImportSelector.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ImportAutoConfigurationImportSelector.java
@@ -150,10 +150,4 @@ class ImportAutoConfigurationImportSelector extends AutoConfigurationImportSelec
 	public int getOrder() {
 		return super.getOrder() - 1;
 	}
-
-	@Override
-	protected void handleInvalidExcludes(List<String> invalidExcludes) {
-		// Ignore for test
-	}
-
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelectorTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelectorTests.java
@@ -56,7 +56,7 @@ class AutoConfigurationImportSelectorTests {
 
 	private final MockEnvironment environment = new MockEnvironment();
 
-	private List<AutoConfigurationImportFilter> filters = new ArrayList<>();
+	private final List<AutoConfigurationImportFilter> filters = new ArrayList<>();
 
 	@BeforeEach
 	void setup() {
@@ -149,25 +149,6 @@ class AutoConfigurationImportSelectorTests {
 		assertThat(this.importSelector.getLastEvent().getExclusions()).contains(
 				FreeMarkerAutoConfiguration.class.getName(), MustacheAutoConfiguration.class.getName(),
 				ThymeleafAutoConfiguration.class.getName());
-	}
-
-	@Test
-	void nonAutoConfigurationClassExclusionsShouldThrowException() {
-		assertThatIllegalStateException()
-				.isThrownBy(() -> selectImports(EnableAutoConfigurationWithFaultyClassExclude.class));
-	}
-
-	@Test
-	void nonAutoConfigurationClassNameExclusionsWhenPresentOnClassPathShouldThrowException() {
-		assertThatIllegalStateException()
-				.isThrownBy(() -> selectImports(EnableAutoConfigurationWithFaultyClassNameExclude.class));
-	}
-
-	@Test
-	void nonAutoConfigurationPropertyExclusionsWhenPresentOnClassPathShouldThrowException() {
-		this.environment.setProperty("spring.autoconfigure.exclude",
-				"org.springframework.boot.autoconfigure.AutoConfigurationImportSelectorTests.TestConfiguration");
-		assertThatIllegalStateException().isThrownBy(() -> selectImports(BasicEnableAutoConfiguration.class));
 	}
 
 	@Test


### PR DESCRIPTION
Spring Boot *AutoConfiguration-classes exclusion management is actually a hell. Thanks to the `spring-boot-autoconfigure` module which is suited to be a `global` module for everything.

The issue that has motivated me to do such pull request is all the things that have been pulled up when I added `spring-boot-starter-data-r2dbc` and `org.jooq:jooq` dependencies. Adding these dependencies automatically triggers creation of `ConnectionFactory`, `TransactionManager`, repository support released beans, `JOOQ`' related `DSL` and `Configuration` beans creation. **BUT I was needed only to have `ConnectionFactory`!**.

I don't want to manage transactions through Spring. And I don't want Spring to create JOOQ related beans — I am going to manage them right in the business logic code using `DSL.using(connectionFactory). ...` API.

So I started to exclude these auto configurations manually.
My `main method` with `@SpringAutoConfiguration` annotation started to getting bigger on the almost fresh project. At another project it already has 15 `exclusionName` rules !
```
@SpringBootApplication(
    excludeName = [
        "org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration",
        "org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration",
        "org.springframework.boot.autoconfigure.r2dbc.R2dbcTransactionManagerAutoConfiguration",
        "org.springframework.boot.autoconfigure.jooq.JooqAutoConfiguration",
    ]
)
class SpringAutoconfigurePracticeApplication

fun main(args: Array<String>) {
    runApplication<SpringAutoconfigurePracticeApplication>(*args)
}
```

Comparing to Spring, Micronaut doesn't have such problem because configuration classes ship with features inside the same jar. Hence, if you don't need some configuration to apply or even to exist — just remove the jar from the classpath. 

I suggest to allow glob patterns in `excludeName` parameter to make this block shorter:
```
@SpringBootApplication(
    excludeName = [
        "org.springframework.boot.autoconfigure.flyway", // valid because exact path
        "org.springframework.boot.autoconfigure.r2dbc.*", // valid glob
        "org.springframework.boot.autoconfigure.jooq.**", // valid glob
    ]
)
class SpringAutoconfigurePracticeApplication

fun main(args: Array<String>) {
    runApplication<SpringAutoconfigurePracticeApplication>(*args)
}
```
