### PR TITLE
Refine `BackgroundPreinitializer` code reachability

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/BackgroundPreinitializer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/BackgroundPreinitializer.java
@@ -64,12 +64,8 @@ public class BackgroundPreinitializer implements ApplicationListener<SpringAppli
 
 	private static final CountDownLatch preinitializationComplete = new CountDownLatch(1);
 
-	private static final boolean ENABLED;
-
-	static {
-		ENABLED = !Boolean.getBoolean(IGNORE_BACKGROUNDPREINITIALIZER_PROPERTY_NAME) && !NativeDetector.inNativeImage()
-				&& Runtime.getRuntime().availableProcessors() > 1;
-	}
+	private static final boolean ENABLED = !Boolean.getBoolean(IGNORE_BACKGROUNDPREINITIALIZER_PROPERTY_NAME)
+			&& Runtime.getRuntime().availableProcessors() > 1;
 
 	@Override
 	public int getOrder() {
@@ -78,7 +74,7 @@ public class BackgroundPreinitializer implements ApplicationListener<SpringAppli
 
 	@Override
 	public void onApplicationEvent(SpringApplicationEvent event) {
-		if (!ENABLED) {
+		if (!ENABLED || NativeDetector.inNativeImage()) {
 			return;
 		}
 		if (event instanceof ApplicationEnvironmentPreparedEvent


### PR DESCRIPTION
GraalVM code reachability algorithm is not able to evaluate at build time that `ENABLED` static field is always false in a native image, shipping unreachable code.

Before this commit, building a native image with `-H:+PrintAnalysisCallTree` shows that the following methods are included:
- `BackgroundPreinitializer$1.<init>(BackgroundPreinitializer):void`
- `BackgroundPreinitializer$1.run():void`
- `BackgroundPreinitializer$1.runSafely(Runnable):void`
- `BackgroundPreinitializer$CharsetInitializer.run():void`
- `BackgroundPreinitializer$ConversionServiceInitializer.run():void`
- `BackgroundPreinitializer$JacksonInitializer.run():void`
- `BackgroundPreinitializer$MessageConverterInitializer.run():void`
- `BackgroundPreinitializer$ValidationInitializer.run():void`
- `BackgroundPreinitializer.<clinit>():void`
- `BackgroundPreinitializer.getOrder():int`
- `BackgroundPreinitializer.onApplicationEvent(ApplicationEvent):void`
- `BackgroundPreinitializer.onApplicationEvent(SpringApplicationEvent):void`
- `BackgroundPreinitializer.performPreinitialization():void`

After this commit, only those are included:
- `BackgroundPreinitializer.<clinit>():void`
- `BackgroundPreinitializer.getOrder():int`
- `BackgroundPreinitializer.onApplicationEvent(ApplicationEvent):void`
- `BackgroundPreinitializer.onApplicationEvent(SpringApplicationEvent):void`