### PR TITLE
Polish SecurityProperties

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/SecurityProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/SecurityProperties.java
@@ -17,8 +17,7 @@
 package org.springframework.boot.autoconfigure.security;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -83,8 +82,7 @@ public class SecurityProperties {
 		/**
 		 * Security filter chain dispatcher types.
 		 */
-		private Set<DispatcherType> dispatcherTypes = new HashSet<>(Arrays.asList(DispatcherType.ASYNC,
-				DispatcherType.ERROR, DispatcherType.REQUEST, DispatcherType.FORWARD, DispatcherType.INCLUDE));
+		private Set<DispatcherType> dispatcherTypes = EnumSet.allOf(DispatcherType.class);
 
 		public int getOrder() {
 			return this.order;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/servlet/SecurityAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/servlet/SecurityAutoConfigurationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.security.servlet;
 
 import java.security.interfaces.RSAPublicKey;
+import java.util.EnumSet;
 
 import jakarta.servlet.DispatcherType;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -161,8 +162,7 @@ class SecurityAutoConfigurationTests {
 							DelegatingFilterProxyRegistrationBean.class);
 					assertThat(bean)
 							.extracting("dispatcherTypes", InstanceOfAssertFactories.iterable(DispatcherType.class))
-							.containsOnly(DispatcherType.ASYNC, DispatcherType.ERROR, DispatcherType.REQUEST,
-									DispatcherType.INCLUDE, DispatcherType.FORWARD);
+							.containsOnly(EnumSet.allOf(DispatcherType.class).toArray(new DispatcherType[0]));
 				});
 	}
 


### PR DESCRIPTION
This updates `SecurityProperties.Filter#dispatcherTypes` to use `EnumSet#allOf` instead of explicitly listing all the dispatcher types. This is IMO more readable and better expresses the intent that filter is now being mapped to all dispatcher types.

See #33090.