### PR TITLE
Tracer library HTTP instrumentation is auto-configured unnecessarily

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java
@@ -35,13 +35,6 @@ import brave.baggage.CorrelationScopeCustomizer;
 import brave.baggage.CorrelationScopeDecorator;
 import brave.context.slf4j.MDCScopeDecorator;
 import brave.handler.SpanHandler;
-import brave.http.HttpClientHandler;
-import brave.http.HttpClientRequest;
-import brave.http.HttpClientResponse;
-import brave.http.HttpServerHandler;
-import brave.http.HttpServerRequest;
-import brave.http.HttpServerResponse;
-import brave.http.HttpTracing;
 import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.ScopeDecorator;
@@ -51,8 +44,6 @@ import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
 import io.micrometer.tracing.brave.bridge.BraveBaggageManager;
 import io.micrometer.tracing.brave.bridge.BraveCurrentTraceContext;
-import io.micrometer.tracing.brave.bridge.BraveHttpClientHandler;
-import io.micrometer.tracing.brave.bridge.BraveHttpServerHandler;
 import io.micrometer.tracing.brave.bridge.BravePropagator;
 import io.micrometer.tracing.brave.bridge.BraveSpanCustomizer;
 import io.micrometer.tracing.brave.bridge.BraveTracer;
@@ -145,24 +136,6 @@ public class BraveAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean
-	public HttpTracing httpTracing(Tracing tracing) {
-		return HttpTracing.newBuilder(tracing).build();
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
-	public HttpServerHandler<HttpServerRequest, HttpServerResponse> httpServerHandler(HttpTracing httpTracing) {
-		return HttpServerHandler.create(httpTracing);
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
-	public HttpClientHandler<HttpClientRequest, HttpClientResponse> httpClientHandler(HttpTracing httpTracing) {
-		return HttpClientHandler.create(httpTracing);
-	}
-
-	@Bean
 	@ConditionalOnMissingBean(io.micrometer.tracing.Tracer.class)
 	BraveTracer braveTracerBridge(brave.Tracer tracer, CurrentTraceContext currentTraceContext) {
 		return new BraveTracer(tracer, new BraveCurrentTraceContext(currentTraceContext), BRAVE_BAGGAGE_MANAGER);
@@ -172,20 +145,6 @@ public class BraveAutoConfiguration {
 	@ConditionalOnMissingBean
 	BravePropagator bravePropagator(Tracing tracing) {
 		return new BravePropagator(tracing);
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
-	BraveHttpServerHandler braveHttpServerHandler(
-			HttpServerHandler<HttpServerRequest, HttpServerResponse> httpServerHandler) {
-		return new BraveHttpServerHandler(httpServerHandler);
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
-	BraveHttpClientHandler braveHttpClientHandler(
-			HttpClientHandler<HttpClientRequest, HttpClientResponse> httpClientHandler) {
-		return new BraveHttpClientHandler(httpClientHandler);
 	}
 
 	@Bean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java
@@ -18,18 +18,12 @@ package org.springframework.boot.actuate.autoconfigure.tracing;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.regex.Pattern;
 
-import io.micrometer.tracing.SamplerFunction;
 import io.micrometer.tracing.SpanCustomizer;
-import io.micrometer.tracing.otel.bridge.DefaultHttpClientAttributesGetter;
-import io.micrometer.tracing.otel.bridge.DefaultHttpServerAttributesExtractor;
 import io.micrometer.tracing.otel.bridge.EventListener;
 import io.micrometer.tracing.otel.bridge.EventPublishingContextWrapper;
 import io.micrometer.tracing.otel.bridge.OtelBaggageManager;
 import io.micrometer.tracing.otel.bridge.OtelCurrentTraceContext;
-import io.micrometer.tracing.otel.bridge.OtelHttpClientHandler;
-import io.micrometer.tracing.otel.bridge.OtelHttpServerHandler;
 import io.micrometer.tracing.otel.bridge.OtelPropagator;
 import io.micrometer.tracing.otel.bridge.OtelSpanCustomizer;
 import io.micrometer.tracing.otel.bridge.OtelTracer;
@@ -162,20 +156,6 @@ public class OpenTelemetryAutoConfiguration {
 	OtelCurrentTraceContext otelCurrentTraceContext(EventPublisher publisher) {
 		ContextStorage.addWrapper(new EventPublishingContextWrapper(publisher));
 		return new OtelCurrentTraceContext();
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
-	OtelHttpClientHandler otelHttpClientHandler(OpenTelemetry openTelemetry) {
-		return new OtelHttpClientHandler(openTelemetry, null, null, SamplerFunction.deferDecision(),
-				new DefaultHttpClientAttributesGetter());
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
-	OtelHttpServerHandler otelHttpServerHandler(OpenTelemetry openTelemetry) {
-		return new OtelHttpServerHandler(openTelemetry, null, null, Pattern.compile(""),
-				new DefaultHttpServerAttributesExtractor());
 	}
 
 	@Bean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfigurationTests.java
@@ -25,21 +25,12 @@ import brave.Tracing;
 import brave.baggage.BaggagePropagation;
 import brave.baggage.CorrelationScopeConfig.SingleCorrelationField;
 import brave.handler.SpanHandler;
-import brave.http.HttpClientHandler;
-import brave.http.HttpClientRequest;
-import brave.http.HttpClientResponse;
-import brave.http.HttpServerHandler;
-import brave.http.HttpServerRequest;
-import brave.http.HttpServerResponse;
-import brave.http.HttpTracing;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.ScopeDecorator;
 import brave.propagation.Propagation;
 import brave.propagation.Propagation.Factory;
 import brave.sampler.Sampler;
 import io.micrometer.tracing.brave.bridge.BraveBaggageManager;
-import io.micrometer.tracing.brave.bridge.BraveHttpClientHandler;
-import io.micrometer.tracing.brave.bridge.BraveHttpServerHandler;
 import io.micrometer.tracing.brave.bridge.BraveSpanCustomizer;
 import io.micrometer.tracing.brave.bridge.BraveTracer;
 import io.micrometer.tracing.brave.bridge.CompositeSpanHandler;
@@ -49,7 +40,6 @@ import io.micrometer.tracing.exporter.SpanFilter;
 import io.micrometer.tracing.exporter.SpanReporter;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
-import org.mockito.Answers;
 
 import org.springframework.boot.actuate.autoconfigure.tracing.BraveAutoConfigurationTests.SpanHandlerConfiguration.AdditionalSpanHandler;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -81,17 +71,10 @@ class BraveAutoConfigurationTests {
 			assertThat(context).hasSingleBean(CurrentTraceContext.class);
 			assertThat(context).hasSingleBean(Factory.class);
 			assertThat(context).hasSingleBean(Sampler.class);
-			assertThat(context).hasSingleBean(HttpTracing.class);
-			assertThat(context).hasSingleBean(HttpServerHandler.class);
-			assertThat(context).hasSingleBean(HttpClientHandler.class);
 			assertThat(context).hasSingleBean(BraveTracer.class);
-			assertThat(context).hasSingleBean(BraveHttpServerHandler.class);
-			assertThat(context).hasSingleBean(BraveHttpClientHandler.class);
 			assertThat(context).hasSingleBean(Propagation.Factory.class);
 			assertThat(context).hasSingleBean(BaggagePropagation.FactoryBuilder.class);
 			assertThat(context).hasSingleBean(BraveTracer.class);
-			assertThat(context).hasSingleBean(BraveHttpServerHandler.class);
-			assertThat(context).hasSingleBean(BraveHttpClientHandler.class);
 			assertThat(context).hasSingleBean(CompositeSpanHandler.class);
 			assertThat(context).hasSingleBean(SpanCustomizer.class);
 			assertThat(context).hasSingleBean(BraveSpanCustomizer.class);
@@ -111,24 +94,10 @@ class BraveAutoConfigurationTests {
 			assertThat(context).hasSingleBean(Factory.class);
 			assertThat(context).hasBean("customSampler");
 			assertThat(context).hasSingleBean(Sampler.class);
-			assertThat(context).hasBean("customHttpTracing");
-			assertThat(context).hasSingleBean(HttpTracing.class);
-			assertThat(context).hasBean("customHttpServerHandler");
-			assertThat(context).hasSingleBean(HttpServerHandler.class);
-			assertThat(context).hasBean("customHttpClientHandler");
-			assertThat(context).hasSingleBean(HttpClientHandler.class);
 			assertThat(context).hasBean("customMicrometerTracer");
 			assertThat(context).hasSingleBean(io.micrometer.tracing.Tracer.class);
 			assertThat(context).hasBean("customBraveBaggageManager");
 			assertThat(context).hasSingleBean(BraveBaggageManager.class);
-			assertThat(context).hasBean("customBraveHttpServerHandler");
-			assertThat(context).hasSingleBean(BraveHttpServerHandler.class);
-			assertThat(context).hasBean("customBraveHttpClientHandler");
-			assertThat(context).hasSingleBean(BraveHttpClientHandler.class);
-			assertThat(context).hasBean("customHttpServerHandler");
-			assertThat(context).hasSingleBean(HttpServerHandler.class);
-			assertThat(context).hasBean("customHttpClientHandler");
-			assertThat(context).hasSingleBean(HttpClientHandler.class);
 			assertThat(context).hasBean("customCompositeSpanHandler");
 			assertThat(context).hasSingleBean(CompositeSpanHandler.class);
 			assertThat(context).hasBean("customSpanCustomizer");
@@ -140,11 +109,7 @@ class BraveAutoConfigurationTests {
 
 	@Test
 	void shouldSupplyMicrometerBeans() {
-		this.contextRunner.run((context) -> {
-			assertThat(context).hasSingleBean(BraveTracer.class);
-			assertThat(context).hasSingleBean(BraveHttpServerHandler.class);
-			assertThat(context).hasSingleBean(BraveHttpClientHandler.class);
-		});
+		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(BraveTracer.class));
 	}
 
 	@Test
@@ -388,23 +353,6 @@ class BraveAutoConfigurationTests {
 		}
 
 		@Bean
-		HttpTracing customHttpTracing() {
-			return mock(HttpTracing.class);
-		}
-
-		@Bean
-		HttpServerHandler<HttpServerRequest, HttpServerResponse> customHttpServerHandler() {
-			HttpTracing httpTracing = mock(HttpTracing.class, Answers.RETURNS_MOCKS);
-			return HttpServerHandler.create(httpTracing);
-		}
-
-		@Bean
-		HttpClientHandler<HttpClientRequest, HttpClientResponse> customHttpClientHandler() {
-			HttpTracing httpTracing = mock(HttpTracing.class, Answers.RETURNS_MOCKS);
-			return HttpClientHandler.create(httpTracing);
-		}
-
-		@Bean
 		io.micrometer.tracing.Tracer customMicrometerTracer() {
 			return mock(io.micrometer.tracing.Tracer.class);
 		}
@@ -412,16 +360,6 @@ class BraveAutoConfigurationTests {
 		@Bean
 		BraveBaggageManager customBraveBaggageManager() {
 			return mock(BraveBaggageManager.class);
-		}
-
-		@Bean
-		BraveHttpServerHandler customBraveHttpServerHandler() {
-			return mock(BraveHttpServerHandler.class);
-		}
-
-		@Bean
-		BraveHttpClientHandler customBraveHttpClientHandler() {
-			return mock(BraveHttpClientHandler.class);
 		}
 
 		@Bean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfigurationTests.java
@@ -21,8 +21,6 @@ import java.util.List;
 
 import io.micrometer.tracing.SpanCustomizer;
 import io.micrometer.tracing.otel.bridge.OtelCurrentTraceContext;
-import io.micrometer.tracing.otel.bridge.OtelHttpClientHandler;
-import io.micrometer.tracing.otel.bridge.OtelHttpServerHandler;
 import io.micrometer.tracing.otel.bridge.OtelPropagator;
 import io.micrometer.tracing.otel.bridge.OtelSpanCustomizer;
 import io.micrometer.tracing.otel.bridge.OtelTracer;
@@ -68,8 +66,6 @@ class OpenTelemetryAutoConfigurationTests {
 			assertThat(context).hasSingleBean(OtelTracer.class);
 			assertThat(context).hasSingleBean(EventPublisher.class);
 			assertThat(context).hasSingleBean(OtelCurrentTraceContext.class);
-			assertThat(context).hasSingleBean(OtelHttpClientHandler.class);
-			assertThat(context).hasSingleBean(OtelHttpServerHandler.class);
 			assertThat(context).hasSingleBean(OpenTelemetry.class);
 			assertThat(context).hasSingleBean(SdkTracerProvider.class);
 			assertThat(context).hasSingleBean(ContextPropagators.class);
@@ -91,8 +87,6 @@ class OpenTelemetryAutoConfigurationTests {
 			assertThat(context).doesNotHaveBean(OtelTracer.class);
 			assertThat(context).doesNotHaveBean(EventPublisher.class);
 			assertThat(context).doesNotHaveBean(OtelCurrentTraceContext.class);
-			assertThat(context).doesNotHaveBean(OtelHttpClientHandler.class);
-			assertThat(context).doesNotHaveBean(OtelHttpServerHandler.class);
 			assertThat(context).doesNotHaveBean(OpenTelemetry.class);
 			assertThat(context).doesNotHaveBean(SdkTracerProvider.class);
 			assertThat(context).doesNotHaveBean(ContextPropagators.class);
@@ -116,10 +110,6 @@ class OpenTelemetryAutoConfigurationTests {
 			assertThat(context).hasSingleBean(EventPublisher.class);
 			assertThat(context).hasBean("customOtelCurrentTraceContext");
 			assertThat(context).hasSingleBean(OtelCurrentTraceContext.class);
-			assertThat(context).hasBean("customOtelHttpClientHandler");
-			assertThat(context).hasSingleBean(OtelHttpClientHandler.class);
-			assertThat(context).hasBean("customOtelHttpServerHandler");
-			assertThat(context).hasSingleBean(OtelHttpServerHandler.class);
 			assertThat(context).hasBean("customOpenTelemetry");
 			assertThat(context).hasSingleBean(OpenTelemetry.class);
 			assertThat(context).hasBean("customSdkTracerProvider");
@@ -219,16 +209,6 @@ class OpenTelemetryAutoConfigurationTests {
 		@Bean
 		OtelCurrentTraceContext customOtelCurrentTraceContext() {
 			return mock(OtelCurrentTraceContext.class);
-		}
-
-		@Bean
-		OtelHttpClientHandler customOtelHttpClientHandler() {
-			return mock(OtelHttpClientHandler.class);
-		}
-
-		@Bean
-		OtelHttpServerHandler customOtelHttpServerHandler() {
-			return mock(OtelHttpServerHandler.class);
 		}
 
 		@Bean


### PR DESCRIPTION
Since it was decided that instead of using the tracing libraries (Brave, OTel) HTTP support, we will do something similar instrumentation time, we can remove the auto-configuration for these beans. (cc: @bclozel @marcingrzejszczak)

Slightly connected issue: #33228
