### PR TITLE
Document SystemTest cache miss

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/test/SystemTestPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/test/SystemTestPlugin.java
@@ -84,6 +84,7 @@ public class SystemTestPlugin implements Plugin<Project> {
 		systemTest.shouldRunAfter(JavaPlugin.TEST_TASK_NAME);
 		if (isCi()) {
 			systemTest.getOutputs().upToDateWhen(NEVER);
+			systemTest.getOutputs().doNotCacheIf("System tests are always rerun on CI", (task) -> true);
 		}
 	}
 


### PR DESCRIPTION
## Overview

Document build cache miss to ease detection of (new) performance regression.

## Details

The `systemTest` task is being rerun [systematically on CI](https://github.com/spring-projects/spring-boot/blob/main/buildSrc/src/main/java/org/springframework/boot/build/test/SystemTestPlugin.java#L86)
https://ge.junit.org/c/tz35q4eso3ktg/we4fflr3ipauu/task-inputs?cacheability=cacheable&expanded=WyJpcGFwaG1zcmhwdDVlLXJvb3RzcGVjJDIkMSJd&task-text=shad#change-ipaphmsrhpt5e-rootSpec$2$1-0-0

Marking the task as non cacheable will prevent from analyzing the same cache miss in the future.