### PR TITLE
Add beforeEach tests to OutputExtensionExtendWithTests

### DIFF
--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/OutputExtensionExtendWithTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/OutputExtensionExtendWithTests.java
@@ -17,9 +17,7 @@
 package org.springframework.boot.test.system;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,18 +28,24 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @ExtendWith(OutputCaptureExtension.class)
 @ExtendWith(OutputExtensionExtendWithTests.BeforeAllExtension.class)
+@ExtendWith(OutputExtensionExtendWithTests.BeforeEachExtension.class)
 class OutputExtensionExtendWithTests {
 
 	@Test
-	void captureShouldReturnOutputCapturedBeforeTestMethod(CapturedOutput output) {
+	void captureShouldReturnOutputCapturedBeforeAllTestMethod(CapturedOutput output) {
 		assertThat(output).contains("Before all").doesNotContain("Hello");
+	}
+
+	@Test
+	void captureShouldReturnOutputCapturedBeforeEachTestMethod(CapturedOutput output) {
+		assertThat(output).contains("Before each").doesNotContain("Hello");
 	}
 
 	@Test
 	void captureShouldReturnAllCapturedOutput(CapturedOutput output) {
 		System.out.println("Hello World");
 		System.err.println("Error!!!");
-		assertThat(output).contains("Before all").contains("Hello World").contains("Error!!!");
+		assertThat(output).contains("Before all").contains("Before each").contains("Hello World").contains("Error!!!");
 	}
 
 	static class BeforeAllExtension implements BeforeAllCallback {
@@ -49,6 +53,15 @@ class OutputExtensionExtendWithTests {
 		@Override
 		public void beforeAll(ExtensionContext context) {
 			System.out.println("Before all");
+		}
+
+	}
+
+	static class BeforeEachExtension implements BeforeEachCallback {
+
+		@Override
+		public void beforeEach(ExtensionContext context) {
+			System.out.println("Before each");
 		}
 
 	}


### PR DESCRIPTION
Added to increase test coverage for OutputExtension.

Test Method
- `captureShouldReturnOutputCapturedBeforeEachTestMethod`