### PR TITLE
Improve test coverage for OutputCaptureRule

### DIFF
--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/OutputCaptureRuleTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/OutputCaptureRuleTests.java
@@ -38,9 +38,20 @@ public class OutputCaptureRuleTests {
 	}
 
 	@Test
+	public void getAllShouldReturnAllCapturedOutput() {
+		System.out.println("Hello World");
+		assertThat(this.output.getAll()).contains("Hello World");
+	}
+
+	@Test
+	public void getOutShouldReturnAllCapturedOutput() {
+		System.out.println("Hello World");
+		assertThat(this.output.getOut()).contains("Hello World");
+	}
+
+	@Test
 	public void captureShouldBeAssertable() {
 		System.out.println("Hello World");
 		assertThat(this.output).contains("Hello World");
 	}
-
 }

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/OutputCaptureRuleTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/OutputCaptureRuleTests.java
@@ -40,13 +40,18 @@ public class OutputCaptureRuleTests {
 	@Test
 	public void getAllShouldReturnAllCapturedOutput() {
 		System.out.println("Hello World");
-		assertThat(this.output.getAll()).contains("Hello World");
+		System.err.println("Hello Error");
+
+		assertThat(this.output.getAll()).contains("Hello World", "Hello Error");
 	}
 
 	@Test
 	public void getOutShouldOnlyReturnOutputCapturedFromSystemOut() {
 		System.out.println("Hello World");
+		System.err.println("Hello Error");
+
 		assertThat(this.output.getOut()).contains("Hello World");
+		assertThat(this.output.getOut()).doesNotContain("Hello Error");
 	}
 
 	@Test
@@ -57,7 +62,10 @@ public class OutputCaptureRuleTests {
 
 	@Test
 	public void getErrShouldOnlyReturnOutputCapturedFromSystemErr() {
+		System.out.println("Hello World");
 		System.err.println("Hello Error");
+
 		assertThat(this.output.getErr()).contains("Hello Error");
+		assertThat(this.output.getErr()).doesNotContain("Hello World");
 	}
 }

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/OutputCaptureRuleTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/OutputCaptureRuleTests.java
@@ -54,4 +54,10 @@ public class OutputCaptureRuleTests {
 		System.out.println("Hello World");
 		assertThat(this.output).contains("Hello World");
 	}
+
+	@Test
+	public void getErrShouldReturnAllCapturedOutput() {
+		System.err.println("Hello Error");
+		assertThat(this.output.getErr()).contains("Hello Error");
+	}
 }

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/OutputCaptureRuleTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/OutputCaptureRuleTests.java
@@ -44,7 +44,7 @@ public class OutputCaptureRuleTests {
 	}
 
 	@Test
-	public void getOutShouldReturnAllCapturedOutput() {
+	public void getOutShouldOnlyReturnOutputCapturedFromSystemOut() {
 		System.out.println("Hello World");
 		assertThat(this.output.getOut()).contains("Hello World");
 	}
@@ -56,7 +56,7 @@ public class OutputCaptureRuleTests {
 	}
 
 	@Test
-	public void getErrShouldReturnAllCapturedOutput() {
+	public void getErrShouldOnlyReturnOutputCapturedFromSystemErr() {
 		System.err.println("Hello Error");
 		assertThat(this.output.getErr()).contains("Hello Error");
 	}


### PR DESCRIPTION
The test was added because there were not enough tests for the method of class OutputCaptureRule.

Method list
- getAll
- getOut
- getErr