### PR TITLE
Fix no effect of custom SessionRepositoryCustomizer in application context

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java
@@ -31,6 +31,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.session.SessionRepository;
 import org.springframework.session.config.SessionRepositoryCustomizer;
@@ -64,6 +66,7 @@ class JdbcSessionConfiguration {
 	}
 
 	@Bean
+	@Order(Ordered.HIGHEST_PRECEDENCE)
 	SessionRepositoryCustomizer<JdbcIndexedSessionRepository> springBootSessionRepositoryCustomizer(
 			SessionProperties sessionProperties, JdbcSessionProperties jdbcSessionProperties,
 			ServerProperties serverProperties) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationJdbcTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationJdbcTests.java
@@ -49,6 +49,7 @@ import org.springframework.session.data.mongo.MongoIndexedSessionRepository;
 import org.springframework.session.data.redis.RedisIndexedSessionRepository;
 import org.springframework.session.hazelcast.HazelcastIndexedSessionRepository;
 import org.springframework.session.jdbc.JdbcIndexedSessionRepository;
+import org.springframework.session.jdbc.PostgreSqlJdbcIndexedSessionRepositoryCustomizer;
 import org.springframework.session.jdbc.config.annotation.SpringSessionDataSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -243,6 +244,24 @@ class SessionAutoConfigurationJdbcTests extends AbstractSessionAutoConfiguration
 						.hasBean("customInitializer"));
 	}
 
+	@Test
+	void whenTheUserDefinesTheirOwnJdbcIndexedSessionRepositoryCustomizerThenDefaultConfigurationIsOverwritten() {
+		String expectedCreateSessionAttributeQuery = """
+				INSERT INTO SPRING_SESSION_ATTRIBUTES (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES)
+				VALUES (?, ?, ?)
+				ON CONFLICT (SESSION_PRIMARY_ID, ATTRIBUTE_NAME)
+				DO UPDATE SET ATTRIBUTE_BYTES = EXCLUDED.ATTRIBUTE_BYTES
+				""";
+
+		this.contextRunner.withUserConfiguration(CustomJdbcIndexedSessionRepositoryCustomizerConfiguration.class)
+				.withConfiguration(AutoConfigurations.of(JdbcSessionConfiguration.class)).run((context) -> {
+					JdbcIndexedSessionRepository repository = validateSessionRepository(context,
+							JdbcIndexedSessionRepository.class);
+					assertThat(repository).hasFieldOrPropertyWithValue("createSessionAttributeQuery",
+							expectedCreateSessionAttributeQuery);
+				});
+	}
+
 	@Configuration
 	static class SessionDataSourceConfiguration {
 
@@ -285,6 +304,16 @@ class SessionAutoConfigurationJdbcTests extends AbstractSessionAutoConfiguration
 		@Bean
 		DataSourceScriptDatabaseInitializer customInitializer(DataSource dataSource) {
 			return new DataSourceScriptDatabaseInitializer(dataSource, new DatabaseInitializationSettings());
+		}
+
+	}
+
+	@Configuration
+	static class CustomJdbcIndexedSessionRepositoryCustomizerConfiguration {
+
+		@Bean
+		PostgreSqlJdbcIndexedSessionRepositoryCustomizer postgreSqlJdbcIndexedSessionRepositoryCustomizer() {
+			return new PostgreSqlJdbcIndexedSessionRepositoryCustomizer();
 		}
 
 	}


### PR DESCRIPTION
This PR fixes the issue #33463. 

With the new release of Spring Boot v3 the [SpringBootJdbcHttpSessionConfiguration](https://github.com/spring-projects/spring-boot/blob/76858aebc2c9e77c02a81b59362623852bf83ca2/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java#L71) was replaced with the [SessionRepositoryCustomizer](https://github.com/spring-projects/spring-boot/blob/216d15997a682b019822edb37d12caaa897ddeb3/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration.java#L67).

```java
@Bean
SessionRepositoryCustomizer<JdbcIndexedSessionRepository> springBootSessionRepositoryCustomizer(
		SessionProperties sessionProperties, JdbcSessionProperties jdbcSessionProperties,
		ServerProperties serverProperties) {
	return (sessionRepository) -> {
		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
		map.from(sessionProperties.determineTimeout(() -> serverProperties.getServlet().getSession().getTimeout()))
				.to(sessionRepository::setDefaultMaxInactiveInterval);

		map.from(jdbcSessionProperties::getTableName).to(sessionRepository::setTableName); // --> relevant line
		map.from(jdbcSessionProperties::getFlushMode).to(sessionRepository::setFlushMode);
		map.from(jdbcSessionProperties::getSaveMode).to(sessionRepository::setSaveMode);
		map.from(jdbcSessionProperties::getCleanupCron).to(sessionRepository::setCleanupCron);
	};

}
```

This change led to the linked issue because in the Spring Session project the [line](https://github.com/spring-projects/spring-session/blob/c98a7be0e2ced7f795018f05397dca4bd5ca8212/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfiguration.java#L147) in `JdbcHttpSessionConfiguration` now has more than one `sessionRepositoryCustomizers` and they are executed in the wrong order.

```java
@Bean
public JdbcIndexedSessionRepository sessionRepository() {
	// ...
	JdbcIndexedSessionRepository sessionRepository = new JdbcIndexedSessionRepository(jdbcTemplate,
			this.transactionOperations);
	// ...
	this.sessionRepositoryCustomizers
			.forEach((sessionRepositoryCustomizer) -> sessionRepositoryCustomizer.customize(sessionRepository));
	return sessionRepository;
}
```


By default the first few session repository customizer are the custom defined one's (e.g. a `PostgreSqlJdbcIndexedSessionRepositoryCustomizer`, it updates a query). After that the `springBootSessionRepositoryCustomizer` is executed which sets the table name and in return updates all queries to their respective defaults (see [here](https://github.com/spring-projects/spring-session/blob/62ec64310b7e284b5b0c40745cb968e20de6fdd3/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcIndexedSessionRepository.java#L298)).

```java
public void setTableName(String tableName) {
	Assert.hasText(tableName, "Table name must not be empty");
	this.tableName = tableName.trim();
	prepareQueries(); // --> this line updates all queries to their defaults
}
```

To fix this the order of the `springBootSessionRepositoryCustomizer` bean is set to highest precedence so that the bean is the first one in the [list](https://github.com/spring-projects/spring-session/blob/c98a7be0e2ced7f795018f05397dca4bd5ca8212/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfiguration.java#L147).

This fix should be identical to the implementation in Spring Boot 2.7 because in the "old" implementation the logic of `springBootSessionRepositoryCustomizer` is executed before other customizer's.