### PR TITLE
Add max http response header size configuration for tomcat and jetty

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -490,6 +490,11 @@ public class ServerProperties {
 		 */
 		private final Remoteip remoteip = new Remoteip();
 
+		/**
+		 * Maximum size of the HTTP response header.
+		 */
+		private DataSize maxHttpResponseHeaderSize = DataSize.ofKilobytes(8);
+
 		public DataSize getMaxHttpFormPostSize() {
 			return this.maxHttpFormPostSize;
 		}
@@ -644,6 +649,14 @@ public class ServerProperties {
 
 		public Remoteip getRemoteip() {
 			return this.remoteip;
+		}
+
+		public DataSize getMaxHttpResponseHeaderSize() {
+			return maxHttpResponseHeaderSize;
+		}
+
+		public void setMaxHttpResponseHeaderSize(DataSize maxHttpResponseHeaderSize) {
+			this.maxHttpResponseHeaderSize = maxHttpResponseHeaderSize;
 		}
 
 		/**
@@ -1096,6 +1109,11 @@ public class ServerProperties {
 		 */
 		private Duration connectionIdleTimeout;
 
+		/**
+		 * Maximum size of the HTTP response header.
+		 */
+		private DataSize maxHttpResponseHeaderSize = DataSize.ofKilobytes(8);
+
 		public Accesslog getAccesslog() {
 			return this.accesslog;
 		}
@@ -1118,6 +1136,14 @@ public class ServerProperties {
 
 		public void setConnectionIdleTimeout(Duration connectionIdleTimeout) {
 			this.connectionIdleTimeout = connectionIdleTimeout;
+		}
+
+		public DataSize getMaxHttpResponseHeaderSize() {
+			return maxHttpResponseHeaderSize;
+		}
+
+		public void setMaxHttpResponseHeaderSize(DataSize maxHttpResponseHeaderSize) {
+			this.maxHttpResponseHeaderSize = maxHttpResponseHeaderSize;
 		}
 
 		/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -69,6 +69,8 @@ import org.springframework.util.unit.DataSize;
  * @author Victor Mandujano
  * @author Chris Bono
  * @author Parviz Rozikov
+ * @author Florian Storz
+ * @author Michael Weidmann
  * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = true)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
@@ -53,6 +53,8 @@ import org.springframework.util.unit.DataSize;
  * @author Phillip Webb
  * @author HaiTao Zhang
  * @author Rafiullah Hamedy
+ * @author Florian Storz
+ * @author Michael Weidmann
  * @since 2.0.0
  */
 public class JettyWebServerFactoryCustomizer

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
@@ -96,8 +96,8 @@ public class TomcatWebServerFactoryCustomizer
 				.when(this::isPositive)
 				.to((maxHttpRequestHeaderSize) -> customizeMaxHttpRequestHeaderSize(factory, maxHttpRequestHeaderSize));
 		propertyMapper.from(tomcatProperties::getMaxHttpResponseHeaderSize).whenNonNull().asInt(DataSize::toBytes)
-				.when(this::isPositive)
-				.to((maxHttpResponseHeaderSize) -> customizeMaxHttpResponseHeaderSize(factory, maxHttpResponseHeaderSize));
+				.when(this::isPositive).to((maxHttpResponseHeaderSize) -> customizeMaxHttpResponseHeaderSize(factory,
+						maxHttpResponseHeaderSize));
 		propertyMapper.from(tomcatProperties::getMaxSwallowSize).whenNonNull().asInt(DataSize::toBytes)
 				.to((maxSwallowSize) -> customizeMaxSwallowSize(factory, maxSwallowSize));
 		propertyMapper.from(tomcatProperties::getMaxHttpFormPostSize).asInt(DataSize::toBytes)
@@ -156,7 +156,8 @@ public class TomcatWebServerFactoryCustomizer
 	}
 
 	private void customizeMaxKeepAliveRequests(ConfigurableTomcatWebServerFactory factory, int maxKeepAliveRequests) {
-		customizeHandler(factory, maxKeepAliveRequests, AbstractHttp11Protocol.class, AbstractHttp11Protocol::setMaxKeepAliveRequests);
+		customizeHandler(factory, maxKeepAliveRequests, AbstractHttp11Protocol.class,
+				AbstractHttp11Protocol::setMaxKeepAliveRequests);
 	}
 
 	private void customizeMaxConnections(ConfigurableTomcatWebServerFactory factory, int maxConnections) {
@@ -164,7 +165,8 @@ public class TomcatWebServerFactoryCustomizer
 	}
 
 	private void customizeConnectionTimeout(ConfigurableTomcatWebServerFactory factory, Duration connectionTimeout) {
-		customizeHandler(factory, (int) connectionTimeout.toMillis(), AbstractProtocol.class, AbstractProtocol::setConnectionTimeout);
+		customizeHandler(factory, (int) connectionTimeout.toMillis(), AbstractProtocol.class,
+				AbstractProtocol::setConnectionTimeout);
 	}
 
 	private void customizeRelaxedPathChars(ConfigurableTomcatWebServerFactory factory, String relaxedChars) {
@@ -236,19 +238,23 @@ public class TomcatWebServerFactoryCustomizer
 
 	private void customizeMaxHttpRequestHeaderSize(ConfigurableTomcatWebServerFactory factory,
 			int maxHttpRequestHeaderSize) {
-		customizeHandler(factory, maxHttpRequestHeaderSize, AbstractHttp11Protocol.class, AbstractHttp11Protocol::setMaxHttpRequestHeaderSize);
+		customizeHandler(factory, maxHttpRequestHeaderSize, AbstractHttp11Protocol.class,
+				AbstractHttp11Protocol::setMaxHttpRequestHeaderSize);
 	}
 
 	private void customizeMaxHttpResponseHeaderSize(ConfigurableTomcatWebServerFactory factory,
 			int maxHttpResponseHeaderSize) {
-		customizeHandler(factory, maxHttpResponseHeaderSize, AbstractHttp11Protocol.class, AbstractHttp11Protocol::setMaxHttpResponseHeaderSize);
+		customizeHandler(factory, maxHttpResponseHeaderSize, AbstractHttp11Protocol.class,
+				AbstractHttp11Protocol::setMaxHttpResponseHeaderSize);
 	}
 
 	private void customizeMaxSwallowSize(ConfigurableTomcatWebServerFactory factory, int maxSwallowSize) {
-		customizeHandler(factory, maxSwallowSize, AbstractHttp11Protocol.class, AbstractHttp11Protocol::setMaxSwallowSize);
+		customizeHandler(factory, maxSwallowSize, AbstractHttp11Protocol.class,
+				AbstractHttp11Protocol::setMaxSwallowSize);
 	}
 
-	private <T extends ProtocolHandler> void customizeHandler(ConfigurableTomcatWebServerFactory factory, int value, Class<T> type, ObjIntConsumer<T> consumer) {
+	private <T extends ProtocolHandler> void customizeHandler(ConfigurableTomcatWebServerFactory factory, int value,
+			Class<T> type, ObjIntConsumer<T> consumer) {
 		factory.addConnectorCustomizers((connector) -> {
 			ProtocolHandler handler = connector.getProtocolHandler();
 			if (type.isAssignableFrom(handler.getClass())) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
@@ -132,10 +132,12 @@ public class TomcatWebServerFactoryCustomizer
 		return value > 0;
 	}
 
+	@SuppressWarnings("rawtypes")
 	private void customizeAcceptCount(ConfigurableTomcatWebServerFactory factory, int acceptCount) {
 		customizeHandler(factory, acceptCount, AbstractProtocol.class, AbstractProtocol::setAcceptCount);
 	}
 
+	@SuppressWarnings("rawtypes")
 	private void customizeProcessorCache(ConfigurableTomcatWebServerFactory factory, int processorCache) {
 		customizeHandler(factory, processorCache, AbstractProtocol.class, AbstractProtocol::setProcessorCache);
 	}
@@ -155,15 +157,18 @@ public class TomcatWebServerFactoryCustomizer
 		});
 	}
 
+	@SuppressWarnings("rawtypes")
 	private void customizeMaxKeepAliveRequests(ConfigurableTomcatWebServerFactory factory, int maxKeepAliveRequests) {
 		customizeHandler(factory, maxKeepAliveRequests, AbstractHttp11Protocol.class,
 				AbstractHttp11Protocol::setMaxKeepAliveRequests);
 	}
 
+	@SuppressWarnings("rawtypes")
 	private void customizeMaxConnections(ConfigurableTomcatWebServerFactory factory, int maxConnections) {
 		customizeHandler(factory, maxConnections, AbstractProtocol.class, AbstractProtocol::setMaxConnections);
 	}
 
+	@SuppressWarnings("rawtypes")
 	private void customizeConnectionTimeout(ConfigurableTomcatWebServerFactory factory, Duration connectionTimeout) {
 		customizeHandler(factory, (int) connectionTimeout.toMillis(), AbstractProtocol.class,
 				AbstractProtocol::setConnectionTimeout);
@@ -228,26 +233,31 @@ public class TomcatWebServerFactoryCustomizer
 		return this.serverProperties.getForwardHeadersStrategy().equals(ServerProperties.ForwardHeadersStrategy.NATIVE);
 	}
 
+	@SuppressWarnings("rawtypes")
 	private void customizeMaxThreads(ConfigurableTomcatWebServerFactory factory, int maxThreads) {
 		customizeHandler(factory, maxThreads, AbstractProtocol.class, AbstractProtocol::setMaxThreads);
 	}
 
+	@SuppressWarnings("rawtypes")
 	private void customizeMinThreads(ConfigurableTomcatWebServerFactory factory, int minSpareThreads) {
 		customizeHandler(factory, minSpareThreads, AbstractProtocol.class, AbstractProtocol::setMinSpareThreads);
 	}
 
+	@SuppressWarnings("rawtypes")
 	private void customizeMaxHttpRequestHeaderSize(ConfigurableTomcatWebServerFactory factory,
 			int maxHttpRequestHeaderSize) {
 		customizeHandler(factory, maxHttpRequestHeaderSize, AbstractHttp11Protocol.class,
 				AbstractHttp11Protocol::setMaxHttpRequestHeaderSize);
 	}
 
+	@SuppressWarnings("rawtypes")
 	private void customizeMaxHttpResponseHeaderSize(ConfigurableTomcatWebServerFactory factory,
 			int maxHttpResponseHeaderSize) {
 		customizeHandler(factory, maxHttpResponseHeaderSize, AbstractHttp11Protocol.class,
 				AbstractHttp11Protocol::setMaxHttpResponseHeaderSize);
 	}
 
+	@SuppressWarnings("rawtypes")
 	private void customizeMaxSwallowSize(ConfigurableTomcatWebServerFactory factory, int maxSwallowSize) {
 		customizeHandler(factory, maxSwallowSize, AbstractHttp11Protocol.class,
 				AbstractHttp11Protocol::setMaxSwallowSize);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
@@ -59,6 +59,8 @@ import java.util.stream.Collectors;
  * @author Rafiullah Hamedy
  * @author Victor Mandujano
  * @author Parviz Rozikov
+ * @author Florian Storz
+ * @author Michael Weidmann
  * @since 2.0.0
  */
 public class TomcatWebServerFactoryCustomizer

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizerTests.java
@@ -212,6 +212,68 @@ class TomcatWebServerFactoryCustomizerTests {
 	}
 
 	@Test
+	void defaultMaxHttpRequestHeaderSize() {
+		customizeAndRunServer((server) -> assertThat(
+				((AbstractHttp11Protocol<?>) server.getTomcat().getConnector().getProtocolHandler())
+						.getMaxHttpRequestHeaderSize()).isEqualTo(DataSize.ofKilobytes(8).toBytes()));
+	}
+
+	@Test
+	void customMaxHttpRequestHeaderSize() {
+		bind("server.max-http-request-header-size=10MB");
+		customizeAndRunServer((server) -> assertThat(
+				((AbstractHttp11Protocol<?>) server.getTomcat().getConnector().getProtocolHandler())
+						.getMaxHttpRequestHeaderSize()).isEqualTo(DataSize.ofMegabytes(10).toBytes()));
+	}
+
+	@Test
+	void customMaxRequestHttpHeaderSizeIgnoredIfNegative() {
+		bind("server.max-http-request-header-size=-1");
+		customizeAndRunServer((server) -> assertThat(
+				((AbstractHttp11Protocol<?>) server.getTomcat().getConnector().getProtocolHandler())
+						.getMaxHttpRequestHeaderSize()).isEqualTo(DataSize.ofKilobytes(8).toBytes()));
+	}
+
+	@Test
+	void customMaxRequestHttpHeaderSizeIgnoredIfZero() {
+		bind("server.max-http-request-header-size=0");
+		customizeAndRunServer((server) -> assertThat(
+				((AbstractHttp11Protocol<?>) server.getTomcat().getConnector().getProtocolHandler())
+						.getMaxHttpRequestHeaderSize()).isEqualTo(DataSize.ofKilobytes(8).toBytes()));
+	}
+
+	@Test
+	void defaultMaxHttpResponseHeaderSize() {
+		customizeAndRunServer((server) -> assertThat(
+				((AbstractHttp11Protocol<?>) server.getTomcat().getConnector().getProtocolHandler())
+						.getMaxHttpResponseHeaderSize()).isEqualTo(DataSize.ofKilobytes(8).toBytes()));
+	}
+
+	@Test
+	void customMaxHttpResponseHeaderSize() {
+		bind("server.tomcat.max-http-response-header-size=10MB");
+		customizeAndRunServer((server) -> assertThat(
+				((AbstractHttp11Protocol<?>) server.getTomcat().getConnector().getProtocolHandler())
+						.getMaxHttpResponseHeaderSize()).isEqualTo(DataSize.ofMegabytes(10).toBytes()));
+	}
+
+	@Test
+	void customMaxResponseHttpHeaderSizeIgnoredIfNegative() {
+		bind("server.tomcat.max-http-response-header-size=-1");
+		customizeAndRunServer((server) -> assertThat(
+				((AbstractHttp11Protocol<?>) server.getTomcat().getConnector().getProtocolHandler())
+						.getMaxHttpResponseHeaderSize()).isEqualTo(DataSize.ofKilobytes(8).toBytes()));
+	}
+
+	@Test
+	void customMaxResponseHttpHeaderSizeIgnoredIfZero() {
+		bind("server.tomcat.max-http-response-header-size=0");
+		customizeAndRunServer((server) -> assertThat(
+				((AbstractHttp11Protocol<?>) server.getTomcat().getConnector().getProtocolHandler())
+						.getMaxHttpResponseHeaderSize()).isEqualTo(DataSize.ofKilobytes(8).toBytes()));
+	}
+
+	@Test
 	void customMaxSwallowSize() {
 		bind("server.tomcat.max-swallow-size=10MB");
 		customizeAndRunServer((server) -> assertThat(

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/service/HttpHeaderService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/service/HttpHeaderService.java
@@ -6,14 +6,16 @@ import smoketest.jetty.util.RandomStringUtil;
 
 @Component
 public class HttpHeaderService {
+
 	@Value("${server.jetty.max-http-response-header-size}")
 	private int maxHttpResponseHeaderSize;
 
 	/**
 	 * generate a random byte array that
 	 * <ol>
-	 * 	 <li>is longer than configured <code>server.jetty.max-http-response-header-size</code></li>
-	 * 	 <li>is url encoded by base 64 encode the random value</li>
+	 * <li>is longer than configured
+	 * <code>server.jetty.max-http-response-header-size</code></li>
+	 * <li>is url encoded by base 64 encode the random value</li>
 	 * </ol>
 	 * @return a base64 encoded string of random bytes
 	 */

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/service/HttpHeaderService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/service/HttpHeaderService.java
@@ -1,0 +1,24 @@
+package smoketest.jetty.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import smoketest.jetty.util.RandomStringUtil;
+
+@Component
+public class HttpHeaderService {
+	@Value("${server.jetty.max-http-response-header-size}")
+	private int maxHttpResponseHeaderSize;
+
+	/**
+	 * generate a random byte array that
+	 * <ol>
+	 * 	 <li>is longer than configured <code>server.jetty.max-http-response-header-size</code></li>
+	 * 	 <li>is url encoded by base 64 encode the random value</li>
+	 * </ol>
+	 * @return a base64 encoded string of random bytes
+	 */
+	public String getHeaderValue() {
+		return RandomStringUtil.getRandomBase64EncodedString(maxHttpResponseHeaderSize + 1);
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/util/RandomStringUtil.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/util/RandomStringUtil.java
@@ -4,11 +4,14 @@ import java.util.Base64;
 import java.util.Random;
 
 public class RandomStringUtil {
-	private RandomStringUtil() {}
+
+	private RandomStringUtil() {
+	}
 
 	public static String getRandomBase64EncodedString(int length) {
 		byte[] responseHeader = new byte[length];
 		new Random().nextBytes(responseHeader);
 		return Base64.getEncoder().encodeToString(responseHeader);
 	}
+
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/util/RandomStringUtil.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/util/RandomStringUtil.java
@@ -1,0 +1,14 @@
+package smoketest.jetty.util;
+
+import java.util.Base64;
+import java.util.Random;
+
+public class RandomStringUtil {
+	private RandomStringUtil() {}
+
+	public static String getRandomBase64EncodedString(int length) {
+		byte[] responseHeader = new byte[length];
+		new Random().nextBytes(responseHeader);
+		return Base64.getEncoder().encodeToString(responseHeader);
+	}
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/web/SampleController.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/web/SampleController.java
@@ -16,7 +16,9 @@
 
 package smoketest.jetty.web;
 
+import jakarta.servlet.http.HttpServletResponse;
 import smoketest.jetty.service.HelloWorldService;
+import smoketest.jetty.service.HttpHeaderService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -29,10 +31,20 @@ public class SampleController {
 	@Autowired
 	private HelloWorldService helloWorldService;
 
+	@Autowired
+	private HttpHeaderService httpHeaderService;
+
 	@GetMapping("/")
 	@ResponseBody
 	public String helloWorld() {
 		return this.helloWorldService.getHelloMessage();
 	}
 
+	@GetMapping("/max-http-response-header")
+	@ResponseBody
+	public String maxHttpResponseHeader(HttpServletResponse response) {
+		String headerValue = httpHeaderService.getHeaderValue();
+		response.addHeader("x-max-header", headerValue);
+		return this.helloWorldService.getHelloMessage();
+	}
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/web/SampleController.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/web/SampleController.java
@@ -47,4 +47,5 @@ public class SampleController {
 		response.addHeader("x-max-header", headerValue);
 		return this.helloWorldService.getHelloMessage();
 	}
+
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/resources/application.properties
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 server.compression.enabled: true
 server.compression.min-response-size: 1
+server.max-http-request-header-size=1000
 server.jetty.threads.acceptors=2
+server.jetty.max-http-response-header-size=1000

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/test/java/smoketest/jetty/SampleJettyApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/test/java/smoketest/jetty/SampleJettyApplicationTests.java
@@ -86,4 +86,5 @@ class SampleJettyApplicationTests {
 		ResponseEntity<String> entity = this.restTemplate.exchange("/", HttpMethod.GET, httpEntity, String.class);
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.REQUEST_HEADER_FIELDS_TOO_LARGE);
 	}
+
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/test/java/smoketest/jetty/SampleJettyApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/test/java/smoketest/jetty/SampleJettyApplicationTests.java
@@ -40,6 +40,14 @@ import smoketest.jetty.util.RandomStringUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Basic integration tests for demo application.
+ *
+ * @author Dave Syer
+ * @author Andy Wilkinson
+ * @author Florian Storz
+ * @author Michael Weidmann
+ */
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ExtendWith(OutputCaptureExtension.class)
 class SampleJettyApplicationTests {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/service/HttpHeaderService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/service/HttpHeaderService.java
@@ -1,0 +1,24 @@
+package smoketest.tomcat.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import smoketest.tomcat.util.RandomStringUtil;
+
+@Component
+public class HttpHeaderService {
+	@Value("${server.tomcat.max-http-response-header-size}")
+	private int maxHttpResponseHeaderSize;
+
+	/**
+	 * generate a random byte array that
+	 * <ol>
+	 * 	 <li>is longer than configured <code>server.jetty.max-http-response-header-size</code></li>
+	 * 	 <li>is url encoded by base 64 encode the random value</li>
+	 * </ol>
+	 * @return a base64 encoded string of random bytes
+	 */
+	public String getHeaderValue() {
+		return RandomStringUtil.getRandomBase64EncodedString(maxHttpResponseHeaderSize + 1);
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/service/HttpHeaderService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/service/HttpHeaderService.java
@@ -6,14 +6,16 @@ import smoketest.tomcat.util.RandomStringUtil;
 
 @Component
 public class HttpHeaderService {
+
 	@Value("${server.tomcat.max-http-response-header-size}")
 	private int maxHttpResponseHeaderSize;
 
 	/**
 	 * generate a random byte array that
 	 * <ol>
-	 * 	 <li>is longer than configured <code>server.jetty.max-http-response-header-size</code></li>
-	 * 	 <li>is url encoded by base 64 encode the random value</li>
+	 * <li>is longer than configured
+	 * <code>server.jetty.max-http-response-header-size</code></li>
+	 * <li>is url encoded by base 64 encode the random value</li>
 	 * </ol>
 	 * @return a base64 encoded string of random bytes
 	 */

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/util/RandomStringUtil.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/util/RandomStringUtil.java
@@ -4,11 +4,14 @@ import java.util.Base64;
 import java.util.Random;
 
 public class RandomStringUtil {
-	private RandomStringUtil() {}
+
+	private RandomStringUtil() {
+	}
 
 	public static String getRandomBase64EncodedString(int length) {
 		byte[] responseHeader = new byte[length];
 		new Random().nextBytes(responseHeader);
 		return Base64.getEncoder().encodeToString(responseHeader);
 	}
+
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/util/RandomStringUtil.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/util/RandomStringUtil.java
@@ -1,0 +1,14 @@
+package smoketest.tomcat.util;
+
+import java.util.Base64;
+import java.util.Random;
+
+public class RandomStringUtil {
+	private RandomStringUtil() {}
+
+	public static String getRandomBase64EncodedString(int length) {
+		byte[] responseHeader = new byte[length];
+		new Random().nextBytes(responseHeader);
+		return Base64.getEncoder().encodeToString(responseHeader);
+	}
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/web/SampleController.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/web/SampleController.java
@@ -16,12 +16,14 @@
 
 package smoketest.tomcat.web;
 
+import jakarta.servlet.http.HttpServletResponse;
 import smoketest.tomcat.service.HelloWorldService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import smoketest.tomcat.service.HttpHeaderService;
 
 @Controller
 public class SampleController {
@@ -29,10 +31,20 @@ public class SampleController {
 	@Autowired
 	private HelloWorldService helloWorldService;
 
+	@Autowired
+	private HttpHeaderService httpHeaderService;
+
 	@GetMapping("/")
 	@ResponseBody
 	public String helloWorld() {
 		return this.helloWorldService.getHelloMessage();
 	}
 
+	@GetMapping("/max-http-response-header")
+	@ResponseBody
+	public String maxHttpResponseHeader(HttpServletResponse response) {
+		String headerValue = httpHeaderService.getHeaderValue();
+		response.addHeader("x-max-header", headerValue);
+		return this.helloWorldService.getHelloMessage();
+	}
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/web/SampleController.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/web/SampleController.java
@@ -47,4 +47,5 @@ public class SampleController {
 		response.addHeader("x-max-header", headerValue);
 		return this.helloWorldService.getHelloMessage();
 	}
+
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/resources/application.properties
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 server.compression.enabled: true
 server.compression.min-response-size: 1
+server.max-http-request-header-size=1000
 server.tomcat.connection-timeout=5s
+server.tomcat.max-http-response-header-size=1000

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/test/java/smoketest/tomcat/SampleTomcatApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-tomcat/src/test/java/smoketest/tomcat/SampleTomcatApplicationTests.java
@@ -50,6 +50,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Dave Syer
  * @author Andy Wilkinson
+ * @author Florian Storz
+ * @author Michael Weidmann
  */
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ExtendWith(OutputCaptureExtension.class)


### PR DESCRIPTION
This PR adds the feature described in #33380.

The configuration of the maximum size of the HTTP response header is only available on Tomcat and Jetty. That's why the configuration is only implemented for these two servers.

Besides the implementation the tests and smoke tests are extended.