### PR TITLE
Update instead of replace environment in bootBuildImage documentation

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-build-image-env-proxy.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-build-image-env-proxy.gradle
@@ -5,10 +5,8 @@ plugins {
 
 // tag::env[]
 tasks.named("bootBuildImage") {
-	environment = [
-			"HTTP_PROXY" : "http://proxy.example.com",
-			"HTTPS_PROXY": "https://proxy.example.com"
-	]
+	environment["HTTP_PROXY"] = "http://proxy.example.com"
+	environment["HTTPS_PROXY"] = "https://proxy.example.com"
 }
 // end::env[]
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-build-image-env-runtime.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-build-image-env-runtime.gradle
@@ -9,10 +9,8 @@ tasks.named("bootJar") {
 
 // tag::env-runtime[]
 tasks.named("bootBuildImage") {
-	environment = [
-			"BPE_DELIM_JAVA_TOOL_OPTIONS" : " ",
-			"BPE_APPEND_JAVA_TOOL_OPTIONS" : "-XX:+HeapDumpOnOutOfMemoryError"
-	]
+	environment["BPE_DELIM_JAVA_TOOL_OPTIONS"] = " "
+	environment["BPE_APPEND_JAVA_TOOL_OPTIONS"] = "-XX:+HeapDumpOnOutOfMemoryError"
 }
 // end::env-runtime[]
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-build-image-env.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-build-image-env.gradle
@@ -5,7 +5,7 @@ plugins {
 
 // tag::env[]
 tasks.named("bootBuildImage") {
-	environment = ["BP_JVM_VERSION" : "17"]
+	environment["BP_JVM_VERSION"] = "17"
 }
 // end::env[]
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-build-image-env.gradle.kts
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/packaging/boot-build-image-env.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 // tag::env[]
 tasks.named<BootBuildImage>("bootBuildImage") {
-	environment.set(mapOf("BP_JVM_VERSION" to "17"))
+	environment.set(environment.get() + mapOf("BP_JVM_VERSION" to "17"))
 }
 // end::env[]
 


### PR DESCRIPTION
Updates the documentation for `bootBuildImage` to update `environment` instead of replacing it so that defaults / automatic values are preserved.

Closes gh-32886