### PR TITLE
Upgrade to Logback 1.3.5

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MeterRegistryConfigurerIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MeterRegistryConfigurerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import org.junit.jupiter.api.Test;
-import org.slf4j.impl.StaticLoggerBinder;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.atlas.AtlasMetricsExportAutoConfiguration;
@@ -76,8 +76,7 @@ class MeterRegistryConfigurerIntegrationTests {
 	void counterIsIncrementedOncePerEventWithoutCompositeMeterRegistry() {
 		new ApplicationContextRunner().with(MetricsRun.limitedTo(JmxMetricsExportAutoConfiguration.class))
 				.withConfiguration(AutoConfigurations.of(LogbackMetricsAutoConfiguration.class)).run((context) -> {
-					Logger logger = ((LoggerContext) StaticLoggerBinder.getSingleton().getLoggerFactory())
-							.getLogger("test-logger");
+					Logger logger = ((LoggerContext) LoggerFactory.getILoggerFactory()).getLogger("test-logger");
 					logger.error("Error.");
 					Map<String, MeterRegistry> registriesByName = context.getBeansOfType(MeterRegistry.class);
 					assertThat(registriesByName).hasSize(1);
@@ -92,8 +91,7 @@ class MeterRegistryConfigurerIntegrationTests {
 				.with(MetricsRun.limitedTo(JmxMetricsExportAutoConfiguration.class,
 						PrometheusMetricsExportAutoConfiguration.class))
 				.withConfiguration(AutoConfigurations.of(LogbackMetricsAutoConfiguration.class)).run((context) -> {
-					Logger logger = ((LoggerContext) StaticLoggerBinder.getSingleton().getLoggerFactory())
-							.getLogger("test-logger");
+					Logger logger = ((LoggerContext) LoggerFactory.getILoggerFactory()).getLogger("test-logger");
 					logger.error("Error.");
 					Map<String, MeterRegistry> registriesByName = context.getBeansOfType(MeterRegistry.class);
 					assertThat(registriesByName).hasSize(3);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/logging/ConditionEvaluationReportLoggingListenerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/logging/ConditionEvaluationReportLoggingListenerTests.java
@@ -23,7 +23,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.impl.StaticLoggerBinder;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionEvaluationReport;
@@ -147,8 +147,8 @@ class ConditionEvaluationReportLoggingListenerTests {
 	}
 
 	private void withDebugLogging(Runnable runnable) {
-		LoggerContext context = (LoggerContext) StaticLoggerBinder.getSingleton().getLoggerFactory();
-		Logger logger = context.getLogger(ConditionEvaluationReportLoggingListener.class);
+		Logger logger = ((LoggerContext) LoggerFactory.getILoggerFactory())
+				.getLogger(ConditionEvaluationReportLoggingListener.class);
 		Level currentLevel = logger.getLevel();
 		logger.setLevel(Level.DEBUG);
 		try {

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1128,14 +1128,14 @@ bom {
 			]
 		}
 	}
-	library("Log4j2", "2.17.2") {
+	library("Log4j2", "2.19.0") {
 		group("org.apache.logging.log4j") {
 			imports = [
 				"log4j-bom"
 			]
 		}
 	}
-	library("Logback", "1.4.1") {
+	library("Logback", "1.3.5") {
 		group("ch.qos.logback") {
 			modules = [
 				"logback-access",

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1135,7 +1135,7 @@ bom {
 			]
 		}
 	}
-	library("Logback", "1.2.11") {
+	library("Logback", "1.4.1") {
 		group("ch.qos.logback") {
 			modules = [
 				"logback-access",
@@ -1619,7 +1619,7 @@ bom {
 			]
 		}
 	}
-	library("SLF4J", "1.7.36") {
+	library("SLF4J", "2.0.2") {
 		group("org.slf4j") {
 			modules = [
 				"jcl-over-slf4j",
@@ -1628,9 +1628,11 @@ bom {
 				"slf4j-api",
 				"slf4j-ext",
 				"slf4j-jcl",
+				"slf4j-jdk-platform-logging",
 				"slf4j-jdk14",
 				"slf4j-log4j12",
 				"slf4j-nop",
+				"slf4j-reload4j",
 				"slf4j-simple"
 			]
 		}

--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-log4j2/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-log4j2/build.gradle
@@ -5,7 +5,7 @@ plugins {
 description = "Starter for using Log4j2 for logging. An alternative to spring-boot-starter-logging"
 
 dependencies {
-	api("org.apache.logging.log4j:log4j-slf4j-impl")
+	api("org.apache.logging.log4j:log4j-slf4j2-impl")
 	api("org.apache.logging.log4j:log4j-core")
 	api("org.apache.logging.log4j:log4j-jul")
 	api("org.slf4j:jul-to-slf4j")

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/LogbackInitializer.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/LogbackInitializer.java
@@ -19,7 +19,7 @@ package org.springframework.boot.loader.tools;
 import ch.qos.logback.classic.Level;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.impl.StaticLoggerBinder;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.util.ClassUtils;
 
@@ -32,7 +32,7 @@ import org.springframework.util.ClassUtils;
 public abstract class LogbackInitializer {
 
 	public static void initialize() {
-		if (ClassUtils.isPresent("org.slf4j.impl.StaticLoggerBinder", null)
+		if (ClassUtils.isPresent("org.slf4j.LoggerFactory", null)
 				&& ClassUtils.isPresent("ch.qos.logback.classic.Logger", null)) {
 			new Initializer().setRootLogLevel();
 		}
@@ -41,7 +41,7 @@ public abstract class LogbackInitializer {
 	private static class Initializer {
 
 		void setRootLogLevel() {
-			ILoggerFactory factory = StaticLoggerBinder.getSingleton().getLoggerFactory();
+			ILoggerFactory factory = LoggerFactory.getILoggerFactory();
 			Logger logger = factory.getLogger(Logger.ROOT_LOGGER_NAME);
 			((ch.qos.logback.classic.Logger) logger).setLevel(Level.INFO);
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/SpringBootPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/SpringBootPropertySource.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.logging.log4j2;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
@@ -27,6 +28,7 @@ import org.apache.logging.log4j.util.PropertySource;
  * Spring Boot {@link PropertySource} that disables Log4j2's shutdown hook.
  *
  * @author Andy Wilkinson
+ * @author Ivan Brusentsev
  * @since 2.5.2
  */
 public class SpringBootPropertySource implements PropertySource {
@@ -61,4 +63,8 @@ public class SpringBootPropertySource implements PropertySource {
 		return this.properties.containsKey(key);
 	}
 
+	@Override
+	public Collection<String> getPropertyNames() {
+		return this.properties.keySet();
+	}
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
@@ -25,6 +25,7 @@ import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
+import ch.qos.logback.core.spi.ScanException;
 import ch.qos.logback.core.util.FileSize;
 import ch.qos.logback.core.util.OptionHelper;
 
@@ -145,7 +146,12 @@ class DefaultLogbackConfiguration {
 	}
 
 	private String resolve(LogbackConfigurator config, String val) {
-		return OptionHelper.substVars(val, config.getContext());
+		try {
+			return OptionHelper.substVars(val, config.getContext());
+		}
+		catch (ScanException ex) {
+			throw new RuntimeException(ex);
+		}
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -38,9 +38,9 @@ import ch.qos.logback.core.status.Status;
 import ch.qos.logback.core.util.StatusListenerConfigHelper;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.bridge.SLF4JBridgeHandler;
-import org.slf4j.impl.StaticLoggerBinder;
 
 import org.springframework.boot.logging.LogFile;
 import org.springframework.boot.logging.LogLevel;
@@ -290,7 +290,7 @@ public class LogbackLoggingSystem extends Slf4JLoggingSystem {
 	}
 
 	private LoggerContext getLoggerContext() {
-		ILoggerFactory factory = StaticLoggerBinder.getSingleton().getLoggerFactory();
+		ILoggerFactory factory = LoggerFactory.getILoggerFactory();
 		Assert.isInstanceOf(LoggerContext.class, factory,
 				() -> String.format(
 						"LoggerFactory is not a Logback LoggerContext but Logback is on "

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringProfileAction.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringProfileAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,102 +16,29 @@
 
 package org.springframework.boot.logging.logback;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import ch.qos.logback.core.joran.action.Action;
-import ch.qos.logback.core.joran.event.InPlayListener;
-import ch.qos.logback.core.joran.event.SaxEvent;
-import ch.qos.logback.core.joran.spi.ActionException;
-import ch.qos.logback.core.joran.spi.InterpretationContext;
-import ch.qos.logback.core.joran.spi.Interpreter;
-import ch.qos.logback.core.util.OptionHelper;
+import ch.qos.logback.core.joran.action.BaseModelAction;
+import ch.qos.logback.core.joran.spi.SaxEventInterpretationContext;
+import ch.qos.logback.core.model.Model;
 import org.xml.sax.Attributes;
 
-import org.springframework.core.env.Environment;
-import org.springframework.core.env.Profiles;
-import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
-
 /**
- * Logback {@link Action} to support {@code <springProfile>} tags. Allows section of a
- * logback configuration to only be enabled when a specific profile is active.
+ * Logback {@link BaseModelAction} for {@code <springProperty>} tags. Allows a section of
+ * a Logback configuration to only be enabled when a specific profile is active.
  *
  * @author Phillip Webb
  * @author Eddú Meléndez
+ * @author Andy Wilkinson
+ * @see SpringProfileModel
+ * @see SpringProfileModelHandler
  */
-class SpringProfileAction extends Action implements InPlayListener {
-
-	private final Environment environment;
-
-	private int depth = 0;
-
-	private boolean acceptsProfile;
-
-	private List<SaxEvent> events;
-
-	SpringProfileAction(Environment environment) {
-		this.environment = environment;
-	}
+class SpringProfileAction extends BaseModelAction {
 
 	@Override
-	public void begin(InterpretationContext ic, String name, Attributes attributes) throws ActionException {
-		this.depth++;
-		if (this.depth != 1) {
-			return;
-		}
-		ic.pushObject(this);
-		this.acceptsProfile = acceptsProfiles(ic, attributes);
-		this.events = new ArrayList<>();
-		ic.addInPlayListener(this);
-	}
-
-	private boolean acceptsProfiles(InterpretationContext ic, Attributes attributes) {
-		if (this.environment == null) {
-			return false;
-		}
-		String[] profileNames = StringUtils
-				.trimArrayElements(StringUtils.commaDelimitedListToStringArray(attributes.getValue(NAME_ATTRIBUTE)));
-		if (profileNames.length == 0) {
-			return false;
-		}
-		for (int i = 0; i < profileNames.length; i++) {
-			profileNames[i] = OptionHelper.substVars(profileNames[i], ic, this.context);
-		}
-		return this.environment.acceptsProfiles(Profiles.of(profileNames));
-	}
-
-	@Override
-	public void end(InterpretationContext ic, String name) throws ActionException {
-		this.depth--;
-		if (this.depth != 0) {
-			return;
-		}
-		ic.removeInPlayListener(this);
-		verifyAndPop(ic);
-		if (this.acceptsProfile) {
-			addEventsToPlayer(ic);
-		}
-	}
-
-	private void verifyAndPop(InterpretationContext ic) {
-		Object o = ic.peekObject();
-		Assert.state(o != null, "Unexpected null object on stack");
-		Assert.isInstanceOf(SpringProfileAction.class, o, "logback stack error");
-		Assert.state(o == this, "ProfileAction different than current one on stack");
-		ic.popObject();
-	}
-
-	private void addEventsToPlayer(InterpretationContext ic) {
-		Interpreter interpreter = ic.getJoranInterpreter();
-		this.events.remove(0);
-		this.events.remove(this.events.size() - 1);
-		interpreter.getEventPlayer().addEventsDynamically(this.events, 1);
-	}
-
-	@Override
-	public void inPlay(SaxEvent event) {
-		this.events.add(event);
+	protected Model buildCurrentModel(SaxEventInterpretationContext interpretationContext, String name,
+			Attributes attributes) {
+		SpringProfileModel model = new SpringProfileModel();
+		model.setName(attributes.getValue(NAME_ATTRIBUTE));
+		return model;
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringProfileModel.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringProfileModel.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.logging.logback;
+
+import ch.qos.logback.core.model.NamedModel;
+
+/**
+ * Logback {@link NamedModel model} to support {@code <springProfile>} tags.
+ *
+ * @author Andy Wilkinson
+ * @see SpringProfileAction
+ * @see SpringProfileModelHandler
+ */
+class SpringProfileModel extends NamedModel {
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringProfileModelHandler.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringProfileModelHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.logging.logback;
+
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.model.Model;
+import ch.qos.logback.core.model.processor.ModelHandlerBase;
+import ch.qos.logback.core.model.processor.ModelHandlerException;
+import ch.qos.logback.core.model.processor.ModelInterpretationContext;
+import ch.qos.logback.core.spi.ScanException;
+import ch.qos.logback.core.util.OptionHelper;
+
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.util.StringUtils;
+
+/**
+ * Logback {@link ModelHandlerBase model handler} to support {@code <springProfile>} tags.
+ *
+ * @author Phillip Webb
+ * @author Eddú Meléndez
+ * @author Andy Wilkinson
+ * @see SpringProfileModel
+ * @see SpringProfileAction
+ */
+class SpringProfileModelHandler extends ModelHandlerBase {
+
+	private final Environment environment;
+
+	SpringProfileModelHandler(Context context, Environment environment) {
+		super(context);
+		this.environment = environment;
+	}
+
+	@Override
+	public void handle(ModelInterpretationContext intercon, Model model) throws ModelHandlerException {
+		SpringProfileModel profileModel = (SpringProfileModel) model;
+		if (!acceptsProfiles(intercon, profileModel)) {
+			model.markAsSkipped();
+		}
+	}
+
+	private boolean acceptsProfiles(ModelInterpretationContext ic, SpringProfileModel model) {
+		if (this.environment == null) {
+			return false;
+		}
+		String[] profileNames = StringUtils
+				.trimArrayElements(StringUtils.commaDelimitedListToStringArray(model.getName()));
+		if (profileNames.length == 0) {
+			return false;
+		}
+		for (int i = 0; i < profileNames.length; i++) {
+			try {
+				profileNames[i] = OptionHelper.substVars(profileNames[i], ic, this.context);
+			}
+			catch (ScanException ex) {
+				throw new RuntimeException(ex);
+			}
+		}
+		return this.environment.acceptsProfiles(Profiles.of(profileNames));
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringPropertyModel.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringPropertyModel.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.logging.logback;
+
+import ch.qos.logback.core.model.NamedModel;
+
+/**
+ * Logback {@link NamedModel model} to support {@code <springProperty>} tags. Allows
+ * Logback properties to be sourced from the Spring environment.
+ *
+ * @author Andy Wilkinson
+ * @see SpringPropertyAction
+ * @see SpringPropertyModelHandler
+ */
+class SpringPropertyModel extends NamedModel {
+
+	private String scope;
+
+	private String defaultValue;
+
+	private String source;
+
+	String getScope() {
+		return this.scope;
+	}
+
+	void setScope(String scope) {
+		this.scope = scope;
+	}
+
+	String getDefaultValue() {
+		return this.defaultValue;
+	}
+
+	void setDefaultValue(String defaultValue) {
+		this.defaultValue = defaultValue;
+	}
+
+	String getSource() {
+		return this.source;
+	}
+
+	void setSource(String source) {
+		this.source = source;
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringPropertyModelHandler.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringPropertyModelHandler.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.logging.logback;
+
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.joran.action.ActionUtil;
+import ch.qos.logback.core.joran.action.ActionUtil.Scope;
+import ch.qos.logback.core.model.Model;
+import ch.qos.logback.core.model.ModelUtil;
+import ch.qos.logback.core.model.processor.ModelHandlerBase;
+import ch.qos.logback.core.model.processor.ModelHandlerException;
+import ch.qos.logback.core.model.processor.ModelInterpretationContext;
+import ch.qos.logback.core.util.OptionHelper;
+
+import org.springframework.core.env.Environment;
+
+/**
+ * Logback {@link ModelHandlerBase model handler} to support {@code <springProperty>}
+ * tags. Allows Logback properties to be sourced from the Spring environment.
+ *
+ * @author Phillip Webb
+ * @author Eddú Meléndez
+ * @author Madhura Bhave
+ * @author Andy Wilkinson
+ * @see SpringPropertyAction
+ * @see SpringPropertyModel
+ */
+class SpringPropertyModelHandler extends ModelHandlerBase {
+
+	private final Environment environment;
+
+	SpringPropertyModelHandler(Context context, Environment environment) {
+		super(context);
+		this.environment = environment;
+	}
+
+	@Override
+	public void handle(ModelInterpretationContext intercon, Model model) throws ModelHandlerException {
+		SpringPropertyModel propertyModel = (SpringPropertyModel) model;
+		Scope scope = ActionUtil.stringToScope(propertyModel.getScope());
+		String defaultValue = propertyModel.getDefaultValue();
+		String source = propertyModel.getSource();
+		if (OptionHelper.isNullOrEmpty(propertyModel.getName()) || OptionHelper.isNullOrEmpty(source)) {
+			addError("The \"name\" and \"source\" attributes of <springProperty> must be set");
+		}
+		ModelUtil.setProperty(intercon, propertyModel.getName(), getValue(source, defaultValue), scope);
+	}
+
+	private String getValue(String source, String defaultValue) {
+		if (this.environment == null) {
+			addWarn("No Spring Environment available to resolve " + source);
+			return defaultValue;
+		}
+		return this.environment.getProperty(source, defaultValue);
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
@@ -41,8 +41,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
-import org.slf4j.impl.StaticLoggerBinder;
 
 import org.springframework.boot.DefaultBootstrapContext;
 import org.springframework.boot.SpringApplication;
@@ -101,7 +101,7 @@ class LoggingApplicationListenerTests {
 
 	private final LoggingApplicationListener listener = new LoggingApplicationListener();
 
-	private final LoggerContext loggerContext = (LoggerContext) StaticLoggerBinder.getSingleton().getLoggerFactory();
+	private final LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
 
 	private final ch.qos.logback.classic.Logger logger = this.loggerContext.getLogger(getClass());
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -43,8 +43,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
-import org.slf4j.impl.StaticLoggerBinder;
 
 import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.boot.logging.AbstractLoggingSystemTests;
@@ -102,7 +102,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		System.getProperties().remove(LoggingSystemProperties.FILE_LOG_CHARSET);
 		this.systemPropertyNames = new HashSet<>(System.getProperties().keySet());
 		this.loggingSystem.cleanUp();
-		this.logger = ((LoggerContext) StaticLoggerBinder.getSingleton().getLoggerFactory()).getLogger(getClass());
+		this.logger = ((LoggerContext) LoggerFactory.getILoggerFactory()).getLogger(getClass());
 		this.environment = new MockEnvironment();
 		ConversionService conversionService = ApplicationConversionService.getSharedInstance();
 		this.environment.setConversionService((ConfigurableConversionService) conversionService);
@@ -113,7 +113,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 	void cleanUp() {
 		System.getProperties().keySet().retainAll(this.systemPropertyNames);
 		this.loggingSystem.cleanUp();
-		((LoggerContext) StaticLoggerBinder.getSingleton().getLoggerFactory()).stop();
+		((LoggerContext) LoggerFactory.getILoggerFactory()).stop();
 	}
 
 	@Test
@@ -242,7 +242,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 	void getLoggingConfigurationForALL() {
 		this.loggingSystem.beforeInitialize();
 		initialize(this.initializationContext, null, null);
-		Logger logger = (Logger) StaticLoggerBinder.getSingleton().getLoggerFactory().getLogger(getClass().getName());
+		Logger logger = (Logger) LoggerFactory.getILoggerFactory().getLogger(getClass().getName());
 		logger.setLevel(Level.ALL);
 		LoggerConfiguration configuration = this.loggingSystem.getLoggerConfiguration(getClass().getName());
 		assertThat(configuration)
@@ -254,7 +254,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.loggingSystem.beforeInitialize();
 		initialize(this.initializationContext, null, null);
 		this.loggingSystem.setLogLevel(getClass().getName(), LogLevel.TRACE);
-		Logger logger = (Logger) StaticLoggerBinder.getSingleton().getLoggerFactory().getLogger(getClass().getName());
+		Logger logger = (Logger) LoggerFactory.getILoggerFactory().getLogger(getClass().getName());
 		assertThat(logger.getLevel()).isEqualTo(Level.TRACE);
 	}
 
@@ -515,9 +515,9 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.environment.setProperty("logging.logback.rollingpolicy.max-history", "20");
 		this.loggingSystem.beforeInitialize();
 		initialize(this.initializationContext, null, null);
-		LoggerContext loggerContext = (LoggerContext) StaticLoggerBinder.getSingleton().getLoggerFactory();
+		LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
 		Map<String, String> properties = loggerContext.getCopyOfPropertyMap();
-		Set<String> expectedProperties = new HashSet<String>();
+		Set<String> expectedProperties = new HashSet<>();
 		ReflectionUtils.doWithFields(LogbackLoggingSystemProperties.class,
 				(field) -> expectedProperties.add((String) field.get(null)), this::isPublicStaticFinal);
 		expectedProperties.removeAll(Arrays.asList("LOG_FILE", "LOG_PATH"));
@@ -532,7 +532,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 
 	@Test
 	void initializationIsOnlyPerformedOnceUntilCleanedUp() {
-		LoggerContext loggerContext = (LoggerContext) StaticLoggerBinder.getSingleton().getLoggerFactory();
+		LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
 		LoggerContextListener listener = mock(LoggerContextListener.class);
 		loggerContext.addListener(listener);
 		this.loggingSystem.beforeInitialize();
@@ -627,7 +627,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	private static Logger getRootLogger() {
-		ILoggerFactory factory = StaticLoggerBinder.getSingleton().getLoggerFactory();
+		ILoggerFactory factory = LoggerFactory.getILoggerFactory();
 		LoggerContext context = (LoggerContext) factory;
 		return context.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/SpringBootJoranConfiguratorTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/SpringBootJoranConfiguratorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.impl.StaticLoggerBinder;
 
 import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
 import org.springframework.boot.logging.LoggingInitializationContext;
@@ -65,8 +64,7 @@ class SpringBootJoranConfiguratorTests {
 		this.environment = new MockEnvironment();
 		this.initializationContext = new LoggingInitializationContext(this.environment);
 		this.configurator = new SpringBootJoranConfigurator(this.initializationContext);
-		StaticLoggerBinder binder = StaticLoggerBinder.getSingleton();
-		this.context = (LoggerContext) binder.getLoggerFactory();
+		this.context = (LoggerContext) LoggerFactory.getILoggerFactory();
 		this.logger = this.context.getLogger(getClass());
 	}
 

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -3,6 +3,12 @@
 		"-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
 		"https://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
+	<suppress files="ConditionEvaluationReportLoggingListenerTests\.java" checks="IllegalImport" />
+	<suppress files="LoggingApplicationListenerTests\.java" checks="IllegalImport" />
+	<suppress files="LogbackInitializer\.java" checks="IllegalImport" />
+	<suppress files="LogbackLoggingSystem\.java" checks="IllegalImport" />
+	<suppress files="LogbackLoggingSystemTests\.java" checks="IllegalImport" />
+	<suppress files="MeterRegistryConfigurerIntegrationTests\.java" checks="IllegalImport" />
 	<suppress files="SpringApplicationTests\.java" checks="FinalClass" />
 	<suppress files=".+Configuration\.java" checks="HideUtilityClassConstructor" />
 	<suppress files=".+Application\.java" checks="HideUtilityClassConstructor" />


### PR DESCRIPTION
I encountered the [LOGBACK-1162](https://jira.qos.ch/browse/LOGBACK-1162) bug using Spring Boot Framework. 
This bug was fixed in Logback 1.3.+ versions, so I decided to update the Spring Boot dependency accordingly. As Spring Boot 2.x has to support Java 8, the latest compatible Logback version is 1.3.5 - [Logback 1.4.x works only with Java 11](https://logback.qos.ch/dependencies.html).
The Spring Boot 3.x has been already upgraded to Logback 1.4.5. So this change contains cherry-picking from Spring Boot 3.0 with upgrading to Logback 1.4.5 and downgrading Logback to 1.3.5 with tuning necessary libraries versions.
