### PR TITLE
Update Spring Security filter dispatcher types docs to reflect change in default value

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2722,6 +2722,8 @@
       "defaultValue": [
         "async",
         "error",
+        "forward",
+        "include",
         "request"
       ]
     },

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/web/servlet.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/web/servlet.adoc
@@ -397,9 +397,6 @@ The error page filter can only forward the request to the correct error page if 
 By default, WebSphere Application Server 8.0 and later commits the response upon successful completion of a servlet's service method.
 You should disable this behavior by setting `com.ibm.ws.webcontainer.invokeFlushAfterService` to `false`.
 
-If you are using Spring Security and want to access the principal in an error page, you must configure Spring Security's filter to be invoked on error dispatches.
-To do so, set the `spring.security.filter.dispatcher-types` property to `async, error, forward, request`.
-
 
 
 [[web.servlet.spring-mvc.cors]]


### PR DESCRIPTION
This aligns configuration metadata and documentation with new defaults for `spring.security.filter.dispatcher-types` property.

See #33090.