### PR TITLE
Allow JoranConfigurators to be passed ahead of time in logback

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -188,7 +188,7 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 		if (isAlreadyInitialized(loggerContext)) {
 			return;
 		}
-		if (!initializeFromAotGeneratedArtifactsIfPossible(initializationContext, configurators, logFile)) {
+		if (!initializeFromAotGeneratedArtifactsIfPossible(initializationContext, this.configurators, logFile)) {
 			super.initialize(initializationContext, configLocation, logFile);
 		}
 		loggerContext.getTurboFilterList().remove(FILTER);
@@ -265,7 +265,7 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 	private void configureByResourceUrl(LoggingInitializationContext initializationContext, LoggerContext loggerContext,
 			URL url) throws JoranException {
 		if (url.toString().endsWith("xml")) {
-			JoranConfigurator configurator = new SpringBootJoranConfigurator(initializationContext, configurators);
+			JoranConfigurator configurator = new SpringBootJoranConfigurator(initializationContext, this.configurators);
 			configurator.setContext(loggerContext);
 			configurator.doConfigure(url);
 		}
@@ -421,7 +421,7 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 				.getObject(key);
 		context.removeObject(key);
 		this.configurators = beanFactory.getBeansOfType(JoranConfigurator.class).values();
-		this.configurators.forEach(configurator -> configurator.setContext(context));
+		this.configurators.forEach((configurator) -> configurator.setContext(context));
 		return contribution;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -20,6 +20,8 @@ import java.net.URL;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.ConsoleHandler;
@@ -82,6 +84,8 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 	private static final String CONFIGURATION_FILE_PROPERTY = "logback.configurationFile";
 
 	private static final LogLevels<Level> LEVELS = new LogLevels<>();
+
+	private Collection<JoranConfigurator> configurators = Collections.emptyList();
 
 	static {
 		LEVELS.map(LogLevel.TRACE, Level.TRACE);
@@ -184,7 +188,7 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 		if (isAlreadyInitialized(loggerContext)) {
 			return;
 		}
-		if (!initializeFromAotGeneratedArtifactsIfPossible(initializationContext, logFile)) {
+		if (!initializeFromAotGeneratedArtifactsIfPossible(initializationContext, configurators, logFile)) {
 			super.initialize(initializationContext, configLocation, logFile);
 		}
 		loggerContext.getTurboFilterList().remove(FILTER);
@@ -196,7 +200,7 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 	}
 
 	private boolean initializeFromAotGeneratedArtifactsIfPossible(LoggingInitializationContext initializationContext,
-			LogFile logFile) {
+																  Collection<JoranConfigurator> configurators, LogFile logFile) {
 		if (!AotDetector.useGeneratedArtifacts()) {
 			return false;
 		}
@@ -205,7 +209,7 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 		}
 		LoggerContext loggerContext = getLoggerContext();
 		stopAndReset(loggerContext);
-		SpringBootJoranConfigurator configurator = new SpringBootJoranConfigurator(initializationContext);
+		SpringBootJoranConfigurator configurator = new SpringBootJoranConfigurator(initializationContext, configurators);
 		configurator.setContext(loggerContext);
 		return configurator.configureUsingAotGeneratedArtifacts();
 	}
@@ -260,7 +264,7 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 	private void configureByResourceUrl(LoggingInitializationContext initializationContext, LoggerContext loggerContext,
 			URL url) throws JoranException {
 		if (url.toString().endsWith("xml")) {
-			JoranConfigurator configurator = new SpringBootJoranConfigurator(initializationContext);
+			JoranConfigurator configurator = new SpringBootJoranConfigurator(initializationContext, configurators);
 			configurator.setContext(loggerContext);
 			configurator.doConfigure(url);
 		}
@@ -415,6 +419,8 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 		BeanFactoryInitializationAotContribution contribution = (BeanFactoryInitializationAotContribution) context
 				.getObject(key);
 		context.removeObject(key);
+		this.configurators = beanFactory.getBeansOfType(JoranConfigurator.class).values();
+		this.configurators.forEach(configurator -> configurator.setContext(context));
 		return contribution;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -200,7 +200,7 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 	}
 
 	private boolean initializeFromAotGeneratedArtifactsIfPossible(LoggingInitializationContext initializationContext,
-																  Collection<JoranConfigurator> configurators, LogFile logFile) {
+			Collection<JoranConfigurator> configurators, LogFile logFile) {
 		if (!AotDetector.useGeneratedArtifacts()) {
 			return false;
 		}
@@ -209,7 +209,8 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 		}
 		LoggerContext loggerContext = getLoggerContext();
 		stopAndReset(loggerContext);
-		SpringBootJoranConfigurator configurator = new SpringBootJoranConfigurator(initializationContext, configurators);
+		SpringBootJoranConfigurator configurator = new SpringBootJoranConfigurator(initializationContext,
+				configurators);
 		configurator.setContext(loggerContext);
 		return configurator.configureUsingAotGeneratedArtifacts();
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringBootJoranConfigurator.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringBootJoranConfigurator.java
@@ -114,7 +114,7 @@ class SpringBootJoranConfigurator extends JoranConfigurator {
 		ruleStore.addRule(new ElementSelector("configuration/springProperty"), SpringPropertyAction::new);
 		ruleStore.addRule(new ElementSelector("*/springProfile"), SpringProfileAction::new);
 		ruleStore.addTransparentPathPart("springProfile");
-		configurators.forEach(configurator -> configurator.addElementSelectorAndActionAssociations(ruleStore));
+		thi.configurators.forEach((configurator) -> configurator.addElementSelectorAndActionAssociations(ruleStore));
 	}
 
 	boolean configureUsingAotGeneratedArtifacts() {
@@ -134,7 +134,7 @@ class SpringBootJoranConfigurator extends JoranConfigurator {
 			getContext().putObject(BeanFactoryInitializationAotContribution.class.getName(),
 					new LogbackConfigurationAotContribution(model, getModelInterpretationContext(), getContext()));
 		}
-		configurators.forEach(configurator -> configurator.processModel(model));
+		this.configurators.forEach((configurator) -> configurator.processModel(model));
 	}
 
 	private boolean isAotProcessingInProgress() {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringBootJoranConfigurator.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringBootJoranConfigurator.java
@@ -78,13 +78,15 @@ import org.springframework.util.function.SingletonSupplier;
 class SpringBootJoranConfigurator extends JoranConfigurator {
 
 	private final LoggingInitializationContext initializationContext;
+
 	private final Collection<JoranConfigurator> configurators;
 
 	SpringBootJoranConfigurator(LoggingInitializationContext initializationContext) {
 		this(initializationContext, Collections.emptyList());
 	}
 
-	SpringBootJoranConfigurator(LoggingInitializationContext initializationContext, Collection<JoranConfigurator> configurators) {
+	SpringBootJoranConfigurator(LoggingInitializationContext initializationContext,
+			Collection<JoranConfigurator> configurators) {
 		this.initializationContext = initializationContext;
 		this.configurators = configurators;
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringBootJoranConfigurator.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringBootJoranConfigurator.java
@@ -114,7 +114,7 @@ class SpringBootJoranConfigurator extends JoranConfigurator {
 		ruleStore.addRule(new ElementSelector("configuration/springProperty"), SpringPropertyAction::new);
 		ruleStore.addRule(new ElementSelector("*/springProfile"), SpringProfileAction::new);
 		ruleStore.addTransparentPathPart("springProfile");
-		thi.configurators.forEach((configurator) -> configurator.addElementSelectorAndActionAssociations(ruleStore));
+		this.configurators.forEach((configurator) -> configurator.addElementSelectorAndActionAssociations(ruleStore));
 	}
 
 	boolean configureUsingAotGeneratedArtifacts() {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -38,11 +38,9 @@ import ch.qos.logback.classic.spi.LoggerContextListener;
 import ch.qos.logback.core.ConsoleAppender;
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
 import ch.qos.logback.core.joran.action.Action;
-import ch.qos.logback.core.joran.spi.ActionException;
 import ch.qos.logback.core.joran.spi.ElementSelector;
 import ch.qos.logback.core.joran.spi.RuleStore;
 import ch.qos.logback.core.joran.spi.SaxEventInterpretationContext;
-import ch.qos.logback.core.model.processor.DefaultProcessor;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
 import ch.qos.logback.core.util.StatusPrinter;
@@ -55,7 +53,6 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.boot.logging.AbstractLoggingSystemTests;
@@ -75,6 +72,7 @@ import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
+
 import org.xml.sax.Attributes;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -663,9 +663,8 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 
 	@Test
 	void whenContextHasNoAotContributionThenProcessAheadOfTimeReturnsNull() {
-		BeanFactoryInitializationAotContribution contribution = this.loggingSystem.processAheadOfTime(
-				new DefaultListableBeanFactory()
-		);
+		BeanFactoryInitializationAotContribution contribution = this.loggingSystem
+				.processAheadOfTime(new DefaultListableBeanFactory());
 		assertThat(contribution).isNull();
 	}
 
@@ -674,9 +673,8 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		LoggerContext context = ((LoggerContext) LoggerFactory.getILoggerFactory());
 		context.putObject(BeanFactoryInitializationAotContribution.class.getName(),
 				mock(BeanFactoryInitializationAotContribution.class));
-		BeanFactoryInitializationAotContribution contribution = this.loggingSystem.processAheadOfTime(
-				new DefaultListableBeanFactory()
-		);
+		BeanFactoryInitializationAotContribution contribution = this.loggingSystem
+				.processAheadOfTime(new DefaultListableBeanFactory());
 		assertThat(context.getObject(BeanFactoryInitializationAotContribution.class.getName())).isNull();
 		assertThat(contribution).isNotNull();
 	}
@@ -687,7 +685,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		context.putObject(BeanFactoryInitializationAotContribution.class.getName(),
 				mock(BeanFactoryInitializationAotContribution.class));
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
-		beanFactory.registerSingleton("joranConfigurator1", new JoranConfigurator(){
+		beanFactory.registerSingleton("joranConfigurator1", new JoranConfigurator() {
 			@Override
 			public void addElementSelectorAndActionAssociations(RuleStore ruleStore) {
 				ruleStore.addRule(new ElementSelector("*/rule1"), () -> new Action() {
@@ -710,9 +708,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 				});
 			}
 		});
-		this.loggingSystem.processAheadOfTime(
-				beanFactory
-		);
+		this.loggingSystem.processAheadOfTime(beanFactory);
 		this.loggingSystem.beforeInitialize();
 		initialize(this.initializationContext, "classpath:logback-custom-rules.xml", null);
 		assertThat(output).doesNotContain("Ignoring unknown property [rule1] in [ch.qos.logback.classic.LoggerContext]")

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
+import org.xml.sax.Attributes;
 
 import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -72,8 +73,6 @@ import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
-
-import org.xml.sax.Attributes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;

--- a/spring-boot-project/spring-boot/src/test/resources/logback-custom-rules.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/logback-custom-rules.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%property{LOG_FILE} [%t] ${PID:-????} %c{1}: %m%n BOOTBOOT</pattern>
+		</encoder>
+	</appender>
+	<rule1/>
+	<rule2/>
+	<root level="INFO">
+		<appender-ref ref="CONSOLE" />
+	</root>
+</configuration>


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Hello Spring Boot team,

I'm quite new here and I don't know what kind of checklist I need to pass prior to submitting a pull request, sorry about that.

I am trying to understand what kind of changes I am expected to do to use spring-boot 3 in my company.

Logback team has deactivated xml declaration of rules `<newRule>` since logback 1.3 for security purposes, so we have to do it programmatically.

`SpringBootJoranConfigurator` declares a limited set of rules, so I thought it would be nice to let the user provide its own JoranConfigurators ahead of time.

I need that, because I don't want some critical information to be sent in the logs messages.
One of the rule we have in my company is `ObfuscationRule`, it is a requirement to have it in spring-boot 3.

Thank you for your help.
Related issue (not from me : #24992)
@philwebb would be the one-to-go developper for this item.