### PR TITLE
Adding Unleash Auto-Configuration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-autoconfigure/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	optional("io.rsocket:rsocket-transport-netty")
 	optional("io.undertow:undertow-servlet")
 	optional("io.undertow:undertow-websockets-jsr")
+	optional("io.getunleash:unleash-client-java")
 	optional("jakarta.jms:jakarta.jms-api")
 	optional("jakarta.mail:jakarta.mail-api")
 	optional("jakarta.json.bind:jakarta.json.bind-api")

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/ConditionalOnUnleashRequiredProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/ConditionalOnUnleashRequiredProperties.java
@@ -25,12 +25,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Shortcut for
- * <pre class="code">
+ * Shortcut for <pre class="code">
  * &#064;@ConditionalOnProperty({
  *     "spring.unleash.app-name",
- *     "spring.unleash.api-url",
- *     "spring.unleash.api-client-secret"
+ *     "spring.unleash.unleash-api",
+ *     "spring.unleash.api-key"
  * })
  * </pre>
  *
@@ -39,9 +38,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Documented
-@ConditionalOnProperty({
-    "spring.unleash.app-name",
-    "spring.unleash.api-url",
-    "spring.unleash.api-client-secret"
-})
-@interface ConditionalOnUnleashRequiredProperties { }
+@ConditionalOnProperty({ "spring.unleash.app-name", "spring.unleash.unleash-api", "spring.unleash.api-key" })
+@interface ConditionalOnUnleashRequiredProperties {
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/ConditionalOnUnleashRequiredProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/ConditionalOnUnleashRequiredProperties.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.unleash;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Shortcut for
+ * <pre class="code">
+ * &#064;@ConditionalOnProperty({
+ *     "spring.unleash.app-name",
+ *     "spring.unleash.api-url",
+ *     "spring.unleash.api-client-secret"
+ * })
+ * </pre>
+ *
+ * @author Max Schwaab
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Documented
+@ConditionalOnProperty({
+    "spring.unleash.app-name",
+    "spring.unleash.api-url",
+    "spring.unleash.api-client-secret"
+})
+@interface ConditionalOnUnleashRequiredProperties { }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashAutoConfiguration.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.unleash;
+
+import io.getunleash.CustomHttpHeadersProvider;
+import io.getunleash.DefaultUnleash;
+import io.getunleash.Unleash;
+import io.getunleash.UnleashContextProvider;
+import io.getunleash.event.UnleashSubscriber;
+import io.getunleash.repository.ToggleBootstrapProvider;
+import io.getunleash.strategy.Strategy;
+import io.getunleash.util.UnleashConfig;
+import io.getunleash.util.UnleashScheduledExecutor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+
+import java.net.Proxy;
+import java.util.List;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Unleash.<br>
+ * For available configuration options see the
+ * <a href="https://github.com/Unleash/unleash-client-java#configuration-options">Unleash Java client documentation</a>.
+ *
+ * @author Max Schwaab
+ */
+@AutoConfiguration
+@Conditional(UnleashPropertiesOrUnleashConfig.class)
+class UnleashAutoConfiguration {
+
+  @AutoConfiguration
+  @ConditionalOnUnleashRequiredProperties
+  @EnableConfigurationProperties(UnleashProperties.class)
+  static class EnableUnleashProperties {
+
+    @Bean
+    UnleashConfigBuilderCustomizer propertiesConfigBuilderCustomizer(final UnleashProperties properties) {
+      return new UnleashPropertiesConfigBuilderCustomizer(properties);
+    }
+
+  }
+
+  @Bean
+  @ConditionalOnMissingBean({ Unleash.class, UnleashConfig.class })
+  UnleashConfig unleashConfig(final List<UnleashConfigBuilderCustomizer> configBuilderCustomizers) {
+    final UnleashConfig.Builder configBuilder = UnleashConfig.builder();
+
+    configBuilderCustomizers.forEach(customizer -> customizer.customize(configBuilder));
+
+    return configBuilder.build();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(Unleash.class)
+  Unleash unleash(final UnleashConfig unleashConfig) {
+    return new DefaultUnleash(unleashConfig);
+  }
+
+  @Bean
+  UnleashConfigBuilderCustomizer beanConfigBuilderCustomizer(
+      @Autowired(required = false)
+      final UnleashContextProvider contextProvider,
+      @Autowired(required = false)
+      final Strategy fallbackStrategy,
+      @Autowired(required = false)
+      final CustomHttpHeadersProvider httpHeadersProvider,
+      @Autowired(required = false)
+      final Proxy proxy,
+      @Autowired(required = false)
+      final UnleashScheduledExecutor scheduledExecutor,
+      @Autowired(required = false)
+      final UnleashSubscriber subscriber,
+      @Autowired(required = false)
+      final ToggleBootstrapProvider toggleBootstrapProvider) {
+    return new UnleashBeanConfigBuilderCustomizer(
+        contextProvider,
+        fallbackStrategy,
+        httpHeadersProvider,
+        proxy,
+        scheduledExecutor,
+        subscriber,
+        toggleBootstrapProvider
+    );
+  }
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashAutoConfiguration.java
@@ -23,7 +23,9 @@ import io.getunleash.UnleashContextProvider;
 import io.getunleash.event.UnleashSubscriber;
 import io.getunleash.repository.ToggleBootstrapProvider;
 import io.getunleash.strategy.Strategy;
+import io.getunleash.util.MetricSenderFactory;
 import io.getunleash.util.UnleashConfig;
+import io.getunleash.util.UnleashFeatureFetcherFactory;
 import io.getunleash.util.UnleashScheduledExecutor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -39,7 +41,8 @@ import java.util.List;
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Unleash.<br>
  * For available configuration options see the
- * <a href="https://github.com/Unleash/unleash-client-java#configuration-options">Unleash Java client documentation</a>.
+ * <a href="https://github.com/Unleash/unleash-client-java#configuration-options">Unleash
+ * Java client documentation</a>.
  *
  * @author Max Schwaab
  */
@@ -47,59 +50,47 @@ import java.util.List;
 @Conditional(UnleashPropertiesOrUnleashConfig.class)
 class UnleashAutoConfiguration {
 
-  @AutoConfiguration
-  @ConditionalOnUnleashRequiredProperties
-  @EnableConfigurationProperties(UnleashProperties.class)
-  static class EnableUnleashProperties {
+	@AutoConfiguration
+	@ConditionalOnUnleashRequiredProperties
+	@EnableConfigurationProperties(UnleashProperties.class)
+	static class EnableUnleashProperties {
 
-    @Bean
-    UnleashConfigBuilderCustomizer propertiesConfigBuilderCustomizer(final UnleashProperties properties) {
-      return new UnleashPropertiesConfigBuilderCustomizer(properties);
-    }
+		@Bean
+		UnleashConfigBuilderCustomizer propertiesConfigBuilderCustomizer(final UnleashProperties properties) {
+			return new UnleashPropertiesConfigBuilderCustomizer(properties);
+		}
 
-  }
+	}
 
-  @Bean
-  @ConditionalOnMissingBean({ Unleash.class, UnleashConfig.class })
-  UnleashConfig unleashConfig(final List<UnleashConfigBuilderCustomizer> configBuilderCustomizers) {
-    final UnleashConfig.Builder configBuilder = UnleashConfig.builder();
+	@Bean
+	@ConditionalOnMissingBean({ Unleash.class, UnleashConfig.class })
+	UnleashConfig unleashConfig(final List<UnleashConfigBuilderCustomizer> configBuilderCustomizers) {
+		final UnleashConfig.Builder configBuilder = UnleashConfig.builder();
 
-    configBuilderCustomizers.forEach(customizer -> customizer.customize(configBuilder));
+		configBuilderCustomizers.forEach(customizer -> customizer.customize(configBuilder));
 
-    return configBuilder.build();
-  }
+		return configBuilder.build();
+	}
 
-  @Bean
-  @ConditionalOnMissingBean(Unleash.class)
-  Unleash unleash(final UnleashConfig unleashConfig) {
-    return new DefaultUnleash(unleashConfig);
-  }
+	@Bean
+	@ConditionalOnMissingBean(Unleash.class)
+	Unleash unleash(final UnleashConfig unleashConfig) {
+		return new DefaultUnleash(unleashConfig);
+	}
 
-  @Bean
-  UnleashConfigBuilderCustomizer beanConfigBuilderCustomizer(
-      @Autowired(required = false)
-      final UnleashContextProvider contextProvider,
-      @Autowired(required = false)
-      final Strategy fallbackStrategy,
-      @Autowired(required = false)
-      final CustomHttpHeadersProvider httpHeadersProvider,
-      @Autowired(required = false)
-      final Proxy proxy,
-      @Autowired(required = false)
-      final UnleashScheduledExecutor scheduledExecutor,
-      @Autowired(required = false)
-      final UnleashSubscriber subscriber,
-      @Autowired(required = false)
-      final ToggleBootstrapProvider toggleBootstrapProvider) {
-    return new UnleashBeanConfigBuilderCustomizer(
-        contextProvider,
-        fallbackStrategy,
-        httpHeadersProvider,
-        proxy,
-        scheduledExecutor,
-        subscriber,
-        toggleBootstrapProvider
-    );
-  }
+	@Bean
+	UnleashConfigBuilderCustomizer beanConfigBuilderCustomizer(
+			@Autowired(required = false) final UnleashContextProvider contextProvider,
+			@Autowired(required = false) final UnleashFeatureFetcherFactory featureFetcherFactory,
+			@Autowired(required = false) final Strategy fallbackStrategy,
+			@Autowired(required = false) final CustomHttpHeadersProvider httpHeadersProvider,
+			@Autowired(required = false) final MetricSenderFactory metricSenderFactory,
+			@Autowired(required = false) final Proxy proxy,
+			@Autowired(required = false) final UnleashScheduledExecutor scheduledExecutor,
+			@Autowired(required = false) final UnleashSubscriber subscriber,
+			@Autowired(required = false) final ToggleBootstrapProvider toggleBootstrapProvider) {
+		return new UnleashBeanConfigBuilderCustomizer(contextProvider, featureFetcherFactory, fallbackStrategy, httpHeadersProvider, metricSenderFactory, proxy,
+				scheduledExecutor, subscriber, toggleBootstrapProvider);
+	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashBeanConfigBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashBeanConfigBuilderCustomizer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.unleash;
+
+import io.getunleash.CustomHttpHeadersProvider;
+import io.getunleash.UnleashContextProvider;
+import io.getunleash.event.UnleashSubscriber;
+import io.getunleash.repository.ToggleBootstrapProvider;
+import io.getunleash.strategy.Strategy;
+import io.getunleash.util.UnleashConfig;
+import io.getunleash.util.UnleashScheduledExecutor;
+
+import javax.annotation.Nullable;
+import java.net.Proxy;
+
+/**
+ * A {@link UnleashConfigBuilderCustomizer} that applies non null
+ * constructor args to a {@link UnleashConfig.Builder}.
+ *
+ * @author Max Schwaab
+ */
+class UnleashBeanConfigBuilderCustomizer implements UnleashConfigBuilderCustomizer {
+
+  private final UnleashContextProvider contextProvider;
+  private final Strategy fallbackStrategy;
+  private final CustomHttpHeadersProvider httpHeadersProvider;
+  private final Proxy proxy;
+  private final UnleashScheduledExecutor scheduledExecutor;
+  private final UnleashSubscriber subscriber;
+  private final ToggleBootstrapProvider toggleBootstrapProvider;
+
+  UnleashBeanConfigBuilderCustomizer(
+      @Nullable final UnleashContextProvider contextProvider,
+      @Nullable final Strategy fallbackStrategy,
+      @Nullable final CustomHttpHeadersProvider httpHeadersProvider,
+      @Nullable final Proxy proxy,
+      @Nullable final UnleashScheduledExecutor scheduledExecutor,
+      @Nullable final UnleashSubscriber subscriber,
+      @Nullable final ToggleBootstrapProvider toggleBootstrapProvider) {
+    this.contextProvider = contextProvider;
+    this.fallbackStrategy = fallbackStrategy;
+    this.httpHeadersProvider = httpHeadersProvider;
+    this.proxy = proxy;
+    this.scheduledExecutor = scheduledExecutor;
+    this.subscriber = subscriber;
+    this.toggleBootstrapProvider = toggleBootstrapProvider;
+  }
+
+  @Override
+  public void customize(final UnleashConfig.Builder configBuilder) {
+    if (fallbackStrategy != null) {
+      configBuilder.fallbackStrategy(fallbackStrategy);
+    }
+    if (httpHeadersProvider != null) {
+      configBuilder.customHttpHeadersProvider(httpHeadersProvider);
+    }
+    if (proxy != null) {
+      configBuilder.proxy(proxy);
+    }
+    if (scheduledExecutor != null) {
+      configBuilder.scheduledExecutor(scheduledExecutor);
+    }
+    if (subscriber != null) {
+      configBuilder.subscriber(subscriber);
+    }
+    if (toggleBootstrapProvider != null) {
+      configBuilder.toggleBootstrapProvider(toggleBootstrapProvider);
+    }
+    if (contextProvider != null) {
+      configBuilder.unleashContextProvider(contextProvider);
+    }
+  }
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashBeanConfigBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashBeanConfigBuilderCustomizer.java
@@ -21,68 +21,85 @@ import io.getunleash.UnleashContextProvider;
 import io.getunleash.event.UnleashSubscriber;
 import io.getunleash.repository.ToggleBootstrapProvider;
 import io.getunleash.strategy.Strategy;
+import io.getunleash.util.MetricSenderFactory;
 import io.getunleash.util.UnleashConfig;
+import io.getunleash.util.UnleashFeatureFetcherFactory;
 import io.getunleash.util.UnleashScheduledExecutor;
 
 import javax.annotation.Nullable;
 import java.net.Proxy;
 
 /**
- * A {@link UnleashConfigBuilderCustomizer} that applies non null
- * constructor args to a {@link UnleashConfig.Builder}.
+ * A {@link UnleashConfigBuilderCustomizer} that applies non null constructor args to a
+ * {@link UnleashConfig.Builder}.
  *
  * @author Max Schwaab
  */
 class UnleashBeanConfigBuilderCustomizer implements UnleashConfigBuilderCustomizer {
 
-  private final UnleashContextProvider contextProvider;
-  private final Strategy fallbackStrategy;
-  private final CustomHttpHeadersProvider httpHeadersProvider;
-  private final Proxy proxy;
-  private final UnleashScheduledExecutor scheduledExecutor;
-  private final UnleashSubscriber subscriber;
-  private final ToggleBootstrapProvider toggleBootstrapProvider;
+	private final UnleashContextProvider contextProvider;
 
-  UnleashBeanConfigBuilderCustomizer(
-      @Nullable final UnleashContextProvider contextProvider,
-      @Nullable final Strategy fallbackStrategy,
-      @Nullable final CustomHttpHeadersProvider httpHeadersProvider,
-      @Nullable final Proxy proxy,
-      @Nullable final UnleashScheduledExecutor scheduledExecutor,
-      @Nullable final UnleashSubscriber subscriber,
-      @Nullable final ToggleBootstrapProvider toggleBootstrapProvider) {
-    this.contextProvider = contextProvider;
-    this.fallbackStrategy = fallbackStrategy;
-    this.httpHeadersProvider = httpHeadersProvider;
-    this.proxy = proxy;
-    this.scheduledExecutor = scheduledExecutor;
-    this.subscriber = subscriber;
-    this.toggleBootstrapProvider = toggleBootstrapProvider;
-  }
+	private final UnleashFeatureFetcherFactory featureFetcherFactory;
 
-  @Override
-  public void customize(final UnleashConfig.Builder configBuilder) {
-    if (fallbackStrategy != null) {
-      configBuilder.fallbackStrategy(fallbackStrategy);
-    }
-    if (httpHeadersProvider != null) {
-      configBuilder.customHttpHeadersProvider(httpHeadersProvider);
-    }
-    if (proxy != null) {
-      configBuilder.proxy(proxy);
-    }
-    if (scheduledExecutor != null) {
-      configBuilder.scheduledExecutor(scheduledExecutor);
-    }
-    if (subscriber != null) {
-      configBuilder.subscriber(subscriber);
-    }
-    if (toggleBootstrapProvider != null) {
-      configBuilder.toggleBootstrapProvider(toggleBootstrapProvider);
-    }
-    if (contextProvider != null) {
-      configBuilder.unleashContextProvider(contextProvider);
-    }
-  }
+	private final Strategy fallbackStrategy;
+
+	private final CustomHttpHeadersProvider httpHeadersProvider;
+
+	private final MetricSenderFactory metricSenderFactory;
+
+	private final Proxy proxy;
+
+	private final UnleashScheduledExecutor scheduledExecutor;
+
+	private final UnleashSubscriber subscriber;
+
+	private final ToggleBootstrapProvider toggleBootstrapProvider;
+
+	UnleashBeanConfigBuilderCustomizer(@Nullable final UnleashContextProvider contextProvider, @Nullable final UnleashFeatureFetcherFactory featureFetcherFactory,
+			@Nullable final Strategy fallbackStrategy, @Nullable final CustomHttpHeadersProvider httpHeadersProvider,
+			@Nullable final MetricSenderFactory metricSenderFactory, @Nullable final Proxy proxy, @Nullable final UnleashScheduledExecutor scheduledExecutor,
+			@Nullable final UnleashSubscriber subscriber,
+			@Nullable final ToggleBootstrapProvider toggleBootstrapProvider) {
+		this.contextProvider = contextProvider;
+		this.featureFetcherFactory = featureFetcherFactory;
+		this.fallbackStrategy = fallbackStrategy;
+		this.httpHeadersProvider = httpHeadersProvider;
+		this.proxy = proxy;
+		this.metricSenderFactory = metricSenderFactory;
+		this.scheduledExecutor = scheduledExecutor;
+		this.subscriber = subscriber;
+		this.toggleBootstrapProvider = toggleBootstrapProvider;
+	}
+
+	@Override
+	public void customize(final UnleashConfig.Builder configBuilder) {
+		if (contextProvider != null) {
+			configBuilder.unleashContextProvider(contextProvider);
+		}
+		if (featureFetcherFactory != null) {
+			configBuilder.unleashFeatureFetcherFactory(featureFetcherFactory);
+		}
+		if (fallbackStrategy != null) {
+			configBuilder.fallbackStrategy(fallbackStrategy);
+		}
+		if (httpHeadersProvider != null) {
+			configBuilder.customHttpHeadersProvider(httpHeadersProvider);
+		}
+		if (proxy != null) {
+			configBuilder.proxy(proxy);
+		}
+		if (metricSenderFactory != null) {
+			configBuilder.metricsSenderFactory(metricSenderFactory);
+		}
+		if (scheduledExecutor != null) {
+			configBuilder.scheduledExecutor(scheduledExecutor);
+		}
+		if (subscriber != null) {
+			configBuilder.subscriber(subscriber);
+		}
+		if (toggleBootstrapProvider != null) {
+			configBuilder.toggleBootstrapProvider(toggleBootstrapProvider);
+		}
+	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashConfigBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashConfigBuilderCustomizer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.unleash;
+
+import io.getunleash.util.UnleashConfig;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize the
+ * {@link UnleashConfig} via a {@link UnleashConfig.Builder} whilst retaining default auto-configuration.
+ *
+ * @author Max Schwaab
+ */
+public interface UnleashConfigBuilderCustomizer {
+  void customize(UnleashConfig.Builder configBuilder);
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashConfigBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashConfigBuilderCustomizer.java
@@ -20,10 +20,13 @@ import io.getunleash.util.UnleashConfig;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link UnleashConfig} via a {@link UnleashConfig.Builder} whilst retaining default auto-configuration.
+ * {@link UnleashConfig} via a {@link UnleashConfig.Builder} whilst retaining default
+ * auto-configuration.
  *
  * @author Max Schwaab
  */
 public interface UnleashConfigBuilderCustomizer {
-  void customize(UnleashConfig.Builder configBuilder);
+
+	void customize(UnleashConfig.Builder configBuilder);
+
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashProperties.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.unleash;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration properties for Unleash.
+ *
+ * @author Max Schwaab
+ */
+@Validated
+@ConfigurationProperties(prefix = "spring.unleash")
+class UnleashProperties {
+
+  @NotBlank
+  private String appName;
+  @NotBlank
+  private String apiUrl;
+  @NotBlank
+  private String apiClientSecret;
+  private boolean disableMetrics;
+  private boolean enableProxyAuthenticationByJvmProperties;
+  private boolean synchronousFetchOnInitialisation;
+  private String backUpFile;
+  private String environment;
+  private String instanceId;
+  private String namePrefix;
+  private String projectName;
+  private Long fetchTogglesInterval;
+  private Long sendMetricsInterval;
+  private Map<String, String> customHeaders = new HashMap<>();
+
+  public String getAppName() {
+    return appName;
+  }
+
+  public UnleashProperties setAppName(final String appName) {
+    this.appName = appName;
+    return this;
+  }
+
+  public String getApiUrl() {
+    return apiUrl;
+  }
+
+  public UnleashProperties setApiUrl(final String apiUrl) {
+    this.apiUrl = apiUrl;
+    return this;
+  }
+
+  public String getApiClientSecret() {
+    return apiClientSecret;
+  }
+
+  public UnleashProperties setApiClientSecret(final String apiClientSecret) {
+    this.apiClientSecret = apiClientSecret;
+    return this;
+  }
+
+  public boolean isDisableMetrics() {
+    return disableMetrics;
+  }
+
+  public UnleashProperties setDisableMetrics(final boolean disableMetrics) {
+    this.disableMetrics = disableMetrics;
+    return this;
+  }
+
+  public boolean isEnableProxyAuthenticationByJvmProperties() {
+    return enableProxyAuthenticationByJvmProperties;
+  }
+
+  public UnleashProperties setEnableProxyAuthenticationByJvmProperties(final boolean enableProxyAuthenticationByJvmProperties) {
+    this.enableProxyAuthenticationByJvmProperties = enableProxyAuthenticationByJvmProperties;
+    return this;
+  }
+
+  public boolean isSynchronousFetchOnInitialisation() {
+    return synchronousFetchOnInitialisation;
+  }
+
+  public UnleashProperties setSynchronousFetchOnInitialisation(final boolean synchronousFetchOnInitialisation) {
+    this.synchronousFetchOnInitialisation = synchronousFetchOnInitialisation;
+    return this;
+  }
+
+  public String getBackUpFile() {
+    return backUpFile;
+  }
+
+  public UnleashProperties setBackUpFile(final String backUpFile) {
+    this.backUpFile = backUpFile;
+    return this;
+  }
+
+  public String getEnvironment() {
+    return environment;
+  }
+
+  public UnleashProperties setEnvironment(final String environment) {
+    this.environment = environment;
+    return this;
+  }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  public UnleashProperties setInstanceId(final String instanceId) {
+    this.instanceId = instanceId;
+    return this;
+  }
+
+  public String getNamePrefix() {
+    return namePrefix;
+  }
+
+  public UnleashProperties setNamePrefix(final String namePrefix) {
+    this.namePrefix = namePrefix;
+    return this;
+  }
+
+  public String getProjectName() {
+    return projectName;
+  }
+
+  public UnleashProperties setProjectName(final String projectName) {
+    this.projectName = projectName;
+    return this;
+  }
+
+  public Long getFetchTogglesInterval() {
+    return fetchTogglesInterval;
+  }
+
+  public UnleashProperties setFetchTogglesInterval(final Long fetchTogglesInterval) {
+    this.fetchTogglesInterval = fetchTogglesInterval;
+    return this;
+  }
+
+  public Long getSendMetricsInterval() {
+    return sendMetricsInterval;
+  }
+
+  public UnleashProperties setSendMetricsInterval(final Long sendMetricsInterval) {
+    this.sendMetricsInterval = sendMetricsInterval;
+    return this;
+  }
+
+  public Map<String, String> getCustomHeaders() {
+    return customHeaders;
+  }
+
+  public UnleashProperties setCustomHeaders(final Map<String, String> customHeaders) {
+    this.customHeaders = customHeaders;
+    return this;
+  }
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashProperties.java
@@ -32,148 +32,281 @@ import java.util.Map;
 @ConfigurationProperties(prefix = "spring.unleash")
 class UnleashProperties {
 
-  @NotBlank
-  private String appName;
-  @NotBlank
-  private String apiUrl;
-  @NotBlank
-  private String apiClientSecret;
-  private boolean disableMetrics;
-  private boolean enableProxyAuthenticationByJvmProperties;
-  private boolean synchronousFetchOnInitialisation;
-  private String backUpFile;
-  private String environment;
-  private String instanceId;
-  private String namePrefix;
-  private String projectName;
-  private Long fetchTogglesInterval;
-  private Long sendMetricsInterval;
-  private Map<String, String> customHeaders = new HashMap<>();
+	/**
+	 * The name of the application as shown in the Unleash UI. Registered applications are listed on the Applications page.
+	 */
+	@NotBlank
+	private String appName;
 
-  public String getAppName() {
-    return appName;
-  }
+	/**
+	 * The URL of the Unleash API.
+	 */
+	@NotBlank
+	private String unleashApi;
 
-  public UnleashProperties setAppName(final String appName) {
-    this.appName = appName;
-    return this;
-  }
+	/**
+	 * The api key to use for authenticating against the Unleash API.
+	 */
+	@NotBlank
+	private String apiKey;
 
-  public String getApiUrl() {
-    return apiUrl;
-  }
+	/**
+	 * A boolean indicating whether the client should disable sending usage metrics to the Unleash server.
+	 */
+	private boolean disableMetrics;
 
-  public UnleashProperties setApiUrl(final String apiUrl) {
-    this.apiUrl = apiUrl;
-    return this;
-  }
+	/**
+	 * A boolean indicating whether the client should poll the unleash api for updates to toggles.
+	 */
+	private boolean disablePolling;
 
-  public String getApiClientSecret() {
-    return apiClientSecret;
-  }
+	/**
+	 * Enable support for using JVM properties for HTTP proxy authentication.
+	 */
+	private boolean enableProxyAuthenticationByJvmProperties;
 
-  public UnleashProperties setApiClientSecret(final String apiClientSecret) {
-    this.apiClientSecret = apiClientSecret;
-    return this;
-  }
+	/**
+	 * Whether the client should fetch toggle configuration synchronously (in a blocking manner).
+	 */
+	private boolean synchronousFetchOnInitialisation;
 
-  public boolean isDisableMetrics() {
-    return disableMetrics;
-  }
+	/**
+	 * The path to the file where local backups get stored.
+	 */
+	private String backUpFile;
 
-  public UnleashProperties setDisableMetrics(final boolean disableMetrics) {
-    this.disableMetrics = disableMetrics;
-    return this;
-  }
+	/**
+	 * 	The name of the current environment.
+	 */
+	private String environment;
 
-  public boolean isEnableProxyAuthenticationByJvmProperties() {
-    return enableProxyAuthenticationByJvmProperties;
-  }
+	/**
+	 * A unique(-ish) identifier for your instance. Typically a hostname, pod id or something similar.
+	 * Unleash uses this to separate metrics from the client SDKs with the same appName.
+	 */
+	private String instanceId;
 
-  public UnleashProperties setEnableProxyAuthenticationByJvmProperties(final boolean enableProxyAuthenticationByJvmProperties) {
-    this.enableProxyAuthenticationByJvmProperties = enableProxyAuthenticationByJvmProperties;
-    return this;
-  }
+	/**
+	 * If provided, the client will only fetch toggles whose name starts with the provided value.
+	 */
+	private String namePrefix;
 
-  public boolean isSynchronousFetchOnInitialisation() {
-    return synchronousFetchOnInitialisation;
-  }
+	/**
+	 * If provided, the client will only fetch toggles from the specified project.
+	 * (This can also be achieved with an API token).
+	 */
+	private String projectName;
 
-  public UnleashProperties setSynchronousFetchOnInitialisation(final boolean synchronousFetchOnInitialisation) {
-    this.synchronousFetchOnInitialisation = synchronousFetchOnInitialisation;
-    return this;
-  }
+	/**
+	 * How often (in seconds) the client should check for toggle updates. Set to 0 if you want to only check once.
+	 */
+	private Long fetchTogglesInterval;
 
-  public String getBackUpFile() {
-    return backUpFile;
-  }
+	/**
+	 * Connect timeout for fetch toggles operation in seconds.
+	 */
+	private Long fetchTogglesConnectTimeoutSeconds;
 
-  public UnleashProperties setBackUpFile(final String backUpFile) {
-    this.backUpFile = backUpFile;
-    return this;
-  }
+	/**
+	 * Read timeout for fetch toggles operation in seconds.
+	 */
+	private Long fetchTogglesReadTimeoutSeconds;
 
-  public String getEnvironment() {
-    return environment;
-  }
+	/**
+	 * How often (in seconds) the client should send metrics to the Unleash server.
+	 * Ignored if you disable metrics with the disableMetrics method.
+	 */
+	private Long sendMetricsInterval;
 
-  public UnleashProperties setEnvironment(final String environment) {
-    this.environment = environment;
-    return this;
-  }
+	/**
+	 * Connect timeout for send metrics operation in seconds.
+	 */
+	private Long sendMetricsConnectTimeoutSeconds;
 
-  public String getInstanceId() {
-    return instanceId;
-  }
+	/**
+	 * Read timeout for send metrics operation in seconds.
+	 */
+	private Long sendMetricsReadTimeoutSeconds;
 
-  public UnleashProperties setInstanceId(final String instanceId) {
-    this.instanceId = instanceId;
-    return this;
-  }
+	/**
+	 * Add a custom HTTP header to the list of HTTP headers that will the client sends to the Unleash API.
+	 * Each method call will add a new header.
+	 * Note: in most cases, you'll need to use this method to provide an API token.<br>
+	 * <br>
+	 * Headers can be defined as a map in YAML.
+	 */
+	private Map<String, String> customHeaders = new HashMap<>();
 
-  public String getNamePrefix() {
-    return namePrefix;
-  }
+	public String getAppName() {
+		return appName;
+	}
 
-  public UnleashProperties setNamePrefix(final String namePrefix) {
-    this.namePrefix = namePrefix;
-    return this;
-  }
+	public UnleashProperties setAppName(final String appName) {
+		this.appName = appName;
+		return this;
+	}
 
-  public String getProjectName() {
-    return projectName;
-  }
+	public String getUnleashApi() {
+		return unleashApi;
+	}
 
-  public UnleashProperties setProjectName(final String projectName) {
-    this.projectName = projectName;
-    return this;
-  }
+	public UnleashProperties setUnleashApi(final String unleashApi) {
+		this.unleashApi = unleashApi;
+		return this;
+	}
 
-  public Long getFetchTogglesInterval() {
-    return fetchTogglesInterval;
-  }
+	public String getApiKey() {
+		return apiKey;
+	}
 
-  public UnleashProperties setFetchTogglesInterval(final Long fetchTogglesInterval) {
-    this.fetchTogglesInterval = fetchTogglesInterval;
-    return this;
-  }
+	public UnleashProperties setApiKey(final String apiKey) {
+		this.apiKey = apiKey;
+		return this;
+	}
 
-  public Long getSendMetricsInterval() {
-    return sendMetricsInterval;
-  }
+	public boolean isDisableMetrics() {
+		return disableMetrics;
+	}
 
-  public UnleashProperties setSendMetricsInterval(final Long sendMetricsInterval) {
-    this.sendMetricsInterval = sendMetricsInterval;
-    return this;
-  }
+	public UnleashProperties setDisableMetrics(final boolean disableMetrics) {
+		this.disableMetrics = disableMetrics;
+		return this;
+	}
 
-  public Map<String, String> getCustomHeaders() {
-    return customHeaders;
-  }
+	public boolean isDisablePolling() {
+		return disablePolling;
+	}
 
-  public UnleashProperties setCustomHeaders(final Map<String, String> customHeaders) {
-    this.customHeaders = customHeaders;
-    return this;
-  }
+	public UnleashProperties setDisablePolling(final boolean disablePolling) {
+		this.disablePolling = disablePolling;
+		return this;
+	}
+
+	public boolean isEnableProxyAuthenticationByJvmProperties() {
+		return enableProxyAuthenticationByJvmProperties;
+	}
+
+	public UnleashProperties setEnableProxyAuthenticationByJvmProperties(
+			final boolean enableProxyAuthenticationByJvmProperties) {
+		this.enableProxyAuthenticationByJvmProperties = enableProxyAuthenticationByJvmProperties;
+		return this;
+	}
+
+	public boolean isSynchronousFetchOnInitialisation() {
+		return synchronousFetchOnInitialisation;
+	}
+
+	public UnleashProperties setSynchronousFetchOnInitialisation(final boolean synchronousFetchOnInitialisation) {
+		this.synchronousFetchOnInitialisation = synchronousFetchOnInitialisation;
+		return this;
+	}
+
+	public String getBackUpFile() {
+		return backUpFile;
+	}
+
+	public UnleashProperties setBackUpFile(final String backUpFile) {
+		this.backUpFile = backUpFile;
+		return this;
+	}
+
+	public String getEnvironment() {
+		return environment;
+	}
+
+	public UnleashProperties setEnvironment(final String environment) {
+		this.environment = environment;
+		return this;
+	}
+
+	public String getInstanceId() {
+		return instanceId;
+	}
+
+	public UnleashProperties setInstanceId(final String instanceId) {
+		this.instanceId = instanceId;
+		return this;
+	}
+
+	public String getNamePrefix() {
+		return namePrefix;
+	}
+
+	public UnleashProperties setNamePrefix(final String namePrefix) {
+		this.namePrefix = namePrefix;
+		return this;
+	}
+
+	public String getProjectName() {
+		return projectName;
+	}
+
+	public UnleashProperties setProjectName(final String projectName) {
+		this.projectName = projectName;
+		return this;
+	}
+
+	public Long getFetchTogglesInterval() {
+		return fetchTogglesInterval;
+	}
+
+	public UnleashProperties setFetchTogglesInterval(final Long fetchTogglesInterval) {
+		this.fetchTogglesInterval = fetchTogglesInterval;
+		return this;
+	}
+
+	public Long getFetchTogglesConnectTimeoutSeconds() {
+		return fetchTogglesConnectTimeoutSeconds;
+	}
+
+	public UnleashProperties setFetchTogglesConnectTimeoutSeconds(final Long fetchTogglesConnectTimeoutSeconds) {
+		this.fetchTogglesConnectTimeoutSeconds = fetchTogglesConnectTimeoutSeconds;
+		return this;
+	}
+
+	public Long getFetchTogglesReadTimeoutSeconds() {
+		return fetchTogglesReadTimeoutSeconds;
+	}
+
+	public UnleashProperties setFetchTogglesReadTimeoutSeconds(final Long fetchTogglesReadTimeoutSeconds) {
+		this.fetchTogglesReadTimeoutSeconds = fetchTogglesReadTimeoutSeconds;
+		return this;
+	}
+
+	public Long getSendMetricsInterval() {
+		return sendMetricsInterval;
+	}
+
+	public UnleashProperties setSendMetricsInterval(final Long sendMetricsInterval) {
+		this.sendMetricsInterval = sendMetricsInterval;
+		return this;
+	}
+
+	public Long getSendMetricsConnectTimeoutSeconds() {
+		return sendMetricsConnectTimeoutSeconds;
+	}
+
+	public UnleashProperties setSendMetricsConnectTimeoutSeconds(final Long sendMetricsConnectTimeoutSeconds) {
+		this.sendMetricsConnectTimeoutSeconds = sendMetricsConnectTimeoutSeconds;
+		return this;
+	}
+
+	public Long getSendMetricsReadTimeoutSeconds() {
+		return sendMetricsReadTimeoutSeconds;
+	}
+
+	public UnleashProperties setSendMetricsReadTimeoutSeconds(final Long sendMetricsReadTimeoutSeconds) {
+		this.sendMetricsReadTimeoutSeconds = sendMetricsReadTimeoutSeconds;
+		return this;
+	}
+
+	public Map<String, String> getCustomHeaders() {
+		return customHeaders;
+	}
+
+	public UnleashProperties setCustomHeaders(final Map<String, String> customHeaders) {
+		this.customHeaders = customHeaders;
+		return this;
+	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesConfigBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesConfigBuilderCustomizer.java
@@ -27,44 +27,57 @@ import org.apache.commons.lang3.StringUtils;
  */
 class UnleashPropertiesConfigBuilderCustomizer implements UnleashConfigBuilderCustomizer {
 
-  private final UnleashProperties properties;
+	private final UnleashProperties properties;
 
-  UnleashPropertiesConfigBuilderCustomizer(final UnleashProperties properties) {
-    this.properties = properties;
-  }
+	UnleashPropertiesConfigBuilderCustomizer(final UnleashProperties properties) {
+		this.properties = properties;
+	}
 
-  @Override
-  public void customize(final UnleashConfig.Builder configBuilder) {
-    configBuilder.appName(properties.getAppName())
-        .unleashAPI(properties.getApiUrl())
-        .apiKey(properties.getApiClientSecret())
-        .namePrefix(properties.getNamePrefix())
-        .projectName(properties.getProjectName())
-        .synchronousFetchOnInitialisation(properties.isSynchronousFetchOnInitialisation());
+	@Override
+	public void customize(final UnleashConfig.Builder configBuilder) {
+		configBuilder.appName(properties.getAppName()).unleashAPI(properties.getUnleashApi())
+				.apiKey(properties.getApiKey()).namePrefix(properties.getNamePrefix())
+				.projectName(properties.getProjectName())
+				.synchronousFetchOnInitialisation(properties.isSynchronousFetchOnInitialisation());
 
-    if (properties.isDisableMetrics()) {
-      configBuilder.disableMetrics();
-    }
-    if (properties.isEnableProxyAuthenticationByJvmProperties()) {
-      configBuilder.enableProxyAuthenticationByJvmProperties();
-    }
-    if (StringUtils.isNotBlank(properties.getEnvironment())) {
-      configBuilder.environment(properties.getEnvironment());
-    }
-    if (StringUtils.isNotBlank(properties.getInstanceId())) {
-      configBuilder.instanceId(properties.getInstanceId());
-    }
-    if (StringUtils.isNotBlank(properties.getBackUpFile())) {
-      configBuilder.backupFile(properties.getBackUpFile());
-    }
-    if (properties.getFetchTogglesInterval() != null) {
-      configBuilder.fetchTogglesInterval(properties.getFetchTogglesInterval());
-    }
-    if (properties.getSendMetricsInterval() != null) {
-      configBuilder.sendMetricsInterval(properties.getSendMetricsInterval());
-    }
+		if (properties.isDisableMetrics()) {
+			configBuilder.disableMetrics();
+		}
+		if (properties.isDisablePolling()) {
+			configBuilder.disablePolling();
+		}
+		if (properties.isEnableProxyAuthenticationByJvmProperties()) {
+			configBuilder.enableProxyAuthenticationByJvmProperties();
+		}
+		if (StringUtils.isNotBlank(properties.getEnvironment())) {
+			configBuilder.environment(properties.getEnvironment());
+		}
+		if (StringUtils.isNotBlank(properties.getInstanceId())) {
+			configBuilder.instanceId(properties.getInstanceId());
+		}
+		if (StringUtils.isNotBlank(properties.getBackUpFile())) {
+			configBuilder.backupFile(properties.getBackUpFile());
+		}
+		if (properties.getFetchTogglesInterval() != null) {
+			configBuilder.fetchTogglesInterval(properties.getFetchTogglesInterval());
+		}
+		if (properties.getFetchTogglesConnectTimeoutSeconds() != null) {
+			configBuilder.fetchTogglesConnectTimeoutSeconds(properties.getFetchTogglesConnectTimeoutSeconds());
+		}
+		if (properties.getFetchTogglesReadTimeoutSeconds() != null) {
+			configBuilder.fetchTogglesReadTimeoutSeconds(properties.getFetchTogglesReadTimeoutSeconds());
+		}
+		if (properties.getSendMetricsInterval() != null) {
+			configBuilder.sendMetricsInterval(properties.getSendMetricsInterval());
+		}
+		if (properties.getSendMetricsConnectTimeoutSeconds() != null) {
+			configBuilder.sendMetricsConnectTimeoutSeconds(properties.getSendMetricsConnectTimeoutSeconds());
+		}
+		if (properties.getSendMetricsReadTimeoutSeconds() != null) {
+			configBuilder.sendMetricsReadTimeoutSeconds(properties.getSendMetricsReadTimeoutSeconds());
+		}
 
-    properties.getCustomHeaders().forEach(configBuilder::customHttpHeader);
-  }
+		properties.getCustomHeaders().forEach(configBuilder::customHttpHeader);
+	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesConfigBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesConfigBuilderCustomizer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.unleash;
+
+import io.getunleash.util.UnleashConfig;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A {@link UnleashConfigBuilderCustomizer} that applies properties from a
+ * {@link UnleashProperties} to a {@link UnleashConfig.Builder}.
+ *
+ * @author Max Schwaab
+ */
+class UnleashPropertiesConfigBuilderCustomizer implements UnleashConfigBuilderCustomizer {
+
+  private final UnleashProperties properties;
+
+  UnleashPropertiesConfigBuilderCustomizer(final UnleashProperties properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public void customize(final UnleashConfig.Builder configBuilder) {
+    configBuilder.appName(properties.getAppName())
+        .unleashAPI(properties.getApiUrl())
+        .apiKey(properties.getApiClientSecret())
+        .namePrefix(properties.getNamePrefix())
+        .projectName(properties.getProjectName())
+        .synchronousFetchOnInitialisation(properties.isSynchronousFetchOnInitialisation());
+
+    if (properties.isDisableMetrics()) {
+      configBuilder.disableMetrics();
+    }
+    if (properties.isEnableProxyAuthenticationByJvmProperties()) {
+      configBuilder.enableProxyAuthenticationByJvmProperties();
+    }
+    if (StringUtils.isNotBlank(properties.getEnvironment())) {
+      configBuilder.environment(properties.getEnvironment());
+    }
+    if (StringUtils.isNotBlank(properties.getInstanceId())) {
+      configBuilder.instanceId(properties.getInstanceId());
+    }
+    if (StringUtils.isNotBlank(properties.getBackUpFile())) {
+      configBuilder.backupFile(properties.getBackUpFile());
+    }
+    if (properties.getFetchTogglesInterval() != null) {
+      configBuilder.fetchTogglesInterval(properties.getFetchTogglesInterval());
+    }
+    if (properties.getSendMetricsInterval() != null) {
+      configBuilder.sendMetricsInterval(properties.getSendMetricsInterval());
+    }
+
+    properties.getCustomHeaders().forEach(configBuilder::customHttpHeader);
+  }
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesOrUnleashConfig.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesOrUnleashConfig.java
@@ -25,14 +25,18 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
  */
 class UnleashPropertiesOrUnleashConfig extends AnyNestedCondition {
 
-  public UnleashPropertiesOrUnleashConfig() {
-    super(ConfigurationPhase.REGISTER_BEAN);
-  }
+	public UnleashPropertiesOrUnleashConfig() {
+		super(ConfigurationPhase.REGISTER_BEAN);
+	}
 
-  @ConditionalOnUnleashRequiredProperties
-  static class UnleashRequiredProperties { }
+	@ConditionalOnUnleashRequiredProperties
+	static class UnleashRequiredProperties {
 
-  @ConditionalOnBean(UnleashConfig.class)
-  static class UnleashConfigBean { }
+	}
+
+	@ConditionalOnBean(UnleashConfig.class)
+	static class UnleashConfigBean {
+
+	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesOrUnleashConfig.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesOrUnleashConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.unleash;
+
+import io.getunleash.util.UnleashConfig;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+
+/**
+ * Condition for enabling {@link UnleashAutoConfiguration}.
+ */
+class UnleashPropertiesOrUnleashConfig extends AnyNestedCondition {
+
+  public UnleashPropertiesOrUnleashConfig() {
+    super(ConfigurationPhase.REGISTER_BEAN);
+  }
+
+  @ConditionalOnUnleashRequiredProperties
+  static class UnleashRequiredProperties { }
+
+  @ConditionalOnBean(UnleashConfig.class)
+  static class UnleashConfigBean { }
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/package-info.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/unleash/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * {@link org.springframework.boot.autoconfigure.AutoConfiguration} for Unleash.
+ *
+ * @author Max Schwaab
+ */
+package org.springframework.boot.autoconfigure.unleash;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/unleash/UnleashAutoConfigurationTest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/unleash/UnleashAutoConfigurationTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.unleash;
+
+import io.getunleash.CustomHttpHeadersProvider;
+import io.getunleash.FakeUnleash;
+import io.getunleash.Unleash;
+import io.getunleash.UnleashContextProvider;
+import io.getunleash.event.UnleashSubscriber;
+import io.getunleash.repository.ClientFeaturesResponse;
+import io.getunleash.repository.FeatureFetcher;
+import io.getunleash.repository.FeatureToggleResponse;
+import io.getunleash.repository.ToggleBootstrapProvider;
+import io.getunleash.strategy.Strategy;
+import io.getunleash.util.UnleashConfig;
+import io.getunleash.util.UnleashFeatureFetcherFactory;
+import io.getunleash.util.UnleashScheduledExecutor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.net.Proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link UnleashAutoConfiguration}.
+ *
+ * @author Max Schwaab
+ */
+@DisplayName("UnleashAutoConfiguration")
+class UnleashAutoConfigurationTest {
+
+  private static final String[] UNLEASH_REQUIRED_PROPERTIES = new String[]{
+      "spring.unleash.app-name=TestApp",
+      "spring.unleash.api-url=https://unleash.com",
+      "spring.unleash.api-client-secret=c13n753cr37"
+  };
+  private static final FeatureFetcher NO_OP_FEATURE_FETCHER = () -> new ClientFeaturesResponse(FeatureToggleResponse.Status.NOT_CHANGED, 200);
+  private static final UnleashFeatureFetcherFactory NO_OP_FEATURE_FETCHER_FACTORY = config -> NO_OP_FEATURE_FETCHER;
+  private static final UnleashConfig CUSTOM_UNLEASH_CONFIG = UnleashConfig.builder()
+      .appName("CustomTestApp")
+      .unleashAPI("https://custom.unleash.com")
+      .apiKey("cu570mc13n753cr37")
+      .disableMetrics()
+      .unleashFeatureFetcherFactory(NO_OP_FEATURE_FETCHER_FACTORY)
+      .build();
+
+  private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+      .withConfiguration(AutoConfigurations.of(UnleashAutoConfiguration.class));
+
+  @Test
+  void shouldNotCreateUnleashOnAppNameOrUnleashConfigNotPresent() {
+    this.contextRunner.withPropertyValues(
+            "spring.unleash.api-url=https://unleash.com",
+            "spring.unleash.api-client-secret=c13n753cr37"
+        )
+        .run((ctx) -> assertThat(ctx).doesNotHaveBean(Unleash.class));
+  }
+
+  @Test
+  void shouldNotCreateUnleashOnApiUrlOrUnleashConfigNotPresent() {
+    this.contextRunner.withPropertyValues(
+        "spring.unleash.app-name=TestApp",
+            "spring.unleash.api-client-secret=c13n753cr37"
+        )
+        .run((ctx) -> assertThat(ctx).doesNotHaveBean(Unleash.class));
+  }
+
+  @Test
+  void shouldNotCreateUnleashOnApiClientSecretOrUnleashConfigNotPresent() {
+    this.contextRunner.withPropertyValues(
+        "spring.unleash.app-name=TestApp",
+            "spring.unleash.api-url=https://unleash.com"
+        )
+        .run((ctx) -> assertThat(ctx).doesNotHaveBean(Unleash.class));
+  }
+
+  @Test
+  void shouldNotCreateUnleashOnUnleashBeanAlreadyPresent() {
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .withBean("customUnleash", Unleash.class, FakeUnleash::new)
+        .run((ctx) -> assertThat(ctx).doesNotHaveBean("unleash"));
+  }
+
+  @Test
+  void shouldCreateUnleashOnUnleashRequiredPropertiesPresent() {
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .run((ctx) -> assertThat(ctx).hasSingleBean(Unleash.class));
+  }
+
+  @Test
+  void shouldCreateUnleashOnUnleashConfigPresent() {
+    this.contextRunner.withBean(UnleashConfig.class, () -> CUSTOM_UNLEASH_CONFIG)
+        .run((ctx) -> assertThat(ctx).hasSingleBean(Unleash.class));
+  }
+
+  @Test
+  void shouldCreateUnleashPropertiesOnRequiredPropertiesPresent() {
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .run((ctx) -> assertThat(ctx).hasSingleBean(UnleashProperties.class));
+  }
+
+  @Test
+  void shouldNotCreateUnleashPropertiesOnRequiredPropertiesNotPresent() {
+    this.contextRunner.run((ctx) -> assertThat(ctx).doesNotHaveBean(UnleashProperties.class));
+  }
+
+  @Test
+  void shouldCreateUnleashConfig() {
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .run((ctx) -> assertThat(ctx).hasSingleBean(UnleashConfig.class));
+  }
+
+  @Test
+  void shouldNotCreateUnleashConfigOnUnleashConfigBeanAlreadyPresent() {
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .withBean("customUnleashConfig", UnleashConfig.class, () -> CUSTOM_UNLEASH_CONFIG)
+        .run((ctx) -> assertThat(ctx).doesNotHaveBean("unleashConfig"));
+  }
+
+  @Test
+  void shouldNotCreateUnleashConfigOnUnleashBeanAlreadyPresent() {
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .withBean("customUnleash", Unleash.class, FakeUnleash::new)
+        .run((ctx) -> assertThat(ctx).doesNotHaveBean("unleashConfig").doesNotHaveBean(UnleashConfig.class));
+  }
+
+  @Test
+  void shouldCreateUnleashPropertiesConfigBuilderCustomizerOnUnleashRequiredPropertiesPresent() {
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .run((ctx) -> assertThat(ctx).hasSingleBean(UnleashPropertiesConfigBuilderCustomizer.class));
+  }
+
+  @Test
+  void shouldNotCreateUnleashPropertiesConfigBuilderCustomizerOnUnleashRequiredPropertiesNotPresent() {
+    this.contextRunner.run((ctx) -> assertThat(ctx).doesNotHaveBean(UnleashPropertiesConfigBuilderCustomizer.class));
+  }
+
+  @Test
+  void shouldCreateUnleashBeanConfigBuilderCustomizer() {
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .run((ctx) -> assertThat(ctx).hasSingleBean(UnleashBeanConfigBuilderCustomizer.class));
+  }
+
+  @Test
+  void shouldUseAdditionalUnleashConfigBuilderCustomizer() {
+    final UnleashConfigBuilderCustomizer unleashConfigBuilderCustomizerMock = mock(UnleashConfigBuilderCustomizer.class);
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .withBean("customUnleash", UnleashConfigBuilderCustomizer.class, () -> unleashConfigBuilderCustomizerMock)
+        .run((ctx) -> verify(unleashConfigBuilderCustomizerMock).customize(any(UnleashConfig.Builder.class)));
+  }
+
+  @Test
+  void shouldCustomizeUnleashContextProvider() {
+    final UnleashContextProvider unleashContextProviderMock = mock(UnleashContextProvider.class);
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .withBean("customUnleashContextProvider", UnleashContextProvider.class, () -> unleashContextProviderMock)
+        .run((ctx) -> assertThat(ctx).getBean(UnleashConfig.class).hasFieldOrPropertyWithValue("contextProvider", unleashContextProviderMock));
+  }
+
+  @Test
+  void shouldCustomizeStrategy() {
+    final Strategy fallbackStrategyMock = mock(Strategy.class);
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .withBean("customFallbackStrategy", Strategy.class, () -> fallbackStrategyMock)
+        .run((ctx) -> assertThat(ctx).getBean(UnleashConfig.class).hasFieldOrPropertyWithValue("fallbackStrategy", fallbackStrategyMock));
+  }
+
+  @Test
+  void shouldCustomizeCustomHttpHeadersProvider() {
+    final CustomHttpHeadersProvider customHttpHeadersProviderMock = mock(CustomHttpHeadersProvider.class);
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .withBean("customHttpHeadersProvider", CustomHttpHeadersProvider.class, () -> customHttpHeadersProviderMock)
+        .run((ctx) -> assertThat(ctx).getBean(UnleashConfig.class).hasFieldOrPropertyWithValue("customHttpHeadersProvider", customHttpHeadersProviderMock));
+  }
+
+  @Test
+  void shouldCustomizeProxy() {
+    final Proxy customProxy = Proxy.NO_PROXY;
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .withBean("customProxy", Proxy.class, () -> customProxy)
+        .run((ctx) -> assertThat(ctx).getBean(UnleashConfig.class).hasFieldOrPropertyWithValue("proxy", customProxy));
+  }
+
+  @Test
+  void shouldCustomizeUnleashScheduledExecutor() {
+    final UnleashScheduledExecutor unleashScheduledExecutorMock = mock(UnleashScheduledExecutor.class);
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .withBean("customUnleashScheduledExecutor", UnleashScheduledExecutor.class, () -> unleashScheduledExecutorMock)
+        .run((ctx) -> assertThat(ctx).getBean(UnleashConfig.class).hasFieldOrPropertyWithValue("unleashScheduledExecutor", unleashScheduledExecutorMock));
+  }
+
+  @Test
+  void shouldCustomizeUnleashSubscriber() {
+    final UnleashSubscriber unleashSubscriberMock = mock(UnleashSubscriber.class);
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .withBean("customUnleashSubscriber", UnleashSubscriber.class, () -> unleashSubscriberMock)
+        .run((ctx) -> assertThat(ctx).getBean(UnleashConfig.class).hasFieldOrPropertyWithValue("unleashSubscriber", unleashSubscriberMock));
+  }
+
+  @Test
+  void shouldCustomizeToggleBootstrapProvider() {
+    final ToggleBootstrapProvider toggleBootstrapProviderMock = mock(ToggleBootstrapProvider.class);
+    this.contextRunner.withPropertyValues(UNLEASH_REQUIRED_PROPERTIES)
+        .withBean("customToggleBootstrapProvider", ToggleBootstrapProvider.class, () -> toggleBootstrapProviderMock)
+        .run((ctx) -> assertThat(ctx).getBean(UnleashConfig.class).hasFieldOrPropertyWithValue("toggleBootstrapProvider", toggleBootstrapProviderMock));
+  }
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/unleash/UnleashBeanConfigBuilderCustomizerTest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/unleash/UnleashBeanConfigBuilderCustomizerTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.unleash;
+
+import io.getunleash.CustomHttpHeadersProvider;
+import io.getunleash.UnleashContextProvider;
+import io.getunleash.event.UnleashSubscriber;
+import io.getunleash.repository.ToggleBootstrapProvider;
+import io.getunleash.strategy.Strategy;
+import io.getunleash.util.UnleashConfig;
+import io.getunleash.util.UnleashScheduledExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.Proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link UnleashBeanConfigBuilderCustomizer}.
+ *
+ * @author Max Schwaab
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UnleashBeanConfigBuilderCustomizer")
+class UnleashBeanConfigBuilderCustomizerTest {
+
+  @Mock
+  private UnleashContextProvider contextProviderMock;
+  @Mock
+  private Strategy fallbackStrategyMock;
+  @Mock
+  private CustomHttpHeadersProvider httpHeadersProviderMock;
+  @Mock
+  private Proxy proxyMock;
+  @Mock
+  private UnleashScheduledExecutor scheduledExecutorMock;
+  @Mock
+  private UnleashSubscriber subscriberMock;
+  @Mock
+  private ToggleBootstrapProvider toggleBootstrapProviderMock;
+
+  private UnleashBeanConfigBuilderCustomizer customizer;
+  private UnleashConfig.Builder configBuilder;
+
+  @BeforeEach
+  void setUp() {
+    customizer = new UnleashBeanConfigBuilderCustomizer(
+        contextProviderMock,
+        fallbackStrategyMock,
+        httpHeadersProviderMock,
+        proxyMock,
+        scheduledExecutorMock,
+        subscriberMock,
+        toggleBootstrapProviderMock
+    );
+    configBuilder = UnleashConfig.builder()
+        .appName("TestApp")
+        .unleashAPI("http://unleash.com")
+        .apiKey("c13n753cr37");
+  }
+
+  @Test
+  void shouldCustomizeContextProvider() {
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getContextProvider()).isEqualTo(contextProviderMock);
+  }
+
+  @Test
+  void shouldCustomizeFallbackStrategy() {
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getFallbackStrategy()).isEqualTo(fallbackStrategyMock);
+  }
+
+  @Test
+  void shouldCustomizeHttpHeadersProvider() {
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getCustomHttpHeadersProvider()).isEqualTo(httpHeadersProviderMock);
+  }
+
+  @Test
+  void shouldCustomizeProxy() {
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getProxy()).isEqualTo(proxyMock);
+  }
+
+  @Test
+  void shouldCustomizeSchedulerExecutor() {
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getScheduledExecutor()).isEqualTo(scheduledExecutorMock);
+  }
+
+  @Test
+  void shouldCustomizeSubscriber() {
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getSubscriber()).isEqualTo(subscriberMock);
+  }
+
+  @Test
+  void shouldCustomizeToggleBootstrapProvider() {
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getToggleBootstrapProvider()).isEqualTo(toggleBootstrapProviderMock);
+  }
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/unleash/UnleashBeanConfigBuilderCustomizerTest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/unleash/UnleashBeanConfigBuilderCustomizerTest.java
@@ -21,7 +21,9 @@ import io.getunleash.UnleashContextProvider;
 import io.getunleash.event.UnleashSubscriber;
 import io.getunleash.repository.ToggleBootstrapProvider;
 import io.getunleash.strategy.Strategy;
+import io.getunleash.util.MetricSenderFactory;
 import io.getunleash.util.UnleashConfig;
+import io.getunleash.util.UnleashFeatureFetcherFactory;
 import io.getunleash.util.UnleashScheduledExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -43,88 +45,105 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("UnleashBeanConfigBuilderCustomizer")
 class UnleashBeanConfigBuilderCustomizerTest {
 
-  @Mock
-  private UnleashContextProvider contextProviderMock;
-  @Mock
-  private Strategy fallbackStrategyMock;
-  @Mock
-  private CustomHttpHeadersProvider httpHeadersProviderMock;
-  @Mock
-  private Proxy proxyMock;
-  @Mock
-  private UnleashScheduledExecutor scheduledExecutorMock;
-  @Mock
-  private UnleashSubscriber subscriberMock;
-  @Mock
-  private ToggleBootstrapProvider toggleBootstrapProviderMock;
+	@Mock
+	private UnleashContextProvider contextProviderMock;
 
-  private UnleashBeanConfigBuilderCustomizer customizer;
-  private UnleashConfig.Builder configBuilder;
+	@Mock
+	private UnleashFeatureFetcherFactory featureFetcherFactoryMock;
 
-  @BeforeEach
-  void setUp() {
-    customizer = new UnleashBeanConfigBuilderCustomizer(
-        contextProviderMock,
-        fallbackStrategyMock,
-        httpHeadersProviderMock,
-        proxyMock,
-        scheduledExecutorMock,
-        subscriberMock,
-        toggleBootstrapProviderMock
-    );
-    configBuilder = UnleashConfig.builder()
-        .appName("TestApp")
-        .unleashAPI("http://unleash.com")
-        .apiKey("c13n753cr37");
-  }
+	@Mock
+	private Strategy fallbackStrategyMock;
 
-  @Test
-  void shouldCustomizeContextProvider() {
-    customizer.customize(configBuilder);
+	@Mock
+	private CustomHttpHeadersProvider httpHeadersProviderMock;
 
-    assertThat(configBuilder.build().getContextProvider()).isEqualTo(contextProviderMock);
-  }
+	@Mock
+	private MetricSenderFactory metricSenderFactoryMock;
+	@Mock
+	private Proxy proxyMock;
 
-  @Test
-  void shouldCustomizeFallbackStrategy() {
-    customizer.customize(configBuilder);
+	@Mock
+	private UnleashScheduledExecutor scheduledExecutorMock;
 
-    assertThat(configBuilder.build().getFallbackStrategy()).isEqualTo(fallbackStrategyMock);
-  }
+	@Mock
+	private UnleashSubscriber subscriberMock;
 
-  @Test
-  void shouldCustomizeHttpHeadersProvider() {
-    customizer.customize(configBuilder);
+	@Mock
+	private ToggleBootstrapProvider toggleBootstrapProviderMock;
 
-    assertThat(configBuilder.build().getCustomHttpHeadersProvider()).isEqualTo(httpHeadersProviderMock);
-  }
+	private UnleashBeanConfigBuilderCustomizer customizer;
 
-  @Test
-  void shouldCustomizeProxy() {
-    customizer.customize(configBuilder);
+	private UnleashConfig.Builder configBuilder;
 
-    assertThat(configBuilder.build().getProxy()).isEqualTo(proxyMock);
-  }
+	@BeforeEach
+	void setUp() {
+		customizer = new UnleashBeanConfigBuilderCustomizer(contextProviderMock, featureFetcherFactoryMock, fallbackStrategyMock,
+				httpHeadersProviderMock, metricSenderFactoryMock, proxyMock, scheduledExecutorMock, subscriberMock, toggleBootstrapProviderMock);
+		configBuilder = UnleashConfig.builder().appName("TestApp").unleashAPI("https://unleash.com")
+				.apiKey("c13n753cr37");
+	}
 
-  @Test
-  void shouldCustomizeSchedulerExecutor() {
-    customizer.customize(configBuilder);
+	@Test
+	void shouldCustomizeContextProvider() {
+		customizer.customize(configBuilder);
 
-    assertThat(configBuilder.build().getScheduledExecutor()).isEqualTo(scheduledExecutorMock);
-  }
+		assertThat(configBuilder.build().getContextProvider()).isEqualTo(contextProviderMock);
+	}
 
-  @Test
-  void shouldCustomizeSubscriber() {
-    customizer.customize(configBuilder);
+	@Test
+	void shouldCustomizeFeatureFetcherFactory() {
+		customizer.customize(configBuilder);
 
-    assertThat(configBuilder.build().getSubscriber()).isEqualTo(subscriberMock);
-  }
+		assertThat(configBuilder.build().getUnleashFeatureFetcherFactory()).isEqualTo(featureFetcherFactoryMock);
+	}
 
-  @Test
-  void shouldCustomizeToggleBootstrapProvider() {
-    customizer.customize(configBuilder);
+	@Test
+	void shouldCustomizeFallbackStrategy() {
+		customizer.customize(configBuilder);
 
-    assertThat(configBuilder.build().getToggleBootstrapProvider()).isEqualTo(toggleBootstrapProviderMock);
-  }
+		assertThat(configBuilder.build().getFallbackStrategy()).isEqualTo(fallbackStrategyMock);
+	}
+
+	@Test
+	void shouldCustomizeHttpHeadersProvider() {
+		customizer.customize(configBuilder);
+
+		assertThat(configBuilder.build().getCustomHttpHeadersProvider()).isEqualTo(httpHeadersProviderMock);
+	}
+
+	@Test
+	void shouldCustomizeMetricsSenderFactory() {
+		customizer.customize(configBuilder);
+
+		assertThat(configBuilder.build().getMetricSenderFactory()).isEqualTo(metricSenderFactoryMock);
+	}
+
+	@Test
+	void shouldCustomizeProxy() {
+		customizer.customize(configBuilder);
+
+		assertThat(configBuilder.build().getProxy()).isEqualTo(proxyMock);
+	}
+
+	@Test
+	void shouldCustomizeSchedulerExecutor() {
+		customizer.customize(configBuilder);
+
+		assertThat(configBuilder.build().getScheduledExecutor()).isEqualTo(scheduledExecutorMock);
+	}
+
+	@Test
+	void shouldCustomizeSubscriber() {
+		customizer.customize(configBuilder);
+
+		assertThat(configBuilder.build().getSubscriber()).isEqualTo(subscriberMock);
+	}
+
+	@Test
+	void shouldCustomizeToggleBootstrapProvider() {
+		customizer.customize(configBuilder);
+
+		assertThat(configBuilder.build().getToggleBootstrapProvider()).isEqualTo(toggleBootstrapProviderMock);
+	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesConfigBuilderCustomizerTest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesConfigBuilderCustomizerTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.unleash;
+
+import io.getunleash.util.UnleashConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+/**
+ * Tests for {@link UnleashPropertiesConfigBuilderCustomizer}.
+ *
+ * @author Max Schwaab
+ */
+@DisplayName("UnleashPropertiesConfigBuilderCustomizer")
+class UnleashPropertiesConfigBuilderCustomizerTest {
+
+  private UnleashProperties properties;
+  private UnleashConfigBuilderCustomizer customizer;
+  private UnleashConfig.Builder configBuilder;
+
+  @BeforeEach
+  void setUp() {
+    properties = new UnleashProperties()
+         .setAppName("TestApp")
+         .setApiUrl("http://unleash.com")
+         .setApiClientSecret("c13n753cr37");
+    customizer = new UnleashPropertiesConfigBuilderCustomizer(properties);
+    configBuilder = UnleashConfig.builder();
+  }
+
+  @Test
+  void shouldCustomizeAppName() {
+    final String appName = "MyAppName";
+
+    properties.setAppName(appName);
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getAppName()).isEqualTo(appName);
+  }
+
+  @Test
+  void shouldCustomizeApiUrl() {
+    final String apiUrl = "http://my.unleash.com";
+
+    properties.setApiUrl(apiUrl);
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getUnleashAPI()).isEqualTo(URI.create(apiUrl));
+  }
+
+  @Test
+  void shouldCustomizeApiClientSecret() {
+    final String apiClientSecret = "MyApi";
+
+    properties.setApiClientSecret(apiClientSecret);
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getCustomHttpHeaders()).containsExactly(entry("Authorization", apiClientSecret));
+  }
+
+  @Test
+  void shouldCustomizeDisableMetrcis() {
+    properties.setDisableMetrics(true);
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().isDisableMetrics()).isTrue();
+  }
+
+  @Test
+  void shouldCustomizeEnableProxyAuthenticationByJvmProperties() {
+    properties.setEnableProxyAuthenticationByJvmProperties(true);
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().isProxyAuthenticationByJvmProperties()).isTrue();
+  }
+
+  @Test
+  void shouldCustomizeSynchronousFetchOnInitialisation() {
+    properties.setSynchronousFetchOnInitialisation(true);
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().isSynchronousFetchOnInitialisation()).isTrue();
+  }
+
+  @Test
+  void shouldCustomizeBackupFile() {
+    final String backupFile = "myBackupFile";
+
+    properties.setBackUpFile(backupFile);
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getBackupFile()).isEqualTo(backupFile);
+  }
+
+  @Test
+  void shouldCustomizeEnvironement() {
+    final String environment = "myEnv";
+
+    properties.setEnvironment(environment);
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getEnvironment()).isEqualTo(environment);
+  }
+
+  @Test
+  void shouldCustomizeInstanceId() {
+    final String instanceId = "myInstance";
+
+    properties.setInstanceId(instanceId);
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getInstanceId()).isEqualTo(instanceId);
+  }
+
+  @Test
+  void shouldCustomizeNamePrefix() {
+    final String namePrefix = "myPrefix";
+
+    properties.setNamePrefix(namePrefix);
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getNamePrefix()).isEqualTo(namePrefix);
+  }
+
+  @Test
+  void shouldCustomizeProjectName() {
+    final String projectName = "myProjectName";
+
+    properties.setProjectName(projectName);
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getProjectName()).isEqualTo(projectName);
+  }
+
+  @Test
+  void shouldCustomizeFetchTogglesInterval() {
+    final long fetchTogglesInterval = 100;
+
+    properties.setFetchTogglesInterval(fetchTogglesInterval);
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getFetchTogglesInterval()).isEqualTo(fetchTogglesInterval);
+  }
+
+  @Test
+  void shouldCustomizeSendMetricsInterval() {
+    final long sendMetricsInterval = 100;
+
+    properties.setSendMetricsInterval(sendMetricsInterval);
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getSendMetricsInterval()).isEqualTo(sendMetricsInterval);
+  }
+
+  @Test
+  void shouldCustomizeCustomHeaders() {
+    final Map<String, String> customHeaders = Map.of(
+        "X-Wayfair", "WFN",
+        "Accept", "application/json"
+    );
+
+    properties.setCustomHeaders(customHeaders);
+    customizer.customize(configBuilder);
+
+    assertThat(configBuilder.build().getCustomHttpHeaders()).contains(
+        entry("X-Wayfair", "WFN"),
+        entry("Accept", "application/json")
+    );
+  }
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesConfigBuilderCustomizerTest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesConfigBuilderCustomizerTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,158 +37,202 @@ import static org.assertj.core.api.Assertions.entry;
 @DisplayName("UnleashPropertiesConfigBuilderCustomizer")
 class UnleashPropertiesConfigBuilderCustomizerTest {
 
-  private UnleashProperties properties;
-  private UnleashConfigBuilderCustomizer customizer;
-  private UnleashConfig.Builder configBuilder;
+	private UnleashProperties properties;
 
-  @BeforeEach
-  void setUp() {
-    properties = new UnleashProperties()
-         .setAppName("TestApp")
-         .setApiUrl("http://unleash.com")
-         .setApiClientSecret("c13n753cr37");
-    customizer = new UnleashPropertiesConfigBuilderCustomizer(properties);
-    configBuilder = UnleashConfig.builder();
-  }
+	private UnleashConfigBuilderCustomizer customizer;
 
-  @Test
-  void shouldCustomizeAppName() {
-    final String appName = "MyAppName";
+	private UnleashConfig.Builder configBuilder;
 
-    properties.setAppName(appName);
-    customizer.customize(configBuilder);
+	@BeforeEach
+	void setUp() {
+		properties = new UnleashProperties().setAppName("TestApp").setUnleashApi("https://unleash.com")
+				.setApiKey("c13n753cr37");
+		customizer = new UnleashPropertiesConfigBuilderCustomizer(properties);
+		configBuilder = UnleashConfig.builder();
+	}
 
-    assertThat(configBuilder.build().getAppName()).isEqualTo(appName);
-  }
+	@Test
+	void shouldCustomizeAppName() {
+		final String appName = "MyAppName";
 
-  @Test
-  void shouldCustomizeApiUrl() {
-    final String apiUrl = "http://my.unleash.com";
+		properties.setAppName(appName);
+		customizer.customize(configBuilder);
 
-    properties.setApiUrl(apiUrl);
-    customizer.customize(configBuilder);
+		assertThat(configBuilder.build().getAppName()).isEqualTo(appName);
+	}
 
-    assertThat(configBuilder.build().getUnleashAPI()).isEqualTo(URI.create(apiUrl));
-  }
+	@Test
+	void shouldCustomizeUnleashApi() {
+		final String unleashApi = "https://my.unleash.com";
 
-  @Test
-  void shouldCustomizeApiClientSecret() {
-    final String apiClientSecret = "MyApi";
+		properties.setUnleashApi(unleashApi);
+		customizer.customize(configBuilder);
 
-    properties.setApiClientSecret(apiClientSecret);
-    customizer.customize(configBuilder);
+		assertThat(configBuilder.build().getUnleashAPI()).isEqualTo(URI.create(unleashApi));
+	}
 
-    assertThat(configBuilder.build().getCustomHttpHeaders()).containsExactly(entry("Authorization", apiClientSecret));
-  }
+	@Test
+	void shouldCustomizeApiKey() {
+		final String apiKey = "MyApi";
 
-  @Test
-  void shouldCustomizeDisableMetrcis() {
-    properties.setDisableMetrics(true);
-    customizer.customize(configBuilder);
+		properties.setApiKey(apiKey);
+		customizer.customize(configBuilder);
 
-    assertThat(configBuilder.build().isDisableMetrics()).isTrue();
-  }
+		assertThat(configBuilder.build().getCustomHttpHeaders())
+				.containsExactly(entry("Authorization", apiKey));
+	}
 
-  @Test
-  void shouldCustomizeEnableProxyAuthenticationByJvmProperties() {
-    properties.setEnableProxyAuthenticationByJvmProperties(true);
-    customizer.customize(configBuilder);
+	@Test
+	void shouldCustomizeDisableMetrics() {
+		properties.setDisableMetrics(true);
+		customizer.customize(configBuilder);
 
-    assertThat(configBuilder.build().isProxyAuthenticationByJvmProperties()).isTrue();
-  }
+		assertThat(configBuilder.build().isDisableMetrics()).isTrue();
+	}
 
-  @Test
-  void shouldCustomizeSynchronousFetchOnInitialisation() {
-    properties.setSynchronousFetchOnInitialisation(true);
-    customizer.customize(configBuilder);
+	@Test
+	void shouldCustomizeDisablePolling() {
+		properties.setDisablePolling(true);
+		customizer.customize(configBuilder);
 
-    assertThat(configBuilder.build().isSynchronousFetchOnInitialisation()).isTrue();
-  }
+		assertThat(configBuilder.build().isDisablePolling()).isTrue();
+	}
 
-  @Test
-  void shouldCustomizeBackupFile() {
-    final String backupFile = "myBackupFile";
+	@Test
+	void shouldCustomizeEnableProxyAuthenticationByJvmProperties() {
+		properties.setEnableProxyAuthenticationByJvmProperties(true);
+		customizer.customize(configBuilder);
 
-    properties.setBackUpFile(backupFile);
-    customizer.customize(configBuilder);
+		assertThat(configBuilder.build().isProxyAuthenticationByJvmProperties()).isTrue();
+	}
 
-    assertThat(configBuilder.build().getBackupFile()).isEqualTo(backupFile);
-  }
+	@Test
+	void shouldCustomizeSynchronousFetchOnInitialisation() {
+		properties.setSynchronousFetchOnInitialisation(true);
+		customizer.customize(configBuilder);
 
-  @Test
-  void shouldCustomizeEnvironement() {
-    final String environment = "myEnv";
+		assertThat(configBuilder.build().isSynchronousFetchOnInitialisation()).isTrue();
+	}
 
-    properties.setEnvironment(environment);
-    customizer.customize(configBuilder);
+	@Test
+	void shouldCustomizeBackupFile() {
+		final String backupFile = "myBackupFile";
 
-    assertThat(configBuilder.build().getEnvironment()).isEqualTo(environment);
-  }
+		properties.setBackUpFile(backupFile);
+		customizer.customize(configBuilder);
 
-  @Test
-  void shouldCustomizeInstanceId() {
-    final String instanceId = "myInstance";
+		assertThat(configBuilder.build().getBackupFile()).isEqualTo(backupFile);
+	}
 
-    properties.setInstanceId(instanceId);
-    customizer.customize(configBuilder);
+	@Test
+	void shouldCustomizeEnvironment() {
+		final String environment = "myEnv";
 
-    assertThat(configBuilder.build().getInstanceId()).isEqualTo(instanceId);
-  }
+		properties.setEnvironment(environment);
+		customizer.customize(configBuilder);
 
-  @Test
-  void shouldCustomizeNamePrefix() {
-    final String namePrefix = "myPrefix";
+		assertThat(configBuilder.build().getEnvironment()).isEqualTo(environment);
+	}
 
-    properties.setNamePrefix(namePrefix);
-    customizer.customize(configBuilder);
+	@Test
+	void shouldCustomizeInstanceId() {
+		final String instanceId = "myInstance";
 
-    assertThat(configBuilder.build().getNamePrefix()).isEqualTo(namePrefix);
-  }
+		properties.setInstanceId(instanceId);
+		customizer.customize(configBuilder);
 
-  @Test
-  void shouldCustomizeProjectName() {
-    final String projectName = "myProjectName";
+		assertThat(configBuilder.build().getInstanceId()).isEqualTo(instanceId);
+	}
 
-    properties.setProjectName(projectName);
-    customizer.customize(configBuilder);
+	@Test
+	void shouldCustomizeNamePrefix() {
+		final String namePrefix = "myPrefix";
 
-    assertThat(configBuilder.build().getProjectName()).isEqualTo(projectName);
-  }
+		properties.setNamePrefix(namePrefix);
+		customizer.customize(configBuilder);
 
-  @Test
-  void shouldCustomizeFetchTogglesInterval() {
-    final long fetchTogglesInterval = 100;
+		assertThat(configBuilder.build().getNamePrefix()).isEqualTo(namePrefix);
+	}
 
-    properties.setFetchTogglesInterval(fetchTogglesInterval);
-    customizer.customize(configBuilder);
+	@Test
+	void shouldCustomizeProjectName() {
+		final String projectName = "myProjectName";
 
-    assertThat(configBuilder.build().getFetchTogglesInterval()).isEqualTo(fetchTogglesInterval);
-  }
+		properties.setProjectName(projectName);
+		customizer.customize(configBuilder);
 
-  @Test
-  void shouldCustomizeSendMetricsInterval() {
-    final long sendMetricsInterval = 100;
+		assertThat(configBuilder.build().getProjectName()).isEqualTo(projectName);
+	}
 
-    properties.setSendMetricsInterval(sendMetricsInterval);
-    customizer.customize(configBuilder);
+	@Test
+	void shouldCustomizeFetchTogglesInterval() {
+		final long fetchTogglesInterval = 100;
 
-    assertThat(configBuilder.build().getSendMetricsInterval()).isEqualTo(sendMetricsInterval);
-  }
+		properties.setFetchTogglesInterval(fetchTogglesInterval);
+		customizer.customize(configBuilder);
 
-  @Test
-  void shouldCustomizeCustomHeaders() {
-    final Map<String, String> customHeaders = Map.of(
-        "X-Wayfair", "WFN",
-        "Accept", "application/json"
-    );
+		assertThat(configBuilder.build().getFetchTogglesInterval()).isEqualTo(fetchTogglesInterval);
+	}
 
-    properties.setCustomHeaders(customHeaders);
-    customizer.customize(configBuilder);
+	@Test
+	void shouldCustomizeFetchTogglesConnectTimeoutSeconds() {
+		final long fetchTogglesConnectTimeout = 10;
 
-    assertThat(configBuilder.build().getCustomHttpHeaders()).contains(
-        entry("X-Wayfair", "WFN"),
-        entry("Accept", "application/json")
-    );
-  }
+		properties.setFetchTogglesConnectTimeoutSeconds(fetchTogglesConnectTimeout);
+		customizer.customize(configBuilder);
+
+		assertThat(configBuilder.build().getFetchTogglesConnectTimeout()).isEqualTo(Duration.of(fetchTogglesConnectTimeout, ChronoUnit.SECONDS));
+	}
+
+	@Test
+	void shouldCustomizeFetchTogglesReadTimeoutSeconds() {
+		final long fetchTogglesReadTimeout = 10;
+
+		properties.setFetchTogglesReadTimeoutSeconds(fetchTogglesReadTimeout);
+		customizer.customize(configBuilder);
+
+		assertThat(configBuilder.build().getFetchTogglesReadTimeout()).isEqualTo(Duration.of(fetchTogglesReadTimeout, ChronoUnit.SECONDS));
+	}
+
+	@Test
+	void shouldCustomizeSendMetricsInterval() {
+		final long sendMetricsInterval = 100;
+
+		properties.setSendMetricsInterval(sendMetricsInterval);
+		customizer.customize(configBuilder);
+
+		assertThat(configBuilder.build().getSendMetricsInterval()).isEqualTo(sendMetricsInterval);
+	}
+
+	@Test
+	void shouldCustomizeSendMetricsConnectTimeoutSeconds() {
+		final long sendMetricsConnectTimeout = 10;
+
+		properties.setSendMetricsConnectTimeoutSeconds(sendMetricsConnectTimeout);
+		customizer.customize(configBuilder);
+
+		assertThat(configBuilder.build().getSendMetricsConnectTimeout()).isEqualTo(Duration.of(sendMetricsConnectTimeout, ChronoUnit.SECONDS));
+	}
+
+	@Test
+	void shouldCustomizeSendMetricsReadTimeoutSeconds() {
+		final long sendMetricsReadTimeout = 10;
+
+		properties.setSendMetricsReadTimeoutSeconds(sendMetricsReadTimeout);
+		customizer.customize(configBuilder);
+
+		assertThat(configBuilder.build().getSendMetricsReadTimeout()).isEqualTo(Duration.of(sendMetricsReadTimeout, ChronoUnit.SECONDS));
+	}
+
+	@Test
+	void shouldCustomizeCustomHeaders() {
+		final Map<String, String> customHeaders = Map.of("X-Wayfair", "WFN", "Accept", "application/json");
+
+		properties.setCustomHeaders(customHeaders);
+		customizer.customize(configBuilder);
+
+		assertThat(configBuilder.build().getCustomHttpHeaders()).contains(entry("X-Wayfair", "WFN"),
+				entry("Accept", "application/json"));
+	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesTest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.unleash;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link UnleashProperties}.
+ *
+ * @author Max Schwaab
+ */
+@DisplayName("UnleashProperties")
+class UnleashPropertiesTest {
+
+  private static final String MUST_NOT_BE_BLANK_MESSAGE = "must not be blank";
+
+  private static UnleashProperties properties = new UnleashProperties();
+
+  private ValidatorFactory validatorFactory;
+  private Validator validator;
+
+  @BeforeEach
+  void setUp() {
+    properties.setAppName("TestApp")
+        .setApiUrl("http://unleash.com")
+        .setApiClientSecret("c13n753cr37");
+    validatorFactory = Validation.buildDefaultValidatorFactory();
+    validator = validatorFactory.getValidator();
+  }
+
+  @AfterEach
+  void tearDown() {
+    validatorFactory.close();
+  }
+
+  @ParameterizedTest(name = "{0} violates validation on argument {2}")
+  @MethodSource("validatedSettersWithInvalidArgs")
+  void setValidatedStringPropertyShouldReturnViolationOnBlankString(final String methodName, final Function<String, UnleashProperties> setter, final String value) {
+    assertThat(validator.validate(setter.apply(value)))
+        .extracting(ConstraintViolation::getMessage)
+        .containsExactly(MUST_NOT_BE_BLANK_MESSAGE);
+  }
+
+  private static Stream<Arguments> validatedSettersWithInvalidArgs() {
+    final Function<String, UnleashProperties> setAppName = properties::setAppName;
+    final Function<String, UnleashProperties> setApiUrl = properties::setApiUrl;
+    final Function<String, UnleashProperties> setApiClientSecret = properties::setApiClientSecret;
+
+    return Stream.of(
+        Arguments.of("setAppName", setAppName, null),
+        Arguments.of("setAppName", setAppName, ""),
+        Arguments.of("setAppName", setAppName, " "),
+        Arguments.of("setApiUrl", setApiUrl, null),
+        Arguments.of("setApiUrl", setApiUrl, ""),
+        Arguments.of("setApiUrl", setApiUrl, " "),
+        Arguments.of("setApiClientSecret", setApiClientSecret, null),
+        Arguments.of("setApiClientSecret", setApiClientSecret, ""),
+        Arguments.of("setApiClientSecret", setApiClientSecret, " ")
+    );
+  }
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesTest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/unleash/UnleashPropertiesTest.java
@@ -40,51 +40,45 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("UnleashProperties")
 class UnleashPropertiesTest {
 
-  private static final String MUST_NOT_BE_BLANK_MESSAGE = "must not be blank";
+	private static final String MUST_NOT_BE_BLANK_MESSAGE = "must not be blank";
 
-  private static UnleashProperties properties = new UnleashProperties();
+	private static UnleashProperties properties = new UnleashProperties();
 
-  private ValidatorFactory validatorFactory;
-  private Validator validator;
+	private ValidatorFactory validatorFactory;
 
-  @BeforeEach
-  void setUp() {
-    properties.setAppName("TestApp")
-        .setApiUrl("http://unleash.com")
-        .setApiClientSecret("c13n753cr37");
-    validatorFactory = Validation.buildDefaultValidatorFactory();
-    validator = validatorFactory.getValidator();
-  }
+	private Validator validator;
 
-  @AfterEach
-  void tearDown() {
-    validatorFactory.close();
-  }
+	@BeforeEach
+	void setUp() {
+		properties.setAppName("TestApp").setUnleashApi("https://unleash.com").setApiKey("c13n753cr37");
+		validatorFactory = Validation.buildDefaultValidatorFactory();
+		validator = validatorFactory.getValidator();
+	}
 
-  @ParameterizedTest(name = "{0} violates validation on argument {2}")
-  @MethodSource("validatedSettersWithInvalidArgs")
-  void setValidatedStringPropertyShouldReturnViolationOnBlankString(final String methodName, final Function<String, UnleashProperties> setter, final String value) {
-    assertThat(validator.validate(setter.apply(value)))
-        .extracting(ConstraintViolation::getMessage)
-        .containsExactly(MUST_NOT_BE_BLANK_MESSAGE);
-  }
+	@AfterEach
+	void tearDown() {
+		validatorFactory.close();
+	}
 
-  private static Stream<Arguments> validatedSettersWithInvalidArgs() {
-    final Function<String, UnleashProperties> setAppName = properties::setAppName;
-    final Function<String, UnleashProperties> setApiUrl = properties::setApiUrl;
-    final Function<String, UnleashProperties> setApiClientSecret = properties::setApiClientSecret;
+	@ParameterizedTest(name = "{0} violates validation on argument {2}")
+	@MethodSource("validatedSettersWithInvalidArgs")
+	void setValidatedStringPropertyShouldReturnViolationOnBlankString(final String methodName,
+			final Function<String, UnleashProperties> setter, final String value) {
+		assertThat(validator.validate(setter.apply(value))).extracting(ConstraintViolation::getMessage)
+				.containsExactly(MUST_NOT_BE_BLANK_MESSAGE);
+	}
 
-    return Stream.of(
-        Arguments.of("setAppName", setAppName, null),
-        Arguments.of("setAppName", setAppName, ""),
-        Arguments.of("setAppName", setAppName, " "),
-        Arguments.of("setApiUrl", setApiUrl, null),
-        Arguments.of("setApiUrl", setApiUrl, ""),
-        Arguments.of("setApiUrl", setApiUrl, " "),
-        Arguments.of("setApiClientSecret", setApiClientSecret, null),
-        Arguments.of("setApiClientSecret", setApiClientSecret, ""),
-        Arguments.of("setApiClientSecret", setApiClientSecret, " ")
-    );
-  }
+	private static Stream<Arguments> validatedSettersWithInvalidArgs() {
+		final Function<String, UnleashProperties> setAppName = properties::setAppName;
+		final Function<String, UnleashProperties> setUnleashApi = properties::setUnleashApi;
+		final Function<String, UnleashProperties> setApiKey = properties::setApiKey;
+
+		return Stream.of(Arguments.of("setAppName", setAppName, null), Arguments.of("setAppName", setAppName, ""),
+				Arguments.of("setAppName", setAppName, " "), Arguments.of("setUnleashApi", setUnleashApi, null),
+				Arguments.of("setUnleashApi", setUnleashApi, ""), Arguments.of("setUnleashApi", setUnleashApi, " "),
+				Arguments.of("setApiKey", setApiKey, null),
+				Arguments.of("setApiKey", setApiKey, ""),
+				Arguments.of("setApiKey", setApiKey, " "));
+	}
 
 }

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1513,6 +1513,13 @@ bom {
 			]
 		}
 	}
+	library("Unleash Client", "7.0.0") {
+		group("io.getunleash") {
+			modules = [
+					"unleash-client-java"
+			]
+		}
+	}
 	library("Versions Maven Plugin", "2.12.0") {
 		group("org.codehaus.mojo") {
 			plugins = [


### PR DESCRIPTION
# Adding Unleash Auto-Configuration

Added an auto-configuration for [Unleash](https://www.getunleash.io/) feature toggles that works either with properties or a provided UnleashConfig bean. This works on the latest 7.0.0 [Unleash Java client](https://github.com/Unleash/unleash-client-java) release.

The Unleash client is under Apache 2.0 license, so I belief this should work together with the Spring Boot Apache 2.0 license.

Created tests to make sure everything works as intended.

I didn't really find a place for documentation. If I overlooked it, please advice and I'll add some documentation around this feature. In general it's based on the [clients config options](https://github.com/Unleash/unleash-client-java#configuration-options).
