### PR TITLE
`ScheduledBeanLazyInitializationExcludeFilter` is auto-configured even when annotation-based scheduled has not been enabled

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/task/TaskSchedulingAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/task/TaskSchedulingAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ public class TaskSchedulingAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnBean(name = TaskManagementConfigUtils.SCHEDULED_ANNOTATION_PROCESSOR_BEAN_NAME)
 	public static LazyInitializationExcludeFilter scheduledBeanLazyInitializationExcludeFilter() {
 		return new ScheduledBeanLazyInitializationExcludeFilter();
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/task/TaskSchedulingAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/task/TaskSchedulingAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,12 @@ class TaskSchedulingAutoConfigurationTests {
 	@Test
 	void noSchedulingDoesNotExposeTaskScheduler() {
 		this.contextRunner.run((context) -> assertThat(context).doesNotHaveBean(TaskScheduler.class));
+	}
+
+	@Test
+	void noSchedulingDoesNotExposeScheduledBeanLazyInitializationExcludeFilter() {
+		this.contextRunner.run(
+				(context) -> assertThat(context).doesNotHaveBean(ScheduledBeanLazyInitializationExcludeFilter.class));
 	}
 
 	@Test


### PR DESCRIPTION
This PR makes the exposure of `ScheduledBeanLazyInitializationExcludeFilter` conditional on the annotation `@EnableScheduling`.

When the property `spring.main.lazy-initialization` is set to `true`, the `LazyInitializationBeanFactoryPostProcessor` currently applies the `ScheduledBeanLazyInitializationExcludeFilter` to each bean definition. This is independent of whether the user has opted in to scheduling with `@EnableScheduling` or not.

The goal of the PR is to improve the start-up performance of applications that use lazy initialization but not scheduling. An example could be a short-lived Spring Batch app that contains multiple job beans but executes only a single job when started and exits afterwards. Such an app would not use scheduling and profits from not initializing all beans on start up.

I've assembled a toy application with a flame graph here: https://github.com/hpoettker/lazy-scheduler-demo

About 3% of the whole application run-time is spent on the `ScheduledBeanLazyInitializationExcludeFilter`.

The start-up time (as logged by the application) varies between runs. But on my machine it's about 0.65 seconds and reduces to 0.60 seconds when the `TaskSchedulingAutoConfiguration` is excluded. 